### PR TITLE
fix SOU-1981 issues against strict appearancetable.xsd

### DIFF
--- a/xml/signals/SOU-1981/appearance-CL-2-arm-highspace-absolute.xml
+++ b/xml/signals/SOU-1981/appearance-CL-2-arm-highspace-absolute.xml
@@ -23,7 +23,13 @@
         <date>2017-03-16</date>
         <authorinitials>GPM</authorinitials>
         <revremark>Original Edition</revremark>
-    </revision>    
+    </revision>
+    <revision>
+        <revnumber>2</revnumber>
+        <date>2019-12-30</date>
+        <authorinitials>BM</authorinitials>
+        <revremark>Add missing 'Approach Slow' aspect definition</revremark>
+    </revision>
   </revhistory>
   
   <aspecttable>SOU 1981</aspecttable>

--- a/xml/signals/SOU-1981/appearance-CL-2-arm-highspace-absolute.xml
+++ b/xml/signals/SOU-1981/appearance-CL-2-arm-highspace-absolute.xml
@@ -61,6 +61,13 @@
 	  <imagelink>../../../resources/icons/smallschematics/aspects/SOU-1981/SOU-CL-2-Arm-highspaced-absolute/rule-307.gif</imagelink>
     </appearance>
 	
+	<appearance>
+      <aspectname>Approach Slow</aspectname>
+      <show>flashyellow</show>
+      <show>red</show>
+	  <imagelink>../../../resources/icons/smallschematics/aspects/SOU-1981/SOU-CL-2-Arm-highspaced-absolute/rule-307.gif</imagelink>
+    </appearance>
+	
     <appearance>
       <aspectname>Restricted Proceed</aspectname>
       <show>red</show>

--- a/xml/signals/SOU-1981/appearance-CL-2-arm-permissive.xml
+++ b/xml/signals/SOU-1981/appearance-CL-2-arm-permissive.xml
@@ -23,7 +23,13 @@
         <date>2017-03-16</date>
         <authorinitials>GPM</authorinitials>
         <revremark>Original Edition</revremark>
-    </revision>    
+    </revision>
+    <revision>
+        <revnumber>2</revnumber>
+        <date>2019-12-30</date>
+        <authorinitials>BM</authorinitials>
+        <revremark>Correct specificaspects 'danger' and 'held'; remove mast's unsupported aspects from aspecttable.</revremark>
+    </revision>
   </revhistory>
   
   <aspecttable>SOU 1981</aspecttable>

--- a/xml/signals/SOU-1981/appearance-CL-2-arm-permissive.xml
+++ b/xml/signals/SOU-1981/appearance-CL-2-arm-permissive.xml
@@ -80,7 +80,7 @@
    <specificappearances>
    
     <danger>
-      <aspect>Stop</aspect>
+      <aspect>Restricted Proceed</aspect>
     </danger>
 	
 	<permissive>
@@ -88,7 +88,7 @@
 	</permissive>
 	
     <held>
-      <aspect>Stop</aspect>
+      <aspect>Restricted Proceed</aspect>
     </held>
 	
   </specificappearances>
@@ -98,103 +98,78 @@
 	<aspectMapping>
 	  <advancedAspect>Clear</advancedAspect>
 	  <ourAspect>Clear</ourAspect>
-	  <ourAspect>Diverging Route Clear (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Clear (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Approach Diverging</advancedAspect>
 	  <ourAspect>Clear</ourAspect>
-	  <ourAspect>Diverging Route Clear (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Clear (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Advance Approach</advancedAspect>
 	  <ourAspect>Clear</ourAspect>
-	  <ourAspect>Diverging Route Clear (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Clear (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Diverging Route Clear (Medium)</advancedAspect>
 	  <ourAspect>Approach Diverging</ourAspect>
-	  <ourAspect>Diverging Route Clear (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Clear (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Diverging Route Clear (Slow)</advancedAspect>
 	  <ourAspect>Approach Slow</ourAspect>
-	  <ourAspect>Diverging Route Approach Slow (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Approach Slow (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Approach Slow</advancedAspect>
 	  <ourAspect>Clear</ourAspect>
-	  <ourAspect>Diverging Route Clear (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Clear (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Diverging Route Approach Slow (Medium)</advancedAspect>
 	  <ourAspect>Approach Diverging</ourAspect>
-	  <ourAspect>Diverging Route Clear (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Clear (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Diverging Route Approach Slow (Slow)</advancedAspect>
 	  <ourAspect>Approach Diverging</ourAspect>
-	  <ourAspect>Diverging Route Clear (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Clear (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Approach</advancedAspect>
 	  <ourAspect>Advance Approach</ourAspect>
-	  <ourAspect>Diverging Route Clear (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Clear (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Diverging Route Approach (Medium)</advancedAspect>
 	  <ourAspect>Approach Diverging</ourAspect>
-	  <ourAspect>Diverging Route Clear (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Clear (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Diverging Route Approach (Slow)</advancedAspect>
 	  <ourAspect>Approach Diverging</ourAspect>
-	  <ourAspect>Diverging Route Clear (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Clear (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Restricted Proceed</advancedAspect>
 	  <ourAspect>Approach</ourAspect>
-	  <ourAspect>Diverging Route Approach</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	
 	<aspectMapping>
 	  <advancedAspect>Stop</advancedAspect>
 	  <ourAspect>Approach</ourAspect>
-	  <ourAspect>Diverging Route Approach (Medium)</ourAspect>
-	  <ourAspect>Diverging Route Approach (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>	
 	

--- a/xml/signals/SOU-1981/appearance-CL-3-arm-absolute.xml
+++ b/xml/signals/SOU-1981/appearance-CL-3-arm-absolute.xml
@@ -24,6 +24,12 @@
         <authorinitials>GPM</authorinitials>
         <revremark>Original Edition</revremark>
     </revision>    
+    <revision>
+        <revnumber>2</revnumber>
+        <date>2019-12-30</date>
+        <authorinitials>BM</authorinitials>
+        <revremark>update "ourAspect" to values which mast supports.</revremark>
+    </revision>
   </revhistory>
   
   <aspecttable>SOU 1981</aspecttable>

--- a/xml/signals/SOU-1981/appearance-CL-3-arm-absolute.xml
+++ b/xml/signals/SOU-1981/appearance-CL-3-arm-absolute.xml
@@ -249,7 +249,8 @@
 	<aspectMapping>
 	  <advancedAspect>Restricted Proceed</advancedAspect>
 	  <ourAspect>Approach</ourAspect>
-	  <ourAspect>Diverging Route Approach</ourAspect>
+	  <ourAspect>Diverging Route Approach (Medium)</ourAspect>
+	  <ourAspect>Diverging Route Approach (Slow)</ourAspect>
 	  <ourAspect>Restricted Proceed</ourAspect>
 	</aspectMapping>
 	


### PR DESCRIPTION
Passes development branch's 12/28/2019 appearancetable.xsd checks if all commented checks there are un-commented.

@bobjacobsen , this should resolve SOU-1981 issues w.r.t. #7621 .
