### PR TITLE
Audio cleanup

### DIFF
--- a/java/test/apps/gui3/FirstTimeStartUpWizardTest.java
+++ b/java/test/apps/gui3/FirstTimeStartUpWizardTest.java
@@ -74,6 +74,7 @@ public class FirstTimeStartUpWizardTest {
 
     @After
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();  // eventually want to test ShutDownTasks?
         JUnitUtil.resetApplication();
         JUnitUtil.tearDown();
     }

--- a/java/test/apps/gui3/dp3/DecoderPro3Test.java
+++ b/java/test/apps/gui3/dp3/DecoderPro3Test.java
@@ -49,10 +49,6 @@ public class DecoderPro3Test {
                 JUnitUtil.initDebugThrottleManager();
             }
 
-            @Override
-            protected void installShutDownManager() {
-                // done automatically now as part of InstanceManager default handling
-            }
         };
         Assert.assertNotNull(a);
         // shutdown the application
@@ -71,6 +67,7 @@ public class DecoderPro3Test {
 
     @After
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();  // eventually want to test ShutDownTasks?
         JUnitUtil.resetApplication();
         JUnitUtil.tearDown();
     }

--- a/java/test/apps/gui3/mdi/MDITest.java
+++ b/java/test/apps/gui3/mdi/MDITest.java
@@ -48,11 +48,6 @@ public class MDITest {
                 JUnitUtil.initMemoryManager();
                 JUnitUtil.initDebugThrottleManager();
             }
-
-            @Override
-            protected void installShutDownManager() {
-                // done automatically now as part of InstanceManager default handling
-            }
         };
         Assert.assertNotNull(a);
         // shutdown the application
@@ -69,6 +64,7 @@ public class MDITest {
 
     @After
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();  // eventually want to test ShutDownTasks?
         JUnitUtil.resetApplication();
         JUnitUtil.tearDown();
     }

--- a/java/test/apps/gui3/paned/PanedTest.java
+++ b/java/test/apps/gui3/paned/PanedTest.java
@@ -51,10 +51,6 @@ public class PanedTest {
                 JUnitUtil.initDebugThrottleManager();
             }
 
-            @Override
-            protected void installShutDownManager() {
-                // done automatically now as part of InstanceManager default handling
-            }
         };
         Assert.assertNotNull(a);
         // shutdown the application
@@ -73,6 +69,7 @@ public class PanedTest {
 
     @After
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();  // eventually want to test ShutDownTasks?
         JUnitUtil.resetApplication();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/beantable/AudioTablePanelTest.java
+++ b/java/test/jmri/jmrit/beantable/AudioTablePanelTest.java
@@ -34,6 +34,9 @@ public class AudioTablePanelTest {
 
     @After
     public void tearDown() {
+        // this created an audio manager, clean that up
+        jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
+
         jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/vsdecoder/EngineSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/EngineSoundTest.java
@@ -26,6 +26,9 @@ public class EngineSoundTest {
 
     @After
     public void tearDown() {
+        // this created an audio manager, clean that up
+        jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
+
         jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/vsdecoder/NotchSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/NotchSoundTest.java
@@ -43,6 +43,10 @@ public class NotchSoundTest {
     @After
     public void tearDown() {
         uut = null;
+
+        // this created an audio manager, clean that up
+        jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
+
         jmri.util.JUnitAppender.suppressErrorMessage("Unhandled audio format type 0");
         jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/vsdecoder/NotchTransitionTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/NotchTransitionTest.java
@@ -43,6 +43,10 @@ public class NotchTransitionTest {
     @After
     public void tearDown() {
         uut = null;
+
+        // this created an audio manager, clean that up
+        jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
+
         jmri.util.JUnitAppender.suppressErrorMessage("Unhandled audio format type 0");
         jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/vsdecoder/VSDConfigPanelTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDConfigPanelTest.java
@@ -28,6 +28,9 @@ public class VSDConfigPanelTest {
 
     @After
     public void tearDown() {
+        // this created an audio manager, clean that up
+        jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
+
         jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -934,9 +934,9 @@ public class JUnitUtil {
     }
 
     /**
-     * Warns if the {@link jmri.ShutDownManager} was not left empty. Normally
-     * run as part of the 
-     * default end-of-test code.
+     * Errors if the {@link jmri.ShutDownManager} was not left empty. Normally
+     * run as part of the default end-of-test code. Considered an error so that
+     * CI will flag these and tests will be improved.
      *
      * @see #clearShutDownManager()
      * @see #initShutDownManager()
@@ -948,7 +948,7 @@ public class JUnitUtil {
         List<ShutDownTask> list = sm.tasks();
         while (list != null && !list.isEmpty()) {
             ShutDownTask task = list.get(0);
-            log.warn("Test {} left ShutDownTask registered: {} (of type {})}", getTestClassName(), task.getName(), task.getClass(), 
+            log.error("Test {} left ShutDownTask registered: {} (of type {})}", getTestClassName(), task.getName(), task.getClass(), 
                         Log4JUtil.shortenStacktrace(new Exception("traceback")));
             sm.deregister(task);
             list = sm.tasks();  // avoid ConcurrentModificationException


### PR DESCRIPTION
 - clean up AudioManager at end of tests that create one, thus preventing orphan ShutDownTask

 - Since this completes(*) the removal of orphan ShutDownTasks, change that check from WARN to ERROR so that CI will flag any new ones introduced.

*) First version of this PR left one case, so that the flagging can be checked.  That'll be committed and pushed after the first CI runs go through OK.