### PR TITLE
Windows Installer remove JMRI Demo Shortcut

### DIFF
--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -50,6 +50,11 @@
 ; -------------------------------------------------------------------------
 ; - Version History
 ; -------------------------------------------------------------------------
+; - Version 0.1.26.0
+; - Remove JMRIDemo link
+; - Rename Tools and Demos Folder to Tools
+; - use https link for Java download and JMRI Website
+; -------------------------------------------------------------------------
 ; - Version 0.1.25.0
 ; - Backup and remove lib folder
 ; -------------------------------------------------------------------------
@@ -307,7 +312,7 @@
   ; -- usually, this will be determined by the build.xml ant script
   !define JRE_VER   "1.8"                       ; Required JRE version
 !endif
-!define INST_VER  "0.1.25.0"                    ; Installer version
+!define INST_VER  "0.1.26.0"                    ; Installer version
 !define PNAME     "${APP}.${JMRI_VER}"          ; Name of installer.exe
 !define SRCDIR    "."                           ; Path to head of sources
 InstallDir        "$PROGRAMFILES\JMRI"          ; Default install directory
@@ -341,7 +346,7 @@ SetCompressor /SOLID /FINAL lzma
 ; -------------------------------------------------------------------------
 ; - Defines for downloading
 ; -------------------------------------------------------------------------
-!define JRE_URL     "http://java.com/winoffline_installer/"
+!define JRE_URL     "https://java.com/winoffline_installer/"
 !define INTERNET_CONNECTION_CONFIGURED 64  ; 0x40
 !define INTERNET_CONNECTION_LAN 2          ; 0x02
 !define INTERNET_CONNECTION_MODEM 1        ; 0x01
@@ -621,8 +626,11 @@ SectionGroup "JMRI Core Files" SEC_CORE
     Delete "$SMPROGRAMS\$0\Tools and Demos\InstallTest.pif" ; -- for Win98
     Delete "$SMPROGRAMS\$0\Tools and Demos\DecoderPro3.lnk"
     Delete "$SMPROGRAMS\$0\Tools and Demos\Preferences.lnk"
+    Delete "$SMPROGRAMS\$0\Tools\InstallTest.lnk"
+    Delete "$SMPROGRAMS\$0\Tools\Preferences.lnk"
     Delete "$SMPROGRAMS\$0\Uninstall.lnk"
     RMDir "$SMPROGRAMS\$0\Tools and Demos\"
+    RMDir "$SMPROGRAMS\$0\Tools\"
     RMDir "$SMPROGRAMS\$0\"
 
     ; -- Remove any predictably-named JMRI shortcuts from the Desktop
@@ -774,8 +782,8 @@ SectionGroup "Start menu shortcuts" SEC_SMSC
                    "apps.SoundPro.SoundPro" \
                    "$INSTDIR\SoundPro80x80.ico" 0 "" "" \
                    "Start SoundPro"
-    CreateDirectory "$SMPROGRAMS\$SMFOLDER\Tools and Demos"
-    CreateShortcut "$SMPROGRAMS\$SMFOLDER\Tools and Demos\InstallTest.lnk" \
+    CreateDirectory "$SMPROGRAMS\$SMFOLDER\Tools"
+    CreateShortcut "$SMPROGRAMS\$SMFOLDER\Tools\InstallTest.lnk" \
                    "$INSTDIR\InstallTest.bat" \
                    "" \
                    "$INSTDIR\InstallTest80x80.ico" 0 "" "" \
@@ -784,28 +792,18 @@ SectionGroup "Start menu shortcuts" SEC_SMSC
     IfFileExists "$PROFILE\JMRI\*.*" +2
       CreateDirectory "$PROFILE\JMRI"
       ; -- Now create a shortcut to it
-      CreateShortcut "$SMPROGRAMS\$SMFOLDER\Tools and Demos\Preferences.lnk" \
+      CreateShortcut "$SMPROGRAMS\$SMFOLDER\Tools\Preferences.lnk" \
                    "%HOMEDRIVE%%HOMEPATH%\JMRI" \
                    "" \
                    "" "" "" "" \
                    "Open JMRI Preferences Folder"
-    SetFileAttributes "$SMPROGRAMS\$SMFOLDER\Tools and Demos\Preferences.lnk" READONLY
+    SetFileAttributes "$SMPROGRAMS\$SMFOLDER\Tools\Preferences.lnk" READONLY
     CreateShortcut "$SMPROGRAMS\$SMFOLDER\Uninstall.lnk" \
                    "$INSTDIR\Uninstall.exe" \
                    "/$MultiUser.InstallMode"
     !insertmacro MUI_STARTMENU_WRITE_END
   SectionEnd ; SEC_SCSMSC
 
-  Section /o "Additional Tools and Demos" SEC_OCSMSC
-    SectionIn 2
-    !insertmacro MUI_STARTMENU_WRITE_BEGIN JMRIStartMenu
-    CreateShortcut "$SMPROGRAMS\$SMFOLDER\Tools and Demos\JmriDemo.lnk" \
-                   "$INSTDIR\LaunchJMRI.exe" \
-                   "apps.JmriDemo.JMRIdemo" \
-                   "$INSTDIR\decpro5.ico" 0 "" "" \
-                   "Start JMRI Demo"
-    !insertmacro MUI_STARTMENU_WRITE_END
-  SectionEnd ; SEC_OCSMSC
 SectionGroupEnd ; SEC_SMSC
 
 SectionGroup "Desktop Shortcuts" SEC_DTSC
@@ -859,7 +857,7 @@ Section "-PostProcessing" SEC_POST
   WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\JMRI" \
                  "Publisher" "JMRI Community"
   WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\JMRI" \
-                 "URLInfoAbout" "http://jmri.org/"
+                 "URLInfoAbout" "https://jmri.org/"
   WriteRegDWORD SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\JMRI" \
                  "NoModify" 1
   WriteRegDWORD SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\JMRI" \

--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -956,7 +956,6 @@ LangString DESC_SEC_XML ${LANG_ENGLISH} "XML files (Decoder definitions, etc.)"
 LangString DESC_SEC_WEB ${LANG_ENGLISH} "Web files"
 LangString DESC_SEC_SMSC ${LANG_ENGLISH} "Select Start Menu Shortcuts to create"
 LangString DESC_SEC_SCSMSC ${LANG_ENGLISH} "Creates Start menu shortcuts for DecoderPro, PanelPro and InstallTest"
-LangString DESC_SEC_OCSMSC ${LANG_ENGLISH} "Creates Start menu shortcut for JMRI Demo"
 LangString DESC_SEC_DTSC ${LANG_ENGLISH} "Select Desktop Shortcuts to create."
 LangString DESC_SEC_DPDTSC ${LANG_ENGLISH} "Creates a Desktop shortcut for DecoderPro"
 LangString DESC_SEC_PPDTSC ${LANG_ENGLISH} "Creates a Desktop shortcut for PanelPro"
@@ -977,7 +976,6 @@ LangString MESSAGE_WIN2K_OR_LATER ${LANG_ENGLISH} "${APP} version ${JMRI_VER} is
   !insertmacro MUI_DESCRIPTION_TEXT ${SEC_WEB} $(DESC_SEC_WEB)
   !insertmacro MUI_DESCRIPTION_TEXT ${SEC_SMSC} $(DESC_SEC_SMSC)
   !insertmacro MUI_DESCRIPTION_TEXT ${SEC_SCSMSC} $(DESC_SEC_SCSMSC)
-  !insertmacro MUI_DESCRIPTION_TEXT ${SEC_OCSMSC} $(DESC_SEC_OCSMSC)
   !insertmacro MUI_DESCRIPTION_TEXT ${SEC_DTSC} $(DESC_SEC_DTSC)
   !insertmacro MUI_DESCRIPTION_TEXT ${SEC_DPDTSC} $(DESC_SEC_DPDTSC)
   !insertmacro MUI_DESCRIPTION_TEXT ${SEC_PPDTSC} $(DESC_SEC_PPDTSC)


### PR DESCRIPTION
After next production release.

Remove JMRIDemo link
Rename "Tools and Demos" Folder to "Tools"
https link for Java download and JMRI Website
Closes #5951