### PR TITLE
fix NW-1981 issue against strict appearancetable.xsd

### DIFF
--- a/xml/signals/NW-1981/appearance-CPL-1-arm-permissive.xml
+++ b/xml/signals/NW-1981/appearance-CPL-1-arm-permissive.xml
@@ -30,6 +30,12 @@
         <authorinitials>GPM</authorinitials>
         <revremark>Corrected the aspect mapping to eliminate aspects not possible on this signal.</revremark>
     </revision>
+    <revision>
+        <revnumber>3</revnumber>
+        <date>2019-12-30</date>
+        <authorinitials>BM</authorinitials>
+        <revremark>Add missing 'Not Lit' aspect</revremark>
+    </revision>
   </revhistory>
 
   <aspecttable>N&amp;W 1981</aspecttable>

--- a/xml/signals/NW-1981/appearance-CPL-1-arm-permissive.xml
+++ b/xml/signals/NW-1981/appearance-CPL-1-arm-permissive.xml
@@ -59,6 +59,12 @@
       <reference>Page 66</reference>
       <imagelink>../../../resources/icons/smallschematics/aspects/NW-1981/NW-CPL-1arm-permissive/rule-291.gif</imagelink>
     </appearance>
+    
+    <appearance>
+        <aspectname>Not Lit</aspectname>
+        <show>dark</show>
+      <imagelink>../../../resources/icons/smallschematics/aspects/NW-1981/NW-CPL-1arm-permissive/notlit.gif</imagelink>
+    </appearance>
 
   </appearances>
 


### PR DESCRIPTION
Passes development branch's 12/28/2019 appearancetable.xsd checks if all commented checks there are un-commented.

@bobjacobsen , this should resolve NW-1981 issues w.r.t. #7621 .