### PR TITLE
test: Add PIT to maven testing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,11 @@
 
         <plugins>
             <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>1.4.10</version>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.8</version><!--$NO-MVN-MAN-VER$-->


### PR DESCRIPTION
Allow [PIT](http://pitest.org) to be used from maven when desired (not in CI tests):
```
mvn test pitest:mutationCoverage pitest:report
```
will generate reports in `/target/pit-reports/` and will take a long while to run (note that on first run, a number of dependencies will be downloaded for PIT).

To execute against a single package tree in JMRI, execute as (using `jmri.server.json` as an example):
```
mvn -Dtest=jmri.server.json.\*\* -DtargetClasses=jmri.server.json.\* -DtargetTests=jmri.server.json.\* test pitest:mutationCoverage pitest:report
```

Above command lines are for Linux, macOS, and WSL (Windows Subsystem for Linux, an optional feature of Windows 10).