### PR TITLE
Mark testStopButton as intermittent

### DIFF
--- a/java/test/jmri/jmrit/throttle/ThrottleFrameTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottleFrameTest.java
@@ -152,6 +152,7 @@ public class ThrottleFrameTest {
     @Test
     public void testStopButton() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         to.setAddressValue(new DccLocoAddress(42, false));
         to.setSpeedSlider(28);


### PR DESCRIPTION
Mark `jmri.jmrit.throttle.ThrottleFrameTest.testStopButton()` as intermittent so that it's tested separately.