### PR TITLE
remove double message suppress

### DIFF
--- a/java/test/jmri/server/json/JsonClientHandlerTest.java
+++ b/java/test/jmri/server/json/JsonClientHandlerTest.java
@@ -195,7 +195,6 @@ public class JsonClientHandlerTest {
                 connection.getObjectMapper().readTree("{\"type\":\"test\", \"data\":{\"throws\":\"JmriException\"}}");
         instance.onMessage(node);
         JsonNode message = connection.getMessage();
-        JUnitAppender.assertWarnMessage("Unsupported operation attempted");
         Assert.assertNotNull("Response provided", message);
         JsonNode data = message.path(JSON.DATA);
         Assert.assertTrue("Response is an object", message.isObject());


### PR DESCRIPTION
PR #7666 and #7688 both touched the same code, resulting in an OK merge but a new error in testing.  Not sure why the CI didn't catch that.  This removes the duplication.