### PR TITLE
Ignore tests failing on jenkins

### DIFF
--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
@@ -387,6 +387,7 @@ public class LayoutEditorToolsTest {
     }
 
     @Test
+    @Ignore("causes error on jenkins; exhausts failure retries")
     public void testSetSignalsAtTurnoutFromMenu() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
@@ -541,6 +542,7 @@ public class LayoutEditorToolsTest {
     }
 
     @Test
+    @Ignore("causes error on jenkins; exhausts failure retries")
     public void testGetSignalHeadIcon() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         VirtualSignalHead h = new VirtualSignalHead("IH1");


### PR DESCRIPTION
These have been consistently failing on the jenkins jacoco build ( ant logalltest running on Linux ) for several weeks.

This may or may not include the test that is causing the job to time out.