### PR TITLE
Update window position check for multiple screens. Fixes JMRI/JMRI#7598

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -364,7 +364,7 @@
     <h3>Preferences</h3>
         <a id="Preferences" name="Preferences"></a>
         <ul>
-            <li></li>
+            <li>Updated saved window positions to cope with multiple screen setups (<a href="https://github.com/JMRI/JMRI/pull/7616">PR #7616</a>)</li>
         </ul>
 
     <h3>Resources</h3>


### PR DESCRIPTION
This modifies the window position check to look at the intersection between the proposed window position/size rectangle and the position/size rectangles of any connected screens.

Only if one or more of those screen-window rectangles intersect do we then use the saved parameters. Otherwise use the default size & position.