### PR TITLE
Clean up ZeroConf at end of tests

### DIFF
--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -10,12 +10,10 @@ import jmri.jmrit.display.controlPanelEditor.ControlPanelEditor;
 import jmri.util.JUnitUtil;
 import jmri.util.junit.rules.RetryRule;
 import jmri.util.swing.JemmyUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.*;
+import org.junit.rules.Timeout;
+
 import org.netbeans.jemmy.operators.JDialogOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JRadioButtonOperator;
@@ -29,6 +27,9 @@ import org.netbeans.jemmy.operators.JRadioButtonOperator;
  */
 public class NXFrameTest {
 
+    @Rule
+    public org.junit.rules.Timeout globalTimeout = org.junit.rules.Timeout.seconds(20);  // timeout (seconds) for all test methods in this test class.
+    
     @Rule
     public RetryRule retryRule = new RetryRule(2);  // allow 3 tries
 
@@ -127,7 +128,7 @@ public class NXFrameTest {
         panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
     }
 
-    @Test
+    @Test(timeout=30000)  // timeout, this test only, is 30 seconds
     public void testNXWarrant() throws Exception {
         // The first part of this test duplicates testNXWarrantSetup().  It
         // then goes on to test a Warrant through the WarrantTableFrame.

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -893,6 +893,7 @@ public class JUnitUtil {
             JUnitUtil.waitFor(() -> {
                 return (manager.allServices().isEmpty());
             }, "Stopping all ZeroConf Services");
+            manager.dispose();
         }
     }
 

--- a/java/test/jmri/util/MultipartMessageTest.java
+++ b/java/test/jmri/util/MultipartMessageTest.java
@@ -56,6 +56,7 @@ public class MultipartMessageTest {
             log.debug("NPE shutting down web server", npe2);
             //Assert.fail("Null Pointer Exception occured during teardown:" + npe2);
         }
+        JUnitUtil.resetZeroConfServiceManager();
         jmri.util.JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
 - Include `dispose` of ZeroConfManager when resetting
 - Add reset at end of MultiPartMessageTest