### PR TITLE
Expands info shown in the OpenLCB monitor

### DIFF
--- a/java/src/jmri/jmrix/AbstractMonPane.java
+++ b/java/src/jmri/jmrix/AbstractMonPane.java
@@ -298,6 +298,7 @@ public abstract class AbstractMonPane extends JmriPanel {
         pane1.add(alwaysOnTopCheckBox);
         pane1.add(autoScrollCheckBox);
         paneA.add(pane1);
+        addCustomControlPanes(paneA);
 
         JPanel pane2 = new JPanel();
         pane2.setLayout(new BoxLayout(pane2, BoxLayout.X_AXIS));
@@ -350,6 +351,13 @@ public abstract class AbstractMonPane extends JmriPanel {
         // connect to data source
         init();
 
+    }
+
+    /**
+     * Expand the display with additional options specific to the hardware.
+     * @param parent a Panel (with vertical BoxLayout); overrides should add a new Panel with horizontal BoxLayout to hold the additional options.
+     */
+    protected void addCustomControlPanes(JPanel parent) {
     }
 
     private int timerCount = 0;

--- a/java/src/jmri/jmrix/openlcb/swing/monitor/Bundle.java
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/Bundle.java
@@ -24,7 +24,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class Bundle extends jmri.jmrix.openlcb.swing.Bundle {
 
     @CheckForNull
-    private static final String name = null; // NOI18N
+    private static final String name = "jmri.jmrix.openlcb.swing.monitor.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/openlcb/swing/monitor/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/Bundle.properties
@@ -1,0 +1,4 @@
+
+CheckBoxShowNodeName = Show Name for Node
+CheckBoxShowEvent = Event (First)
+CheckBoxShowEventAll = Event (All)

--- a/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
@@ -77,6 +77,12 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
     @Override
     public void dispose() {
         memo.getTrafficController().removeCanListener(this);
+
+        UserPreferencesManager pm = InstanceManager.getDefault(UserPreferencesManager.class);
+        pm.setSimplePreferenceState(nodeNameCheck, nodeNameCheckBox.isSelected());
+        pm.setSimplePreferenceState(eventCheck, eventCheckBox.isSelected());
+        pm.setSimplePreferenceState(eventAllCheck, eventAllCheckBox.isSelected());
+
         super.dispose();
     }
 

--- a/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
@@ -177,11 +177,15 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
                 }
             } else {
                 Message msg = list.get(0);
-                formatted = prefix + ": " + list.get(0).toString();
+                StringBuilder sb = new StringBuilder();
+                sb.append(prefix);
+                sb.append(": ");
+                sb.append(list.get(0).toString());
                 if (nodeNameCheckBox.isSelected() && olcbInterface != null) {
                     String name = olcbInterface.getNodeStore().findNode(list.get(0).getSourceNodeID()).getSimpleNodeIdent().getUserName();
                     if (name != null && !name.equals("")) {
-                        formatted = formatted + "\n  Src: " + name;
+                        sb.append("\n  Src: ");
+                        sb.append(name);
                     }
                 }
                 if ((eventCheckBox.isSelected() || eventAllCheckBox.isSelected()) && olcbInterface != null && msg instanceof EventMessage) {
@@ -189,14 +193,17 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
                     EventTable.EventTableEntry[] descr =
                             olcbInterface.getEventTable().getEventInfo(ev).getAllEntries();
                     if (descr.length > 0) {
-                        formatted = formatted + "\n  Event: " + descr[0].getDescription();
+                        sb.append("\n  Event: ");
+                        sb.append(descr[0].getDescription());
                     }
                     if (eventAllCheckBox.isSelected()) {
                         for (int i = 1; i < descr.length; i++) {
-                            formatted = formatted + "\n  Event: " + descr[i].getDescription();
+                            sb.append("\n  Event: ");
+                            sb.append(descr[i].getDescription());
                         }
                     }
                 }
+                formatted = sb.toString();
             }
         } else {
             // control type


### PR DESCRIPTION
This PR adds a couple of checkbox options to the OpenLCB Monitor.
When enabled, these will print additional information about a message into the log:
- the source node name (according to SNIP)
- a textual description for the given event ID if it is an EventMessage
- additional textual descriptions if more than one is available.

These options can help users understand what is happening on their layout better, especially on a busy bus.

This feature was requested at the OpenLCB User Group Forum at a recent convention.