### PR TITLE
WIP 🚧 Fix erroneous method deprecation

### DIFF
--- a/jython/AudioPlayer.py
+++ b/jython/AudioPlayer.py
@@ -168,9 +168,9 @@ class AudioPlayerFrame (JmriJFrame):
         # Now populate
         self.sourceCombo.addItem(self.SELECT)
         # Retrieve system name list of AudioSources
-        for source in audio.getNamedBeanSet(Audio.SOURCE):
+        for source in audio.getSystemNameList(Audio.SOURCE):
             # Add available sources to the list
-            self.sourceCombo.addItem(source.getSystemName())
+            self.sourceCombo.addItem(source)
 
     def whenRangeChanged(self, event):
         # store value & update sliders


### PR DESCRIPTION
#6546 erroneous deprecated use of this method which is an explicit implementation within the AudioManager to return audio subtypes.

Reverting to previous form to avoid errors when attempting to run this script.