### PR TITLE
Fix bug in getDestAddr()

### DIFF
--- a/java/src/jmri/jmrix/loconet/lnsvf2/LnSv2MessageContents.java
+++ b/java/src/jmri/jmrix/loconet/lnsvf2/LnSv2MessageContents.java
@@ -114,6 +114,7 @@ public class LnSv2MessageContents {
      */
     public LnSv2MessageContents(LocoNetMessage m)
             throws java.lang.IllegalArgumentException {
+        
         log.debug("interpreting a LocoNet message - may be an SV2 message");  // NOI18N
         if (!isSupportedSv2Message(m)) {
             log.debug("interpreting a LocoNet message is NOT an SV2 message");   // NOI18N
@@ -154,7 +155,6 @@ public class LnSv2MessageContents {
         d4 = m.getElement(SV2_SVD4_ELEMENT_INDEX)
                 + (((svx2 & SV2_SV_D4_D4X7_CHECK_MASK) == SV2_SV_D4_D4X7_CHECK_MASK)
                 ? 0x80 : 0);
-        return;
     }
 
     /**
@@ -321,6 +321,7 @@ public class LnSv2MessageContents {
                         sv_adr,
                         d1);
                 break;
+                
             case (SV_CMD_WRITE_ONE_REPLY):    
                 returnString = Bundle.getMessage(locale, "SV2_WRITE_ONE_REPLY_INTERPRETED", 
                         src,
@@ -328,12 +329,14 @@ public class LnSv2MessageContents {
                         sv_adr,
                         d1);
                 break;
+                
             case (SV_CMD_QUERY_ONE):
                 returnString = Bundle.getMessage(locale, "SV2_READ_ONE_REQUEST_INTERPRETED", 
                         src,
                         dst,
                         sv_adr);
                 break;
+                
             case (SV_CMD_REPORT_ONE):    
                 returnString = Bundle.getMessage(locale, "SV2_READ_ONE_REPORT_INTERPRETED", 
                         src,
@@ -341,6 +344,7 @@ public class LnSv2MessageContents {
                         sv_adr,
                         d1);
                 break;
+                
             case (SV_CMD_WRITE_ONE_MASKED):
                 returnString = Bundle.getMessage(locale, "SV2_WRITE_ONE_MASKED_INTERPRETED", 
                         src,
@@ -349,6 +353,7 @@ public class LnSv2MessageContents {
                         d1,
                         d2);
                 break;
+                
             case (SV_CMD_WRITE_ONE_MASKED_REPLY):    
                 returnString = Bundle.getMessage(locale, "SV2_WRITE_ONE_MASKED_REPLY_INTERPRETED", 
                         src,
@@ -357,6 +362,7 @@ public class LnSv2MessageContents {
                         d1,
                         d2);
                 break;
+                
             case (SV_CMD_WRITE_FOUR):
                 /* Note: This code does not track total available SVs.  Total 
                         available SVs can vary by SV device type.  So the simple 
@@ -373,6 +379,7 @@ public class LnSv2MessageContents {
                         d3,
                         d4);
                 break;
+                
             case (SV_CMD_WRITE_FOUR_REPLY):    
                 /* Note: This code does not track total available SVs.  Total 
                         available SVs can vary by SV device type.  So the simple 
@@ -389,6 +396,7 @@ public class LnSv2MessageContents {
                         d3,
                         d4);
                 break;
+                
             case (SV_CMD_QUERY_FOUR):
                 /* Note: This code does not track total available SVs.  Total 
                         available SVs can vary by SV device type.  So the simple 
@@ -401,6 +409,7 @@ public class LnSv2MessageContents {
                         sv_adr,
                         sv_adr+3);
                 break;
+                
             case (SV_CMD_REPORT_FOUR):    
                 /* Note: This code does not track total available SVs.  Total 
                         available SVs can vary by SV device type.  So the simple 
@@ -417,10 +426,12 @@ public class LnSv2MessageContents {
                         d3,
                         d4);
                 break;
+                
             case (SV_CMD_DISCOVER_DEVICES_QUERY):
                 returnString = Bundle.getMessage(locale, "SV2_DISCOVER_DEVICES_INTERPRETED", 
                         src);
                 break;
+                
             case (SV_CMD_DISCOVER_DEVICE_REPORT):
                 returnString = Bundle.getMessage(locale, "SV2_DEVICE_TYPE_REPORT_INTEPRETED",
                         src,
@@ -430,11 +441,13 @@ public class LnSv2MessageContents {
                         d1 + (256 * d2),
                         d3 + (256 * d4));
                 break;
+                
             case (SV_CMD_IDENTIFY_DEVICE_BY_DEVICE_ADDRESS):
                 returnString = Bundle.getMessage(locale, "SV2_IDENTIFY_DEVICE_REQUEST_INTEPRETED",
                         src,
                         dst);
                 break;
+                
             case (SV_CMD_IDENTIFY_DEVICE_BY_DEVICE_ADDRESS_REPLY):    
                 returnString = Bundle.getMessage(locale, "SV2_DEVICE_IDENTITY_REPORT_INTEPRETED",
                         src,
@@ -444,6 +457,7 @@ public class LnSv2MessageContents {
                         d1 + (256 * d2),    // product id
                         d3 + (256 * d4));   // serial number
                 break;
+                
             case (SV_CMD_CHANGE_ADDRESS_REQUEST):
                 returnString = Bundle.getMessage(locale, "SV2_CHANGE_ADDRESS_REQUEST_INTEPRETED",
                         src,
@@ -453,6 +467,7 @@ public class LnSv2MessageContents {
                         d1 + (256 * d2),    // product id
                         d3 + (256 * d4));   // serial number
                 break;
+                
             case (SV_CMD_CHANGE_ADDRESS_REPLY):
                 /*
                 Using only a single SV2 Programming Format message, it is impossible 
@@ -467,25 +482,29 @@ public class LnSv2MessageContents {
                         (d3 == 0) &&
                         (d4 == 0)) {
                     // this is probably a change address reply where a reconfigure is required
-                returnString = Bundle.getMessage(locale, "SV2_CHANGE_ADDRESS_REPLY_NEEDS_RECONFIGURE_INTEPRETED",
-                        src,
-                        dst // old SV device address
-                        );
+                    returnString = Bundle.getMessage(locale,
+                            "SV2_CHANGE_ADDRESS_REPLY_NEEDS_RECONFIGURE_INTEPRETED",
+                            src,
+                            dst // old SV device address
+                            );
+                } else {
+                    returnString = Bundle.getMessage(locale,
+                            "SV2_CHANGE_ADDRESS_REPLY_INTEPRETED",
+                            src,
+                            dst, // new SV device address
+                            sv_adrl,            // manufacturer id
+                            sv_adrh,            // device id
+                            d1 + (256 * d2),    // product id
+                            d3 + (256 * d4));   // serial number
+                }
                 break;
-                } else 
-                returnString = Bundle.getMessage(locale, "SV2_CHANGE_ADDRESS_REPLY_INTEPRETED",
-                        src,
-                        dst, // new SV device address
-                        sv_adrl,            // manufacturer id
-                        sv_adrh,            // device id
-                        d1 + (256 * d2),    // product id
-                        d3 + (256 * d4));   // serial number
-                break;
+                
             case (SV_CMD_RECONFIGURE_REQUEST):
                 returnString = Bundle.getMessage(locale, "SV2_RECONFIGURE_REQUEST_INTEPRETED", 
                         src,
                         dst);
                 break;
+                
             case (SV_CMD_RECONFIGURE_REPLY):
                 returnString = Bundle.getMessage(locale, "SV2_DEVICE_RECONFIGURE_REPLY_INTEPRETED",
                         src,
@@ -495,9 +514,11 @@ public class LnSv2MessageContents {
                         d1 + (256 * d2),    // product id
                         d3 + (256 * d4));   // serial number
                 break;
+                
             default:
                 return Bundle.getMessage(locale, "SV2_UNDEFINED_MESSAGE");
         }
+        
         log.debug("interpreted: " + returnString);  // NOI18N
         return returnString+"\n";  // NOI18N
     }
@@ -581,6 +602,7 @@ public class LnSv2MessageContents {
     public int getSingleReadReportData() {
         return d1;
     }
+    
     /**
      * Create a LocoNet message containing an SV Programming Format 2 message
      * @param source  source device address (7 bit, for &lt;SRC&gt;)
@@ -597,9 +619,10 @@ public class LnSv2MessageContents {
     public static LocoNetMessage createSv2Message (int source, int command, 
             int destination, int svNum, int d1, int d2, int d3, int d4) 
         throws java.lang.IllegalArgumentException {
-            if ( ! isSupportedSv2Command(command)) {
-                throw new java.lang.IllegalArgumentException("Command is not a supported SV2 command"); // NOI18N
-            }
+        
+        if ( ! isSupportedSv2Command(command)) {
+            throw new java.lang.IllegalArgumentException("Command is not a supported SV2 command"); // NOI18N
+        }
         LocoNetMessage m = new LocoNetMessage(SV2_LENGTH_ELEMENT_VALUE);
         m.setOpCode(LnConstants.OPC_PEER_XFER);
         m.setElement(SV2_LENGTH_ELEMENT_INDEX, SV2_LENGTH_ELEMENT_VALUE);
@@ -636,7 +659,7 @@ public class LnSv2MessageContents {
     
     public int getDestAddr() {
         if (sv_cmd != Sv2Command.SV2_DISCOVER_ALL.cmd) {
-            return dst_l + 246*dst_h;
+            return dst_l + 256*dst_h;
         }
         return -1;
     }
@@ -664,10 +687,7 @@ public class LnSv2MessageContents {
     }
     
     public boolean isSvReconfigureReply() {
-        if (sv_cmd == Sv2Command.SV2_RECONFIGURE_DEVICE_REPLY.cmd) {
-            return true;
-        }
-        return false;
+        return (sv_cmd == Sv2Command.SV2_RECONFIGURE_DEVICE_REPLY.cmd);
     }
 
     public int getSv2DeveloperID() {
@@ -792,7 +812,6 @@ public class LnSv2MessageContents {
         if ((m.getElement(3) != Sv2Command.SV2_QUERY_ONE.cmd) && 
                 (m.getElement(3) != Sv2Command.SV2_QUERY_FOUR.cmd)) {
             return null;
-            
         }
         LocoNetMessage n = m;
         n.setElement(3, n.getElement(3) + 0x40);
@@ -865,20 +884,17 @@ public class LnSv2MessageContents {
     }
 
     public boolean isSvChangeAddressReply() {
-        if (sv_cmd == Sv2Command.SV2_CHANGE_DEVICE_ADDRESS_REPLY.cmd) {
-            return true;
-        }
-        return false;
+        return (sv_cmd == Sv2Command.SV2_CHANGE_DEVICE_ADDRESS_REPLY.cmd);
     }
     
     public static LocoNetMessage createSvDiscoverQueryMessage() {
-     return createSv2Message(1, 
+        return createSv2Message(1, 
                 Sv2Command.SV2_DISCOVER_ALL.cmd, 
                 0, 0, 0, 0, 0, 0);
      }
     
     public static LocoNetMessage createSvReadRequest() {
-     return createSv2Message(1, 
+        return createSv2Message(1, 
                 Sv2Command.SV2_DISCOVER_ALL.cmd, 
                 0, 0, 0, 0, 0, 0);
      }
@@ -920,6 +936,7 @@ public class LnSv2MessageContents {
         Sv2Command(int cmd) {
             this.cmd = cmd;
         }
+        
         int getCmd() {return cmd;}
         
         public static int getCmd(Sv2Command mt) {


### PR DESCRIPTION
This PR fixes an invalid constant in getDestAddr(). While doing that, I also removed a couple of redundant if statements and a redundant return statement. I also fixed indentation in some places.

@bobjacobsen 
@devel-bobm 
Can anyone of you check that this code is working? It seems that I'm the first one that's using getDestAddr() so that's probably why this error hasn't been discovered until now.