### PR TITLE
Terminate threads at end of tests

### DIFF
--- a/java/src/jmri/util/zeroconf/ZeroConfServiceManager.java
+++ b/java/src/jmri/util/zeroconf/ZeroConfServiceManager.java
@@ -305,7 +305,7 @@ public class ZeroConfServiceManager implements InstanceManagerAutoDefault, Dispo
         }
         CountDownLatch nsLatch = new CountDownLatch(getDNSes().size());
         new HashMap<>(getDNSes()).values().parallelStream().forEach((dns) -> {
-            new Thread(() -> {
+            Thread t = new Thread(() -> {
                 dns.unregisterAllServices();
                 if (close) {
                     try {
@@ -315,7 +315,9 @@ public class ZeroConfServiceManager implements InstanceManagerAutoDefault, Dispo
                     }
                 }
                 nsLatch.countDown();
-            }).start();
+            });
+            t.setName("dns.close in ZerConfServiceManager#stopAll");
+            t.start();
         });
         try {
             zcLatch.await();

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1289,7 +1289,9 @@ public class JUnitUtil {
         "JMRI Common Timer",
         "BluecoveAsynchronousShutdownThread", // from LocoNet BlueTooth implementation
         "Keep-Alive-Timer",                 // from "system" group
-        "process reaper"                    // observed in macOS JRE
+        "process reaper",                   // observed in macOS JRE
+        "SIGINT handler",                   // observed in JmDNS; clean shutdown takes time
+        "Multihomed mDNS.Timer",            // observed in JmDNS; clean shutdown takes time
     }));
     static List<Thread> threadsSeen = new ArrayList<>();
 

--- a/java/test/jmri/util/zeroconf/ZeroConfServiceEventTest.java
+++ b/java/test/jmri/util/zeroconf/ZeroConfServiceEventTest.java
@@ -34,6 +34,21 @@ public class ZeroConfServiceEventTest {
     @After
     public void tearDown() throws Exception {
         JUnitUtil.resetZeroConfServiceManager();
+        
+        // wait for dns threads to end
+        Thread.getAllStackTraces().keySet().forEach((t) -> 
+            {
+                String name = t.getName();
+                if (! name.equals("dns.close in ZerConfServiceManager#stopAll")) return; // skip
+                
+                try {
+                    t.join(5000); // wait up to 35 seconds for that thread to end; 
+                } catch (InterruptedException e) {
+                    // nothing, just means that thread was terminated externally
+                }
+            }
+        );        
+        
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/util/zeroconf/ZeroConfServiceManagerTest.java
+++ b/java/test/jmri/util/zeroconf/ZeroConfServiceManagerTest.java
@@ -46,10 +46,24 @@ public class ZeroConfServiceManagerTest {
     public void tearDown() throws Exception {
         JUnitUtil.resetZeroConfServiceManager();
         manager = null;
-        JUnitUtil.clearShutDownManager();
+        
+        // wait for dns threads to end
+        Thread.getAllStackTraces().keySet().forEach((t) -> 
+            {
+                String name = t.getName();
+                if (! name.equals("dns.close in ZerConfServiceManager#stopAll")) return; // skip
+                
+                try {
+                    t.join(5000); // wait up to 35 seconds for that thread to end; 
+                } catch (InterruptedException e) {
+                    // nothing, just means that thread was terminated externally
+                }
+            }
+        );        
+        
         JUnitUtil.tearDown();
     }
-
+    
     /**
      * Test of create method, of class ZeroConfServiceManager.
      */

--- a/java/test/jmri/util/zeroconf/ZeroConfServiceTest.java
+++ b/java/test/jmri/util/zeroconf/ZeroConfServiceTest.java
@@ -41,6 +41,21 @@ public class ZeroConfServiceTest {
     @After
     public void tearDown() throws Exception {
         JUnitUtil.resetZeroConfServiceManager();
+        
+        // wait for dns threads to end
+        Thread.getAllStackTraces().keySet().forEach((t) -> 
+            {
+                String name = t.getName();
+                if (! name.equals("dns.close in ZerConfServiceManager#stopAll")) return; // skip
+                
+                try {
+                    t.join(5000); // wait up to 35 seconds for that thread to end; 
+                } catch (InterruptedException e) {
+                    // nothing, just means that thread was terminated externally
+                }
+            }
+        );        
+        
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
 - Make sure threads terminating certain JmDNS operations are done before moving on from test.
 - Ignore a couple more system threads when checking for remnant test threads