### PR TITLE
Use CheckStyle to flag bad logging argument

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -38,6 +38,15 @@
       <!-- message is appended to "Line matches the illegal pattern " -->
       <property name="message" value="edu.umd.cs.findbugs.annotations.NonNull (replace with javax.annotations.Nonnull)" />
     </module>
+    <module name="Regexp">
+      <!-- Flag uses of e.g. {0} in a logging statement (should be {} )  -->
+      <!-- the attribute takes the regex string, without Java quoting, then uses the Java regex support -->
+      <property name="format" value="log\..*\(.*\{[0-9][0-9]*}"/>
+      <property name="illegalPattern" value="true"/>
+      <property name="severity" value="error"/>
+      <!-- message is appended to "Line matches the illegal pattern " -->
+      <property name="message" value="{digit} in logging call, should be {}" />
+    </module>
   </module>
   <module name="NewlineAtEndOfFile">
     <property name="severity" value="error"/>

--- a/java/src/jmri/jmrit/dualdecoder/DualDecoderSelectPane.java
+++ b/java/src/jmri/jmrit/dualdecoder/DualDecoderSelectPane.java
@@ -273,13 +273,13 @@ public class DualDecoderSelectPane extends javax.swing.JPanel implements jmri.Pr
             case IDLE:
             default:
                 // shouldn't happen, reset and ignore
-                log.warn("Unexpected init programming reply: {0} {1}", value, retcode);
+                log.warn("Unexpected init programming reply: {} {}", value, retcode);
                 state = IDLE;
                 break;
             case FIRSTCV16:
                 state = FIRSTCV15;
                 if (retcode != ProgListener.OK) {
-                    log.debug("Readback error: {0} {1}", retcode, value);
+                    log.debug("Readback error: {} {}", retcode, value);
                     status.setText(Bundle.getMessage("WriteCVFailed", 15, 7));
                     state = IDLE;
                 } else { // is OK
@@ -289,7 +289,7 @@ public class DualDecoderSelectPane extends javax.swing.JPanel implements jmri.Pr
             case FIRSTCV15:
                 state = SECONDCV16;
                 if (retcode != ProgListener.OK) {
-                    log.debug("Readback error: {0} {1}", retcode, value);
+                    log.debug("Readback error: {} {}", retcode, value);
                     status.setText(Bundle.getMessage("WriteCVFailed", 16, 7));
                     state = IDLE;
                 } else { // is OK
@@ -298,7 +298,7 @@ public class DualDecoderSelectPane extends javax.swing.JPanel implements jmri.Pr
                 break;
             case SECONDCV16:
                 if (retcode != ProgListener.OK) {
-                    log.debug("Readback error: {0} {1}", retcode, value);
+                    log.debug("Readback error: {} {}", retcode, value);
                     status.setText(Bundle.getMessage("WriteCVFailed", 16, 1));
                     state = IDLE;
                 } else { // is OK

--- a/java/src/jmri/jmrit/powerpanel/PowerPane.java
+++ b/java/src/jmri/jmrit/powerpanel/PowerPane.java
@@ -119,7 +119,7 @@ public class PowerPane extends jmri.util.swing.JmriPanel
                     onOffStatus.setText(Bundle.getMessage("StatusUnknown"));
                 } else {
                     onOffStatus.setText(Bundle.getMessage("StatusUnknown"));
-                    log.error("Unexpected state value: {0}", selectMenu.getManager().getPower());
+                    log.error("Unexpected state value: {}", selectMenu.getManager().getPower());
                 }
             } catch (JmriException ex) {
                 onOffStatus.setText(Bundle.getMessage("StatusUnknown"));
@@ -165,7 +165,7 @@ public class PowerPane extends jmri.util.swing.JmriPanel
             try {
                 selectMenu.getManager().setPower(PowerManager.ON);
             } catch (JmriException e) {
-                log.error("Exception trying to turn power on {0}", e);
+                log.error("Exception trying to turn power on {}", e);
             }
         }
     }
@@ -178,7 +178,7 @@ public class PowerPane extends jmri.util.swing.JmriPanel
             try {
                 selectMenu.getManager().setPower(PowerManager.OFF);
             } catch (JmriException e) {
-                log.error("Exception trying to turn power off {0}", e);
+                log.error("Exception trying to turn power off {}", e);
             }
         }
     }
@@ -194,7 +194,7 @@ public class PowerPane extends jmri.util.swing.JmriPanel
             try {
                 selectMenu.getManager().setPower(PowerManager.IDLE);
             } catch (JmriException e) {
-                log.error("Exception trying to set power to idle {0}", e);
+                log.error("Exception trying to set power to idle {}", e);
             }
         }
     }
@@ -213,7 +213,7 @@ public class PowerPane extends jmri.util.swing.JmriPanel
                 onOffStatus.setText(Bundle.getMessage("StatusUnknown"));
             } else {
                 onOffStatus.setText(Bundle.getMessage("StatusUnknown"));
-                log.error("Unexpected state value: {0}", listening.getPower());
+                log.error("Unexpected state value: {}", listening.getPower());
             }
         } catch (JmriException ex) {
             onOffStatus.setText(Bundle.getMessage("StatusUnknown"));

--- a/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
@@ -465,7 +465,7 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
                         Bundle.getMessage("ErrorTitle"),
                         JOptionPane.ERROR_MESSAGE);
                 this.disableDownloadVerifyButtons();
-                log.warn("Invalid dmf file 'Options' value {0}",text);
+                log.warn("Invalid dmf file 'Options' value {}",text);
                 return;
             }
         }
@@ -494,7 +494,7 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
             }
             
             if (interpretationProblem == true) {
-                log.warn("Invalid dmf file 'Erase Blk Size' value {0}",text);
+                log.warn("Invalid dmf file 'Erase Blk Size' value {}",text);
                 JOptionPane.showMessageDialog(this,
                         Bundle.getMessage("ErrorInvalidEraseBlkSize", text, "Erase Blk Size"), // NOI18N
                         Bundle.getMessage("ErrorTitle"), // NOI18N

--- a/java/src/jmri/jmrix/mrc/MrcMessage.java
+++ b/java/src/jmri/jmrix/mrc/MrcMessage.java
@@ -21,7 +21,7 @@ public class MrcMessage {
     // create a new one
     public MrcMessage(int len) {
         if (len < 1) {
-            log.error("invalid length in call to ctor: {0}", len);  //IN18N
+            log.error("invalid length in call to ctor: {}", len);  //IN18N
         }
         _nDataChars = len;
         _dataChars = new int[len];
@@ -190,7 +190,7 @@ public class MrcMessage {
                 i = m.putHeader(MrcPackets.FUNCTIONGROUP6PACKETHEADER);
                 break;
             default:
-                log.error("Invalid function group: {0}", group);  //IN18N
+                log.error("Invalid function group: {}", group);  //IN18N
                 return null;
         }
 
@@ -345,7 +345,7 @@ public class MrcMessage {
      */
     static public MrcMessage setClockRatio(int ratio) {
         if (ratio < 0 || ratio > 60) {
-            log.error("ratio number too large: {0}", ratio); //IN18N
+            log.error("ratio number too large: {}", ratio); //IN18N
         }
         MrcMessage m = new MrcMessage(MrcPackets.getSetClockRatioPacketLength());
         m.setMessageClass(MrcInterface.CLOCK);
@@ -367,10 +367,10 @@ public class MrcMessage {
      */
     static public MrcMessage setClockTime(int hour, int minute) {
         if (hour < 0 || hour > 23) {
-            log.error("hour number out of range : {0}", hour); //IN18N
+            log.error("hour number out of range : {}", hour); //IN18N
         }
         if (minute < 0 || minute > 59) {
-            log.error("minute number out of range : {0}", minute); //IN18N
+            log.error("minute number out of range : {}", minute); //IN18N
         }
         MrcMessage m = new MrcMessage(MrcPackets.getSetClockTimePacketLength());
         m.setMessageClass(MrcInterface.CLOCK);

--- a/java/src/jmri/jmrix/mrc/MrcPacketizer.java
+++ b/java/src/jmri/jmrix/mrc/MrcPacketizer.java
@@ -114,7 +114,7 @@ public class MrcPacketizer extends MrcTrafficController {
                 }
             }
         } catch (RuntimeException e) {
-            log.warn("passing to xmit: unexpected exception: {0}", e); //IN18N
+            log.warn("passing to xmit: unexpected exception: {}", e); //IN18N
         }
     }
 
@@ -474,7 +474,7 @@ public class MrcPacketizer extends MrcTrafficController {
                     // done with this one
                 } catch (MrcMessageException e) {
                     // just let it ride for now
-                    log.warn("run: unexpected MrcMessageException: {0}", e); //IN18N
+                    log.warn("run: unexpected MrcMessageException: {}", e); //IN18N
                 } catch (java.io.EOFException e) {
                     // posted from idle port when enableReceiveTimeout used
                     log.trace("EOFException, is Mrc serial I/O using timeouts?");

--- a/java/src/jmri/jmrix/pricom/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/pricom/downloader/LoaderPane.java
@@ -120,7 +120,7 @@ public class LoaderPane extends javax.swing.JPanel {
     }
 
     synchronized void sendBytes(byte[] bytes) {
-        log.debug("Send {0}: {1}", bytes.length, jmri.util.StringUtil.hexStringFromBytes(bytes));
+        log.debug("Send {}: {}", bytes.length, jmri.util.StringUtil.hexStringFromBytes(bytes));
         try {
             // send the STX at the start
             byte startbyte = 0x02;


### PR DESCRIPTION
Logging uses "{}"  to indicate text substitution, not "{0}"

This PR:
 - Fixes six files that use the wrong form
 - Makes it a CheckStyle error to have the wrong form