### PR TITLE
WIP Don't let Portal be a NamedBean

### DIFF
--- a/java/src/jmri/jmrit/beantable/AbstractPortalTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/AbstractPortalTableDataModel.java
@@ -1,0 +1,1233 @@
+package jmri.jmrit.beantable;
+
+import java.awt.Component;
+import java.awt.Font;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyVetoException;
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.CheckForNull;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.RowSorter;
+import javax.swing.SwingWorker;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableModel;
+import jmri.InstanceManager;
+import jmri.JmriException;
+import jmri.Manager;
+import jmri.NamedBean;
+import jmri.NamedBeanHandleManager;
+import jmri.NamedBeanPropertyDescriptor;
+import jmri.UserPreferencesManager;
+import jmri.NamedBean.DisplayOptions;
+import jmri.jmrit.display.layoutEditor.LayoutBlock;
+import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
+import jmri.swing.JTablePersistenceManager;
+import jmri.util.davidflanagan.HardcopyWriter;
+import jmri.util.swing.XTableColumnModel;
+import jmri.util.table.ButtonEditor;
+import jmri.util.table.ButtonRenderer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Table data model for display of NamedBean manager contents.
+ *
+ * @author Bob Jacobsen Copyright (C) 2003
+ * @author Dennis Miller Copyright (C) 2006
+ * @param <T> the type of Portal supported by this model
+ */
+abstract public class AbstractPortalTableDataModel<T extends jmri.jmrit.logix.Portal> extends AbstractTableModel implements PropertyChangeListener {
+
+    static public final int SYSNAMECOL = 0;
+    static public final int USERNAMECOL = 1;
+    static public final int VALUECOL = 2;
+    static public final int COMMENTCOL = 3;
+    static public final int DELETECOL = 4;
+    static public final int NUMCOLUMN = 5;
+    protected List<String> sysNameList = null;
+    boolean noWarnDelete = false;
+//    NamedBeanHandleManager nbMan = InstanceManager.getDefault(NamedBeanHandleManager.class);
+//    protected final List<NamedBeanPropertyDescriptor<?>> propertyColumns;
+
+    public AbstractPortalTableDataModel() {
+        super();
+        getManager().addPropertyChangeListener(this);
+//        propertyColumns = new ArrayList<>(getManager().getKnownBeanProperties());
+        updateNameList();
+    }
+/*
+    protected int getPropertyColumnCount() {
+        return propertyColumns.size();
+    }
+
+    protected NamedBeanPropertyDescriptor<?> getPropertyColumnDescriptor(int column) {
+        int totalCount = getColumnCount();
+        int propertyCount = propertyColumns.size();
+        int tgt = column - (totalCount - propertyCount);
+        if (tgt < 0) {
+            return null;
+        }
+        return propertyColumns.get(tgt);
+    }
+*/
+    @SuppressWarnings("deprecation") // needs careful unwinding for Set operations & generics
+    protected synchronized void updateNameList() {
+        // first, remove listeners from the individual objects
+        if (sysNameList != null) {
+            for (int i = 0; i < sysNameList.size(); i++) {
+                // if object has been deleted, it's not here; ignore it
+                T b = getBySystemName(sysNameList.get(i));
+                if (b != null) {
+                    b.removePropertyChangeListener(this);
+                }
+            }
+        }
+        sysNameList = getManager().getSystemNameList();
+        // and add them back in
+        for (int i = 0; i < sysNameList.size(); i++) {
+            // if object has been deleted, it's not here; ignore it
+            T b = getBySystemName(sysNameList.get(i));
+            if (b != null) {
+                b.addPropertyChangeListener(this);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void propertyChange(PropertyChangeEvent e) {
+        if (e.getPropertyName().equals("length")) {
+            // a new NamedBean is available in the manager
+            updateNameList();
+            log.debug("Table changed length to {}", sysNameList.size());
+            fireTableDataChanged();
+        } else if (matchPropertyName(e)) {
+            // a value changed.  Find it, to avoid complete redraw
+            if (e.getSource() instanceof NamedBean) {
+                String name = ((NamedBean) e.getSource()).getSystemName();
+                int row = sysNameList.indexOf(name);
+                log.debug("Update cell {},{} for {}", row, VALUECOL, name);
+                // since we can add columns, the entire row is marked as updated
+                try {
+                    fireTableRowsUpdated(row, row);
+                } catch (Exception ex) {
+                    log.error("Exception updating table", ex);
+                }
+            }
+        }
+    }
+
+    /**
+     * Is this property event announcing a change this table should display?
+     * <p>
+     * Note that events will come both from the NamedBeans and also from the
+     * manager
+     *
+     * @param e the event to match
+     * @return true if the property name is of interest, false otherwise
+     */
+    protected boolean matchPropertyName(PropertyChangeEvent e) {
+        return (e.getPropertyName().contains("State")
+                || e.getPropertyName().contains("Appearance")
+                || e.getPropertyName().contains("Comment"))
+                || e.getPropertyName().contains("UserName");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getRowCount() {
+        return sysNameList.size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getColumnCount() {
+        return NUMCOLUMN;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getColumnName(int col) {
+        switch (col) {
+            case SYSNAMECOL:
+                return Bundle.getMessage("ColumnSystemName"); // "System Name";
+            case USERNAMECOL:
+                return Bundle.getMessage("ColumnUserName");   // "User Name";
+            case VALUECOL:
+                return Bundle.getMessage("ColumnState");      // "State";
+            case COMMENTCOL:
+                return Bundle.getMessage("ColumnComment");    // "Comment";
+            case DELETECOL:
+                return "";
+            default:
+                return "unknown";
+/*
+                NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
+                if (desc == null) {
+                    return "unknown";
+                }
+                return desc.getColumnHeaderText();
+*/
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<?> getColumnClass(int col) {
+        switch (col) {
+            case SYSNAMECOL:
+                return NamedBean.class; // can't get class of T
+            case USERNAMECOL:
+            case COMMENTCOL:
+                return String.class;
+            case VALUECOL:
+            case DELETECOL:
+                return JButton.class;
+            default:
+                return null;
+/*
+                NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
+                if (desc == null) {
+                    return null;
+                }
+                return desc.getValueClass();
+*/
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCellEditable(int row, int col) {
+        String uname;
+        switch (col) {
+            case VALUECOL:
+            case COMMENTCOL:
+            case DELETECOL:
+                return true;
+            case USERNAMECOL:
+                T b = getBySystemName(sysNameList.get(row));
+                uname = b.getUserName();
+                return ((uname == null) || uname.equals(""));
+            default:
+                return false;
+/*
+                NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
+                if (desc == null) {
+                    return false;
+                }
+                return desc.isEditable(getBySystemName(sysNameList.get(row)));
+*/
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getValueAt(int row, int col) {
+        T b;
+        switch (col) {
+            case SYSNAMECOL:  // slot number
+                return getBySystemName(sysNameList.get(row));
+            case USERNAMECOL:  // return user name
+                // sometimes, the TableSorter invokes this on rows that no longer exist, so we check
+                b = getBySystemName(sysNameList.get(row));
+                return (b != null) ? b.getUserName() : null;
+            case VALUECOL:  //
+                return getValue(sysNameList.get(row));
+            case COMMENTCOL:
+                b = getBySystemName(sysNameList.get(row));
+                return (b != null) ? b.getComment() : null;
+            case DELETECOL:  //
+                return Bundle.getMessage("ButtonDelete");
+            default:
+                log.error("internal state inconsistent with table requst for {} {}", row, col);
+                return null;
+/*
+                NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
+                if (desc == null) {
+                    log.error("internal state inconsistent with table requst for {} {}", row, col);
+                    return null;
+                }
+                b = getBySystemName(sysNameList.get(row));
+                Object value = b.getProperty(desc.propertyKey);
+                if (value == null) {
+                    return desc.defaultValue;
+                }
+                return value;
+*/
+        }
+    }
+
+    public int getPreferredWidth(int col) {
+        switch (col) {
+            case SYSNAMECOL:
+                return new JTextField(5).getPreferredSize().width;
+            case COMMENTCOL:
+            case USERNAMECOL:
+                return new JTextField(15).getPreferredSize().width; // TODO I18N using Bundle.getMessage()
+            case VALUECOL: // not actually used due to the configureTable, setColumnToHoldButton, configureButton
+            case DELETECOL: // not actually used due to the configureTable, setColumnToHoldButton, configureButton
+                return new JTextField(22).getPreferredSize().width;
+            default:
+                log.warn("Unexpected column in getPreferredWidth: {}", col);
+                return new JTextField(8).getPreferredSize().width;
+/*
+                NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
+                if (desc == null || desc.getColumnHeaderText() == null) {
+                    log.warn("Unexpected column in getPreferredWidth: {}", col);
+                    return new JTextField(8).getPreferredSize().width;
+                }
+                return new JTextField(desc.getColumnHeaderText()).getPreferredSize().width;
+*/
+        }
+    }
+
+    abstract public String getValue(String systemName);
+
+    abstract protected jmri.jmrit.logix.PortalManager getManager();
+
+    protected void setManager(@Nonnull jmri.jmrit.logix.PortalManager man) {
+    }
+
+    abstract protected T getBySystemName(@Nonnull String name);
+
+    abstract protected T getByUserName(@Nonnull String name);
+
+    abstract protected void clickOn(T t);
+
+    public int getDisplayDeleteMsg() {
+        return InstanceManager.getDefault(UserPreferencesManager.class).getMultipleChoiceOption(getMasterClassName(), "deleteInUse");
+    }
+
+    public void setDisplayDeleteMsg(int boo) {
+        InstanceManager.getDefault(UserPreferencesManager.class).setMultipleChoiceOption(getMasterClassName(), "deleteInUse", boo);
+    }
+
+    abstract protected String getMasterClassName();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setValueAt(Object value, int row, int col) {
+        switch (col) {
+            case USERNAMECOL:
+                // Directly changing the username should only be possible if the username was previously null or ""
+                // check to see if user name already exists
+                if (value.equals("")) {
+                    value = null;
+                } else {
+                    T nB = getByUserName((String) value);
+                    if (nB != null) {
+                        log.error("User name is not unique {}", value);
+                        String msg = Bundle.getMessage("WarningUserName", new Object[]{("" + value)});
+                        JOptionPane.showMessageDialog(null, msg,
+                                Bundle.getMessage("WarningTitle"),
+                                JOptionPane.ERROR_MESSAGE);
+                        return;
+                    }
+                }
+                T nBean = getBySystemName(sysNameList.get(row));
+                nBean.setUserName((String) value);
+/*
+                if (nbMan.inUse(sysNameList.get(row), nBean)) {
+                    String msg = Bundle.getMessage("UpdateToUserName", new Object[]{getBeanType(), value, sysNameList.get(row)});
+                    int optionPane = JOptionPane.showConfirmDialog(null,
+                            msg, Bundle.getMessage("UpdateToUserNameTitle"),
+                            JOptionPane.YES_NO_OPTION);
+                    if (optionPane == JOptionPane.YES_OPTION) {
+                        //This will update the bean reference from the systemName to the userName
+                        try {
+                            nbMan.updateBeanFromSystemToUser(nBean);
+                        } catch (JmriException ex) {
+                            //We should never get an exception here as we already check that the username is not valid
+                            log.error("Impossible exception setting user name", ex);
+                        }
+                    }
+                }
+*/
+                fireTableRowsUpdated(row, row);
+                break;
+            case COMMENTCOL:
+                getBySystemName(sysNameList.get(row)).setComment(
+                        (String) value);
+                fireTableRowsUpdated(row, row);
+                break;
+            case VALUECOL:
+                // button fired, swap state
+                T t = getBySystemName(sysNameList.get(row));
+                clickOn(t);
+                break;
+            case DELETECOL:
+                // button fired, delete Bean
+                deleteBean(row, col);
+                break;
+/*
+            default:
+                NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
+                if (desc == null) {
+                    break;
+                }
+                Portal b = getBySystemName(sysNameList.get(row));
+                b.setProperty(desc.propertyKey, value);
+*/
+        }
+    }
+
+    protected void deleteBean(int row, int col) {
+        DeleteBeanWorker worker = new DeleteBeanWorker(getBySystemName(sysNameList.get(row)));
+        worker.execute();
+    }
+
+    /**
+     * Delete the bean after all the checking has been done.
+     * <p>
+     * Separate so that it can be easily subclassed if other functionality is
+     * needed.
+     *
+     * @param bean NamedBean to delete
+     */
+    void doDelete(T bean) {
+        try {
+            getManager().deleteBean(bean, "DoDelete");
+        } catch (PropertyVetoException e) {
+            //At this stage the DoDelete shouldn't fail, as we have already done a can delete, which would trigger a veto
+            log.error(e.getMessage());
+        }
+    }
+
+    /**
+     * Configure a table to have our standard rows and columns. This is
+     * optional, in that other table formats can use this table model. But we
+     * put it here to help keep it consistent. This also persists the table user
+     * interface state.
+     *
+     * @param table {@link JTable} to configure
+     */
+    public void configureTable(JTable table) {
+        // Property columns will be invisible at start.
+        setPropertyColumnsVisible(table, false);
+
+        // allow reordering of the columns
+        table.getTableHeader().setReorderingAllowed(true);
+
+        // have to shut off autoResizeMode to get horizontal scroll to work (JavaSwing p 541)
+        table.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+
+        // resize columns as requested
+        for (int i = 0; i < table.getColumnCount(); i++) {
+            int width = getPreferredWidth(i);
+            table.getColumnModel().getColumn(i).setPreferredWidth(width);
+        }
+        table.sizeColumnsToFit(-1);
+
+        configValueColumn(table);
+        configDeleteColumn(table);
+
+        MouseListener popupListener = new PopupListener();
+        table.addMouseListener(popupListener);
+        this.persistTable(table);
+
+    }
+
+    protected void configValueColumn(JTable table) {
+        // have the value column hold a button
+        setColumnToHoldButton(table, VALUECOL, configureButton());
+    }
+
+    public JButton configureButton() {
+        // pick a large size
+        JButton b = new JButton(Bundle.getMessage("BeanStateInconsistent"));
+        b.putClientProperty("JComponent.sizeVariant", "small");
+        b.putClientProperty("JButton.buttonType", "square");
+        return b;
+    }
+
+    protected void configDeleteColumn(JTable table) {
+        // have the delete column hold a button
+        setColumnToHoldButton(table, DELETECOL,
+                new JButton(Bundle.getMessage("ButtonDelete")));
+    }
+
+    /**
+     * Service method to setup a column so that it will hold a button for its
+     * values
+     *
+     * @param table  {@link JTable} to use
+     * @param column Column to setup
+     * @param sample Typical button, used for size
+     */
+    protected void setColumnToHoldButton(JTable table, int column, JButton sample) {
+        // install a button renderer & editor
+        ButtonRenderer buttonRenderer = new ButtonRenderer();
+        table.setDefaultRenderer(JButton.class, buttonRenderer);
+        TableCellEditor buttonEditor = new ButtonEditor(new JButton());
+        table.setDefaultEditor(JButton.class, buttonEditor);
+        // ensure the table rows, columns have enough room for buttons
+        table.setRowHeight(sample.getPreferredSize().height);
+        table.getColumnModel().getColumn(column)
+                .setPreferredWidth((sample.getPreferredSize().width) + 4);
+    }
+
+    synchronized public void dispose() {
+        getManager().removePropertyChangeListener(this);
+        if (sysNameList != null) {
+            for (int i = 0; i < sysNameList.size(); i++) {
+                T b = getBySystemName(sysNameList.get(i));
+                if (b != null) {
+                    b.removePropertyChangeListener(this);
+                }
+            }
+        }
+    }
+
+    /**
+     * Method to self print or print preview the table. Printed in equally sized
+     * columns across the page with headings and vertical lines between each
+     * column. Data is word wrapped within a column. Can handle data as strings,
+     * comboboxes or booleans
+     *
+     * @param w the printer writer
+     */
+    public void printTable(HardcopyWriter w) {
+        // determine the column size - evenly sized, with space between for lines
+        int columnSize = (w.getCharactersPerLine() - this.getColumnCount() - 1) / this.getColumnCount();
+
+        // Draw horizontal dividing line
+        w.write(w.getCurrentLineNumber(), 0, w.getCurrentLineNumber(),
+                (columnSize + 1) * this.getColumnCount());
+
+        // print the column header labels
+        String[] columnStrings = new String[this.getColumnCount()];
+        // Put each column header in the array
+        for (int i = 0; i < this.getColumnCount(); i++) {
+            columnStrings[i] = this.getColumnName(i);
+        }
+        w.setFontStyle(Font.BOLD);
+        printColumns(w, columnStrings, columnSize);
+        w.setFontStyle(0);
+        w.write(w.getCurrentLineNumber(), 0, w.getCurrentLineNumber(),
+                (columnSize + 1) * this.getColumnCount());
+
+        // now print each row of data
+        // create a base string the width of the column
+        StringBuilder spaces = new StringBuilder(""); // NOI18N
+        for (int i = 0; i < columnSize; i++) {
+            spaces.append(" "); // NOI18N
+        }
+        for (int i = 0; i < this.getRowCount(); i++) {
+            for (int j = 0; j < this.getColumnCount(); j++) {
+                //check for special, non string contents
+                Object value = this.getValueAt(i, j);
+                if (value == null) {
+                    columnStrings[j] = spaces.toString();
+                } else if (value instanceof JComboBox<?>) {
+                    columnStrings[j] = ((JComboBox<?>) value).getSelectedItem().toString();
+                } else {
+                    // Boolean or String
+                    columnStrings[j] = value.toString();
+                }
+            }
+            printColumns(w, columnStrings, columnSize);
+            w.write(w.getCurrentLineNumber(), 0, w.getCurrentLineNumber(),
+                    (columnSize + 1) * this.getColumnCount());
+        }
+        w.close();
+    }
+
+    protected void printColumns(HardcopyWriter w, String columnStrings[], int columnSize) {
+        // create a base string the width of the column
+        StringBuilder spaces = new StringBuilder(""); // NOI18N
+        for (int i = 0; i < columnSize; i++) {
+            spaces.append(" "); // NOI18N
+        }
+        // loop through each column
+        boolean complete = false;
+        while (!complete) {
+            StringBuilder lineString = new StringBuilder(""); // NOI18N
+            complete = true;
+            for (int i = 0; i < columnStrings.length; i++) {
+                String columnString = ""; // NOI18N
+                // if the column string is too wide cut it at word boundary (valid delimiters are space, - and _)
+                // use the intial part of the text,pad it with spaces and place the remainder back in the array
+                // for further processing on next line
+                // if column string isn't too wide, pad it to column width with spaces if needed
+                if (columnStrings[i].length() > columnSize) {
+                    boolean noWord = true;
+                    for (int k = columnSize; k >= 1; k--) {
+                        if (columnStrings[i].substring(k - 1, k).equals(" ")
+                                || columnStrings[i].substring(k - 1, k).equals("-")
+                                || columnStrings[i].substring(k - 1, k).equals("_")) {
+                            columnString = columnStrings[i].substring(0, k)
+                                    + spaces.substring(columnStrings[i].substring(0, k).length());
+                            columnStrings[i] = columnStrings[i].substring(k);
+                            noWord = false;
+                            complete = false;
+                            break;
+                        }
+                    }
+                    if (noWord) {
+                        columnString = columnStrings[i].substring(0, columnSize);
+                        columnStrings[i] = columnStrings[i].substring(columnSize);
+                        complete = false;
+                    }
+
+                } else {
+                    columnString = columnStrings[i] + spaces.substring(columnStrings[i].length());
+                    columnStrings[i] = "";
+                }
+                lineString.append(columnString).append(" "); // NOI18N
+            }
+            try {
+                w.write(lineString.toString());
+                //write vertical dividing lines
+                for (int i = 0; i < w.getCharactersPerLine(); i = i + columnSize + 1) {
+                    w.write(w.getCurrentLineNumber(), i, w.getCurrentLineNumber() + 1, i);
+                }
+                w.write("\n"); // NOI18N
+            } catch (IOException e) {
+                log.warn("error during printing: {}", e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Create and configure a new table using the given model and row sorter.
+     *
+     * @param name   the name of the table
+     * @param model  the data model for the table
+     * @param sorter the row sorter for the table; if null, the table will not
+     *               be sortable
+     * @return the table
+     * @throws NullPointerException if name or model is null
+     */
+    public JTable makeJTable(@Nonnull String name, @Nonnull TableModel model, @CheckForNull RowSorter<? extends TableModel> sorter) {
+        Objects.requireNonNull(name, "the table name must be nonnull");
+        Objects.requireNonNull(model, "the table model must be nonnull");
+        return this.configureJTable(name, new JTable(model), sorter);
+    }
+
+    /**
+     * Configure a new table using the given model and row sorter.
+     *
+     * @param table  the table to configure
+     * @param name   the table name
+     * @param sorter the row sorter for the table; if null, the table will not
+     *               be sortable
+     * @return the table
+     * @throws NullPointerException if table or the table name is null
+     */
+    protected JTable configureJTable(@Nonnull String name, @Nonnull JTable table, @CheckForNull RowSorter<? extends TableModel> sorter) {
+        Objects.requireNonNull(table, "the table must be nonnull");
+        Objects.requireNonNull(name, "the table name must be nonnull");
+        table.setRowSorter(sorter);
+        table.setName(name);
+        table.getTableHeader().setReorderingAllowed(true);
+        table.setColumnModel(new XTableColumnModel());
+        table.createDefaultColumnsFromModel();
+        addMouseListenerToHeader(table);
+        return table;
+    }
+
+    abstract protected String getBeanType();/*{
+     return "Bean";
+     }*/
+
+    /**
+     * Updates the visibility settings of the property columns.
+     *
+     * @param table   the JTable object for the current display.
+     * @param visible true to make the proeprty columns visible, false to hide.
+     */
+    public void setPropertyColumnsVisible(JTable table, boolean visible) {
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+//        for (int i = getColumnCount() - 1; i >= getColumnCount() - getPropertyColumnCount(); --i) {
+        for (int i = getColumnCount() - 1; i >= getColumnCount(); --i) {
+            TableColumn column = columnModel.getColumnByModelIndex(i);
+            columnModel.setColumnVisible(column, visible);
+        }
+    }
+
+    protected void showPopup(MouseEvent e) {
+        JTable source = (JTable) e.getSource();
+        int row = source.rowAtPoint(e.getPoint());
+        int column = source.columnAtPoint(e.getPoint());
+        if (!source.isRowSelected(row)) {
+            source.changeSelection(row, column, false, false);
+        }
+        final int rowindex = source.convertRowIndexToModel(row);
+
+        JPopupMenu popupMenu = new JPopupMenu();
+        JMenuItem menuItem = new JMenuItem(Bundle.getMessage("CopyName"));
+        menuItem.addActionListener((ActionEvent e1) -> {
+            copyName(rowindex, 0);
+        });
+        popupMenu.add(menuItem);
+
+        menuItem = new JMenuItem(Bundle.getMessage("Rename"));
+        menuItem.addActionListener((ActionEvent e1) -> {
+            renameBean(rowindex, 0);
+        });
+        popupMenu.add(menuItem);
+/*
+        menuItem = new JMenuItem(Bundle.getMessage("Clear"));
+        menuItem.addActionListener((ActionEvent e1) -> {
+            removeName(rowindex, 0);
+        });
+        popupMenu.add(menuItem);
+
+        menuItem = new JMenuItem(Bundle.getMessage("Move"));
+        menuItem.addActionListener((ActionEvent e1) -> {
+            moveBean(rowindex, 0);
+        });
+        popupMenu.add(menuItem);
+*/
+        menuItem = new JMenuItem(Bundle.getMessage("ButtonDelete"));
+        menuItem.addActionListener((ActionEvent e1) -> {
+            deleteBean(rowindex, 0);
+        });
+        popupMenu.add(menuItem);
+
+        popupMenu.show(e.getComponent(), e.getX(), e.getY());
+    }
+
+    public void copyName(int row, int column) {
+        T nBean = getBySystemName(sysNameList.get(row));
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        StringSelection name = new StringSelection(nBean.getUserName());
+        clipboard.setContents(name, null);
+    }
+
+    public void renameBean(int row, int column) {
+        T nBean = getBySystemName(sysNameList.get(row));
+        String oldName = nBean.getUserName();
+        JTextField _newName = new JTextField(20);
+        _newName.setText(oldName);
+        Object[] renameBeanOption = {Bundle.getMessage("ButtonCancel"), Bundle.getMessage("ButtonOK"), _newName};
+        int retval = JOptionPane.showOptionDialog(null,
+                Bundle.getMessage("RenameFrom", oldName), Bundle.getMessage("RenameTitle", getBeanType()),
+                0, JOptionPane.INFORMATION_MESSAGE, null,
+                renameBeanOption, renameBeanOption[2]);
+
+        if (retval != 1) {
+            return;
+        }
+        String value = _newName.getText();
+
+        if (value.equals(oldName)) {
+            //name not changed.
+            return;
+        } else {
+            T nB = getByUserName(value);
+            if (nB != null) {
+                log.error("User name is not unique {}", value);
+                String msg = Bundle.getMessage("WarningUserName", new Object[]{("" + value)});
+                JOptionPane.showMessageDialog(null, msg,
+                        Bundle.getMessage("WarningTitle"),
+                        JOptionPane.ERROR_MESSAGE);
+                return;
+            }
+        }
+
+        if (!allowBlockNameChange("Rename", nBean, value)) return;  // NOI18N
+
+        nBean.setUserName(value);
+        fireTableRowsUpdated(row, row);
+/*
+        if (!value.equals("")) {
+            if (oldName == null || oldName.equals("")) {
+                if (!nbMan.inUse(sysNameList.get(row), nBean)) {
+                    return;
+                }
+                String msg = Bundle.getMessage("UpdateToUserName", new Object[]{getBeanType(), value, sysNameList.get(row)});
+                int optionPane = JOptionPane.showConfirmDialog(null,
+                        msg, Bundle.getMessage("UpdateToUserNameTitle"),
+                        JOptionPane.YES_NO_OPTION);
+                if (optionPane == JOptionPane.YES_OPTION) {
+                    //This will update the bean reference from the systemName to the userName
+                    try {
+                        nbMan.updateBeanFromSystemToUser(nBean);
+                    } catch (JmriException ex) {
+                        //We should never get an exception here as we already check that the username is not valid
+                        log.error("Impossible exception renaming Bean", ex);
+                    }
+                }
+
+            } else {
+                nbMan.renameBean(oldName, value, nBean);
+            }
+
+        } else {
+            //This will update the bean reference from the old userName to the SystemName
+            nbMan.updateBeanFromUserToSystem(nBean);
+        }
+*/
+    }
+/*
+    public void removeName(int row, int column) {
+        T nBean = getBySystemName(sysNameList.get(row));
+        if (!allowBlockNameChange("Remove", nBean, "")) return;  // NOI18N
+        String msg = Bundle.getMessage("UpdateToSystemName", new Object[]{getBeanType()});
+        int optionPane = JOptionPane.showConfirmDialog(null,
+                msg, Bundle.getMessage("UpdateToSystemNameTitle"),
+                JOptionPane.YES_NO_OPTION);
+        if (optionPane == JOptionPane.YES_OPTION) {
+            nbMan.updateBeanFromUserToSystem(nBean);
+        }
+        nBean.setUserName(null);
+        fireTableRowsUpdated(row, row);
+    }
+*/
+    /*
+     * Determine whether it is safe to rename/remove a Block user name.
+     * <p>The user name is used by the LayoutBlock to link to the block and
+     * by Layout Editor track components to link to the layout block.
+     * @oaram changeType This will be Remove or Rename.
+     * @param bean The affected bean.  Only the Block bean is of interest.
+     * @param newName For Remove this will be empty, for Rename it will be the new user name.
+     * @return true to continue with the user name change.
+     */
+    boolean allowBlockNameChange(String changeType, T bean, String newName) {
+        if (!bean.getBeanType().equals("Block")) return true;  // NOI18N
+
+        // If there is no layout block or the block name is empty, Block rename and remove are ok without notification.
+        String oldName = bean.getUserName();
+        if (oldName == null) return true;
+        LayoutBlock layoutBlock = jmri.InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(oldName);
+        if (layoutBlock == null) return true;
+
+        // Remove is not allowed if there is a layout block
+        if (changeType.equals("Remove")) {
+            log.warn("Cannot remove user name for block {}", oldName);  // NOI18N
+                JOptionPane.showMessageDialog(null,
+                        Bundle.getMessage("BlockRemoveUserNameWarning", oldName),  // NOI18N
+                        Bundle.getMessage("WarningTitle"),  // NOI18N
+                        JOptionPane.WARNING_MESSAGE);
+            return false;
+        }
+
+        // Confirmation dialog
+        int optionPane = JOptionPane.showConfirmDialog(null,
+                Bundle.getMessage("BlockChangeUserName", oldName, newName),  // NOI18N
+                Bundle.getMessage("QuestionTitle"),  // NOI18N
+                JOptionPane.YES_NO_OPTION);
+        if (optionPane == JOptionPane.YES_OPTION) {
+            return true;
+        }
+        return false;
+    }
+/*
+    @SuppressWarnings("deprecation") // needs careful unwinding for Set operations & generics
+    public void moveBean(int row, int column) {
+        final T t = getBySystemName(sysNameList.get(row));
+        String currentName = t.getUserName();
+        T oldNameBean = getBySystemName(sysNameList.get(row));
+
+        if ((currentName == null) || currentName.equals("")) {
+            JOptionPane.showMessageDialog(null, Bundle.getMessage("MoveDialogErrorMessage"));
+            return;
+        }
+
+        JComboBox<String> box = new JComboBox<>();
+        List<String> nameList = getManager().getSystemNameList();
+        for (int i = 0; i < nameList.size(); i++) {
+            T nb = getBySystemName(nameList.get(i));
+            //Only add items that do not have a username assigned.
+            if (nb.getDisplayName().equals(nameList.get(i))) {
+                box.addItem(nameList.get(i));
+            }
+        }
+
+        int retval = JOptionPane.showOptionDialog(null,
+                Bundle.getMessage("MoveDialog", getBeanType(), currentName, oldNameBean.getSystemName()),
+                Bundle.getMessage("MoveDialogTitle"),
+                0, JOptionPane.INFORMATION_MESSAGE, null,
+                new Object[]{Bundle.getMessage("ButtonCancel"), Bundle.getMessage("ButtonOK"), box}, null);
+        log.debug("Dialog value {} selected {}:{}", retval, box.getSelectedIndex(), box.getSelectedItem());
+        if (retval != 1) {
+            return;
+        }
+        String entry = (String) box.getSelectedItem();
+        T newNameBean = getBySystemName(entry);
+        if (oldNameBean != newNameBean) {
+            oldNameBean.setUserName(null);
+            newNameBean.setUserName(currentName);
+            InstanceManager.getDefault(NamedBeanHandleManager.class).moveBean(oldNameBean, newNameBean, currentName);
+            if (nbMan.inUse(newNameBean.getSystemName(), newNameBean)) {
+                String msg = Bundle.getMessage("UpdateToUserName", new Object[]{getBeanType(), currentName, sysNameList.get(row)});
+                int optionPane = JOptionPane.showConfirmDialog(null, msg, Bundle.getMessage("UpdateToUserNameTitle"), JOptionPane.YES_NO_OPTION);
+                if (optionPane == JOptionPane.YES_OPTION) {
+                    try {
+                        nbMan.updateBeanFromSystemToUser(newNameBean);
+                    } catch (JmriException ex) {
+                        //We should never get an exception here as we already check that the username is not valid
+                        log.error("Impossible exception moving Bean", ex);
+                    }
+                }
+            }
+            fireTableRowsUpdated(row, row);
+            InstanceManager.getDefault(UserPreferencesManager.class).
+                    showInfoMessage(Bundle.getMessage("ReminderTitle"),
+                            Bundle.getMessage("UpdateComplete", getBeanType()),
+                            getMasterClassName(), "remindSaveReLoad");
+        }
+    }
+*/
+    protected void showTableHeaderPopup(MouseEvent e, JTable table) {
+        JPopupMenu popupMenu = new JPopupMenu();
+        XTableColumnModel tcm = (XTableColumnModel) table.getColumnModel();
+        for (int i = 0; i < tcm.getColumnCount(false); i++) {
+            TableColumn tc = tcm.getColumnByModelIndex(i);
+            String columnName = table.getModel().getColumnName(i);
+            if (columnName != null && !columnName.equals("")) {
+                JCheckBoxMenuItem menuItem = new JCheckBoxMenuItem(table.getModel().getColumnName(i), tcm.isColumnVisible(tc));
+                menuItem.addActionListener(new HeaderActionListener(tc, tcm));
+                popupMenu.add(menuItem);
+            }
+
+        }
+        popupMenu.show(e.getComponent(), e.getX(), e.getY());
+    }
+
+    protected void addMouseListenerToHeader(JTable table) {
+        MouseListener mouseHeaderListener = new TableHeaderListener(table);
+        table.getTableHeader().addMouseListener(mouseHeaderListener);
+    }
+
+    /**
+     * Persist the state of the table after first setting the table to the last
+     * persisted state.
+     *
+     * @param table the table to persist
+     * @throws NullPointerException if the name of the table is null
+     */
+    public void persistTable(@Nonnull JTable table) throws NullPointerException {
+        InstanceManager.getOptionalDefault(JTablePersistenceManager.class).ifPresent((manager) -> {
+            setColumnIdentities(table);
+            manager.resetState(table); // throws NPE if table name is null
+            manager.persist(table);
+        });
+    }
+
+    /**
+     * Stop persisting the state of the table.
+     *
+     * @param table the table to stop persisting
+     * @throws NullPointerException if the name of the table is null
+     */
+    public void stopPersistingTable(@Nonnull JTable table) throws NullPointerException {
+        InstanceManager.getOptionalDefault(JTablePersistenceManager.class).ifPresent((manager) -> {
+            manager.stopPersisting(table); // throws NPE if table name is null
+        });
+    }
+
+    /**
+     * Set identities for any columns that need an identity. It is recommended
+     * that all columns get a constant identity to prevent identities from being
+     * subject to changes due to translation.
+     * <p>
+     * The default implementation sets column identities to the String
+     * {@code Column#} where {@code #} is the model index for the column. Note
+     * that if the TableColumnModel is a
+     * {@link jmri.util.swing.XTableColumnModel}, the index includes hidden
+     * columns.
+     *
+     * @param table the table to set identities for
+     */
+    protected void setColumnIdentities(JTable table) {
+        Objects.requireNonNull(table.getModel(), "Table must have data model");
+        Objects.requireNonNull(table.getColumnModel(), "Table must have column model");
+        Enumeration<TableColumn> columns;
+        if (table.getColumnModel() instanceof XTableColumnModel) {
+            columns = ((XTableColumnModel) table.getColumnModel()).getColumns(false);
+        } else {
+            columns = table.getColumnModel().getColumns();
+        }
+        int i = 0;
+        while (columns.hasMoreElements()) {
+            TableColumn column = columns.nextElement();
+            if (column.getIdentifier() == null || column.getIdentifier().toString().isEmpty()) {
+                column.setIdentifier(String.format("Column%d", i));
+            }
+            i += 1;
+        }
+    }
+
+    static class HeaderActionListener implements ActionListener {
+
+        TableColumn tc;
+        XTableColumnModel tcm;
+
+        HeaderActionListener(TableColumn tc, XTableColumnModel tcm) {
+            this.tc = tc;
+            this.tcm = tcm;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            JCheckBoxMenuItem check = (JCheckBoxMenuItem) e.getSource();
+            //Do not allow the last column to be hidden
+            if (!check.isSelected() && tcm.getColumnCount(true) == 1) {
+                return;
+            }
+            tcm.setColumnVisible(tc, check.isSelected());
+        }
+    }
+
+    class DeleteBeanWorker extends SwingWorker<Void, Void> {
+
+        T t;
+
+        public DeleteBeanWorker(T bean) {
+            t = bean;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Void doInBackground() {
+            StringBuilder message = new StringBuilder();
+            try {
+                getManager().deleteBean(t, "CanDelete");  // NOI18N
+            } catch (PropertyVetoException e) {
+                if (e.getPropertyChangeEvent().getPropertyName().equals("DoNotDelete")) { //NOI18N
+                    log.warn(e.getMessage());
+                    message.append(Bundle.getMessage("VetoDeleteBean", t.getBeanType(), t.getDisplayName(DisplayOptions.USERNAME_SYSTEMNAME), e.getMessage()));
+                    JOptionPane.showMessageDialog(null, message.toString(),
+                            Bundle.getMessage("WarningTitle"),
+                            JOptionPane.ERROR_MESSAGE);
+                    return null;
+                }
+                message.append(e.getMessage());
+            }
+            int count = t.getListenerRefs().size();
+            log.debug("Delete with {}", count);
+            if (getDisplayDeleteMsg() == 0x02 && message.toString().equals("")) {
+                doDelete(t);
+            } else {
+                final JDialog dialog = new JDialog();
+                dialog.setTitle(Bundle.getMessage("WarningTitle"));
+                dialog.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                JPanel container = new JPanel();
+                container.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+                container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
+                if (count > 0) { // warn of listeners attached before delete
+
+                    JLabel question = new JLabel(Bundle.getMessage("DeletePrompt", t.getDisplayName(DisplayOptions.USERNAME_SYSTEMNAME)));
+                    question.setAlignmentX(Component.CENTER_ALIGNMENT);
+                    container.add(question);
+
+                    ArrayList<String> listenerRefs = t.getListenerRefs();
+                    if (listenerRefs.size() > 0) {
+                        ArrayList<String> listeners = new ArrayList<>();
+                        for (int i = 0; i < listenerRefs.size(); i++) {
+                            if (!listeners.contains(listenerRefs.get(i))) {
+                                listeners.add(listenerRefs.get(i));
+                            }
+                        }
+
+                        message.append("<br>");
+                        message.append(Bundle.getMessage("ReminderInUse", count));
+                        message.append("<ul>");
+                        for (int i = 0; i < listeners.size(); i++) {
+                            message.append("<li>");
+                            message.append(listeners.get(i));
+                            message.append("</li>");
+                        }
+                        message.append("</ul>");
+
+                        JEditorPane pane = new JEditorPane();
+                        pane.setContentType("text/html");
+                        pane.setText("<html>" + message.toString() + "</html>");
+                        pane.setEditable(false);
+                        JScrollPane jScrollPane = new JScrollPane(pane);
+                        container.add(jScrollPane);
+                    }
+                } else {
+                    String msg = MessageFormat.format(
+                            Bundle.getMessage("DeletePrompt"),
+                            new Object[]{t.getUserName()});
+                    JLabel question = new JLabel(msg);
+                    question.setAlignmentX(Component.CENTER_ALIGNMENT);
+                    container.add(question);
+                }
+
+                final JCheckBox remember = new JCheckBox(Bundle.getMessage("MessageRememberSetting"));
+                remember.setFont(remember.getFont().deriveFont(10f));
+                remember.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+                JButton yesButton = new JButton(Bundle.getMessage("ButtonYes"));
+                JButton noButton = new JButton(Bundle.getMessage("ButtonNo"));
+                JPanel button = new JPanel();
+                button.setAlignmentX(Component.CENTER_ALIGNMENT);
+                button.add(yesButton);
+                button.add(noButton);
+                container.add(button);
+
+                noButton.addActionListener((ActionEvent e) -> {
+                    //there is no point in remembering this the user will never be
+                    //able to delete a bean!
+                    dialog.dispose();
+                });
+
+                yesButton.addActionListener((ActionEvent e) -> {
+                    if (remember.isSelected()) {
+                        setDisplayDeleteMsg(0x02);
+                    }
+                    doDelete(t);
+                    dialog.dispose();
+                });
+                container.add(remember);
+                container.setAlignmentX(Component.CENTER_ALIGNMENT);
+                container.setAlignmentY(Component.CENTER_ALIGNMENT);
+                dialog.getContentPane().add(container);
+                dialog.pack();
+                dialog.setLocation((Toolkit.getDefaultToolkit().getScreenSize().width) / 2 - dialog.getWidth() / 2, (Toolkit.getDefaultToolkit().getScreenSize().height) / 2 - dialog.getHeight() / 2);
+                dialog.setModal(true);
+                dialog.setVisible(true);
+            }
+            return null;
+        }
+
+        /**
+         * {@inheritDoc} Minimal implementation to catch and log errors
+         */
+        @Override
+        protected void done() {
+            try {
+                get();  // called to get errors
+            } catch (InterruptedException | java.util.concurrent.ExecutionException e) {
+                log.error("Exception while deleting bean", e);
+            }
+        }
+    }
+
+    class PopupListener extends MouseAdapter {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void mousePressed(MouseEvent e) {
+            if (e.isPopupTrigger()) {
+                showPopup(e);
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void mouseReleased(MouseEvent e) {
+            if (e.isPopupTrigger()) {
+                showPopup(e);
+            }
+        }
+    }
+
+    class PopupMenuRemoveName implements ActionListener {
+
+        int row;
+
+        PopupMenuRemoveName(int row) {
+            this.row = row;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            deleteBean(row, 0);
+        }
+    }
+
+    class TableHeaderListener extends MouseAdapter {
+
+        JTable table;
+
+        TableHeaderListener(JTable tbl) {
+            super();
+            table = tbl;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void mousePressed(MouseEvent e) {
+            if (e.isPopupTrigger()) {
+                showTableHeaderPopup(e, table);
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void mouseReleased(MouseEvent e) {
+            if (e.isPopupTrigger()) {
+                showTableHeaderPopup(e, table);
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void mouseClicked(MouseEvent e) {
+            if (e.isPopupTrigger()) {
+                showTableHeaderPopup(e, table);
+            }
+        }
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(AbstractPortalTableDataModel.class);
+}

--- a/java/src/jmri/jmrit/beantable/oblock/PortalTableModel.java
+++ b/java/src/jmri/jmrit/beantable/oblock/PortalTableModel.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Pete Cressman (C) 2010
  */
-public class PortalTableModel extends jmri.jmrit.beantable.BeanTableDataModel<Portal> {
+public class PortalTableModel extends jmri.jmrit.beantable.AbstractPortalTableDataModel<Portal> {
 
     public static final int FROM_BLOCK_COLUMN = 0;
     public static final int NAME_COLUMN = 1;
@@ -58,14 +58,14 @@ public class PortalTableModel extends jmri.jmrit.beantable.BeanTableDataModel<Po
     }
 
     @Override
-    public Manager<Portal> getManager() {
+    public PortalManager getManager() {
         _manager = InstanceManager.getDefault(PortalManager.class);
         return _manager;
     }
 
     @Override
     public Portal getBySystemName(String name) {
-        return _manager.getBySystemName(name);
+        return _manager.getByUserName(name);
     }
 
     @Override
@@ -129,7 +129,7 @@ public class PortalTableModel extends jmri.jmrit.beantable.BeanTableDataModel<Po
         Portal portal = null;
         if (row < sysNameList.size()) {
             String name = sysNameList.get(row);
-            portal = _manager.getBySystemName(name);
+            portal = _manager.getByUserName(name);
         }
         if (portal == null) {
             if (col == DELETE_COL) {
@@ -193,7 +193,7 @@ public class PortalTableModel extends jmri.jmrit.beantable.BeanTableDataModel<Po
                     msg = Bundle.getMessage("SametoFromBlock", fromBlock.getDisplayName());
                 }
                 if (msg==null) {
-                    Portal portal = _manager.createNewPortal(null, tempRow[NAME_COLUMN]);
+                    Portal portal = _manager.createNewPortal(tempRow[NAME_COLUMN]);
                     if (portal != null) {
                         portal.setToBlock(toBlock, false);
                         portal.setFromBlock(fromBlock, false);
@@ -212,7 +212,7 @@ public class PortalTableModel extends jmri.jmrit.beantable.BeanTableDataModel<Po
         }
 
         String name = sysNameList.get(row);
-        Portal portal = _manager.getBySystemName(name);
+        Portal portal = _manager.getByUserName(name);
         if (portal == null) {
             log.error("Portal null, getValueAt row= " + row + ", col= " + col + ", "
                     + "portalListSize= " + _manager.getObjectCount());

--- a/java/src/jmri/jmrit/display/controlPanelEditor/CircuitBuilder.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/CircuitBuilder.java
@@ -438,7 +438,7 @@ public class CircuitBuilder {
             for (int i = 0; i < _noPortalIcon.size(); i++) {
                 Portal portal = _noPortalIcon.get(i);
                 JMenuItem mi = new JMenuItem(portal.toString());
-                mi.setActionCommand(portal.getSystemName());
+                mi.setActionCommand(portal.getUserName());
                 mi.addActionListener(editPortalAction);
                 blockNeeds.add(mi);
             }

--- a/java/src/jmri/jmrit/display/controlPanelEditor/EditPortalFrame.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/EditPortalFrame.java
@@ -525,7 +525,7 @@ public class EditPortalFrame extends EditFrame implements ListSelectionListener 
             Portal portal = _homeBlock.getPortalByName(name);
             if (portal == null) {
                 PortalManager portalMgr = InstanceManager.getDefault(PortalManager.class);
-                portal = portalMgr.createNewPortal(null, name);
+                portal = portalMgr.createNewPortal(name);
                 portal.setFromBlock(_homeBlock, false);
                 _portalList.dataChange();
             }

--- a/java/src/jmri/jmrit/display/controlPanelEditor/PortalIcon.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/PortalIcon.java
@@ -37,7 +37,7 @@ public class PortalIcon extends PositionableIcon implements PropertyChangeListen
     public static final String TO_ARROW = "toArrow";
     public static final String FROM_ARROW = "fromArrow";
 
-    private NamedBeanHandle<Portal> _portalHdl;
+    private Portal _portal;
     private String _status;
     private boolean _regular = true; // true when TO_ARROW shows entry into ToBlock
     private boolean _hide = false; // true when arrow should NOT show entry into ToBlock
@@ -115,10 +115,7 @@ public class PortalIcon extends PositionableIcon implements PropertyChangeListen
     }
 
     public Portal getPortal() {
-        if (_portalHdl == null) {
-            return null;
-        }
-        return _portalHdl.getBean();
+        return _portal;
     }
 
     @SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification="Portals always have userNames")
@@ -126,7 +123,7 @@ public class PortalIcon extends PositionableIcon implements PropertyChangeListen
         if (portal == null) {
             return;
         }
-        if (_portalHdl != null) {
+        if (_portal != null) {
             Portal port = getPortal();
             if (port.equals(portal)) {
                 return;
@@ -135,8 +132,7 @@ public class PortalIcon extends PositionableIcon implements PropertyChangeListen
             }
         }
         // Portals always have userNames
-        _portalHdl = InstanceManager.getDefault(NamedBeanHandleManager.class)
-                .getNamedBeanHandle(portal.getUserName(), portal);
+        _portal = portal;
         portal.addPropertyChangeListener(this);
         setName(portal.getName());
         setToolTip(new ToolTip(portal.getDescription(), 0, 0));
@@ -162,7 +158,9 @@ public class PortalIcon extends PositionableIcon implements PropertyChangeListen
 
     @Override
     public NamedBean getNamedBean() {
-        return getPortal();
+        // This needs to be fixed.
+        throw new UnsupportedOperationException("this operation is currently not supported");
+//        return getPortal();
     }
 
     @Override

--- a/java/src/jmri/jmrit/logix/PortalManager.java
+++ b/java/src/jmri/jmrit/logix/PortalManager.java
@@ -1,8 +1,30 @@
 package jmri.jmrit.logix;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.beans.PropertyVetoException;
+import java.beans.VetoableChangeListener;
+import java.beans.VetoableChangeSupport;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 import jmri.InstanceManager;
-import jmri.jmrix.internal.InternalSystemConnectionMemo;
+import jmri.Manager;
+import jmri.NamedBean;
+import jmri.beans.PropertyChangeProvider;
+import jmri.beans.VetoableChangeProvider;
+import jmri.jmrix.SystemConnectionMemo;
 import jmri.managers.AbstractManager;
+import jmri.util.NamedBeanComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,31 +53,25 @@ import org.slf4j.LoggerFactory;
  *
  * @author Pete Cressman Copyright (C) 2014
  */
-public class PortalManager extends AbstractManager<Portal>
-        implements jmri.InstanceManagerAutoDefault {
+public class PortalManager implements PropertyChangeProvider, VetoableChangeProvider,
+        PropertyChangeListener, VetoableChangeListener, jmri.InstanceManagerAutoDefault {
 
     public PortalManager() {
-        super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
     }
 
-    @Override
     public int getXMLOrder() {
         return jmri.Manager.OBLOCKS;
     }
 
-    @Override
     public char typeLetter() {
         return 'P';
     }
 
     /*
      * Method to create a new Portal. Returns null if a
-     * Portal with the same systemName or userName already exists. 
-     *
-     * Generate a systemName if called with sName == null and 
-     * non null userName.
+     * Portal with the same userName already exists. 
      */
-    public Portal createNewPortal(String sName, String userName) {
+    public Portal createNewPortal(String userName) {
         // Check that Portal does not already exist
         Portal portal;
         if (userName != null && userName.trim().length() > 0) {
@@ -66,30 +82,181 @@ public class PortalManager extends AbstractManager<Portal>
         } else {  // must have a user name for backward compatibility
             return null;
         }
-        if (sName == null) {
-            sName = getAutoSystemName();
-        } else {
-            if (log.isDebugEnabled()) log.debug("createNewPortal called with system name \"{}\"", sName);
-        }
-        if (!sName.startsWith(getSystemNamePrefix())) {
-            sName = getSystemNamePrefix() + sName;
-        }
-        if (sName.length() < getSystemNamePrefix().length()+1) {
-            return null;
-        }
-        portal = getBySystemName(sName);
-        if (portal != null) {
-            return null;
-        }
         // Portal does not exist, create a new Portal
-        portal = new Portal(sName, userName);
+        portal = new Portal(userName);
         // save in the maps
         register(portal);
 
-        // Keep track of the last created auto system name
-        updateAutoNumber(sName);
-
         return portal;
+    }
+
+    /*
+     * Method to create a new Portal. Returns null if a
+     * Portal with the same userName already exists. 
+     * @deprecated since 4.17.5.
+     */
+    @Deprecated // 4.17.5
+    public Portal createNewPortal(String sName, String userName) {
+        return createNewPortal(userName);
+    }
+
+    /**
+     * Method for a UI to delete a bean.
+     * <p>
+     * The UI should first request a "CanDelete", this will return a list of
+     * locations (and descriptions) where the bean is in use via throwing a
+     * VetoException, then if that comes back clear, or the user agrees with the
+     * actions, then a "DoDelete" can be called which inform the listeners to
+     * delete the bean, then it will be deregistered and disposed of.
+     * <p>
+     * If a property name of "DoNotDelete" is thrown back in the VetoException
+     * then the delete process should be aborted.
+     *
+     * @param bean     The Portal to be deleted
+     * @param property The programmatic name of the request. "CanDelete" will
+     *                 enquire with all listeners if the item can be deleted.
+     *                 "DoDelete" tells the listener to delete the item.
+     * @throws java.beans.PropertyVetoException - If the recipients wishes the
+     *                                          delete to be aborted (see
+     *                                          above).
+     */
+    @OverridingMethodsMustInvokeSuper
+    public void deleteBean(@Nonnull Portal bean, @Nonnull String property) throws PropertyVetoException {
+        try {
+            fireVetoableChange(property, bean, null);
+        } catch (PropertyVetoException e) {
+            throw e;  // don't go on to check for delete.
+        }
+        if (property.equals("DoDelete")) { // NOI18N
+            deregister(bean);
+            bean.dispose();
+        }
+    }
+
+    /**
+     * Remember a Portal created outside the manager.
+     *
+     * @param s the bean
+     * @throws DuplicateSystemNameException if a different bean with the same system
+     *                                    name is already registered in the
+     *                                    manager
+     */
+    public void register(@Nonnull Portal s) {
+        String userName = s.getUserName();
+
+        Portal existingPortal = getBeanByUserName(userName);
+        if (existingPortal != null) {
+            if (s == existingPortal) {
+                log.debug("the named bean is registered twice: {}", userName);
+            } else {
+                log.error("systemName is already registered: {}", userName);
+                throw new NamedBean.DuplicateSystemNameException("systemName is already registered: " + userName);
+            }
+        }
+
+        // clear caches
+        cachedSystemNameArray = null;
+        cachedSystemNameList = null;
+        cachedNamedBeanList = null;
+        
+        // save this bean
+        _beans.add(s);
+        _tuser.put(userName, s);
+
+        // notifications
+        int position = getPosition(s);
+        fireDataListenersAdded(position, position, s);
+        fireIndexedPropertyChange("beans", position, null, s);
+        firePropertyChange("length", null, _beans.size());
+        // listen for name and state changes to forward
+        s.addPropertyChangeListener(this);
+    }
+
+    /** {@inheritDoc} */
+    @OverridingMethodsMustInvokeSuper
+    public void deregister(Portal s) {
+        int position = getPosition(s);
+
+        // clear caches
+        cachedSystemNameArray = null;
+        cachedSystemNameList = null;
+        cachedNamedBeanList = null;
+
+        // stop listening for user name changes
+        s.removePropertyChangeListener(this);
+        
+        // remove bean from local storage
+        _beans.remove(s);
+        String userName = s.getUserName();
+        _tuser.remove(userName);
+        
+        // notifications
+        fireDataListenersRemoved(position, position, s);
+        fireIndexedPropertyChange("beans", position, s, null);
+        firePropertyChange("length", null, _beans.size());
+    }
+
+    /**
+     * Locate an existing instance based on a user name. Returns null if no
+     * instance already exists.
+     *
+     * @param userName System Name of the required NamedBean
+     * @return requested NamedBean object or null if none exists
+     */
+    public Portal getBeanByUserName(@Nonnull String userName) {
+        return _tuser.get(userName);
+    }
+
+    // not efficient, but does job for now
+    private int getPosition(Portal s) {
+        int position = 0;
+        for (Portal portal : _beans) {
+            if (s == portal) {
+                return position;
+            }
+            position++;
+        }
+        return -1;
+    }
+
+    private final List<ManagerDataListener<Portal>> listeners = new ArrayList<>();
+
+    private boolean muted = false;
+    
+    /**
+     * Temporarily suppress DataListener notifications.
+     * <p>
+     * This avoids O(N^2) behavior when doing bulk updates, i.e. when loading
+     * lots of Beans. Note that this is (1) optional, in the sense that the
+     * manager is not required to mute and (2) if present, its' temporary, in
+     * the sense that the manager must do a cumulative notification when done.
+     *
+     * @param muted true if notifications should be suppressed; false otherwise
+     */
+    public void setDataListenerMute(boolean m) {
+        if (muted && !m) {
+            // send a total update, as we haven't kept track of specifics
+            ManagerDataEvent<Portal> e = new ManagerDataEvent<>(this, ManagerDataEvent.CONTENTS_CHANGED, 0, getObjectCount()-1, null);
+            for (ManagerDataListener<Portal> listener : listeners) {
+                listener.contentsChanged(e);
+            }          
+        }
+        this.muted = m;
+    }
+
+    protected void fireDataListenersAdded(int start, int end, Portal changedBean) {
+        if (muted) return;
+        ManagerDataEvent<Portal> e = new ManagerDataEvent<>(this, ManagerDataEvent.INTERVAL_ADDED, start, end, changedBean);
+        for (ManagerDataListener<Portal> m : listeners) {
+            m.intervalAdded(e);
+        }
+    }
+    protected void fireDataListenersRemoved(int start, int end, Portal changedBean) {
+        if (muted) return;
+        ManagerDataEvent<Portal> e = new ManagerDataEvent<>(this, ManagerDataEvent.INTERVAL_REMOVED, start, end, changedBean);
+        for (ManagerDataListener<Portal> m : listeners) {
+            m.intervalRemoved(e);
+        }
     }
 
     /**
@@ -118,11 +285,12 @@ public class PortalManager extends AbstractManager<Portal>
         return null;
     }
 
+    /**
+     * @deprecated since 4.17.5.
+     */
+    @Deprecated // 4.17.5
     public Portal getBySystemName(String name) {
-        if (name == null || name.trim().length() == 0) {
-            return null;
-        }
-        return _tsys.get(name);
+        return null;
     }
 
     public Portal getByUserName(String key) {
@@ -138,22 +306,454 @@ public class PortalManager extends AbstractManager<Portal>
         }
         Portal portal = getPortal(name);
         if (portal == null) {
-            portal = createNewPortal(null, name);
+            portal = createNewPortal(name);
         }
         return portal;
     }
 
+    private PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+
+    /** {@inheritDoc} */
+    @OverridingMethodsMustInvokeSuper
     @Override
-    protected void registerSelf() {
-        // Override, don't register, OBlockManager does store and load of Portals
+    public synchronized void addPropertyChangeListener(PropertyChangeListener l) {
+        pcs.addPropertyChangeListener(l);
     }
 
+    /** {@inheritDoc} */
+    @OverridingMethodsMustInvokeSuper
+    public synchronized void removePropertyChangeListener(PropertyChangeListener l) {
+        pcs.removePropertyChangeListener(l);
+    }
+
+    /** {@inheritDoc} */
     @Override
+    @OverridingMethodsMustInvokeSuper
+    public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener) {
+        pcs.addPropertyChangeListener(propertyName, listener);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Nonnull
+    @OverridingMethodsMustInvokeSuper
+    public PropertyChangeListener[] getPropertyChangeListeners() {
+        return pcs.getPropertyChangeListeners();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Nonnull
+    @OverridingMethodsMustInvokeSuper
+    public PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
+        return pcs.getPropertyChangeListeners(propertyName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void removePropertyChangeListener(String propertyName, PropertyChangeListener listener) {
+        pcs.removePropertyChangeListener(propertyName, listener);
+    }
+
+    @OverridingMethodsMustInvokeSuper
+    protected void firePropertyChange(String p, Object old, Object n) {
+        pcs.firePropertyChange(p, old, n);
+    }
+
+    @OverridingMethodsMustInvokeSuper
+    protected void fireIndexedPropertyChange(String propertyName, int index, Object oldValue, Object newValue) {
+        pcs.fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
+    }
+
+    private VetoableChangeSupport vcs = new VetoableChangeSupport(this);
+
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public synchronized void addVetoableChangeListener(VetoableChangeListener l) {
+        vcs.addVetoableChangeListener(l);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public synchronized void removeVetoableChangeListener(VetoableChangeListener l) {
+        vcs.removeVetoableChangeListener(l);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void addVetoableChangeListener(String propertyName, VetoableChangeListener listener) {
+        vcs.addVetoableChangeListener(propertyName, listener);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Nonnull
+    @OverridingMethodsMustInvokeSuper
+    public VetoableChangeListener[] getVetoableChangeListeners() {
+        return vcs.getVetoableChangeListeners();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Nonnull
+    @OverridingMethodsMustInvokeSuper
+    public VetoableChangeListener[] getVetoableChangeListeners(String propertyName) {
+        return vcs.getVetoableChangeListeners(propertyName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void removeVetoableChangeListener(String propertyName, VetoableChangeListener listener) {
+        vcs.removeVetoableChangeListener(propertyName, listener);
+    }
+
+    /**
+     * Method to inform all registered listeners of a vetoable change. If the
+     * propertyName is "CanDelete" ALL listeners with an interest in the bean
+     * will throw an exception, which is recorded returned back to the invoking
+     * method, so that it can be presented back to the user. However if a
+     * listener decides that the bean can not be deleted then it should throw an
+     * exception with a property name of "DoNotDelete", this is thrown back up
+     * to the user and the delete process should be aborted.
+     *
+     * @param p   The programmatic name of the property that is to be changed.
+     *            "CanDelete" will enquire with all listerners if the item can
+     *            be deleted. "DoDelete" tells the listerner to delete the item.
+     * @param old The old value of the property.
+     * @param n   The new value of the property.
+     * @throws PropertyVetoException - if the recipients wishes the delete to be
+     *                               aborted.
+     */
+    @OverridingMethodsMustInvokeSuper
+    protected void fireVetoableChange(String p, Object old, Object n) throws PropertyVetoException {
+        PropertyChangeEvent evt = new PropertyChangeEvent(this, p, old, n);
+        if (p.equals("CanDelete")) { //IN18N
+            StringBuilder message = new StringBuilder();
+            for (VetoableChangeListener vc : vcs.getVetoableChangeListeners()) {
+                try {
+                    vc.vetoableChange(evt);
+                } catch (PropertyVetoException e) {
+                    if (e.getPropertyChangeEvent().getPropertyName().equals("DoNotDelete")) { //IN18N
+                        log.info(e.getMessage());
+                        throw e;
+                    }
+                    message.append(e.getMessage());
+                    message.append("<hr>"); //IN18N
+                }
+            }
+            throw new PropertyVetoException(message.toString(), evt);
+        } else {
+            try {
+                vcs.fireVetoableChange(evt);
+            } catch (PropertyVetoException e) {
+                log.error("Change vetoed.", e);
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
+
+        if ("CanDelete".equals(evt.getPropertyName())) { //IN18N
+            StringBuilder message = new StringBuilder();
+            message.append(Bundle.getMessage("VetoFoundIn", getBeanTypeHandled()))
+                    .append("<ul>");
+            boolean found = false;
+            for (Portal nb : _beans) {
+                try {
+                    nb.vetoableChange(evt);
+                } catch (PropertyVetoException e) {
+                    if (e.getPropertyChangeEvent().getPropertyName().equals("DoNotDelete")) { //IN18N
+                        throw e;
+                    }
+                    found = true;
+                    message.append("<li>")
+                            .append(e.getMessage())
+                            .append("</li>");
+                }
+            }
+            message.append("</ul>")
+                    .append(Bundle.getMessage("VetoWillBeRemovedFrom", getBeanTypeHandled()));
+            if (found) {
+                throw new PropertyVetoException(message.toString(), evt);
+            }
+        }
+    }
+
+    public String getBeanTypeHandled() {
+        return Bundle.getMessage("BeanNamePortal");
+    }
+
+    /**
+     * The PropertyChangeListener interface in this class is intended to keep
+     * track of user name changes to individual NamedBeans. It is not completely
+     * implemented yet. In particular, listeners are not added to newly
+     * registered objects.
+     *
+     * @param e the event
+     */
+    @Override
+    @SuppressWarnings("unchecked") // The cast of getSource() to E can't be checked due to type erasure, but we catch errors
+    @OverridingMethodsMustInvokeSuper
+    public void propertyChange(PropertyChangeEvent e) {
+        if (e.getPropertyName().equals("UserName")) {
+            String old = (String) e.getOldValue();  // previous user name
+            String now = (String) e.getNewValue();  // current user name
+            try { // really should always succeed
+                Portal t = (Portal) e.getSource();
+                if (old != null) {
+                    _tuser.remove(old); // remove old name for this bean
+                }
+                if (now != null) {
+                    // was there previously a bean with the new name?
+                    if (_tuser.get(now) != null && _tuser.get(now) != t) {
+                        // If so, clear. Note that this is not a "move" operation
+                        _tuser.get(now).setUserName(null);
+                    }
+
+                    _tuser.put(now, t); // put new name for this bean
+                }
+            } catch (ClassCastException ex) {
+                log.error("Received event of wrong type {}", e.getSource().getClass().getName(), ex);
+            }
+
+            // called DisplayListName, as DisplayName might get used at some point by a NamedBean
+            firePropertyChange("DisplayListName", old, now); //IN18N
+        }
+    }
+
+    /**
+     * This provides an
+     * {@linkplain java.util.Collections#unmodifiableSet unmodifiable} SortedSet
+     * of Portals in user-name order.
+     * <p>
+     * Note: This is the fastest of the accessors, and is the only long-term
+     * form.
+     * <p>
+     * Note: This is a live set; the contents are kept up to date
+     *
+     * @return Unmodifiable access to a SortedSet of Portals
+     */
+    @Nonnull
+    public SortedSet<Portal> getNamedBeanSet() {
+        return Collections.unmodifiableSortedSet(_beans);
+    }
+
+    /** {@inheritDoc} */
+    @CheckReturnValue
+    public int getObjectCount() {
+        return _beans.size();
+    }
+
+    /**
+     * This provides an
+     * {@linkplain java.util.Collections#unmodifiableList unmodifiable} List of
+     * system names.
+     * <p>
+     * Note: this is ordered by the underlying NamedBeans, not on the Strings
+     * themselves.
+     * <p>
+     * Note: Access via {@link #getNamedBeanSet()} is faster.
+     * <p>
+     * Note: This is not a live list; the contents don't stay up to date
+     *
+     * @return Unmodifiable access to a list of system names
+     * @deprecated 4.17.5 - use direct access via {@link #getNamedBeanSet()}
+     */
+    @Nonnull
+    @Deprecated // 4.17.5
+    public List<String> getSystemNameList() {
+        // jmri.util.Log4JUtil.deprecationWarning(log, "getSystemNameList");
+        if (cachedSystemNameList == null) {
+            cachedSystemNameList = new ArrayList<>();
+            for (Portal b : _beans) {
+                cachedSystemNameList.add(b.getSystemName());
+            }
+        }
+        return Collections.unmodifiableList(cachedSystemNameList);
+    }
+
     public String getBeanTypeHandled(boolean plural) {
         return Bundle.getMessage(plural ? "BeanNamePortals" : "BeanNamePortal");
     }
 
+
+
+
+    /**
+     * Intended to be equivalent to {@link javax.swing.event.ListDataListener}
+     * without introducing a Swing dependency into core JMRI.
+     *
+     * @param <Portal> the type to support listening for
+     * @since JMRI 4.11.4
+     */
+    interface ManagerDataListener<Portal> {
+
+        /**
+         * Sent when the contents of the list has changed in a way that's too
+         * complex to characterize with the previous methods.
+         *
+         * @param e encapsulates event information
+         */
+        void contentsChanged(ManagerDataEvent<Portal> e);
+
+        /**
+         * Sent after the indices in the index0,index1 interval have been
+         * inserted in the data model.
+         *
+         * @param e encapsulates the event information
+         */
+        void intervalAdded(ManagerDataEvent<Portal> e);
+
+        /**
+         * Sent after the indices in the index0,index1 interval have been
+         * removed from the data model.
+         *
+         * @param e encapsulates the event information
+         */
+        void intervalRemoved(ManagerDataEvent<Portal> e);
+    }
+
+    /**
+     * Defines an event that encapsulates changes to a list.
+     * <p>
+     * Intended to be equivalent to {@link javax.swing.event.ListDataEvent}
+     * without introducing a Swing dependency into core JMRI.
+     *
+     * @param <Portal> the type to support in the event
+     * @since JMRI 4.11.4
+     */
+    @javax.annotation.concurrent.Immutable
+    public final class ManagerDataEvent<Portal> extends java.util.EventObject {
+
+        /**
+         * Equal to {@link javax.swing.event.ListDataEvent#CONTENTS_CHANGED}
+         */
+        final static public int CONTENTS_CHANGED = 0;
+        /**
+         * Equal to {@link javax.swing.event.ListDataEvent#INTERVAL_ADDED}
+         */
+        final static public int INTERVAL_ADDED = 1;
+        /**
+         * Equal to {@link javax.swing.event.ListDataEvent#INTERVAL_REMOVED}
+         */
+        final static public int INTERVAL_REMOVED = 2;
+
+        final private int type;
+        final private int index0;
+        final private int index1;
+        final private Portal changedBean; // used when just one bean is added or removed as an efficiency measure
+        final private PortalManager source;
+
+        /**
+         * Creates a <code>ListDataEvent</code> object.
+         *
+         * @param source      the source of the event (<code>null</code> not
+         *                    permitted).
+         * @param type        the type of the event (should be one of
+         *                    {@link #CONTENTS_CHANGED}, {@link #INTERVAL_ADDED}
+         *                    or {@link #INTERVAL_REMOVED}, although this is not
+         *                    enforced).
+         * @param index0      the index for one end of the modified range of
+         *                    list elements.
+         * @param index1      the index for the other end of the modified range
+         *                    of list elements.
+         * @param changedBean used when just one bean is added or removed,
+         *                    otherwise null
+         */
+        public ManagerDataEvent(@Nonnull PortalManager source, int type, int index0, int index1, Portal changedBean) {
+            super(source);
+            this.source = source;
+            this.type = type;
+            this.index0 = Math.min(index0, index1);  // from javax.swing.event.ListDataEvent implementation
+            this.index1 = Math.max(index0, index1);  // from javax.swing.event.ListDataEvent implementation
+            this.changedBean = changedBean;
+        }
+
+        /**
+         * Returns the source of the event in a type-safe manner.
+         *
+         * @return the event source
+         */
+        @Override
+        public PortalManager getSource() {
+            return source;
+        }
+
+        /**
+         * Returns the index of the first item in the range of modified list
+         * items.
+         *
+         * @return The index of the first item in the range of modified list
+         *         items.
+         */
+        public int getIndex0() {
+            return index0;
+        }
+
+        /**
+         * Returns the index of the last item in the range of modified list
+         * items.
+         *
+         * @return The index of the last item in the range of modified list
+         *         items.
+         */
+        public int getIndex1() {
+            return index1;
+        }
+
+        /**
+         * Returns the changed portal or null
+         *
+         * @return null if more than one bean was changed
+         */
+        public Portal getChangedBean() {
+            return changedBean;
+        }
+
+        /**
+         * Returns a code representing the type of this event, which is usually
+         * one of {@link #CONTENTS_CHANGED}, {@link #INTERVAL_ADDED} or
+         * {@link #INTERVAL_REMOVED}.
+         *
+         * @return The event type.
+         */
+        public int getType() {
+            return type;
+        }
+
+        /**
+         * Returns a string representing the state of this event.
+         *
+         * @return A string.
+         */
+        @Override
+        public String toString() {
+            return getClass().getName() + "[type=" + type + ",index0=" + index0 + ",index1=" + index1 + "]";
+        }
+    }
+
+
+
+
+
+    protected TreeSet<Portal> _beans = new TreeSet<>();
+    protected Hashtable<String, Portal> _tuser = new Hashtable<>();  // stores known Portal instances by user name
+
+    // caches
+    private String[] cachedSystemNameArray = null;
+    private ArrayList<String> cachedSystemNameList = null;
+    private ArrayList<Portal> cachedNamedBeanList = null;
+
     private final static Logger log = LoggerFactory.getLogger(PortalManager.class);
+
 }
 
 

--- a/java/src/jmri/jmrit/logix/WarrantBundle.properties
+++ b/java/src/jmri/jmrit/logix/WarrantBundle.properties
@@ -1,5 +1,10 @@
 # WarrantBundle.properties
 #
+
+# Keys from jmri.managers.ManagersBundle.properties
+VetoFoundIn         = Found in the following <b>{0}s</b>
+VetoWillBeRemovedFrom = It will be removed from the {0}s
+
 # OBlock and Warrant GUI properties
 
 MenuWarrant     = Warrants

--- a/java/src/jmri/jmrit/logix/configurexml/OBlockManagerXml.java
+++ b/java/src/jmri/jmrit/logix/configurexml/OBlockManagerXml.java
@@ -221,8 +221,8 @@ public class OBlockManagerXml // extends XmlFile
     private Portal getPortal(String name) {
         Portal portal = _portalMgr.providePortal(name);
         if (portal == null) {
-            portal = _portalMgr.createNewPortal(null, name);
-            log.debug("create Portal: ({}, {})", portal.getSystemName(), name);
+            portal = _portalMgr.createNewPortal(name);
+            log.debug("create Portal: ({})", name);
         }
         return portal;
     }


### PR DESCRIPTION
Portals doesn't use system name. PR #7549/ #7552 removes system name from Portal, but that breaks the contract of NamedBean, since a NamedBean must have a system name.

I created this PR to investigate if it's easy or hard to make Portal not implement the NamedBean interface.

So far, I have noticed some things:
- I needed to copy `BeanTableDataModel` to `AbstractPortalTableDataModel`, since BeanTableDataModel is based on named beans. This creates duplicated code.
- The table has a column `comment` but it doesn't seems that the comment is stored and loaded in the panel file. Either the comment column should be removed in the table or the comment should be saved in the panel file.
- `jmri.jmrit.display.controlPanelEditor.PortalIcon` has the method `public NamedBean getNamedBean()`. This method now throws an exception. I did this to make the code compile, but this needs to be fixed. I think this is the most tricky part to get this PR work.