### PR TITLE
Add reference Id for Add-On Apps within html/apps/index.shtml

### DIFF
--- a/help/en/html/apps/index.shtml
+++ b/help/en/html/apps/index.shtml
@@ -80,7 +80,8 @@
         installation folder.</dd>
       </dl>
 
-      <h2>Add-on Applications</h2>
+      <h2><a name="addonApplications" id=
+        "addonApplications">Add-on Applications</a></h2>
        Hobbyists have created applications that work with JMRI
        to provide extra capabilities.
        


### PR DESCRIPTION
To allow addition of sidebar item referencing this section of the apps helps page.