### PR TITLE
Reorder Tools Sidebar to improve usability

### DIFF
--- a/help/en/html/tools/Sidebar.shtml
+++ b/help/en/html/tools/Sidebar.shtml
@@ -8,9 +8,9 @@
 
             <!--#include virtual="/help/en/parts/SidebarTools.shtml" -->
 
-            <!--#include virtual="/help/en/parts/SidebarSupportedHardware.shtml" -->
-
             <!--#include virtual="/help/en/parts/SidebarLayoutAutomation.shtml" -->
+	    
+	    <!--#include virtual="/help/en/parts/SidebarSupportedHardware.shtml" -->    
 
          </dl>
 


### PR DESCRIPTION
Moved list of supported hardware after list of Layout Automation tools.  Seemed like that should be more prominent as a sidebar for many tools.