### PR TITLE
Fix read NPE while reading config.xml file, add test

### DIFF
--- a/java/src/jmri/jmrit/consisttool/ConsistFile.java
+++ b/java/src/jmri/jmrit/consisttool/ConsistFile.java
@@ -32,9 +32,11 @@ import org.slf4j.LoggerFactory;
  */
 public class ConsistFile extends XmlFile implements PropertyChangeListener {
 
-    private static final String CONSISTNUMBER = "consistNumber"; //NOI18N
-    private static final String LONGADDRESS = "longAddress"; //NOI18N
     private static final String CONSIST = "consist"; //NOI18N
+    private static final String CONSISTID = "id"; //NOI18N
+    private static final String CONSISTNUMBER = "consistNumber"; //NOI18N
+    private static final String DCCLOCOADDRESS = "dccLocoAddress"; //NOI18N
+    private static final String LONGADDRESS = "longAddress"; //NOI18N
     private static final String LOCODIR = "locoDir"; // NOI18N
     private static final String LOCONAME = "locoName"; //NOI18N
     private static final String LOCOROSTERID = "locoRosterId"; // NOI18N
@@ -90,7 +92,7 @@ public class ConsistFile extends XmlFile implements PropertyChangeListener {
 
     }
 
-    public void readConsistLocoList(Element consist,Consist newConsist) {
+    public void readConsistLocoList(Element consist, Consist newConsist) {
         // read each child of locomotive in the consist from the file
         // and restore it's information to memory.
         Iterator<Element> childIterator = consist.getDescendants(new ElementFilter("loco"));
@@ -98,7 +100,7 @@ public class ConsistFile extends XmlFile implements PropertyChangeListener {
             Element e;
             do {
                 e = childIterator.next();
-                Attribute number = e.getAttribute(CONSISTNUMBER);
+                Attribute number = e.getAttribute(DCCLOCOADDRESS);
                 log.debug("adding Loco {}", number);
                 DccLocoAddress address = readLocoAddress(e);
 
@@ -126,7 +128,7 @@ public class ConsistFile extends XmlFile implements PropertyChangeListener {
         }
     }
 
-    private void readConsistType(Element consist,Consist newConsist){
+    private void readConsistType(Element consist, Consist newConsist){
         // read and set the consist type
         Attribute type = consist.getAttribute("type");
         if (type != null) {
@@ -140,7 +142,7 @@ public class ConsistFile extends XmlFile implements PropertyChangeListener {
 
     private void readConsistId(Element consist,Consist newConsist){
         // Read the consist ID from the file
-        Attribute cID = consist.getAttribute("id");
+        Attribute cID = consist.getAttribute(CONSISTID);
         if (cID != null) {
             // use the value read from the file
             newConsist.setConsistID(cID.getValue());
@@ -166,7 +168,7 @@ public class ConsistFile extends XmlFile implements PropertyChangeListener {
 
     private DccLocoAddress readLocoAddress(Element loco){
         DccLocoAddress address;
-        Attribute number = loco.getAttribute(CONSISTNUMBER);
+        Attribute number = loco.getAttribute(DCCLOCOADDRESS);
         Attribute isLong = loco.getAttribute(LONGADDRESS);
         if (isLong != null ) {
             // use the values from the file
@@ -191,7 +193,7 @@ public class ConsistFile extends XmlFile implements PropertyChangeListener {
      */
     private Element consistToXml(Consist consist) {
         Element e = new Element(CONSIST);
-        e.setAttribute("id", consist.getConsistID());
+        e.setAttribute(CONSISTID, consist.getConsistID());
         e.setAttribute(CONSISTNUMBER, "" + consist.getConsistAddress()
                 .getNumber());
         e.setAttribute(LONGADDRESS, consist.getConsistAddress()

--- a/java/test/jmri/jmrit/consisttool/ConsistFileTest.java
+++ b/java/test/jmri/jmrit/consisttool/ConsistFileTest.java
@@ -42,7 +42,7 @@ public class ConsistFileTest {
     @Test
     public void testReadFile() throws java.io.IOException, org.jdom2.JDOMException {
         ConsistFile file = new ConsistFile();
-        ConsistManager cm = InstanceManager.getDefault(ConsistManager.class);
+        InstanceManager.getDefault(ConsistManager.class);
         file.readFile("java/test/jmri/jmrit/consisttool/consist.xml");
     }
 

--- a/java/test/jmri/jmrit/consisttool/ConsistFileTest.java
+++ b/java/test/jmri/jmrit/consisttool/ConsistFileTest.java
@@ -40,6 +40,13 @@ public class ConsistFileTest {
     }
 
     @Test
+    public void testReadFile() throws java.io.IOException, org.jdom2.JDOMException {
+        ConsistFile file = new ConsistFile();
+        ConsistManager cm = InstanceManager.getDefault(ConsistManager.class);
+        file.readFile("java/test/jmri/jmrit/consisttool/consist.xml");
+    }
+
+    @Test
     public void testWriteFile() throws java.io.IOException {
         ConsistFile file = new ConsistFile();
         ConsistManager cm = InstanceManager.getDefault(ConsistManager.class);

--- a/java/test/jmri/jmrit/consisttool/consist.xml
+++ b/java/test/jmri/jmrit/consisttool/consist.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/consistRoster.xsl" type="text/xsl"?>
+<!DOCTYPE consist-roster-config SYSTEM "/xml/DTD/consist-roster-config.dtd">
+<consist-roster-config>
+  <!--Written by JMRI version 4.17.8ish+jake+20200103T2106Z+R7c13c6be12 on Fri Jan 03 13:07:38 PST 2020-->
+  <roster>
+    <consist id="11(S)" consistNumber="11" longAddress="no" type="DAC">
+      <loco dccLocoAddress="1" longAddress="no" locoDir="normal" locoName="lead" />
+      <loco dccLocoAddress="2" longAddress="no" locoDir="normal" locoName="mid" locoMidNumber="1" />
+      <loco dccLocoAddress="3" longAddress="no" locoDir="normal" locoName="rear" />
+    </consist>
+  </roster>
+</consist-roster-config>


### PR DESCRIPTION
Fix problem reading consist.xml file (since last November). An NPE occurs which prevents a fully-functional startup.

This branch is based on v4.17.8, so can also be merged to v4.18