### PR TITLE
fix issues in B&O semaphore

### DIFF
--- a/xml/signals/B&O-Semaphore/appearance-bumper.xml
+++ b/xml/signals/B&O-Semaphore/appearance-bumper.xml
@@ -50,9 +50,6 @@
     <danger>
       <aspect>Stop</aspect>
     </danger>
-    <permissive>
-      <aspect>Restricting</aspect>
-    </permissive>
     <held>
       <aspect>Stop</aspect>
     </held>


### PR DESCRIPTION
Passes development branch's 12/28/2019 appearancetable.xsd checks if all commented checks there are un-commented.

@SuzieTall , @bobjacobsen , this should resolve B&O-Semaphore issue w.r.t. #7621 .