### PR TITLE
Handle CBUS address validation errors

### DIFF
--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -452,6 +452,6 @@ InvalidSystemNameNotUpperCase        = System name "{0}" contains lowercase char
 InvalidSystemNameNotInteger          = "{0}" must be an integer after "{1}".
 InvalidSystemNameIntegerLessThan     = Number in "{0}" must be greater than or equal to {1}.
 InvalidSystemNameIntegerGreaterThan  = Number in "{0}" must be less than or equal to {1}.
-sInvalidSystemNameCBUS                = {0}
+InvalidSystemNameCBUS                = {0}
 # Ideally this kind of failure would be parsed into something more specific
 InvalidSystemNameFailedRegex         = "{0}" did not match regular expression "{1}".

--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -452,5 +452,6 @@ InvalidSystemNameNotUpperCase        = System name "{0}" contains lowercase char
 InvalidSystemNameNotInteger          = "{0}" must be an integer after "{1}".
 InvalidSystemNameIntegerLessThan     = Number in "{0}" must be greater than or equal to {1}.
 InvalidSystemNameIntegerGreaterThan  = Number in "{0}" must be less than or equal to {1}.
+InvalidSystemNameCBUS                = "{0}" must be a valid CBUS address after "{1}".
 # Ideally this kind of failure would be parsed into something more specific
 InvalidSystemNameFailedRegex         = "{0}" did not match regular expression "{1}".

--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -452,6 +452,6 @@ InvalidSystemNameNotUpperCase        = System name "{0}" contains lowercase char
 InvalidSystemNameNotInteger          = "{0}" must be an integer after "{1}".
 InvalidSystemNameIntegerLessThan     = Number in "{0}" must be greater than or equal to {1}.
 InvalidSystemNameIntegerGreaterThan  = Number in "{0}" must be less than or equal to {1}.
-InvalidSystemNameCBUS                = "{0}" must be a valid CBUS address after "{1}".
+sInvalidSystemNameCBUS                = {0}
 # Ideally this kind of failure would be parsed into something more specific
 InvalidSystemNameFailedRegex         = "{0}" did not match regular expression "{1}".

--- a/java/src/jmri/jmrit/beantable/AbstractTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableAction.java
@@ -2,6 +2,7 @@ package jmri.jmrit.beantable;
 
 import java.awt.event.ActionEvent;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.HashMap;
 import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
@@ -153,7 +154,7 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
      * Increments trailing digits of a system/user name (string) I.E. "Geo7"
      * returns "Geo8" Note: preserves leading zeros: "Geo007" returns "Geo008"
      * Also, if no trailing digits, appends "1": "Geo" returns "Geo1"
-     * 
+     *
      * @param name the system or user name string
      * @return the same name with trailing digits incremented by one
      */
@@ -215,7 +216,7 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
 
     /**
      * Configure the combo box listing managers.
-     * 
+     *
      * @param comboBox     the combo box to configure
      * @param manager      the current manager
      * @param managerClass the implemented manager class for the current
@@ -248,6 +249,23 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
         } else {
             comboBox.setSelectedItem(manager);
         }
+    }
+
+    /**
+     * Remove the Add panel prefixBox listener before disposal.
+     * The listener is created when the Add panel is defined.  It persists after the
+     * the Add panel has been disposed.  When the next Add is created, AbstractTableAction
+     * sets the default connection as the current selection.  This triggers validation before
+     * the new Add panel is created.
+     * <p>
+     * The listener is removed by the controlling table action before disposing of the Add
+     * panel after Close or Create.
+     * @param prefixBox The prefix combobox that might contain the listener.
+     */
+    protected void removePrefixBoxListener(ManagerComboBox<E> prefixBox) {
+        Arrays.asList(prefixBox.getActionListeners()).forEach((l) -> {
+            prefixBox.removeActionListener(l);
+        });
     }
 
     private static final Logger log = LoggerFactory.getLogger(AbstractTableAction.class);

--- a/java/src/jmri/jmrit/beantable/AddNewHardwareDevicePanel.java
+++ b/java/src/jmri/jmrit/beantable/AddNewHardwareDevicePanel.java
@@ -28,7 +28,7 @@ public class AddNewHardwareDevicePanel extends jmri.util.swing.JmriPanel {
 
     /**
      * Create the panel.
-     * 
+     *
      * @param sysAddress text field for the system name or address
      * @param sysAddressValidator validation control for sysAddress
      * @param userName text field for the optional user name
@@ -37,7 +37,7 @@ public class AddNewHardwareDevicePanel extends jmri.util.swing.JmriPanel {
      * @param addRange check box to allow creation of multiple NamedBeans
      * @param addButton button to trigger creation of NamedBean
      * @param cancelListener listener to attach to the cancel button
-     * @param rangeListener listener that controls if addRange is enabled 
+     * @param rangeListener listener that controls if addRange is enabled
      * @param statusBar area where status messages can be presented
      */
     public AddNewHardwareDevicePanel(@Nonnull JTextField sysAddress,
@@ -129,6 +129,7 @@ public class AddNewHardwareDevicePanel extends jmri.util.swing.JmriPanel {
         prefixBox.addActionListener((evt) -> {
             Manager<?> manager = prefixBox.getSelectedItem();
             if (manager != null) {
+                sysAddress.setText("");     // Reset saved text before switching managers
                 sysAddressValidator.setManager(manager);
             }
         });

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -474,7 +474,7 @@ public class LightTableAction extends AbstractTableAction<Light> {
                 public JLabel updateLabel(String value, int row) {
                     if (iconHeight > 0) { // if necessary, increase row height;
                         log.debug("TODO adjust table row height for Lights?");
-                        //table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5)); 
+                        //table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5));
                     }
                     if (value.equals(Bundle.getMessage("StateOff")) && offIcon != null) {
                         label = new JLabel(offIcon);
@@ -1342,6 +1342,7 @@ public class LightTableAction extends AbstractTableAction<Light> {
         lightCreatedOrUpdated = false;
         // finally, get rid of the add/edit Frame
         if (addFrame != null) {
+            removePrefixBoxListener(prefixBox);
             addFrame.dispose();
             addFrame = null;
             create.removePropertyChangeListener(colorChangeListener);
@@ -1839,19 +1840,19 @@ public class LightTableAction extends AbstractTableAction<Light> {
             int offMin = (Integer) fastMinuteSpinner2.getValue(); // minutes
 
             g.setFastClockControlSchedule(onHour, onMin, offHour, offMin);
-            
+
             if (g.onOffTimesFaulty()) {
                 status1.setText(Bundle.getMessage("LightWarn11"));
                 status1.setForeground(Color.red);
                 return false;
             }
-            
+
             if (g.areFollowerTimesFaulty(currentList)) {
                 status1.setText(Bundle.getMessage("LightWarn12"));
                 status1.setForeground(Color.red);
                 return false;
             }
-            
+
         } else if (turnoutStatusControl.equals(typeBox.getSelectedItem())) {
             boolean error = false;
             Turnout t = null;

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -329,6 +329,7 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
     }
 
     void cancelPressed(ActionEvent e) {
+        removePrefixBoxListener(prefixBox);
         addFrame.setVisible(false);
         addFrame.dispose();
         addFrame = null;
@@ -432,6 +433,7 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
         }
 
         pref.setComboBoxLastSelection(systemSelectionCombo, prefixBox.getSelectedItem().getMemo().getUserName());
+        removePrefixBoxListener(prefixBox);
         addFrame.setVisible(false);
         addFrame.dispose();
         addFrame = null;

--- a/java/src/jmri/jmrit/beantable/SensorTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SensorTableAction.java
@@ -154,6 +154,7 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
     }
 
     void cancelPressed(ActionEvent e) {
+        removePrefixBoxListener(prefixBox);
         addFrame.setVisible(false);
         addFrame.dispose();
         addFrame = null;
@@ -267,6 +268,7 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
         }
 
         p.setComboBoxLastSelection(systemSelectionCombo, prefixBox.getSelectedItem().getMemo().getUserName());
+        removePrefixBoxListener(prefixBox);
         addFrame.setVisible(false);
         addFrame.dispose();
         addFrame = null;

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -1633,6 +1633,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
     }
 
     void cancelPressed(ActionEvent e) {
+        removePrefixBoxListener(prefixBox);
         addFrame.setVisible(false);
         addFrame.dispose();
         addFrame = null;
@@ -1829,6 +1830,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         }
 
         pref.setComboBoxLastSelection(systemSelectionCombo, prefixBox.getSelectedItem().getMemo().getUserName()); // store user pref
+        removePrefixBoxListener(prefixBox);
         addFrame.setVisible(false);
         addFrame.dispose();
         addFrame = null;

--- a/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
@@ -93,7 +93,7 @@ public class CbusLightManager extends AbstractLightManager {
         try {
             validateAddressFormat(name.substring(getSystemNamePrefix().length()));
         } catch (IllegalArgumentException ex) {
-            throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCBUS", name, getSystemNamePrefix());
+            throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCBUS", ex.getMessage());
         }
         return name;
     }

--- a/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
@@ -90,7 +90,11 @@ public class CbusLightManager extends AbstractLightManager {
     @Override
     public String validateSystemNameFormat(String name, Locale locale) {
         validateSystemNamePrefix(name, locale);
-        validateAddressFormat(name.substring(getSystemNamePrefix().length()));
+        try {
+            validateAddressFormat(name.substring(getSystemNamePrefix().length()));
+        } catch (IllegalArgumentException ex) {
+            throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCBUS", name, getSystemNamePrefix());
+        }
         return name;
     }
 

--- a/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
@@ -128,7 +128,11 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager {
     @Override
     public String validateSystemNameFormat(String name, Locale locale) {
         validateSystemNamePrefix(name, locale);
-        validateAddressFormat(name.substring(getSystemNamePrefix().length()));
+        try {
+            validateAddressFormat(name.substring(getSystemNamePrefix().length()));
+        } catch (IllegalArgumentException ex) {
+            throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCBUS", name, getSystemNamePrefix());
+        }
         return name;
     }
 

--- a/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
@@ -131,7 +131,7 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager {
         try {
             validateAddressFormat(name.substring(getSystemNamePrefix().length()));
         } catch (IllegalArgumentException ex) {
-            throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCBUS", name, getSystemNamePrefix());
+            throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCBUS", ex.getMessage());
         }
         return name;
     }

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
@@ -139,7 +139,7 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
         try {
             validateAddressFormat(name.substring(getSystemNamePrefix().length()));
         } catch (IllegalArgumentException ex) {
-            throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCBUS", name, getSystemNamePrefix());
+            throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCBUS", ex.getMessage());
         }
         return name;
     }

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
@@ -37,7 +37,7 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
         return (CanSystemConnectionMemo) memo;
     }
 
-    /** 
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -50,8 +50,8 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
         return result;
     }
 
-    /** 
-     * {@inheritDoc} 
+    /**
+     * {@inheritDoc}
      */
     @Override
     protected Turnout createNewTurnout(String systemName, String userName) {
@@ -71,16 +71,16 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
         return t;
     }
 
-    /** 
-     * {@inheritDoc} 
+    /**
+     * {@inheritDoc}
      */
     @Override
     public boolean allowMultipleAdditions(String systemName) {
         return true;
     }
 
-    /** 
-     * {@inheritDoc} 
+    /**
+     * {@inheritDoc}
      */
     @Override
     public String createSystemName(String curAddress, String prefix) throws JmriException {
@@ -95,8 +95,8 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
         return prefix + typeLetter() + newAddress;
     }
 
-    /** 
-     * {@inheritDoc} 
+    /**
+     * {@inheritDoc}
      */
     @Override
     public String getNextValidAddress(String curAddress, String prefix) throws JmriException {
@@ -136,12 +136,16 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
     @Override
     public String validateSystemNameFormat(String name, Locale locale) {
         validateSystemNamePrefix(name, locale);
-        validateAddressFormat(name.substring(getSystemNamePrefix().length()));
+        try {
+            validateAddressFormat(name.substring(getSystemNamePrefix().length()));
+        } catch (IllegalArgumentException ex) {
+            throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCBUS", name, getSystemNamePrefix());
+        }
         return name;
     }
 
-    /** 
-     * {@inheritDoc} 
+    /**
+     * {@inheritDoc}
      */
     @Override
     public NameValidity validSystemNameFormat(String systemName) {

--- a/java/test/jmri/jmrit/beantable/TurnoutTableWindowTest.java
+++ b/java/test/jmri/jmrit/beantable/TurnoutTableWindowTest.java
@@ -93,6 +93,7 @@ public class TurnoutTableWindowTest {
         Assert.assertEquals("name content", "1", hwAddressField.getText());
 
         cbo.selectItem("Internal");
+        jtfo.setText("1");
         Assert.assertEquals("Selected system item", internal, cbo.getSelectedItem()); // this connection type is always available
 
         // Find the Add Create button


### PR DESCRIPTION
- CBUS address validation errors were not being caught by validateSystemNameFormat which resulted in a Java exception.
- Remove the prefix combo listener before addFrame disposal.  When creating a new frame, the old listener was being triggered which tried to use the default connection to validate the old name from the previous add.
- Reset the retained name content when switching connections.