### PR TITLE
Add no-check schema to some appearance files and then enforce full schema on rest

### DIFF
--- a/xml/schema/appearancetable-no-check.xsd
+++ b/xml/schema/appearancetable-no-check.xsd
@@ -280,17 +280,23 @@
         <xs:field xpath="."/>
     </xs:key>
 
+<!-- the following consistency check is disabled as this is the no-check version of this schema -->
+<!-- 
     <xs:keyref name="specificAppearancesAspectExists" refer="appearanceAspectName">
       <xs:annotation><xs:documentation>The specificAppearancesAspectExists check constrains each specificappearances aspect element to refer to an existing appearance aspectname. </xs:documentation></xs:annotation>
       <xs:selector xpath="./specificappearances/*/aspect"/>
       <xs:field xpath="."/>
     </xs:keyref>
+ -->
 
+<!-- the following consistency check is disabled as this is the no-check version of this schema -->
+<!-- 
     <xs:keyref name="aspecMappingOurAspectExists" refer="appearanceAspectName">
       <xs:annotation><xs:documentation>The aspecMappingOurAspectExists check constrains each ourAspect element to refer to an existing appearance aspectname.</xs:documentation></xs:annotation>
       <xs:selector xpath="./aspectMappings/aspectMapping/ourAspect"/>
       <xs:field xpath="."/>
     </xs:keyref>
+ -->
 
   </xs:element>
   

--- a/xml/signals/AAR-1946/appearance-PL-2-high.xml
+++ b/xml/signals/AAR-1946/appearance-PL-2-high.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2010</year>

--- a/xml/signals/AAR-1946/appearance-SL-2-high-abs.xml
+++ b/xml/signals/AAR-1946/appearance-SL-2-high-abs.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/AAR-1946/appearance-SL-2-high-pbs.xml
+++ b/xml/signals/AAR-1946/appearance-SL-2-high-pbs.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/B&O-1957/appearance-PL-2-high.xml
+++ b/xml/signals/B&O-1957/appearance-PL-2-high.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2010</year>

--- a/xml/signals/B&O-1957/appearance-SL-2-high-abs.xml
+++ b/xml/signals/B&O-1957/appearance-SL-2-high-abs.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/B&O-1957/appearance-SL-2-high-pbs.xml
+++ b/xml/signals/B&O-1957/appearance-SL-2-high-pbs.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/B&O-1980/appearance-CPL-High-NJInternational.xml
+++ b/xml/signals/B&O-1980/appearance-CPL-High-NJInternational.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/B&O-1980/appearance-CPL-High-permissive.xml
+++ b/xml/signals/B&O-1980/appearance-CPL-High-permissive.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/B&O-2009/appearance-block.xml
+++ b/xml/signals/B&O-2009/appearance-block.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-bothm.xml
+++ b/xml/signals/B&O-2009/appearance-bothm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-boths.xml
+++ b/xml/signals/B&O-2009/appearance-boths.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-fast.xml
+++ b/xml/signals/B&O-2009/appearance-fast.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-fast1.xml
+++ b/xml/signals/B&O-2009/appearance-fast1.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-fastm.xml
+++ b/xml/signals/B&O-2009/appearance-fastm.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-fasts.xml
+++ b/xml/signals/B&O-2009/appearance-fasts.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-full.xml
+++ b/xml/signals/B&O-2009/appearance-full.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-junc.xml
+++ b/xml/signals/B&O-2009/appearance-junc.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-junm.xml
+++ b/xml/signals/B&O-2009/appearance-junm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-med.xml
+++ b/xml/signals/B&O-2009/appearance-med.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-med1.xml
+++ b/xml/signals/B&O-2009/appearance-med1.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-medm.xml
+++ b/xml/signals/B&O-2009/appearance-medm.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-meds.xml
+++ b/xml/signals/B&O-2009/appearance-meds.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/B&O-2009/appearance-slow.xml
+++ b/xml/signals/B&O-2009/appearance-slow.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2014</year>

--- a/xml/signals/BNSF-1996/appearance-SE-2D.xml
+++ b/xml/signals/BNSF-1996/appearance-SE-2D.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2013</year>
     <holder>JMRI</holder>

--- a/xml/signals/BNSF-1996/appearance-SL-3A.xml
+++ b/xml/signals/BNSF-1996/appearance-SL-3A.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2013</year>
     <holder>JMRI</holder>

--- a/xml/signals/BNSF-1996/appearance-SL-3L3.xml
+++ b/xml/signals/BNSF-1996/appearance-SL-3L3.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2013</year>
     <holder>JMRI</holder>

--- a/xml/signals/BR-2003/appearance-3-i.xml
+++ b/xml/signals/BR-2003/appearance-3-i.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/CNJ-1974/appearance-SL-2-abs.xml
+++ b/xml/signals/CNJ-1974/appearance-SL-2-abs.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/CNJ-1974/appearance-SL-2-pbs.xml
+++ b/xml/signals/CNJ-1974/appearance-SL-2-pbs.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/CNJ-1974/appearance-SL-3-pbs.xml
+++ b/xml/signals/CNJ-1974/appearance-SL-3-pbs.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/CROR-2008/appearance-CROR-1-Hi.xml
+++ b/xml/signals/CROR-2008/appearance-CROR-1-Hi.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2012</year>
     <holder>JMRI</holder>

--- a/xml/signals/CROR-2008/appearance-CROR-1A-Hi.xml
+++ b/xml/signals/CROR-2008/appearance-CROR-1A-Hi.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2012</year>
     <holder>JMRI</holder>

--- a/xml/signals/CROR-2008/appearance-CROR-1R-Hi.xml
+++ b/xml/signals/CROR-2008/appearance-CROR-1R-Hi.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2012</year>
     <holder>JMRI</holder>

--- a/xml/signals/CROR-2008/appearance-CROR-2O-Hi.xml
+++ b/xml/signals/CROR-2008/appearance-CROR-2O-Hi.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2012</year>
     <holder>JMRI</holder>

--- a/xml/signals/CROR-2008/appearance-CROR-2OD-Hi.xml
+++ b/xml/signals/CROR-2008/appearance-CROR-2OD-Hi.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2012</year>
     <holder>JMRI</holder>

--- a/xml/signals/CROR-2008/appearance-CROR-2OL-Hi.xml
+++ b/xml/signals/CROR-2008/appearance-CROR-2OL-Hi.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2012</year>
     <holder>JMRI</holder>

--- a/xml/signals/CROR-2008/appearance-CROR-2SD-Hi.xml
+++ b/xml/signals/CROR-2008/appearance-CROR-2SD-Hi.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2012</year>
     <holder>JMRI</holder>

--- a/xml/signals/CROR-2008/appearance-CROR-2SL-Hi.xml
+++ b/xml/signals/CROR-2008/appearance-CROR-2SL-Hi.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2012</year>
     <holder>JMRI</holder>

--- a/xml/signals/CROR-2008/appearance-CROR-3L-Hi.xml
+++ b/xml/signals/CROR-2008/appearance-CROR-3L-Hi.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2012</year>
     <holder>JMRI</holder>

--- a/xml/signals/CSX-1998/appearance-CLS-3-3-2-hi.xml
+++ b/xml/signals/CSX-1998/appearance-CLS-3-3-2-hi.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/CSX-1998/appearance-CLS-3-3-2A-hi.xml
+++ b/xml/signals/CSX-1998/appearance-CLS-3-3-2A-hi.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/CSX-2014-Chessie/appearance-CO-1-3-1-hi.xml
+++ b/xml/signals/CSX-2014-Chessie/appearance-CO-1-3-1-hi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="/xml/XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2010</year>
     <year>2016</year>

--- a/xml/signals/CSX-2014-Chessie/appearance-CO-1-3-2-hi.xml
+++ b/xml/signals/CSX-2014-Chessie/appearance-CO-1-3-2-hi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="/xml/XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2010</year>
     <year>2016</year>

--- a/xml/signals/CSX-2014-Chessie/appearance-CO-1-3-3-hi.xml
+++ b/xml/signals/CSX-2014-Chessie/appearance-CO-1-3-3-hi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="/xml/XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2010</year>
     <year>2016</year>

--- a/xml/signals/CSX-2014-Chessie/appearance-CO-3-2-2-hi.xml
+++ b/xml/signals/CSX-2014-Chessie/appearance-CO-3-2-2-hi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="/xml/XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2010</year>
     <year>2016</year>

--- a/xml/signals/CSX-2014-Chessie/appearance-CO-3-3-1-hi.xml
+++ b/xml/signals/CSX-2014-Chessie/appearance-CO-3-3-1-hi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="/xml/XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2010</year>
     <year>2016</year>

--- a/xml/signals/CSX-2014-Chessie/appearance-CO-3-3-lo.xml
+++ b/xml/signals/CSX-2014-Chessie/appearance-CO-3-3-lo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="/xml/XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2010</year>
     <year>2016</year>

--- a/xml/signals/CSX-2014-Chessie/appearance-CO-3-hi.xml
+++ b/xml/signals/CSX-2014-Chessie/appearance-CO-3-hi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="/xml/XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2010</year>
     <year>2016</year>

--- a/xml/signals/CSX-2014-Chessie/appearance-CO-3p-lo.xml
+++ b/xml/signals/CSX-2014-Chessie/appearance-CO-3p-lo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="/xml/XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2010</year>
     <year>2016</year>

--- a/xml/signals/NS-2008/appearance-171.xml
+++ b/xml/signals/NS-2008/appearance-171.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/NS-2008/appearance-CLS-3-3-hi.xml
+++ b/xml/signals/NS-2008/appearance-CLS-3-3-hi.xml
@@ -2,7 +2,7 @@
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
 <appearancetable
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd"
+  xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2012</year>

--- a/xml/signals/NW-1981/appearance-CPL-2-arm-permissive.xml
+++ b/xml/signals/NW-1981/appearance-CPL-2-arm-permissive.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/NYC-1956/appearance-SL-2-high-abs.xml
+++ b/xml/signals/NYC-1956/appearance-SL-2-high-abs.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/PRR-1956/appearance-PL-2-low.xml
+++ b/xml/signals/PRR-1956/appearance-PL-2-low.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2010</year>

--- a/xml/signals/ProRail-1954/appearance-Approach.xml
+++ b/xml/signals/ProRail-1954/appearance-Approach.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2016</year>
     <holder>JMRI</holder>

--- a/xml/signals/ProRail-1954/appearance-Dwarf.xml
+++ b/xml/signals/ProRail-1954/appearance-Dwarf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="../../XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2016</year>
     <holder>JMRI</holder>

--- a/xml/signals/RG-1965/appearance-SL-2-low-abs.xml
+++ b/xml/signals/RG-1965/appearance-SL-2-low-abs.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/SLSF-1973/appearance-SL-3-b.xml
+++ b/xml/signals/SLSF-1973/appearance-SL-3-b.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/SLSF-1973/appearance-SL-3-c.xml
+++ b/xml/signals/SLSF-1973/appearance-SL-3-c.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/SLSF-1973/appearance-SL-3-d.xml
+++ b/xml/signals/SLSF-1973/appearance-SL-3-d.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/SLSF-1973/appearance-SL-3.xml
+++ b/xml/signals/SLSF-1973/appearance-SL-3.xml
@@ -3,7 +3,7 @@
 
 <appearancetable
     xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable.xsd"
+    xsi:noNamespaceSchemaLocation = "http://jmri.org/xml/schema/appearancetable-no-check.xsd"
 >
 
   <copyright xmlns="http://docbook.org/ns/docbook">

--- a/xml/signals/SPTCO-1969/appearance-SL-1-A.xml
+++ b/xml/signals/SPTCO-1969/appearance-SL-1-A.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="/xml/XSLT/appearancetable.xsl" type="text/xsl"?>
-<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable.xsd">
+<appearancetable xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/appearancetable-no-check.xsd">
   <copyright xmlns="http://docbook.org/ns/docbook">
     <year>2009</year>
     <year>2015</year>


### PR DESCRIPTION
See #7621, #7632 and #7771 for background.

There are still some signal system appearance-definition files that don't pass internal consistency checks.   This is about 15% of files. But it would be good to get a fully-validating schema on the other 85%. That way anybody editing or creating a new version from those won'l make an uncaught mistake.

This PR creates a -no-checks schema which doesn't include the most stringent two checks, and applies it to just the files that don't pass those.  In then turns on the checks for the other 85% of files.