### PR TITLE
fix: allow invalid routes system names

### DIFF
--- a/java/src/jmri/managers/DefaultRouteManager.java
+++ b/java/src/jmri/managers/DefaultRouteManager.java
@@ -54,7 +54,7 @@ public class DefaultRouteManager extends AbstractManager<Route>
             return r;
         }
         // Route does not exist, create a new route
-        r = new DefaultRoute(validateSystemNameFormat(systemName), userName);
+        r = new DefaultRoute(systemName, userName);
         // save in the maps
         register(r);
 


### PR DESCRIPTION
Route system names must start with "IR", however, we have not enforced that. #7666 began enforcing that, but we should introduce this enforcement on a nicer glide path than suddenly introducing it in 4.17.7.