### PR TITLE
Bugfix:LayoutEditorTools-Signal heads created without icons

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
@@ -13636,16 +13636,16 @@ public class LayoutEditorTools {
         }
         SignalHeadIcon l = new SignalHeadIcon(layoutEditor);
         l.setSignalHead(signalName);
-        l.setIcon(Bundle.getMessage("SignalHeadStateRed"), signalIconEditor.getIcon(0));
-        l.setIcon(Bundle.getMessage("SignalHeadStateFlashingRed"), signalIconEditor.getIcon(1));
-        l.setIcon(Bundle.getMessage("SignalHeadStateYellow"), signalIconEditor.getIcon(2));
-        l.setIcon(Bundle.getMessage("SignalHeadStateFlashingYellow"), signalIconEditor.getIcon(3));
-        l.setIcon(Bundle.getMessage("SignalHeadStateGreen"), signalIconEditor.getIcon(4));
-        l.setIcon(Bundle.getMessage("SignalHeadStateFlashingGreen"), signalIconEditor.getIcon(5));
-        l.setIcon(Bundle.getMessage("SignalHeadStateDark"), signalIconEditor.getIcon(6));
-        l.setIcon(Bundle.getMessage("SignalHeadStateHeld"), signalIconEditor.getIcon(7));
-        l.setIcon(Bundle.getMessage("SignalHeadStateLunar"), signalIconEditor.getIcon(8));
-        l.setIcon(Bundle.getMessage("SignalHeadStateFlashingLunar"), signalIconEditor.getIcon(9));
+        l.setIcon("SignalHeadStateRed", signalIconEditor.getIcon(0));
+        l.setIcon("SignalHeadStateFlashingRed", signalIconEditor.getIcon(1));
+        l.setIcon("SignalHeadStateYellow", signalIconEditor.getIcon(2));
+        l.setIcon("SignalHeadStateFlashingYellow", signalIconEditor.getIcon(3));
+        l.setIcon("SignalHeadStateGreen", signalIconEditor.getIcon(4));
+        l.setIcon("SignalHeadStateFlashingGreen", signalIconEditor.getIcon(5));
+        l.setIcon("SignalHeadStateDark", signalIconEditor.getIcon(6));
+        l.setIcon("SignalHeadStateHeld", signalIconEditor.getIcon(7));
+        l.setIcon("SignalHeadStateLunar", signalIconEditor.getIcon(8));
+        l.setIcon("SignalHeadStateFlashingLunar", signalIconEditor.getIcon(9));
         l.rotate(90);
         return l;
     }


### PR DESCRIPTION
Steps to reproduce:
1. Open JMRI (PanelPro).
2. Open the Turnouts table (Tools -> Tables -> Turnouts menu) and create 5 turnouts (I user named them "turnout #0" - "#4")
3. Open the Signal Heads table (Tools -> Tables -> Signal Heads menu) and create 4 Signal Heads (I user named them "signal head #1" - "#4")
3a.     Select the "Single Output" signal head type
3b. 	System name "SH1" (thru "SH4")
3c. 	User Name "signal head 1 (thru "signal head 4")
3d. 	Turnout 1; "Use Existing" and choose "turnout #1 (IT1)" (thru #4 (IT4)) from turnout menu
3e. 	Appearance when Closed ==> "green"
3f. 	Appearance when Thrown ==> "red"
3g. 	(repeat for Signal Heads 2 thru four)
4. Create New Layout Editor panel (Panels -> New Panel -> Layout Editor)
5. Add a RH Turnout
6. Contexually click on it and select the "Edit" popup (dropdown?) menu item
7. Select "turnout #0" as the turnout.
8. Type "turnout #0 block" in the "Block" text field and click the "Create/Edit" button.
9. Contexually click on it again and select the "Set Signal Heads..." popup (dropdown?) menu item
9a. 	"Set Signal Heads at Turnout" dialog should appear
10. Select the "Place All Signal Head Icons" checkbox
10a. 	All four "Add the above Signal Head Icon to Panel" checkboxes should now be checked
11. Select "signal head 1" thru 4 for the "Throat - Continuing", "Throat - Diverging", "Continuing", and "Diverging" popup menus.
12. Click the "Change Signal Head Icon" button
12a. 	"Change Signal Head Icon" dialog should appear
12b. 	Verify that icons appear as you would expect ("red" -> "red", "green" -> "green", etc.)
13. Close "Change Signal Head Icon" dialog
14. In the "Set Signal Heads at Turnout" dialog click the "Done" button.
14a. Four signal heads should appear on the Layout

At this point the signal heads look like red "X"'s… is this correct?

@dsand47 "No"
