### PR TITLE
Java11 updates

### DIFF
--- a/java/src/jmri/jmrit/Sound.java
+++ b/java/src/jmri/jmrit/Sound.java
@@ -151,7 +151,9 @@ public class Sound {
         }
     }
     
+    /** {@inheritDoc} */
     @Override
+    @SuppressWarnings("deprecation") // finalize deprecated in Java 9, but not yet removed
     public void finalize() throws Throwable {
         try {
             if (!streaming) {
@@ -358,6 +360,7 @@ public class Sound {
             this.url = url;
         }
 
+        /** {@inheritDoc} */
         @Override
         public void run() {
             // Note: some of the following is based on code from 

--- a/java/src/jmri/jmrit/beantable/oblock/TableFrames.java
+++ b/java/src/jmri/jmrit/beantable/oblock/TableFrames.java
@@ -161,10 +161,10 @@ public class TableFrames extends jmri.util.JmriJFrame implements InternalFrameLi
         menuItem.addActionListener(actionListener);
         if (SystemType.isMacOSX()) {
             menuItem.setAccelerator(
-                    KeyStroke.getKeyStroke(KeyEvent.VK_X, InputEvent.META_MASK));
+                    KeyStroke.getKeyStroke(KeyEvent.VK_X, InputEvent.META_DOWN_MASK));
         } else {
             menuItem.setAccelerator(
-                    KeyStroke.getKeyStroke(KeyEvent.VK_X, InputEvent.CTRL_MASK));
+                    KeyStroke.getKeyStroke(KeyEvent.VK_X, InputEvent.CTRL_DOWN_MASK));
         }
         menuItem.setMnemonic(KeyEvent.VK_T);
         editMenu.add(menuItem);
@@ -174,10 +174,10 @@ public class TableFrames extends jmri.util.JmriJFrame implements InternalFrameLi
         menuItem.addActionListener(actionListener);
         if (SystemType.isMacOSX()) {
             menuItem.setAccelerator(
-                    KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.META_MASK));
+                    KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.META_DOWN_MASK));
         } else {
             menuItem.setAccelerator(
-                    KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_MASK));
+                    KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK));
         }
         menuItem.setMnemonic(KeyEvent.VK_C);
         editMenu.add(menuItem);
@@ -187,10 +187,10 @@ public class TableFrames extends jmri.util.JmriJFrame implements InternalFrameLi
         menuItem.addActionListener(actionListener);
         if (SystemType.isMacOSX()) {
             menuItem.setAccelerator(
-                    KeyStroke.getKeyStroke(KeyEvent.VK_V, InputEvent.META_MASK));
+                    KeyStroke.getKeyStroke(KeyEvent.VK_V, InputEvent.META_DOWN_MASK));
         } else {
             menuItem.setAccelerator(
-                    KeyStroke.getKeyStroke(KeyEvent.VK_V, InputEvent.CTRL_MASK));
+                    KeyStroke.getKeyStroke(KeyEvent.VK_V, InputEvent.CTRL_DOWN_MASK));
         }
         menuItem.setMnemonic(KeyEvent.VK_P);
         editMenu.add(menuItem);

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -3195,7 +3195,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                                 ancestor,
                                 event.getID(),
                                 event.getWhen(),
-                                event.getModifiers(),
+                                event.getModifiersEx(),
                                 event.getX(),
                                 event.getY(),
                                 event.getXOnScreen(),

--- a/java/src/jmri/jmrit/throttle/ControlPanel.java
+++ b/java/src/jmri/jmrit/throttle/ControlPanel.java
@@ -1280,9 +1280,9 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         @Override
         public void mousePressed(MouseEvent e) {
             if (log.isDebugEnabled()) {
-                log.debug("pressed " + (e.getModifiers() & MouseEvent.BUTTON1_MASK) + " " + e.isPopupTrigger()
-                        + " " + (e.getModifiers() & (MouseEvent.ALT_MASK + MouseEvent.META_MASK + MouseEvent.CTRL_MASK))
-                        + (" " + MouseEvent.ALT_MASK + "/" + MouseEvent.META_MASK + "/" + MouseEvent.CTRL_MASK));
+                log.debug("pressed " + (e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) + " " + e.isPopupTrigger()
+                        + " " + (e.getModifiersEx() & (MouseEvent.ALT_DOWN_MASK + MouseEvent.META_DOWN_MASK + MouseEvent.CTRL_DOWN_MASK))
+                        + (" " + MouseEvent.ALT_DOWN_MASK + "/" + MouseEvent.META_DOWN_MASK + "/" + MouseEvent.CTRL_DOWN_MASK));
             }
             if (e.isPopupTrigger() && parentFrame.isSelected()) {
                 try {
@@ -1305,8 +1305,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         @Override
         public void mouseReleased(MouseEvent e) {
             if (log.isDebugEnabled()) {
-                log.debug("released " + (e.getModifiers() & MouseEvent.BUTTON1_MASK) + " " + e.isPopupTrigger()
-                        + " " + (e.getModifiers() & (MouseEvent.ALT_MASK + InputEvent.META_MASK + MouseEvent.CTRL_MASK)));
+                log.debug("released " + (e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) + " " + e.isPopupTrigger()
+                        + " " + (e.getModifiersEx() & (MouseEvent.ALT_DOWN_MASK + InputEvent.META_DOWN_MASK + MouseEvent.CTRL_DOWN_MASK)));
             }
             if (e.isPopupTrigger()) {
                 try {

--- a/java/src/jmri/jmrit/throttle/FunctionButton.java
+++ b/java/src/jmri/jmrit/throttle/FunctionButton.java
@@ -345,9 +345,9 @@ public class FunctionButton extends JToggleButton implements ActionListener {
         @Override
         public void mousePressed(MouseEvent e) {
             if (log.isDebugEnabled()) {
-                log.debug("pressed " + (e.getModifiers() & MouseEvent.BUTTON1_MASK) + " " + e.isPopupTrigger()
-                        + " " + (e.getModifiers() & (MouseEvent.ALT_MASK + MouseEvent.META_MASK + MouseEvent.CTRL_MASK))
-                        + (" " + MouseEvent.ALT_MASK + "/" + MouseEvent.META_MASK + "/" + MouseEvent.CTRL_MASK));
+                log.debug("pressed " + (e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) + " " + e.isPopupTrigger()
+                        + " " + (e.getModifiersEx() & (MouseEvent.ALT_DOWN_MASK + MouseEvent.META_DOWN_MASK + MouseEvent.CTRL_DOWN_MASK))
+                        + (" " + MouseEvent.ALT_DOWN_MASK + "/" + MouseEvent.META_DOWN_MASK + "/" + MouseEvent.CTRL_DOWN_MASK));
             }
             JToggleButton button = (JToggleButton) e.getSource();
             if (e.isPopupTrigger()) {
@@ -355,8 +355,8 @@ public class FunctionButton extends JToggleButton implements ActionListener {
                         e.getX(), e.getY());
             } /* Must check button mask since some platforms wait
              for mouse release to do popup. */ else if (button.isEnabled()
-                    && ((e.getModifiers() & MouseEvent.BUTTON1_MASK) != 0)
-                    && ((e.getModifiers() & (MouseEvent.ALT_MASK + MouseEvent.META_MASK + MouseEvent.CTRL_MASK)) == 0)
+                    && ((e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) != 0)
+                    && ((e.getModifiersEx() & (MouseEvent.ALT_DOWN_MASK + MouseEvent.META_DOWN_MASK + MouseEvent.CTRL_DOWN_MASK)) == 0)
                     && !isLockable) {
                 changeState(true);
             }
@@ -374,8 +374,8 @@ public class FunctionButton extends JToggleButton implements ActionListener {
         @Override
         public void mouseReleased(MouseEvent e) {
             if (log.isDebugEnabled()) {
-                log.debug("released " + (e.getModifiers() & MouseEvent.BUTTON1_MASK) + " " + e.isPopupTrigger()
-                        + " " + (e.getModifiers() & (MouseEvent.ALT_MASK + MouseEvent.META_MASK + MouseEvent.CTRL_MASK)));
+                log.debug("released " + (e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) + " " + e.isPopupTrigger()
+                        + " " + (e.getModifiersEx() & (MouseEvent.ALT_DOWN_MASK + MouseEvent.META_DOWN_MASK + MouseEvent.CTRL_DOWN_MASK)));
             }
             JToggleButton button = (JToggleButton) e.getSource();
             if (e.isPopupTrigger()) {
@@ -384,8 +384,8 @@ public class FunctionButton extends JToggleButton implements ActionListener {
             } // mouse events have to be unmodified; to change function, so that
             // we don't act on 1/2 of a popup request.
             else if (button.isEnabled()
-                    && ((e.getModifiers() & MouseEvent.BUTTON1_MASK) != 0)
-                    && ((e.getModifiers() & (MouseEvent.ALT_MASK + MouseEvent.META_MASK + MouseEvent.CTRL_MASK)) == 0)) {
+                    && ((e.getModifiersEx() & MouseEvent.BUTTON1_DOWN_MASK) != 0)
+                    && ((e.getModifiersEx() & (MouseEvent.ALT_DOWN_MASK + MouseEvent.META_DOWN_MASK + MouseEvent.CTRL_DOWN_MASK)) == 0)) {
                 if (!isLockable) {
                     changeState(false);
                 } else {

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -1173,6 +1173,7 @@ abstract public class AbstractMRTrafficController {
     // to request termination, which might have happened
     // before in any case
     @Override
+    @SuppressWarnings("deprecation") // finalize deprecated in Java 9, but not yet removed
     protected final void finalize() throws Throwable {
         terminate();
         super.finalize();

--- a/java/src/jmri/jmrix/ecos/EcosTrafficController.java
+++ b/java/src/jmri/jmrix/ecos/EcosTrafficController.java
@@ -6,8 +6,6 @@ import jmri.jmrix.AbstractMRListener;
 import jmri.jmrix.AbstractMRMessage;
 import jmri.jmrix.AbstractMRReply;
 import jmri.jmrix.AbstractMRTrafficController;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Converts Stream-based I/O to/from ECOS messages. The "EcosInterface" side
@@ -41,17 +39,19 @@ public class EcosTrafficController extends AbstractMRTrafficController implement
 
     EcosSystemConnectionMemo adaptermemo;
 
-    // The methods to implement the EcosInterface
+    /** {@inheritDoc} */
     @Override
     public synchronized void addEcosListener(EcosListener l) {
         this.addListener(l);
     }
 
+    /** {@inheritDoc} */
     @Override
     public synchronized void removeEcosListener(EcosListener l) {
         this.removeListener(l);
     }
 
+    /** {@inheritDoc} */
     @Override
     protected int enterProgModeDelayTime() {
         // we should to wait at least a second after enabling the programming track
@@ -59,6 +59,7 @@ public class EcosTrafficController extends AbstractMRTrafficController implement
     }
 
     /**
+     * {@inheritDoc}
      * Forward an EcosMessage to all registered EcosInterface listeners.
      */
     @Override
@@ -67,6 +68,7 @@ public class EcosTrafficController extends AbstractMRTrafficController implement
     }
 
     /**
+     * {@inheritDoc}
      * Forward a EcosReply to all registered EcosInterface listeners.
      */
     @Override
@@ -74,24 +76,25 @@ public class EcosTrafficController extends AbstractMRTrafficController implement
         ((EcosListener) client).reply((EcosReply) r);
     }
 
+    /** {@inheritDoc} */
     @Override
     protected AbstractMRMessage pollMessage() {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     protected AbstractMRListener pollReplyHandler() {
         return null;
     }
 
-    /**
-     * Forward a pre-formatted message to the actual interface.
-     */
+    /** {@inheritDoc} */
     @Override
     public void sendEcosMessage(EcosMessage m, EcosListener reply) {
         sendMessage(m, reply);
     }
 
+    /** {@inheritDoc} */
     @Override
     protected void forwardToPort(AbstractMRMessage m, AbstractMRListener reply) {
         super.forwardToPort(m, reply);
@@ -107,7 +110,9 @@ public class EcosTrafficController extends AbstractMRTrafficController implement
         return EcosMessage.getProgMode();
     }
 
-    //Ecos doesn't support this function!
+    /**
+     *  ECoS doesn't support this function.
+     */
     @Override
     protected AbstractMRMessage enterNormalMode() {
         return EcosMessage.getExitProgMode();
@@ -118,6 +123,7 @@ public class EcosTrafficController extends AbstractMRTrafficController implement
     // migration is complete
     final static protected EcosTrafficController self = null;
 
+    /** {@inheritDoc} */
     @Override
     protected AbstractMRReply newReply() {
         EcosReply reply = new EcosReply();
@@ -125,6 +131,7 @@ public class EcosTrafficController extends AbstractMRTrafficController implement
     }
 
     /**
+     * {@inheritDoc}
      * @return for now, receive always OK
      */
     @Override
@@ -132,6 +139,7 @@ public class EcosTrafficController extends AbstractMRTrafficController implement
         return true;
     }
 
+    /** {@inheritDoc} */
     @Override
     protected boolean endOfMessage(AbstractMRReply msg) {
         // detect that the reply buffer ends with "COMMAND: " (note ending
@@ -154,7 +162,6 @@ public class EcosTrafficController extends AbstractMRTrafficController implement
         return false;
     }
 
-    // Override the finalize method for this class
     public boolean sendWaitMessage(EcosMessage m, AbstractMRListener reply) {
         if (log.isDebugEnabled()) {
             log.debug("Send a message and wait for the response");
@@ -182,6 +189,7 @@ public class EcosTrafficController extends AbstractMRTrafficController implement
         return true;
     }
 
+    /** {@inheritDoc} */
     @Override
     protected void terminate() {
         if (log.isDebugEnabled()) {
@@ -282,6 +290,6 @@ public class EcosTrafficController extends AbstractMRTrafficController implement
         }
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EcosTrafficController.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(EcosTrafficController.class);
 
 }

--- a/java/src/jmri/util/BusyGlassPane.java
+++ b/java/src/jmri/util/BusyGlassPane.java
@@ -148,7 +148,7 @@ public class BusyGlassPane extends JComponent {
                 component.dispatchEvent(new MouseEvent(component,
                         eventID,
                         e.getWhen(),
-                        e.getModifiers(),
+                        e.getModifiersEx(),
                         componentPoint.x,
                         componentPoint.y,
                         e.getClickCount(),

--- a/java/src/jmri/util/MenuScroller.java
+++ b/java/src/jmri/util/MenuScroller.java
@@ -518,6 +518,7 @@ public class MenuScroller
      * @see MenuScroller#dispose()
      */
     @Override
+    @SuppressWarnings("deprecation") // finalize deprecated in Java 9, but not yet removed
     public void finalize() throws Throwable {
         dispose();
     }


### PR DESCRIPTION
This branch contains various migrations for Java 11

 - The `InputEvent.META_MASK`, `InputEvent.CTRL_MASK` and `InputEvent.SHIFT_MASK` constants et al were deprecated in Java 9. They are to be replaced by `InputEvent.META_MASK_DOWN`, `InputEvent.CTRL_MASK_DOWN` and `InputEvent.SHIFT_MASK_DOWN` et al which were introduced in Java 1.4
  - Related to the above, the `InputEvent#getModifiers()` method was deprecated in Java 9 to be replaced by use of the extended modifier keys and the `getModifiersEx()` method that was introduced in Java 1.4
  - Java 9 marked `Object#finalize()` as deprecated, but didn't mark it for removal. It occurred in `jmri.jmrit.Sound`. `jmri.util.MenuScroller` and `jmri.jmrix.AbstractMRTrafficController`; those were annotated away.  Some other classes had comments changed for clarity.
 
 Marked as "AfterNextProductionRelease" in case there are any (vertant or inadvertant) change to user experience.  Not expecting any, as most of the changes are in log.debug calls, but there are non-debug changes in
  - BusyGlassPane
  - java/src/jmri/jmrit/beantable/oblock/TableFrames
  - jmri/jmrit/display/layoutEditor/LayoutEditor
  
All of which points out that having some common idioms, if not code, for keystroke and mouse button access would be a very good idea. Additional work found along those lines:

  - `java.awt.Toollkit#getMenuShortcutKeyMask` was deprecated in Java 10.  The replacement, `#getMenuShortcutKeyMaskEx`, was only introduced in Java 10, which means that it's not yet available to JMRI (as it's not in Java 8). Making a common routine for creating the shortcut KeyCode would be good, but there's no common ancestor for:
     - java/src/jmri/util/JmriJFrame.java
     - java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
     - java/src/jmri/jmrit/ctc/editor/gui/FrmMainForm.java

Also:
   
 - It would (probably) be better to actually rework `jmri.jmrit.Sound`, `jmri/util/MenuScroller` and their uses to avoid the need for `finalize()` since those objects come and go in normal operation. (In general, listeners can be garbage collected without further work, so there might not be a purpose to `finalize` even now)
   
