### PR TITLE
Fix car load replace attributes

### DIFF
--- a/help/en/package/jmri/jmrit/operations/Operations.shtml
+++ b/help/en/package/jmri/jmrit/operations/Operations.shtml
@@ -2943,24 +2943,28 @@
    
    <a name="AlternateTrack" id="AlternateTrack"></a>
    <h4>Alternate Track or "Off Spot"</h4>
-   You can add an alternate track to a spur from the "Tools" menu accessed from either the edit spur
-   or the edit schedule windows. The program when it finds a spur full will send cars to the track
-   you specify as the alternate track. The alternate track feature can be used to create an "Off
-   Spot" track for your cars. Once you specify a track as an alternate, only cars destined for the
-   spur will be placed on the alternate track. You can also use the same alternate track for several
-   spurs.
-
-   <p>Adding an alternate track will normally increase the number of cars that the program
-    routes to a spur / schedule. The program refers to these cars as "inbound" to the spur/industry.
-    For a car to be "inbound" is has to be transported by trains that don't directly service the
-    spur/industry. The maximum number of inbound cars to a spur with an alternate track is
-    determined by the length of the spur and the alternate track. So if the spur could hold 6 cars,
-    and the alternate track 5, then the program would allow a maximum of 11 cars to be sent to the
-    spur.</p>
+   You can add an alternate track to a spur from the "Tools" menu accessed from either the edit spur or the edit
+   schedule windows. The program when it finds a spur full will send cars to the track you specify as the alternate
+   track. The alternate track feature can be used to create an "Off Spot" track for your cars. Once you specify a track
+   as an alternate, only cars destined for the spur will be placed on the alternate track. You can also use the same
+   alternate track for several spurs.
 
    <p>
-    You can see all "inbound" cars by using the sort by "FD" or <a href="#FinalDestination">Final
-     Destination</a> in the <a href="#Cars">Cars</a> window.
+    Normally during the train build process, the program will check the alternate track for cars after assigning cars
+    from the spur to the train being built. This way cars on the alternate are used to keep the spur full. Note that the
+    <a href="#PlannedPickUps">Planned Pick Ups</a> feature can defeat the movement of cars from the alternate to the
+    spur, so it is recommended that you don't use both features for a spur.
+   </p>
+
+   <p>Adding an alternate track will normally increase the number of cars that the program routes to a spur /
+    schedule. The program refers to these cars as "inbound" to the spur/industry. For a car to be "inbound" is has to be
+    transported by trains that don't directly service the spur/industry. The maximum number of inbound cars to a spur
+    with an alternate track is determined by the length of the spur and the alternate track. So if the spur could hold 6
+    cars, and the alternate track 5, then the program would allow a maximum of 11 cars to be sent to the spur.</p>
+
+   <p>
+    You can see all "inbound" cars by using the sort by "FD" or <a href="#FinalDestination">Final Destination</a> in the
+    <a href="#Cars">Cars</a> window.
    </p>
 
    <a name="PlannedPickUps" id="PlannedPickUps"></a>
@@ -3008,6 +3012,11 @@
    <p>Guaranteeing that cars will be picked up from a track can be a bit tricky, so it is
     recommended that you not use this feature until you become an expert with regards to using this
     program, otherwise you will most likely overload your tracks when using this feature.</p>
+
+   <p>
+    Also recommended is that you not use the <a href="#AlternateTrack">Alternate Track</a> feature and planned
+    pickups at the same time for a spur. It can defeat car movement from the alternate track to the spur.
+   </p>
 
    <a name="TrackDestinations" id="TrackDestinations"></a>
    <h4>Track Destinations</h4>

--- a/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle.properties
+++ b/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle.properties
@@ -356,7 +356,8 @@ Totals              = Totals:
 PrePlanedPickups    = Percentage of rolling stock you want the program to ignore
 PPWarningMessage 	= Advanced feature! Please read help before using. Warning can cause track overloading!
 PPWarningMessage2	= Used to tell the program to ignore some percentage of rolling stock. 100% = ignore all.
-#Disabled            = Disabled
+PPWarningConfiguration = Error Track Configuration
+PPWarningAlternate	= Recommended that you don't use Planned Pickups and the Alternate Track feature on the same spur. See help.
 
 # status messages when placing rolling stock
 okay                = okay

--- a/java/src/jmri/jmrit/operations/locations/tools/AlternateTrackFrame.java
+++ b/java/src/jmri/jmrit/operations/locations/tools/AlternateTrackFrame.java
@@ -2,11 +2,12 @@ package jmri.jmrit.operations.locations.tools;
 
 import java.awt.Dimension;
 import java.awt.GridBagLayout;
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JPanel;
+
+import javax.swing.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import jmri.jmrit.operations.OperationsFrame;
 import jmri.jmrit.operations.OperationsXml;
 import jmri.jmrit.operations.locations.Location;
@@ -14,8 +15,6 @@ import jmri.jmrit.operations.locations.Track;
 import jmri.jmrit.operations.locations.TrackEditFrame;
 import jmri.jmrit.operations.setup.Control;
 import jmri.jmrit.operations.setup.Setup;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Frame that allows user to select alternate track and options.
@@ -52,7 +51,7 @@ class AlternateTrackFrame extends OperationsFrame implements java.beans.Property
             updateTrackCombobox();
             _track.getLocation().addPropertyChangeListener(this);
         }
-        
+
         JPanel pControls = new JPanel();
         pControls.add(saveButton);
         saveButton.setEnabled(_track != null);
@@ -63,10 +62,11 @@ class AlternateTrackFrame extends OperationsFrame implements java.beans.Property
         getContentPane().add(pAlternate);
         getContentPane().add(pControls);
         
-        initMinimumSize(new Dimension(Control.panelWidth300, Control.panelHeight100));
-        
+        addHelpMenu("package.jmri.jmrit.operations.Operations_AlternateTrack", true); // NOI18N
+
+        initMinimumSize(new Dimension(Control.panelWidth300, Control.panelHeight200));
     }
-    
+
     private void updateTrackCombobox() {
         _track.getLocation().updateComboBox(trackBox);
         trackBox.removeItem(_track); // remove this track from consideration
@@ -76,6 +76,13 @@ class AlternateTrackFrame extends OperationsFrame implements java.beans.Property
     @Override
     public void buttonActionPerformed(java.awt.event.ActionEvent ae) {
         if (ae.getSource() == saveButton) {
+            // warn user that planned pickups and alternate track don't work
+            // together
+            if (trackBox.getSelectedItem() != null && _track.getIgnoreUsedLengthPercentage() > 0) {
+                JOptionPane.showMessageDialog(null, Bundle.getMessage("PPWarningAlternate"),
+                        Bundle.getMessage("PPWarningConfiguration"),
+                        JOptionPane.ERROR_MESSAGE);
+            }
             _track.setAlternateTrack((Track) trackBox.getSelectedItem());
             OperationsXml.save();
             if (Setup.isCloseWindowOnSaveEnabled()) {
@@ -83,7 +90,7 @@ class AlternateTrackFrame extends OperationsFrame implements java.beans.Property
             }
         }
     }
-    
+
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
         if (Control.SHOW_PROPERTY) {

--- a/java/src/jmri/jmrit/operations/locations/tools/IgnoreUsedTrackFrame.java
+++ b/java/src/jmri/jmrit/operations/locations/tools/IgnoreUsedTrackFrame.java
@@ -3,21 +3,18 @@ package jmri.jmrit.operations.locations.tools;
 
 import java.awt.Dimension;
 import java.awt.GridBagLayout;
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
+
+import javax.swing.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import jmri.jmrit.operations.OperationsFrame;
 import jmri.jmrit.operations.OperationsXml;
 import jmri.jmrit.operations.locations.Track;
 import jmri.jmrit.operations.locations.TrackEditFrame;
 import jmri.jmrit.operations.setup.Control;
 import jmri.jmrit.operations.setup.Setup;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Planned Pick ups.
@@ -118,6 +115,11 @@ class IgnoreUsedTrackFrame extends OperationsFrame {
             }
             if (_track != null) {
                 _track.setIgnoreUsedLengthPercentage(percentage);
+                if (_track.getAlternateTrack() != null && percentage > 0) {
+                    JOptionPane.showMessageDialog(null, Bundle.getMessage("PPWarningAlternate"),
+                            Bundle.getMessage("PPWarningConfiguration"),
+                            JOptionPane.ERROR_MESSAGE);
+                }
             }
             // save location file
             OperationsXml.save();

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/tools/CarLoadEditFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/tools/CarLoadEditFrame.java
@@ -53,7 +53,7 @@ public class CarLoadEditFrame extends OperationsFrame implements java.beans.Prop
     public CarLoadEditFrame() {
     }
 
-    String _type;
+    String _type; // car type name
     boolean menuActive = false;
 
     public void initComponents(String type, String selectedItem) {
@@ -62,7 +62,6 @@ public class CarLoadEditFrame extends OperationsFrame implements java.beans.Prop
 
         setTitle(MessageFormat.format(Bundle.getMessage("TitleCarEditLoad"), new Object[]{type}));
 
-        // track which combo box is being edited
         _type = type;
         loadComboboxes();
         loadComboBox.setSelectedItem(selectedItem);
@@ -190,10 +189,10 @@ public class CarLoadEditFrame extends OperationsFrame implements java.beans.Prop
             carLoads.deleteName(_type, deleteLoad);
         }
         if (ae.getSource() == replaceButton) {
-            String oldLoad = (String) loadComboBox.getSelectedItem();
-            if (oldLoad.equals(carLoads.getDefaultEmptyName())) {
+            String oldLoadName = (String) loadComboBox.getSelectedItem();
+            if (oldLoadName.equals(carLoads.getDefaultEmptyName())) {
                 if (JOptionPane.showConfirmDialog(this, MessageFormat.format(Bundle.getMessage("replaceDefaultEmpty"),
-                        new Object[]{oldLoad, loadName}), Bundle.getMessage("replaceAll"),
+                        new Object[]{oldLoadName, loadName}), Bundle.getMessage("replaceAll"),
                         JOptionPane.YES_NO_OPTION) != JOptionPane.YES_OPTION) {
                     return;
                 }
@@ -205,12 +204,12 @@ public class CarLoadEditFrame extends OperationsFrame implements java.beans.Prop
                     return;
                 }
                 carLoads.setDefaultEmptyName(loadName);
-                replaceAllLoads(oldLoad, loadName);
+                replaceAllLoads(oldLoadName, loadName);
                 return;
             }
-            if (oldLoad.equals(carLoads.getDefaultLoadName())) {
+            if (oldLoadName.equals(carLoads.getDefaultLoadName())) {
                 if (JOptionPane.showConfirmDialog(this, MessageFormat.format(Bundle.getMessage("replaceDefaultLoad"),
-                        new Object[]{oldLoad, loadName}), Bundle.getMessage("replaceAll"),
+                        new Object[]{oldLoadName, loadName}), Bundle.getMessage("replaceAll"),
                         JOptionPane.YES_NO_OPTION) != JOptionPane.YES_OPTION) {
                     return;
                 }
@@ -222,20 +221,29 @@ public class CarLoadEditFrame extends OperationsFrame implements java.beans.Prop
                     return;
                 }
                 carLoads.setDefaultLoadName(loadName);
-                replaceAllLoads(oldLoad, loadName);
+                replaceAllLoads(oldLoadName, loadName);
                 return;
             }
             if (JOptionPane.showConfirmDialog(this, MessageFormat.format(Bundle.getMessage("replaceMsg"), new Object[]{
-                    oldLoad, loadName}), Bundle.getMessage("replaceAll"),
+                    oldLoadName, loadName}), Bundle.getMessage("replaceAll"),
                     JOptionPane.YES_NO_OPTION) != JOptionPane.YES_OPTION) {
                 return;
             }
+            // Comboboxes get deselected during the addName operation
+            String loadType = carLoads.getLoadType(_type, oldLoadName);
+            String loadPriority = carLoads.getPriority(_type, oldLoadName);
+            String pickupComment = carLoads.getPickupComment(_type, oldLoadName);
+            String dropComment = carLoads.getDropComment(_type, oldLoadName);
+            
             carLoads.addName(_type, loadName);
-            replaceLoad(_type, oldLoad, loadName);
-            carLoads.deleteName(_type, oldLoad);
+            carLoads.setLoadType(_type, loadName, loadType);
+            carLoads.setPriority(_type, loadName, loadPriority);
+            carLoads.setPickupComment(_type, loadName, pickupComment);
+            carLoads.setDropComment(_type, loadName, dropComment);
+            replaceLoad(_type, oldLoadName, loadName);
+            carLoads.deleteName(_type, oldLoadName);
         }
         if (ae.getSource() == saveButton) {
-            log.debug("CarLoadEditFrame save button pressed");
             carLoads.setLoadType(_type, (String) loadComboBox.getSelectedItem(), (String) loadTypeComboBox
                     .getSelectedItem());
             carLoads.setPriority(_type, (String) loadComboBox.getSelectedItem(),

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/tools/CarLoadEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/tools/CarLoadEditFrameTest.java
@@ -2,6 +2,11 @@ package jmri.jmrit.operations.rollingstock.cars.tools;
 
 import java.awt.GraphicsEnvironment;
 import java.text.MessageFormat;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
 import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsTestCase;
 import jmri.jmrit.operations.rollingstock.cars.CarLoad;
@@ -9,9 +14,6 @@ import jmri.jmrit.operations.rollingstock.cars.CarLoads;
 import jmri.jmrit.operations.setup.Control;
 import jmri.util.JUnitUtil;
 import jmri.util.swing.JemmyUtil;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
 
 /**
  * Tests for the Operations CarLoadEditFrame class
@@ -90,6 +92,10 @@ public class CarLoadEditFrameTest extends OperationsTestCase {
         // create load to replace
         CarLoads cl = InstanceManager.getDefault(CarLoads.class);
         cl.addName("Boxcar", "Test Load");
+        cl.setLoadType("Boxcar", "Test Load", "EMpty");
+        cl.setPriority("Boxcar", "Test Load", "Medium");
+        cl.setDropComment("Boxcar", "Test Load", "Drop Comment");
+        cl.setPickupComment("Boxcar", "Test Load", "Pickup Comment");
         
         CarLoadEditFrame f = new CarLoadEditFrame();
         f.initComponents("Boxcar", "Test Load");
@@ -100,8 +106,12 @@ public class CarLoadEditFrameTest extends OperationsTestCase {
         // dialog window should appear
         JemmyUtil.pressDialogButton(Bundle.getMessage("replaceAll"), Bundle.getMessage("ButtonYes"));
         
-        Assert.assertFalse("exists", cl.containsName("Boxcar", "Test Load"));
+        Assert.assertFalse("deleted", cl.containsName("Boxcar", "Test Load"));
         Assert.assertTrue("exists", cl.containsName("Boxcar", "Replace Load"));
+        Assert.assertEquals("Confirm load type", cl.getLoadType("Boxcar", "Replace Load"), "EMpty");
+        Assert.assertEquals("Confirm load priority", cl.getPriority("Boxcar", "Replace Load"), "Medium");
+        Assert.assertEquals("Confirm drop comment", cl.getDropComment("Boxcar", "Replace Load"), "Drop Comment");
+        Assert.assertEquals("Confirm pickup comment", cl.getPickupComment("Boxcar", "Replace Load"), "Pickup Comment");
 
         JUnitUtil.dispose(f);
     }


### PR DESCRIPTION
Two  bug fixes.  One fixes the replace car load, previously it didn't copy all of a loads attributes to the replacement name.  Second bug fix warns user not to combine the two features of planned pickups and the alternate track feature.