### PR TITLE
Minor doc updates

### DIFF
--- a/help/en/html/doc/Technical/JVMCapabilities.shtml
+++ b/help/en/html/doc/Technical/JVMCapabilities.shtml
@@ -206,6 +206,9 @@
       system will have updated to this Java version; many will be
       using an older one. 
 
+      <p>JMRI development requires Java 8u101 or later.  8u101 contains a certificate
+      change that's needed to link to some remote Javadocs.
+      
       <p><a href=
       "http://www.oracle.com/technetwork/java/javase/config-417990.html">
       Oracle's page on Java 1.7 requirements</a> says "Note:
@@ -219,12 +222,12 @@
       JMRI's 
       <a href="http://jmri.org/install/WindowsNew.shtml">Windows installation page</a>
       keeps updated information on this.
-      Several JMRI users have reporter that Java 1.8_151 is the last one that 
+      Several JMRI users have reported that Java 1.8_151 is the last one that 
       can be cleanly installed and run on XP.  See
       the
       <a href="https://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase8-2177648.html">Java download archive page</a>
       for links to that.</p>
-              
+
       <p>As of April 18, 2018, the
       the <a href="https://java.com/en/download/release_notice.jsp">Oracle Java 8 page</a> was saying:
 <blockquote cite="https://java.com/en/download/release_notice.jsp">
@@ -239,9 +242,9 @@
         <li><a href="http://www.oracle.com/technetwork/java/javaseproducts/documentation/jdk10certconfig-4417031.html">Java 10</a></li>
       </ul>
 
-    <p><a href="http://openjdk.java.net/projects/jdk/11/">Oracle Java 11</a>, 
+    <p><a href="http://openjdk.java.net/projects/jdk/11/">Java 11</a>, 
         made available in September 2018, 
-        will be a "Long Term Support" release.  Java 9 and 10 will not be.
+        will be a "Long Term Support" release.  Java 9, 10, 12 and 13 will not be.
 
       <P>Java 11 only runs on 64-bit Windows versions (no 32-bit).
 

--- a/help/en/html/doc/Technical/index.shtml
+++ b/help/en/html/doc/Technical/index.shtml
@@ -269,7 +269,7 @@
         form, but you must give JMRI credit for their content.</li>
       </ul>
       <p>If you have any questions about this, please <a href=
-      "mailto:jmri@pacbell.net">contact us</a> directly.</p>
+      "mailto:jmri@jmri.net">contact us</a> directly.</p>
 
       <h2>Visualizations of JMRI Development Activity</h2>
 

--- a/help/en/html/tools/signaling/SignalMasts.shtml
+++ b/help/en/html/tools/signaling/SignalMasts.shtml
@@ -71,7 +71,7 @@
 
         <p>From the Signal Mast Table's <b>Tools</b> menu you may
         configure Signal Mast Repeaters. These mirror another mast,
-        and van be set as Slave, merely following the other Mast,
+        and can be set as Slave, merely following the other Mast,
         or as a two way coupling so clicking he Repeater on your
         Panel also sets the Master.</p>
 

--- a/help/fr/html/doc/Technical/index.shtml
+++ b/help/fr/html/doc/Technical/index.shtml
@@ -254,7 +254,7 @@ pour JMRI leur contenu.
 </ul>
 
 Si vous avez des questions &#224; ce sujet, s'il vous pla&#238;t
-<a href="mailto:jmri@pacbell.net">nous contacter</a> directement.
+<a href="mailto:jmri@jmri.net">nous contacter</a> directement.
 
 <h2>D&#233;veloppeur Code Swarm</h2>
 <p>Nous avons cr&#233;&#233; un <a href="/community/visuals/codeswarm.shtml"> Code Swarm of JMRI


### PR DESCRIPTION
 - correct email address two places
 - type "van" instead of "can"
 - note about Java 8u101 as minimum minor version for development