### PR TITLE
define missing 'Not Lit' aspect in WM-1980

### DIFF
--- a/xml/signals/WM-1980/appearance-USS-R2-1-arm-low-marker-permissive.xml
+++ b/xml/signals/WM-1980/appearance-USS-R2-1-arm-low-marker-permissive.xml
@@ -23,6 +23,12 @@
         <authorinitials>GPM</authorinitials>
         <revremark>Initial version of the signal set.</revremark>
     </revision>
+    <revision>
+        <revnumber>2</revnumber>
+        <date>2019-12-30</date>
+        <authorinitials>BM</authorinitials>
+        <revremark>Add missing 'Not Lit' aspect definition</revremark>
+    </revision>
   </revhistory>
 
   <aspecttable>WM 1980</aspecttable>
@@ -63,7 +69,14 @@
       <reference>Page 145</reference>
       <imagelink>../../../resources/icons/smallschematics/aspects/WM-1980/WM_RYG-G_Permissive/Rule-W291.gif</imagelink>
     </appearance>
-
+    
+    <appearance>
+        <aspectname>Not Lit</aspectname>
+        <show>dark</show>
+        <show>dark</show>
+        <imagelink>../../../resources/icons/smallschematics/aspects/WM-1980/WM_RYG-G_Permissive/unlit.gif</imagelink>
+    </appearance>
+    
   </appearances>
 
   <specificappearances>

--- a/xml/signals/WM-1980/appearance-USS-R2-1-arm-permissive.xml
+++ b/xml/signals/WM-1980/appearance-USS-R2-1-arm-permissive.xml
@@ -23,6 +23,12 @@
         <authorinitials>GPM</authorinitials>
         <revremark>Initial version of the signal set.</revremark>
     </revision>
+    <revision>
+        <revnumber>2</revnumber>
+        <date>2019-12-30</date>
+        <authorinitials>BM</authorinitials>
+        <revremark>Add missing 'Not Lit' aspect definition</revremark>
+    </revision>
   </revhistory>
 
   <aspecttable>WM 1980</aspecttable>
@@ -51,6 +57,12 @@
       <show>red</show>
       <reference>Page 66</reference>
       <imagelink>../../../resources/icons/smallschematics/aspects/WM-1980/WM_RYG_Permissive/Rule-W291.gif</imagelink>
+    </appearance>
+
+    <appearance>
+        <aspectname>Not Lit</aspectname>
+        <show>dark</show>
+        <imagelink>../../../resources/icons/smallschematics/aspects/WM-1980/WM_RYG_Permissive/unlit.gif</imagelink>
     </appearance>
 
   </appearances>


### PR DESCRIPTION
Passes development branch's 12/28/2019 appearancetable.xsd checks if all commented checks there are un-commented.

@gpmccartney , @bobjacobsen , this should resolve WM-1980 issues w.r.t. #7621 .