### PR TITLE
Ensure javax.annotation.Nullable not used

### DIFF
--- a/help/en/html/doc/Technical/SpotBugs.shtml
+++ b/help/en/html/doc/Technical/SpotBugs.shtml
@@ -218,14 +218,15 @@ scanning through the code.
       <p>We do not use these annotations:</p>
 
       <ul>
-        <li><a href=
+        <li><a name="nullable" id="nullable"></a>
+            <a href=
                "http://findbugs.sourceforge.net/manual/annotations.html"><code>
                     javax.annotation.Nullable</code></a> - This doesn't really
-        mean what people think it does, as SpotBugs doesn't really
-        check anything when this is used. From the SpotBugs documentation:
-        <blockquote>
-              SpotBugs will treat the annotated items as though they had
-              no annotation. In practice this annotation is useful only
+                mean what people think it does, as SpotBugs doesn't really
+                check anything when this is used. From the SpotBugs documentation:
+          <blockquote>
+            SpotBugs will treat the annotated items as though they had
+            no annotation. In practice this annotation is useful only
             for overriding an overarching NonNull annotation. Use
             javax.annotation.ParametersAreNullableByDefault to set it
             for an entire class. Prefer the use of

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -80,6 +80,16 @@ public class ArchitectureTest {
                             .should()
                                 .dependOnClassesThat().haveFullyQualifiedName("java.util.Timer");
      
+    /**
+     * No access to javax.annotation.Nullable except the FindBugsCheck test routine
+     */
+    @ArchTest 
+    public static final ArchRule checkNullableAnnotationRestricted = noClasses().that()
+                                // classes with permitted access
+                                .haveNameNotMatching("apps\\.FindBugsCheck")
+                            .should()
+                                .dependOnClassesThat().haveFullyQualifiedName("javax.annotation.Nullable");
+     
    /**
      * No jmri.jmrix in basic interfaces.
      * <p>

--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -155,17 +155,6 @@ We roll some general code maintenance items into the release process.
         grep -lr '\t' jython/ | grep '\.py'
 ```
 
-- Check for Nullable annotations, which should be @CheckForNull instead (OK to have two and four in FindBugsCheck respectively, others should be removed)
-```
-        grep -r javax.annotation.Nullable java/src java/test
-        grep -r @Nullable java/src java/test
-```
-
-- Check for code that's using native Java Timers; see jmri.util.TimerUtil for background (requires code has been built; should only mention jmri/util/TimerUtil.class):
-```
-        grep -rl 'java.util.Timer\x01' target/
-```
-
 - Run "ant alltest"; make sure they all pass; fix problems and commit back (might also take the jvisualvm data below)
 
 - Run "ant decoderpro"; check for no startup errors, right version, help index present and working OK. Fix problems and commit back.


### PR DESCRIPTION
Add a post-compile check for the use of `javax.annotation.Nullable`, see our [writeup on annotations and SpotBugs](https://www.jmri.org/help/en/html/doc/Technical/SpotBugs.shtml#nullable) for more info.