### PR TITLE
Improve algorithm to deal with resizing on multi-screen environments

### DIFF
--- a/java/src/jmri/jmrit/mailreport/ReportContext.java
+++ b/java/src/jmri/jmrit/mailreport/ReportContext.java
@@ -23,6 +23,7 @@ import jmri.profile.Profile;
 import jmri.profile.ProfileManager;
 import jmri.util.FileUtil;
 import jmri.util.JmriInsets;
+import jmri.util.JmriJFrame;
 import jmri.util.PortNameMapper;
 import jmri.util.PortNameMapper.SerialPortFriendlyName;
 import jmri.util.zeroconf.ZeroConfService;
@@ -207,19 +208,9 @@ public class ReportContext {
             addString("Environment max bounds: " + ge.getMaximumWindowBounds());
 
             try {
-                GraphicsDevice[] gs = ge.getScreenDevices();
-                for (GraphicsDevice gd : gs) {
-                    Rectangle virtualBounds = new Rectangle();
-                    Insets virtualInsets = new Insets(0, 0, 0, 0);
-                    for (GraphicsConfiguration gc: gd.getConfigurations()) {
-                        virtualBounds = virtualBounds.union(gc.getBounds());
-                        virtualInsets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
-                    }
-                    addString("Device: " + gd.getIDstring() + " virtualBounds = " + virtualBounds.getBounds());
-                    addString("Device: " + gd.getIDstring() + " virtualInsets = " + virtualInsets);
-                    addString("Device: " + gd.getIDstring() + " bounds = " + gd.getDefaultConfiguration().getBounds()
-                            + " " + gd.getDefaultConfiguration().toString());
-                    addString("Device: " + gd.getIDstring() + " insets = " + Toolkit.getDefaultToolkit().getScreenInsets(gd.getDefaultConfiguration()));
+                for (JmriJFrame.ScreenDimensions sd: JmriJFrame.getScreenDimensions()) {
+                    addString("Device: " + sd.getGraphicsDevice().getIDstring() + " bounds = " + sd.getBounds());
+                    addString("Device: " + sd.getGraphicsDevice().getIDstring() + " insets = " + sd.getInsets());
                 }
             } catch (HeadlessException ex) {
                 addString("Exception getting device bounds " + ex.getMessage());

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -242,7 +242,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
 
     /**
      * Iterates through the attached displays and retrieves bounds, insets
-     * & id for each screen.
+     * and id for each screen.
      * Size of returned ArrayList equals the number of detected displays.
      * @return ArrayList of screen bounds and insets
      */

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -247,7 +247,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      * @return ArrayList of screen bounds and insets
      */
     public static ArrayList<ScreenDimensions> getScreenDimensions() {
-        ArrayList<ScreenDimensions> screenDimensions = new ArrayList();
+        ArrayList<ScreenDimensions> screenDimensions = new ArrayList<>();
         for (GraphicsDevice gd: GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()) {
             Rectangle bounds = new Rectangle();
             Insets insets = new Insets(0, 0, 0, 0);
@@ -598,6 +598,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
             }
         }
         // As a fall-back, return the first display which is the primary
+        log.debug("Falling back to using the primary display");
         return getScreenDimensions().get(0);
     }
 

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -586,18 +586,6 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         return (escapeKeyActionClosesWindow && getEscapeKeyAction() != null);
     }
 
-    /**
-     * {@inheritDoc}
-     * Provide a maximum frame size that is limited to what can fit on the
-     * screen after toolbars, etc are deducted.
-     * <p>
-     * Some of the methods used here return null pointers on some Java
-     * implementations, however, so this will return the superclasses's maximum
-     * size if the algorithm used here fails.
-     *
-     * @return the maximum window size
-     */
-
     private ScreenDimensions getContainingDisplay(Point location) {
         // Loop through attached screen to determine which
         // contains the top-left origin point of this window
@@ -613,6 +601,17 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         return getScreenDimensions().get(0);
     }
 
+    /**
+     * {@inheritDoc}
+     * Provide a maximum frame size that is limited to what can fit on the
+     * screen after toolbars, etc are deducted.
+     * <p>
+     * Some of the methods used here return null pointers on some Java
+     * implementations, however, so this will return the superclasses's maximum
+     * size if the algorithm used here fails.
+     *
+     * @return the maximum window size
+     */
     @Override
     public Dimension getMaximumSize() {
         // adjust maximum size to full screen minus any toolbars

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -7,6 +7,7 @@ import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Insets;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -179,8 +180,6 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
                 boolean isVisible = false;
                 log.debug("Initial window location & size: {}", window);
 
-                Dimension screen = getToolkit().getScreenSize();
-                log.debug("getScreenSize returns W:{}, H:{}", screen.getWidth(), screen.getHeight());
                 log.debug("Detected {} screens.",GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices().length);
                 log.debug(windowFrameRef);
                 if (reuseFrameSavedPosition) {
@@ -219,18 +218,13 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
                 // with any of these screens - in other words, ensure that this frame would be (partially) visible
                 // on at least one of the connected screens
                 //
-                for (GraphicsDevice gd: GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()) {
-                    Rectangle virtualBounds = new Rectangle();
-                    Insets insets = new Insets(0, 0, 0, 0);
-                    for (GraphicsConfiguration gc: gd.getConfigurations()) {
-                        virtualBounds = virtualBounds.union(gc.getBounds());
-                        insets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
-                    }
-                    boolean canShow = window.intersects(virtualBounds);
-                    log.debug("Screen {} bounds {}, {}", gd.getIDstring(), virtualBounds.getBounds(), insets);
-                    log.debug("Does \"{}\" window {} fit on screen {}? {}", getTitle(), window, gd.getIDstring(), canShow);
+                for (ScreenDimensions sd: getScreenDimensions()) {
+                    boolean canShow = window.intersects(sd.getBounds());
                     if (canShow) isVisible = true;
+                    log.debug("Screen {} bounds {}, {}", sd.getGraphicsDevice().getIDstring(), sd.getBounds(), sd.getInsets());
+                    log.debug("Does \"{}\" window {} fit on screen {}? {}", getTitle(), window, sd.getGraphicsDevice().getIDstring(), canShow);
                 }
+
                 log.debug("Can \"{}\" window {} display on a screen? {}", getTitle(), window, isVisible);
 
                 //
@@ -244,6 +238,57 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
                 }
             }
         });
+    }
+
+    /**
+     * Iterates through the attached displays and retrieves bounds, insets
+     * & id for each screen.
+     * Size of returned ArrayList equals the number of detected displays.
+     * @return ArrayList of screen bounds and insets
+     */
+    public static ArrayList<ScreenDimensions> getScreenDimensions() {
+        ArrayList<ScreenDimensions> screenDimensions = new ArrayList();
+        for (GraphicsDevice gd: GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()) {
+            Rectangle bounds = new Rectangle();
+            Insets insets = new Insets(0, 0, 0, 0);
+            for (GraphicsConfiguration gc: gd.getConfigurations()) {
+                if (bounds.isEmpty()) {
+                    bounds = gc.getBounds();
+                } else {
+                    bounds = bounds.union(gc.getBounds());
+                }
+                insets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
+            }
+            screenDimensions.add(new ScreenDimensions(bounds, insets, gd));
+        }
+        return screenDimensions;
+    }
+
+    /**
+     * Represents the dimensions of an attached screen/display
+     */
+    public static class ScreenDimensions {
+        private Rectangle bounds;
+        private Insets insets;
+        private GraphicsDevice gd;
+
+        public ScreenDimensions(Rectangle bounds, Insets insets, GraphicsDevice gd) {
+            this.bounds = bounds;
+            this.insets = insets;
+            this.gd = gd;
+        }
+
+        public Rectangle getBounds() {
+            return bounds;
+        }
+
+        public Insets getInsets() {
+            return insets;
+        }
+
+        public GraphicsDevice getGraphicsDevice() {
+            return gd;
+        }
     }
 
     /**
@@ -320,36 +365,42 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         log.trace("reSizeToFitOnScreen of \"{}\" starts with maximum size {}", getTitle(), dim);
         log.trace("reSizeToFitOnScreen starts with preferred height {} width {}", height, width);
         log.trace("reSizeToFitOnScreen starts with location {},{}", getX(), getY());
+        // Normalise the location
+        ScreenDimensions sd = getContainingDisplay(this.getLocation());
+        Point locationOnDisplay = new Point(getLocation().x - sd.getBounds().x, getLocation().y - sd.getBounds().y);
+        log.trace("reSizeToFitScreen normalises origin to {}, {}", locationOnDisplay.x, locationOnDisplay.y);
 
-        if ((width + this.getX()) >= dim.getWidth()) {
+        if ((width + locationOnDisplay.x) >= dim.getWidth()) {
             // not fit in width, try to move position left
-            int offsetX = (width + this.getX()) - (int) dim.getWidth(); // pixels too large
+            int offsetX = (width + locationOnDisplay.x) - (int) dim.getWidth(); // pixels too large
             log.trace("reSizeToFitScreen moves \"{}\" left {} pixels", getTitle(), offsetX);
-            int positionX = this.getX() - offsetX;
+            int positionX = locationOnDisplay.x - offsetX;
             if (positionX < 0) {
                 log.trace("reSizeToFitScreen sets \"{}\" X to zero", getTitle());
                 positionX = 0;
             }
-            this.setLocation(positionX, this.getY());
+            this.setLocation(positionX + sd.getBounds().x, this.getY());
+            log.trace("reSizeToFitOnScreen during X calculation sets location {}, {}", positionX + sd.getBounds().x, this.getY());
             // try again to see if it doesn't fit
-            if ((width + this.getX()) >= dim.getWidth()) {
-                width = width - (int) ((width + this.getX()) - dim.getWidth());
+            if ((width + locationOnDisplay.x) >= dim.getWidth()) {
+                width = width - (int) ((width + locationOnDisplay.x) - dim.getWidth());
                 log.trace("reSizeToFitScreen sets \"{}\" width to {}", getTitle(), width);
             }
         }
-        if ((height + this.getY()) >= dim.getHeight()) {
+        if ((height + locationOnDisplay.y) >= dim.getHeight()) {
             // not fit in height, try to move position up
-            int offsetY = (height + this.getY()) - (int) dim.getHeight(); // pixels too large
+            int offsetY = (height + locationOnDisplay.y) - (int) dim.getHeight(); // pixels too large
             log.trace("reSizeToFitScreen moves \"{}\" up {} pixels", getTitle(), offsetY);
-            int positionY = this.getY() - offsetY;
+            int positionY = locationOnDisplay.y - offsetY;
             if (positionY < 0) {
                 log.trace("reSizeToFitScreen sets \"{}\" Y to zero", getTitle());
                 positionY = 0;
             }
-            this.setLocation(this.getX(), positionY);
+            this.setLocation(this.getX(), positionY + sd.getBounds().y);
+            log.trace("reSizeToFitOnScreen during Y calculation sets location {}, {}", this.getX(), positionY + sd.getBounds().y);
             // try again to see if it doesn't fit
             if ((height + this.getY()) >= dim.getHeight()) {
-                height = height - (int) ((height + this.getY()) - dim.getHeight());
+                height = height - (int) ((height + locationOnDisplay.y) - dim.getHeight());
                 log.trace("reSizeToFitScreen sets \"{}\" height to {}", getTitle(), height);
             }
         }
@@ -546,21 +597,33 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      *
      * @return the maximum window size
      */
+
+    private ScreenDimensions getContainingDisplay(Point location) {
+        // Loop through attached screen to determine which
+        // contains the top-left origin point of this window
+        for (ScreenDimensions sd: getScreenDimensions()) {
+            boolean isOnThisScreen = sd.getBounds().contains(location);
+            log.debug("Is \"{}\" window origin {} located on screen {}? {}", getTitle(), this.getLocation(), sd.getGraphicsDevice().getIDstring(), isOnThisScreen);
+            if (isOnThisScreen) {
+                // We've found the screen that contains this origin
+                return sd;
+            }
+        }
+        // As a fall-back, return the first display which is the primary
+        return getScreenDimensions().get(0);
+    }
+
     @Override
     public Dimension getMaximumSize() {
         // adjust maximum size to full screen minus any toolbars
         try {
-            // Try our own alorithm. This throws null-pointer exceptions on
+            // Try our own algorithm. This throws null-pointer exceptions on
             // some Java installs, however, for unknown reasons, so be
             // prepared to fall back.
             try {
-                // First, ask for the physical screen size
-                Dimension screen = getToolkit().getScreenSize();
-
-                // Next, ask for any insets on the screen.
-                Insets insets = JmriInsets.getInsets();
-                int widthInset = insets.right + insets.left;
-                int heightInset = insets.top + insets.bottom;
+                ScreenDimensions sd = getContainingDisplay(this.getLocation());
+                int widthInset = sd.getInsets().right + sd.getInsets().left;
+                int heightInset = sd.getInsets().top + sd.getInsets().bottom;
 
                 // If insets are zero, guess based on system type
                 if (widthInset == 0 && heightInset == 0) {
@@ -596,10 +659,10 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
                 }
 
                 // calculate size as screen size minus space needed for offsets
-                log.trace("getMaximumSize returns normally {},{}", (screen.width - widthInset), (screen.height - heightInset));
-                return new Dimension(screen.width - widthInset, screen.height - heightInset);
+                log.trace("getMaximumSize returns normally {},{}", (sd.getBounds().width - widthInset), (sd.getBounds().height - heightInset));
+                return new Dimension(sd.getBounds().width - widthInset, sd.getBounds().height - heightInset);
 
-            } catch (NoSuchMethodError e) {
+        } catch (NoSuchMethodError e) {
                 Dimension screen = getToolkit().getScreenSize();
                 log.trace("getMaximumSize returns approx due to failure {},{}", screen.width, screen.height);
                 return new Dimension(screen.width, screen.height - 45); // approximate this...


### PR DESCRIPTION
Further work for #7598 

Continuation of work in #7616

This updated algorithm determines which display the location (i.e. top-left corner) of the window would be displayed upon and then uses the extents of that display to perform adjustments.

Right now, this won't like windows that span across multiple displays as, under certain circumstance, will resize to fit solely on the single display where the origin point of the window is.

So, further work is still required, but this is, hopefully, an improvement on the previous situation.