### PR TITLE
Implement getSystemNamePrefix for Logix and LRoute Fixes

### DIFF
--- a/java/src/jmri/jmrit/beantable/LRouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LRouteTableAction.java
@@ -402,7 +402,6 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
             outputTS.add(new RouteOutputSensor(systemName, userName));
             alignTS.add(new AlignElement(systemName, userName));
         });
-
         jmri.LightManager lm = InstanceManager.lightManagerInstance();
         lm.getNamedBeanSet().forEach((nb) -> {
             String userName = nb.getUserName();
@@ -886,8 +885,8 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
      * Set up Create/Edit LRoute pane
      */
     void makeEditWindow() {
+        buildLists();
         if (_addFrame == null) {
-            buildLists();
             _addFrame = new JmriJFrame(rbx.getString("LRouteAddTitle"), false, false);
             _addFrame.addHelpMenu("package.jmri.jmrit.beantable.LRouteAddEdit", true);
             _addFrame.setLocation(100, 30);
@@ -1133,11 +1132,7 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
                 public void windowClosing(java.awt.event.WindowEvent e) {
                     // remind to save, if Route was created or edited
                     if (routeDirty) {
-                        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                                showInfoMessage(Bundle.getMessage("ReminderTitle"), Bundle.getMessage("ReminderSaveString", Bundle.getMessage("BeanNameLRoute")),
-                                        getClassName(),
-                                        "remindSaveRoute"); // NOI18N
-                        routeDirty = false;
+                        showReminderMessage();
                     }
                     clearPage();
                     _addFrame.setVisible(false);
@@ -1158,7 +1153,14 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
         } else {
             _addFrame.setVisible(true);
         }
-    }   // addPressed
+    }
+
+    void showReminderMessage() {
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
+            showInfoMessage(Bundle.getMessage("ReminderTitle"), Bundle.getMessage("ReminderSaveString", Bundle.getMessage("BeanNameLRoute")),
+                    getClassName(),
+                    "remindSaveRoute"); // NOI18N
+    }
 
     /*
      * Utility for addPressed
@@ -1979,6 +1981,10 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
         _newRouteType = true;
         _newRouteButton.doClick();
         _lockCheckBox.setSelected(_lock);
+        if (routeDirty) {
+            showReminderMessage();
+            routeDirty = false;
+        }
         _addFrame.setVisible(false);
     }
 
@@ -2372,10 +2378,17 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
         }
     }
 
-    public final static String LOGIX_SYS_NAME = "RTX";
-    public final static String LOGIX_INITIALIZER = LOGIX_SYS_NAME + "INITIALIZER";
-    public final static String CONDITIONAL_SYS_PREFIX = LOGIX_SYS_NAME + "C";
+    public final static String LOGIX_SYS_NAME;
+    public final static String LOGIX_INITIALIZER;
+    public final static String CONDITIONAL_SYS_PREFIX;
     public final static String CONDITIONAL_USER_PREFIX = "Route ";
+
+    static {
+        String logixPrefix = InstanceManager.getDefault(jmri.LogixManager.class).getSystemNamePrefix();
+        LOGIX_SYS_NAME = logixPrefix + ":RTX";
+        LOGIX_INITIALIZER = LOGIX_SYS_NAME + "INITIALIZER";
+        CONDITIONAL_SYS_PREFIX = LOGIX_SYS_NAME + "C";
+    }
 
     public final static int SENSOR_TYPE = 1;
     public final static int TURNOUT_TYPE = 2;
@@ -2477,12 +2490,12 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
         }
 
         static jmri.util.AlphanumComparator ac = new jmri.util.AlphanumComparator();
-    
+
         @Override
         public int compare(RouteElement e1, RouteElement e2) {
             String s1 = e1.getSysName();
             String s2 = e2.getSysName();
-            
+
             int p1len = Manager.getSystemPrefixLength(s1);
             int p2len = Manager.getSystemPrefixLength(s2);
 
@@ -2491,11 +2504,11 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
 
             char c1 = s1.charAt(p1len);
             char c2 = s2.charAt(p2len);
-           
+
             if (c1 == c2) return ac.compare(s1.substring(p1len+1), s2.substring(p2len+1));
             else return (c1 > c2) ? +1 : -1 ;
         }
-        
+
     }
 
     /**

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -1081,27 +1081,24 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
     }
 
     /**
-     * Check validity of Logix system name.
-     * <p>
-     * Fixes name if it doesn't start with "IX".
-     *
-     * @return false if name has length &lt; 1 after displaying a dialog
+     * Check for a valid Logix system name.
+     * A valid name has a Logix prefix, normally IX, and at least 1 additional character.
+     * The prefix will be added if necessary.
+     * makeSystemName errors are logged to the system console and a dialog is displayed.
+     * @return true if the name is now valid.
      */
     boolean checkLogixSysName() {
         String sName = _systemName.getText();
-        if ((sName.length() < 1)) {
-            // Entered system name is blank or too short
+
+        try {
+            sName = InstanceManager.getDefault(jmri.LogixManager.class).makeSystemName(sName);
+        } catch (jmri.NamedBean.BadSystemNameException ex) {
             JOptionPane.showMessageDialog(addLogixFrame,
                     Bundle.getMessage("LogixError8"), Bundle.getMessage("ErrorTitle"), // NOI18N
                     JOptionPane.ERROR_MESSAGE);
             return false;
         }
-        if ((sName.length() < 2) || (sName.charAt(0) != 'I')
-                || (sName.charAt(1) != 'X')) {
-            // System name does not begin with IX, prefix IX to it
-            String s = sName;
-            sName = "IX" + s;  // NOI18N
-        }
+
         _systemName.setText(sName);
         return true;
     }

--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -849,11 +849,7 @@ public class RouteTableAction extends AbstractTableAction<Route> {
             public void windowClosing(java.awt.event.WindowEvent e) {
                 // remind to save, if Route was created or edited
                 if (routeDirty) {
-                    InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                            showInfoMessage(Bundle.getMessage("ReminderTitle"),
-                                    Bundle.getMessage("ReminderSaveString", Bundle.getMessage("MenuItemRouteTable")),
-                                    getClassName(),
-                                    "remindSaveRoute"); //NOI18N
+                    showReminderMessage();
                     routeDirty = false;
                 }
                 // hide addFrame
@@ -872,6 +868,14 @@ public class RouteTableAction extends AbstractTableAction<Route> {
         // display the window
         addFrame.setVisible(true);
         autoSystemName();
+    }
+
+    void showReminderMessage() {
+        InstanceManager.getDefault(jmri.UserPreferencesManager.class).
+                showInfoMessage(Bundle.getMessage("ReminderTitle"),  // NOI18N
+                        Bundle.getMessage("ReminderSaveString", Bundle.getMessage("MenuItemRouteTable")),  // NOI18N
+                        getClassName(),
+                        "remindSaveRoute"); //NOI18N
     }
 
     void autoSystemName() {
@@ -1846,6 +1850,9 @@ public class RouteTableAction extends AbstractTableAction<Route> {
      * Cancel Add mode.
      */
     void cancelAdd() {
+        if (routeDirty) {
+            showReminderMessage();
+        }
         curRoute = null;
         finishUpdate();
         status1.setText(createInst);
@@ -2073,9 +2080,15 @@ public class RouteTableAction extends AbstractTableAction<Route> {
 
     private boolean showAll = true;   // false indicates show only included Turnouts
 
-    public final static String LOGIX_SYS_NAME = "RTX";
-    public final static String CONDITIONAL_SYS_PREFIX = LOGIX_SYS_NAME + "C";
+    public final static String LOGIX_SYS_NAME;
+    public final static String CONDITIONAL_SYS_PREFIX;
     private static int ROW_HEIGHT;
+
+    static {
+        String logixPrefix = InstanceManager.getDefault(jmri.LogixManager.class).getSystemNamePrefix();
+        LOGIX_SYS_NAME = logixPrefix + ":RTX:";
+        CONDITIONAL_SYS_PREFIX = LOGIX_SYS_NAME + "C";
+    }
 
     private static String[] COLUMN_NAMES = {Bundle.getMessage("ColumnSystemName"),
         Bundle.getMessage("ColumnUserName"),

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
@@ -13609,7 +13609,8 @@ public class LayoutEditorTools {
         String turnoutName = turn.getDisplayName();
         String farTurnoutName = farTurn.getDisplayName();
 
-        String logixName = "IX_LAYOUTSLIP:" + slip.ident;
+        String logixPrefix = InstanceManager.getDefault(jmri.LogixManager.class).getSystemNamePrefix();
+        String logixName = logixPrefix + "IX_LAYOUTSLIP:" + slip.ident;
         String sensorName = "IS:" + logixName + "C" + number;
         try {
             InstanceManager.sensorManagerInstance().provideSensor(sensorName);

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
@@ -13610,7 +13610,7 @@ public class LayoutEditorTools {
         String farTurnoutName = farTurn.getDisplayName();
 
         String logixPrefix = InstanceManager.getDefault(jmri.LogixManager.class).getSystemNamePrefix();
-        String logixName = logixPrefix + "IX_LAYOUTSLIP:" + slip.ident;
+        String logixName = logixPrefix + ":IX_LAYOUTSLIP:" + slip.ident;
         String sensorName = "IS:" + logixName + "C" + number;
         try {
             InstanceManager.sensorManagerInstance().provideSensor(sensorName);

--- a/java/src/jmri/jmrit/sensorgroup/SensorGroupFrame.java
+++ b/java/src/jmri/jmrit/sensorgroup/SensorGroupFrame.java
@@ -47,11 +47,17 @@ public class SensorGroupFrame extends jmri.util.JmriJFrame {
 
     private final static String namePrefix = "SENSOR GROUP:";  // should be upper case
     private final static String nameDivider = ":";
-    public final static String logixSysName = "SYS";
+    public final static String logixSysName;
     public final static String logixUserName = "System Logix";
-    public final static String ConditionalSystemPrefix = logixSysName + "_SGC_";
+    public final static String ConditionalSystemPrefix;
     private final static String ConditionalUserPrefix = "Sensor Group ";
     private int rowHeight;
+
+    static {
+        String logixPrefix = InstanceManager.getDefault(jmri.LogixManager.class).getSystemNamePrefix();
+        logixSysName = logixPrefix + ":SYS";
+        ConditionalSystemPrefix = logixSysName + "_SGC_";
+    }
 
     SensorTableModel _sensorModel;
     JScrollPane _sensorScrollPane;
@@ -280,7 +286,7 @@ public class SensorGroupFrame extends jmri.util.JmriJFrame {
             String cUserName = ConditionalUserPrefix + group;
             for (int i = 0; i < logix.getNumConditionals(); i++) {
                 String name = logix.getConditionalByNumberOrder(i);
-                if (cSystemName.equals(name) || cUserName.equals(name)) {
+                if (cSystemName.equalsIgnoreCase(name) || cUserName.equals(name)) {     // Ignore case for compatibility
                     Conditional c = InstanceManager.getDefault(jmri.ConditionalManager.class).getBySystemName(name);
                     if (c == null) {
                         log.error("Conditional \"" + name + "\" expected but NOT found in Logix " + logix.getSystemName());
@@ -382,7 +388,7 @@ public class SensorGroupFrame extends jmri.util.JmriJFrame {
             String[] msgs = logix.deleteConditional(sysName);
             if (msgs != null) {
                 if (showMsg) {
-                    javax.swing.JOptionPane.showMessageDialog(this, 
+                    javax.swing.JOptionPane.showMessageDialog(this,
                             Bundle.getMessage("MessageError41") + " " + msgs[0] + " (" + msgs[1] + ") "
                             + Bundle.getMessage("MessageError42") + " " + msgs[2] + " (" + msgs[3] + "), "
                             + Bundle.getMessage("MessageError43") + " " + msgs[4] + " (" + msgs[5] + "). "

--- a/java/src/jmri/jmrit/ussctc/Follower.java
+++ b/java/src/jmri/jmrit/ussctc/Follower.java
@@ -15,7 +15,8 @@ import jmri.implementation.DefaultRoute;
  */
 public class Follower implements Constants {
 
-    final static String namePrefix = commonNamePrefix + "FOLLOWER" + commonNameSuffix; // NOI18N
+    static String routePrefix = InstanceManager.getDefault(jmri.RouteManager.class).getSystemNamePrefix();
+    final static String namePrefix = routePrefix + ":" + commonNamePrefix + "FOLLOWER" + commonNameSuffix; // NOI18N
 
     /**
      * Nobody can build anonymous object
@@ -93,7 +94,7 @@ public class Follower implements Constants {
         this.output = outputName;
 
         // find existing thrown route to get info
-        String nameT = namePrefix + "T" + nameDivider + output;        
+        String nameT = namePrefix + "T" + nameDivider + output;
 
         RouteManager rm = InstanceManager.getDefault(jmri.RouteManager.class);
         Route r = rm.getBySystemName(nameT);

--- a/java/src/jmri/jmrit/ussctc/OsIndicator.java
+++ b/java/src/jmri/jmrit/ussctc/OsIndicator.java
@@ -22,7 +22,8 @@ import jmri.implementation.DefaultConditionalAction;
  */
 public class OsIndicator implements Constants {
 
-    final static String namePrefix = commonNamePrefix + "OsIndicator" + commonNameSuffix; //NOI18N
+    static String logixPrefix = InstanceManager.getDefault(jmri.LogixManager.class).getSystemNamePrefix();
+    final static String namePrefix = logixPrefix + ":" + commonNamePrefix + "OsIndicator" + commonNameSuffix; //NOI18N
 
     /**
      * Nobody can build anonymous object

--- a/java/src/jmri/managers/ManagersBundle.properties
+++ b/java/src/jmri/managers/ManagersBundle.properties
@@ -40,3 +40,7 @@ ManagerDefaultSelector.AllInternal = JMRI is defaulting to internal systems for 
 RouteManager.SystemNameChanged.Message = <html>The System Name of {0} route was changed.<br><br>Please verify that references to this route still work.<br>Review the logs to see how the route was renamed.</html>
 RouteManager.SystemNamesChanged.Message = <html>The System Name of {0} routes were changed.<br><br>Please verify that references to these routes still work.<br>Review the logs to which routes were renamed.</html>
 Manager.SystemNamesChanged.Title = Changed System Name of {0} {1}
+LogixManager.SystemNameChanged.Message = <html>The System Name of {0} Logix was changed.<br><br>Please verify that references to this Logix still work.<br>Review the logs to see how the Logix was renamed.</html>
+LogixManager.SystemNamesChanged.Message = <html>The System Name of {0} Logixs were changed.<br><br>Please verify that references to these Logixs still work.<br>Review the logs to which logixs were renamed.</html>
+ConditionalManager.SystemNameChanged.Message = <html>The System Name of {0} Conditional was changed.<br><br>Please verify that references to this Conditional still work.<br>Review the logs to see how the Conditional was renamed.</html>
+ConditionalManager.SystemNamesChanged.Message = <html>The System Name of {0} Conditionals were changed.<br><br>Please verify that references to these Conditionals still work.<br>Review the logs to which Conditionals were renamed.</html>

--- a/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
@@ -412,7 +412,10 @@ public class DefaultConditionalManagerXml extends jmri.managers.configurexml.Abs
         }
 
         if (namesChanged > 0) {
-            if (!GraphicsEnvironment.isHeadless()) {
+            // TODO: replace the System property check with an in-application mechanism
+            // for notifying users of multiple changes that can be silenced as part of
+            // normal operations
+            if (!GraphicsEnvironment.isHeadless() && !Boolean.getBoolean("jmri.test.no-dialogs")) {
                 JOptionPane.showMessageDialog(null,
                         Bundle.getMessage(namesChanged > 1 ? "ConditionalManager.SystemNamesChanged.Message" : "ConditionalManager.SystemNameChanged.Message", namesChanged),
                         Bundle.getMessage("Manager.SystemNamesChanged.Title", namesChanged, cm.getBeanTypeHandled(namesChanged > 1)),

--- a/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
@@ -302,8 +302,10 @@ public class DefaultConditionalManagerXml extends jmri.managers.configurexml.Abs
                 }
                 variable.setType(Conditional.Type.getOperatorFromIntValue(
                         Integer.parseInt(cvar.getAttribute("type").getValue())));  // NOI18N
-                variable.setName(cvar
-                        .getAttribute("systemName").getValue());  // NOI18N
+
+                String tempName = cvar.getAttribute("systemName").getValue();  // NOI18N
+                variable.setName(tempName.equals("RTXINITIALIZER") ? systemNamePrefix + ":" + tempName : tempName);  // NOI18N
+
                 if (cvar.getAttribute("dataString") != null) {  // NOI18N
                     variable.setDataString(cvar
                             .getAttribute("dataString").getValue());  // NOI18N

--- a/java/src/jmri/managers/configurexml/DefaultLogixManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultLogixManagerXml.java
@@ -196,7 +196,10 @@ public class DefaultLogixManagerXml extends jmri.managers.configurexml.AbstractN
         }
 
         if (namesChanged > 0) {
-            if (!GraphicsEnvironment.isHeadless()) {
+            // TODO: replace the System property check with an in-application mechanism
+            // for notifying users of multiple changes that can be silenced as part of
+            // normal operations
+            if (!GraphicsEnvironment.isHeadless() && !Boolean.getBoolean("jmri.test.no-dialogs")) {
                 JOptionPane.showMessageDialog(null,
                         Bundle.getMessage(namesChanged > 1 ? "LogixManager.SystemNamesChanged.Message" : "LogixManager.SystemNameChanged.Message", namesChanged),
                         Bundle.getMessage("Manager.SystemNamesChanged.Title", namesChanged, lxm.getBeanTypeHandled(namesChanged > 1)),

--- a/java/test/jmri/jmrit/entryexit/load/EntryExitTest.xml
+++ b/java/test/jmri/jmrit/entryexit/load/EntryExitTest.xml
@@ -511,14 +511,14 @@
   </signalmastlogics>
   <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
     <logix userName="Initialize" enabled="yes">
-      <systemName>RTXINITIALIZER</systemName>
+      <systemName>IX:RTXINITIALIZER</systemName>
       <userName>Initialize</userName>
-      <logixConditional systemName="RTXINITIALIZER1T" order="0" />
+      <logixConditional systemName="IX:RTXINITIALIZER1T" order="0" />
     </logix>
   </logixs>
   <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
-    <conditional systemName="RTXINITIALIZER1T" userName="Route 1C Initialize" antecedent="R1" logicType="3" triggerOnChange="yes">
-      <systemName>RTXINITIALIZER1T</systemName>
+    <conditional systemName="IX:RTXINITIALIZER1T" userName="Route 1C Initialize" antecedent="R1" logicType="3" triggerOnChange="yes">
+      <systemName>IX:RTXINITIALIZER1T</systemName>
       <userName>Route 1C Initialize</userName>
       <conditionalStateVariable operator="4" negated="no" type="0" systemName="RTXINITIALIZER" dataString="" num1="0" num2="0" triggersCalc="yes" />
       <conditionalAction option="1" type="9" systemName="Reset" data="2" delay="0" string="" />

--- a/java/test/jmri/jmrit/entryexit/load/EntryExitTest.xml
+++ b/java/test/jmri/jmrit/entryexit/load/EntryExitTest.xml
@@ -520,7 +520,7 @@
     <conditional systemName="IX:RTXINITIALIZER1T" userName="Route 1C Initialize" antecedent="R1" logicType="3" triggerOnChange="yes">
       <systemName>IX:RTXINITIALIZER1T</systemName>
       <userName>Route 1C Initialize</userName>
-      <conditionalStateVariable operator="4" negated="no" type="0" systemName="RTXINITIALIZER" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="4" negated="no" type="0" systemName="IX:RTXINITIALIZER" dataString="" num1="0" num2="0" triggersCalc="yes" />
       <conditionalAction option="1" type="9" systemName="Reset" data="2" delay="0" string="" />
     </conditional>
   </conditionals>

--- a/java/test/jmri/jmrit/logix/valid/IndicatorDemoTest.xml
+++ b/java/test/jmri/jmrit/logix/valid/IndicatorDemoTest.xml
@@ -1185,19 +1185,19 @@
       <logixConditional systemName="IX:AUTO:0003C10" order="8" />
     </logix>
     <logix userName="InitSignalMast" enabled="yes">
-      <systemName>MAST INIT</systemName>
+      <systemName>IX:MAST INIT</systemName>
       <userName>InitSignalMast</userName>
-      <logixConditional systemName="MAST INITC1" order="0" />
+      <logixConditional systemName="IX:MAST INITC1" order="0" />
     </logix>
     <logix userName="Initialize" enabled="yes">
-      <systemName>RTXINITIALIZER</systemName>
+      <systemName>IX:RTXINITIALIZER</systemName>
       <userName>Initialize</userName>
-      <logixConditional systemName="RTXINITIALIZER1T" order="0" />
+      <logixConditional systemName="IX:RTXINITIALIZER1T" order="0" />
     </logix>
     <logix userName="System Logix" enabled="yes">
-      <systemName>SYS</systemName>
+      <systemName>IX:SYS</systemName>
       <userName>System Logix</userName>
-      <logixConditional systemName="SYS_SGC_WARRANTS" order="0" />
+      <logixConditional systemName="IX:SYS_SGC_WARRANTS" order="0" />
     </logix>
   </logixs>
   <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
@@ -1304,18 +1304,18 @@
       <conditionalAction option="1" type="12" systemName="TrainName" data="-1" delay="0" string="EZX" />
       <conditionalAction option="1" type="12" systemName="TrainId" data="-1" delay="0" string="SantaFe" />
     </conditional>
-    <conditional systemName="MAST INITC1" userName="Signal Mast Init" antecedent="R1 and R2" logicType="2" triggerOnChange="yes">
-      <systemName>MAST INITC1</systemName>
+    <conditional systemName="IX:MAST INITC1" userName="Signal Mast Init" antecedent="R1 and R2" logicType="2" triggerOnChange="yes">
+      <systemName>IX:MAST INITC1</systemName>
       <userName>Signal Mast Init</userName>
       <conditionalStateVariable operator="4" negated="no" type="1" systemName="init" dataString="" num1="0" num2="0" triggersCalc="yes" />
       <conditionalStateVariable operator="5" negated="no" type="2" systemName="init" dataString="" num1="0" num2="0" triggersCalc="yes" />
       <conditionalAction option="1" type="37" systemName="Triple Head Color" data="-1" delay="0" string="Clear" />
       <conditionalAction option="1" type="37" systemName="Triple Head Approach" data="-1" delay="0" string="Approach Medium" />
     </conditional>
-    <conditional systemName="RTXINITIALIZER1T" userName="Route 1C Initialize" antecedent="R1" logicType="3" triggerOnChange="yes">
-      <systemName>RTXINITIALIZER1T</systemName>
+    <conditional systemName="IX:RTXINITIALIZER1T" userName="Route 1C Initialize" antecedent="R1" logicType="3" triggerOnChange="yes">
+      <systemName>IX:RTXINITIALIZER1T</systemName>
       <userName>Route 1C Initialize</userName>
-      <conditionalStateVariable operator="4" negated="no" type="0" systemName="RTXINITIALIZER" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="4" negated="no" type="0" systemName="IX:RTXINITIALIZER" dataString="" num1="0" num2="0" triggersCalc="yes" />
       <conditionalAction option="1" type="3" systemName="SigEBMain1" data="4" delay="0" string="" />
       <conditionalAction option="1" type="3" systemName="SigEBMain2" data="16" delay="0" string="" />
       <conditionalAction option="1" type="9" systemName="init" data="4" delay="0" string="" />
@@ -1360,8 +1360,8 @@
       <conditionalAction option="1" type="2" systemName="toWayFarAway" data="2" delay="0" string="" />
       <conditionalAction option="1" type="2" systemName="YardSpurs" data="4" delay="0" string="" />
     </conditional>
-    <conditional systemName="SYS_SGC_WARRANTS" userName="Sensor Group warrants" antecedent="" logicType="2" triggerOnChange="yes">
-      <systemName>SYS_SGC_WARRANTS</systemName>
+    <conditional systemName="IX:SYS_SGC_WARRANTS" userName="Sensor Group warrants" antecedent="" logicType="2" triggerOnChange="yes">
+      <systemName>IX:SYS_SGC_WARRANTS</systemName>
       <userName>Sensor Group warrants</userName>
       <conditionalStateVariable operator="5" negated="no" type="1" systemName="IS201" dataString="" num1="0" num2="0" triggersCalc="yes" />
       <conditionalStateVariable operator="5" negated="no" type="1" systemName="IS202" dataString="" num1="0" num2="0" triggersCalc="yes" />

--- a/java/test/jmri/jmrit/logix/valid/LogixActionTest.xml
+++ b/java/test/jmri/jmrit/logix/valid/LogixActionTest.xml
@@ -414,7 +414,7 @@
         <conditional systemName="IX:RTXINITIALIZER1T" userName="Route 1C " antecedent="R1" logicType="3" triggerOnChange="yes">
             <systemName>IX:RTXINITIALIZER1T</systemName>
             <userName>Route 1C</userName>
-            <conditionalStateVariable operator="4" negated="no" type="0" systemName="RTXINITIALIZER" dataString="" num1="0" num2="0" triggersCalc="yes" />
+            <conditionalStateVariable operator="4" negated="no" type="0" systemName="IX:RTXINITIALIZER" dataString="" num1="0" num2="0" triggersCalc="yes" />
             <conditionalAction option="1" type="9" systemName="Occupancy OB1" data="4" delay="0" string="" />
             <conditionalAction option="1" type="9" systemName="Occupancy OB2" data="4" delay="0" string="" />
             <conditionalAction option="1" type="9" systemName="Occupancy OB3" data="4" delay="0" string="" />

--- a/java/test/jmri/jmrit/logix/valid/LogixActionTest.xml
+++ b/java/test/jmri/jmrit/logix/valid/LogixActionTest.xml
@@ -331,9 +331,9 @@
             <userName>EnableTest</userName>
             <logixConditional systemName="IXEnableTestC1" order="0" />
         </logix>
-        <logix systemName="RTXINITIALIZER" enabled="yes">
-            <systemName>RTXINITIALIZER</systemName>
-            <logixConditional systemName="RTXINITIALIZER1T" order="0" />
+        <logix systemName="IX:RTXINITIALIZER" enabled="yes">
+            <systemName>IX:RTXINITIALIZER</systemName>
+            <logixConditional systemName="IX:RTXINITIALIZER1T" order="0" />
         </logix>
     </logixs>
     <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
@@ -411,8 +411,8 @@
             <conditionalAction option="1" type="13" systemName="ActionTests" data="-1" delay="0" string="" />
             <conditionalAction option="2" type="14" systemName="ActionTests" data="-1" delay="0" string="" />
         </conditional>
-        <conditional systemName="RTXINITIALIZER1T" userName="Route 1C " antecedent="R1" logicType="3" triggerOnChange="yes">
-            <systemName>RTXINITIALIZER1T</systemName>
+        <conditional systemName="IX:RTXINITIALIZER1T" userName="Route 1C " antecedent="R1" logicType="3" triggerOnChange="yes">
+            <systemName>IX:RTXINITIALIZER1T</systemName>
             <userName>Route 1C</userName>
             <conditionalStateVariable operator="4" negated="no" type="0" systemName="RTXINITIALIZER" dataString="" num1="0" num2="0" triggersCalc="yes" />
             <conditionalAction option="1" type="9" systemName="Occupancy OB1" data="4" delay="0" string="" />


### PR DESCRIPTION
Logix is changed to use the getSystemNamePrefix process.  This includes other tools that generate Logix.  This results in system changes that will not be backward compatible.  Assuming a prefix of IX, the following are the created names:
- Standard Logix format is not changed.
- Sensor Groups:  SYS => IX:SYS
- LRoutes:  RTX??? => IX:RTX???
- Exported Routes: RTX?? => IX:RTX:???
- Slip Logix: IX_LAYOUTSLIP:??? => IX:IX_LAYOUTSLIP:???
- USS_CTC Logix:  Not changed due to issues getting it to run.  TODO

The save reminders for Routes and LRoutes have been changed to be more timely.  The LRoute object lists are re-built with each Add invocation to pick up user name changes.  The LRoute internal lists will require complete overhaul to support named bean handles.