### PR TITLE
Handle warning emitted in test

### DIFF
--- a/java/test/jmri/server/json/JsonClientHandlerTest.java
+++ b/java/test/jmri/server/json/JsonClientHandlerTest.java
@@ -195,6 +195,7 @@ public class JsonClientHandlerTest {
                 connection.getObjectMapper().readTree("{\"type\":\"test\", \"data\":{\"throws\":\"JmriException\"}}");
         instance.onMessage(node);
         JsonNode message = connection.getMessage();
+        JUnitAppender.assertWarnMessage("Unsupported operation attempted");
         Assert.assertNotNull("Response provided", message);
         JsonNode data = message.path(JSON.DATA);
         Assert.assertTrue("Response is an object", message.isObject());


### PR DESCRIPTION
Warnings logged in tests should be handled. The Jenkins "Separate Tests" job flags all that are not.  This fixes one that was recently introduced.