### PR TITLE
Deprecate getSystemNameList for sub-types and provide getNamedBeanSet

### DIFF
--- a/java/src/jmri/AudioManager.java
+++ b/java/src/jmri/AudioManager.java
@@ -161,4 +161,10 @@ public interface AudioManager extends Manager<Audio> {
      */
     public void cleanup();
 
+    /**
+     * Determine if this AudioManager is initialised
+     * @return true if initialised
+     */
+    public boolean isInitialised();
+
 }

--- a/java/src/jmri/AudioManager.java
+++ b/java/src/jmri/AudioManager.java
@@ -1,6 +1,7 @@
 package jmri;
 
 import java.util.List;
+import java.util.SortedSet;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jmri.jmrit.audio.AudioFactory;
@@ -147,9 +148,22 @@ public interface AudioManager extends Manager<Audio> {
      *
      * @param subType sub-type to retrieve
      * @return List of specified Audio sub-type objects' system names.
+     * @deprecated 4.17.6 use direct access via {@link #getNamedBeanSet(char)}
      */
     @Nonnull
+    @Deprecated
     public List<String> getSystemNameList(char subType);
+
+    /**
+     * Get the specified Audio sub-type NamedBeans.
+     *
+     * @param subType sub-type to retrieve
+     * @return Unmodifiable access to a SortedSet of NamedBeans for the specified Audio sub-type .
+     * 
+     * @since 4.17.6
+     */
+    @Nonnull
+    public SortedSet<Audio> getNamedBeanSet(char subType);
 
     /**
      * Perform any initialisation operations

--- a/java/src/jmri/implementation/AbstractAudio.java
+++ b/java/src/jmri/implementation/AbstractAudio.java
@@ -1,6 +1,7 @@
 package jmri.implementation;
 
 import jmri.Audio;
+import jmri.InstanceManager;
 
 /**
  * Base implementation of the Audio class.
@@ -57,6 +58,12 @@ public abstract class AbstractAudio extends AbstractNamedBean implements Audio {
      * cleanup routines.
      */
     abstract protected void cleanup();
+
+    @Override
+    public void dispose() {
+        InstanceManager.getDefault(jmri.AudioManager.class).deregister(this);
+        super.dispose();
+    }
 
     /**
      * Static method to round a float value to the specified number of decimal

--- a/java/src/jmri/jmrit/audio/AbstractAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/AbstractAudioFactory.java
@@ -88,6 +88,7 @@ public abstract class AbstractAudioFactory implements AudioFactory {
                 AbstractAudioThread.snooze(100);
             }
         }
+        initialised = false;
     }
 
     @Override

--- a/java/src/jmri/jmrit/audio/AbstractAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/AbstractAudioFactory.java
@@ -66,6 +66,8 @@ public abstract class AbstractAudioFactory implements AudioFactory {
         return true;
     }
 
+    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
+            justification = "OK to write to static variables to record static library status")
     @Override
     public void cleanup() {
 

--- a/java/src/jmri/jmrit/audio/AudioFactory.java
+++ b/java/src/jmri/jmrit/audio/AudioFactory.java
@@ -44,6 +44,12 @@ public interface AudioFactory {
     public void cleanup();
 
     /**
+     * Determine if this AudioFactory is initialised
+     * @return true if initialised
+     */
+    public boolean isInitialised();
+
+    /**
      * Provide a specific new AudioBuffer object.
      *
      * @param systemName for this object instance

--- a/java/src/jmri/jmrit/audio/DefaultAudioManager.java
+++ b/java/src/jmri/jmrit/audio/DefaultAudioManager.java
@@ -244,6 +244,7 @@ public class DefaultAudioManager extends AbstractAudioManager {
         log.info("Shutting down active AudioFactory");
         InstanceManager.getDefault(jmri.ShutDownManager.class).deregister(audioShutDownTask);
         activeAudioFactory.cleanup();
+        initialised = false;
     }
 
     @Override

--- a/java/src/jmri/jmrit/audio/DefaultAudioManager.java
+++ b/java/src/jmri/jmrit/audio/DefaultAudioManager.java
@@ -214,6 +214,14 @@ public class DefaultAudioManager extends AbstractAudioManager {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isInitialised() {
+        return initialised;
+    }
+
     @Override
     @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
             justification = "Synchronized method to ensure correct counter manipulation")

--- a/java/src/jmri/jmrit/audio/DefaultAudioManager.java
+++ b/java/src/jmri/jmrit/audio/DefaultAudioManager.java
@@ -252,6 +252,10 @@ public class DefaultAudioManager extends AbstractAudioManager {
         log.info("Shutting down active AudioFactory");
         InstanceManager.getDefault(jmri.ShutDownManager.class).deregister(audioShutDownTask);
         if (activeAudioFactory != null) activeAudioFactory.cleanup();
+        // Reset counters
+        countBuffers = 0;
+        countSources = 0;
+        countListeners = 0;
         // Record that we're no longer initialised
         initialised = false;
     }

--- a/java/src/jmri/jmrit/audio/DefaultAudioManager.java
+++ b/java/src/jmri/jmrit/audio/DefaultAudioManager.java
@@ -251,7 +251,8 @@ public class DefaultAudioManager extends AbstractAudioManager {
         // Shutdown AudioFactory and close the output device
         log.info("Shutting down active AudioFactory");
         InstanceManager.getDefault(jmri.ShutDownManager.class).deregister(audioShutDownTask);
-        activeAudioFactory.cleanup();
+        if (activeAudioFactory != null) activeAudioFactory.cleanup();
+        // Record that we're no longer initialised
         initialised = false;
     }
 

--- a/java/src/jmri/jmrit/audio/DefaultAudioManager.java
+++ b/java/src/jmri/jmrit/audio/DefaultAudioManager.java
@@ -197,7 +197,7 @@ public class DefaultAudioManager extends AbstractAudioManager {
 //      activeAudioFactory = new LWJGLAudioFactory();
 //      if (activeAudioFactory.init()) return;
 //
-//      // Next try JOAL
+        // Next try JOAL
         log.debug("Try to initialise JoalAudioFactory");
         activeAudioFactory = new JoalAudioFactory();
         if (activeAudioFactory.init()) return;

--- a/java/src/jmri/jmrit/audio/DefaultAudioManager.java
+++ b/java/src/jmri/jmrit/audio/DefaultAudioManager.java
@@ -127,7 +127,7 @@ public class DefaultAudioManager extends AbstractAudioManager {
 
     /**
      * Attempt to create and initialise an AudioFactory, working
-     * down a preference heirarchy. Result is in activeAudioFactory.
+     * down a preference hierarchy. Result is in activeAudioFactory.
      * Uses null implementation to always succeed
      */
     private void createFactory() {

--- a/java/src/jmri/jmrit/audio/DefaultAudioManager.java
+++ b/java/src/jmri/jmrit/audio/DefaultAudioManager.java
@@ -282,6 +282,8 @@ public class DefaultAudioManager extends AbstractAudioManager {
         super.deregister(s);
     }
 
+    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
+            justification = "OK to write to static variables to record static library status")
     @Override
     public void cleanup() {
         // Shutdown AudioFactory and close the output device

--- a/java/src/jmri/jmrit/audio/JavaSoundAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/JavaSoundAudioFactory.java
@@ -1,7 +1,8 @@
 package jmri.jmrit.audio;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.Mixer;
 import jmri.Audio;
@@ -104,37 +105,34 @@ public class JavaSoundAudioFactory extends AbstractAudioFactory {
         // Get the active AudioManager
         AudioManager am = InstanceManager.getDefault(jmri.AudioManager.class);
 
-        // Retrieve list of Audio Objects and remove the sources
-        for (Audio audio : am.getNamedBeanSet()) {
-            if (audio.getSubType() == Audio.SOURCE) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Removing JavaSoundAudioSource: " + audio.getSystemName());
-                }
-                // Cast to JavaSoundAudioSource and cleanup
-                ((JavaSoundAudioSource) audio).cleanup();
+        // Retrieve list of AudioSource objects and remove the sources
+        SortedSet<Audio> sources = new TreeSet<>(am.getNamedBeanSet(Audio.SOURCE));
+        for (Audio source: sources) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing JavaSoundAudioSource: {}", source.getSystemName());
             }
+            // Cast to JavaSoundAudioSource and cleanup
+            ((JavaSoundAudioSource) source).cleanup();
         }
 
-        // Now, re-retrieve list of Audio objects and remove the buffers
-        for (Audio audio : am.getNamedBeanSet()) {
-            if (audio.getSubType() == Audio.BUFFER) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Removing JavaSoundAudioBuffer: " + audio.getSystemName());
-                }
-                // Cast to JavaSoundAudioBuffer and cleanup
-                ((JavaSoundAudioBuffer) audio).cleanup();
+        // Now, retrieve list of AudioBuffer objects and remove the buffers
+        SortedSet<Audio> buffers = new TreeSet<>(am.getNamedBeanSet(Audio.BUFFER));
+        for (Audio buffer : buffers) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing JavaSoundAudioBuffer: {}", buffer.getSystemName());
             }
+            // Cast to JavaSoundAudioBuffer and cleanup
+            ((JavaSoundAudioBuffer) buffer).cleanup();
         }
 
-        // Lastly, re-retrieve list and remove listener.
-        for (Audio audio : am.getNamedBeanSet()) {
-            if (audio.getSubType() == Audio.LISTENER) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Removing JavaSoundAudioListener: " + audio.getSystemName());
-                }
-                // Cast to JavaSoundAudioListener and cleanup
-                ((JavaSoundAudioListener) audio).cleanup();
+        // Lastly, retrieve list of AudioListener objects and remove listener.
+        SortedSet<Audio> listeners = new TreeSet<>(am.getNamedBeanSet(Audio.LISTENER));
+        for (Audio listener : listeners) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing JavaSoundAudioListener: {}", listener.getSystemName());
             }
+            // Cast to JavaSoundAudioListener and cleanup
+            ((JavaSoundAudioListener) listener).cleanup();
         }
 
         // Finally, shutdown JavaSound and close the output device

--- a/java/src/jmri/jmrit/audio/JavaSoundAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/JavaSoundAudioFactory.java
@@ -140,6 +140,7 @@ public class JavaSoundAudioFactory extends AbstractAudioFactory {
         // Finally, shutdown JavaSound and close the output device
         log.debug("Shutting down JavaSound");
         mixer = null;
+        initialised = false;
     }
 
     @Override

--- a/java/src/jmri/jmrit/audio/JavaSoundAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/JavaSoundAudioFactory.java
@@ -144,6 +144,11 @@ public class JavaSoundAudioFactory extends AbstractAudioFactory {
     }
 
     @Override
+    public boolean isInitialised() {
+        return initialised;
+    }
+
+    @Override
     public AudioBuffer createNewBuffer(String systemName, String userName) {
         return new JavaSoundAudioBuffer(systemName, userName);
     }

--- a/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
@@ -110,6 +110,12 @@ public class JoalAudioBuffer extends AbstractAudioBuffer {
      * @return true, if initialisation successful
      */
     private boolean init() {
+        // Check that the JoalAudioFactory exists
+        if (al == null) {
+            log.warn("Al Factory not yet initialised");
+            return false;
+        }
+
         // Try to create an empty buffer that will hold the actual sound data
         al.alGenBuffers(1, dataStorageBuffer, 0);
         if (JoalAudioFactory.checkALError()) {

--- a/java/src/jmri/jmrit/audio/JoalAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioFactory.java
@@ -397,6 +397,11 @@ public class JoalAudioFactory extends AbstractAudioFactory {
     }
 
     @Override
+    public boolean isInitialised() {
+        return initialised;
+    }
+
+    @Override
     public AudioBuffer createNewBuffer(String systemName, String userName) {
         return new JoalAudioBuffer(systemName, userName);
     }

--- a/java/src/jmri/jmrit/audio/JoalAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioFactory.java
@@ -8,7 +8,8 @@ import com.jogamp.openal.ALException;
 import com.jogamp.openal.ALFactory;
 import com.jogamp.openal.util.ALut;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import jmri.Audio;
 import jmri.AudioManager;
 import jmri.InstanceManager;
@@ -357,37 +358,34 @@ public class JoalAudioFactory extends AbstractAudioFactory {
         // Get the active AudioManager
         AudioManager am = InstanceManager.getDefault(jmri.AudioManager.class);
 
-        // Retrieve list of Audio Objects and remove the sources
-        for (Audio audio : am.getNamedBeanSet()) {
-            if (audio.getSubType() == Audio.SOURCE) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Removing JoalAudioSource: " + audio.getSystemName());
-                }
-                // Cast to JoalAudioSource and cleanup
-                ((JoalAudioSource) audio).cleanup();
+        // Retrieve list of AudioSource objects and remove the sources
+        SortedSet<Audio> sources = new TreeSet<>(am.getNamedBeanSet(Audio.SOURCE));
+        for (Audio source: sources) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing JoalAudioSource: {}", source.getSystemName());
             }
+            // Cast to JoalAudioSource and cleanup
+            ((JoalAudioSource) source).cleanup();
         }
 
-        // Now, re-retrieve list of Audio objects and remove the buffers
-        for (Audio audio : am.getNamedBeanSet()) {
-            if (audio.getSubType() == Audio.BUFFER) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Removing JoalAudioBuffer: " + audio.getSystemName());
-                }
-                // Cast to JoalAudioBuffer and cleanup
-                ((JoalAudioBuffer) audio).cleanup();
+        // Now, retrieve list of AudioBuffer objects and remove the buffers
+        SortedSet<Audio> buffers = new TreeSet<>(am.getNamedBeanSet(Audio.BUFFER));
+        for (Audio buffer : buffers) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing JoalAudioBuffer: {}", buffer.getSystemName());
             }
+            // Cast to JoalAudioBuffer and cleanup
+            ((JoalAudioBuffer) buffer).cleanup();
         }
 
-        // Lastly, re-retrieve list and remove listener.
-        for (Audio audio : am.getNamedBeanSet()) {
-            if (audio.getSubType() == Audio.LISTENER) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Removing JoalAudioListener: " + audio.getSystemName());
-                }
-                // Cast to JoalAudioListener and cleanup
-                ((JoalAudioListener) audio).cleanup();
+        // Lastly, retrieve list of AudioListener objects and remove listener.
+        SortedSet<Audio> listeners = new TreeSet<>(am.getNamedBeanSet(Audio.LISTENER));
+        for (Audio listener : listeners) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing JoalAudioListener: {}", listener.getSystemName());
             }
+            // Cast to JoalAudioListener and cleanup
+            ((JoalAudioListener) listener).cleanup();
         }
 
         // Finally, shutdown OpenAL and close the output device

--- a/java/src/jmri/jmrit/audio/JoalAudioSource.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioSource.java
@@ -106,10 +106,21 @@ public class JoalAudioSource extends AbstractAudioSource {
      * @return True if initialised
      */
     private boolean init() {
-        // Generate the AudioSource
-        if (!isAudioAlive()) {
+        // Check that the JoalAudioFactory exists
+        if (al == null) {
+            log.warn("Al Factory not yet initialised");
             return false;
         }
+
+        // Now, check that the audio command thread exists
+        if (!isAudioAlive()) {
+            log.debug("Command thread not yet alive...");
+            return false;
+        } else {
+            log.debug("Command thread is alive - continue.");
+        }
+
+        // Generate the AudioSource
         al.alGenSources(1, _source, 0);
         if (JoalAudioFactory.checkALError()) {
             log.warn("Error creating JoalSource ({})", this.getSystemName());
@@ -124,6 +135,7 @@ public class JoalAudioSource extends AbstractAudioSource {
      *
      * (called from DefaultAudioFactory command queue)
      *
+     * @param audioBuffer AudioBuffer to queue
      * @return True if successfully queued.
      */
     @Override
@@ -164,6 +176,7 @@ public class JoalAudioSource extends AbstractAudioSource {
      *
      * (called from DefaultAudioFactory command queue)
      *
+     * @param audioBuffers AudioBuffers to queue
      * @return True if successfully queued.
      */
     @Override

--- a/java/src/jmri/jmrit/audio/NullAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/NullAudioFactory.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.audio;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import jmri.Audio;
 import jmri.AudioManager;
@@ -57,6 +58,8 @@ public class NullAudioFactory extends AbstractAudioFactory {
                 + " version - " + jmri.Version.name(); // NOI18N
     }
 
+    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
+            justification = "OK to write to static variables to record static library status")
     @Override
     public void cleanup() {
         // Stop the command thread

--- a/java/src/jmri/jmrit/audio/NullAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/NullAudioFactory.java
@@ -105,6 +105,11 @@ public class NullAudioFactory extends AbstractAudioFactory {
     }
 
     @Override
+    public boolean isInitialised() {
+        return initialised;
+    }
+
+    @Override
     public AudioBuffer createNewBuffer(String systemName, String userName) {
         return new NullAudioBuffer(systemName, userName);
     }

--- a/java/src/jmri/jmrit/audio/NullAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/NullAudioFactory.java
@@ -101,6 +101,7 @@ public class NullAudioFactory extends AbstractAudioFactory {
         // Finally, shutdown NullAudio and close the output device
         log.debug("Shutting down NullAudio");
         // Do nothing
+        initialised = false;
     }
 
     @Override

--- a/java/src/jmri/jmrit/audio/NullAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/NullAudioFactory.java
@@ -1,7 +1,8 @@
 package jmri.jmrit.audio;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import jmri.Audio;
 import jmri.AudioManager;
 import jmri.InstanceManager;
@@ -68,37 +69,34 @@ public class NullAudioFactory extends AbstractAudioFactory {
         // Get the active AudioManager
         AudioManager am = InstanceManager.getDefault(jmri.AudioManager.class);
 
-        // Retrieve list of Audio Objects and remove the sources
-        for (Audio audio : am.getNamedBeanSet()) {
-            if (audio.getSubType() == Audio.SOURCE) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Removing NullAudioSource: " + audio.getSystemName());
-                }
-                // Cast to NullAudioSource and cleanup
-                ((NullAudioSource) audio).cleanup();
+        // Retrieve list of AudioSource objects and remove the sources
+        SortedSet<Audio> sources = new TreeSet<>(am.getNamedBeanSet(Audio.SOURCE));
+        for (Audio source: sources) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing NullAudioSource: {}", source.getSystemName());
             }
+            // Cast to NullAudioSource and cleanup
+            ((NullAudioSource) source).cleanup();
         }
 
-        // Now, re-retrieve list of Audio objects and remove the buffers
-        for (Audio audio : am.getNamedBeanSet()) {
-            if (audio.getSubType() == Audio.BUFFER) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Removing NullAudioBuffer: " + audio.getSystemName());
-                }
-                // Cast to NullAudioBuffer and cleanup
-                ((NullAudioBuffer) audio).cleanup();
+        // Now, retrieve list of AudioBuffer objects and remove the buffers
+        SortedSet<Audio> buffers = new TreeSet<>(am.getNamedBeanSet(Audio.BUFFER));
+        for (Audio buffer : buffers) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing NullAudioBuffer: {}", buffer.getSystemName());
             }
+            // Cast to NullAudioBuffer and cleanup
+            ((NullAudioBuffer) buffer).cleanup();
         }
 
-        // Lastly, re-retrieve list and remove listener.
-        for (Audio audio : am.getNamedBeanSet()) {
-            if (audio.getSubType() == Audio.LISTENER) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Removing NullAudioListener: " + audio.getSystemName());
-                }
-                // Cast to NullAudioListener and cleanup
-                ((NullAudioListener) audio).cleanup();
+        // Lastly, retrieve list of AudioListener objects and remove listener.
+        SortedSet<Audio> listeners = new TreeSet<>(am.getNamedBeanSet(Audio.LISTENER));
+        for (Audio listener : listeners) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing NullAudioListener: {}", listener.getSystemName());
             }
+            // Cast to NullAudioListener and cleanup
+            ((NullAudioListener) listener).cleanup();
         }
 
         // Finally, shutdown NullAudio and close the output device

--- a/java/src/jmri/jmrit/audio/configurexml/DefaultAudioManagerXml.java
+++ b/java/src/jmri/jmrit/audio/configurexml/DefaultAudioManagerXml.java
@@ -47,6 +47,7 @@ public class DefaultAudioManagerXml extends AbstractAudioManagerConfigXML {
      * it.
      *
      * @param shared Top level Element to unpack.
+     * @param perNode Per-node top level Element to unpack.
      * @return true if successful
      */
     @Override

--- a/java/src/jmri/jmrit/audio/swing/AbstractAudioFrame.java
+++ b/java/src/jmri/jmrit/audio/swing/AbstractAudioFrame.java
@@ -42,9 +42,9 @@ abstract public class AbstractAudioFrame extends JmriJFrame {
     static final float FLT_PRECISION = 1 / (float) INT_PRECISION;
 
     // Common UI components for Add/Edit Audio
-    private static final JLabel sysNameLabel = new JLabel(Bundle.getMessage("LabelSystemName"));
+    private static final JLabel SYS_NAME_LABEL = new JLabel(Bundle.getMessage("LabelSystemName"));
     JTextField sysName = new JTextField(5);
-    private static final JLabel userNameLabel = new JLabel(Bundle.getMessage("LabelUserName"));
+    private static final JLabel USER_NAME_LABEL = new JLabel(Bundle.getMessage("LabelUserName"));
     JTextField userName = new JTextField(15);
 
     /**
@@ -74,13 +74,13 @@ abstract public class AbstractAudioFrame extends JmriJFrame {
 
         p = new JPanel();
         p.setLayout(new FlowLayout());
-        p.add(sysNameLabel);
+        p.add(SYS_NAME_LABEL);
         p.add(sysName);
         frame.getContentPane().add(p);
 
         p = new JPanel();
         p.setLayout(new FlowLayout());
-        p.add(userNameLabel);
+        p.add(USER_NAME_LABEL);
         p.add(userName);
         frame.getContentPane().add(p);
 

--- a/java/src/jmri/jmrit/audio/swing/AudioBufferFrame.java
+++ b/java/src/jmri/jmrit/audio/swing/AudioBufferFrame.java
@@ -65,7 +65,7 @@ public class AudioBufferFrame extends AbstractAudioFrame {
     JFileChooser fileChooser;
     // AudioWaveFormPanel waveForm = new AudioWaveFormPanel();
 
-    private final static String prefix = "IAB";
+    private final static String PREFIX = "IAB";
 
     @SuppressWarnings("OverridableMethodCallInConstructor")
     public AudioBufferFrame(String title, AudioTableDataModel model) {
@@ -190,7 +190,7 @@ public class AudioBufferFrame extends AbstractAudioFrame {
     @SuppressWarnings("UnnecessaryBoxing")
     public void resetFrame() {
         synchronized (lock) {
-            sysName.setText(prefix + nextCounter()); // NOI18N
+            sysName.setText(PREFIX + nextCounter()); // NOI18N
         }
         userName.setText(null);
         url.setText(null);
@@ -257,7 +257,7 @@ public class AudioBufferFrame extends AbstractAudioFrame {
 
     void applyPressed(ActionEvent e) {
         String sName = sysName.getText();
-        if (entryError(sName, prefix, "" + counter)) {
+        if (entryError(sName, PREFIX, "" + counter)) {
             return;
         }
         String user = userName.getText();

--- a/java/src/jmri/jmrit/audio/swing/AudioListenerFrame.java
+++ b/java/src/jmri/jmrit/audio/swing/AudioListenerFrame.java
@@ -48,7 +48,7 @@ public class AudioListenerFrame extends AbstractAudioFrame {
     JSpinner metersPerUnit = new JSpinner();
     JLabel metersPerUnitLabel = new JLabel(Bundle.getMessage("UnitM/U"));
 
-    private final static String prefix = "IAL";
+    private final static String PREFIX = "IAL";
 
     @SuppressWarnings("OverridableMethodCallInConstructor")
     public AudioListenerFrame(String title, AudioTableDataModel model) {
@@ -136,7 +136,7 @@ public class AudioListenerFrame extends AbstractAudioFrame {
 
     private void applyPressed(ActionEvent e) {
         String sName = sysName.getText();
-        if (entryError(sName, prefix, "$")) { // no index for AudioListener
+        if (entryError(sName, PREFIX, "$")) { // no index for AudioListener
             return;
         }
         String user = userName.getText();

--- a/java/src/jmri/jmrit/audio/swing/AudioSourceFrame.java
+++ b/java/src/jmri/jmrit/audio/swing/AudioSourceFrame.java
@@ -336,17 +336,17 @@ public class AudioSourceFrame extends AbstractAudioFrame {
         AudioManager am = InstanceManager.getDefault(jmri.AudioManager.class);
         assignedBuffer.removeAllItems();
         assignedBuffer.addItem("Select buffer from list");
-        am.getSystemNameList(Audio.BUFFER).stream().forEach((s) -> {
-            Audio a = am.getAudio(s);
+        am.getNamedBeanSet(Audio.BUFFER).stream().forEach((s) -> {
+            Audio a = am.getAudio(s.getSystemName());
             if (a != null) {
                 String u = a.getUserName();
                 if (u != null) {
                     assignedBuffer.addItem(u);
                 } else {
-                    assignedBuffer.addItem(s);
+                    assignedBuffer.addItem(s.getSystemName());
                 }
             } else {
-                assignedBuffer.addItem(s);
+                assignedBuffer.addItem(s.getSystemName());
             }
         });
     }

--- a/java/src/jmri/jmrit/audio/swing/AudioSourceFrame.java
+++ b/java/src/jmri/jmrit/audio/swing/AudioSourceFrame.java
@@ -79,7 +79,7 @@ public class AudioSourceFrame extends AbstractAudioFrame {
     JSpinner fadeOutTime = new JSpinner();
     JLabel fadeTimeUnitsLabel = new JLabel(Bundle.getMessage("UnitMS"));
 
-    private final static String prefix = "IAS";
+    private final static String PREFIX = "IAS";
 
     @SuppressWarnings("OverridableMethodCallInConstructor")
     public AudioSourceFrame(String title, AudioTableDataModel model) {
@@ -274,7 +274,7 @@ public class AudioSourceFrame extends AbstractAudioFrame {
     @Override
     public void resetFrame() {
         synchronized (lock) {
-            sysName.setText(prefix + nextCounter());
+            sysName.setText(PREFIX + nextCounter());
         }
         userName.setText(null);
         assignedBuffer.setSelectedIndex(0);
@@ -353,7 +353,7 @@ public class AudioSourceFrame extends AbstractAudioFrame {
 
     private void applyPressed(ActionEvent e) {
         String sName = sysName.getText();
-        if (entryError(sName, prefix, "" + counter)) {
+        if (entryError(sName, PREFIX, "" + counter)) {
             return;
         }
         String user = userName.getText();

--- a/java/src/jmri/jmrit/beantable/AudioTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AudioTableAction.java
@@ -297,6 +297,7 @@ public class AudioTableAction extends AbstractTableAction<Audio> {
          *
          * @param subType Audio sub-type to update
          */
+        @SuppressWarnings("deprecation") // needs careful unwinding for Set operations & generics
         protected synchronized void updateSpecificNameList(char subType) {
             // first, remove listeners from the individual objects
             if (sysNameList != null) {

--- a/java/src/jmri/jmrit/vsdecoder/AudioUtil.java
+++ b/java/src/jmri/jmrit/vsdecoder/AudioUtil.java
@@ -182,7 +182,7 @@ public class AudioUtil {
             } catch (AudioException | IllegalArgumentException e) {
                 log.warn("Error on provideAudio", e);
                 if (log.isDebugEnabled()) {
-                    jmri.InstanceManager.getDefault(jmri.AudioManager.class).getSystemNameList(Audio.BUFFER).stream().forEach((s) -> {
+                    jmri.InstanceManager.getDefault(jmri.AudioManager.class).getNamedBeanSet(Audio.BUFFER).stream().forEach((s) -> {
                         log.debug("\tBuffer: {}", s);
                     });
                 }

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoder.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoder.java
@@ -134,12 +134,12 @@ public class VSDecoder implements PropertyChangeListener {
 
         if (log.isDebugEnabled()) {
             log.debug("VSDecoder Init Complete.  Audio Objects Created:");
-            for (String s : jmri.InstanceManager.getDefault(jmri.AudioManager.class).getSystemNameList(Audio.SOURCE)) {
+            jmri.InstanceManager.getDefault(jmri.AudioManager.class).getNamedBeanSet(Audio.SOURCE).forEach((s) -> {
                 log.debug("\tSource: {}", s);
-            }
-            for (String s : jmri.InstanceManager.getDefault(jmri.AudioManager.class).getSystemNameList(Audio.BUFFER)) {
+            });
+            jmri.InstanceManager.getDefault(jmri.AudioManager.class).getNamedBeanSet(Audio.BUFFER).forEach((s) -> {
                 log.debug("\tBuffer: {}", s);
-            }
+            });
         }
     }
 

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoder.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoder.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * generates sounds in responds to them.
  * <p>
  * Each VSDecoder implements exactly one Sound Profile (describes a particular
- * type of locomtive, say, an EMD GP7).
+ * type of locomotive, say, an EMD GP7).
  * <hr>
  * This file is part of JMRI.
  * <p>

--- a/java/src/jmri/managers/AbstractAudioManager.java
+++ b/java/src/jmri/managers/AbstractAudioManager.java
@@ -1,6 +1,5 @@
 package jmri.managers;
 
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.util.Objects;
 

--- a/java/src/jmri/managers/configurexml/AbstractAudioManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractAudioManagerConfigXML.java
@@ -68,8 +68,8 @@ public abstract class AbstractAudioManagerConfigXML extends AbstractNamedBeanMan
             }
             // also, don't store if we don't have any Sources or Buffers
             // (no need to store the automatically created Listener object by itself)
-            if (am.getSystemNameList(Audio.SOURCE).isEmpty()
-                    && am.getSystemNameList(Audio.BUFFER).isEmpty()) {
+            if (am.getNamedBeanSet(Audio.SOURCE).isEmpty()
+                    && am.getNamedBeanSet(Audio.BUFFER).isEmpty()) {
                 return null;
             }
             // finally, don't store if the only Sources and Buffers are for the
@@ -87,13 +87,13 @@ public abstract class AbstractAudioManagerConfigXML extends AbstractNamedBeanMan
             }
 
             log.debug("Found {} VSD objects of {} objects", vsdObjectCount,
-                    am.getSystemNameList(Audio.SOURCE).size() + am.getSystemNameList(Audio.BUFFER).size()
+                    am.getNamedBeanSet(Audio.SOURCE).size() + am.getNamedBeanSet(Audio.BUFFER).size()
             );
 
             // check if the total number of Sources and Buffers is equal to
             // the number of VSD objects - if so, exit.
-            if (am.getSystemNameList(Audio.SOURCE).size()
-                    + am.getSystemNameList(Audio.BUFFER).size() == vsdObjectCount) {
+            if (am.getNamedBeanSet(Audio.SOURCE).size()
+                    + am.getNamedBeanSet(Audio.BUFFER).size() == vsdObjectCount) {
                 log.debug("Only VSD objects - nothing to store");
                 return null;
             }

--- a/java/test/jmri/jmrit/audio/DefaultAudioManagerTest.java
+++ b/java/test/jmri/jmrit/audio/DefaultAudioManagerTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.audio;
 
+import jmri.Audio;
+import jmri.AudioException;
 import jmri.InstanceManager;
 import jmri.jmrix.internal.InternalSystemConnectionMemo;
 import jmri.util.JUnitUtil;
@@ -38,6 +40,38 @@ public class DefaultAudioManagerTest extends jmri.managers.AbstractManagerTestBa
         int expResult = jmri.Manager.AUDIO;
         int result = l.getXMLOrder();
         Assert.assertEquals("Verify DefaultAudioManager XMLOrder", expResult, result);
+    }
+
+    /**
+     * Test of getNamedBeanSet method, of class DefaultAudioManager.
+     */
+    @Test
+    public void testGetNamedBeanSet() {
+        int expResult = 1;
+        int result = l.getNamedBeanSet(Audio.LISTENER).size();
+        Assert.assertEquals("Verify that we get one listener", expResult, result);
+
+        // Now let's create a couple of buffers
+        boolean canCreateBuffers = true;
+        try {
+            l.provideAudio("IAB1");
+            l.provideAudio("IAB2");
+        
+        } catch (AudioException ex) {
+            canCreateBuffers = false;
+        }
+
+        Assert.assertTrue("Verify buffers created without error", canCreateBuffers);
+
+        expResult = 2;
+        result = l.getNamedBeanSet(Audio.BUFFER).size();
+        Assert.assertEquals("Verify that we get two buffers", expResult, result);
+
+        // Now verify that the complete set of Audio objects is returned
+        // 1 Listener & 2 Buffers
+        expResult = 3;
+        result = l.getNamedBeanSet().size();
+        Assert.assertEquals("Verify that we get two buffers & one listener", expResult, result);
     }
 
     @Before

--- a/java/test/jmri/jmrit/audio/DefaultAudioManagerTest.java
+++ b/java/test/jmri/jmrit/audio/DefaultAudioManagerTest.java
@@ -27,10 +27,7 @@ public class DefaultAudioManagerTest extends jmri.managers.AbstractManagerTestBa
     @Test
     public void testGetActiveAudioFactory() {
         AudioFactory result = l.getActiveAudioFactory();
-        l.init();
-        JUnitUtil.waitFor(()->{return l.isInitialised();});
         Assert.assertNotNull("Verify that ActiveAudioFactory is not null", result);
-        l.cleanup();
     }
 
     /**
@@ -47,10 +44,14 @@ public class DefaultAudioManagerTest extends jmri.managers.AbstractManagerTestBa
     public void setUp() {
         JUnitUtil.setUp();
         l = new DefaultAudioManager(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
+        l.init();
+        JUnitUtil.waitFor(()->{return l.isInitialised();});
     }
 
     @After
     public void tearDown() {
+        l.cleanup();
+        JUnitUtil.waitFor(()->{return !l.isInitialised();});
         l = null;
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/audio/DefaultAudioManagerTest.java
+++ b/java/test/jmri/jmrit/audio/DefaultAudioManagerTest.java
@@ -12,12 +12,35 @@ import org.junit.Test;
  * Test simple functioning of DefaultAudioManager
  *
  * @author	Paul Bender Copyright (C) 2017
+ * @author	Matthew Harris Copyright (C) 2019
  */
 public class DefaultAudioManagerTest extends jmri.managers.AbstractManagerTestBase<jmri.AudioManager,jmri.Audio> {
 
     @Test
     public void testCtor() {
         Assert.assertNotNull("exists", l);
+    }
+
+    /**
+     * Test of getActiveAudioFactory method, of class DefaultAudioManager.
+     */
+    @Test
+    public void testGetActiveAudioFactory() {
+        AudioFactory result = l.getActiveAudioFactory();
+        l.init();
+        JUnitUtil.waitFor(()->{return l.isInitialised();});
+        Assert.assertNotNull("Verify that ActiveAudioFactory is not null", result);
+        l.cleanup();
+    }
+
+    /**
+     * Test of getXMLOrder method, of class DefaultAudioManager.
+     */
+    @Test
+    public void testGetXMLOrder() {
+        int expResult = jmri.Manager.AUDIO;
+        int result = l.getXMLOrder();
+        Assert.assertEquals("Verify DefaultAudioManager XMLOrder", expResult, result);
     }
 
     @Before

--- a/java/test/jmri/jmrit/audio/DefaultAudioManagerTest.java
+++ b/java/test/jmri/jmrit/audio/DefaultAudioManagerTest.java
@@ -56,7 +56,6 @@ public class DefaultAudioManagerTest extends jmri.managers.AbstractManagerTestBa
         try {
             l.provideAudio("IAB1");
             l.provideAudio("IAB2");
-        
         } catch (AudioException ex) {
             canCreateBuffers = false;
         }
@@ -67,9 +66,38 @@ public class DefaultAudioManagerTest extends jmri.managers.AbstractManagerTestBa
         result = l.getNamedBeanSet(Audio.BUFFER).size();
         Assert.assertEquals("Verify that we get two buffers", expResult, result);
 
+        // Now let's create a couple of sources and bind those to the buffers
+        boolean canCreateSources = true;
+        try {
+            AudioSource s = (AudioSource) l.provideAudio("IAS1");
+            s.setAssignedBuffer((AudioBuffer) l.getNamedBean("IAB1"));
+            s = (AudioSource) l.provideAudio("IAS2");
+            s.setAssignedBuffer((AudioBuffer) l.getNamedBean("IAB2"));
+        } catch (AudioException ex) {
+            canCreateSources = false;
+        }
+
+        Assert.assertTrue("Verify sources created without error", canCreateSources);
+
+        expResult = 2;
+        result = l.getNamedBeanSet(Audio.SOURCE).size();
+        Assert.assertEquals("Verify that we get two sources", expResult, result);
+
+        // Now verify Sources and Buffers are bound
+        // First pairing
+        AudioSource s = (AudioSource) l.getAudio("IAS1");
+        AudioBuffer b = (AudioBuffer) l.getAudio("IAB1");
+        AudioBuffer ab = s.getAssignedBuffer();
+        Assert.assertEquals("Verify AudioSource IAS1 bound to AudioBuffer IAB1", b, ab);
+        // Second pairing
+        s = (AudioSource) l.getAudio("IAS1");
+        b = (AudioBuffer) l.getAudio("IAB1");
+        ab = s.getAssignedBuffer();
+        Assert.assertEquals("Verify AudioSource IAS1 bound to AudioBuffer IAB1", b, ab);
+
         // Now verify that the complete set of Audio objects is returned
-        // 1 Listener & 2 Buffers
-        expResult = 3;
+        // 1 Listener, 2 Buffers & 2 Sources
+        expResult = 5;
         result = l.getNamedBeanSet().size();
         Assert.assertEquals("Verify that we get two buffers & one listener", expResult, result);
     }

--- a/java/test/jmri/jmrit/audio/JoalAudioBufferTest.java
+++ b/java/test/jmri/jmrit/audio/JoalAudioBufferTest.java
@@ -17,38 +17,19 @@ import org.junit.Test;
 public class JoalAudioBufferTest {
 
     @Test
-    public void testCtor() {        
-        Assume.assumeNotNull(JoalAudioFactory.getAL()); // Run test method only when JOAL is present.
-        
+    public void testCtor() {
         JoalAudioBuffer l = new JoalAudioBuffer("test");
-        
+
         Assert.assertNotNull("exists", l);
         Assert.assertEquals("test", l.getSystemName());
     }
 
-    /**
-     * This is present to handle the case when JOAL can't 
-     * be instantiated, while still testing at least one line
-     * of JoalAudioBuffer to keep the JaCoCo scan happy.
-     * It runs the ctor only if there isn't a JoalAudioFactory,
-     * and expects an exception.
-     */
-    @Test(expected = java.lang.NullPointerException.class )
-    public void testCtorFail() {
-        Assume.assumeTrue(null == JoalAudioFactory.getAL());
-        
-        new JoalAudioBuffer("test");
-        
-        // no Asserts, because what matters is the thrown exception
-        Assert.fail("Should have thrown");
-    }    
-
     @Test
     public void testC2Stringtor() {
         Assume.assumeNotNull(JoalAudioFactory.getAL()); // Run test method only when JOAL is present.
-        
+
         JoalAudioBuffer l = new JoalAudioBuffer("testsysname","testusername");
-        
+
         Assert.assertNotNull("exists", l);
         Assert.assertEquals("testsysname", l.getSystemName());
         Assert.assertEquals("testusername", l.getUserName());

--- a/java/test/jmri/jmrit/audio/JoalAudioSourceTest.java
+++ b/java/test/jmri/jmrit/audio/JoalAudioSourceTest.java
@@ -7,6 +7,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -18,8 +19,10 @@ public class JoalAudioSourceTest {
 
     @Test
     public void testCtor() {
+        Assume.assumeNotNull(JoalAudioFactory.getAL()); // Run test method only when JOAL is present.
+
         JoalAudioSource l = new JoalAudioSource("test");
-        
+
         Assert.assertNotNull("exists", l);
         Assert.assertEquals("test", l.getSystemName());
         Assert.assertEquals(jmri.Audio.STATE_STOPPED, l.getState());
@@ -29,10 +32,8 @@ public class JoalAudioSourceTest {
 
     @Test
     public void testC2Stringtor() {
-        Assume.assumeNotNull(JoalAudioFactory.getAL()); // Run test method only when JOAL is present.
-
         JoalAudioSource l = new JoalAudioSource("testsysname","testusername");
-        
+
         Assert.assertNotNull("exists", l);
         Assert.assertEquals("testsysname", l.getSystemName());
         Assert.assertEquals("testusername", l.getUserName());

--- a/java/test/jmri/jmrit/beantable/AudioTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/AudioTableActionTest.java
@@ -91,7 +91,6 @@ public class AudioTableActionTest extends AbstractTableActionBase<Audio> {
     @After
     @Override
     public void tearDown() {
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.clearShutDownManager(); // should be converted to check of scheduled ShutDownActions
         JUnitUtil.tearDown();
         a = null;

--- a/java/test/jmri/jmrit/beantable/AudioTableFrameTest.java
+++ b/java/test/jmri/jmrit/beantable/AudioTableFrameTest.java
@@ -30,8 +30,6 @@ public class AudioTableFrameTest extends jmri.util.JmriJFrameTestBase {
 
         // this created an audio manager, clean that up
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
-
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/beantable/AudioTablePanelTest.java
+++ b/java/test/jmri/jmrit/beantable/AudioTablePanelTest.java
@@ -36,8 +36,6 @@ public class AudioTablePanelTest {
     public void tearDown() {
         // this created an audio manager, clean that up
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
-
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/Diesel2SoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/Diesel2SoundTest.java
@@ -30,7 +30,6 @@ public class Diesel2SoundTest {
 
     @After
     public void tearDown() {
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/Diesel3SoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/Diesel3SoundTest.java
@@ -30,7 +30,6 @@ public class Diesel3SoundTest {
 
     @After
     public void tearDown() {
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/DieselSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/DieselSoundTest.java
@@ -30,7 +30,6 @@ public class DieselSoundTest {
 
     @After
     public void tearDown() {
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/EngineSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/EngineSoundTest.java
@@ -28,8 +28,6 @@ public class EngineSoundTest {
     public void tearDown() {
         // this created an audio manager, clean that up
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
-
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/NotchSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/NotchSoundTest.java
@@ -48,7 +48,6 @@ public class NotchSoundTest {
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
 
         jmri.util.JUnitAppender.suppressErrorMessage("Unhandled audio format type 0");
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/vsdecoder/NotchTransitionTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/NotchTransitionTest.java
@@ -48,7 +48,6 @@ public class NotchTransitionTest {
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
 
         jmri.util.JUnitAppender.suppressErrorMessage("Unhandled audio format type 0");
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/vsdecoder/SoundBiteTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/SoundBiteTest.java
@@ -83,7 +83,6 @@ public class SoundBiteTest {
     @After
     public void tearDown() {
         jmri.util.JUnitAppender.suppressErrorMessage("Unhandled audio format type 0");
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         InstanceManager.getDefault(ShutDownManager.class).deregister(damsdt);
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/vsdecoder/Steam1SoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/Steam1SoundTest.java
@@ -30,7 +30,6 @@ public class Steam1SoundTest {
 
     @After
     public void tearDown() {
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/SteamSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/SteamSoundTest.java
@@ -30,7 +30,6 @@ public class SteamSoundTest {
 
     @After
     public void tearDown() {
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/VSDConfigPanelTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDConfigPanelTest.java
@@ -30,8 +30,6 @@ public class VSDConfigPanelTest {
     public void tearDown() {
         // this created an audio manager, clean that up
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
-
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/VSDManagerEventTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDManagerEventTest.java
@@ -31,7 +31,6 @@ public class VSDManagerEventTest {
 
     @After
     public void tearDown() {
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/VSDSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDSoundTest.java
@@ -61,7 +61,6 @@ public class VSDSoundTest {
 
     @After
     public void tearDown() {
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         jmri.util.JUnitUtil.tearDown();
 
     }

--- a/java/test/jmri/jmrit/vsdecoder/VSDecoderFrameTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDecoderFrameTest.java
@@ -28,8 +28,6 @@ public class VSDecoderFrameTest extends jmri.util.JmriJFrameTestBase {
 
         // this created an audio manager, clean that up
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
-
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/VSDecoderManagerTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDecoderManagerTest.java
@@ -30,7 +30,6 @@ public class VSDecoderManagerTest {
 
     @After
     public void tearDown() {
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/VSDecoderPaneTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDecoderPaneTest.java
@@ -71,7 +71,6 @@ public class VSDecoderPaneTest extends jmri.util.swing.JmriPanelTest {
     @After
     @Override
     public void tearDown() {
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/listener/VSDListenerTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/listener/VSDListenerTest.java
@@ -34,7 +34,6 @@ public class VSDListenerTest {
         InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
 
         jmri.util.JUnitAppender.suppressErrorMessage("Unhandled audio format type 0");
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/vsdecoder/swing/VSDConfigDialogTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/swing/VSDConfigDialogTest.java
@@ -37,7 +37,6 @@ public class VSDConfigDialogTest {
 
     @After
     public void tearDown() {
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.resetWindows(false,false);
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/vsdecoder/swing/VSDManagerFrameTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/swing/VSDManagerFrameTest.java
@@ -27,7 +27,6 @@ public class VSDManagerFrameTest extends jmri.util.JmriJFrameTestBase {
         // this created an audio manager, clean that up
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
 
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/swing/VSDecoderPreferencesPaneTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/swing/VSDecoderPreferencesPaneTest.java
@@ -30,7 +30,6 @@ public class VSDecoderPreferencesPaneTest {
 
     @After
     public void tearDown() {        
-        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
This deprecates the legacy `getSystemNameList(char subType)` for audio sub-types and replaces it with a `getNamedBeanSet(char subType)` following the same pattern as when accessing all Audio objects.

An alternative to #7578 meaning script can remain as-is.