### PR TITLE
Deprecate Manager.getBeanByUserName, getBeanBySystemName

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -484,6 +484,15 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>The <code>getBeanByUserName<code> and <code>getBeanBySystemName<code> 
+                calls in the various <code>Manager<code> classes
+                are no longer needed with Java 8 and have been deprecated for eventual
+                removal.  Their replacements are 
+                <code>getByUserName<code> and <code>getBySystemName<code> 
+                respectively.
+                If you use <code>getBeanByUserName<code> and <code>getBeanBySystemName<code> 
+                in script or Java code you've written, please 
+                switch to the new names.
+            </li>
         </ul>
 

--- a/help/en/releasenotes/current-draft-warnings.shtml
+++ b/help/en/releasenotes/current-draft-warnings.shtml
@@ -19,3 +19,14 @@
         to installing JMRI 4.19.1 (or later) and check the JMRI Console to
         see if there are any instructions there.
     </li>
+    <li>
+        The <code>getBeanByUserName<code> and <code>getBeanBySystemName<code> 
+        calls in the various <code>Manager<code> classes
+        are no longer needed with Java 8 and have been deprecated for eventual
+        removal.  Their replacements are 
+        <code>getByUserName<code> and <code>getBySystemName<code> 
+        respectively. 
+        If you use <code>getBeanByUserName<code> and <code>getBeanBySystemName<code> 
+        in script or Java code you've written, please 
+        switch to the new names.
+    </li>

--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -175,18 +175,6 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
 
     @CheckReturnValue
     @CheckForNull
-    public Block getBySystemName(@Nonnull String key) {
-        return _tsys.get(key);
-    }
-
-    @CheckReturnValue
-    @CheckForNull
-    public Block getByUserName(@Nonnull String key) {
-        return _tuser.get(key);
-    }
-
-    @CheckReturnValue
-    @CheckForNull
     public Block getByDisplayName(@Nonnull String key) {
         // First try to find it in the user list.
         // If that fails, look it up in the system list

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -500,6 +500,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
     @CheckForNull
     @Deprecated // 4.19.1
     public default E getBeanBySystemName(@Nonnull String systemName) {
+        jmri.util.Log4JUtil.deprecationWarning(deprecatedManagerLogger, "getBeanBySystemName");
         return getBySystemName(systemName);
     }
 
@@ -514,8 +515,12 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
     @CheckForNull
     @Deprecated // 4.19.1
     public default E getBeanByUserName(@Nonnull String userName) {
+        jmri.util.Log4JUtil.deprecationWarning(deprecatedManagerLogger, "getBeanByUserName");
         return getByUserName(userName);
     }
+
+    // needed for deprecationWarning call above
+    static final org.slf4j.Logger deprecatedManagerLogger = org.slf4j.LoggerFactory.getLogger(Manager.class);
 
     /**
      * Locate an existing instance based on a system name.

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -489,6 +489,35 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
     public SortedSet<E> getNamedBeanSet();
 
     /**
+     * Deprecated form to locate an existing instance based on a system name.
+     *
+     * @param systemName System Name of the required NamedBean
+     * @return requested NamedBean object or null if none exists
+     * @throws IllegalArgumentException if provided name is invalid
+     * @deprecated since 4.19.1
+     */
+    @CheckReturnValue
+    @CheckForNull
+    @Deprecated // 4.19.1
+    public default E getBeanBySystemName(@Nonnull String systemName) {
+        return getBySystemName(systemName);
+    }
+
+    /**
+     * Deprecated form to locate an existing instance based on a user name.
+     *
+     * @param userName System Name of the required NamedBean
+     * @return requested NamedBean object or null if none exists
+     * @deprecated since 4.19.1
+     */
+    @CheckReturnValue
+    @CheckForNull
+    @Deprecated // 4.19.1
+    public default E getBeanByUserName(@Nonnull String userName) {
+        return getByUserName(userName);
+    }
+
+    /**
      * Locate an existing instance based on a system name.
      *
      * @param systemName System Name of the required NamedBean
@@ -497,7 +526,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      */
     @CheckReturnValue
     @CheckForNull
-    public E getBeanBySystemName(@Nonnull String systemName);
+    public E getBySystemName(@Nonnull String systemName);
 
     /**
      * Locate an existing instance based on a user name.
@@ -507,7 +536,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      */
     @CheckReturnValue
     @CheckForNull
-    public E getBeanByUserName(@Nonnull String userName);
+    public E getByUserName(@Nonnull String userName);
 
     /**
      * Locate an existing instance based on a name.

--- a/java/src/jmri/SectionManager.java
+++ b/java/src/jmri/SectionManager.java
@@ -131,14 +131,6 @@ public class SectionManager extends AbstractManager<Section> implements Instance
         return getBySystemName(name);
     }
 
-    public Section getBySystemName(String key) {
-        return _tsys.get(key);
-    }
-
-    public Section getByUserName(String key) {
-        return _tuser.get(key);
-    }
-
     /**
      * Validate all Sections.
      *

--- a/java/src/jmri/TransitManager.java
+++ b/java/src/jmri/TransitManager.java
@@ -120,14 +120,6 @@ public class TransitManager extends AbstractManager<Transit> implements Instance
         return getBySystemName(name);
     }
 
-    public Transit getBySystemName(String key) {
-        return  _tsys.get(key);
-    }
-
-    public Transit getByUserName(String key) {
-        return _tuser.get(key);
-    }
-
     /**
      * Remove an existing Transit.
      *

--- a/java/src/jmri/implementation/AbstractIdTag.java
+++ b/java/src/jmri/implementation/AbstractIdTag.java
@@ -49,7 +49,7 @@ public abstract class AbstractIdTag extends AbstractNamedBean implements IdTag, 
     private String findPrefix() {
         List<Manager<IdTag>> managerList = InstanceManager.getDefault(ProxyIdTagManager.class).getManagerList();
         for (Manager<IdTag> m : managerList) {
-            if (m.getBeanBySystemName(mSystemName) != null) {
+            if (m.getBySystemName(mSystemName) != null) {
                 return m.getSystemPrefix();
             }
         }

--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -667,15 +667,18 @@ public class DefaultConditional extends AbstractNamedBean
                             if (sname == null) {
                                 errorList.add("Conditional system name null during cancel turnout timers for "  // NOI18N
                                         + action.getDeviceName());
+                                continue; // no more processing of this one
                             }
+                            
                             Conditional c = cmg.getBySystemName(sname);
                             if (c == null) {
                                 errorList.add("Conditional null during cancel turnout timers for "  // NOI18N
                                         + action.getDeviceName());
-                            } else {
-                                c.cancelTurnoutTimer(devName);
-                                actionCount++;
+                                continue; // no more processing of this one
                             }
+                            
+                            c.cancelTurnoutTimer(devName);
+                            actionCount++;
                         }
                         break;
                     case LOCK_TURNOUT:
@@ -809,15 +812,17 @@ public class DefaultConditional extends AbstractNamedBean
                             if (sname == null) {
                                 errorList.add("Conditional system name null during cancel sensor timers for "  // NOI18N
                                         + action.getDeviceName());
+                                continue; // no more processing of this one
                             }
                             Conditional c = cm.getBySystemName(sname);
                             if (c == null) {
                                 errorList.add("Conditional null during cancel sensor timers for "  // NOI18N
                                         + action.getDeviceName());
-                            } else {
-                                c.cancelSensorTimer(devName);
-                                actionCount++;
+                                continue; // no more processing of this one
                             }
+                            
+                            c.cancelSensorTimer(devName);
+                            actionCount++;
                         }
                         break;
                     case SET_LIGHT:

--- a/java/src/jmri/implementation/configurexml/DoubleTurnoutSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/DoubleTurnoutSignalHeadXml.java
@@ -86,7 +86,7 @@ public class DoubleTurnoutSignalHeadXml extends jmri.managers.configurexml.Abstr
 
         SignalHead existingBean =
                 InstanceManager.getDefault(jmri.SignalHeadManager.class)
-                        .getBeanBySystemName(sys);
+                        .getBySystemName(sys);
 
         if ((existingBean != null) && (existingBean != h)) {
             log.error("systemName is already registered: {}", sys);

--- a/java/src/jmri/implementation/configurexml/LsDecSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/LsDecSignalHeadXml.java
@@ -105,7 +105,7 @@ public class LsDecSignalHeadXml extends jmri.managers.configurexml.AbstractNamed
 
         SignalHead existingBean =
                 InstanceManager.getDefault(jmri.SignalHeadManager.class)
-                        .getBeanBySystemName(sys);
+                        .getBySystemName(sys);
 
         if ((existingBean != null) && (existingBean != h)) {
             log.error("systemName is already registered: {}", sys);

--- a/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
@@ -171,7 +171,7 @@ public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNam
         loadCommon(h, shared);
 
         SignalHead existingBean = InstanceManager.getDefault(jmri.SignalHeadManager.class)
-                        .getBeanBySystemName(sys);
+                        .getBySystemName(sys);
 
         if ((existingBean != null) && (existingBean != h)) {
             log.error("systemName is already registered: {}", sys);

--- a/java/src/jmri/implementation/configurexml/QuadOutputSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/QuadOutputSignalHeadXml.java
@@ -70,7 +70,7 @@ public class QuadOutputSignalHeadXml extends TripleTurnoutSignalHeadXml {
 
         SignalHead existingBean =
                 InstanceManager.getDefault(jmri.SignalHeadManager.class)
-                        .getBeanBySystemName(sys);
+                        .getBySystemName(sys);
 
         if ((existingBean != null) && (existingBean != h)) {
             log.error("systemName is already registered: {}", sys);

--- a/java/src/jmri/implementation/configurexml/SE8cSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/SE8cSignalHeadXml.java
@@ -83,7 +83,7 @@ public class SE8cSignalHeadXml extends jmri.managers.configurexml.AbstractNamedB
         loadCommon(h, shared);
 
         SignalHead existingBean = InstanceManager.getDefault(jmri.SignalHeadManager.class)
-                        .getBeanBySystemName(sys);
+                        .getBySystemName(sys);
 
         if ((existingBean != null) && (existingBean != h)) {
             log.error("systemName is already registered: {}", sys);

--- a/java/src/jmri/implementation/configurexml/SingleTurnoutSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/SingleTurnoutSignalHeadXml.java
@@ -112,7 +112,7 @@ public class SingleTurnoutSignalHeadXml extends jmri.managers.configurexml.Abstr
 
         SignalHead existingBean =
                 InstanceManager.getDefault(jmri.SignalHeadManager.class)
-                        .getBeanBySystemName(sys);
+                        .getBySystemName(sys);
 
         if ((existingBean != null) && (existingBean != h)) {
             log.error("systemName is already registered: {}", sys);

--- a/java/src/jmri/implementation/configurexml/TripleOutputSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/TripleOutputSignalHeadXml.java
@@ -70,7 +70,7 @@ public class TripleOutputSignalHeadXml extends DoubleTurnoutSignalHeadXml {
         loadCommon(h, shared);
 
         SignalHead existingBean = InstanceManager.getDefault(jmri.SignalHeadManager.class)
-                        .getBeanBySystemName(sys);
+                        .getBySystemName(sys);
 
         if ((existingBean != null) && (existingBean != h)) {
             log.error("systemName is already registered: {}", sys);

--- a/java/src/jmri/implementation/configurexml/TripleTurnoutSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/TripleTurnoutSignalHeadXml.java
@@ -70,7 +70,7 @@ public class TripleTurnoutSignalHeadXml extends DoubleTurnoutSignalHeadXml {
 
         SignalHead existingBean =
                 InstanceManager.getDefault(jmri.SignalHeadManager.class)
-                        .getBeanBySystemName(sys);
+                        .getBySystemName(sys);
 
         if ((existingBean != null) && (existingBean != h)) {
             log.error("systemName is already registered: {}", sys);

--- a/java/src/jmri/implementation/configurexml/VirtualSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/VirtualSignalHeadXml.java
@@ -54,7 +54,7 @@ public class VirtualSignalHeadXml extends jmri.managers.configurexml.AbstractNam
 
         SignalHead existingBean =
                 InstanceManager.getDefault(jmri.SignalHeadManager.class)
-                        .getBeanBySystemName(sys);
+                        .getBySystemName(sys);
 
         if ((existingBean != null) && (existingBean != h)) {
             log.error("systemName is already registered: {}", sys);

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -1261,7 +1261,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
                         } else if (key.equals("chgUname")) {         // NOI18N
                             Logix x = _logixManager.getBySystemName(lgxName);
                             if (x == null) {
-                                log.error("Found no logix for name {} when changing user name (1)", lgxname);
+                                log.error("Found no logix for name {} when changing user name (1)", lgxName);
                                 return;
                             }
                             x.setUserName(value);
@@ -1288,7 +1288,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
                         } else if (key.equals("chgUname")) {         // NOI18N
                             Logix x = _logixManager.getBySystemName(lgxName);
                             if (x == null) {
-                                log.error("Found no logix for name {} when changing user name (2)", lgxname);
+                                log.error("Found no logix for name {} when changing user name (2)", lgxName);
                                 return;
                             }
                             x.setUserName(value);

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -1260,6 +1260,10 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
                             deletePressed(value);
                         } else if (key.equals("chgUname")) {         // NOI18N
                             Logix x = _logixManager.getBySystemName(lgxName);
+                            if (x == null) {
+                                log.error("Found no logix for name {} when changing user name (1)", lgxname);
+                                return;
+                            }
                             x.setUserName(value);
                             m.fireTableDataChanged();
                         }
@@ -1283,6 +1287,10 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
                             deletePressed(value);
                         } else if (key.equals("chgUname")) {         // NOI18N
                             Logix x = _logixManager.getBySystemName(lgxName);
+                            if (x == null) {
+                                log.error("Found no logix for name {} when changing user name (2)", lgxname);
+                                return;
+                            }
                             x.setUserName(value);
                             m.fireTableDataChanged();
                         }

--- a/java/src/jmri/jmrit/beantable/Maintenance.java
+++ b/java/src/jmri/jmrit/beantable/Maintenance.java
@@ -383,10 +383,10 @@ public class Maintenance {
         justification = "null return for normal (no error) case is easy to check, and this is a really wierd array")
     // This should probably return an instance of a custom type rather than a bunch of string names
     static private String[] checkForOneTypeAndNames( @Nonnull Manager<? extends NamedBean> manager, @Nonnull String type, @Nonnull String beanName) {
-        NamedBean bean = manager.getBeanBySystemName(beanName);
+        NamedBean bean = manager.getBySystemName(beanName);
         if (bean != null) return new String[]{type, bean.getUserName(), bean.getSystemName(), Integer.toString(bean.getNumPropertyChangeListeners())};
 
-        bean = manager.getBeanByUserName(beanName);
+        bean = manager.getByUserName(beanName);
         if (bean != null) return new String[]{type, bean.getUserName(), bean.getSystemName(), Integer.toString(bean.getNumPropertyChangeListeners())};
 
         return null;

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -175,18 +175,6 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
         return null;
     }
 
-    @CheckReturnValue
-    @CheckForNull
-    public LayoutBlock getBySystemName(@Nonnull String key) {
-        return _tsys.get(key);
-    }
-
-    @CheckReturnValue
-    @CheckForNull
-    public LayoutBlock getByUserName(@Nonnull String key) {
-        return _tuser.get(key);
-    }
-
     /**
      * Find a LayoutBlock with a specified Sensor assigned as its
      * occupancy sensor.

--- a/java/src/jmri/jmrit/entryexit/EntryExitPairs.java
+++ b/java/src/jmri/jmrit/entryexit/EntryExitPairs.java
@@ -212,6 +212,7 @@ public class EntryExitPairs implements jmri.Manager<DestinationPoints>, jmri.Ins
         return ENTRYEXIT;
     }
 
+    /** {@inheritDoc} */
     public DestinationPoints getBySystemName(String systemName) {
         for (Source e : nxpair.values()) {
             DestinationPoints pd = e.getByUniqueId(systemName);
@@ -224,13 +225,7 @@ public class EntryExitPairs implements jmri.Manager<DestinationPoints>, jmri.Ins
 
     /** {@inheritDoc} */
     @Override
-    public DestinationPoints getBeanBySystemName(@Nonnull String systemName) {
-        return getBySystemName(systemName);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public DestinationPoints getBeanByUserName(@Nonnull String userName) {
+    public DestinationPoints getByUserName(@Nonnull String userName) {
         for (Source e : nxpair.values()) {
             DestinationPoints pd = e.getByUserName(userName);
             if (pd != null) {
@@ -243,11 +238,11 @@ public class EntryExitPairs implements jmri.Manager<DestinationPoints>, jmri.Ins
     /** {@inheritDoc} */
     @Override
     public DestinationPoints getNamedBean(@Nonnull String name) {
-        DestinationPoints b = getBeanByUserName(name);
+        DestinationPoints b = getByUserName(name);
         if (b != null) {
             return b;
         }
-        return getBeanBySystemName(name);
+        return getBySystemName(name);
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logix/OBlockManager.java
+++ b/java/src/jmri/jmrit/logix/OBlockManager.java
@@ -87,14 +87,6 @@ public class OBlockManager extends AbstractManager<OBlock>
         return getBySystemName(name);
     }
 
-    public OBlock getBySystemName(@Nonnull String name) {
-        return _tsys.get(name);
-    }
-
-    public OBlock getByUserName(@Nonnull String key) {
-        return _tuser.get(key);
-    }
-
     @Override
     public OBlock provide(@Nonnull String name) throws IllegalArgumentException {
         return provideOBlock(name);

--- a/java/src/jmri/jmrit/logix/WarrantManager.java
+++ b/java/src/jmri/jmrit/logix/WarrantManager.java
@@ -103,14 +103,6 @@ public class WarrantManager extends AbstractManager<Warrant>
         return getBySystemName(name);
     }
 
-    public Warrant getBySystemName(String name) {
-        return _tsys.get(name);
-    }
-
-    public Warrant getByUserName(String key) {
-        return _tuser.get(key);
-    }
-
     public Warrant provideWarrant(String name) {
         if (name == null || name.trim().length() == 0) {
             return null;

--- a/java/src/jmri/jmrit/picker/PickListModel.java
+++ b/java/src/jmri/jmrit/picker/PickListModel.java
@@ -156,7 +156,7 @@ public abstract class PickListModel<E extends NamedBean> extends BeanTableDataMo
     @Override
     @CheckForNull
     public E getBySystemName(@Nonnull String name) {
-        return getManager().getBeanBySystemName(name);
+        return getManager().getBySystemName(name);
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/picker/PickListModel.java
+++ b/java/src/jmri/jmrit/picker/PickListModel.java
@@ -163,7 +163,7 @@ public abstract class PickListModel<E extends NamedBean> extends BeanTableDataMo
     @Override
     @CheckForNull
     protected E getByUserName(@Nonnull String name) {
-        return getManager().getBeanByUserName(name);
+        return getManager().getByUserName(name);
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
@@ -522,7 +522,7 @@ public class VSDecoderManager implements PropertyChangeListener {
     }
 
     protected void registerBeanListener(Manager beanManager, String sysName) {
-        NamedBean b = beanManager.getBeanBySystemName(sysName);
+        NamedBean b = beanManager.getBySystemName(sysName);
         if (b == null) {
             log.debug("No bean by name {}", sysName);
             return;

--- a/java/src/jmri/managers/AbstractLightManager.java
+++ b/java/src/jmri/managers/AbstractLightManager.java
@@ -71,24 +71,6 @@ public abstract class AbstractLightManager extends AbstractManager<Light>
      * {@inheritDoc}
      */
     @Override
-    @CheckForNull
-    public Light getBySystemName(@Nonnull String name) {
-        return _tsys.get(name);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @CheckForNull
-    public Light getByUserName(@Nonnull String key) {
-        return _tuser.get(key);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     @Nonnull
     public Light newLight(@Nonnull String systemName, @CheckForNull String userName) {
         log.debug("newLight: {};{}",

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -112,28 +112,28 @@ public abstract class AbstractManager<E extends NamedBean> implements Manager<E>
      * Get a NamedBean by its system name.
      *
      * @param systemName the system name
-     * @return the result of {@link #getBeanBySystemName(java.lang.String)}
+     * @return the result of {@link #getBySystemName(java.lang.String)}
      *         with systemName
      * @deprecated since 4.15.6; use
-     * {@link #getBeanBySystemName(java.lang.String)} instead
+     * {@link #getBySystemName(java.lang.String)} instead
      */
     @Deprecated
     protected E getInstanceBySystemName(String systemName) {
-        return getBeanBySystemName(systemName);
+        return getBySystemName(systemName);
     }
 
     /**
      * Get a NamedBean by its user name.
      *
      * @param userName the user name
-     * @return the result of {@link #getBeanByUserName(java.lang.String)} call,
+     * @return the result of {@link #getByUserName(java.lang.String)} call,
      *         with userName
      * @deprecated since 4.15.6; use
-     * {@link #getBeanByUserName(java.lang.String)} instead
+     * {@link #getByUserName(java.lang.String)} instead
      */
     @Deprecated
     protected E getInstanceByUserName(String userName) {
-        return getBeanByUserName(userName);
+        return getByUserName(userName);
     }
 
     /** {@inheritDoc} */
@@ -144,7 +144,7 @@ public abstract class AbstractManager<E extends NamedBean> implements Manager<E>
 
     /**
      * Protected method used by subclasses to over-ride the default behavior of
-     * getBeanBySystemName when a simple string lookup is not sufficient
+     * getBySystemName when a simple string lookup is not sufficient
      *
      * @param systemName the system name to check.
      * @param comparator a Comparator encapsulating the system specific comparison behavior.

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -140,7 +140,7 @@ public abstract class AbstractManager<E extends NamedBean> implements Manager<E>
 
     /** {@inheritDoc} */
     @Override
-    public E getBeanBySystemName(@Nonnull String systemName) {
+    public E getBySystemName(@Nonnull String systemName) {
         return _tsys.get(systemName);
     }
 
@@ -152,7 +152,7 @@ public abstract class AbstractManager<E extends NamedBean> implements Manager<E>
      * @param comparator a Comparator encapsulating the system specific comparison behavior.
      * @return A named bean of the appropriate type, or null if not found.
      */
-    protected E getBySystemName(String systemName,Comparator<String> comparator){
+    protected E getBySystemName(String systemName, Comparator<String> comparator){
         for(Map.Entry<String,E> e:_tsys.entrySet()){
             if(0==comparator.compare(e.getKey(),systemName)){
                 return e.getValue();
@@ -163,7 +163,7 @@ public abstract class AbstractManager<E extends NamedBean> implements Manager<E>
 
     /** {@inheritDoc} */
     @Override
-    public E getBeanByUserName(@Nonnull String userName) {
+    public E getByUserName(@Nonnull String userName) {
         String normalizedUserName = NamedBean.normalizeUserName(userName);
         return normalizedUserName != null ? _tuser.get(normalizedUserName) : null;
     }
@@ -173,12 +173,12 @@ public abstract class AbstractManager<E extends NamedBean> implements Manager<E>
     public E getNamedBean(@Nonnull String name) {
         String normalizedUserName = NamedBean.normalizeUserName(name);
         if (normalizedUserName != null) {
-            E b = getBeanByUserName(normalizedUserName);
+            E b = getByUserName(normalizedUserName);
             if (b != null) {
                 return b;
             }
         }
-        return getBeanBySystemName(name);
+        return getBySystemName(name);
     }
 
     /** {@inheritDoc} */
@@ -199,7 +199,7 @@ public abstract class AbstractManager<E extends NamedBean> implements Manager<E>
     public void register(@Nonnull E s) {
         String systemName = s.getSystemName();
 
-        E existingBean = getBeanBySystemName(systemName);
+        E existingBean = getBySystemName(systemName);
         if (existingBean != null) {
             if (s == existingBean) {
                 log.debug("the named bean is registered twice: {}", systemName);

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -15,8 +15,6 @@ import jmri.NamedBean;
 import jmri.NamedBean.DuplicateSystemNameException;
 import jmri.NamedBeanPropertyDescriptor;
 import jmri.jmrix.SystemConnectionMemo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Abstract partial implementation for all Manager-type classes.
@@ -702,6 +700,6 @@ public abstract class AbstractManager<E extends NamedBean> implements Manager<E>
         return b.toString();
     }
 
-    private static final Logger log = LoggerFactory.getLogger(AbstractManager.class);
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractManager.class);
 
 }

--- a/java/src/jmri/managers/AbstractMemoryManager.java
+++ b/java/src/jmri/managers/AbstractMemoryManager.java
@@ -68,18 +68,6 @@ public abstract class AbstractMemoryManager extends AbstractManager<Memory>
 
     /** {@inheritDoc} */
     @Override
-    public Memory getBySystemName(@Nonnull String name) {
-        return _tsys.get(name);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Memory getByUserName(@Nonnull String key) {
-        return _tuser.get(key);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public @Nonnull Memory newMemory(@Nonnull String systemName, @CheckForNull String userName) {
         log.debug("new Memory: {}; {}", systemName, userName); // NOI18N
         Objects.requireNonNull(systemName, "Value of requested systemName cannot be null");

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -168,11 +168,11 @@ abstract public class AbstractProxyManager<E extends NamedBean> implements Proxy
     /** {@inheritDoc} */
     @Override
     public E getNamedBean(@Nonnull String name) {
-        E t = getBeanByUserName(name);
+        E t = getByUserName(name);
         if (t != null) {
             return t;
         }
-        return getBeanBySystemName(name);
+        return getBySystemName(name);
     }
 
     /**
@@ -215,22 +215,22 @@ abstract public class AbstractProxyManager<E extends NamedBean> implements Proxy
 
     /** {@inheritDoc} */
     @Override
-    public E getBeanBySystemName(@Nonnull String systemName) {
+    public E getBySystemName(@Nonnull String systemName) {
         // System names can be matched to managers by system and type at front of name
         int index = matchTentative(systemName);
         if (index >= 0) {
             Manager<E> m = getMgr(index);
-            return m.getBeanBySystemName(systemName);
+            return m.getBySystemName(systemName);
         }
-        log.debug("getBeanBySystemName did not find manager from name {}, defer to default manager", systemName); // NOI18N
-        return getDefaultManager().getBeanBySystemName(systemName);
+        log.debug("getBySystemName did not find manager from name {}, defer to default manager", systemName); // NOI18N
+        return getDefaultManager().getBySystemName(systemName);
     }
 
     /** {@inheritDoc} */
     @Override
-    public E getBeanByUserName(@Nonnull String userName) {
+    public E getByUserName(@Nonnull String userName) {
         for (Manager<E> m : this.mgrs) {
-            E b = m.getBeanByUserName(userName);
+            E b = m.getByUserName(userName);
             if (b != null) {
                 return b;
             }

--- a/java/src/jmri/managers/AbstractReporterManager.java
+++ b/java/src/jmri/managers/AbstractReporterManager.java
@@ -147,7 +147,7 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
         // Some implementations of createNewReporter() registers the bean, some
         // don't. Check if the bean is registered and register it if it isn't
         // registered.
-        if (getBeanBySystemName(systemName) == null) {
+        if (getBySystemName(systemName) == null) {
             // save in the maps
             register(r);
         }

--- a/java/src/jmri/managers/AbstractReporterManager.java
+++ b/java/src/jmri/managers/AbstractReporterManager.java
@@ -68,18 +68,6 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
 
     /** {@inheritDoc} */
     @Override
-    public Reporter getBySystemName(@Nonnull String name) {
-        return _tsys.get(name);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Reporter getByUserName(@Nonnull String key) {
-        return _tuser.get(key);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     @Nonnull
     public String getBeanTypeHandled(boolean plural) {
         return Bundle.getMessage(plural ? "BeanNameReporters" : "BeanNameReporter");

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -69,25 +69,15 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         }
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Sensor getBeanBySystemName(@Nonnull String key) {
-        return this.getBySystemName(key);
-    }
-    
-    /** {@inheritDoc} */
+    /** {@inheritDoc} 
+     * Special handling for numeric argument, which is treated as the suffix of a new system name
+    */
     @Override
     public Sensor getBySystemName(@Nonnull String key) {
         if (isNumber(key)) {
             key = makeSystemName(key);
         }
         return _tsys.get(key);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Sensor getByUserName(@Nonnull String key) {
-        return _tuser.get(key);
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/managers/AbstractSignalHeadManager.java
+++ b/java/src/jmri/managers/AbstractSignalHeadManager.java
@@ -57,18 +57,6 @@ public class AbstractSignalHeadManager extends AbstractManager<SignalHead>
 
     /** {@inheritDoc} */
     @Override
-    public SignalHead getBySystemName(@Nonnull String name) {
-        return _tsys.get(name);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public SignalHead getByUserName(@Nonnull String key) {
-        return _tuser.get(key);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     @Nonnull
     public String getBeanTypeHandled(boolean plural) {
         return Bundle.getMessage(plural ? "BeanNameSignalHeads" : "BeanNameSignalHead");

--- a/java/src/jmri/managers/AbstractTurnoutManager.java
+++ b/java/src/jmri/managers/AbstractTurnoutManager.java
@@ -64,18 +64,6 @@ public abstract class AbstractTurnoutManager extends AbstractManager<Turnout>
 
     /** {@inheritDoc} */
     @Override
-    public Turnout getBySystemName(@Nonnull String name) {
-        return _tsys.get(name);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Turnout getByUserName(@Nonnull String key) {
-        return _tuser.get(key);
-    }
-
-    /** {@inheritDoc} */
-    @Override
     @Nonnull
     public Turnout newTurnout(@Nonnull String systemName, @CheckForNull String userName) {
         Objects.requireNonNull(systemName, "SystemName cannot be null. UserName was " + ((userName == null) ? "null" : userName));  // NOI18N

--- a/java/src/jmri/managers/AbstractTurnoutManager.java
+++ b/java/src/jmri/managers/AbstractTurnoutManager.java
@@ -108,7 +108,7 @@ public abstract class AbstractTurnoutManager extends AbstractManager<Turnout>
 
         // Some implementations of createNewTurnout() register the new bean,
         // some don't. 
-        if (getBeanBySystemName(s.getSystemName()) == null) {
+        if (getBySystemName(s.getSystemName()) == null) {
             // save in the maps if successful
             register(s);
         }

--- a/java/src/jmri/managers/DefaultIdTagManager.java
+++ b/java/src/jmri/managers/DefaultIdTagManager.java
@@ -45,16 +45,19 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         super(memo);
     }
 
+    /** {@inheritDoc} */
     @Override
     public int getXMLOrder() {
         return jmri.Manager.IDTAGS;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isInitialised() {
         return initialised;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void init() {
         log.debug("init called");
@@ -91,6 +94,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
     }
 
     /**
+     * {@inheritDoc} 
      * Don't want to store this information
      */
     @Override
@@ -98,17 +102,20 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         // override to do nothing
     }
 
+    /** {@inheritDoc} */
     @Override
     public char typeLetter() {
         return 'D';
     }
 
+    /** {@inheritDoc} */
     @Override
     @Nonnull
     public IdTag provide(@Nonnull String name) throws IllegalArgumentException {
         return provideIdTag(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     @Nonnull
     public IdTag provideIdTag(@Nonnull String name) throws IllegalArgumentException {
@@ -128,6 +135,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public IdTag getIdTag(@Nonnull String name) {
         if (!initialised && !loading) {
@@ -147,6 +155,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         return getBySystemName(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public IdTag getBySystemName(@Nonnull String name) {
         if (!initialised && !loading) {
@@ -155,6 +164,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         return _tsys.get(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public IdTag getByUserName(@Nonnull String key) {
         if (!initialised && !loading) {
@@ -163,6 +173,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         return _tuser.get(key);
     }
 
+    /** {@inheritDoc} */
     @Override
     public IdTag getByTagID(@Nonnull String tagID) {
         if (!initialised && !loading) {
@@ -180,6 +191,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         return new DefaultIdTag(systemName, userName);
     }
 
+    /** {@inheritDoc} */
     @Override
     @Nonnull
     public IdTag newIdTag(@Nonnull String systemName, @CheckForNull String userName) {
@@ -220,18 +232,21 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         return s;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void register(@Nonnull IdTag s) {
         super.register(s);
         this.setDirty(true);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void deregister(@Nonnull IdTag s) {
         super.deregister(s);
         this.setDirty(true);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
         super.propertyChange(e);
@@ -253,6 +268,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         log.debug("...done reading IdTag details");
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setStateStored(boolean state) {
         if (!initialised && !loading) {
@@ -266,6 +282,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         firePropertyChange("StateStored", old, state);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isStateStored() {
         if (!initialised && !loading) {
@@ -274,6 +291,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         return storeState;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void setFastClockUsed(boolean fastClock) {
         if (!initialised && !loading) {
@@ -287,6 +305,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         firePropertyChange("UseFastClock", old, fastClock);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isFastClockUsed() {
         if (!initialised && !loading) {
@@ -295,6 +314,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         return useFastClock;
     }
 
+    /** {@inheritDoc} */
     @Override
     @Nonnull
     public List<IdTag> getTagsForReporter(@Nonnull Reporter reporter, long threshold) {
@@ -330,12 +350,14 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
         this.dirty = dirty;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void dispose() {
         InstanceManager.getDefault(ShutDownManager.class).deregister(this.shutDownTask);
         super.dispose();
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getBeanTypeHandled(boolean plural) {
         return Bundle.getMessage(plural ? "BeanNameReporters" : "BeanNameReporter");

--- a/java/src/jmri/managers/DefaultLogixManager.java
+++ b/java/src/jmri/managers/DefaultLogixManager.java
@@ -151,16 +151,6 @@ public class DefaultLogixManager extends AbstractManager<Logix>
         return getBySystemName(name);
     }
 
-    @Override
-    public Logix getBySystemName(String name) {
-        return _tsys.get(name);
-    }
-
-    @Override
-    public Logix getByUserName(String key) {
-        return _tuser.get(key);
-    }
-
     /**
      * Support for loading Logixs in a disabled state to debug loops
      */

--- a/java/src/jmri/managers/DefaultRouteManager.java
+++ b/java/src/jmri/managers/DefaultRouteManager.java
@@ -121,16 +121,6 @@ public class DefaultRouteManager extends AbstractManager<Route>
         return getBySystemName(name);
     }
 
-    @Override
-    public Route getBySystemName(@Nonnull String name) {
-        return _tsys.get(name);
-    }
-
-    @Override
-    public Route getByUserName(@Nonnull String key) {
-        return _tuser.get(key);
-    }
-
     /**
      * 
      * @return the default instance of DefaultRouteManager

--- a/java/src/jmri/managers/ProxyIdTagManager.java
+++ b/java/src/jmri/managers/ProxyIdTagManager.java
@@ -116,28 +116,6 @@ public class ProxyIdTagManager extends AbstractProxyManager<IdTag>
     }
 
     /**
-     * Locate an instance based on a system name.
-     *
-     * @return requested IdTag object or null if none exists
-     */
-    @Override
-    public IdTag getBySystemName(@Nonnull String systemName) {
-        init();
-        return super.getBeanBySystemName(systemName);
-    }
-
-    /**
-     * Locate an instance based on a user name.
-     *
-     * @return requested Turnout object or null if none exists
-     */
-    @Override
-    public IdTag getByUserName(@Nonnull String userName) {
-        init();
-        return super.getBeanByUserName(userName);
-    }
-
-    /**
      * Get an instance with the specified system and user names. Note that
      * two calls with the same arguments will get the same instance; there is
      * only one IdTag object representing a given physical light and therefore

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -63,26 +63,6 @@ public class ProxyLightManager extends AbstractProxyManager<Light>
     }
 
     /**
-     * Locate an instance based on a system name.
-     *
-     * @return requested Light object or null if none exists
-     */
-    @Override
-    public Light getBySystemName(@Nonnull String systemName) {
-        return super.getBeanBySystemName(systemName);
-    }
-
-    /**
-     * Locate an instance based on a user name.
-     *
-     * @return requested Light object or null if none exists
-     */
-    @Override
-    public Light getByUserName(@Nonnull String userName) {
-        return super.getBeanByUserName(userName);
-    }
-
-    /**
      * Return an instance with the specified system and user names. Note that
      * two calls with the same arguments will get the same instance; there is
      * only one Light object representing a given physical light and therefore

--- a/java/src/jmri/managers/ProxyReporterManager.java
+++ b/java/src/jmri/managers/ProxyReporterManager.java
@@ -52,26 +52,6 @@ public class ProxyReporterManager extends AbstractProxyManager<Reporter> impleme
     @Nonnull
     public Reporter provide(@Nonnull String name) throws IllegalArgumentException { return provideReporter(name); }
 
-    /**
-     * Locate an instance based on a system name.
-     *
-     * @return requested Reporter object or null if none exists
-     */
-    @Override
-    public Reporter getBySystemName(@Nonnull String sName) {
-        return super.getBeanBySystemName(sName);
-    }
-
-    /**
-     * Locate an instance based on a user name.
-     *
-     * @return requested Reporter object or null if none exists
-     */
-    @Override
-    public Reporter getByUserName(@Nonnull String userName) {
-        return super.getBeanByUserName(userName);
-    }
-
     @Override
     public Reporter getByDisplayName(@Nonnull String key) {
         // First try to find it in the user list.

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -55,26 +55,6 @@ public class ProxySensorManager extends AbstractProxyManager<Sensor>
     public Sensor provide(@Nonnull String name) throws IllegalArgumentException { return provideSensor(name); }
 
     /**
-     * Locate an instance based on a system name.
-     *
-     * @return requested Turnout object or null if none exists
-     */
-    @Override
-    public Sensor getBySystemName(@Nonnull String sName) {
-        return super.getBeanBySystemName(sName);
-    }
-
-    /**
-     * Locate an instance based on a user name.
-     *
-     * @return requested Turnout object or null if none exists
-     */
-    @Override
-    public Sensor getByUserName(@Nonnull String userName) {
-        return super.getBeanByUserName(userName);
-    }
-
-    /**
      * Return an instance with the specified system and user names. Note that
      * two calls with the same arguments will get the same instance; there is
      * only one Sensor object representing a given physical turnout and

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -63,26 +63,6 @@ public class ProxyTurnoutManager extends AbstractProxyManager<Turnout> implement
     public Turnout provide(@Nonnull String name) throws IllegalArgumentException { return provideTurnout(name); }
 
     /**
-     * Locate an instance based on a system name.
-     *
-     * @return requested Turnout object or null if none exists
-     */
-    @Override
-    public Turnout getBySystemName(@Nonnull String systemName) {
-        return super.getBeanBySystemName(systemName);
-    }
-
-    /**
-     * Locate an instance based on a user name.
-     *
-     * @return requested Turnout object or null if none exists
-     */
-    @Override
-    public Turnout getByUserName(@Nonnull String userName) {
-        return super.getBeanByUserName(userName);
-    }
-
-    /**
      * Get an instance with the specified system and user names. Note that
      * two calls with the same arguments will get the same instance; there is
      * only one Sensor object representing a given physical turnout and

--- a/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
@@ -184,7 +184,7 @@ public abstract class AbstractNamedBeanManagerConfigXML extends jmri.configurexm
                         rawUserName, rawSystemName, normalizedUserName);
             }
             if (normalizedUserName != null) {
-                NamedBean bean = manager.getBeanByUserName(normalizedUserName);
+                NamedBean bean = manager.getByUserName(normalizedUserName);
                 if (bean != null && !bean.getSystemName().equals(rawSystemName)) {
                     log.warn("User name \"{}\" already exists as system name \"{}\"", normalizedUserName, bean.getSystemName());
                 }

--- a/java/src/jmri/server/json/JsonNamedBeanSocketService.java
+++ b/java/src/jmri/server/json/JsonNamedBeanSocketService.java
@@ -50,9 +50,9 @@ public class JsonNamedBeanSocketService<T extends NamedBean, H extends JsonNamed
         T bean = null;
         // protect against a request made with a user name instead of a system name
         if (!method.equals(PUT)) {
-            bean = service.getManager().getBeanBySystemName(name);
+            bean = service.getManager().getBySystemName(name);
             if (bean == null) {
-                bean = service.getManager().getBeanByUserName(name);
+                bean = service.getManager().getByUserName(name);
                 if (bean != null) {
                     // set to warn so users can provide specific feedback to developers of JSON clients
                     log.warn("{} request for {} made with user name \"{}\"; should use system name", method, type, name);
@@ -70,7 +70,7 @@ public class JsonNamedBeanSocketService<T extends NamedBean, H extends JsonNamed
             case PUT:
                 JsonNode message = service.doPut(type, name, data, locale, id);
                 connection.sendMessage(message, id);
-                bean = service.getManager().getBeanBySystemName(message.path(DATA).path(NAME).asText());
+                bean = service.getManager().getBySystemName(message.path(DATA).path(NAME).asText());
                 break;
             case GET:
             default:
@@ -95,7 +95,7 @@ public class JsonNamedBeanSocketService<T extends NamedBean, H extends JsonNamed
     }
 
     protected void addListenerToBean(String name) {
-        addListenerToBean(service.getManager().getBeanBySystemName(name));
+        addListenerToBean(service.getManager().getBySystemName(name));
     }
 
     protected void addListenerToBean(T bean) {
@@ -108,7 +108,7 @@ public class JsonNamedBeanSocketService<T extends NamedBean, H extends JsonNamed
 
     protected void removeListenersFromRemovedBeans() {
         for (T bean : new HashSet<>(beanListeners.keySet())) {
-            if (service.getManager().getBeanBySystemName(bean.getSystemName()) == null) {
+            if (service.getManager().getBySystemName(bean.getSystemName()) == null) {
                 beanListeners.remove(bean);
             }
         }

--- a/java/src/jmri/server/json/idtag/JsonIdTagHttpService.java
+++ b/java/src/jmri/server/json/idtag/JsonIdTagHttpService.java
@@ -56,7 +56,7 @@ public class JsonIdTagHttpService extends JsonNamedBeanHttpService<IdTag> {
         if (node.isNull()) {
             idTag.setWhereLastSeen(null);
         } else if (node.isTextual()) {
-            Reporter reporter = InstanceManager.getDefault(ReporterManager.class).getBeanBySystemName(node.asText());
+            Reporter reporter = InstanceManager.getDefault(ReporterManager.class).getBySystemName(node.asText());
             if (reporter != null) {
                 idTag.setWhereLastSeen(reporter);
             } else {

--- a/java/src/jmri/server/json/layoutblock/JsonLayoutBlockHttpService.java
+++ b/java/src/jmri/server/json/layoutblock/JsonLayoutBlockHttpService.java
@@ -52,7 +52,7 @@ public class JsonLayoutBlockHttpService extends JsonNonProvidedNamedBeanHttpServ
 
     @Override
     public JsonNode doGet(String type, String name, JsonNode data, Locale locale, int id) throws JsonException {
-        return doGet(InstanceManager.getDefault(LayoutBlockManager.class).getBeanBySystemName(name), name, type, locale, id);
+        return doGet(InstanceManager.getDefault(LayoutBlockManager.class).getBySystemName(name), name, type, locale, id);
     }
 
     @Override
@@ -86,7 +86,7 @@ public class JsonLayoutBlockHttpService extends JsonNonProvidedNamedBeanHttpServ
 
     @Override
     public JsonNode doPost(String type, String name, JsonNode data, Locale locale, int id) throws JsonException {
-        return doPost(InstanceManager.getDefault(LayoutBlockManager.class).getBeanBySystemName(name), data, name, type, locale, id);
+        return doPost(InstanceManager.getDefault(LayoutBlockManager.class).getBySystemName(name), data, name, type, locale, id);
     }
 
     public JsonNode doPost(LayoutBlock layoutBlock, JsonNode data, String name, String type, Locale locale, int id) throws JsonException {
@@ -123,7 +123,7 @@ public class JsonLayoutBlockHttpService extends JsonNonProvidedNamedBeanHttpServ
         if (!data.path(MEMORY).isMissingNode()) {
             string = !data.path(MEMORY).isNull() ? data.path(MEMORY).asText() : null;
             if (string != null) {
-                Memory memory = InstanceManager.getDefault(MemoryManager.class).getBeanBySystemName(string);
+                Memory memory = InstanceManager.getDefault(MemoryManager.class).getBySystemName(string);
                 if (memory == null) {
                     throw new JsonException(HttpServletResponse.SC_NOT_FOUND, Bundle.getMessage(locale, JsonException.ERROR_NOT_FOUND, MEMORY, string), id);
                 }
@@ -135,7 +135,7 @@ public class JsonLayoutBlockHttpService extends JsonNonProvidedNamedBeanHttpServ
         if (!data.path(OCCUPANCY_SENSOR).isMissingNode()) {
             string = !data.path(OCCUPANCY_SENSOR).isNull() ? data.path(OCCUPANCY_SENSOR).asText() : null;
             if (string != null) {
-                Sensor sensor = InstanceManager.getDefault(SensorManager.class).getBeanBySystemName(string);
+                Sensor sensor = InstanceManager.getDefault(SensorManager.class).getBySystemName(string);
                 if (sensor == null) {
                     throw new JsonException(HttpServletResponse.SC_NOT_FOUND, Bundle.getMessage(locale, JsonException.ERROR_NOT_FOUND, SENSOR, string), id);
                 }
@@ -178,7 +178,7 @@ public class JsonLayoutBlockHttpService extends JsonNonProvidedNamedBeanHttpServ
 
     @Override
     public void doDelete(String type, String name, JsonNode data, Locale locale, int id) throws JsonException {
-        LayoutBlock layoutBlock = InstanceManager.getDefault(LayoutBlockManager.class).getBeanBySystemName(name);
+        LayoutBlock layoutBlock = InstanceManager.getDefault(LayoutBlockManager.class).getBySystemName(name);
         if (layoutBlock == null) {
             throw new JsonException(HttpServletResponse.SC_NOT_FOUND, Bundle.getMessage(locale, JsonException.ERROR_NOT_FOUND, type, name), id);
         }

--- a/java/src/jmri/server/json/layoutblock/JsonLayoutBlockSocketService.java
+++ b/java/src/jmri/server/json/layoutblock/JsonLayoutBlockSocketService.java
@@ -81,7 +81,7 @@ public class JsonLayoutBlockSocketService extends JsonSocketService<JsonLayoutBl
 
     private void removeListenersFromRemovedBeans() {
         for (LayoutBlock layoutBlock : new HashSet<>(layoutBlockListeners.keySet())) {
-            if (InstanceManager.getDefault(LayoutBlockManager.class).getBeanBySystemName(layoutBlock.getSystemName()) == null) {
+            if (InstanceManager.getDefault(LayoutBlockManager.class).getBySystemName(layoutBlock.getSystemName()) == null) {
                 layoutBlockListeners.remove(layoutBlock);
             }
         }

--- a/java/src/jmri/server/json/operations/JsonOperationsHttpService.java
+++ b/java/src/jmri/server/json/operations/JsonOperationsHttpService.java
@@ -461,7 +461,7 @@ public class JsonOperationsHttpService extends JsonHttpService {
         // set things that throw exceptions first
         if (!data.path(REPORTER).isMissingNode()) {
             String name = data.path(REPORTER).asText();
-            Reporter reporter = InstanceManager.getDefault(ReporterManager.class).getBeanBySystemName(name);
+            Reporter reporter = InstanceManager.getDefault(ReporterManager.class).getBySystemName(name);
             if (reporter != null) {
                 location.setReporter(reporter);
             } else {
@@ -482,7 +482,7 @@ public class JsonOperationsHttpService extends JsonHttpService {
         // set things that throw exceptions first
         if (!data.path(REPORTER).isMissingNode()) {
             String name = data.path(REPORTER).asText();
-            Reporter reporter = InstanceManager.getDefault(ReporterManager.class).getBeanBySystemName(name);
+            Reporter reporter = InstanceManager.getDefault(ReporterManager.class).getBySystemName(name);
             if (reporter != null) {
                 track.setReporter(reporter);
             } else {

--- a/java/src/jmri/server/json/signalhead/JsonSignalHeadSocketService.java
+++ b/java/src/jmri/server/json/signalhead/JsonSignalHeadSocketService.java
@@ -75,7 +75,7 @@ public class JsonSignalHeadSocketService extends JsonSocketService<JsonSignalHea
     private void removeListenersFromRemovedBeans() {
         SignalHeadManager manager = InstanceManager.getDefault(SignalHeadManager.class);
         for (String name : new HashSet<>(beanListeners.keySet())) {
-            if (manager.getBeanBySystemName(name) == null) {
+            if (manager.getBySystemName(name) == null) {
                 beanListeners.remove(name);
             }
         }

--- a/java/src/jmri/util/swing/JmriBeanComboBox.java
+++ b/java/src/jmri/util/swing/JmriBeanComboBox.java
@@ -167,7 +167,7 @@ public class JmriBeanComboBox extends JComboBox<String> implements java.beans.Pr
         } else {
             for (int i = 0; i < nameList.size(); i++) {
                 String name = nameList.get(i);
-                NamedBean nBean = _manager.getBeanBySystemName(name);
+                NamedBean nBean = _manager.getBySystemName(name);
 
                 if (nBean != null) {
                     String uname = nBean.getUserName();
@@ -491,11 +491,11 @@ public class JmriBeanComboBox extends JComboBox<String> implements java.beans.Pr
         if (comboBoxText != null) {
 
             //try user name
-            result = uDaManager.getBeanByUserName(comboBoxText);
+            result = uDaManager.getByUserName(comboBoxText);
 
             if (null == result) {
                 //try system name
-                //note: don't use getBeanBySystemName here
+                //note: don't use getBySystemName here
                 //throws an IllegalArgumentException if text is invalid
                 result = uDaManager.getNamedBean(comboBoxText);
             }

--- a/java/test/jmri/jmrit/beantable/TransitTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/TransitTableActionTest.java
@@ -79,8 +79,8 @@ public class TransitTableActionTest extends AbstractTableActionBase<Transit> {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assume.assumeTrue(a.includeAddButton());
         Transit t1 = InstanceManager.getDefault(jmri.TransitManager.class).createNewTransit("t1","test transit");
-        TransitSection ts1 = new TransitSection(InstanceManager.getDefault(SectionManager.class).getBeanBySystemName("TS1"),0,0);
-        TransitSection ts2 = new TransitSection(InstanceManager.getDefault(SectionManager.class).getBeanBySystemName("TS2"),0,0);
+        TransitSection ts1 = new TransitSection(InstanceManager.getDefault(SectionManager.class).getBySystemName("TS1"),0,0);
+        TransitSection ts2 = new TransitSection(InstanceManager.getDefault(SectionManager.class).getBySystemName("TS2"),0,0);
         t1.addTransitSection(ts1);
         t1.addTransitSection(ts2);
 

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
@@ -240,8 +240,8 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         }
         Turnout t = l.provideTurnout(name.toUpperCase());
         Assert.assertNotNull(t);
-        Assert.assertNotEquals(t, l.getBeanBySystemName(name));
-        Assert.assertNull(l.getBeanBySystemName(name));
+        Assert.assertNotEquals(t, l.getBySystemName(name));
+        Assert.assertNull(l.getBySystemName(name));
     }
 
     @Test

--- a/java/test/jmri/managers/AbstractProvidingManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractProvidingManagerTestBase.java
@@ -86,11 +86,11 @@ public abstract class AbstractProvidingManagerTestBase<T extends ProvidingManage
         f1.set(e2, e1.getSystemName());
 
         // Remove bean if it's already registered
-        if (l.getBeanBySystemName(e1.getSystemName()) != null) {
+        if (l.getBySystemName(e1.getSystemName()) != null) {
             l.deregister(e1);
         }
         // Remove bean if it's already registered
-        if (l.getBeanBySystemName(e2.getSystemName()) != null) {
+        if (l.getBySystemName(e2.getSystemName()) != null) {
             l.deregister(e2);
         }
 

--- a/java/test/jmri/managers/TurnoutManagerScaffold.java
+++ b/java/test/jmri/managers/TurnoutManagerScaffold.java
@@ -246,16 +246,6 @@ public class TurnoutManagerScaffold implements TurnoutManager {
     }
 
     @Override
-    public Turnout getBeanBySystemName(@Nonnull String systemName) {
-        return null;
-    }
-
-    @Override
-    public Turnout getBeanByUserName(@Nonnull String userName) {
-        return null;
-    }
-
-    @Override
     public Turnout getNamedBean(@Nonnull String name) {
         return null;
     }

--- a/java/test/jmri/server/json/block/JsonBlockHttpServiceTest.java
+++ b/java/test/jmri/server/json/block/JsonBlockHttpServiceTest.java
@@ -226,9 +226,9 @@ public class JsonBlockHttpServiceTest extends JsonNamedBeanHttpServiceTestBase<B
         }
         manager.createNewBlock("IB1", null);
         // delete existing bean (no named listener)
-        assertNotNull(manager.getBeanBySystemName("IB1"));
+        assertNotNull(manager.getBySystemName("IB1"));
         service.doDelete(service.getType(), "IB1", message, locale, 42);
-        assertNull(manager.getBeanBySystemName("IB1"));
+        assertNull(manager.getBySystemName("IB1"));
         Block block = manager.createNewBlock("IB1", null);
         assertNotNull(block);
         block.addPropertyChangeListener(new PropertyChangeListener() {
@@ -248,10 +248,10 @@ public class JsonBlockHttpServiceTest extends JsonNamedBeanHttpServiceTestBase<B
             assertEquals("Test Listener", ex.getAdditionalData().path(JSON.CONFLICT).path(0).asText());
             message = message.put(JSON.FORCE_DELETE, ex.getAdditionalData().path(JSON.FORCE_DELETE).asText());
         }
-        assertNotNull(manager.getBeanBySystemName("IB1"));
+        assertNotNull(manager.getBySystemName("IB1"));
         // will throw if prior catch failed
         service.doDelete(service.getType(), "IB1", message, locale, 0);
-        assertNull(manager.getBeanBySystemName("IB1"));
+        assertNull(manager.getBySystemName("IB1"));
         try {
             // deleting again should throw an exception
             service.doDelete(service.getType(), "IB1", NullNode.getInstance(), locale, 0);

--- a/java/test/jmri/server/json/idtag/JsonIdTagHttpServiceTest.java
+++ b/java/test/jmri/server/json/idtag/JsonIdTagHttpServiceTest.java
@@ -158,9 +158,9 @@ public class JsonIdTagHttpServiceTest extends JsonNamedBeanHttpServiceTestBase<I
         IdTagManager manager = InstanceManager.getDefault(IdTagManager.class);
         manager.provide("ID1");
         // delete an idTag
-        assertNotNull(manager.getBeanBySystemName("ID1"));
+        assertNotNull(manager.getBySystemName("ID1"));
         service.doDelete(JsonIdTag.IDTAG, "ID1", NullNode.getInstance(), locale, 0);
-        assertNull(manager.getBeanBySystemName("ID1"));
+        assertNull(manager.getBySystemName("ID1"));
         manager.provide("ID1").addPropertyChangeListener(new PropertyChangeListener() {
 
             @Override
@@ -169,7 +169,7 @@ public class JsonIdTagHttpServiceTest extends JsonNamedBeanHttpServiceTestBase<I
             }
         }, "ID1", "Test Listener");
         // delete an idTag with a named listener ref
-        assertNotNull(manager.getBeanBySystemName("ID1"));
+        assertNotNull(manager.getBySystemName("ID1"));
         try {
             // first attempt should fail on conflict
             service.doDelete(JsonIdTag.IDTAG, "ID1", NullNode.getInstance(), locale, 0);
@@ -180,10 +180,10 @@ public class JsonIdTagHttpServiceTest extends JsonNamedBeanHttpServiceTestBase<I
             assertEquals("Test Listener", ex.getAdditionalData().path(JSON.CONFLICT).path(0).asText());
             message = message.put(JSON.FORCE_DELETE, ex.getAdditionalData().path(JSON.FORCE_DELETE).asText());
         }
-        assertNotNull(manager.getBeanBySystemName("ID1"));
+        assertNotNull(manager.getBySystemName("ID1"));
         // will throw if prior catch failed
         service.doDelete(JsonIdTag.IDTAG, "ID1", message, locale, 0);
-        assertNull(manager.getBeanBySystemName("ID1"));
+        assertNull(manager.getBySystemName("ID1"));
         try {
             // deleting again should throw an exception
             service.doDelete(JsonIdTag.IDTAG, "ID1", NullNode.getInstance(), locale, 0);

--- a/java/test/jmri/server/json/layoutblock/JsonLayoutBlockSocketServiceTest.java
+++ b/java/test/jmri/server/json/layoutblock/JsonLayoutBlockSocketServiceTest.java
@@ -145,10 +145,10 @@ public class JsonLayoutBlockSocketServiceTest {
             assertEquals("Test Listener", ex.getAdditionalData().path(JSON.CONFLICT).path(0).asText());
             message = message.put(JSON.FORCE_DELETE, ex.getAdditionalData().path(JSON.FORCE_DELETE).asText());
         }
-        assertNotNull("LayoutBlock not deleted", manager.getBeanBySystemName(lb.getSystemName()));
+        assertNotNull("LayoutBlock not deleted", manager.getBySystemName(lb.getSystemName()));
         // will throw if prior catch failed
         instance.onMessage(JsonLayoutBlock.LAYOUTBLOCK, message, JSON.DELETE, locale, 42);
-        assertNull("LayoutBlock deleted", manager.getBeanBySystemName(lb.getSystemName()));
+        assertNull("LayoutBlock deleted", manager.getBySystemName(lb.getSystemName()));
         try {
             // deleting again should throw an exception
             instance.onMessage(JsonLayoutBlock.LAYOUTBLOCK, message, JSON.DELETE, locale, 42);

--- a/java/test/jmri/server/json/reporter/JsonReporterHttpServiceTest.java
+++ b/java/test/jmri/server/json/reporter/JsonReporterHttpServiceTest.java
@@ -179,7 +179,7 @@ public class JsonReporterHttpServiceTest extends JsonNamedBeanHttpServiceTestBas
         assertNotNull(manager.getReporter("IR1"));
         // will throw if prior catch failed
         service.doDelete(REPORTER, "IR1", message, locale, 0);
-        assertNull(manager.getBeanBySystemName("IR1"));
+        assertNull(manager.getBySystemName("IR1"));
         try {
             // deleting again should throw an exception
             service.doDelete(REPORTER, "IR1", NullNode.getInstance(), locale, 0);

--- a/java/test/jmri/server/json/sensor/JsonSensorHttpServiceTest.java
+++ b/java/test/jmri/server/json/sensor/JsonSensorHttpServiceTest.java
@@ -164,9 +164,9 @@ public class JsonSensorHttpServiceTest extends JsonNamedBeanHttpServiceTestBase<
         }
         manager.newSensor("IS1", null);
         // delete existing bean (no named listener)
-        assertNotNull(manager.getBeanBySystemName("IS1"));
+        assertNotNull(manager.getBySystemName("IS1"));
         service.doDelete(service.getType(), "IS1", message, locale, 42);
-        assertNull(manager.getBeanBySystemName("IS1"));
+        assertNull(manager.getBySystemName("IS1"));
         Sensor sensor = manager.newSensor("IS1", null);
         assertNotNull(sensor);
         sensor.addPropertyChangeListener(new PropertyChangeListener() {
@@ -186,10 +186,10 @@ public class JsonSensorHttpServiceTest extends JsonNamedBeanHttpServiceTestBase<
             assertEquals("Test Listener", ex.getAdditionalData().path(JSON.CONFLICT).path(0).asText());
             message = message.put(JSON.FORCE_DELETE, ex.getAdditionalData().path(JSON.FORCE_DELETE).asText());
         }
-        assertNotNull(manager.getBeanBySystemName("IS1"));
+        assertNotNull(manager.getBySystemName("IS1"));
         // will throw if prior catch failed
         service.doDelete(service.getType(), "IS1", message, locale, 0);
-        assertNull(manager.getBeanBySystemName("IS1"));
+        assertNull(manager.getBySystemName("IS1"));
         try {
             // deleting again should throw an exception
             service.doDelete(service.getType(), "IS1", NullNode.getInstance(), locale, 0);

--- a/java/test/jmri/server/json/turnout/JsonTurnoutSocketServiceTest.java
+++ b/java/test/jmri/server/json/turnout/JsonTurnoutSocketServiceTest.java
@@ -119,14 +119,14 @@ public class JsonTurnoutSocketServiceTest {
         assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
         manager.register(turnout1);
         JUnitUtil.waitFor(() -> {
-            return manager.getBeanBySystemName("IT1") != null;
+            return manager.getBySystemName("IT1") != null;
         });
         message = connection.getMessage();
         assertNotNull("Message is not null", message);
         assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
         manager.register(turnout2);
         JUnitUtil.waitFor(() -> {
-            return manager.getBeanBySystemName("IT2") != null;
+            return manager.getBySystemName("IT2") != null;
         });
         message = connection.getMessage();
         assertNotNull("Message is not null", message);
@@ -134,7 +134,7 @@ public class JsonTurnoutSocketServiceTest {
         assertNotNull("Turnout 2 exists", turnout2);
         manager.deleteBean(turnout2, "");
         JUnitUtil.waitFor(() -> {
-            return manager.getBeanBySystemName("IT2") == null;
+            return manager.getBySystemName("IT2") == null;
         });
         message = connection.getMessage();
         assertNotNull("Message is not null", message);

--- a/java/test/jmri/swing/NamedBeanComboBoxTest.java
+++ b/java/test/jmri/swing/NamedBeanComboBoxTest.java
@@ -234,7 +234,7 @@ public class NamedBeanComboBoxTest {
         assertEquals("IS1", c.getText());
         assertEquals(Validation.Type.NONE, ((JInputValidator) c.getInputVerifier()).getValidation().getType());
         Sensor s1 = t.getSelectedItem();
-        assertEquals(s1, m.getBeanBySystemName("IS1"));
+        assertEquals(s1, m.getBySystemName("IS1"));
 
         c.setText("K ");
         c.getInputVerifier().verify(c); // manually force validation because not on AWT thread
@@ -260,7 +260,7 @@ public class NamedBeanComboBoxTest {
         assertEquals("IS1", c.getText());
         assertEquals(Validation.Type.INFORMATION, ((JInputValidator) c.getInputVerifier()).getValidation().getType());
         s1 = t.getSelectedItem();
-        assertEquals(s1, m.getBeanBySystemName("IS1"));
+        assertEquals(s1, m.getBySystemName("IS1"));
 
         c.setText("K ");
         c.getInputVerifier().verify(c); // manually force validation because not on AWT thread
@@ -286,7 +286,7 @@ public class NamedBeanComboBoxTest {
         assertEquals("IS1", c.getText());
         assertEquals(Validation.Type.NONE, ((JInputValidator) c.getInputVerifier()).getValidation().getType());
         s1 = t.getSelectedItem();
-        assertEquals(s1, m.getBeanBySystemName("IS1"));
+        assertEquals(s1, m.getBySystemName("IS1"));
 
         c.setText("K ");
         c.getInputVerifier().verify(c); // manually force validation because not on AWT thread
@@ -314,7 +314,7 @@ public class NamedBeanComboBoxTest {
         assertEquals("IS1", c.getText());
         assertEquals(Validation.Type.INFORMATION, ((JInputValidator) c.getInputVerifier()).getValidation().getType());
         s1 = t.getSelectedItem();
-        assertEquals(s1, m.getBeanBySystemName("IS1"));
+        assertEquals(s1, m.getBySystemName("IS1"));
 
         c.setText("K ");
         c.getInputVerifier().verify(c); // manually force validation because not on AWT thread


### PR DESCRIPTION
Java's support for generics has improved since the 1st version, and it's no longer necessary to have both `Manager.getBeanByUserName` and `Manager.getByUserName`, both `Manager.getBeanBySystemName` and `Manager.getBySystemName`.

This PR deprecates for eventual removal (emitting a warning in the meantime if used) Manager.getBeanByUserName` and `Manager.getBeanBySystemName`