### PR TITLE
fix: Test IdTagManager does not use persistent storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coveragereport
 tests.log
 cucumber-results.xml
 cucumber-results.json
+failed_files.txt
 
 # runtime artifacts
 messages.log*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,11 @@
     ],
     "java.test.defaultConfig": "JMRI",
     "java.format.settings.profile": "JMRI",
-    "java.format.settings.url": ".settings/org.eclipse.jdt.core.prefs"
+    "java.format.settings.url": ".settings/org.eclipse.jdt.core.prefs",
+    "files.exclude": {
+        "**/.classpath": true,
+        "**/.project": true,
+        "**/.settings": true,
+        "**/.factorypath": true
+    }
 }

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -787,9 +787,30 @@ public class JUnitUtil {
         InstanceManager.setDefault(PowerManager.class, new PowerManagerScaffold());
     }
 
+    /**
+     * Initialize an {@link IdTagManager} that does not use persistent storage.
+     * If needing an IdTagManager that does use persistent storage use
+     * {@code InstanceManager.setDefault(IdTagManager.class, new DefaultIdTagManager(InstanceManager.getDefault(InternalSystemConnectionMemo.class)));}
+     * to initialize an IdTagManager in the {@code @Before} annotated method of
+     * the test class or allow the {@link DefaultIdTagManager} to be
+     * automatically initialized when needed.
+     */
     public static void initIdTagManager() {
-        InstanceManager.reset(jmri.IdTagManager.class);
-        InstanceManager.store(new DefaultIdTagManager(InstanceManager.getDefault(InternalSystemConnectionMemo.class)), jmri.IdTagManager.class);
+        InstanceManager.reset(IdTagManager.class);
+        InstanceManager.setDefault(IdTagManager.class,
+                new DefaultIdTagManager(InstanceManager.getDefault(InternalSystemConnectionMemo.class)) {
+                    @Override
+                    public void writeIdTagDetails() {
+                        // do not actually write tags
+                        this.dirty = false;
+                    }
+
+                    @Override
+                    public void readIdTagDetails() {
+                        // do not actually read tags
+                        this.dirty = false;
+                    }
+                });
     }
 
     public static void initRailComManager() {


### PR DESCRIPTION
This is the simplest change to avoid having `IdTags` get written to or read from disk while testing. If a test requires an `IdTagManager` that does interact with persistent storage, simply do not use this method to initialize it, since it will automatically initialize when needed.

Addresses #7493 (needs to be verified on Jenkins build server)