### PR TITLE
Update AppVeyor image to get more recent JDK

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ install:
   - java -version
   - javac -version
   - mvn -version
-  - ant -version
 build: off
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+# select image with Java 1.8 221
+image: Visual Studio 2019
+
 version: '{build}'
 clone_depth: 50
 skip_commits:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ skip_commits:
   
 install:
 # Available choices on https://www.appveyor.com/docs/windows-images-software/#java
-  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+  - SET JAVA_HOME=C:\Program Files\Java\jdk11
 #  - echo JAVA_HOME %JAVA_HOME%
   - SET GECKODRIVER=C:\Tools\WebDriver
   - SET CHROMEDRIVER=C:\Tools\WebDriver\chromedriver.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ skip_commits:
   
 install:
 # Available choices on https://www.appveyor.com/docs/windows-images-software/#java
-  - SET JAVA_HOME=C:\Program Files\Java\jdk11
+  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
 #  - echo JAVA_HOME %JAVA_HOME%
   - SET GECKODRIVER=C:\Tools\WebDriver
   - SET CHROMEDRIVER=C:\Tools\WebDriver\chromedriver.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ install:
   - java -version
   - javac -version
   - mvn -version
+  - ant -version
 build: off
 
 environment:


### PR DESCRIPTION
Add

```
image: Visual Studio 2019
```

To appveyor.yml to have AppVeyor use a more-recent JDK.  The goal is to see if the repeated Swing NPEs are due to use of an older JDK.
