### PR TITLE
Bypass enforcement of IR prefix on routes

### DIFF
--- a/java/src/jmri/managers/DefaultRouteManager.java
+++ b/java/src/jmri/managers/DefaultRouteManager.java
@@ -67,6 +67,26 @@ public class DefaultRouteManager extends AbstractManager<Route>
     /**
      * {@inheritDoc}
      *
+     * Permit Route names without a "R" type letter. Marked as deprecated because this
+     * is temporary; it should be entirely removed once a migration is complete.
+     * @deprecated formally in 4.17.7
+     */
+    @Deprecated // 4.17.7
+    @Override
+    @javax.annotation.Nonnull
+    public String validateSystemNameFormat(@javax.annotation.Nonnull String name, @javax.annotation.Nonnull java.util.Locale locale) 
+                        throws jmri.NamedBean.BadSystemNameException {
+        try {
+            validateSystemNamePrefix(name, locale);
+        } catch (jmri.NamedBean.BadSystemNameException e) {
+            jmri.util.Log4JUtil.warnOnce(log, "Invalid Route Name: {} must start with IR", name, new Exception("traceback"));
+        }
+        return name;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * Keep autostring in line with {@link #provideRoute(String, String)},
      * {@link #getSystemPrefix()} and {@link #typeLetter()}
      */

--- a/java/test/jmri/managers/DefaultRouteManagerTest.java
+++ b/java/test/jmri/managers/DefaultRouteManagerTest.java
@@ -18,6 +18,14 @@ public class DefaultRouteManagerTest extends AbstractProvidingManagerTestBase<jm
     public void testCTor() {
         Assert.assertNotNull("exists",l);
     }
+    
+    @Test
+    @Override
+    @Deprecated // 4.17.7, eventually should check for IR in which case remove this test to allow super implementation
+    public void testProvideEmpty() throws IllegalArgumentException {
+        l.provide("Foo"); // this should _NOT_ throw an IllegalArgumentException currently
+        jmri.util.JUnitAppender.assertWarnMessage("Invalid Route Name: Foo must start with IR");
+    }
 
     // The minimal setup for log4J
     @Before


### PR DESCRIPTION
Allows routes to still be defined without an "IR" prefix on the system name.