### PR TITLE
Include SidebarTools and SidebarSystemAutomation in Sidebar.shtml

### DIFF
--- a/help/en/html/tools/scripting/Sidebar.shtml
+++ b/help/en/html/tools/scripting/Sidebar.shtml
@@ -29,50 +29,9 @@
 		    </ul>
 		</dd>
 
-		<dt><h3><a href="../index.shtml">Tools</a></h3></dt>
-		<dd>JMRI provides powerful tools for working with your
-		layout.
-			<ul>
-			<li><a href="../Turnouts.shtml">Turnouts</a>
-			<li><a href="../Lights.shtml">Lights</a>
-			<li><a href="../Sensors.shtml">Sensors</a>
-			<li><a href="../throttle/ThrottleMain.shtml">Throttles</a>
-			<li><a href="../consisttool/ConsistTool.shtml">Consisting</a>
-			<li><a href="../signaling/index.shtml">Signaling</a>
-			<li><a href="../Blocks.shtml">Blocks</a>
-			<li><a href="../Reporters.shtml">Reporters</a>
-			<li><a href="../Memories.shtml">Memory Variables</a>
-			<li><a href="../Routes.shtml">Routes</a>
-			<li><a href="../LRoutes.shtml">LRoutes</a>
-	        <li><a href="../Sections.shtml">Sections</a>
-	        <li><a href="../Transits.shtml">Transits</a>
-			<li><a href="../Logix.shtml">Logix</a>
-			<li><a href="../fastclock/index.shtml">Fast Clocks</a>
-			<li><a href="../speedometer/index.shtml">Speedometer</a>
-			<li><a href="../Audio.shtml">Audio</a>
-			<li><a href="../IdTags.shtml">Id Tags</a>
-			<li><a href="../TimeTable.shtml">Timetable</a>
-	
-	    <li><a href="../index.shtml#systemSpecificTools">System-specific...</a>
-	    </ul>
-		</dd>
+            <!--#include virtual="/help/en/parts/SidebarTools.shtml" -->
 
-		<dt><h3><a href="../automation/index.shtml">Layout Automation</a></h3></dt>
-		<dd>JMRI can be used to automate parts 
-		of your layout, from simply controlling a crossing gate
-		to running trains in the background.
-	        <ul>
-	          <li><a href="../signaling/index.shtml">Signaling</a>
-		  <li><a href="../EntryExit.shtml">Entry Exit (NX)</a>
-		  <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
-                  <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
-		  <li><a href="../Routes.shtml">Routes</a>
-                  <li><a href="../LRoutes.shtml">LRoutes</a>
-	          <li><a href="../fastclock/index.shtml">Fast Clocks</a>
-	          <li><a href="../uss/index.shtml">USS CTC</a>
-	          <li class="here"><a href="../scripting/index.shtml">Scripting</a>
-	        </ul>
-		</dd>
+            <!--#include virtual="/help/en/parts/SidebarLayoutAutomation.shtml" -->	
 
 	  </dl>
 


### PR DESCRIPTION
Implement the new approach of including Parts Files such as SidebarTools and  SidebarSystemAutomation  rather than listing all the individual items within Sidebar.shtml. When completed in all copies of Sidebar.shtml, will improve consistency and reduce maintenance across the JMRI help pages.