### PR TITLE
Added cross-ref to LRoutes in Routes documentation

### DIFF
--- a/help/en/html/tools/Routes.shtml
+++ b/help/en/html/tools/Routes.shtml
@@ -31,6 +31,13 @@
       <h1>JMRI: Routes Documentation</h1>
 
       <h2>What are Routes?</h2>
+      
+      <p>[After reading this page, see also the <a href="LRoutes.shtml">LRoutes documentation</a>.
+      LRoutes offer extended routing capabilities, transparently implementing them as a series of 
+      <a href="Logix.shtml">Logix conditionals</a>. LRoutes are set up similarly to and are
+      capable of performing all of the tasks of Routes - and more. They can even trigger a Route 
+      for complete compatibility.]</p>
+
 
       <p>Routes are collections of Turnouts and/or Sensors whose
       states may be set all at once. Also when a Route is


### PR DESCRIPTION
Added a cross reference to LRoutes in the main Routes page so users will see the relationship even if LRoutes doesn’t appear in the Sidebar (there are almost 50 Sidebar files and they are not all in sync).  Suggested by @silverailscolo - thanks!