### PR TITLE
Javadoc syntax fixes

### DIFF
--- a/java/src/jmri/jmrit/display/SignalHeadIcon.java
+++ b/java/src/jmri/jmrit/display/SignalHeadIcon.java
@@ -530,7 +530,6 @@ public class SignalHeadIcon extends PositionableIcon implements java.beans.Prope
      * Change the SignalHead state when the icon is clicked. Note that this
      * change may not be permanent if there is logic controlling the signal
      * head.
-     * <p>
      */
     @Override
     public void doMouseClicked(java.awt.event.MouseEvent e) {

--- a/java/src/jmri/util/JmriInsets.java
+++ b/java/src/jmri/util/JmriInsets.java
@@ -21,10 +21,7 @@ import org.slf4j.LoggerFactory;
  * The standard insets command fails on Linux - this class attempts to rectify
  * that.
  * <p>
- * <a href="http://forums.sun.com/thread.jspa?threadID=5169228&start=29">
  * Borrows heavily from the Linsets class created by: A. Tres Finocchiaro
- * </a>
- *
  *
  * @author Matt Harris
  */


### PR DESCRIPTION
 - remove empty `<p>` tag
 - remove dead link, which means I don't have to fix it's format

These showed up when running Javadoc with JDK 11