### PR TITLE
Schematest only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,8 @@ env:
   - RUN_ORDER=filesystem
   - CC_TEST_REPORTER_ID=1d1326c4dfaeede878b46588cda440432d1dd6ec605d2c99af7b240ac7db0477
   matrix:
-  - HEADLESS=false STATIC=false
+  - HEADLESS=false STATIC=false jmri.skipschematests=true
+                                # skipping XML Schema validation in long-running task, still done below
   - HEADLESS=true STATIC=false
   - HEADLESS=true STATIC=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,7 @@ env:
   - RUN_ORDER=filesystem
   - CC_TEST_REPORTER_ID=1d1326c4dfaeede878b46588cda440432d1dd6ec605d2c99af7b240ac7db0477
   matrix:
-  - HEADLESS=false STATIC=false jmri.skipschematests=true
-                                # skipping XML Schema validation in long-running task, still done below
+  - HEADLESS=false STATIC=false 
   - HEADLESS=true STATIC=false
   - HEADLESS=true STATIC=true
 

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -34,10 +34,12 @@ if [[ "${HEADLESS}" == "true" ]] ; then
     fi
 else
     # run full GUI test suite and fail on coverage issues
+    #       skipping XML Schema validation in long-running task, still done in headless
     mvn verify -U -P travis-coverage --batch-mode \
         -Dsurefire.printSummary=${PRINT_SUMMARY} \
         -Dsurefire.runOrder=${RUN_ORDER} \
         -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \
         -Djava.awt.headless=${HEADLESS} \
+        -Djmri.skipschematests=true \
         -Dcucumber.options="--tags 'not @Ignore'"
 fi

--- a/xml/decoders/0NMRA.xml
+++ b/xml/decoders/0NMRA.xml
@@ -58,7 +58,7 @@
   <decoder>
     <family name="NMRA standard CV definitions" mfg="NMRA">
       <xi:include href="http://jmri.org/xml/decoders/nmra/outputs1-4.xml"/>
-      <model model="NMRA standard CV definitions"/>
+      <Xmodel model="NMRA standard CV definitions"/>
     </family>
     <programming direct="yes" paged="yes" register="yes" ops="yes"/>
     <variables>

--- a/xml/decoders/0NMRA.xml
+++ b/xml/decoders/0NMRA.xml
@@ -58,7 +58,7 @@
   <decoder>
     <family name="NMRA standard CV definitions" mfg="NMRA">
       <xi:include href="http://jmri.org/xml/decoders/nmra/outputs1-4.xml"/>
-      <Xmodel model="NMRA standard CV definitions"/>
+      <model model="NMRA standard CV definitions"/>
     </family>
     <programming direct="yes" paged="yes" register="yes" ops="yes"/>
     <variables>


### PR DESCRIPTION
In Travis CI, tell the graphical (not HEADLESS) job that it doesn't have to run the XML Schema verifications. Those are being done anyway in the HEADLESS STATIC=false job. By not repeating them in the graphical job it gets done bit sooner.  This  reduces the odds of the job timing out.
