### PR TITLE
test: Ignore tests failing consistently

### DIFF
--- a/java/test/jmri/server/json/block/JsonBlockHttpServiceTest.java
+++ b/java/test/jmri/server/json/block/JsonBlockHttpServiceTest.java
@@ -31,6 +31,7 @@ import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -280,6 +281,7 @@ public class JsonBlockHttpServiceTest extends JsonNamedBeanHttpServiceTestBase<B
      *
      * @throws jmri.server.json.JsonException if something goes wrong
      */
+    @Ignore("Until upstream sources are fixed; see #7633")
     @Test
     public void testDoSchema() throws JsonException {
         JsonBlockHttpService instance = new JsonBlockHttpService(mapper);

--- a/java/test/jmri/server/json/idtag/JsonIdTagHttpServiceTest.java
+++ b/java/test/jmri/server/json/idtag/JsonIdTagHttpServiceTest.java
@@ -28,6 +28,7 @@ import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -211,6 +212,7 @@ public class JsonIdTagHttpServiceTest extends JsonNamedBeanHttpServiceTestBase<I
      *
      * @throws jmri.server.json.JsonException if something goes wrong
      */
+    @Ignore("Until upstream sources are fixed; see #7633")
     @Test
     public void testDoSchema() throws JsonException {
         JsonIdTagHttpService instance = new JsonIdTagHttpService(mapper);

--- a/java/test/jmri/server/json/schema/JsonSchemaSocketServiceTest.java
+++ b/java/test/jmri/server/json/schema/JsonSchemaSocketServiceTest.java
@@ -18,6 +18,7 @@ import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -108,6 +109,7 @@ public class JsonSchemaSocketServiceTest {
      * @throws JmriException on unexpected exception
      * @throws JsonException on unexpected exception
      */
+    @Ignore("Until upstream sources are fixed; see #7633")
     @Test
     public void testOnMessageValidRequests() throws IOException, JmriException, JsonException {
         String type = JSON.SCHEMA;


### PR DESCRIPTION
See #7633. These tests fail when explicitly validating that a json-schema is a json-schema valid json-schema (other tests implicitely test this, so there are no worries about creating invalid json-schema).

The immediate cause of this is that the Java URLConnection class will not follow an HTTP 301 redirect from the http to the https redirect.

This has also revealed that when a json-schema defines an object in a JSON message to be a json-schema, the json schema validator ignores the mapping to not use the remote resource. Because this needs to be fixed upstream, tests that JSON messages containing json-schema are valid need to be ignored until this is fixed upstream.