### PR TITLE
fix: Install PulseAudio in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install graphviz ; fi
   # install pulseaudio-module-x11 on Ubuntu after everything else
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y install pulseaudio-module-x11
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y install pulseaudio-module-x11 ; fi
 
 install:
   - mvn verify -DskipTests=true -Dmaven.javadoc.skip=true -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install graphviz ; fi
   # install pulseaudio-module-x11 and dependencies on Ubuntu after everything else
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y install libpulse0=1:8.0-0ubuntu3.10 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y --allow-downgrades install libpulse0=1:8.0-0ubuntu3.10 ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y install pulseaudio-module-x11 ; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ os:
   - linux
 #  - osx # temporarilly disabled -- its more complex than originally anticipated to do conditional matrixes based on PR/push differentiation
 
-dist: xenial
+dist: bionic
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ before_install:
   # install graphviz on macOS
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install graphviz ; fi
-  # install pulseaudio-module-x11 on Ubuntu after everything else
+  # install pulseaudio-module-x11 and dependencies on Ubuntu after everything else
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y install libpulse0=1:8.0-0ubuntu3.10 ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y install pulseaudio-module-x11 ; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     - libalut0
     - dbus-x11
     - tidy
-    - pulseaudio-module-x11
   firefox: latest
   chrome: beta
 
@@ -27,6 +26,8 @@ before_install:
   # install graphviz on macOS
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install graphviz ; fi
+  # install pulseaudio-module-x11 on Ubuntu after everything else
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -y install pulseaudio-module-x11
 
 install:
   - mvn verify -DskipTests=true -Dmaven.javadoc.skip=true -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jdk:
 
 addons:
   apt:
+    update: true
     packages:
     - graphviz
     - libalut0
@@ -52,7 +53,7 @@ os:
   - linux
 #  - osx # temporarilly disabled -- its more complex than originally anticipated to do conditional matrixes based on PR/push differentiation
 
-dist: bionic
+dist: xenial
 
 sudo: required
 


### PR DESCRIPTION
Travis CI depends on the Ubuntu "Universe" repositories which published a newer version of PulseAudio (1:8.0-ubuntu3.11) without publishing newer versions of every package built from the PulseAudio sources. This PR explicitly locks PulseAudio to version 1:8.0-ubuntu3.10 and it "works for now".

It looks like there may be an updated version of `pulseaudio-module-x11` makings its way to Ubuntu, at which point we should probably revert this PR to use the standard mechanisms again, since they will allow auto-updating to "just work" provided the upstream vendor does not make a mistake.