### PR TITLE
Update web site "Sidebar" access

### DIFF
--- a/help/en/Acknowledgements.shtml
+++ b/help/en/Acknowledgements.shtml
@@ -207,7 +207,7 @@
         <a href="http://jmri.org/k/UDRP/index.shtml">despicable
         behavior</a>, and wrote a scripting example page</li>
 
-        <li><a href="https://github.com/JMRI/JMRI/pulls?utf8=✓&q=author%3Asilverailscolo+">Egbert Broerse</a>,
+        <li><a href="https://github.com/JMRI/JMRI/pulls?q=author%3Asilverailscolo+">Egbert Broerse</a>,
         <!-- silverailscolo --> who worked on translations, added
         Switchboards, graphic state display in the tables,
         the Output Matrix signal mast and the Rio Grande 1965
@@ -317,8 +317,8 @@
         <li>Bob Coleman added the CTI Acela support and did a huge
         amount of work on the operations code tests.</li>
 
-        <li>Jeff Collell, <!--- auctionsjeff --->
-            who added Light support for OpenLCB.<li>
+        <li>Jeff Collell, <!-- auctionsjeff -->
+            who added Light support for OpenLCB.</li>
 
         <li>Joe Comuzzi <!-- jcomuzzi -->
         added new icon tests and added a definition for  CNJ 1974 signals </li>
@@ -327,7 +327,7 @@
         decoder definitions for MRC decoders and the Kato
         FL11.</li>
 
-        <li><a href="https://github.com/JMRI/JMRI/pulls?utf8=✓&q=author%3Apetecressman+">Peter Cressman</a>
+        <li><a href="https://github.com/JMRI/JMRI/pulls?q=author%3Apetecressman+">Peter Cressman</a>
         provided a major improvement to Logix,
         improved Sensor Groups, fixed some problems in Routes, and
         provided the Warrant system for scripted running</li>
@@ -391,7 +391,7 @@
 
         <li>Mike Dunston, <!-- atanisoft -->
             who provided 
-            <a href="https://github.com/JMRI/JMRI/pull/4533">several updates</a> 
+            <a href="https://github.com/JMRI/JMRI/pulls?q=author%3Aatanisoft+">several updates</a> 
             for the DCC++ code</li>
 
         <li>Joe Ellis provided the DecoderPro configuration files
@@ -495,10 +495,10 @@
             
         <li>Mark Gurries, who provided loaner equipment and great
             ideas. He's currently working on decoder definitions for
-            DecoderPro </li>
-        
+            DecoderPro
         <a name="H" id="H"></a>
-
+        </li>
+        
         <li>Victoria K. Hall led the legal action that held Matt
         Katzer responsible for his depredations against JMRI</li>
 
@@ -553,18 +553,17 @@
         </li>
         
         <li>Osvaldo Hojvat provided definitions for several
-                    <a href-"http://www.ldhtrenes.com.ar">LDH</a>
+                    <a href="http://www.ldhtrenes.com.ar">LDH</a>
                     decoders</li>
               
         <li>Hornby Hobbys, who provided a full set of TTS manuals 
         plus information regarding various CVs.</li>
         
         <li>Al Huberty, who organized our first users meeting at
-        the NMRA Toronto convention</li>
-        
+        the NMRA Toronto convention
         <a name="I" id="I"></a>
-
         <a name="J" id="J"></a>
+        </li>
 
         <li>AJ Ireland of Digitrax, who loaned equipment, answered
         questions and made valuable suggestions</li>
@@ -638,7 +637,7 @@
         <li>Matjaz Krajnc, who provided better code and icons for
         the web throttle</li>
         
-        <li>Andrew Kroll, who improved the Operations documentation</a>
+        <li>Andrew Kroll, who improved the Operations documentation</li>
 
         <li>Ross Kudlick, who researched options switches on
         Digitrax command stations</li>
@@ -933,7 +932,7 @@
         <li>Joe Salemi, who contributed the Atlas 345 decoder
         definition and updated the TCS Tx definition.</li>
 
-        <li><a href="https://github.com/JMRI/JMRI/pulls?utf8=✓&q=author%3Adsand47+">Dave Sand</a>, <!-- dsand47 -->
+        <li><a href="https://github.com/JMRI/JMRI/pulls?q=author%3Adsand47+">Dave Sand</a>, <!-- dsand47 -->
         who's worked on Layout Editor, Logix, 
         Entry/Exit signaling and other things.</li>
         
@@ -1106,7 +1105,7 @@
 
         <li>George Warner, who changed all the TextFields to editable
         comboboxes (with drop-down menus); added a 2nd turnout
-        circle for slips and added left, right & bottom options
+        circle for slips and added left, right &amp; bottom options
         for the toolbar (and re-laid out same) in the Layout Editor.
         Added support for DMX512 lighting.
         Also wrote all the slip code for the web server.

--- a/help/en/TemplateBar.shtml
+++ b/help/en/TemplateBar.shtml
@@ -19,7 +19,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
     <h1>JMRI: Page Title???</h1>

--- a/help/en/glossary/index.shtml
+++ b/help/en/glossary/index.shtml
@@ -39,7 +39,7 @@ table.sortable th {
 <body>
 <!--#include virtual="/Header" -->
   <div id="mBody">
-  <!--#include virtual="../html/Sidebar" -->
+  <!--#include virtual="../html/Sidebar.shtml" -->
   <div id="mainContent">
 
   <h1>JMRI: Glossary</h1>

--- a/help/en/html/Sidebar.shtml
+++ b/help/en/html/Sidebar.shtml
@@ -1,0 +1,60 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for help/en/html/ pages -->
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; is...</div>
+	    <dl>
+
+		<dt><h3><a href="tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+		<ul>
+		    <li><a href="tools/Turnouts.shtml">Turnouts</a>
+            <li><a href="tools/Lights.shtml">Lights</a>
+		    <li><a href="tools/Sensors.shtml">Sensors</a>
+		    <li><a href="tools/throttle/ThrottleMain.shtml">Throttles</a>
+		    <li><a href="tools/consisttool/ConsistTool.shtml">Consisting</a>
+            <li><a href="tools/Blocks.shtml">Blocks</a>
+            <li><a href="tools/Reporters.shtml">Reporters</a>
+            <li><a href="tools/Memories.shtml">Memory Variables</a>
+		    <li><a href="tools/Routes.shtml">Routes</a>
+		    <li><a href="tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="tools/Sections.shtml">Sections</a>
+            <li><a href="tools/Transits.shtml">Transits</a>
+		    <li><a href="tools/Logix.shtml">Logix</a>
+		    <li><a href="tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="tools/speedometer/index.shtml">Speedometer</a>
+		    <li><a href="tools/Audio.shtml">Audio</a>
+		    <li><a href="tools/IdTags.shtml">ID Tags</a>
+		    <li><a href="tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="tools/index.shtml#systemSpecificTools">System-specific...</a>
+   	    </ul>
+		</dd>
+
+  	<dt><h3><a href="automation">Layout Automation</a></h3></dt>
+		<dd>Use JMRI to automate parts of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		  <ul>
+		    <li><a href="tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="tools/Routes.shtml">Routes</a>
+		    <li><a href="tools/LRoutes.shtml">LRoutes</a>
+		    <li><a href="tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="tools/scripting/index.shtml">Scripting</a>
+		  </ul>
+		</dd>
+
+	    </dl>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/apps/DecoderPro/CreateDecoder.shtml
+++ b/help/en/html/apps/DecoderPro/CreateDecoder.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
     <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
+++ b/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/Debug.shtml
+++ b/help/en/html/apps/DecoderPro/Debug.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/FAQ.shtml
+++ b/help/en/html/apps/DecoderPro/FAQ.shtml
@@ -27,7 +27,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/FileUpdate.shtml
+++ b/help/en/html/apps/DecoderPro/FileUpdate.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/Files.shtml
+++ b/help/en/html/apps/DecoderPro/Files.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <h1>JMRI: DecoderPro User Guide</h1>
 

--- a/help/en/html/apps/DecoderPro/FnMapping.shtml
+++ b/help/en/html/apps/DecoderPro/FnMapping.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/Ident.shtml
+++ b/help/en/html/apps/DecoderPro/Ident.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/Install.shtml
+++ b/help/en/html/apps/DecoderPro/Install.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/IntroXML.shtml
+++ b/help/en/html/apps/DecoderPro/IntroXML.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/apps/DecoderPro/LocoFile.shtml
+++ b/help/en/html/apps/DecoderPro/LocoFile.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/MoreInfo.shtml
+++ b/help/en/html/apps/DecoderPro/MoreInfo.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/MultiDecoder.shtml
+++ b/help/en/html/apps/DecoderPro/MultiDecoder.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/apps/DecoderPro/NetworkFiles.shtml
+++ b/help/en/html/apps/DecoderPro/NetworkFiles.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/apps/DecoderPro/Programmer.shtml
+++ b/help/en/html/apps/DecoderPro/Programmer.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/Roster.shtml
+++ b/help/en/html/apps/DecoderPro/Roster.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/apps/DecoderPro/RosterFile.shtml
+++ b/help/en/html/apps/DecoderPro/RosterFile.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/Sidebar.shtml
+++ b/help/en/html/apps/DecoderPro/Sidebar.shtml
@@ -1,0 +1,98 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for apps/DecoderPro pages -->
+<hr class="hide">
+<div id="side"> <!-- Block of text on left side of page -->
+
+<dl>
+
+<dt><h3>DecoderPro&reg;</h3></dt>
+<dd>
+	<ul>
+	<li><a href="./Tour.shtml">Quick Tour</a></li>
+	<li><a href="./MoreInfo.shtml">Some Details</a></li>
+	<li><a href="./Files.shtml">Configuration Files</a></li>
+	<li><a href="./Roster.shtml">Working with the Roster</a></li>
+	<li><a href="./FAQ.shtml">FAQ</a></li>
+    <li><a href="../../setup/index.shtml">JMRI Setup</a></li></li>
+	</ul>
+
+<dt><h3>Advanced</h3></dt>
+<dd>
+	<ul>
+	<li><a href="./IntroXML.shtml">Intro to XML files</a></li>
+	<li><a href="./CreateDecoder.shtml">Create your own decoder definition</a></li>
+	<li><a href="./Programmer.shtml">Create a custom programmer definition</a></li>
+	<li><a href="./RosterFile.shtml">Store/update a Roster</a></li>
+	<li><a href="./LocoFile.shtml">Locomotive (Roster) files</a></li>
+	<li><a href="./Debug.shtml">Debugging</a></li>
+	<li><a href="./NetworkFiles.shtml">Sharing Rosters among computers</a></li>
+	<li><a href="./FileUpdate.shtml">Updating decoder definitions</a></li>
+	</ul>
+</dd>
+
+<dt><h3>The Apps</h3></dt>
+<dd>
+	<ul>
+		<li class="here"><a href="../DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+		<li><a href="../PanelPro/index.shtml">PanelPro&trade;</a></li>
+		<li><a href="../DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+		<li><a href="../SoundPro/SoundPro.shtml">SoundPro</a></li>
+		<li><a href="../ManifestCreator/index.shtml">Manifest Creator</a></li>
+        <li><a href="../TrainCrew/index.shtml">TrainCrew</a></li>
+	</ul>
+</dd>
+
+<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+<dd>JMRI provides powerful tools for working with your
+layout.
+	<ul>
+		<li><a href="../../tools/Turnouts.shtml">Turnouts</a></li>
+		<li><a href="../../tools/Lights.shtml">Lights</a></li>
+		<li><a href="../../tools/Sensors.shtml">Sensors</a></li>
+		<li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a></li>
+		<li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a></li>
+		<li><a href="../../tools/Blocks.shtml">Blocks</a></li>
+		<li><a href="../../tools/Reporters.shtml">Reporters</a></li>
+		<li><a href="../../tools/Memories.shtml">Memory Variables</a></li>
+		<li><a href="../../tools/Routes.shtml">Routes</a></li>
+		<li><a href="../../tools/LRoutes.shtml">LRoutes</a></li>
+        <li><a href="../../tools/Sections.shtml">Sections</a></li>
+        <li><a href="../../tools/Transits.shtml">Transits</a></li>
+		<li><a href="../../tools/Logix.shtml">Logix</a></li>
+		<li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a></li>
+		<li><a href="../../tools/speedometer/index.shtml">Speedometer</a></li>
+		<li><a href="../../tools/Audio.shtml">Audio</a></li>
+		<li><a href="../../tools/IdTags.shtml">ID Tags</a></li>
+		<li><a href="../../tools/TimeTable.shtml">Timetable</a></li>
+		
+		<li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a></li>
+	</ul>
+</dd>
+
+<dt><h3><a href="../../tools/automation/index.shtml">Layout Automation</a></h3></dt>
+<dd>JMRI can be used to automate parts 
+of your layout, from simply controlling a crossing gate
+to running trains in the background.
+    <ul>
+    <li><a href="../../tools/signaling/index.shtml">Signaling</a></li>
+    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a></li>
+    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a></li>
+    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a></li>
+    <li><a href="../../tools/Routes.shtml">Routes</a></li>
+    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a></li>
+    <li><a href="../../tools/uss/index.shtml">USS CTC</a></li>
+    <li><a href="../../tools/scripting/index.shtml">Scripting</a></li>
+    </ul>
+</dd>
+		
+</dl>
+</div> <!-- close #side -->
+
+<!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+<!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->
+

--- a/help/en/html/apps/DecoderPro/Tour.shtml
+++ b/help/en/html/apps/DecoderPro/Tour.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DecoderPro User Guide</h1>

--- a/help/en/html/apps/DecoderPro/XML.shtml
+++ b/help/en/html/apps/DecoderPro/XML.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/apps/DecoderPro/index.shtml
+++ b/help/en/html/apps/DecoderPro/index.shtml
@@ -20,7 +20,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/apps/DispatcherPro/Sidebar.shtml
+++ b/help/en/html/apps/DispatcherPro/Sidebar.shtml
@@ -1,0 +1,76 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for apps/DispatcherPro pages -->
+<hr class="hide">
+<div id="side"> <!-- Block of text on left side of page -->
+
+<dl>
+
+<dt><h3>DispatcherPro&trade;</h3></dt>
+<dd>
+   <ul>
+   <li><a href="../../tools/signaling/index.shtml">Signaling</a></li>
+   <li><a href="../../setup/index.shtml">JMRI Setup</a></li>
+   </ul>
+</dd>
+
+<dt><h3>The Apps</h3></dt>
+<dd>
+	<ul>
+		<li><a href="../DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+		<li><a href="../PanelPro/index.shtml">PanelPro&trade;</a></li>
+		<li class="here"><a href="../DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+		<li><a href="../SoundPro/SoundPro.shtml">SoundPro</a></li>
+		<li><a href="../ManifestCreator/index.shtml">Manifest Creator</a></li>
+        <li><a href="../TrainCrew/index.shtml">TrainCrew</a></li>
+	</ul>
+</dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+		<ul>
+			<li><a href="../../tools/Turnouts.shtml">Turnouts</a></li>
+			<li><a href="../../tools/Lights.shtml">Lights</a></li>
+			<li><a href="../../tools/Sensors.shtml">Sensors</a></li>
+			<li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a></li>
+			<li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a></li>
+			<li><a href="../../tools/Blocks.shtml">Blocks</a></li>
+			<li><a href="../../tools/Reporters.shtml">Reporters</a></li>
+			<li><a href="../../tools/Memories.shtml">Memory Variables</a></li>
+			<li><a href="../../tools/Routes.shtml">Routes</a></li>
+			<li><a href="../../tools/LRoutes.shtml">LRoutes</a></li>
+            <li><a href="../../tools/Sections.shtml">Sections</a></li>
+            <li><a href="../../tools/Transits.shtml">Transits</a></li>
+			<li><a href="../../tools/Logix.shtml">Logix</a></li>
+			<li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a></li>
+			<li><a href="../../tools/speedometer/index.shtml">Speedometer</a></li>
+			<li><a href="../../tools/Audio.shtml">Audio</a></li>
+			<li><a href="../../tools/IdTags.shtml">ID Tags</a></li>
+			<li><a href="../../tools/TimeTable.shtml">Timetable</a></li>
+			
+			<li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a></li>
+		</ul>
+		</dd>
+
+  	<dt><h3><a href="../../tools/automation/index.shtml">Layout Automation</a></h3></dt>
+		<dd>JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a></li>
+            <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a></li>
+            <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a></li>
+            <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a></li>
+		    <li><a href="../../tools/Routes.shtml">Routes</a></li>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a></li>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a></li>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a></li>
+		    </ul>
+		</dd>
+
+</dl>
+
+</div>  <!-- closes #side -->
+<!-- /Sidebar -->
+

--- a/help/en/html/apps/DispatcherPro/index.shtml
+++ b/help/en/html/apps/DispatcherPro/index.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: DispatcherPro Main Window</h1>

--- a/help/en/html/apps/ManifestCreator/Sidebar.shtml
+++ b/help/en/html/apps/ManifestCreator/Sidebar.shtml
@@ -1,0 +1,32 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/apps/TrainCrew page(s) -->
+
+<hr class="hide">
+<div id="side"> <!-- Block of text on left side of page -->
+<div style="text-align: center">JMRI&reg; is...</div>
+<dl>
+
+    <dt><h3>Mainfest Creator Links</h3></dt>
+    <dd>
+    <ul>
+    <li><a href="http://manifestcreator.weebly.com">Manifest Creator homepage</a></li>
+    </ul>
+    </dd>
+    
+    <dt><h3>The Apps</h3></dt>
+    <dd>
+		<ul>
+            <li><a href="../DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+            <li><a href="../PanelPro/index.shtml">PanelPro&trade;</a></li>
+            <li><a href="../DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+            <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+            <li><a href="../SoundPro/SoundPro.shtml">SoundPro</a></li>
+		    <li class="here"><a href="../ManifestCreator/index.shtml">Manifest Creator</a></li>
+            <li><a href="../TrainCrew/index.shtml">TrainCrew</a></li>
+		</ul>
+    </dd>
+
+</dl>
+
+</div>  <!-- closes #side -->
+<!-- /Sidebar -->

--- a/help/en/html/apps/ManifestCreator/index.shtml
+++ b/help/en/html/apps/ManifestCreator/index.shtml
@@ -20,7 +20,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/apps/PanelPro/AdvIcons.shtml
+++ b/help/en/html/apps/PanelPro/AdvIcons.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Icons in (Control) Panel Editor</h1>

--- a/help/en/html/apps/PanelPro/FAQ.shtml
+++ b/help/en/html/apps/PanelPro/FAQ.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: PanelPro Frequently Asked Questions</h1>

--- a/help/en/html/apps/PanelPro/ShowPanel.shtml
+++ b/help/en/html/apps/PanelPro/ShowPanel.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Displaying Panel File Contents</h1>

--- a/help/en/html/apps/PanelPro/Sidebar.shtml
+++ b/help/en/html/apps/PanelPro/Sidebar.shtml
@@ -1,0 +1,86 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for apps/PanelPro pages -->
+<hr class="hide">
+<div id="side"> <!-- Block of text on left side of page -->
+
+<dl>
+
+<dt><h3>PanelPro&trade;</h3></dt>
+<dd>
+<ul>
+    <li><a href="../../../package/jmri/jmrit/display/PanelEditor.shtml">Panel Editor</a></li>
+    <li><a href="../../../package/jmri/jmrit/display/ControlPanelEditor.shtml">Control Panel Editor</a></li>
+    <li><a href="../../../package/jmri/jmrit/display/LayoutEditor.shtml">Layout Editor</a></li>
+    <li><a href="../../../package/jmri/jmrit/display/SwitchboardEditor.shtml">Switchboard Editor</a></li>
+    <li><a href="FAQ.shtml">FAQ</a></li>
+    <li><a href="https://jmri.org/community/examples/Gallery.shtml">User's Examples</a></li>
+    <li><a href="https://jmri.org/community/examples/Modules.shtml">Modular Layout Example</a></li>
+    <li><a href="ShowPanel.shtml">Display a Panel File</a></li>
+    <li><a href="AdvIcons.shtml">Advanced Icons</a></li>
+    <li><a href="../../setup/index.shtml">JMRI Setup</a></li>
+</ul>
+</dd>
+
+<dt><h3>The Apps</h3></dt>
+<dd>
+	<ul>
+		<li><a href="../DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+		<li class="here"><a href="../PanelPro/index.shtml">PanelPro&trade;</a></li>
+		<li><a href="../DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+		<li><a href="../SoundPro/SoundPro.shtml">SoundPro</a></li>
+		<li><a href="../ManifestCreator/index.shtml">Manifest Creator</a></li>
+        <li><a href="../TrainCrew/index.shtml">TrainCrew</a></li>
+	</ul>
+</dd>
+
+<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+<dd>JMRI provides powerful tools for working with your
+layout.
+	<ul>
+		<li><a href="../../tools/Turnouts.shtml">Turnouts</a></li>
+		<li><a href="../../tools/Lights.shtml">Lights</a></li>
+		<li><a href="../../tools/Sensors.shtml">Sensors</a></li>
+		<li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a></li>
+		<li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a></li>
+		<li><a href="../../tools/Blocks.shtml">Blocks</a></li>
+		<li><a href="../../tools/Reporters.shtml">Reporters</a></li>
+		<li><a href="../../tools/Memories.shtml">Memory Variables</a></li>
+		<li><a href="../../tools/Routes.shtml">Routes</a></li>
+		<li><a href="../../tools/LRoutes.shtml">LRoutes</a></li>
+        <li><a href="../../tools/Sections.shtml">Sections</a></li>
+        <li><a href="../../tools/Transits.shtml">Transits</a></li>
+		<li><a href="../../tools/Logix.shtml">Logix</a></li>
+		<li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a></li>
+		<li><a href="../../tools/speedometer/index.shtml">Speedometer</a></li>
+		<li><a href="../../tools/Audio.shtml">Audio</a></li>
+		<li><a href="../../tools/IdTags.shtml">ID Tags</a></li>
+		<li><a href="../../tools/TimeTable.shtml">Timetable</a></li>
+		
+		<li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a></li>
+	</ul>
+</dd>
+
+<dt><h3><a href="../../tools/automation/index.shtml">Layout Automation</a></h3></dt>
+<dd>
+  <ul>
+    <li><a href="../../tools/signaling/index.shtml">Signaling</a></li>
+    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a></li>
+    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a></li>
+    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a></li>
+    <li><a href="../../tools/Routes.shtml">Routes</a></li>
+    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a></li>
+    <li><a href="../../tools/uss/index.shtml">USS CTC</a></li>
+    <li><a href="../../tools/scripting/index.shtml">Scripting</a></li>
+    <li><a href="../../doc/Technical/TurnoutFeedback.shtml">Turnout Feedback</a></li>
+  </ul>
+</dd>
+
+</dl>
+
+</div> <!-- End of block of text on left side of page -->
+
+<!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+<!-- /Sidebar-Tail -->

--- a/help/en/html/apps/PanelPro/index.shtml
+++ b/help/en/html/apps/PanelPro/index.shtml
@@ -24,7 +24,7 @@
 <body>
     <!--#include virtual="/Header" -->
     <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: PanelPro</h1>

--- a/help/en/html/apps/Sidebar.shtml
+++ b/help/en/html/apps/Sidebar.shtml
@@ -1,0 +1,124 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/apps pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; is...</div>
+	    <dl>
+		<dt><h3>Applications</h3></dt>
+		<dd>
+		  <ul>
+			<li><a href="DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="SoundPro/SoundPro.shtml">SoundPro</a></li>
+		  </ul>
+        </dd>
+
+		<dt><h3><a href="../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		<ul>
+            <li><a href="../tools/Turnouts.shtml">Turnouts</a></li>
+            <li><a href="../tools/Lights.shtml">Lights</a></li>
+            <li><a href="../tools/Sensors.shtml">Sensors</a></li>
+            <li><a href="../tools/throttle/ThrottleMain.shtml">Throttles</a></li>
+            <li><a href="../tools/consisttool/ConsistTool.shtml">Consisting</a></li>
+            <li><a href="../tools/Blocks.shtml">Blocks</a></li>
+            <li><a href="../tools/Reporters.shtml">Reporters</a></li>
+            <li><a href="../tools/Memories.shtml">Memory Variables</a></li>
+            <li><a href="../tools/Routes.shtml">Routes</a></li>
+            <li><a href="../tools/LRoutes.shtml">LRoutes</a></li>
+            <li><a href="../tools/Sections.shtml">Sections</a></li>
+            <li><a href="../tools/Transits.shtml">Transits</a></li>
+            <li><a href="../tools/Logix.shtml">Logix</a></li>
+            <li><a href="../tools/fastclock/index.shtml">Fast Clocks</a></li>
+            <li><a href="../tools/speedometer/index.shtml">Speedometer</a></li>
+            <li><a href="../tools/Audio.shtml">Audio</a></li>
+            <li><a href="../tools/IdTags.shtml">ID Tags</a></li>
+            <li><a href="../tools/TimeTable.shtml">Timetable</a></li>
+
+            <li><a href="../tools/index.shtml#systemSpecificTools">System-specific...</a></li>
+        </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../tools/automation/index.shtml">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		  <ul>
+		    <li><a href="../tools/signaling/index.shtml">Signaling</a></li>
+		    <li><a href="../tools/EntryExit.shtml">Entry Exit (NX)</a></li>
+		    <li><a href="../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a></li>
+		    <li><a href="../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a></li>
+		    <li><a href="../tools/Routes.shtml">Routes</a></li>
+		    <li><a href="../tools/fastclock/index.shtml">Fast Clocks</a></li>
+		    <li><a href="../tools/uss/index.shtml">USS CTC</a></li>
+		    <li><a href="../tools/scripting/index.shtml">Scripting</a></li>
+		  </ul>
+		</dd>
+		
+<div style="clear: both"></div>
+		<dt><h3 style="padding-left: 1em;"><a href="../hardware/index.shtml">Supported Hardware</a></h3></dt>
+		<dd> 
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 12/2015 -->
+				<li><a href="../hardware/XPressNet/index.shtml">Atlas Commander</a></li>
+				<li><a href="../hardware/bachrus/index.shtml">Bachrus</a></li>
+				<li><a href="../hardware/cmri/CMRI.shtml">C/MRI</a></li>
+				<li><a href="../hardware/acela/index.shtml">CTI Electronics</a></li>
+				<li><a href="../hardware/easydcc/EasyDCC.shtml">CVP EasyDCC</a></li>
+				<li><a href="../hardware/dccpp/index.shtml">DCC++</a></li>
+				<li><a href="../hardware/misc/DccSpecialties.shtml">DCC Specialities</a></li>
+				<li><a href="../hardware/XBee/index.shtml">Digi XBee</a></li>
+				<li><a href="../hardware/digirails/index.shtml">Digikeijs (Digirails)</a></li>
+				<li><a href="../hardware/loconet/Digitrax.shtml">Digitrax</a></li>
+				<li><a href="../hardware/ecos/index.shtml">ESU ECoS</a></li>
+				<li><a href="../hardware/loconet/Fleischmann.shtml">Fleischmann</a></li>
+				<li><a href="../hardware/XPressNet/index.shtml">Hornby</a></li>
+				<li><a href="../hardware/XPressNet/index.shtml">Lenz</a></li>
+				<li><a href="../hardware/tmcc/index.shtml">Lionel TMCC</a></li>
+				<li><a href="../hardware/loconet/Digitrax.shtml">LocoNet</a></li>
+				<li><a href="../hardware/maple/index.shtml">Maple Systems</a></li>
+				<li><a href="../hardware/marklin/index.shtml">M&auml;rklin CS2</a></li>
+				<li><a href="../hardware/can/cbus/index.shtml">MERG CBUS</a></li>
+				<li><a href="../hardware/modbus/index.shtml">Modbus</a></li>
+				<li><a href="../hardware/mqtt/index.shtml">MQTT</a></li>
+				<li><a href="../hardware/mrc/index.shtml">MRC</a></li>
+				<li><a href="../hardware/rps/index.shtml">NAC Services RPS</a></li>
+				<li><a href="../hardware/nce/NCE.shtml">NCE</a></li>
+				<li><a href="../hardware/oaktree/OakTree.shtml">Oak Tree Systems</a></li>
+				<li><a href="../hardware/openlcb/index.shtml">OpenLCB</a></li>
+				<li><a href="../hardware/grapevine/index.shtml">Protrak Grapevine</a></li>
+				<li><a href="../hardware/qsi/index.shtml">QSI Quantum Programmer</a></li>
+				<li><a href="../hardware/raildriver/index.shtml">Pi Engineering RailDriver</a></li>
+				<li><a href="../hardware/pi/index.shtml">Raspberry Pi</a></li>
+				<li><a href="../hardware/XPressNet/index.shtml">Roco</a></li>
+				<li><a href="../hardware/sprog/SPROG.shtml">SPROG</a></li>
+				<li><a href="../hardware/SRCP/index.shtml">SRCP server</a></li>
+				<li><a href="../hardware/tams/index.shtml">TAMS Master Control</a></li>
+				<li><a href="../hardware/loconet/Digitrax.shtml">Uhlenbrock Intellibox</a></li>
+				<li><a href="../hardware/XPressNet/index.shtml">Viessmann Commander</a></li>
+				<li><a href="../hardware/nce/Wangrow.shtml">Wangrow System One</a></li>
+				<li><a href="../hardware/powerline/index.shtml">X10</a></li>
+				<li><a href="../hardware/zimo/Zimo.shtml">Zimo MX-1</a></li>
+				<li><a href="../hardware/XPressNet/index.shtml">ZTC</a></li>
+		    </ul>
+		</dd>
+
+		<div style="clear: both"></div>
+		<dt><h3 style="padding-left: 1em;">Supported Computers</h3></dt>
+		<dd> 
+		  <ul>
+            <li><a href="http://jmri.org/install/WindowsNew.shtml">Windows</a></li>
+            <li><a href="http://jmri.org/install/MacOSX.shtml">Mac OS X</a></li>
+            <li><a href="http://jmri.org/install/Linux.shtml">Linux</a></li>
+            <li><a href="../setup/index.shtml">JMRI Setup</a></li>
+   		  </ul>
+		</dd>
+    </dl>
+
+	</div> <!-- closes #side -->
+<!-- /Sidebar -->

--- a/help/en/html/apps/SoundPro/Sidebar.shtml
+++ b/help/en/html/apps/SoundPro/Sidebar.shtml
@@ -1,0 +1,75 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for apps/SoundPro pages -->
+<hr class="hide">
+<div id="side"> <!-- Block of text on left side of page -->
+
+<dl>
+
+<dt><h3>SoundPro&trade; Info</h3></dt>
+<dd>
+	<ul>
+	<li><a href="../../tools/Audio.shtml">Audio package detail</a></li>
+	<li><a href="../../../package/jmri/jmrit/beantable/AudioTable.shtml">Audio Table</a></li>
+	</ul>
+</dd>
+
+<dt><h3>The Apps</h3></dt>
+<dd>
+	<ul>
+		<li><a href="../DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+		<li><a href="../PanelPro/index.shtml">PanelPro&trade;</a></li>
+		<li><a href="../DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+		<li class="here"><a href="../SoundPro/SoundPro.shtml">SoundPro</a></li>
+		<li><a href="../ManifestCreator/index.shtml">Manifest Creator</a></li>
+        <li><a href="../TrainCrew/index.shtml">TrainCrew</a></li>
+	</ul>
+</dd>
+
+<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+<dd>JMRI provides powerful tools for working with your
+layout.
+	<ul>
+		<li><a href="../../tools/Turnouts.shtml">Turnouts</a></li>
+		<li><a href="../../tools/Lights.shtml">Lights</a></li>
+		<li><a href="../../tools/Sensors.shtml">Sensors</a></li>
+		<li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a></li>
+		<li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a></li>
+		<li><a href="../../tools/Blocks.shtml">Blocks</a></li>
+		<li><a href="../../tools/Reporters.shtml">Reporters</a></li>
+		<li><a href="../../tools/Memories.shtml">Memory Variables</a></li>
+		<li><a href="../../tools/Routes.shtml">Routes</a></li>
+		<li><a href="../../tools/LRoutes.shtml">LRoutes</a></li>
+        <li><a href="../../tools/Sections.shtml">Sections</a></li>
+        <li><a href="../../tools/Transits.shtml">Transits</a></li>
+		<li><a href="../../tools/Logix.shtml">Logix</a></li>
+		<li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a></li>
+		<li><a href="../../tools/speedometer/index.shtml">Speedometer</a></li>
+		<li><a href="../../tools/Audio.shtml">Audio</a></li>
+		<li><a href="../../tools/IdTags.shtml">ID Tags</a></li>
+		<li><a href="../../tools/TimeTable.shtml">Timetable</a></li>
+		
+		<li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a></li>
+	</ul>
+</dd>
+
+<dt><h3><a href="../../tools/automation/index.shtml">Layout Automation</a></h3></dt>
+<dd>JMRI can be used to automate parts 
+of your layout, from simply controlling a crossing gate
+to running trains in the background.
+	<ul>
+	<li><a href="../../tools/signaling/index.shtml">Signaling</a></li>
+	<li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a></li>
+	<li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a></li>
+	<li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a></li>
+	<li><a href="../../tools/Routes.shtml">Routes</a></li>
+	<li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a></li>
+	<li><a href="../../tools/uss/index.shtml">USS CTC</a></li>
+	<li><a href="../../tools/scripting/index.shtml">Scripting</a></li>
+	</ul>
+</dd>
+
+</dl>
+
+</div>  <!-- closes #side -->
+<!-- /Sidebar -->

--- a/help/en/html/apps/SoundPro/SoundPro.shtml
+++ b/help/en/html/apps/SoundPro/SoundPro.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: SoundPro Main Window</h1><img src=

--- a/help/en/html/apps/TrainCrew/Sidebar.shtml
+++ b/help/en/html/apps/TrainCrew/Sidebar.shtml
@@ -1,0 +1,33 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/apps/TrainCrew page(s) -->
+
+<hr class="hide">
+<div id="side"> <!-- Block of text on left side of page -->
+<div style="text-align: center">JMRI&reg; is...</div>
+
+<dl>
+    <dt><h3>TrainCrew Links</h3></dt>
+    <dd>
+    <ul>
+        <li><a href="http://traincrew.conrail1285.com">TrainCrew home</a></li>
+        <li><a href="https://github.com/ekapus/TrainCrew">TrainCrew GitHub</a></li>
+    </ul>
+    </dd>
+
+<dt><h3>The Apps</h3></dt>
+<dd>
+	<ul>
+        <li><a href="../DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+        <li><a href="../PanelPro/index.shtml">PanelPro&trade;</a></li>
+        <li><a href="../DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+        <li><a href="../SoundPro/SoundPro.shtml">SoundPro</a></li>
+        <li><a href="../ManifestCreator/index.shtml">Manifest Creator</a></li>
+        <li class="here"><a href="../TrainCrew/index.shtml">TrainCrew</a></li>
+	</ul>
+</dd>
+
+</dl>
+
+</div>  <!-- closes #side -->
+<!-- /Sidebar -->

--- a/help/en/html/apps/TrainCrew/index.shtml
+++ b/help/en/html/apps/TrainCrew/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/apps/index.shtml
+++ b/help/en/html/apps/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/hardware/MacintoshSerialPorts.shtml
+++ b/help/en/html/hardware/MacintoshSerialPorts.shtml
@@ -29,7 +29,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Setup Support: MacOS Serial Port

--- a/help/en/html/hardware/PDA.shtml
+++ b/help/en/html/hardware/PDA.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Using a PDA to access JMRI

--- a/help/en/html/hardware/SRCP/index.shtml
+++ b/help/en/html/hardware/SRCP/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: SRCP Protocol</h1><a href=

--- a/help/en/html/hardware/Sidebar.shtml
+++ b/help/en/html/hardware/Sidebar.shtml
@@ -1,0 +1,137 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="bachrus/index.shtml">Bachrus</a>
+				<li><a href="cmri/CMRI.shtml">C/MRI</a>
+				<li><a href="acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+				<li><a href="dccpp/index.shtml">DCC++</a>
+				<li><a href="misc/DccSpecialties.shtml">DCC Specialities (Hare)</a>
+				<li><a href="XBee/index.shtml">Digi XBee</a>
+				<li><a href="digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="ecos/index.shtml">ESU ECoS</a>
+				<li><a href="loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="XPressNet/index.shtml">Hornby</a>
+				<li><a href="XPressNet/index.shtml">Lenz</a>
+				<li><a href="tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="maple/index.shtml">Maple Systems</a>
+				<li><a href="marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="modbus/index.shtml">Modbus</a>
+                <li><a href="mqtt/index.shtml">MQTT</a>
+				<li><a href="mrc/index.shtml">MRC</a>
+				<li><a href="rps/index.shtml">NAC Services RPS</a>
+				<li><a href="nce/NCE.shtml">NCE</a>
+				<li><a href="oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="openlcb/index.shtml">OpenLCB</a>
+				<li><a href="grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="pi/index.shtml">Raspberry Pi</a>
+				<li><a href="XPressNet/index.shtml">Roco</a>
+				<li><a href="sprog/SPROG.shtml">SPROG</a>
+				<li><a href="SRCP/index.shtml">SRCP server</a>
+				<li><a href="tams/index.shtml">TAMS Master Control</a>
+				<li><a href="loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="powerline/index.shtml">X10</a>
+				<li><a href="zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <ul>
+                <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            </ul>
+	        <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../tools/Lights.shtml">Lights</a>
+	        <li><a href="../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../tools/Routes.shtml">Routes</a>
+	        <li><a href="../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../tools/Sections.shtml">Sections</a>
+            <li><a href="../tools/Transits.shtml">Transits</a>
+	        <li><a href="../tools/Logix.shtml">Logix</a>
+	        <li><a href="../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../tools/Audio.shtml">Audio</a>
+	        <li><a href="../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../tools/Routes.shtml">Routes</a>
+		    <li><a href="../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/SidebarUp.shtml
+++ b/help/en/html/hardware/SidebarUp.shtml
@@ -1,0 +1,137 @@
+<!-- SidebarUp.shtml -->
+<!-- This is the common sidebar definition for html/hardware/xxx pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../cmri/CMRI.shtml">C/MRI</a>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+				<li><a href="../dccpp/index.shtml">DCC++</a>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialities (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">X10</a>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /SidebarUp.shtml -->

--- a/help/en/html/hardware/TerminalServer.shtml
+++ b/help/en/html/hardware/TerminalServer.shtml
@@ -27,7 +27,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Setup Support: Terminal Server Connection</h1>

--- a/help/en/html/hardware/USBtoSerial.shtml
+++ b/help/en/html/hardware/USBtoSerial.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1><a name="usb2serial" id="usb2serial">Hardware Setup

--- a/help/en/html/hardware/XBee/Sidebar.shtml
+++ b/help/en/html/hardware/XBee/Sidebar.shtml
@@ -1,0 +1,140 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/grapevine pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../CMRI.shtml">C/MRI</a>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+    		    <li><a href="../index.shtml">DCC++</a>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+                <ul>
+                    <li><a href="XBeeNodeConfigurationTool.shtml">Node Config Tool</a>
+                </ul></li>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">X10</a>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/XBee/XBeeNodeConfigurationTool.shtml
+++ b/help/en/html/hardware/XBee/XBeeNodeConfigurationTool.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/hardware/XBee/index.shtml
+++ b/help/en/html/hardware/XBee/index.shtml
@@ -24,7 +24,7 @@
 <body>
 <!--#include virtual="/Header" -->
   <div id="mBody">
-  <!--#include virtual="Sidebar" -->
+  <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
     <!-- Page Body -->
 

--- a/help/en/html/hardware/XPressNet/CreateXNetLogFile.shtml
+++ b/help/en/html/hardware/XPressNet/CreateXNetLogFile.shtml
@@ -19,7 +19,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: XpressNet - Creating an Log File</h1>

--- a/help/en/html/hardware/XPressNet/LI101Configurationtool.shtml
+++ b/help/en/html/hardware/XPressNet/LI101Configurationtool.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>XpressNet LI101F Configuration Tool</h1><img src=

--- a/help/en/html/hardware/XPressNet/LZV100Configurationtool.shtml
+++ b/help/en/html/hardware/XPressNet/LZV100Configurationtool.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>XpressNet LZV100 Configuration Tool</h1><img src=

--- a/help/en/html/hardware/XPressNet/Sidebar.shtml
+++ b/help/en/html/hardware/XPressNet/Sidebar.shtml
@@ -1,0 +1,148 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/XPressNet pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../CMRI.shtml">C/MRI</a>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+    		    <li><a href="../index.shtml">DCC++</a>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="index.shtml">Lenz</a>
+                <ul>
+                    <li><a href="XNetAddressing.shtml">XPressNet Addressing</a>
+                    <li>Tools
+                    <ul>
+                        <li><a href="LI101Configurationtool.shtml">LI101 Config</a>
+                        <li><a href="LZV100Configurationtool.shtml">LZV100 Config</a>
+                        <li><a href="XNetSystemInformationtool.shtml">System Information</a>
+                        <li><a href="CreateXNetLogFile.shtml">XPressNet Log</a>
+                    </ul>
+                    </li>
+                </ul>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">X10</a>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/XPressNet/XNetAddressing.shtml
+++ b/help/en/html/hardware/XPressNet/XNetAddressing.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: XpressNet - Lenz Feedback Bus

--- a/help/en/html/hardware/XPressNet/XNetSystemInformationtool.shtml
+++ b/help/en/html/hardware/XPressNet/XNetSystemInformationtool.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: XpressNet System Information

--- a/help/en/html/hardware/XPressNet/index.shtml
+++ b/help/en/html/hardware/XPressNet/index.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: XpressNet</h1>

--- a/help/en/html/hardware/acela/Names.shtml
+++ b/help/en/html/hardware/acela/Names.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: CTI Acela System Names</h1>

--- a/help/en/html/hardware/acela/index.shtml
+++ b/help/en/html/hardware/acela/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: CTI Acela System</h1>

--- a/help/en/html/hardware/anyma/index.shtml
+++ b/help/en/html/hardware/anyma/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Anyma DMX</h1>

--- a/help/en/html/hardware/bachrus/index.shtml
+++ b/help/en/html/hardware/bachrus/index.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Bachrus</h1>

--- a/help/en/html/hardware/can/Sidebar.shtml
+++ b/help/en/html/hardware/can/Sidebar.shtml
@@ -1,0 +1,143 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/can pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../cmri/CMRI.shtml">C/MRI</a>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+				<li><a href="../dccpp/index.shtml">DCC++</a>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="index.shtml">CAN</a>
+				<ul>
+					<li><a href="scripting.shtml">CAN Scripting</a>
+				    <li><a href="cbus/index.shtml">MERG CBUS</a>
+				    <li><a href="cbus/Names.shtml">MERG CBUS Naming</a>
+				    <li><a href="cbus/Details.shtml">MERG CBUS Connection Details</a>
+				</ul>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">X10</a>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/can/cbus/Details.shtml
+++ b/help/en/html/hardware/can/cbus/Details.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: MERG CBUS - Connection Details</h1>

--- a/help/en/html/hardware/can/cbus/Names.shtml
+++ b/help/en/html/hardware/can/cbus/Names.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI Hardware Support: MERG CBUS - Naming</h1>

--- a/help/en/html/hardware/can/cbus/Sidebar.shtml
+++ b/help/en/html/hardware/can/cbus/Sidebar.shtml
@@ -1,0 +1,143 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/can/cbus (MERG) pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../../cmri/CMRI.shtml">C/MRI</a>
+				<li><a href="../../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+				<li><a href="../../dccpp/index.shtml">DCC++</a>
+				<li><a href="../../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../../maple/index.shtml">Maple Systems</a>
+				<li><a href="../../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../index.shtml">CAN</a>
+				<ul>
+					<li><a href="../scripting.shtml">CAN Scripting</a>
+				    <li><a href="index.shtml">MERG CBUS</a>
+				    <li><a href="Names.shtml">MERG CBUS Naming</a>
+				    <li><a href="Details.shtml">MERG CBUS Connection Details</a>
+				</ul>
+				<li><a href="../../modbus/index.shtml">Modbus</a>
+                <li><a href="../../mqtt/index.shtml">MQTT</a>
+				<li><a href="../../mrc/index.shtml">MRC</a>
+				<li><a href="../../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../../nce/NCE.shtml">NCE</a>
+				<li><a href="../../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../../XPressNet/index.shtml">Roco</a>
+				<li><a href="../../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../../powerline/index.shtml">X10</a>
+				<li><a href="../../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/can/cbus/index.shtml
+++ b/help/en/html/hardware/can/cbus/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
      <h1>JMRI Hardware Support: MERG CBUS Main Support Page</h1>

--- a/help/en/html/hardware/can/index.shtml
+++ b/help/en/html/hardware/can/index.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: CAN: Controller Area Networks</h1>

--- a/help/en/html/hardware/can/scripting.shtml
+++ b/help/en/html/hardware/can/scripting.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: CAN - Scripting</h1>

--- a/help/en/html/hardware/cmri/CMRI.shtml
+++ b/help/en/html/hardware/cmri/CMRI.shtml
@@ -21,7 +21,7 @@
 <body>
 <!--#include virtual="/Header" -->
   <div id="mBody">
-  <!--#include virtual="Sidebar" -->
+  <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Chubb C/MRI</h1><a name="contents" id="contents"></a>

--- a/help/en/html/hardware/cmri/Sidebar.shtml
+++ b/help/en/html/hardware/cmri/Sidebar.shtml
@@ -1,0 +1,140 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/cmri pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="CMRI.shtml">C/MRI</a>
+				<ul>
+				    <li><a href="Signals.shtml">C/MRI Signals</a>
+				</ul>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+				<li><a href="../dccpp/index.shtml">DCC++</a>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">X10</a>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/cmri/Signals.shtml
+++ b/help/en/html/hardware/cmri/Signals.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Chubb C/MRI</h1>

--- a/help/en/html/hardware/dcc4pc/index.shtml
+++ b/help/en/html/hardware/dcc4pc/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
     <p>The DCC4PC hardware is a combined block occupancy detector and RailComm reader built into one. 

--- a/help/en/html/hardware/dccpp/Sensors.shtml
+++ b/help/en/html/hardware/dccpp/Sensors.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DCC++ Sensors</h1>

--- a/help/en/html/hardware/dccpp/Sidebar.shtml
+++ b/help/en/html/hardware/dccpp/Sidebar.shtml
@@ -1,0 +1,141 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/dccpp pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../CMRI.shtml">C/MRI</a>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+    		    <li><a href="index.shtml">DCC++</a>
+				<ul>
+				    <li><a href="Sensors.shtml">DCC++ Sensors</a>
+				    <li><a href="Turnouts.shtml">DCC++ Turnouts</a>
+				</ul>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">X10</a>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/dccpp/Turnouts.shtml
+++ b/help/en/html/hardware/dccpp/Turnouts.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DCC++ Turnouts and Outputs</h1>

--- a/help/en/html/hardware/dccpp/index.shtml
+++ b/help/en/html/hardware/dccpp/index.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: DCC++</h1>

--- a/help/en/html/hardware/digirails/index.shtml
+++ b/help/en/html/hardware/digirails/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Digikeijs (Digirails)</h1><a name=

--- a/help/en/html/hardware/easydcc/EasyDCC.shtml
+++ b/help/en/html/hardware/easydcc/EasyDCC.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: CVP Products EasyDCC</h1><a name="hardware" id=

--- a/help/en/html/hardware/ecos/index.shtml
+++ b/help/en/html/hardware/ecos/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: ESU ECoS</h1><a name="hardware" id=

--- a/help/en/html/hardware/grapevine/Names.shtml
+++ b/help/en/html/hardware/grapevine/Names.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Grapevine System</h1>

--- a/help/en/html/hardware/grapevine/Sidebar.shtml
+++ b/help/en/html/hardware/grapevine/Sidebar.shtml
@@ -1,0 +1,140 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/grapevine pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../CMRI.shtml">C/MRI</a>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+    		    <li><a href="../index.shtml">DCC++</a>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="index.shtml">Protrak Grapevine</a>
+                <ul>
+                    <li><a href="Names.shtml">Grapevine Naming</a>
+                </ul>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">X10</a>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/grapevine/index.shtml
+++ b/help/en/html/hardware/grapevine/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Protrak Grapevine System</h1><a name=

--- a/help/en/html/hardware/hardware-template.shtml
+++ b/help/en/html/hardware/hardware-template.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: [System]</h1>

--- a/help/en/html/hardware/ieee801254/index.shtml
+++ b/help/en/html/hardware/ieee801254/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: IEEE_802.15.4</h1>

--- a/help/en/html/hardware/index.shtml
+++ b/help/en/html/hardware/index.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Hardware Support</h1>

--- a/help/en/html/hardware/jmriclient/index.shtml
+++ b/help/en/html/hardware/jmriclient/index.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: JMRIClient Connection</h1>

--- a/help/en/html/hardware/loconet/Addressing.shtml
+++ b/help/en/html/hardware/loconet/Addressing.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Support: LocoNet&reg; addressing</h1>

--- a/help/en/html/hardware/loconet/BTLocoBridge.shtml
+++ b/help/en/html/hardware/loconet/BTLocoBridge.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting through a Bluetooth

--- a/help/en/html/hardware/loconet/CommandStationConfig.shtml
+++ b/help/en/html/hardware/loconet/CommandStationConfig.shtml
@@ -20,7 +20,7 @@
     <body>
         <!--#include virtual="/Header" -->
         <div id="mBody">
-            <!--#include virtual="Sidebar" -->
+            <!--#include virtual="Sidebar.shtml" -->
             <div id="mainContent">
 
       <h1>Digitrax Command Station Configuration</h1>

--- a/help/en/html/hardware/loconet/DCS240.shtml
+++ b/help/en/html/hardware/loconet/DCS240.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting to a Digitrax DCS240</h1><br>

--- a/help/en/html/hardware/loconet/DCS52.shtml
+++ b/help/en/html/hardware/loconet/DCS52.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting to a Digitrax DCS52</h1><br>

--- a/help/en/html/hardware/loconet/DS54.shtml
+++ b/help/en/html/hardware/loconet/DS54.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: DS54 Examples</h1>

--- a/help/en/html/hardware/loconet/Digitrax.shtml
+++ b/help/en/html/hardware/loconet/Digitrax.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Support: Digitrax LocoNet&reg;</h1>

--- a/help/en/html/hardware/loconet/DigitraxPower/Sidebar.shtml
+++ b/help/en/html/hardware/loconet/DigitraxPower/Sidebar.shtml
@@ -1,0 +1,167 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/can/cbus (MERG) pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../../cmri/CMRI.shtml">C/MRI</a>
+				<li><a href="../../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+				<li><a href="../../dccpp/index.shtml">DCC++</a>
+				<li><a href="../../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../../loconet/Digitrax.shtml">LocoNet</a>
+                <ul>
+                    <li><a href="../LocoNetTools.shtml">LocoNet Tools</a></li>
+                    <li><a href="../LocoNetSim.shtml">LocoNet Simulator</a></li>
+                    <li><a href="../DS54.shtml">DS54</a></li>
+                    <li><a href="../LocoIO.shtml">LocoIO</a></li>
+                    <li>Command Stations</li>
+                    <ul>
+                        <li><a href="../DCS52.shtml">DCS52</a></li>
+                        <li><a href="../DCS240.shtml">DCS240</a></li>
+                        <li><a href="../CommandStationConfig.shtml">OpSw Configuration</a></li>
+                    </ul>
+                    <li>Programmers &amp; Adapters</li>
+                    <ul>
+                        <li><a href="../PR2.shtml">PR2</a></li>
+                        <li><a href="../PR3.shtml">PR3</a></li>
+                        <li><a href="../PR4.shtml">PR4</a></li>
+                        <li><a href="../LocoBuffer.shtml">LocoBuffer</a></li>
+                        <li><a href="../LocoBufferII.shtml">LocoBuffer-II</a></li>
+                        <li><a href="../LocoBufferUSB.shtml">LocoBuffer-USB</a></li>
+                        <li><a href="../MS100.shtml">MS100</a></li>
+                        <li><a href="../KeyspanUSB.shtml">Keyspan USB Adapter</a></li>
+                    </ul>
+                    <li>Networking</li>
+                    <ul>
+                        <li><a href="../LocoNetServer.shtml">LocoNet Client/Server</a></li>
+                        <li><a href="../LbServer.shtml">LocoNetOverTCP LbServer</a></li>
+                        <li><a href="../BTLocoBridge.shtml">LocoBridge Adapter</a></li>
+                        <li><a href="../StandaloneLocoNet.shtml">Standalone LocoNet</a>
+                    </ul>
+                    <li>Technical</li>
+                    <ul>
+                        <li><a href="../Addressing.shtml">Addressing</a></li>
+                        <li><a href="../LocoNetClasses.shtml">Implementation</a></li>
+				        <li class="here">LocoNet Power Issues</li>
+				    </ul>
+				<li><a href="../../maple/index.shtml">Maple Systems</a>
+				<li><a href="../../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../../index.shtml">CAN</a>
+				<li><a href="../../modbus/index.shtml">Modbus</a>
+                <li><a href="../../mqtt/index.shtml">MQTT</a>
+				<li><a href="../../mrc/index.shtml">MRC</a>
+				<li><a href="../../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../../nce/NCE.shtml">NCE</a>
+				<li><a href="../../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../../XPressNet/index.shtml">Roco</a>
+				<li><a href="../../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../../powerline/index.shtml">X10</a>
+				<li><a href="../../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/loconet/DigitraxPower/index.shtml
+++ b/help/en/html/hardware/loconet/DigitraxPower/index.shtml
@@ -23,7 +23,7 @@
 <body>
 <!--#include virtual="/Header" -->
 <div id="mBody">
-  <!--#include virtual="Sidebar" -->
+  <!--#include virtual="Sidebar.shtml" -->
   <div id="mainContent">
 
       <h1>Hardware Support: Measurements on power leads of Digitrax

--- a/help/en/html/hardware/loconet/Fleischmann.shtml
+++ b/help/en/html/hardware/loconet/Fleischmann.shtml
@@ -27,7 +27,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Fleischmann Twin Centre</h1>

--- a/help/en/html/hardware/loconet/KeyspanUSB.shtml
+++ b/help/en/html/hardware/loconet/KeyspanUSB.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Keyspan USB connections</h1>

--- a/help/en/html/hardware/loconet/LbServer.shtml
+++ b/help/en/html/hardware/loconet/LbServer.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting Multiple Computers to

--- a/help/en/html/hardware/loconet/LocoBuffer.shtml
+++ b/help/en/html/hardware/loconet/LocoBuffer.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting a LocoBuffer to

--- a/help/en/html/hardware/loconet/LocoBufferII.shtml
+++ b/help/en/html/hardware/loconet/LocoBufferII.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting a LocoBuffer-II to

--- a/help/en/html/hardware/loconet/LocoBufferUSB.shtml
+++ b/help/en/html/hardware/loconet/LocoBufferUSB.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting a LocoBuffer-USB to

--- a/help/en/html/hardware/loconet/LocoIO.shtml
+++ b/help/en/html/hardware/loconet/LocoIO.shtml
@@ -17,7 +17,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI LocoIO Programmer Tools (deprecated)</h1>

--- a/help/en/html/hardware/loconet/LocoNetClasses.shtml
+++ b/help/en/html/hardware/loconet/LocoNetClasses.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Support: The JMRI LocoNet&reg; implementation</h1>

--- a/help/en/html/hardware/loconet/LocoNetServer.shtml
+++ b/help/en/html/hardware/loconet/LocoNetServer.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting Multiple Computers to

--- a/help/en/html/hardware/loconet/LocoNetSim.shtml
+++ b/help/en/html/hardware/loconet/LocoNetSim.shtml
@@ -24,7 +24,7 @@
     to main content</a></p>
     <!--#include virtual="/Header" -->
     <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
       <div id="mainContent">
 
       <h1>Hardware Support: LocoNet&reg; Simulator</h1>

--- a/help/en/html/hardware/loconet/LocoNetTools.shtml
+++ b/help/en/html/hardware/loconet/LocoNetTools.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: JMRI Tools for LocoNet&reg;

--- a/help/en/html/hardware/loconet/LocoNetworking.shtml
+++ b/help/en/html/hardware/loconet/LocoNetworking.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Methods to Connect Multiple Computers

--- a/help/en/html/hardware/loconet/MS100.shtml
+++ b/help/en/html/hardware/loconet/MS100.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting an MS100 to

--- a/help/en/html/hardware/loconet/PR2.shtml
+++ b/help/en/html/hardware/loconet/PR2.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting to a Digitrax

--- a/help/en/html/hardware/loconet/PR3.shtml
+++ b/help/en/html/hardware/loconet/PR3.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting to a Digitrax PR3

--- a/help/en/html/hardware/loconet/PR4.shtml
+++ b/help/en/html/hardware/loconet/PR4.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Connecting to a Digitrax PR4</h1><a href=

--- a/help/en/html/hardware/loconet/Sidebar.shtml
+++ b/help/en/html/hardware/loconet/Sidebar.shtml
@@ -1,0 +1,173 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/loconet pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../CMRI.shtml">C/MRI</a>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+    		    <li><a href="../index.shtml">DCC++</a>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="Digitrax.shtml"> Digitrax LocoNet&reg;</a>
+                <ul>
+                    <li><a href="LocoNetTools.shtml">LocoNet Tools</a></li>
+                    <li><a href="LocoNetSim.shtml">LocoNet Simulator</a></li>
+                    <li><a href="DS54.shtml">DS54</a></li>
+                    <li><a href="LocoIO.shtml">LocoIO</a></li>
+                    <li>Command Stations</li>
+                    <ul>
+                        <li><a href="DCS52.shtml">DCS52</a></li>
+                        <li><a href="DCS240.shtml">DCS240</a></li>
+                        <li><a href="CommandStationConfig.shtml">OpSw Configuration</a></li>
+                    </ul>
+                    <li>Programmers &amp; Adapters</li>
+                    <ul>
+                        <li><a href="PR2.shtml">PR2</a></li>
+                        <li><a href="PR3.shtml">PR3</a></li>
+                        <li><a href="PR4.shtml">PR4</a></li>
+                        <li><a href="LocoBuffer.shtml">LocoBuffer</a></li>
+                        <li><a href="LocoBufferII.shtml">LocoBuffer-II</a></li>
+                        <li><a href="LocoBufferUSB.shtml">LocoBuffer-USB</a></li>
+                        <li><a href="MS100.shtml">MS100</a></li>
+                        <li><a href="KeyspanUSB.shtml">Keyspan USB Adapter</a></li>
+                    </ul>
+                    <li>Networking</li>
+                    <ul>
+                        <li><a href="LocoNetServer.shtml">LocoNet Client/Server</a></li>
+                        <li><a href="LbServer.shtml">LocoNetOverTCP LbServer</a></li>
+                        <li><a href="BTLocoBridge.shtml">LocoBridge Adapter</a></li>
+                        <li><a href="StandaloneLocoNet.shtml">Standalone LocoNet</a>
+                    </ul>
+                    <li>Technical</li>
+                    <ul>
+                        <li><a href="Addressing.shtml">Addressing</a></li>
+                        <li><a href="LocoNetClasses.shtml">Implementation</a></li>
+                        <li><a href="DigitraxPower/index.shtml">LocoNet Power Issues</a></li>
+                    </ul>
+                </ul>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="Uhlenbrock.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">X10</a>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" align="right" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/loconet/StandaloneLocoNet.shtml
+++ b/help/en/html/hardware/loconet/StandaloneLocoNet.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Standalone LocoNet&reg;</h1>

--- a/help/en/html/hardware/loconet/Uhlenbrock.shtml
+++ b/help/en/html/hardware/loconet/Uhlenbrock.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Uhlenbrock Intellibox</h1>

--- a/help/en/html/hardware/maple/index.shtml
+++ b/help/en/html/hardware/maple/index.shtml
@@ -16,7 +16,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Maple Systems</h1><a href=

--- a/help/en/html/hardware/marklin/index.shtml
+++ b/help/en/html/hardware/marklin/index.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: M&auml;rklin Command Station 2

--- a/help/en/html/hardware/misc/DccSpecialties.shtml
+++ b/help/en/html/hardware/misc/DccSpecialties.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: DCC Specialties Products</h1><a href=

--- a/help/en/html/hardware/modbus/index.shtml
+++ b/help/en/html/hardware/modbus/index.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <img src="http://www.modbus.org/images/logo_new.jpg" alt=

--- a/help/en/html/hardware/mqtt/index.shtml
+++ b/help/en/html/hardware/mqtt/index.shtml
@@ -12,7 +12,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: MQTT</h1>

--- a/help/en/html/hardware/mrc/index.shtml
+++ b/help/en/html/hardware/mrc/index.shtml
@@ -13,7 +13,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: MRC/GaugeMaster Prodigy

--- a/help/en/html/hardware/nce/NCE.shtml
+++ b/help/en/html/hardware/nce/NCE.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
   <h1>Hardware Support: NCE</h1>

--- a/help/en/html/hardware/nce/Wangrow.shtml
+++ b/help/en/html/hardware/nce/Wangrow.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Wangrow System One</h1>

--- a/help/en/html/hardware/oaktree/OakTree.shtml
+++ b/help/en/html/hardware/oaktree/OakTree.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Oak Tree Systems Railroad Control

--- a/help/en/html/hardware/openlcb/Connections.shtml
+++ b/help/en/html/hardware/openlcb/Connections.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: OpenLCB - Connections</h1>

--- a/help/en/html/hardware/openlcb/Details.shtml
+++ b/help/en/html/hardware/openlcb/Details.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: OpenLCB - Technical

--- a/help/en/html/hardware/openlcb/Names.shtml
+++ b/help/en/html/hardware/openlcb/Names.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: OpenLCB - Naming</h1>This page

--- a/help/en/html/hardware/openlcb/OlcbSignalMast.shtml
+++ b/help/en/html/hardware/openlcb/OlcbSignalMast.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: OpenLCB Signal Masts</h1>

--- a/help/en/html/hardware/openlcb/Sidebar.shtml
+++ b/help/en/html/hardware/openlcb/Sidebar.shtml
@@ -1,0 +1,143 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/grapevine pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../CMRI.shtml">C/MRI</a>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+    		    <li><a href="../index.shtml">DCC++</a>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+                <ul>
+                    <li><a href="Names.shtml">Naming</a>
+                    <li><a href="Connections.shtml">Connections</a>
+                    <li><a href="OlcbSignalMast.shtml">Signal Masts</a>
+                    <li><a href="Details.shtml">Details</a>
+                </ul></li>
+				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">X10</a>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/openlcb/index.shtml
+++ b/help/en/html/hardware/openlcb/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: OpenLCB</h1><em>The support on this

--- a/help/en/html/hardware/pi/index.shtml
+++ b/help/en/html/hardware/pi/index.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="../SidebarUp" -->
+      <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Setup Support: Raspberry Pi via GPIO</h1>

--- a/help/en/html/hardware/powerline/Compatibility.shtml
+++ b/help/en/html/hardware/powerline/Compatibility.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Powerline - Compatible Adapters</h1>

--- a/help/en/html/hardware/powerline/Names.shtml
+++ b/help/en/html/hardware/powerline/Names.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Powerline - System Names</h1>

--- a/help/en/html/hardware/powerline/Sidebar.shtml
+++ b/help/en/html/hardware/powerline/Sidebar.shtml
@@ -1,0 +1,141 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/grapevine pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../CMRI.shtml">C/MRI</a>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+    		    <li><a href="../index.shtml">DCC++</a>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">Powerline X10</a>
+                <ul>
+                    <li><a href="Names.shtml">Naming</a>
+                    <li><a href="Compatibility.shtml">Compatibility</a>
+                </ul></li>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/powerline/index.shtml
+++ b/help/en/html/hardware/powerline/index.shtml
@@ -20,7 +20,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Powerline Controllers</h1>

--- a/help/en/html/hardware/qsi/index.shtml
+++ b/help/en/html/hardware/qsi/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: QSI Quantum Programmer</h1>

--- a/help/en/html/hardware/raildriver/Sidebar.shtml
+++ b/help/en/html/hardware/raildriver/Sidebar.shtml
@@ -1,0 +1,140 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/grapevine pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../CMRI.shtml">C/MRI</a>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+    		    <li><a href="../index.shtml">DCC++</a>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+                <ul>
+                    <li><a href="details.shtml">Details</a>
+                </ul></li>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">X10</a>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/raildriver/details.shtml
+++ b/help/en/html/hardware/raildriver/details.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: RailDriver Throttle Details</h1>

--- a/help/en/html/hardware/raildriver/index.shtml
+++ b/help/en/html/hardware/raildriver/index.shtml
@@ -20,7 +20,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: RailDriver Throttle</h1>

--- a/help/en/html/hardware/rfid/index.shtml
+++ b/help/en/html/hardware/rfid/index.shtml
@@ -20,7 +20,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: RFID Readers</h1>

--- a/help/en/html/hardware/roco/z21/Sidebar.shtml
+++ b/help/en/html/hardware/roco/z21/Sidebar.shtml
@@ -1,0 +1,140 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/can/cbus (MERG) pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../../cmri/CMRI.shtml">C/MRI</a>
+				<li><a href="../../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+				<li><a href="../../dccpp/index.shtml">DCC++</a>
+				<li><a href="../../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../../maple/index.shtml">Maple Systems</a>
+				<li><a href="../../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../../index.shtml">CAN</a>
+				<li><a href="../../modbus/index.shtml">Modbus</a>
+                <li><a href="../../mqtt/index.shtml">MQTT</a>
+				<li><a href="../../mrc/index.shtml">MRC</a>
+				<li><a href="../../rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../../nce/NCE.shtml">NCE</a>
+				<li><a href="../../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../../XPressNet/index.shtml">Roco</a>
+                    <ul>
+                        <li><a href="index.shtml">Z21</a>
+                    </ul>
+				<li><a href="../../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../../powerline/index.shtml">X10</a>
+				<li><a href="../../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/roco/z21/index.shtml
+++ b/help/en/html/hardware/roco/z21/index.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Fleischmann/Roco z21/Z21</h1>

--- a/help/en/html/hardware/rps/Sidebar.shtml
+++ b/help/en/html/hardware/rps/Sidebar.shtml
@@ -1,0 +1,140 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/hardware/rps pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; connects to...</div>
+	    <dl>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../bachrus/index.shtml">Bachrus</a>
+				<li><a href="../CMRI.shtml">C/MRI</a>
+				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+    		    <li><a href="../index.shtml">DCC++</a>
+				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
+				<li><a href="../XBee/index.shtml">Digi XBee</a>
+				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../XPressNet/index.shtml">Hornby</a>
+				<li><a href="../XPressNet/index.shtml">Lenz</a>
+				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../maple/index.shtml">Maple Systems</a>
+				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../modbus/index.shtml">Modbus</a>
+                <li><a href="../mqtt/index.shtml">MQTT</a>
+				<li><a href="../mrc/index.shtml">MRC</a>
+				<li><a href="../rps/index.shtml">NAC Services RPS</a>
+                <ul>
+                    <li><a href="sensors.shtml">Sensors</a>
+                </ul></li>
+				<li><a href="../nce/NCE.shtml">NCE</a>
+				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../XPressNet/index.shtml">Roco</a>
+				<li><a href="../sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../SRCP/index.shtml">SRCP server</a>
+				<li><a href="../tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../powerline/index.shtml">X10</a>
+				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout:
+		    <ul>
+	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../../tools/Lights.shtml">Lights</a>
+	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../../tools/Routes.shtml">Routes</a>
+	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../../tools/Sections.shtml">Sections</a>
+            <li><a href="../../tools/Transits.shtml">Transits</a>
+	        <li><a href="../../tools/Logix.shtml">Logix</a>
+	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../../tools/Audio.shtml">Audio</a>
+	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../tools/Routes.shtml">Routes</a>
+		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/hardware/rps/index.shtml
+++ b/help/en/html/hardware/rps/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: NAC Services RPS</h1>

--- a/help/en/html/hardware/rps/sensors.shtml
+++ b/help/en/html/hardware/rps/sensors.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: NAC Services RPS Sensors</h1><em>Please

--- a/help/en/html/hardware/secsi/index.shtml
+++ b/help/en/html/hardware/secsi/index.shtml
@@ -13,7 +13,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: TracTronics SECSI System</h1>

--- a/help/en/html/hardware/sprog/SPROG.shtml
+++ b/help/en/html/hardware/sprog/SPROG.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: SPROG</h1>

--- a/help/en/html/hardware/tams/index.shtml
+++ b/help/en/html/hardware/tams/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Tams MasterControl</h1>

--- a/help/en/html/hardware/tchtech/index.shtml
+++ b/help/en/html/hardware/tchtech/index.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: TCH Technology System (no longer

--- a/help/en/html/hardware/tmcc/index.shtml
+++ b/help/en/html/hardware/tmcc/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: Lionel TMCC</h1><a name="hardware" id=

--- a/help/en/html/hardware/xap/index.shtml
+++ b/help/en/html/hardware/xap/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: xAP</h1>

--- a/help/en/html/hardware/zimo/Zimo.shtml
+++ b/help/en/html/hardware/zimo/Zimo.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="../SidebarUp" -->
+    <!--#include virtual="../SidebarUp.shtml" -->
     <div id="mainContent">
 
       <h1>Hardware Support: ZIMO MX-1</h1><a name="hardware" id=

--- a/help/en/html/setup/Dropbox.shtml
+++ b/help/en/html/setup/Dropbox.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/setup/Errors.shtml
+++ b/help/en/html/setup/Errors.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/setup/Faq.shtml
+++ b/help/en/html/setup/Faq.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/setup/Files.shtml
+++ b/help/en/html/setup/Files.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI Setup: Configuration Files</h1>

--- a/help/en/html/setup/MigrateSystemPrefixes.shtml
+++ b/help/en/html/setup/MigrateSystemPrefixes.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/setup/Sidebar.shtml
+++ b/help/en/html/setup/Sidebar.shtml
@@ -1,0 +1,149 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/setup pages -->
+
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI&reg; is...</div>
+	    <dl>
+
+		<dt><h3><a href="index.shtml">Setup</a></h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../../package/apps/TabbedPreferences.shtml">Preferences Pane</a></li>
+			<li><a href="../setup/profiles.shtml">Configuration Profiles</a></li>
+			<li><a href="../setup/Errors.shtml">Error Codes</a></li>
+			<li><a href="../../package/apps/InstallTest/InstallTest.shtml">InstallTest</a></li>
+			</ul>
+    </dd>
+
+		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
+		<dd> 
+		    <ul>
+            <li><a href="http://jmri.org/install/WindowsNew.shtml">Windows</a>
+            <li><a href="http://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+            <li><a href="http://jmri.org/install/Linux.shtml">Linux</a>
+            <ul>
+	            <li><a href="http://jmri.org/install/Raspbian.shtml">RasPi</a>
+	        </ul>
+            <li><a href="http://jmri.org/install/Debug.shtml">Debugging an installation</a>
+		    </ul>
+		</dd>
+
+		<dt><h3>Applications</h3></dt>
+		<dd>
+			<ul>
+			<li><a href="../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+			<li><a href="../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
+			<li><a href="../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
+	        <li><a href="../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
+			<li><a href="../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
+			</ul>
+        </dd>
+
+		<dt><h3><a href="../tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your layout:
+		    <ul>
+	        <li><a href="../tools/Turnouts.shtml">Turnouts</a>
+	        <li><a href="../tools/Lights.shtml">Lights</a>
+	        <li><a href="../tools/Sensors.shtml">Sensors</a>
+		    <li><a href="../tools/throttle/ThrottleMain.shtml">Throttles</a>
+	        <li><a href="../tools/consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="../tools/Blocks.shtml">Blocks</a>
+		    <li><a href="../tools/Reporters.shtml">Reporters</a>
+		    <li><a href="../tools/Memories.shtml">Memory Variables</a>
+	        <li><a href="../tools/Routes.shtml">Routes</a>
+	        <li><a href="../tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="../tools/Sections.shtml">Sections</a>
+            <li><a href="../tools/Transits.shtml">Transits</a>
+	        <li><a href="../tools/Logix.shtml">Logix</a>
+	        <li><a href="../tools/fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../tools/speedometer/index.shtml">Speedometer</a>
+	        <li><a href="../tools/Audio.shtml">Audio</a>
+	        <li><a href="../tools/IdTags.shtml">Id Tags</a>
+	        <li><a href="../tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="../tools/index.shtml#systemSpecificTools">System-specific...</a>
+            </ul>
+		</dd>
+
+		<dt><h3 style="padding-left: 1em;"><a href="../tools/automation/">Layout Automation</a></h3></dt>
+		<dd>
+		JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="../tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../tools/Routes.shtml">Routes</a>
+		    <li><a href="../tools/LRoutes.shtml">LRoutes</a>
+		    <li><a href="../tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="../tools/scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+		
+<div style="clear: both"></div>
+		<dt><h3 style="padding-left: 1em;"><a href="../hardware/index.shtml">Supported Hardware</a></h3></dt>
+		<dd> 
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="../hardware/XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="../hardware/bachrus/index.shtml">Bachrus</a>
+				<li><a href="../hardware/cmri/CMRI.shtml">C/MRI</a>
+				<li><a href="../hardware/acela/index.shtml">CTI Electronics</a>
+				<li><a href="../hardware/easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+				<li><a href="../hardware/dccpp/index.shtml">DCC++</a>
+				<li><a href="../hardware/misc/DccSpecialties.shtml">DCC Specialities</a>
+				<li><a href="../hardware/XBee/index.shtml">Digi XBee</a>
+				<li><a href="../hardware/digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../hardware/loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="../hardware/ecos/index.shtml">ESU ECoS</a>
+				<li><a href="../hardware/loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="../hardware/XPressNet/index.shtml">Hornby</a>
+				<li><a href="../hardware/XPressNet/index.shtml">Lenz</a>
+				<li><a href="../hardware/tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="../hardware/digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="../hardware/loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="../hardware/maple/index.shtml">Maple Systems</a>
+				<li><a href="../hardware/marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="../hardware/can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="../hardware/modbus/index.shtml">Modbus</a>
+                <li><a href="../hardware/mqtt/index.shtml">MQTT</a>
+				<li><a href="../hardware/mrc/index.shtml">MRC</a>
+				<li><a href="../hardware/rps/index.shtml">NAC Services RPS</a>
+				<li><a href="../hardware/nce/NCE.shtml">NCE</a>
+				<li><a href="../hardware/oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="../hardware/openlcb/index.shtml">OpenLCB</a>
+				<li><a href="../hardware/grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="../hardware/qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="../hardware/raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="../hardware/pi/index.shtml">Raspberry Pi</a>
+				<li><a href="../hardware/XPressNet/index.shtml">Roco</a>
+				<li><a href="../hardware/sprog/SPROG.shtml">SPROG</a>
+				<li><a href="../hardware/SRCP/index.shtml">SRCP server</a>
+				<li><a href="../hardware/tams/index.shtml">TAMS Master Control</a>
+				<li><a href="../hardware/loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="../hardware/XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="../hardware/nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="../hardware/powerline/index.shtml">X10</a>
+				<li><a href="../hardware/zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="../hardware/XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+
+    </dl>
+
+    <a href="/donations.shtml">
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" ALIGN="RIGHT" alt="Donate to JMRI" />
+    </a>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/setup/git.shtml
+++ b/help/en/html/setup/git.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/setup/index.shtml
+++ b/help/en/html/setup/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
       <h1>JMRI&reg;: Setup</h1>

--- a/help/en/html/setup/profiles.shtml
+++ b/help/en/html/setup/profiles.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/Audio.shtml
+++ b/help/en/html/tools/Audio.shtml
@@ -19,7 +19,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Audio Documentation</h1>JMRI Audio objects hold

--- a/help/en/html/tools/Blocks.shtml
+++ b/help/en/html/tools/Blocks.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Blocks Documentation</h1>

--- a/help/en/html/tools/EntryExit.shtml
+++ b/help/en/html/tools/EntryExit.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
     <h1>JMRI: Entry/Exit (NX) Routing Documentation</h1>

--- a/help/en/html/tools/IdTags.shtml
+++ b/help/en/html/tools/IdTags.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/LRoutes.shtml
+++ b/help/en/html/tools/LRoutes.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: LRoute Documentation</h1>

--- a/help/en/html/tools/Lights.shtml
+++ b/help/en/html/tools/Lights.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
     <h1>JMRI: Lights Documentation</h1>

--- a/help/en/html/tools/Logix.shtml
+++ b/help/en/html/tools/Logix.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Logix Documentation</h1>

--- a/help/en/html/tools/Memories.shtml
+++ b/help/en/html/tools/Memories.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Memory Variables Documentation</h1>

--- a/help/en/html/tools/Reporters.shtml
+++ b/help/en/html/tools/Reporters.shtml
@@ -26,7 +26,7 @@
   <div id="container">
     <!--#include virtual="/Header" -->
     <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
       <div id="mainContent">
         <!-- Page Body -->
 

--- a/help/en/html/tools/Routes.shtml
+++ b/help/en/html/tools/Routes.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Routes Documentation</h1>

--- a/help/en/html/tools/Sections.shtml
+++ b/help/en/html/tools/Sections.shtml
@@ -17,7 +17,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Sections Documentation</h1>

--- a/help/en/html/tools/Sensors.shtml
+++ b/help/en/html/tools/Sensors.shtml
@@ -19,7 +19,7 @@
   <div id="container">
     <!--#include virtual="/Header" -->
     <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
       <div id="mainContent">
 
       <h1>JMRI: Sensors Documentation</h1>

--- a/help/en/html/tools/Sidebar.shtml
+++ b/help/en/html/tools/Sidebar.shtml
@@ -1,82 +1,24 @@
-<!-- Sidebar -->
+<!-- Sidebar.shtml -->
 <!-- This is the common sidebar definition for html/tools pages -->
 	<hr class="hide">
-	  <div id="side"> <!-- Block of text on left side of page -->
-	    <div style="text-align: center">JMRI is...</div>
-	    <dl>
+	
+    <div id="side"> <!-- Block of text on left side of page -->
+        <div style="text-align: center">JMRI is...</div>
+        <dl>
 
-		<dt><h3><a href="index.shtml">Common Tools</a></h3></dt>
-		<dd>JMRI provides powerful tools for working with your
-		layout.
-		  <ul>
-		    <li><a href="Turnouts.shtml">Turnouts</a>
-		    <li><a href="Lights.shtml">Lights</a>
-		    <li><a href="Sensors.shtml">Sensors</a>
-		    <li><a href="throttle/ThrottleMain.shtml">Throttles</a>
-		    <li><a href="consisttool/ConsistTool.shtml">Consisting</a>
-		    <li><a href="signaling/index.shtml">Signaling</a>
-		    <li><a href="Blocks.shtml">Blocks</a>
-		    <li><a href="Reporters.shtml">Reporters</a>
-		    <li><a href="Memories.shtml">Memory Variables</a>
-		    <li><a href="Routes.shtml">Routes</a>
-		    <li><a href="LRoutes.shtml">LRoutes</a>
-		    <li><a href="Sections.shtml">Sections</a>
-		    <li><a href="Transits.shtml">Transits</a>
-		    <li><a href="Logix.shtml">Logix</a>
-		    <li><a href="fastclock/index.shtml">Fast Clocks</a>
-		    <li><a href="speedometer/index.shtml">Speedometer</a>
-		    <li><a href="Audio.shtml">Audio</a>
-		    <li><a href="IdTags.shtml">ID Tags</a>
-		    <li><a href="TimeTable.shtml">Timetable</a>
-		  </ul>
-		</dd>
+            <!--#include virtual="/help/en/parts/SidebarTools.shtml" -->
 
-		<dt><h3><a href="index.shtml#systemSpecificTools">System-specific Tools</a></h3></dt>
-		<dd>
-		  <ul>
-		    <li><a href="../hardware/acela/index.shtml#tools">Acela (CTI)</a>
-		    <li><a href="../hardware/cmri/CMRI.shtml#L258">C/MRI</a>
-		    <li><a href="../hardware/can/index.shtml#tools">CAN</a>
-		    <li><a href="../hardware/can/cbus/index.shtml#tools">MERG CBUS</a>
-		    <li><a href="../hardware/dccpp/index.shtml#tools">DCC++</a>
-		    <li><a href="../hardware/easydcc/EasyDCC.shtml#tools">EasyDCC</a>
-		    <li><a href="../hardware/ecos/index.shtml#tools">ESU ECoS</a>
-		    <li><a href="../hardware/grapevine/index.shtml#tools">Grapevine</a>
-		    <li><a href="../hardware/loconet/Digitrax.shtml#tools">LocoNet (Digitrax)</a>
-		    <li><a href="../hardware/marklin/index.shtml#tools">M&auml;rklin</a>
-		    <li><a href="../hardware/nce/NCE.shtml#tools">NCE</a>
-		    <li><a href="../hardware/openlcb/index.shtml#tools">OpenLCB</a>
-		    <li><a href="../hardware/rps/index.shtml#tools">RPS</a>
-		    <li><a href="../hardware/sprog/SPROG.shtml#tools">SPROG</a>
-		    <li><a href="../hardware/XBee/index.shtml#tools">XBee</a>
-		    <li><a href="../hardware/XPressNet/index.shtml#tools">XPressNet (Lenz)</a>
-		  </ul>
-                </dd>
+            <!--#include virtual="/help/en/parts/SidebarSupportedHardware.shtml" -->
 
-		<dt><h3><a href="automation/">Layout Automation</a></h3></dt>
-		<dd>JMRI can be used to automate parts
-		of your layout, from simply controlling a crossing gate
-		to running trains in the background.
-		  <ul>
-		    <li><a href="signaling/index.shtml">Signaling</a>
-                    <li><a href="EntryExit.shtml">Entry Exit (NX)</a>
-                    <li><a href="../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
-                    <li><a href="../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
-		    <li><a href="Routes.shtml">Routes</a>
-		    <li><a href="LRoutes.shtml">LRoutes</a>
-		    <li><a href="fastclock/index.shtml">Fast Clocks</a>
-		    <li><a href="uss/index.shtml">USS CTC</a>
-		    <li><a href="scripting/index.shtml">Scripting</a>
-		  </ul>
-		</dd>
+            <!--#include virtual="/help/en/parts/SidebarLayoutAutomation.shtml" -->
 
-	  </dl>
+         </dl>
 
-	</div> <!-- closes #side -->
+    </div> <!-- closes #side -->
 
     <!-- Sidebar-Tail -->
     <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
     <script type="text/javascript" src="/web/js/here.js"></script>
     <!-- /Sidebar-Tail -->
 
-<!-- /Sidebar -->
+<!-- /Sidebar.shtml -->

--- a/help/en/html/tools/Sidebar.shtml
+++ b/help/en/html/tools/Sidebar.shtml
@@ -1,0 +1,82 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/tools pages -->
+	<hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI is...</div>
+	    <dl>
+
+		<dt><h3><a href="index.shtml">Common Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+		  <ul>
+		    <li><a href="Turnouts.shtml">Turnouts</a>
+		    <li><a href="Lights.shtml">Lights</a>
+		    <li><a href="Sensors.shtml">Sensors</a>
+		    <li><a href="throttle/ThrottleMain.shtml">Throttles</a>
+		    <li><a href="consisttool/ConsistTool.shtml">Consisting</a>
+		    <li><a href="signaling/index.shtml">Signaling</a>
+		    <li><a href="Blocks.shtml">Blocks</a>
+		    <li><a href="Reporters.shtml">Reporters</a>
+		    <li><a href="Memories.shtml">Memory Variables</a>
+		    <li><a href="Routes.shtml">Routes</a>
+		    <li><a href="LRoutes.shtml">LRoutes</a>
+		    <li><a href="Sections.shtml">Sections</a>
+		    <li><a href="Transits.shtml">Transits</a>
+		    <li><a href="Logix.shtml">Logix</a>
+		    <li><a href="fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="speedometer/index.shtml">Speedometer</a>
+		    <li><a href="Audio.shtml">Audio</a>
+		    <li><a href="IdTags.shtml">ID Tags</a>
+		    <li><a href="TimeTable.shtml">Timetable</a>
+		  </ul>
+		</dd>
+
+		<dt><h3><a href="index.shtml#systemSpecificTools">System-specific Tools</a></h3></dt>
+		<dd>
+		  <ul>
+		    <li><a href="../hardware/acela/index.shtml#tools">Acela (CTI)</a>
+		    <li><a href="../hardware/cmri/CMRI.shtml#L258">C/MRI</a>
+		    <li><a href="../hardware/can/index.shtml#tools">CAN</a>
+		    <li><a href="../hardware/can/cbus/index.shtml#tools">MERG CBUS</a>
+		    <li><a href="../hardware/dccpp/index.shtml#tools">DCC++</a>
+		    <li><a href="../hardware/easydcc/EasyDCC.shtml#tools">EasyDCC</a>
+		    <li><a href="../hardware/ecos/index.shtml#tools">ESU ECoS</a>
+		    <li><a href="../hardware/grapevine/index.shtml#tools">Grapevine</a>
+		    <li><a href="../hardware/loconet/Digitrax.shtml#tools">LocoNet (Digitrax)</a>
+		    <li><a href="../hardware/marklin/index.shtml#tools">M&auml;rklin</a>
+		    <li><a href="../hardware/nce/NCE.shtml#tools">NCE</a>
+		    <li><a href="../hardware/openlcb/index.shtml#tools">OpenLCB</a>
+		    <li><a href="../hardware/rps/index.shtml#tools">RPS</a>
+		    <li><a href="../hardware/sprog/SPROG.shtml#tools">SPROG</a>
+		    <li><a href="../hardware/XBee/index.shtml#tools">XBee</a>
+		    <li><a href="../hardware/XPressNet/index.shtml#tools">XPressNet (Lenz)</a>
+		  </ul>
+                </dd>
+
+		<dt><h3><a href="automation/">Layout Automation</a></h3></dt>
+		<dd>JMRI can be used to automate parts
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		  <ul>
+		    <li><a href="signaling/index.shtml">Signaling</a>
+                    <li><a href="EntryExit.shtml">Entry Exit (NX)</a>
+                    <li><a href="../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+                    <li><a href="../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="Routes.shtml">Routes</a>
+		    <li><a href="LRoutes.shtml">LRoutes</a>
+		    <li><a href="fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="uss/index.shtml">USS CTC</a>
+		    <li><a href="scripting/index.shtml">Scripting</a>
+		  </ul>
+		</dd>
+
+	  </dl>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/tools/Signals.shtml
+++ b/help/en/html/tools/Signals.shtml
@@ -26,7 +26,7 @@
   <div id="container">
     <!--#include virtual="/Header" -->
     <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
       <div id="mainContent">
         <!-- Page Body -->
 

--- a/help/en/html/tools/TimeTable.shtml
+++ b/help/en/html/tools/TimeTable.shtml
@@ -72,7 +72,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <span class="since">since 4.13.4</span>

--- a/help/en/html/tools/Transits.shtml
+++ b/help/en/html/tools/Transits.shtml
@@ -17,7 +17,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Transits Documentation</h1>

--- a/help/en/html/tools/Turnouts.shtml
+++ b/help/en/html/tools/Turnouts.shtml
@@ -26,7 +26,7 @@
   <div id="container">
     <!--#include virtual="/Header" -->
     <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
       <div id="mainContent">
         <!-- Page Body -->
 

--- a/help/en/html/tools/automation/Sidebar.shtml
+++ b/help/en/html/tools/automation/Sidebar.shtml
@@ -1,0 +1,64 @@
+<!-- Sidebar -->
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI is...</div>
+	    <dl>
+
+		<dt><h3><a href="../scripting/index.shtml">Scripting</a></h3></dt>
+		<dd>Information on writing scripts to control JMRI in more detail:
+		    <ul>
+		    <li><a href="../scripting/Start.shtml">Introduction</a>
+		    <li><a href="../scripting/Python.shtml">The Language</a>
+		    <li><a href="../scripting/Examples.shtml">Examples</a>
+		    <li><a href="../scripting/ex_set_turnouts.shtml">Example: Setting Turnouts</a>
+		    <li><a href="../scripting/FAQ.shtml">Frequently Asked Questions (FAQs)</a>
+		    <li><a href="../scripting/Jynstruments.shtml">Jynstruments to modify the GUI</a>
+		    </ul>
+		</dd>
+
+		<dt><h3><a href="../index.shtml">Tools</a></h3></dt>
+		<dd>The general objects available to control your layout.
+		    <ul>
+				<li><a href="../Turnouts.shtml">Turnouts</a>
+				<li><a href="../Lights.shtml">Lights</a>
+				<li><a href="../Sensors.shtml">Sensors</a>
+				<li><a href="../throttle/ThrottleMain.shtml">Throttles</a>
+				<li><a href="../consisttool/ConsistTool.shtml">Consisting</a>
+				<li><a href="../signaling/index.shtml">Signaling</a>
+				<li><a href="../Blocks.shtml">Blocks</a>
+				<li><a href="../Reporters.shtml">Reporters</a>
+				<li><a href="../Memories.shtml">Memory Variables</a>
+				<li><a href="../Routes.shtml">Routes</a>
+				<li><a href="../LRoutes.shtml">LRoutes</a>
+		        <li><a href="../Sections.shtml">Sections</a>
+		        <li><a href="../Transits.shtml">Transits</a>
+				<li><a href="../Logix.shtml">Logix</a>
+				<li><a href="../fastclock/index.shtml">Fast Clocks</a>
+				<li><a href="../speedometer/index.shtml">Speedometer</a>
+				<li><a href="../Audio.shtml">Audio</a>
+				<li><a href="../IdTags.shtml">ID Tags</a>
+				<li><a href="../TimeTable.shtml">Timetable</a>
+		
+		    <li><a href="../index.shtml#systemSpecificTools">System-specific...</a>
+		    </ul>
+		</dd>
+
+  	    <dt><h3>Layout Automation</h3></dt>
+		<dd>Other tools for JMRI Automation:
+		    <ul>
+		    <li><a href="../signaling/index.shtml">Signaling</a>
+            <li><a href="../EntryExit.shtml">Entry Exit (NX)</a>
+            <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+            <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+            <li><a href="../Routes.shtml">Routes</a>
+		    <li><a href="../fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../uss/index.shtml">USS CTC</a>
+		    <li><a href="../scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+
+	    </dl>
+
+	</div> <!-- closes #side -->
+
+<!-- /Sidebar -->

--- a/help/en/html/tools/automation/index.shtml
+++ b/help/en/html/tools/automation/index.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/automation/viaJava.shtml
+++ b/help/en/html/tools/automation/viaJava.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/consisttool/ConsistTool.shtml
+++ b/help/en/html/tools/consisttool/ConsistTool.shtml
@@ -20,7 +20,7 @@
 <body>
 <!--#include virtual="/Header" -->
 <div id="mBody">
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 	<h1>JMRI: Consisting Tool</h1>

--- a/help/en/html/tools/consisttool/Sidebar.shtml
+++ b/help/en/html/tools/consisttool/Sidebar.shtml
@@ -1,0 +1,55 @@
+<!-- Sidebar -->
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	  <div style="text-align: center">JMRI is...</div>
+	  <dl>
+
+		<dt><h3><a href="../index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+			<ul>
+			<li><a href="../Turnouts.shtml">Turnouts</a>
+			<li><a href="../Lights.shtml">Lights</a>
+			<li><a href="../Sensors.shtml">Sensors</a>
+			<li><a href="../throttle/ThrottleMain.shtml">Throttles</a>
+			<li class="here"><a href="../consisttool/ConsistTool.shtml">Consisting</a>
+			<li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../Blocks.shtml">Blocks</a>
+			<li><a href="../Reporters.shtml">Reporters</a>
+			<li><a href="../Memories.shtml">Memory Variables</a>
+			<li><a href="../Routes.shtml">Routes</a>
+			<li><a href="../LRoutes.shtml">LRoutes</a>
+	        <li><a href="../Sections.shtml">Sections</a>
+	        <li><a href="../Transits.shtml">Transits</a>
+			<li><a href="../Logix.shtml">Logix</a>
+			<li><a href="../fastclock/index.shtml">Fast Clocks</a>
+			<li><a href="../speedometer/index.shtml">Speedometer</a>
+			<li><a href="../Audio.shtml">Audio</a>
+			<li><a href="../IdTags.shtml">ID Tags</a>
+			<li><a href="../TimeTable.shtml">Timetable</a>
+	
+	    <li><a href="../index.shtml#systemSpecificTools">System-specific...</a>
+	    </ul>
+		</dd>
+
+		<dt><h3><a href="../automation/index.shtml">Layout Automation</a></h3></dt>
+		<dd>JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+	        <ul>
+	        <li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../EntryExit.shtml">Entry Exit (NX)</a>
+			<li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+            <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+			<li><a href="../Routes.shtml">Routes</a>
+	        <li><a href="../fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../uss/index.shtml">USS CTC</a>
+	        <li><a href="../scripting/index.shtml">Scripting</a>
+	        </ul>
+		</dd>
+
+	  </dl>
+
+	</div> <!-- closes #side -->
+
+<!-- /Sidebar -->

--- a/help/en/html/tools/fastclock/LocoNetClock.shtml
+++ b/help/en/html/tools/fastclock/LocoNetClock.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI Fast Clocks - LocoNet Capability</h1>

--- a/help/en/html/tools/fastclock/Sidebar.shtml
+++ b/help/en/html/tools/fastclock/Sidebar.shtml
@@ -1,0 +1,54 @@
+<!-- Sidebar -->
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	  <div style="text-align: center">JMRI is...</div>
+	  <dl>
+
+		<dt><h3><a href="../index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+			<ul>
+			<li><a href="../Turnouts.shtml">Turnouts</a>
+			<li><a href="../Lights.shtml">Lights</a>
+			<li><a href="../Sensors.shtml">Sensors</a>
+			<li><a href="../throttle/ThrottleMain.shtml">Throttles</a>
+			<li><a href="../consisttool/ConsistTool.shtml">Consisting</a>
+			<li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../Blocks.shtml">Blocks</a>
+			<li><a href="../Reporters.shtml">Reporters</a>
+			<li><a href="../Memories.shtml">Memory Variables</a>
+			<li><a href="../Routes.shtml">Routes</a>
+			<li><a href="../LRoutes.shtml">LRoutes</a>
+	        <li><a href="../Sections.shtml">Sections</a>
+	        <li><a href="../Transits.shtml">Transits</a>
+			<li><a href="../Logix.shtml">Logix</a>
+			<li class="here"><a href="../fastclock/index.shtml">Fast Clocks</a>
+			<li><a href="../speedometer/index.shtml">Speedometer</a>
+			<li><a href="../Audio.shtml">Audio</a>
+			<li><a href="../IdTags.shtml">ID Tags</a>
+			<li><a href="../TimeTable.shtml">Timetable</a>
+	
+	    <li><a href="../index.shtml#systemSpecificTools">System-specific...</a>
+	    </ul>
+		</dd>
+
+		<dt><h3><a href="../automation/index.shtml">Layout Automation</a></h3></dt>
+		<dd>JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+	        <ul>
+	        <li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../EntryExit.shtml">Entry Exit (NX)</a>
+			<li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+            <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+			<li><a href="../Routes.shtml">Routes</a>
+			<li><a href="../uss/index.shtml">USS CTC</a>
+	        <li><a href="../scripting/index.shtml">Scripting</a>
+	        </ul>
+		</dd>
+
+	  </dl>
+
+	</div> <!-- closes #side -->
+
+<!-- /Sidebar -->

--- a/help/en/html/tools/fastclock/index.shtml
+++ b/help/en/html/tools/fastclock/index.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Fast Clocks</h1>

--- a/help/en/html/tools/index.shtml
+++ b/help/en/html/tools/index.shtml
@@ -24,7 +24,7 @@
   <div id="container">
     <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
         <!-- Page Body -->
 

--- a/help/en/html/tools/programmer/Sidebar.shtml
+++ b/help/en/html/tools/programmer/Sidebar.shtml
@@ -1,0 +1,55 @@
+<!-- Sidebar -->
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	  <div style="text-align: center">JMRI is...</div>
+	  <dl>
+
+		<dt><h3><a href="../index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+			<ul>
+			<li><a href="../Turnouts.shtml">Turnouts</a>
+			<li><a href="../Lights.shtml">Lights</a>
+			<li><a href="../Sensors.shtml">Sensors</a>
+			<li><a href="../throttle/ThrottleMain.shtml">Throttles</a>
+			<li><a href="../consisttool/ConsistTool.shtml">Consisting</a>
+			<li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../Blocks.shtml">Blocks</a>
+			<li><a href="../Reporters.shtml">Reporters</a>
+			<li><a href="../Memories.shtml">Memory Variables</a>
+			<li><a href="../Routes.shtml">Routes</a>
+			<li><a href="../LRoutes.shtml">LRoutes</a>
+	        <li><a href="../Sections.shtml">Sections</a>
+	        <li><a href="../Transits.shtml">Transits</a>
+			<li><a href="../Logix.shtml">Logix</a>
+			<li><a href="../fastclock/index.shtml">Fast Clocks</a>
+			<li><a href="../speedometer/index.shtml">Speedometer</a>
+			<li><a href="../Audio.shtml">Audio</a>
+			<li><a href="../IdTags.shtml">ID Tags</a>
+			<li><a href="../TimeTable.shtml">Timetable</a>
+	
+	        <li><a href="../index.shtml#systemSpecificTools">System-specific...</a>
+	        </ul>
+		</dd>
+
+		<dt><h3><a href="../automation/index.shtml">Layout Automation</a></h3></dt>
+		<dd>JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+	        <ul>
+	        <li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../EntryExit.shtml">Entry Exit (NX)</a>
+			<li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+            <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+			<li><a href="../Routes.shtml">Routes</a>
+	        <li><a href="../fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../uss/index.shtml">USS CTC</a>
+	        <li><a href="../scripting/index.shtml">Scripting</a>
+	        </ul>
+		</dd>
+
+	  </dl>
+
+	</div> <!-- closes #side -->
+
+<!-- /Sidebar -->

--- a/help/en/html/tools/programmer/messages.shtml
+++ b/help/en/html/tools/programmer/messages.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Error Messages</h1>

--- a/help/en/html/tools/scripting/AppleScript.shtml
+++ b/help/en/html/tools/scripting/AppleScript.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Open Scripting Architecture</h1>

--- a/help/en/html/tools/scripting/Examples.shtml
+++ b/help/en/html/tools/scripting/Examples.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/scripting/HowTo.shtml
+++ b/help/en/html/tools/scripting/HowTo.shtml
@@ -22,7 +22,7 @@
 <body id="HowToTopOfPage">
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/scripting/Jynstruments.shtml
+++ b/help/en/html/tools/scripting/Jynstruments.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Jynstruments</h1>JMRI provides a nice way to

--- a/help/en/html/tools/scripting/Python.shtml
+++ b/help/en/html/tools/scripting/Python.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/scripting/Sidebar.shtml
+++ b/help/en/html/tools/scripting/Sidebar.shtml
@@ -1,0 +1,86 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/tools/scripting pages -->
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	  <div style="text-align: center">JMRI is...</div>
+	  <dl>
+
+		<dt><h3>Scripting</h3></dt>
+		<dd>Information on writing scripts to control JMRI in more detail:
+		    <ul>
+		    <li><a href="Start.shtml">Getting Started</a>
+		    <li><a href="Python.shtml">The Python/Jython Language</a>
+		    <li><a href="ex_set_turnouts.shtml">Example: Setting Turnouts</a>
+		    <li><a href="Examples.shtml">Examples (Links)</a>
+		    <li><a href="HowTo.shtml">JMRI Scripting &quot;How To...&quot;</a>
+			<li><a href="WhatWhere.shtml">JMRI Scripting &quot;What...Where&quot;</a>
+			<li><a href="Jynstruments.shtml">Jynstruments to modify the GUI</a>
+            <li><a href="AppleScript.shtml">Open Scripting (for Mac)</a>
+		    </ul>
+		</dd>
+
+		<dt><h3><a href="Python.shtml">Python and Jython (General Info)</a></h3></dt>
+		<dd>JMRI scripts are in Jython, a version of Python, a popular general-purpose computer language
+		    <ul>
+		    <li><a href="Python.shtml">The Python/Jython Language</a>
+			<li><a href="http://www.python.org" target="_blank">Python home page</a>
+		    <li><a href="http://wiki.python.org/moin/BeginnersGuide/NonProgrammers" target="_blank">Python tutorial for non-programmers</a>
+		    <li><a href="http://wiki.python.org/moin/BeginnersGuide/Programmers" target="_blank">Python tutorial for programmers</a>
+		    </ul>
+		</dd>
+
+		<dt><h3><a href="../index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+			<ul>
+			<li><a href="../Turnouts.shtml">Turnouts</a>
+			<li><a href="../Lights.shtml">Lights</a>
+			<li><a href="../Sensors.shtml">Sensors</a>
+			<li><a href="../throttle/ThrottleMain.shtml">Throttles</a>
+			<li><a href="../consisttool/ConsistTool.shtml">Consisting</a>
+			<li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../Blocks.shtml">Blocks</a>
+			<li><a href="../Reporters.shtml">Reporters</a>
+			<li><a href="../Memories.shtml">Memory Variables</a>
+			<li><a href="../Routes.shtml">Routes</a>
+			<li><a href="../LRoutes.shtml">LRoutes</a>
+	        <li><a href="../Sections.shtml">Sections</a>
+	        <li><a href="../Transits.shtml">Transits</a>
+			<li><a href="../Logix.shtml">Logix</a>
+			<li><a href="../fastclock/index.shtml">Fast Clocks</a>
+			<li><a href="../speedometer/index.shtml">Speedometer</a>
+			<li><a href="../Audio.shtml">Audio</a>
+			<li><a href="../IdTags.shtml">Id Tags</a>
+			<li><a href="../TimeTable.shtml">Timetable</a>
+	
+	    <li><a href="../index.shtml#systemSpecificTools">System-specific...</a>
+	    </ul>
+		</dd>
+
+		<dt><h3><a href="../automation/index.shtml">Layout Automation</a></h3></dt>
+		<dd>JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+	        <ul>
+	          <li><a href="../signaling/index.shtml">Signaling</a>
+		  <li><a href="../EntryExit.shtml">Entry Exit (NX)</a>
+		  <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+                  <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		  <li><a href="../Routes.shtml">Routes</a>
+                  <li><a href="../LRoutes.shtml">LRoutes</a>
+	          <li><a href="../fastclock/index.shtml">Fast Clocks</a>
+	          <li><a href="../uss/index.shtml">USS CTC</a>
+	          <li class="here"><a href="../scripting/index.shtml">Scripting</a>
+	        </ul>
+		</dd>
+
+	  </dl>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/tools/scripting/Start.shtml
+++ b/help/en/html/tools/scripting/Start.shtml
@@ -22,7 +22,7 @@
 <body id="StartTopOfPage">
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/scripting/WhatWhere.shtml
+++ b/help/en/html/tools/scripting/WhatWhere.shtml
@@ -22,7 +22,7 @@
 <body id="WhatWhereTopOfPage">
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/scripting/ex_set_turnouts.shtml
+++ b/help/en/html/tools/scripting/ex_set_turnouts.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/scripting/index.shtml
+++ b/help/en/html/tools/scripting/index.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/signaling/AspectSignaling.shtml
+++ b/help/en/html/tools/signaling/AspectSignaling.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
     <h1>JMRI: Aspect Signaling</h1>

--- a/help/en/html/tools/signaling/DefineNewAspects.shtml
+++ b/help/en/html/tools/signaling/DefineNewAspects.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Defining Your Own Signaling System</h1>This page

--- a/help/en/html/tools/signaling/Logic.shtml
+++ b/help/en/html/tools/signaling/Logic.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Simple Signal Logic</h1>

--- a/help/en/html/tools/signaling/Sidebar.shtml
+++ b/help/en/html/tools/signaling/Sidebar.shtml
@@ -1,0 +1,75 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for tools/Signaling pages -->
+<hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI is...</div>
+	    <dl>
+
+		<dt><h3>Signaling</h3></dt>
+		<dd>Adding signals to your layout with JMRI.
+		    <ul>
+		    <li><a href="SignalingSetup.shtml">Signaling Quick Start</a>
+		    <li><a href="AspectSignaling.shtml">Aspect Signaling</a>
+		    <li><a href="SignalHeads.shtml">Signal Heads</a>
+		    <li><a href="SignalMasts.shtml">Signal Masts</a>
+		    <li><a href="SignalGroups.shtml">Signal Groups</a>
+		    <li><a href="SignalMastLogic.shtml">Signal Mast Logic</a>
+		    <li><a href="interlock/index.shtml">Entry Exit &amp; Interlocking</a>
+		    <li><a href="../../../package/jmri/jmrit/cabsignals/CabSignalPane.shtml">Cab Signaling</a>
+		    </ul>
+		</dd>
+
+		<dt><h3><a href="../index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+			<ul>
+			<li><a href="../Turnouts.shtml">Turnouts</a>
+			<li><a href="../Lights.shtml">Lights</a>
+			<li><a href="../Sensors.shtml">Sensors</a>
+			<li><a href="../throttle/ThrottleMain.shtml">Throttles</a>
+			<li><a href="../consisttool/ConsistTool.shtml">Consisting</a>
+			<li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../Blocks.shtml">Blocks</a>
+			<li><a href="../Reporters.shtml">Reporters</a>
+			<li><a href="../Memories.shtml">Memory Variables</a>
+			<li><a href="../Routes.shtml">Routes</a>
+			<li><a href="../LRoutes.shtml">LRoutes</a>
+	        <li><a href="../Sections.shtml">Sections</a>
+	        <li><a href="../Transits.shtml">Transits</a>
+			<li><a href="../Logix.shtml">Logix</a>
+			<li><a href="../fastclock/index.shtml">Fast Clocks</a>
+			<li><a href="../speedometer/index.shtml">Speedometer</a>
+			<li><a href="../Audio.shtml">Audio</a>
+			<li><a href="../IdTags.shtml">ID Tags</a>
+			<li><a href="../TimeTable.shtml">Timetable</a>
+	
+	    <li><a href="../index.shtml#systemSpecificTools">System-specific...</a>
+	    </ul>
+		</dd>
+
+		<dt><h3><a href="../automation/index.shtml">Layout Automation</a></h3></dt>
+		<dd>JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+	        <ul>
+	        <li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../EntryExit.shtml">Entry Exit (NX)</a>
+			<li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+            <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+			<li><a href="../Routes.shtml">Routes</a>
+	        <li><a href="../fastclock/index.shtml">Fast Clocks</a>
+	        <li><a href="../uss/index.shtml">USS CTC</a>
+	        <li><a href="../scripting/index.shtml">Scripting</a>
+	        </ul>
+		</dd>
+
+	    </dl>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/tools/signaling/SignalGroups.shtml
+++ b/help/en/html/tools/signaling/SignalGroups.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/signaling/SignalHeads.shtml
+++ b/help/en/html/tools/signaling/SignalHeads.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/signaling/SignalMastLogic.shtml
+++ b/help/en/html/tools/signaling/SignalMastLogic.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Signal Mast Logic</h1>

--- a/help/en/html/tools/signaling/SignalMasts.shtml
+++ b/help/en/html/tools/signaling/SignalMasts.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Signal Masts</h1>

--- a/help/en/html/tools/signaling/SignalingSetup.shtml
+++ b/help/en/html/tools/signaling/SignalingSetup.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/signaling/SimpleSignalExample.shtml
+++ b/help/en/html/tools/signaling/SimpleSignalExample.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/signaling/index.shtml
+++ b/help/en/html/tools/signaling/index.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/html/tools/signaling/interlock/Sidebar.shtml
+++ b/help/en/html/tools/signaling/interlock/Sidebar.shtml
@@ -1,0 +1,69 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for tools/Signaling/interlock pages -->
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI is...</div>
+	    <dl>
+
+		<dt><h3><a href="../index.shtml">Signaling</a></h3></dt>
+		<dd>Adding signals to your layout with JMRI.
+		    <ul>
+		    <li><a href="../SignalingSetup.shtml">Signaling Quick Start</a>
+		    <li><a href="../AspectSignaling.shtml">Aspect Signaling</a>
+		    <li><a href="../SignalHeads.shtml">Signal Heads</a>
+		    <li><a href="../SignalMasts.shtml">Signal Masts</a>
+		    <li><a href="../SignalGroups.shtml">Signal Groups</a>
+		    <li><a href="../SignalMastLogic.shtml">Signal Mast Logic</a>
+		    <li class="here">Entry Exit &amp; Interlocking <!-- you're here now -->
+		    </ul>
+		</dd>
+
+		<dt><h3><a href="index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+		    <ul>
+				<li><a href="../../Turnouts.shtml">Turnouts</a>
+				<li><a href="../../Lights.shtml">Lights</a>
+				<li><a href="../../Sensors.shtml">Sensors</a>
+				<li><a href="../../throttle/ThrottleMain.shtml">Throttles</a>
+				<li><a href="../../consisttool/ConsistTool.shtml">Consisting</a>
+				<li><a href="../../signaling/index.shtml">Signaling</a>
+				<li><a href="../../Blocks.shtml">Blocks</a>
+				<li><a href="../../Reporters.shtml">Reporters</a>
+				<li><a href="../../Memories.shtml">Memory Variables</a>
+				<li><a href="../../Routes.shtml">Routes</a>
+				<li><a href="../../LRoutes.shtml">LRoutes</a>
+		        <li><a href="../../Sections.shtml">Sections</a>
+		        <li><a href="../../Transits.shtml">Transits</a>
+				<li><a href="../../Logix.shtml">Logix</a>
+				<li><a href="../../fastclock/index.shtml">Fast Clocks</a>
+				<li><a href="../../speedometer/index.shtml">Speedometer</a>
+				<li><a href="../../Audio.shtml">Audio</a>
+				<li><a href="../../IdTags.shtml">ID Tags</a>
+				<li><a href="../../TimeTable.shtml">Timetable</a>
+		
+		    <li><a href="../../index.shtml#systemSpecificTools">System-specific...</a>
+		   </ul>
+		</dd>
+
+		<dt><h3><a href="../../automation/index.shtml">Layout Automation</a></h3></dt>
+		<dd>JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../index.shtml">Signaling</a>
+  			<li><a href="../../EntryExit.shtml">Entry Exit (NX)</a>
+  			<li><a href="../../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+            <li><a href="../../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="../../Routes.shtml">Routes</a>
+		    <li><a href="../../fastclock/">Fast Clocks</a>
+		    <li><a href="../../uss/index.shtml">USS CTC</a>
+		    <li><a href="../../scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+
+	    </dl>
+
+	</div> <!-- closes #side -->
+
+<!-- /Sidebar -->

--- a/help/en/html/tools/signaling/interlock/index.shtml
+++ b/help/en/html/tools/signaling/interlock/index.shtml
@@ -24,7 +24,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Entry Exit and Interlocking</h1>

--- a/help/en/html/tools/speedometer/NCE-Speedometer.shtml
+++ b/help/en/html/tools/speedometer/NCE-Speedometer.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Speedometer</h1>

--- a/help/en/html/tools/speedometer/Serialsensor.shtml
+++ b/help/en/html/tools/speedometer/Serialsensor.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Speedometer</h1>

--- a/help/en/html/tools/speedometer/Sidebar.shtml
+++ b/help/en/html/tools/speedometer/Sidebar.shtml
@@ -1,0 +1,60 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for tools/speedometer pages -->
+<hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI is...</div>
+	    <dl>
+
+		<dt><h3><a href="index.shtml">Speedometer</a></h3></dt>
+		<dd>Speed matching tool
+		</dd>
+
+		<dt><h3><a href="../index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+			<ul>
+			<li><a href="../Turnouts.shtml">Turnouts</a>
+			<li><a href="../Lights.shtml">Lights</a>
+			<li><a href="../Sensors.shtml">Sensors</a>
+			<li><a href="../throttle/ThrottleMain.shtml">Throttles</a>
+			<li><a href="../consisttool/ConsistTool.shtml">Consisting</a>
+			<li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../Blocks.shtml">Blocks</a>
+			<li><a href="../Reporters.shtml">Reporters</a>
+			<li><a href="../Memories.shtml">Memory Variables</a>
+			<li><a href="../Routes.shtml">Routes</a>
+			<li><a href="../LRoutes.shtml">LRoutes</a>
+	        <li><a href="../Sections.shtml">Sections</a>
+	        <li><a href="../Transits.shtml">Transits</a>
+			<li><a href="../Logix.shtml">Logix</a>
+			<li><a href="../fastclock/index.shtml">Fast Clocks</a>
+			<li class="here"><a href="../speedometer/index.shtml">Speedometer</a>
+			<li><a href="../Audio.shtml">Audio</a>
+			<li><a href="../IdTags.shtml">ID Tags</a>
+			<li><a href="../TimeTable.shtml">Timetable</a>
+	
+	    <li><a href="../index.shtml#systemSpecificTools">System-specific...</a>
+	    </ul>		
+    </dd>
+
+		<dt><h3><a href="../automation/index.shtml">Layout Automation</a></h3></dt>
+		<dd>JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		    <ul>
+		    <li><a href="../signaling/index.shtml">Signaling</a>
+            <li><a href="../EntryExit.shtml">Entry Exit (NX)</a>
+            <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+            <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+            <li><a href="../Routes.shtml">Routes</a>
+		    <li><a href="../fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="../uss/index.shtml">USS CTC</a>
+		    <li><a href="../scripting/index.shtml">Scripting</a>
+		    </ul>
+		</dd>
+
+	    </dl>
+
+	</div> <!-- closes #side -->
+
+<!-- /Sidebar -->

--- a/help/en/html/tools/speedometer/SpeedMatch.shtml
+++ b/help/en/html/tools/speedometer/SpeedMatch.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Speedometer</h1>

--- a/help/en/html/tools/speedometer/index.shtml
+++ b/help/en/html/tools/speedometer/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Speedometer</h1>

--- a/help/en/html/tools/throttle/AdvancedThrottleControl.shtml
+++ b/help/en/html/tools/throttle/AdvancedThrottleControl.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Advanced Throttle Control</h1>

--- a/help/en/html/tools/throttle/BasicThrottleWindow.shtml
+++ b/help/en/html/tools/throttle/BasicThrottleWindow.shtml
@@ -35,7 +35,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Using the Throttle Pane</h1><img src=

--- a/help/en/html/tools/throttle/HowToJMRIOrientedThrottle.shtml
+++ b/help/en/html/tools/throttle/HowToJMRIOrientedThrottle.shtml
@@ -32,7 +32,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>How to build a throttle oriented JMRI interface</h1>For

--- a/help/en/html/tools/throttle/RostersMediaPane.shtml
+++ b/help/en/html/tools/throttle/RostersMediaPane.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h2>Setting Roster Media</h2><img src=

--- a/help/en/html/tools/throttle/Sidebar.shtml
+++ b/help/en/html/tools/throttle/Sidebar.shtml
@@ -1,0 +1,79 @@
+<hr class="hide">
+<!-- This is the common sidebar definition for html/tools/throttle pages -->
+  <div id="side"> <!-- Block of text on left side of page -->
+
+	<dl>
+      <dt><h3><a href="ThrottleTOC.shtml" title="Click to view the Throttle Tool Table of Contents">Throttles</a></h3>
+      </dt>
+      <dd>
+		<ul>
+		  <li><a href="ThrottleMain.shtml" title="The Throttle tool">The Throttle Tool</a>
+		  <li><a href="ToolsMenuThrottleEntry.shtml">Open a...</a></li>
+		  <li><a href="BasicThrottleWindow.shtml">Throttle</a></li>
+		  <li><a href="ThrottleWindowMenus.shtml">Menus</a></li>
+		  <li><a href="ThrottleToolBar.shtml">Toolbar</a></li>
+		  <li><a href="AdvancedThrottleControl.shtml">Controls</a></li>
+		  <li><a href="ThrottlesListWindow.shtml">List</a></li>
+		  <li><a href="ThrottlesPreferencesPane.shtml">Preferences</a><br>
+		  </li>
+		</ul>
+	
+		<ul>
+		  <li>The <a href="RostersMediaPane.shtml">Media and Function Labels</a></li>
+		  <li><a href="../scripting/Jynstruments.shtml">Jynstruments</a></li>
+		  <li><a href="HowToJMRIOrientedThrottle.shtml">Building a Throttle oriented JMRI</a></li>
+		</ul>
+	  </dd>
+	  	        
+	<dt><h3><a href="../index.shtml">Tools</a></h3></dt>
+	<dd>JMRI provides powerful tools for working with your
+	layout.
+			<ul>
+			<li><a href="../Turnouts.shtml">Turnouts</a>
+			<li><a href="../Lights.shtml">Lights</a>
+			<li><a href="../Sensors.shtml">Sensors</a>
+			<li class="here"><a href="../throttle/ThrottleMain.shtml">Throttles</a>
+			<li><a href="../consisttool/ConsistTool.shtml">Consisting</a>
+			<li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../Blocks.shtml">Blocks</a>
+			<li><a href="../Reporters.shtml">Reporters</a>
+			<li><a href="../Memories.shtml">Memory Variables</a>
+			<li><a href="../Routes.shtml">Routes</a>
+			<li><a href="../LRoutes.shtml">LRoutes</a>
+	        <li><a href="../Sections.shtml">Sections</a>
+	        <li><a href="../Transits.shtml">Transits</a>
+			<li><a href="../Logix.shtml">Logix</a>
+			<li><a href="../fastclock/index.shtml">Fast Clocks</a>
+			<li><a href="../speedometer/index.shtml">Speedometer</a>
+			<li><a href="../Audio.shtml">Audio</a>
+			<li><a href="../IdTags.shtml">Id Tags</a>
+			<li><a href="../TimeTable.shtml">Timetable</a>
+		
+		<li><a href="../index.shtml#systemSpecificTools">System-specific...</a>
+		</ul>		
+	</dd>
+
+	<dt><h3><a href="../automation/index.shtml">Layout Automation</a></h3></dt>
+	<dd>JMRI can be used to automate parts 
+	of your layout, from simply controlling a crossing gate
+	to running trains in the background.
+	    <ul>
+	    <li><a href="../signaling/index.shtml">Signaling</a>
+        <li><a href="../EntryExit.shtml">Entry Exit (NX)</a>
+ 		<li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+        <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+        <li><a href="../Routes.shtml">Routes</a>
+	    <li><a href="../fastclock/index.shtml">Fast Clocks</a>
+	    <li><a href="../uss/index.shtml">USS CTC</a>
+	    <li><a href="../scripting/index.shtml">Scripting</a>
+	    </ul>
+	</dd>
+		     
+</dl>
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+</div>

--- a/help/en/html/tools/throttle/ThrottleChapter1.shtml
+++ b/help/en/html/tools/throttle/ThrottleChapter1.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Current Throttle documentation</h1>

--- a/help/en/html/tools/throttle/ThrottleChapter2.shtml
+++ b/help/en/html/tools/throttle/ThrottleChapter2.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Current Throttle documentation</h1>

--- a/help/en/html/tools/throttle/ThrottleChapter3.shtml
+++ b/help/en/html/tools/throttle/ThrottleChapter3.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Current Throttle documentation</h1>

--- a/help/en/html/tools/throttle/ThrottleChapter4.shtml
+++ b/help/en/html/tools/throttle/ThrottleChapter4.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Current Throttle documentation</h1>

--- a/help/en/html/tools/throttle/ThrottleMain.shtml
+++ b/help/en/html/tools/throttle/ThrottleMain.shtml
@@ -27,7 +27,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Throttles Documentation</h1>

--- a/help/en/html/tools/throttle/ThrottleTOC.shtml
+++ b/help/en/html/tools/throttle/ThrottleTOC.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Throttle Documentation</h1>

--- a/help/en/html/tools/throttle/ThrottleToolBar.shtml
+++ b/help/en/html/tools/throttle/ThrottleToolBar.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Throttle pane Toolbar</h1><img src=

--- a/help/en/html/tools/throttle/ThrottleWindowMenus.shtml
+++ b/help/en/html/tools/throttle/ThrottleWindowMenus.shtml
@@ -27,7 +27,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Throttle Menus</h1>

--- a/help/en/html/tools/throttle/ThrottlesListWindow.shtml
+++ b/help/en/html/tools/throttle/ThrottlesListWindow.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Throttles List</h1>

--- a/help/en/html/tools/throttle/ThrottlesPreferencesPane.shtml
+++ b/help/en/html/tools/throttle/ThrottlesPreferencesPane.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Throttles Preferences</h1><img src=

--- a/help/en/html/tools/throttle/ToolsMenuThrottleEntry.shtml
+++ b/help/en/html/tools/throttle/ToolsMenuThrottleEntry.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Tools &gt; Throttles menu</h1><img src=

--- a/help/en/html/tools/tracker/Sidebar.shtml
+++ b/help/en/html/tools/tracker/Sidebar.shtml
@@ -1,0 +1,57 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for tools/tracker pages -->
+          <hr class="hide">
+
+	  <div id="side"> <!-- Block of text on left side of page -->
+	  <div style="text-align: center">JMRI is...</div>
+	  <dl>
+
+		<dt><h3><a href="../index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+			<ul>
+			<li><a href="../Turnouts.shtml">Turnouts</a>
+			<li><a href="../Lights.shtml">Lights</a>
+			<li><a href="../Sensors.shtml">Sensors</a>
+			<li><a href="../throttle/ThrottleMain.shtml">Throttles</a>
+			<li><a href="../consisttool/ConsistTool.shtml">Consisting</a>
+			<li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../Blocks.shtml">Blocks</a>
+			<li><a href="../Reporters.shtml">Reporters</a>
+			<li><a href="../Memories.shtml">Memory Variables</a>
+			<li><a href="../Routes.shtml">Routes</a>
+			<li><a href="../LRoutes.shtml">LRoutes</a>
+	        <li><a href="../Sections.shtml">Sections</a>
+	        <li><a href="../Transits.shtml">Transits</a>
+			<li><a href="../Logix.shtml">Logix</a>
+			<li><a href="../fastclock/index.shtml">Fast Clocks</a>
+			<li><a href="../speedometer/index.shtml">Speedometer</a>
+			<li><a href="../Audio.shtml">Audio</a>
+			<li><a href="../IdTags.shtml">ID Tags</a>
+			<li><a href="../TimeTable.shtml">Timetable</a>
+	
+	        <li><a href="../index.shtml#systemSpecificTools">System-specific...</a>
+	    </ul>
+		</dd>
+
+		<dt><h3><a href="../automation/index.shtml">Layout Automation</a></h3></dt>
+		<dd>JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+	    <ul>
+            <li><a href="../signaling/index.shtml">Signaling</a>
+            <li><a href="../EntryExit.shtml">Entry Exit (NX)</a>
+            <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+            <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+            <li><a href="../Routes.shtml">Routes</a>
+            <li><a href="../fastclock/index.shtml">Fast Clocks</a>
+            <li><a href="../uss/index.shtml">USS CTC</a>
+            <li><a href="../scripting/index.shtml">Scripting</a>
+	    </ul>
+		</dd>
+
+	  </dl>
+
+	</div> <!-- closes #side -->
+
+<!-- /Sidebar -->

--- a/help/en/html/tools/tracker/index.shtml
+++ b/help/en/html/tools/tracker/index.shtml
@@ -25,7 +25,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h2>JMRI: Block Tracking</h2>

--- a/help/en/html/tools/uss/Conventions.shtml
+++ b/help/en/html/tools/uss/Conventions.shtml
@@ -19,7 +19,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h2>JMRI: USS CTC Tools Recommendations</h2>

--- a/help/en/html/tools/uss/Sidebar.shtml
+++ b/help/en/html/tools/uss/Sidebar.shtml
@@ -1,0 +1,57 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for tools/uss pages -->
+          <hr class="hide">
+
+	  <div id="side"> <!-- Block of text on left side of page -->
+	  <div style="text-align: center">JMRI is...</div>
+	  <dl>
+
+		<dt><h3><a href="../index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+			<ul>
+			<li><a href="../Turnouts.shtml">Turnouts</a>
+			<li><a href="../Lights.shtml">Lights</a>
+			<li><a href="../Sensors.shtml">Sensors</a>
+			<li><a href="../throttle/ThrottleMain.shtml">Throttles</a>
+			<li><a href="../consisttool/ConsistTool.shtml">Consisting</a>
+			<li><a href="../signaling/index.shtml">Signaling</a>
+			<li><a href="../Blocks.shtml">Blocks</a>
+			<li><a href="../Reporters.shtml">Reporters</a>
+			<li><a href="../Memories.shtml">Memory Variables</a>
+			<li><a href="../Routes.shtml">Routes</a>
+			<li><a href="../LRoutes.shtml">LRoutes</a>
+	        <li><a href="../Sections.shtml">Sections</a>
+	        <li><a href="../Transits.shtml">Transits</a>
+			<li><a href="../Logix.shtml">Logix</a>
+			<li><a href="../fastclock/index.shtml">Fast Clocks</a>
+			<li><a href="../speedometer/index.shtml">Speedometer</a>
+			<li><a href="../Audio.shtml">Audio</a>
+			<li><a href="../IdTags.shtml">ID Tags</a>
+			<li><a href="../TimeTable.shtml">Timetable</a>
+	
+	    <li><a href="../index.shtml#systemSpecificTools">System-specific...</a>
+	    </ul>
+		</dd>
+
+		<dt><h3><a href="../automation/index.shtml">Layout Automation</a></h3></dt>
+		<dd>JMRI can be used to automate parts 
+		of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+	    <ul>
+	    <li><a href="../signaling/index.shtml">Signaling</a>
+		<li><a href="../EntryExit.shtml">Entry Exit (NX)</a>
+		<li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+        <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		<li><a href="../Routes.shtml">Routes</a>
+	    <li><a href="../fastclock/index.shtml">Fast Clocks</a>
+	    <li class="here">USS CTC
+	    <li><a href="../scripting/index.shtml">Scripting</a>
+	    </ul>
+		</dd>
+
+	  </dl>
+
+	</div> <!-- closes #side -->
+
+<!-- /Sidebar -->

--- a/help/en/html/tools/uss/index.shtml
+++ b/help/en/html/tools/uss/index.shtml
@@ -19,7 +19,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-      <!--#include virtual="Sidebar" -->
+      <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h2>JMRI: Utils USS CTC Tools</h2>

--- a/help/en/html/web/FrameServlet.shtml
+++ b/help/en/html/web/FrameServlet.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Frame Servlet</h1>The JMRI Frame Servlet provides

--- a/help/en/html/web/JsonServlet.shtml
+++ b/help/en/html/web/JsonServlet.shtml
@@ -38,7 +38,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI JSON Servlet</h1>

--- a/help/en/html/web/Operations.shtml
+++ b/help/en/html/web/Operations.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Operations web functions</h1>

--- a/help/en/html/web/PanelServlet.shtml
+++ b/help/en/html/web/PanelServlet.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI Remote Panels</h1>

--- a/help/en/html/web/RosterServlet.shtml
+++ b/help/en/html/web/RosterServlet.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: Roster Servlet</h1>The JMRI Roster Servlet provides

--- a/help/en/html/web/Sidebar.shtml
+++ b/help/en/html/web/Sidebar.shtml
@@ -1,0 +1,36 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for html/web pages -->
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page -->
+	    <div style="text-align: center">JMRI Web Access</div>
+	    <dl>
+
+		<dt><h3><a href="index.shtml">Basic Use</a></h3></dt>
+		<dd>JMRI supports working with your layout from a web browser.
+		    <ul>
+		    <li><a href="index.shtml#Start">Getting Started</a></li>
+		    <li><a href="index.shtml#Configure">Configure</a></li>
+		    <li><a href="index.shtml#files">URLs</a></li>
+		    </ul>
+		</dd>
+
+		<dt><h3>Services</h3></dt>
+		<dd>Details of the JMRI web services.
+		    <ul>
+		    <li><a href="FrameServlet.shtml">Frames</a></li>
+		    <li><a href="JsonServlet.shtml">JSON</a></li>
+		    <li><a href="PanelServlet.shtml">Panels</a></li>
+		    <li><a href="RosterServlet.shtml">Roster</a></li>
+		    </ul>
+		</dd>
+
+	    </dl>
+
+	</div> <!-- closes #side -->
+
+    <!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+    <!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/html/web/XMLIO.shtml
+++ b/help/en/html/web/XMLIO.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI: XML I/O Servlet - no longer

--- a/help/en/html/web/index.shtml
+++ b/help/en/html/web/index.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>JMRI Web Access</h1>

--- a/help/en/manual/DecoderPro/Adv_FunctionLabel.shtml
+++ b/help/en/manual/DecoderPro/Adv_FunctionLabel.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent"></div><a name="Top" id="Top"></a>
 
     <h1>DecoderPro&reg; Advanced Programmer</h1>

--- a/help/en/manual/DecoderPro/Adv_RosterMedia.shtml
+++ b/help/en/manual/DecoderPro/Adv_RosterMedia.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Adv_start.shtml
+++ b/help/en/manual/DecoderPro/Adv_start.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Basic_BasicPane.shtml
+++ b/help/en/manual/DecoderPro/Basic_BasicPane.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Basic_Mode.shtml
+++ b/help/en/manual/DecoderPro/Basic_Mode.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Basic_Start.shtml
+++ b/help/en/manual/DecoderPro/Basic_Start.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>The Basic Programmer</h1>

--- a/help/en/manual/DecoderPro/Comp_Advanced.shtml
+++ b/help/en/manual/DecoderPro/Comp_Advanced.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_Analog.shtml
+++ b/help/en/manual/DecoderPro/Comp_Analog.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_Basic.shtml
+++ b/help/en/manual/DecoderPro/Comp_Basic.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_Consist.shtml
+++ b/help/en/manual/DecoderPro/Comp_Consist.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_FMap.shtml
+++ b/help/en/manual/DecoderPro/Comp_FMap.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_FunctionLabel.shtml
+++ b/help/en/manual/DecoderPro/Comp_FunctionLabel.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_GlobalCVs.shtml
+++ b/help/en/manual/DecoderPro/Comp_GlobalCVs.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_LightFX.shtml
+++ b/help/en/manual/DecoderPro/Comp_LightFX.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_ManfSpecific.shtml
+++ b/help/en/manual/DecoderPro/Comp_ManfSpecific.shtml
@@ -20,7 +20,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_Motor.shtml
+++ b/help/en/manual/DecoderPro/Comp_Motor.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/help/en/manual/DecoderPro/Comp_PrintData.shtml
+++ b/help/en/manual/DecoderPro/Comp_PrintData.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/help/en/manual/DecoderPro/Comp_PrintData_a.shtml
+++ b/help/en/manual/DecoderPro/Comp_PrintData_a.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src=
       "images/Comp_09a_PrintData.png" alt=

--- a/help/en/manual/DecoderPro/Comp_PrintData_b.shtml
+++ b/help/en/manual/DecoderPro/Comp_PrintData_b.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src=
       "images/Comp_09b_PrintData.png" alt=

--- a/help/en/manual/DecoderPro/Comp_PrintData_c.shtml
+++ b/help/en/manual/DecoderPro/Comp_PrintData_c.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src=
       "images/Comp_09c_PrintData.png" alt=

--- a/help/en/manual/DecoderPro/Comp_Setup_Roster.shtml
+++ b/help/en/manual/DecoderPro/Comp_Setup_Roster.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_SoundFX.shtml
+++ b/help/en/manual/DecoderPro/Comp_SoundFX.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_SoundLevels.shtml
+++ b/help/en/manual/DecoderPro/Comp_SoundLevels.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_Speed.shtml
+++ b/help/en/manual/DecoderPro/Comp_Speed.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Comp_Speed_Talble.shtml
+++ b/help/en/manual/DecoderPro/Comp_Speed_Talble.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Dcode_Format.shtml
+++ b/help/en/manual/DecoderPro/Dcode_Format.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Dcode_Start.shtml
+++ b/help/en/manual/DecoderPro/Dcode_Start.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Dcode_Submit.shtml
+++ b/help/en/manual/DecoderPro/Dcode_Submit.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Dcode_Testing.shtml
+++ b/help/en/manual/DecoderPro/Dcode_Testing.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <h1>Decoder Definition</h1>
 

--- a/help/en/manual/DecoderPro/Error.shtml
+++ b/help/en/manual/DecoderPro/Error.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Error Messages</h1>

--- a/help/en/manual/DecoderPro/Installing_JMRI.shtml
+++ b/help/en/manual/DecoderPro/Installing_JMRI.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src="images/logo.gif" alt=
       "JMRI DecoderPro Logo" border="0" height="135" width="160"

--- a/help/en/manual/DecoderPro/Main_CMRI.shtml
+++ b/help/en/manual/DecoderPro/Main_CMRI.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_ConsistControl.shtml
+++ b/help/en/manual/DecoderPro/Main_ConsistControl.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Tool Menu</h1>

--- a/help/en/manual/DecoderPro/Main_Debug.shtml
+++ b/help/en/manual/DecoderPro/Main_Debug.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_EasyDCC.shtml
+++ b/help/en/manual/DecoderPro/Main_EasyDCC.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Edit.shtml
+++ b/help/en/manual/DecoderPro/Main_Edit.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_FastClockSetup.shtml
+++ b/help/en/manual/DecoderPro/Main_FastClockSetup.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Tool Menu</h1>

--- a/help/en/manual/DecoderPro/Main_File.shtml
+++ b/help/en/manual/DecoderPro/Main_File.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_GrapeVine.shtml
+++ b/help/en/manual/DecoderPro/Main_GrapeVine.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_Help.shtml
+++ b/help/en/manual/DecoderPro/Main_Help.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_LocoNet.shtml
+++ b/help/en/manual/DecoderPro/Main_LocoNet.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Main.shtml
+++ b/help/en/manual/DecoderPro/Main_Main.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Menu.shtml
+++ b/help/en/manual/DecoderPro/Main_Menu.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Monitor_Window.shtml
+++ b/help/en/manual/DecoderPro/Main_Monitor_Window.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_NCE.shtml
+++ b/help/en/manual/DecoderPro/Main_NCE.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_OakTreeSystems.shtml
+++ b/help/en/manual/DecoderPro/Main_OakTreeSystems.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_PRICOM.shtml
+++ b/help/en/manual/DecoderPro/Main_PRICOM.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Debug Menu</h1>

--- a/help/en/manual/DecoderPro/Main_Panels.shtml
+++ b/help/en/manual/DecoderPro/Main_Panels.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Powerline.shtml
+++ b/help/en/manual/DecoderPro/Main_Powerline.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_QSI.shtml
+++ b/help/en/manual/DecoderPro/Main_QSI.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_RPS.shtml
+++ b/help/en/manual/DecoderPro/Main_RPS.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_Roster.shtml
+++ b/help/en/manual/DecoderPro/Main_Roster.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_RosterGroup.shtml
+++ b/help/en/manual/DecoderPro/Main_RosterGroup.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_SECSI.shtml
+++ b/help/en/manual/DecoderPro/Main_SECSI.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_SPROG.shtml
+++ b/help/en/manual/DecoderPro/Main_SPROG.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_Speedometer.shtml
+++ b/help/en/manual/DecoderPro/Main_Speedometer.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Tool Menu</h1>

--- a/help/en/manual/DecoderPro/Main_Speeometer.shtml
+++ b/help/en/manual/DecoderPro/Main_Speeometer.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_TMCC.shtml
+++ b/help/en/manual/DecoderPro/Main_TMCC.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_Throttle.shtml
+++ b/help/en/manual/DecoderPro/Main_Throttle.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Throttle_FrameProperties.shtml
+++ b/help/en/manual/DecoderPro/Main_Throttle_FrameProperties.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Throttle_List.shtml
+++ b/help/en/manual/DecoderPro/Main_Throttle_List.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Throttle_addressPanel.shtml
+++ b/help/en/manual/DecoderPro/Main_Throttle_addressPanel.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Throttle_controlPanel.html
+++ b/help/en/manual/DecoderPro/Main_Throttle_controlPanel.html
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Throttle_controlPanel.shtml
+++ b/help/en/manual/DecoderPro/Main_Throttle_controlPanel.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Throttle_functionPanel.html
+++ b/help/en/manual/DecoderPro/Main_Throttle_functionPanel.html
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Throttle_functionPanel.shtml
+++ b/help/en/manual/DecoderPro/Main_Throttle_functionPanel.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Throttle_menubar.shtml
+++ b/help/en/manual/DecoderPro/Main_Throttle_menubar.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Throttle_toolbar.shtml
+++ b/help/en/manual/DecoderPro/Main_Throttle_toolbar.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_Tool.shtml
+++ b/help/en/manual/DecoderPro/Main_Tool.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_TurnoutControl.shtml
+++ b/help/en/manual/DecoderPro/Main_TurnoutControl.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Main_VSD.shtml
+++ b/help/en/manual/DecoderPro/Main_VSD.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Debug Menu</h1>

--- a/help/en/manual/DecoderPro/Main_Window.shtml
+++ b/help/en/manual/DecoderPro/Main_Window.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_XpressNet.shtml
+++ b/help/en/manual/DecoderPro/Main_XpressNet.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_Zimo.shtml
+++ b/help/en/manual/DecoderPro/Main_Zimo.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <h1>DecoderPro&reg; Main Window</h1>
 

--- a/help/en/manual/DecoderPro/Main_acela.shtml
+++ b/help/en/manual/DecoderPro/Main_acela.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Main_lightControl.shtml
+++ b/help/en/manual/DecoderPro/Main_lightControl.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Tool Menu</h1>

--- a/help/en/manual/DecoderPro/Main_wangrow.shtml
+++ b/help/en/manual/DecoderPro/Main_wangrow.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Multi_Decoder_Control.shtml
+++ b/help/en/manual/DecoderPro/Multi_Decoder_Control.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Programmer_Multi_Decoder.shtml
+++ b/help/en/manual/DecoderPro/Programmer_Multi_Decoder.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro/Programmer_OpsMode.shtml
+++ b/help/en/manual/DecoderPro/Programmer_OpsMode.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <div align="center">
         <a name="Top" id="Top"></a> <img src="images/Logo.gif" alt=

--- a/help/en/manual/DecoderPro/Programmer_ServiceMode.shtml
+++ b/help/en/manual/DecoderPro/Programmer_ServiceMode.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Programming Modes</h1>

--- a/help/en/manual/DecoderPro/Programmer_Setup.shtml
+++ b/help/en/manual/DecoderPro/Programmer_Setup.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <h1>Using DecoderPro&reg;</h1>
 

--- a/help/en/manual/DecoderPro/Programmer_SingleCV.shtml
+++ b/help/en/manual/DecoderPro/Programmer_SingleCV.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src="images/Logo.gif" alt=
       "JMRI DecoderPro Logo" border="10" height="117" width="163"

--- a/help/en/manual/DecoderPro/Programmer_Start.shtml
+++ b/help/en/manual/DecoderPro/Programmer_Start.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <div align="center">
         <a name="Top" id="Top"></a> <img src="images/Logo.gif" alt=

--- a/help/en/manual/DecoderPro/Sidebar.shtml
+++ b/help/en/manual/DecoderPro/Sidebar.shtml
@@ -1,0 +1,80 @@
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for (current) DP Manual pages -->
+<hr class="hide">
+
+<div id="side"> <!-- Block of text on left side of page -->
+    <div style="text-align: center"><strong>DecoderPro&reg; Manual</strong></div>
+
+<dl><!-- main table of contents -->
+<dt><h3>Setup JMRI</h3></dt>
+	  <dd>
+    <ul>
+    <li><a href="Installing_JMRI.shtml">Preparing to Install</a></li>
+    </ul>
+    </dd>
+
+<dt><h3>Getting Started</h3></dt>
+    <dd>
+    <ul>
+    <li><a href="Start_DCC.shtml">What is DCC?</a></li>
+    <li><a href="Start_DCC_Systems.shtml">What DCC systems will DecoderPro work with?</a></li>
+    <li><a href="Start_DCC_Hardware.shtml">What hardware do I need?</a></li>
+    <li><a href="Start_DecoderPro.shtml">How do I start the program?</a></li>
+    <li><a href="Start_Preferences.shtml">How do I set up my Preferences?</a></li>
+    </ul>
+    </dd>
+    
+<dt><h3>Using DecoderPro</h3></dt>
+    <dd>
+    <ul>
+    <li><a href="Programmer_Setup.shtml">How do I set up to program a decoder?</a></li>
+    </ul>
+    </dd>
+    
+<dt><h3>DecoderPro&reg; Programming Modes</h3></dt>
+    <dd>
+    <ul>
+    <li><a href="Programmer_Start.shtml">What are the Programming Modes?</a></li>
+    <li><a href="Programmer_SingleCV.shtml">Single CV Programmer</a></li>
+    <li><a href="Programmer_ServiceMode.shtml">Service Mode Programmer</a></li>
+    <li><a href="Programmer_OpsMode.shtml">Ops Mode Programming</a></li>
+    <li><a href="Programmer_Multi_Decoder.shtml">Multi Decoder Control (Programming)</a></li>
+    </ul>
+    </dd>
+
+<dt><h3>The Basic Programmer</h3></dt>
+    <dd>
+    <ul>
+    <li><a href="Basic_Start.shtml">Entering Locomotives in the "Roster"</a></li>
+    <li><a href="Basic_BasicPane.shtml">The basic programmer</a></li>
+    <li><a href="Basic_BasicPane.shtml">Reading the data from the decoder</a></li>
+    <li><a href="Basic_BasicPane.shtml">Entering and editing new data</a></li>
+    <li><a href="Basic_BasicPane.shtml">Writing the new data to the decoder</a></li>
+    <li><a href="Basic_BasicPane.shtml">Saving the new data to a file</a></li>
+    <li><a href="Basic_BasicPane.shtml#Do More">What if I need to do more?</a></li>
+    </ul>
+    </dd>
+    
+<dt><h3>The Comprehensive Programmer</h3></dt>
+    <dd>
+    <ul>
+    <li><a href="Comp_Setup_Roster.shtml">Setup and Roster Panes</a></li>
+    <li><a href="Comp_Basic.shtml">Expanded Basic Pane</a></li>
+    <li><a href="Comp_Motor.shtml">Motor Control Pane</a></li>
+    <li><a href="Comp_Speed.shtml">Speed Control Pane</a></li>
+    <li><a href="Comp_Speed_Talble.shtml">Speed Table Pane</a></li>
+    <li><a href="Comp_FMap.shtml">Function Mapping Pane</a></li>
+    <li><a href="Comp_LightFX.shtml">Lights Pane</a></li>
+    <li><a href="Comp_Consist.shtml">Consisting Pane</a></li>
+    <li><a href="Comp_Advanced.shtml">Advanced Features Pane</a></li>
+    <li><a href="Comp_Analog.shtml">Analog Controls Pane</a></li>
+    <li><a href="Comp_SoundFX.shtml">Sound Pane</a></li>
+    <li><a href="Comp_SoundLevels.shtml"> Sound Levels Pane</a></li>
+    <li><a href="Comp_GlobalCVs.shtml">Global CV Pane</a></li>
+    <li><a href="Comp_ManfSpecific.shtml">Manufacturer-Specific Pane</a></li>
+    <li><a href="Comp_PrintData.shtml">Printing the Decoder Data</a></li>
+    </ul>
+    </dd>
+</dl>
+</div>
+<!-- /Sidebar -->

--- a/help/en/manual/DecoderPro/Start_DCC.shtml
+++ b/help/en/manual/DecoderPro/Start_DCC.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Start_DCC_Hardware.shtml
+++ b/help/en/manual/DecoderPro/Start_DCC_Hardware.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Start_DCC_Systems.shtml
+++ b/help/en/manual/DecoderPro/Start_DCC_Systems.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Start_DecoderPro.shtml
+++ b/help/en/manual/DecoderPro/Start_DecoderPro.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/Start_Preferences.shtml
+++ b/help/en/manual/DecoderPro/Start_Preferences.shtml
@@ -20,7 +20,7 @@
 <body>
 <!--#include virtual="/Header" -->
   <div id="mBody">
-  <!--#include virtual="Sidebar" -->
+  <!--#include virtual="Sidebar.shtml" -->
 
   <div id="mainContent">
     <h1>Getting Started with DecoderPro&reg;</h1>

--- a/help/en/manual/DecoderPro/VSD_File_and_Config.shtml
+++ b/help/en/manual/DecoderPro/VSD_File_and_Config.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Debug Menu</h1>

--- a/help/en/manual/DecoderPro/VSD_Headless.shtml
+++ b/help/en/manual/DecoderPro/VSD_Headless.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Debug Menu</h1>

--- a/help/en/manual/DecoderPro/VSD_LocationsMgr.shtml
+++ b/help/en/manual/DecoderPro/VSD_LocationsMgr.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Debug Menu</h1>

--- a/help/en/manual/DecoderPro/VSD_Manager.shtml
+++ b/help/en/manual/DecoderPro/VSD_Manager.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Debug Menu</h1>

--- a/help/en/manual/DecoderPro/WiThrottle.shtml
+++ b/help/en/manual/DecoderPro/WiThrottle.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro/dp3Roster.shtml
+++ b/help/en/manual/DecoderPro/dp3Roster.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Roster Menu</h1>

--- a/help/en/manual/DecoderPro/index.shtml
+++ b/help/en/manual/DecoderPro/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1><a name="Top" id="Top">JMRI&reg; DecoderPro&reg;

--- a/help/en/manual/DecoderPro3/Adv_FunctionLabel.shtml
+++ b/help/en/manual/DecoderPro3/Adv_FunctionLabel.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Basic_BasicPane.shtml
+++ b/help/en/manual/DecoderPro3/Basic_BasicPane.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Basic_Mode.shtml
+++ b/help/en/manual/DecoderPro3/Basic_Mode.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Basic_Start.shtml
+++ b/help/en/manual/DecoderPro3/Basic_Start.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>The Basic Programmer</h1>

--- a/help/en/manual/DecoderPro3/Comp_Advanced.shtml
+++ b/help/en/manual/DecoderPro3/Comp_Advanced.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Comp_Analog.shtml
+++ b/help/en/manual/DecoderPro3/Comp_Analog.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Comp_Basic.shtml
+++ b/help/en/manual/DecoderPro3/Comp_Basic.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Comp_Consist.shtml
+++ b/help/en/manual/DecoderPro3/Comp_Consist.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Comp_FMap.shtml
+++ b/help/en/manual/DecoderPro3/Comp_FMap.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Comp_GlobalCVs.shtml
+++ b/help/en/manual/DecoderPro3/Comp_GlobalCVs.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Comp_LightFX.shtml
+++ b/help/en/manual/DecoderPro3/Comp_LightFX.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Comp_ManfSpecific.shtml
+++ b/help/en/manual/DecoderPro3/Comp_ManfSpecific.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Comp_Motor.shtml
+++ b/help/en/manual/DecoderPro3/Comp_Motor.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/help/en/manual/DecoderPro3/Comp_PrintData.shtml
+++ b/help/en/manual/DecoderPro3/Comp_PrintData.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Comprehensive Programmer</h1>

--- a/help/en/manual/DecoderPro3/Comp_PrintData_a.shtml
+++ b/help/en/manual/DecoderPro3/Comp_PrintData_a.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src=
       "images/Comp_09a_PrintData.png" alt=

--- a/help/en/manual/DecoderPro3/Comp_PrintData_b.shtml
+++ b/help/en/manual/DecoderPro3/Comp_PrintData_b.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src=
       "images/Comp_09b_PrintData.png" alt=

--- a/help/en/manual/DecoderPro3/Comp_PrintData_c.shtml
+++ b/help/en/manual/DecoderPro3/Comp_PrintData_c.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src=
       "images/Comp_09c_PrintData.png" alt=

--- a/help/en/manual/DecoderPro3/Comp_Setup_Roster.shtml
+++ b/help/en/manual/DecoderPro3/Comp_Setup_Roster.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Comp_SoundLevels.shtml
+++ b/help/en/manual/DecoderPro3/Comp_SoundLevels.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Comp_Speed.shtml
+++ b/help/en/manual/DecoderPro3/Comp_Speed.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Comp_Speed_Talble.shtml
+++ b/help/en/manual/DecoderPro3/Comp_Speed_Talble.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Error.shtml
+++ b/help/en/manual/DecoderPro3/Error.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Error Messages</h1>

--- a/help/en/manual/DecoderPro3/Installing_JMRI.shtml
+++ b/help/en/manual/DecoderPro3/Installing_JMRI.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src="images/Logo.gif" alt=
       "JMRI DecoderPro Logo" border="0" height="135" width="160"

--- a/help/en/manual/DecoderPro3/Main_CMRI.shtml
+++ b/help/en/manual/DecoderPro3/Main_CMRI.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_EasyDCC.shtml
+++ b/help/en/manual/DecoderPro3/Main_EasyDCC.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Main_FastClockSetup.shtml
+++ b/help/en/manual/DecoderPro3/Main_FastClockSetup.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Tool Menu</h1>

--- a/help/en/manual/DecoderPro3/Main_GrapeVine.shtml
+++ b/help/en/manual/DecoderPro3/Main_GrapeVine.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_LocoNet.shtml
+++ b/help/en/manual/DecoderPro3/Main_LocoNet.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Main_Monitor_Window.shtml
+++ b/help/en/manual/DecoderPro3/Main_Monitor_Window.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_NCE.shtml
+++ b/help/en/manual/DecoderPro3/Main_NCE.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Main_OakTreeSystems.shtml
+++ b/help/en/manual/DecoderPro3/Main_OakTreeSystems.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_PRICOM.shtml
+++ b/help/en/manual/DecoderPro3/Main_PRICOM.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Debug Menu</h1>

--- a/help/en/manual/DecoderPro3/Main_Powerline.shtml
+++ b/help/en/manual/DecoderPro3/Main_Powerline.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_QSI.shtml
+++ b/help/en/manual/DecoderPro3/Main_QSI.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_RPS.shtml
+++ b/help/en/manual/DecoderPro3/Main_RPS.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_SECSI.shtml
+++ b/help/en/manual/DecoderPro3/Main_SECSI.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_SPROG.shtml
+++ b/help/en/manual/DecoderPro3/Main_SPROG.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_Speedo.shtml
+++ b/help/en/manual/DecoderPro3/Main_Speedo.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_TMCC.shtml
+++ b/help/en/manual/DecoderPro3/Main_TMCC.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_XpressNet.shtml
+++ b/help/en/manual/DecoderPro3/Main_XpressNet.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_Zimo.shtml
+++ b/help/en/manual/DecoderPro3/Main_Zimo.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_acela.shtml
+++ b/help/en/manual/DecoderPro3/Main_acela.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Main_lightControl.shtml
+++ b/help/en/manual/DecoderPro3/Main_lightControl.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Tool Menu</h1>

--- a/help/en/manual/DecoderPro3/Main_wangrow.shtml
+++ b/help/en/manual/DecoderPro3/Main_wangrow.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/Programmer_OpsMode.shtml
+++ b/help/en/manual/DecoderPro3/Programmer_OpsMode.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <div align="center">
         <a name="Top" id="Top"></a> <img src="images/Logo.gif" alt=

--- a/help/en/manual/DecoderPro3/Programmer_ServiceMode.shtml
+++ b/help/en/manual/DecoderPro3/Programmer_ServiceMode.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Programming Modes</h1>

--- a/help/en/manual/DecoderPro3/Programmer_Setup.shtml
+++ b/help/en/manual/DecoderPro3/Programmer_Setup.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Using DecoderPro&reg;</h1>

--- a/help/en/manual/DecoderPro3/Programmer_SingleCV.shtml
+++ b/help/en/manual/DecoderPro3/Programmer_SingleCV.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src="images/Logo.gif" alt=
       "JMRI DecoderPro Logo" border="10" height="117" width="163"

--- a/help/en/manual/DecoderPro3/RosterMedia.shtml
+++ b/help/en/manual/DecoderPro3/RosterMedia.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Sidebar.shtml
+++ b/help/en/manual/DecoderPro3/Sidebar.shtml
@@ -1,0 +1,105 @@
+
+<!-- Sidebar -->
+<!-- This is the common sidebar definition for (current) DP(3) Manual pages -->
+<hr class="hide">
+
+<div id="side"> <!-- Block of text on left side of page -->
+    <div style="text-align: center"><strong>DecoderPro&reg; Manual</strong></div>
+
+<dl><!-- main table of contents -->
+<dt><h3>Setup JMRI</h3></dt>
+	  <dd>
+    <ul>
+	  <li><a href="Installing_JMRI.shtml">Preparing to Install</a></li>
+    </ul>
+    </dd>
+     
+<dt><h3>Getting Started</h3></dt>
+    <dd>    
+    <ul>
+    <li><a href="Start_DCC.shtml">What is DCC?</a>
+    <li><a href="Start_DCC_Systems.shtml">What DCC systems will DecoderPro work with?</a>
+    <li><a href="Start_DCC_Hardware.shtml">What hardware do I need?</a>
+    <li><a href="Start_DecoderPro.shtml">How do I start the program?</a>
+    <li><a href="Start_DecoderPro_New.shtml">How do I start DecoderPro&reg; program for the First Time User?</a>
+    <li><a href="Start_Preferences.shtml">How do I set up my Preferences?</a>
+    </ul>
+    </dd>
+   
+<dt><h3>Using DecoderPro</h3></dt>   
+    <dd>
+    <ul>
+    <li><a href="Programmer_Setup.shtml">How do I set up to program a decoder?</a>
+    </ul>
+    </dd>
+ 
+<dt><h3>DecoderPro Programming Modes</h3></dt>   
+    <dd>
+    <ul>
+    <li><a href="Programmer_SingleCV.shtml">Single CV Programmer</a></li>
+    <li><a href="Programmer_ServiceMode.shtml">Service Mode Programmer</a></li>
+    <li><a href="Programmer_OpsMode.shtml">Ops Mode Programming</a></li>
+    </ul>
+    </dd>
+   
+<dt><h3>The Basic Programmer</h3></dt>    
+    <dd>
+    <ul>
+    <li><a href="Basic_Start.shtml">Entering Locomotives in the "Roster"</a></li>
+    <li><a href="Basic_BasicPane.shtml">The basic programmer</a></li>
+    <li><a href="Basic_BasicPane.shtml">Reading the data from the decoder</a></li>
+    <li><a href="Basic_BasicPane.shtml">Entering and editing new data</a></li>
+    <li><a href="Basic_BasicPane.shtml">Writing the new data to the decoder</a></li>
+    <li><a href="Basic_BasicPane.shtml">Saving the new data to a file</a></li>
+    <li><a href="Basic_BasicPane.shtml#DoMore">What if I need to do more?</a></li>
+    </ul>
+    </dd>
+<dt><h3>The Comprehensive Programmer</h3></dt>   
+    <dd>
+    <ul>
+    <li><a href="Comp_Setup_Roster.shtml">Setup and Roster Panes</a></li>
+    <li><a href="Comp_Basic.shtml">Expanded Basic Pane</a></li>
+    <li><a href="Comp_Motor.shtml">Motor Control Pane</a></li>
+    <li><a href="Comp_Speed.shtml">Speed Control Pane</a></li>
+    <li><a href="Comp_Speed_Talble.shtml">Speed Table Pane</a></li>
+    <li><a href="Comp_FMap.shtml">Function Mapping Pane</a></li>
+    <li><a href="Comp_LightFX.shtml">Lights Pane</a></li>
+    <li><a href="Comp_Consist.shtml">Consisting Pane</a></li>
+    <li><a href="Comp_Advanced.shtml">Advanced Features Pane</a></li>
+    <li><a href="Comp_Analog.shtml">Analog Controls Pane</a></li>
+    <li><a href="Comp_SoundFX.shtml">Sound Pane</a></li>
+    <li><a href="Comp_SoundLevels.shtml"> Sound Levels Pane</a></li>
+    <li><a href="Comp_GlobalCVs.shtml">Global CV Pane</a></li>
+    <li><a href="Comp_ManfSpecific.shtml">Manufacturer-Specific Pane</a></li>
+    <li><a href="Comp_PrintData.shtml">Printing the Decoder Data</a></li>
+    </ul>
+    </dd>
+    
+<dt><h3>Advanced Features</h3></dt> 
+	   <dd>
+     <ul>
+       <li><a href="Adv_FunctionLabel.shtml">Function Labels Pane</a></li>
+       <li><a href="RosterMedia.shtml">Roster Media</a></li>
+     </ul>
+     </dd>
+<dt><h3>DecoderPro&reg; Main Window</h3></dt>    
+    <dd>
+    <ul>
+      <li><a href="dp3_menubar.shtml">Menu Bar</a></li>
+      <li><a href="dp3_toobar.shtml">Toolbar</a></li>
+      <li><a href="dp3_rosterTable.shtml">Roster Table</a></li>
+      <li><a href="dp3_decoderInfo.shtml">Decoder Information</a></li>
+      <li><a href="dp3_Main_Main.shtml#status">Status Bar</a></li>
+    </ul>
+    </dd>  
+    
+<dt><a name="Error"></a><h3>Error Messages</h3></dt>  
+    <dd>
+    <ul>
+      <li><a href="../../html/setup/Errors.shtml">Error Codes explained</a></li>
+    </ul>
+    </dd>
+    
+</dl>
+</div>
+<!-- /Sidebar -->

--- a/help/en/manual/DecoderPro3/Start_DCC.shtml
+++ b/help/en/manual/DecoderPro3/Start_DCC.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src="images/Logo.gif" alt=
       "JMRI DecoderPro Logo" width="163" height="117" vspace="15"

--- a/help/en/manual/DecoderPro3/Start_DCC_Hardware.shtml
+++ b/help/en/manual/DecoderPro3/Start_DCC_Hardware.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src="images/Logo.gif" alt=
       "JMRI DecoderPro Logo" class="BOXIT" border="10" height="117"

--- a/help/en/manual/DecoderPro3/Start_DCC_Systems.shtml
+++ b/help/en/manual/DecoderPro3/Start_DCC_Systems.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a> <img src="images/Logo.gif" alt=
       "JMRI DecoderPro Logo" class="BOXIT" border="10" height="117"

--- a/help/en/manual/DecoderPro3/Start_DecoderPro.shtml
+++ b/help/en/manual/DecoderPro3/Start_DecoderPro.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Start_DecoderPro_New.shtml
+++ b/help/en/manual/DecoderPro3/Start_DecoderPro_New.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/Start_Preferences.shtml
+++ b/help/en/manual/DecoderPro3/Start_Preferences.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Getting Started with DecoderPro&reg;</h1>

--- a/help/en/manual/DecoderPro3/WiThrottle.shtml
+++ b/help/en/manual/DecoderPro3/WiThrottle.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_Main_ConsistControl.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_ConsistControl.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/dp3_Main_Main.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_Main.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_Main_Speedometer.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_Speedometer.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/dp3_Main_Throttle.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_Throttle.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_Main_Throttle_FrameProperties.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_Throttle_FrameProperties.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_Main_Throttle_List.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_Throttle_List.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_Main_Throttle_addressPanel.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_Throttle_addressPanel.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_Main_Throttle_controlPanel.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_Throttle_controlPanel.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_Main_Throttle_functionPanel.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_Throttle_functionPanel.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_Main_Throttle_menubar.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_Throttle_menubar.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_Main_Throttle_toolbar.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_Throttle_toolbar.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_Main_TurnoutControl.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_TurnoutControl.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_Main_file_print_entry.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_file_print_entry.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_decoderInfo.shtml
+++ b/help/en/manual/DecoderPro3/dp3_decoderInfo.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/dp3_menubar.shtml
+++ b/help/en/manual/DecoderPro3/dp3_menubar.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_rosterTable.shtml
+++ b/help/en/manual/DecoderPro3/dp3_rosterTable.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/dp3_settings_rosterGroups.shtml
+++ b/help/en/manual/DecoderPro3/dp3_settings_rosterGroups.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/DecoderPro3/dp3_toobar.shtml
+++ b/help/en/manual/DecoderPro3/dp3_toobar.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>DecoderPro&reg; Main Window</h1>

--- a/help/en/manual/DecoderPro3/index.shtml
+++ b/help/en/manual/DecoderPro3/index.shtml
@@ -26,7 +26,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Installing_JMRI.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Installing_JMRI.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Main_Main.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Main_Main.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Main_Menu.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Main_Menu.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddCars.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddCars.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddEngine.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddEngine.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddInterchange.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddInterchange.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddLocations.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddLocations.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddRoutes.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddRoutes.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddSiding.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddSiding.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddStaging.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddStaging.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddTrain.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddTrain.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddTrainBuildOptions.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddTrainBuildOptions.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddYard.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_AddYard.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_BuildReportPreveiw.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_BuildReportPreveiw.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_BuildReportPrint.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_BuildReportPrint.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_CarAttributes.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_CarAttributes.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Cars.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Cars.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Cars_Menu.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Cars_Menu.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditEngines.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditEngines.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditLocation.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditLocation.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditLocation_menu.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditLocation_menu.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditLocation_track.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditLocation_track.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditLocation_trackMenu.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditLocation_trackMenu.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditRoutes.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditRoutes.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditTrain.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_EditTrain.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_EngineAttributes.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_EngineAttributes.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Engines.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Engines.shtml
@@ -21,7 +21,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Engines_menu.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Engines_menu.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_ImportCarsFile.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_ImportCarsFile.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_ImportEngines_FromFiles.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_ImportEngines_FromFiles.shtml
@@ -23,7 +23,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_ImportEngines_FromRoster.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_ImportEngines_FromRoster.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_List.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_List.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_Menu.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_Menu.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_Modify_Trains.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_Modify_Trains.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_SwitchList.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_SwitchList.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_byCar.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_byCar.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_print-Preview_ByCarType.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_print-Preview_ByCarType.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_printByCarType.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_printByCarType.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_setCars.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Locations_setCars.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_ManifestPreview.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_ManifestPreview.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_ManifestPrint.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_ManifestPrint.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_PrintOptions.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_PrintOptions.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Routes.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Routes.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Routes_Menu.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Routes_Menu.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_SetEngines.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_SetEngines.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Settings.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Settings.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Settings_Tools_Options.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Settings_Tools_Options.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Settings_menubar.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Settings_menubar.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Start.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Start.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Trains.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Trains.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_TrainsBuild.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_TrainsBuild.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_TrainsModify.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_TrainsModify.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Trains_BuildOptions.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Trains_BuildOptions.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Trains_Menu.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Trains_Menu.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_Trains_Timetable.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_Trains_Timetable.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_TripThruOperations.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_TripThruOperations.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Ops_schedule.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Ops_schedule.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Using JMRI&reg; to Operate Trains</h1>

--- a/help/en/manual/JMRI_OPS_UsersGuide/Sidebar.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Sidebar.shtml
@@ -1,0 +1,56 @@
+<!-- Sidebar -->
+<!-- This is the sidebar definition for (older) OperationsPro Manual pages -->
+<hr class="hide">
+
+<div id="side"> <!-- Block of text at top -->
+    <div style="text-align: center"><strong>The OpsPro Manual</strong></div>
+
+<dl><!-- main table of contents -->
+<dt><h3>Setup JMRI</h3></dt>
+	  <dd>
+    <ul>
+    <li><a href="Installing_JMRI.shtml">Preparing to Install</a></li>
+    </ul>
+    </dd>
+
+<dt><h3>Starting OperationsPro</h3></dt>
+    <dd>
+    <ul>
+    <li><a href="Start_DecoderPro.shtml">Starting JMRI&reg;</a></li>
+    <li><a href="Start_Preferences.shtml">Set Preferences</a></li>
+    </ul>
+    </dd>
+ 
+<dt><h3><a name="Main"></a>Using OperationsPro</h3></dt>
+    <dd>
+    <ul>
+        <li><a href="Main_Main.shtml">Main Window Menu</a></li>
+        <li><a href="Main_Menu.shtml">Tools Menu</a></li>
+ 	    <li><a href="Ops_Start.shtml">Operations</a>
+        <ul>
+            <li><a href="Ops_Settings.shtml">Settings</a></li>
+            <li><a href="Ops_Locations.shtml">Locations</a></li>
+            <li><a href="Ops_Cars.shtml">Cars</a></li>
+            <li><a href="Ops_Engines.shtml">Locomotive</a></li>
+            <li><a href="Ops_Routes.shtml">Routes</a></li>
+            <li><a href="Ops_Trains.shtml">Trains</a></li>
+        </ul></li>
+     <li><a href="Ops_TripThruOperations.shtml">A Trip through OperationsPro</a></li>
+   </ul>
+   </dd>
+<dt><a name="Error"></a><h3>Error Messages</h3></dt>  
+    <dd>
+    <ul>
+      <li><a href="../../html/setup/Errors.shtml">Error Codes explained</a></li>
+    </ul>
+    </dd>
+  
+  </dl>
+</div> <!-- close #side -->
+
+<!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+<!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/manual/JMRI_OPS_UsersGuide/Start_DCC.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Start_DCC.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Start_DCC_Hardware.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Start_DCC_Hardware.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Start_DCC_Systems.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Start_DCC_Systems.shtml
@@ -15,7 +15,7 @@
 <body>
 <!--#include virtual="/Header" -->
     <div id="mBody">
-<!--#include virtual="Sidebar" -->
+<!--#include virtual="Sidebar.shtml" -->
 <div id="mainContent">
 
 <a name="Top"></a>

--- a/help/en/manual/JMRI_OPS_UsersGuide/Start_DecoderPro.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Start_DecoderPro.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/manual/JMRI_OPS_UsersGuide/Start_Preferences.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/Start_Preferences.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>Using JMRI&#174; to Operate Trains</h1>

--- a/help/en/manual/JMRI_OPS_UsersGuide/index.shtml
+++ b/help/en/manual/JMRI_OPS_UsersGuide/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top"></a>
 

--- a/help/en/manual/Sidebar.shtml
+++ b/help/en/manual/Sidebar.shtml
@@ -1,0 +1,106 @@
+<!-- Sidebar -->
+	  <hr class="hide">
+	  <div id="side"> <!-- Block of text on left side of page for /help/en/manual Index page -->
+
+<div id="manual" style="text-align: center;">JMRI Manuals</div>
+
+<dl>
+
+<dt><h3>PDF</h3></dt>
+      <dd>
+      <ul>
+        <li><a href="http://jmri.org/manual/pdf/DP3_Man_3-4.pdf">DP3 Guide v3.4</a></li>
+        <li><a href="http://jmri.org/manual/pdf/DP_man_3-4.pdf">DP Guide v3.4</a></li>
+        <!-- hide old manuals <li><a href="http://jmri.org/manual/pdf/DP3_Man_3-2.pdf">DP3 Guide v3.2</a></li>
+        <li><a href="http://jmri.org/manual/pdf/DP_man_3-2.pdf">DP Guide v3.2</a></li>
+        <li><a href="http://jmri.org/manual/pdf/JMRI_3-0%20Operations_Users%20Guide.pdf">OP Guide v3.0</a></li>
+        <li><a href="http://jmri.org/manual/pdf/DP3_Man_3-0.pdf">DP3 Guide v3.0</a></li>
+        <li><a href="http://jmri.org/manual/pdf/DP_man_3-0.pdf">DP Guide v3.0</a></li> -->
+        <li><a href="http://jmri.org/manual/pdf/DP3_Man_2_14.pdf">DP3 Guide v2.14</a></li>
+      </ul>
+      </dd>
+
+<h3>Online</h3>
+
+<dt>JMRI&reg; v4.x</dt>
+  <dd>
+    <ul>
+        <li style="font-weight: bold;"><a href="../html/apps/DecoderPro/index.shtml">DecoderPro&reg; v4</a></li>
+        <li style="font-weight: bold;"><a href="../package/jmri/jmrit/operations/Operations.shtml">OperationsPro v4</a></li>
+    </ul>
+  </dd>
+
+<dt>JMRI&reg; v3.10</dt>
+  <dd>
+    <ul>
+        <li style="font-weight: bold;"><a href="DecoderPro3/index.shtml">DecoderPro3&reg;</a></li>
+        <li style="font-weight: bold;"><a href="DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+        <li style="font-weight: bold;"><a href="JMRI_OPS_UsersGuide/index.shtml">OperationsPro</li>
+    </ul>
+  </dd>
+
+<!-- 2015/12: hide old intermediate version manuals, too confusing to new users, unnecessary for veterans
+<dt>JMRI&reg; v3.4</dt>
+    <dd>
+    <ul>
+        <li style="font-weight: bold;"><a href="http://jmri.org/manual/3-4_DecoderPro3/index.shtml">DecoderPro3&reg;</a></li>
+        <li style="font-weight: bold;"><a href="http://jmri.org/manual/3-4_DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+        <li style="font-weight: bold;"><a href="http://jmri.org/manual/3-4_JMRI_OPS_UsersGuide/index.shtml">Operations</a></li>
+    </ul>
+    </dd>
+
+<dt>JMRI&reg; v3.2</dt>
+	<dd style="font-weight: bold;">
+    <ul>
+    	<li><a href="http://jmri.org/manual/3-2_DecoderPro3/index.shtml">DecoderPro3&reg;</a></li>
+        <li><a href="http://jmri.org/manual/3-2_DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+        <li><a href="3-2_JMRI_OPS_UsersGuide/index.shtml">Operations</a></li>
+     </ul>
+     </dd>
+
+<dt>JMRI&reg; v3.0</dt>
+    <dd style="font-weight: bold;">
+      <ul>
+        <li><a href="http://jmri.org/manual/3-0_DecoderPro3/index.shtml">DecoderPro3&reg;</a></li>
+        <li><a href="http://jmri.org/manual/3-0_DecoderPro/index.shtml">DecoderPro&reg;</a></li>
+        <li><a href="http://jmri.org/manual/3-0_JMRI_OPS_UsersGuide/index.shtml">Operations</a></li>
+      </ul>
+    </dd>
+ end of hidden list -->
+
+<dt>JMRI&reg; v2.14</dt>
+    <dd style="font-weight: bold;">
+    <ul>
+        <li><a href="http://jmri.org/manual/JMRI_2-14_manual/index.shtml">JMRI&reg; Guide</a></li>
+        <li><a href="http://jmri.org/manual/DP3_2-14_manual/index.shtml">DecoderPro3&reg;</a></li>
+    </ul>
+    </dd>
+
+<!-- <dt>JMRI&reg; v2.12</dt>
+    <dd style="font-weight: bold;">
+    <ul>
+        <li><a href="http://jmri.org/manual/JMRI_2-12_Manual/index.shtml">JMRI&reg; Guide</a></li>
+    </ul>
+    </dd> -->
+
+<dt><h3>Supported Computers</h3></dt>
+    <dd> 
+    <ul>
+		<li><a href="http://jmri.org/install/WindowsNew.shtml">Windows</a>
+		<li><a href="http://jmri.org/install/MacOSX.shtml">Mac OS X</a>
+		<li><a href="http://jmri.org/install/Linux.shtml">Linux</a>
+		<li><a href="../html/setup/index.shtml">Setup JMRI</a>
+    </ul>
+    </dd>  
+  
+</dl>
+
+</div> <!-- close #manual -->
+</div> <!-- close #side -->
+
+<!-- Sidebar-Tail -->
+    <script type="text/javascript" src="/web/js/jquery-2.0.3.min.js"></script>
+    <script type="text/javascript" src="/web/js/here.js"></script>
+<!-- /Sidebar-Tail -->
+
+<!-- /Sidebar -->

--- a/help/en/manual/index.shtml
+++ b/help/en/manual/index.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <a name="Top" id="Top"></a>
 

--- a/help/en/package/jmri/jmrit/blockboss/SimpleSignalExample.shtml
+++ b/help/en/package/jmri/jmrit/blockboss/SimpleSignalExample.shtml
@@ -22,7 +22,7 @@
 <body>
   <!--#include virtual="/Header" -->
   <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
       <!-- Page Body -->
 

--- a/help/en/parts/SidebarLayoutAutomation.shtml
+++ b/help/en/parts/SidebarLayoutAutomation.shtml
@@ -1,0 +1,18 @@
+<!-- SidebarLayoutAutomation.shtml -->
+<!-- This is the common sidebar definition for Layout Automation pages -->
+  	<dt><h3><a href="automation">Layout Automation</a></h3></dt>
+		<dd>Use JMRI to automate parts of your layout, from simply controlling a crossing gate
+		to running trains in the background.
+		  <ul>
+		    <li><a href="/help/en/html/tools/signaling/index.shtml">Signaling</a>
+		    <li><a href="/help/en/html/tools/EntryExit.shtml">Entry Exit (NX)</a>
+		    <li><a href="/help/en/package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
+		    <li><a href="/help/en/package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
+		    <li><a href="/help/en/html/tools/Routes.shtml">Routes</a>
+		    <li><a href="/help/en/html/tools/LRoutes.shtml">LRoutes</a>
+		    <li><a href="/help/en/html/tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="/help/en/html/tools/uss/index.shtml">USS CTC</a>
+		    <li><a href="/help/en/html/tools/scripting/index.shtml">Scripting</a>
+		  </ul>
+		</dd>
+<!-- /SidebarLayoutAutomation.shtml -->

--- a/help/en/parts/SidebarSupportedHardware.shtml
+++ b/help/en/parts/SidebarSupportedHardware.shtml
@@ -1,0 +1,49 @@
+<!-- SidebarSupportedHardware.shtml -->
+<!-- This is the common sidebar definition for supported hardware pages -->
+		<dt><h3 style="padding-left: 1em;"><a href="index.shtml">Supported Hardware</a></h3></dt>
+		<dd>
+		    <ul>
+				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
+				<li><a href="/help/en/html/hardware/XPressNet/index.shtml">Atlas Commander</a>
+				<li><a href="/help/en/html/hardware/bachrus/index.shtml">Bachrus</a>
+				<li><a href="/help/en/html/hardware/cmri/CMRI.shtml">C/MRI</a>
+				<li><a href="/help/en/html/hardware/acela/index.shtml">CTI Electronics (Acela)</a>
+				<li><a href="/help/en/html/hardware/easydcc/EasyDCC.shtml">CVP EasyDCC</a>
+				<li><a href="/help/en/html/hardware/dccpp/index.shtml">DCC++</a>
+				<li><a href="/help/en/html/hardware/misc/DccSpecialties.shtml">DCC Specialities (Hare)</a>
+				<li><a href="/help/en/html/hardware/XBee/index.shtml">Digi XBee</a>
+				<li><a href="/help/en/html/hardware/digirails/index.shtml">Digikeijs (Digirails)</a>
+				<li><a href="/help/en/html/hardware/loconet/Digitrax.shtml">Digitrax</a>
+				<li><a href="/help/en/html/hardware/ecos/index.shtml">ESU ECoS</a>
+				<li><a href="/help/en/html/hardware/loconet/Fleischmann.shtml">Fleischmann</a>
+				<li><a href="/help/en/html/hardware/XPressNet/index.shtml">Hornby</a>
+				<li><a href="/help/en/html/hardware/XPressNet/index.shtml">Lenz</a>
+				<li><a href="/help/en/html/hardware/tmcc/index.shtml">Lionel TMCC</a>
+				<li><a href="/help/en/html/hardware/loconet/Digitrax.shtml">LocoNet</a>
+				<li><a href="/help/en/html/hardware/maple/index.shtml">Maple Systems</a>
+				<li><a href="/help/en/html/hardware/marklin/index.shtml">M&auml;rklin CS2</a>
+				<li><a href="/help/en/html/hardware/can/cbus/index.shtml">MERG CBUS</a>
+				<li><a href="/help/en/html/hardware/modbus/index.shtml">Modbus</a>
+                <li><a href="/help/en/html/hardware/mqtt/index.shtml">MQTT</a>
+				<li><a href="/help/en/html/hardware/mrc/index.shtml">MRC</a>
+				<li><a href="/help/en/html/hardware/rps/index.shtml">NAC Services RPS</a>
+				<li><a href="/help/en/html/hardware/nce/NCE.shtml">NCE</a>
+				<li><a href="/help/en/html/hardware/oaktree/OakTree.shtml">Oak Tree Systems</a>
+				<li><a href="/help/en/html/hardware/openlcb/index.shtml">OpenLCB</a>
+				<li><a href="/help/en/html/hardware/grapevine/index.shtml">Protrak Grapevine</a>
+				<li><a href="/help/en/html/hardware/qsi/index.shtml">QSI Quantum Programmer</a>
+				<li><a href="/help/en/html/hardware/raildriver/index.shtml">Pi Engineering RailDriver</a>
+				<li><a href="/help/en/html/hardware/pi/index.shtml">Raspberry Pi</a>
+				<li><a href="/help/en/html/hardware/XPressNet/index.shtml">Roco</a>
+				<li><a href="/help/en/html/hardware/sprog/SPROG.shtml">SPROG</a>
+				<li><a href="/help/en/html/hardware/SRCP/index.shtml">SRCP server</a>
+				<li><a href="/help/en/html/hardware/tams/index.shtml">TAMS Master Control</a>
+				<li><a href="/help/en/html/hardware/loconet/Digitrax.shtml">Uhlenbrock Intellibox</a>
+				<li><a href="/help/en/html/hardware/XPressNet/index.shtml">Viessmann Commander</a>
+				<li><a href="/help/en/html/hardware/nce/Wangrow.shtml">Wangrow System One</a>
+				<li><a href="/help/en/html/hardware/powerline/index.shtml">X10</a>
+				<li><a href="/help/en/html/hardware/zimo/Zimo.shtml">Zimo MX-1</a>
+				<li><a href="/help/en/html/hardware/XPressNet/index.shtml">ZTC</a>
+		    </ul>
+		</dd>
+<!-- /SidebarSupportedHardware.shtml -->

--- a/help/en/parts/SidebarTools.shtml
+++ b/help/en/parts/SidebarTools.shtml
@@ -1,0 +1,29 @@
+<!-- SidebarTools.shtml -->
+<!-- This is the common sidebar definition for Tools pages -->
+		<dt><h3><a href="tools/index.shtml">Tools</a></h3></dt>
+		<dd>JMRI provides powerful tools for working with your
+		layout.
+		<ul>
+		    <li><a href="/help/en/html/tools/Turnouts.shtml">Turnouts</a>
+            <li><a href="/help/en/html/tools/Lights.shtml">Lights</a>
+		    <li><a href="/help/en/html/tools/Sensors.shtml">Sensors</a>
+		    <li><a href="/help/en/html/tools/throttle/ThrottleMain.shtml">Throttles</a>
+		    <li><a href="/help/en/html/tools/consisttool/ConsistTool.shtml">Consisting</a>
+            <li><a href="/help/en/html/tools/Blocks.shtml">Blocks</a>
+            <li><a href="/help/en/html/tools/Reporters.shtml">Reporters</a>
+            <li><a href="/help/en/html/tools/Memories.shtml">Memory Variables</a>
+		    <li><a href="/help/en/html/tools/Routes.shtml">Routes</a>
+		    <li><a href="/help/en/html/tools/LRoutes.shtml">LRoutes</a>
+            <li><a href="/help/en/html/tools/Sections.shtml">Sections</a>
+            <li><a href="/help/en/html/tools/Transits.shtml">Transits</a>
+		    <li><a href="/help/en/html/tools/Logix.shtml">Logix</a>
+		    <li><a href="/help/en/html/tools/fastclock/index.shtml">Fast Clocks</a>
+		    <li><a href="/help/en/html/tools/speedometer/index.shtml">Speedometer</a>
+		    <li><a href="/help/en/html/tools/Audio.shtml">Audio</a>
+		    <li><a href="/help/en/html/tools/IdTags.shtml">ID Tags</a>
+		    <li><a href="/help/en/html/tools/TimeTable.shtml">Timetable</a>
+
+            <li><a href="/help/en/html/tools/index.shtml#systemSpecificTools">System-specific...</a>
+   	    </ul>
+		</dd>
+<!-- /SidebarTools.shtml -->

--- a/help/fr/Acknowledgements.shtml
+++ b/help/fr/Acknowledgements.shtml
@@ -35,8 +35,8 @@
 			<a href="#A">A</a>|<a href="#B">B</a>|<a href="#C">C</a>|<a href="#D">D</a>|<a href="#E">E</a>|<a href="#F">F</a>|<a href="#G">G</a>|<a href="#H">H</a>|<a href="#I">I</a>|<a href="#J">J</a>|<a href="#K">K</a>|<a href="#L">L</a>|<a href="#M">M</a>|<a href="#N">N</a>|<a href="#O">O</a>|<a href="#P">P</a>|<a href="#Q">Q</a>|<a href="#R">R</a>|<a href="#S">S</a>|<a href="#T">T</a>|<a href="#U">U</a>|<a href="#V">V</a>|<a href="#W">W</a>|<a href="#X">X</a>|<a href="#Y">Y</a>|<a href="#Z">Z</a>
 
 		<ul>
+        <li style="list-style: none"><a name="A" id="A"></a></li>
 
-			<a name="A"></a>
 			<li>Sakae Akanuma provided a Japanese translation.
 			<li>Kerry Albrecht, who helped debug a problem loading panel files
 			<li>Nelson Allison, who provided scripts for Roco cranes
@@ -525,7 +525,7 @@
 			<li>Randall Wood, who updated the fast clock support, improved
 				the XMLIO support with some fixed memory variables,
 				migrated us to Git and GitHub, and build our Travis (Linux/Mac) and
-				Appveyor (Windows) continuous integration & test support.
+				Appveyor (Windows) continuous integration &amp; test support.
 				<a name="X"></a>
 				<a name="Y"></a>
 			<li>Mike Yawn, who provided the instructions for building under Eclipse

--- a/scripts/tidy-check.sh
+++ b/scripts/tidy-check.sh
@@ -9,7 +9,7 @@ else
 fi
 
 # first, scan for whether there's an issue (omitting known fragment files)
-find ${WHERE} -name \*html ! -path 'help/en/releasenotes/*' ! -name Sidebar.shtml -exec echo Filename: {} \;  ! -exec tidy -eq -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | awk -f scripts/tidy.awk | grep Warning 1>&2
+find ${WHERE} -name \*html -exec grep -q DOCTYPE {} \; -exec echo Filename: {} \;  ! -exec tidy -eq -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | awk -f scripts/tidy.awk | grep Warning 1>&2
 
 # swap return code from grep
 if [ $? -eq 0 ]; then

--- a/scripts/tidy-scan.sh
+++ b/scripts/tidy-scan.sh
@@ -10,4 +10,4 @@ else
 fi
 
 # first, scan for whether there's an issue (omitting known fragment files)
-find ${WHERE}  -name \*html ! -path 'help/en/releasenotes/*' ! -name Sidebar.shtml -exec echo Filename: {} \; -exec tidy -e -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | tr '<' '&lt;' | tr '>' '&gt;' | awk -f scripts/tidy.awk
+find ${WHERE}  -name \*html -exec grep -q DOCTYPE {} \; -exec echo Filename: {} \; -exec tidy -e -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | tr '<' '&lt;' | tr '>' '&gt;' | awk -f scripts/tidy.awk


### PR DESCRIPTION
See discussion in #7774 for background.  

 - Create a Sidebar.shtml file from each Sidebar file if it doesn't exist
 - Update the SSI statements to refer to the Sidebar.shtml file
 - Also handle the SidebarUp file found in help/en/html/hardware/*/* similar to above
 - Create SidebarToolsMenu.shtml, SidebarLayoutAutomationMenu.shtml, and SidebarSupportedHardwareMenu.shtml files in a new help/en/parts directory to contain the common contents
 - as a test, change help/en/html/tools/Sidebar.shtml to use the new includes

 - update the scripts/tidy-scan.sh and scripts/tidy-check files to process all the files with DOCTYPE definitions, and not process the fragment files that don't contain them.
 - bring the help/en and help/fr Acknowledgements.shtml files HTML up to spec 

Note:
 - the other Sidebar.shtml files have not been updated. 
 -  only doing the English help/en files are updated here; the French help/fr files will be done if this succeeds
 - Looks like not all the "Tools" menus in the existing sidebars are actually the same.  Not sure if this is a problem or not....
 - This PR is to `master` to get it on the web servers; we'll merge to `development` later as needed.