### PR TITLE
VSDecoder: rework Auto-Load

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderCreationAction.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderCreationAction.java
@@ -2,11 +2,9 @@ package jmri.jmrit.vsdecoder;
 
 import java.awt.event.ActionEvent;
 import java.awt.GraphicsEnvironment;
-import java.io.File;
 import javax.swing.AbstractAction;
 import javax.swing.JFrame;
 import javax.swing.UIManager;
-import javax.swing.JOptionPane;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,25 +52,14 @@ public class VSDecoderCreationAction extends AbstractAction {
      */
     @Override
     public void actionPerformed(ActionEvent e) {
-        String fp = null, fn = null;
-        JFrame tf = null;
-        if (_useNewGUI == true) {
+        String fp;
+        String fn;
+        JFrame tf;
+
+        if (_useNewGUI) {
             tf = VSDecoderManager.instance().provideManagerFrame(); // headless will return null
         } else {
             tf = new VSDecoderFrame(); // old GUI
-        }
-
-        // Handle Auto-Load
-        if (VSDecoderManager.instance().getVSDecoderPreferences().isAutoLoadingDefaultVSDFile() && !GraphicsEnvironment.isHeadless()) {
-            // Force load of a VSD file
-            fp = VSDecoderManager.instance().getVSDecoderPreferences().getDefaultVSDFilePath();
-            fn = VSDecoderManager.instance().getVSDecoderPreferences().getDefaultVSDFileName();
-            if (fn.isEmpty()) {
-                JOptionPane.showMessageDialog(null, "Cannot auto-load VSD File - file name missing - check your VSD Preferences value",
-                        Bundle.getMessage("VSDFileError"), JOptionPane.ERROR_MESSAGE);
-            } else {
-                LoadVSDFileAction.loadVSDFile(fp + File.separator + fn);
-            }
         }
 
         if (tf != null) {

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderCreationAction.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderCreationAction.java
@@ -52,8 +52,6 @@ public class VSDecoderCreationAction extends AbstractAction {
      */
     @Override
     public void actionPerformed(ActionEvent e) {
-        String fp;
-        String fn;
         JFrame tf;
 
         if (_useNewGUI) {

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
@@ -148,7 +148,7 @@ public class VSDConfigDialog extends JDialog {
         rosterSelector.setNonSelectedItem(Bundle.getMessage("EmptyRosterBox"));
         rosterSelector.setToolTipText(Bundle.getMessage("LTPRosterSelectorToolTip"));
         //rosterComboBox.setToolTipText("tool tip for roster box");
-        rosterSelector.addPropertyChangeListener(rosterSelector.SELECTED_ROSTER_ENTRIES, new PropertyChangeListener() {
+        rosterSelector.addPropertyChangeListener("selectedRosterEntries", new PropertyChangeListener() {
             @Override
             public void propertyChange(PropertyChangeEvent pce) {
                 rosterItemSelectAction(null);

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  */
 public class VSDConfigDialog extends JDialog {
 
-    public static final String CONFIG_PROPERTY = "Config";
+    private static final String CONFIG_PROPERTY = "Config";
 
     // Map of Mnemonic KeyEvent values to GUI Components
     private static final Map<String, Integer> Mnemonics = new HashMap<>();
@@ -88,16 +88,21 @@ public class VSDConfigDialog extends JDialog {
     private VSDConfig config; // local reference to the config being constructed by this dialog
     private RosterEntry rosterEntry; // local reference to the selected RosterEntry
 
+    private RosterEntry rosterEntrySelected;
+    private boolean is_auto_loading;
+
     /**
      * Constructor
      *
      * @param parent Ancestor panel
      * @param title  title for the dialog
      * @param c      Config object to be set by the dialog
+     * @param ial    Is Auto Loading
      */
-    public VSDConfigDialog(JPanel parent, String title, VSDConfig c) {
+    public VSDConfigDialog(JPanel parent, String title, VSDConfig c, boolean ial) {
         super(SwingUtilities.getWindowAncestor(parent), title);
         config = c;
+        is_auto_loading = ial;
         VSDecoderManager.instance().addEventListener(new VSDManagerListener() {
             @Override
             public void eventAction(VSDManagerEvent evt) {
@@ -143,7 +148,7 @@ public class VSDConfigDialog extends JDialog {
         rosterSelector.setNonSelectedItem(Bundle.getMessage("EmptyRosterBox"));
         rosterSelector.setToolTipText(Bundle.getMessage("LTPRosterSelectorToolTip"));
         //rosterComboBox.setToolTipText("tool tip for roster box");
-        rosterSelector.addPropertyChangeListener("selectedRosterEntries", new PropertyChangeListener() {
+        rosterSelector.addPropertyChangeListener(rosterSelector.SELECTED_ROSTER_ENTRIES, new PropertyChangeListener() {
             @Override
             public void propertyChange(PropertyChangeEvent pce) {
                 rosterItemSelectAction(null);
@@ -258,7 +263,7 @@ public class VSDConfigDialog extends JDialog {
         this.setVisible(true);
     }
 
-    public void cancelButtonActionPerformed(java.awt.event.ActionEvent ae) {
+    private void cancelButtonActionPerformed(java.awt.event.ActionEvent ae) {
         dispose();
     }
 
@@ -267,7 +272,7 @@ public class VSDConfigDialog extends JDialog {
      */
     private void closeButtonActionPerformed(java.awt.event.ActionEvent ae) {
         if (profileComboBox.getSelectedItem() == null) {
-            config.setProfileName(profileComboBox.getSelectedItem().toString());
+            log.debug("Profile item selected: {}", profileComboBox.getSelectedItem());
             JOptionPane.showMessageDialog(null, "Please select a valid Profile");
             rosterSaveButton.setEnabled(false);
             closeButton.setEnabled(false);
@@ -276,8 +281,8 @@ public class VSDConfigDialog extends JDialog {
             log.debug("Profile item selected: {}", config.getProfileName());
 
             config.setLocoAddress(addressSelector.getAddress());
-            if (rosterSelector.getSelectedRosterEntries().length > 0) {
-                config.setRosterEntry(rosterSelector.getSelectedRosterEntries()[0]);
+            if (getSelectedRosterItem() != null) {
+                config.setRosterEntry(getSelectedRosterItem());
             } else {
                 config.setRosterEntry(null);
             }
@@ -312,9 +317,9 @@ public class VSDConfigDialog extends JDialog {
      * If all VSD Infos are provided, close the Config Dialog.
      */
     private void rosterItemSelectAction(ActionEvent e) {
-        if (rosterSelector.getSelectedRosterEntries().length != 0) {
-            log.debug("Roster Entry selected... {}", rosterSelector.getSelectedRosterEntries()[0]);
-            setRosterEntry(rosterSelector.getSelectedRosterEntries()[0]);
+        if (getSelectedRosterItem() != null) {
+            log.debug("Roster Entry selected... {}", getSelectedRosterItem().getId());
+            setRosterEntry(getSelectedRosterItem());
             enableProfileStuff(true);
 
             log.debug("profile ComboBox selected item: {}", profileComboBox.getSelectedItem());
@@ -328,6 +333,32 @@ public class VSDConfigDialog extends JDialog {
                 closeButton.doClick(); // All done
             }
         }
+    }
+
+    // Roster Entry via Auto-Load from VSDManagerFrame
+    void setRosterItem(RosterEntry s) {
+        rosterEntrySelected = s;
+        log.debug("Auto-Load selected roster id: {}, profile: {}", rosterEntrySelected.getId(),
+                rosterEntrySelected.getAttribute("VSDecoder_Profile"));
+        rosterItemSelectAction(null); // trigger the next step for Auto-Load (works, but does not seem to be implemented correctly)
+    }
+
+    private RosterEntry getRosterItem() {
+        return rosterEntrySelected;
+    }
+
+    private RosterEntry getSelectedRosterItem() {
+        // Used by Auto-Load and non Auto-Load
+        if (is_auto_loading && getRosterItem() != null) {
+            rosterEntrySelected = getRosterItem();
+        } else {
+            if (rosterSelector.getSelectedRosterEntries().length != 0) {
+                rosterEntrySelected = rosterSelector.getSelectedRosterEntries()[0];
+            } else {
+                rosterEntrySelected = null;
+            }
+        }
+        return rosterEntrySelected;
     }
 
     /**
@@ -437,8 +468,8 @@ public class VSDConfigDialog extends JDialog {
         if (profileComboBox.getItemCount() > 0) {
             profileComboBox.setEnabled(true);
             // Enable the roster save button if roster items are available.
-            if (rosterSelector.getSelectedRosterEntries().length > 0) {
-                RosterEntry r = rosterSelector.getSelectedRosterEntries()[0];
+            if (getSelectedRosterItem() != null) {
+                RosterEntry r = getSelectedRosterItem();
                 String profile = r.getAttribute("VSDecoder_Profile");
                 log.debug("Trying to set the ProfileComboBox to this Profile: {}", profile);
                 if (profile != null) {

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
@@ -24,6 +24,8 @@ import javax.swing.JToggleButton;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.EventListenerList;
+import jmri.jmrit.roster.Roster;
+import jmri.jmrit.roster.RosterEntry;
 import jmri.jmrit.vsdecoder.LoadVSDFileAction;
 import jmri.jmrit.vsdecoder.SoundEvent;
 import jmri.jmrit.vsdecoder.VSDConfig;
@@ -91,16 +93,17 @@ public class VSDManagerFrame extends JmriJFrame {
     JPanel decoderBlank;
 
     private VSDConfig config;
-
+    private VSDConfigDialog cd;
     private List<JMenu> menuList;
+    private boolean is_auto_loading;
 
     /**
      * Constructor
      */
     public VSDManagerFrame() {
         super(false, false);
-        config = new VSDConfig();
         this.addPropertyChangeListener(VSDecoderManager.instance());
+        is_auto_loading = VSDecoderManager.instance().getVSDecoderPreferences().isAutoLoadingDefaultVSDFile();
         initGUI();
     }
 
@@ -112,7 +115,7 @@ public class VSDManagerFrame extends JmriJFrame {
     /**
      * Build the GUI components
      */
-    public void initGUI() {
+    private void initGUI() {
         log.debug("initGUI");
         this.setTitle(Bundle.getMessage("VSDManagerFrameTitle"));
         this.buildMenu();
@@ -175,6 +178,39 @@ public class VSDManagerFrame extends JmriJFrame {
         this.setVisible(true);
 
         log.debug("done...");
+
+        // Auto-Load
+        if (is_auto_loading) {
+            log.info("Auto-Loading VSDecoder");
+            String vsdRosterGroup = "VSD";
+            String msg = "";
+            if (Roster.getDefault().getRosterGroupList().contains(vsdRosterGroup)) {
+                List<RosterEntry> rosterList;
+                rosterList = Roster.getDefault().getEntriesInGroup(vsdRosterGroup);
+                if (!rosterList.isEmpty()) {
+                    // Allow <max_decoder> roster entries
+                    int entry_counter = 1;
+                    for (RosterEntry entry : rosterList) {
+                        if (entry_counter <= VSDecoderManager.max_decoder) { 
+                            addButton.doClick(); // simulate an Add-button-click
+                            cd.setRosterItem(entry); // forward the roster entry
+                            entry_counter++;
+                        } else {
+                            msg = "Only " + VSDecoderManager.max_decoder + " Roster Entries allowed. Discarded "
+                                    + (rosterList.size() - VSDecoderManager.max_decoder);
+                        }
+                    }
+                } else {
+                    msg = "No Roster Entry found in Roster Group " + vsdRosterGroup;
+                }
+            } else {
+                msg = "Roster Group \"" + vsdRosterGroup + "\" not found";
+            }
+            if (!msg.isEmpty()) {
+                JOptionPane.showMessageDialog(null, "Auto-Loading: " + msg);
+                log.warn("Auto-Loading VSDecoder aborted");
+            }
+        }
     }
 
     /**
@@ -193,11 +229,12 @@ public class VSDManagerFrame extends JmriJFrame {
         log.debug("Add button pressed");
         config = new VSDConfig(); // Create a new Config for the new VSDecoder.
         // Do something here.  Create a new VSDecoder and add it to the window.
-        VSDConfigDialog d = new VSDConfigDialog(decoderPane, Bundle.getMessage("NewDecoderConfigPaneTitle"), config);
-        d.addPropertyChangeListener(new PropertyChangeListener() {
+        cd = new VSDConfigDialog(decoderPane, Bundle.getMessage("NewDecoderConfigPaneTitle"), config, is_auto_loading);
+        cd.addPropertyChangeListener(new PropertyChangeListener() {
             @Override
             public void propertyChange(PropertyChangeEvent event) {
-                log.debug("property change name {}, old: {}, new: {}", event.getPropertyName(), event.getOldValue(), event.getNewValue());
+                log.debug("property change name {}, old: {}, new: {}", event.getPropertyName(),
+                        event.getOldValue(), event.getNewValue());
                 addButtonPropertyChange(event);
             }
         });
@@ -209,16 +246,19 @@ public class VSDManagerFrame extends JmriJFrame {
      */
     protected void addButtonPropertyChange(PropertyChangeEvent event) {
         log.debug("internal config dialog handler");
-        log.debug("New Config: {}", config);
         // If this decoder already exists, don't create a new Control
         if (VSDecoderManager.instance().getVSDecoderByAddress(config.getLocoAddress().toString()) != null) {
             JOptionPane.showMessageDialog(null, Bundle.getMessage("MgrAddDuplicateMessage"));
+        // If the maximum number of VSDecoders (Controls) is reached, don't create a new Control
+        } else if (VSDecoderManager.instance().getVSDecoderList().size() >= VSDecoderManager.max_decoder) {
+            JOptionPane.showMessageDialog(null, 
+                    "VSDecoder not created. Maximal number is " + String.valueOf(VSDecoderManager.max_decoder));
         } else {
             VSDecoder newDecoder = VSDecoderManager.instance().getVSDecoder(config);
             if (newDecoder == null) {
-                log.warn("no New Decoder constructed! Config: {}", config);
-                String msg = "VSDecoder not created. Maximal number is " + String.valueOf(VSDecoderManager.max_decoder);
-                JOptionPane.showMessageDialog(null, msg);
+                log.warn("No New Decoder constructed! Address: {}, profile: {}, ",
+                        config.getLocoAddress(), config.getProfileName());
+                JOptionPane.showMessageDialog(null, "VSDecoder not created");
                 return;
             }
             VSDControl newControl = new VSDControl(config);
@@ -229,7 +269,8 @@ public class VSDManagerFrame extends JmriJFrame {
             newControl.addPropertyChangeListener(new PropertyChangeListener() {
                 @Override
                 public void propertyChange(PropertyChangeEvent event) {
-                    log.debug("property change name {}, old: {}, new: {}", event.getPropertyName(), event.getOldValue(), event.getNewValue());
+                    log.debug("property change name {}, old: {}, new: {}",
+                            event.getPropertyName(), event.getOldValue(), event.getNewValue());
                     vsdControlPropertyChange(event);
                 }
             });
@@ -310,8 +351,10 @@ public class VSDManagerFrame extends JmriJFrame {
         menuList.add(editMenu);
 
         this.setJMenuBar(new JMenuBar());
+
         this.getJMenuBar().add(fileMenu);
         this.getJMenuBar().add(editMenu);
+
         this.addHelpMenu("package.jmri.jmrit.vsdecoder.swing.VSDManagerFrame", true);
     }
 
@@ -342,7 +385,7 @@ public class VSDManagerFrame extends JmriJFrame {
      * Fire a property change from this object
      */
     // NOTE: should this be public???
-    public void firePropertyChange(PropertyChangeID id, Object oldProp, Object newProp) {
+    private void firePropertyChange(PropertyChangeID id, Object oldProp, Object newProp) {
         // map the property change ID
         String pcname = PCIDMap.get(id);
         PropertyChangeEvent pce = new PropertyChangeEvent(this, pcname, oldProp, newProp);
@@ -354,7 +397,7 @@ public class VSDManagerFrame extends JmriJFrame {
     /**
      * Fire a property change from this object
      */
-    void firePropertyChange(PropertyChangeEvent evt) {
+    private void firePropertyChange(PropertyChangeEvent evt) {
         if (evt == null) {
             log.warn("EVT is NULL!!");
         }

--- a/java/test/jmri/jmrit/vsdecoder/swing/VSDConfigDialogTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/swing/VSDConfigDialogTest.java
@@ -20,7 +20,7 @@ public class VSDConfigDialogTest {
     @Test
     public void testCTor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        VSDConfigDialog t = new VSDConfigDialog(new JPanel(), "test", new VSDConfig());
+        VSDConfigDialog t = new VSDConfigDialog(new JPanel(), "test", new VSDConfig(), false);
         Assert.assertNotNull("exists", t);
         
         // this created an audio manager, clean that up


### PR DESCRIPTION
In [jmriusers](https://groups.io/g/jmriusers/message/165216) the user asked if he "can start the VSD Manager on startup and have all of my roster populated".

This PR offers a solution.