### PR TITLE
Update help sidebar in /hardware/loconet to use Parts

### DIFF
--- a/help/en/html/hardware/loconet/Sidebar.shtml
+++ b/help/en/html/hardware/loconet/Sidebar.shtml
@@ -1,4 +1,4 @@
-<!-- Sidebar -->
+<!-- Sidebar.shtml -->
 <!-- This is the common sidebar definition for html/hardware/loconet pages -->
 
 	  <hr class="hide">
@@ -6,27 +6,9 @@
 	    <div style="text-align: center">JMRI&reg; connects to...</div>
 	    <dl>
 
-		<dt><h3 style="padding-left: 1em;"><a href="../index.shtml">Supported Hardware</a></h3></dt>
+		<dt><h3 style="padding-left: 1em;"><a href="Digitrax.shtml"> Digitrax LocoNet&reg;</a></h3></dt>
 		<dd>
-		    <ul>
-				<!-- copy this list from /root sidebar, compare with /help/en/html/index.shtml, checked 11/2019 -->
-				<li><a href="../XPressNet/index.shtml">Atlas Commander</a>
-				<li><a href="../bachrus/index.shtml">Bachrus</a>
-				<li><a href="../CMRI.shtml">C/MRI</a>
-				<li><a href="../acela/index.shtml">CTI Electronics (Acela)</a>
-				<li><a href="../easydcc/EasyDCC.shtml">CVP EasyDCC</a>
-    		    <li><a href="../index.shtml">DCC++</a>
-				<li><a href="../misc/DccSpecialties.shtml">DCC Specialties (Hare)</a>
-				<li><a href="../XBee/index.shtml">Digi XBee</a>
-				<li><a href="../digirails/index.shtml">Digikeijs (Digirails)</a>
-				<li><a href="../loconet/Digitrax.shtml">Digitrax</a>
-				<li><a href="../ecos/index.shtml">ESU ECoS</a>
-				<li><a href="Fleischmann.shtml">Fleischmann</a>
-				<li><a href="../XPressNet/index.shtml">Hornby</a>
-				<li><a href="../XPressNet/index.shtml">Lenz</a>
-				<li><a href="../tmcc/index.shtml">Lionel TMCC</a>
-				<li><a href="Digitrax.shtml"> Digitrax LocoNet&reg;</a>
-                <ul>
+		  <ul>
                     <li><a href="LocoNetTools.shtml">LocoNet Tools</a></li>
                     <li><a href="LocoNetSim.shtml">LocoNet Simulator</a></li>
                     <li><a href="DS54.shtml">DS54</a></li>
@@ -59,108 +41,25 @@
                     <ul>
                         <li><a href="Addressing.shtml">Addressing</a></li>
                         <li><a href="LocoNetClasses.shtml">Implementation</a></li>
-                        <li><a href="DigitraxPower/index.shtml">LocoNet Power Issues</a></li>
+                        <li><a href="DigitraxPower.shtml">LocoNet Power Issues</a></li>
                     </ul>
                 </ul>
-				<li><a href="../maple/index.shtml">Maple Systems</a>
-				<li><a href="../marklin/index.shtml">M&auml;rklin CS2</a>
-				<li><a href="../can/cbus/index.shtml">MERG CBUS</a>
-				<li><a href="../modbus/index.shtml">Modbus</a>
-                <li><a href="../mqtt/index.shtml">MQTT</a>
-				<li><a href="../mrc/index.shtml">MRC</a>
-				<li><a href="../rps/index.shtml">NAC Services RPS</a>
-				<li><a href="../nce/NCE.shtml">NCE</a>
-				<li><a href="../oaktree/OakTree.shtml">Oak Tree Systems</a>
-				<li><a href="../openlcb/index.shtml">OpenLCB</a>
-				<li><a href="../grapevine/index.shtml">Protrak Grapevine</a>
-				<li><a href="../qsi/index.shtml">QSI Quantum Programmer</a>
-				<li><a href="../raildriver/index.shtml">Pi Engineering RailDriver</a>
-				<li><a href="../pi/index.shtml">Raspberry Pi</a>
-				<li><a href="../XPressNet/index.shtml">Roco</a>
-				<li><a href="../sprog/SPROG.shtml">SPROG</a>
-				<li><a href="../SRCP/index.shtml">SRCP server</a>
-				<li><a href="../tams/index.shtml">TAMS Master Control</a>
-				<li><a href="Uhlenbrock.shtml">Uhlenbrock Intellibox</a>
-				<li><a href="../XPressNet/index.shtml">Viessmann Commander</a>
-				<li><a href="../nce/Wangrow.shtml">Wangrow System One</a>
-				<li><a href="../powerline/index.shtml">X10</a>
-				<li><a href="../zimo/Zimo.shtml">Zimo MX-1</a>
-				<li><a href="../XPressNet/index.shtml">ZTC</a>
-		    </ul>
 		</dd>
 
-		<dt><h3 style="padding-left: 1em;">Installation</h3></dt>
-		<dd> 
-		    <ul>
-            <li><a href="https://jmri.org/install/WindowsNew.shtml">Windows</a>
-            <li><a href="https://jmri.org/install/MacOSX.shtml">Mac OS X</a>
-            <li><a href="https://jmri.org/install/Linux.shtml">Linux</a>
-            <ul>
-	            <li><a href="https://jmri.org/install/Raspbian.shtml">RasPi</a>
-	        </ul>
-            <li><a href="https://jmri.org/install/Debug.shtml">Debugging an installation</a>
-		    </ul>
-		</dd>
+		
+	<!--#include virtual="/help/en/parts/SidebarSupportedHardware.shtml" -->    
 
-		<dt><h3>Applications</h3></dt>
-		<dd>
-			<ul>
-			<li><a href="../../apps/DecoderPro/index.shtml">DecoderPro&reg;</a></li>
-			<li><a href="../../apps/PanelPro/index.shtml">PanelPro&trade;</a></li>
-			<li><a href="../../apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
-	        <li><a href="../../../package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
-			<li><a href="../../apps/SoundPro/SoundPro.shtml">SoundPro</a></li>
-			</ul>
-        </dd>
+	<!--#include virtual="/help/en/parts/SidebarApplications.shtml" -->
 
-		<dt><h3><a href="../../tools/index.shtml">Tools</a></h3></dt>
-		<dd>JMRI provides powerful tools for working with your
-		layout:
-		    <ul>
-	        <li><a href="../../tools/Turnouts.shtml">Turnouts</a>
-	        <li><a href="../../tools/Lights.shtml">Lights</a>
-	        <li><a href="../../tools/Sensors.shtml">Sensors</a>
-		    <li><a href="../../tools/throttle/ThrottleMain.shtml">Throttles</a>
-	        <li><a href="../../tools/consisttool/ConsistTool.shtml">Consisting</a>
-		    <li><a href="../../tools/Blocks.shtml">Blocks</a>
-		    <li><a href="../../tools/Reporters.shtml">Reporters</a>
-		    <li><a href="../../tools/Memories.shtml">Memory Variables</a>
-	        <li><a href="../../tools/Routes.shtml">Routes</a>
-	        <li><a href="../../tools/LRoutes.shtml">LRoutes</a>
-            <li><a href="../../tools/Sections.shtml">Sections</a>
-            <li><a href="../../tools/Transits.shtml">Transits</a>
-	        <li><a href="../../tools/Logix.shtml">Logix</a>
-	        <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
-	        <li><a href="../../tools/speedometer/index.shtml">Speedometer</a>
-	        <li><a href="../../tools/Audio.shtml">Audio</a>
-	        <li><a href="../../tools/IdTags.shtml">Id Tags</a>
-	        <li><a href="../../tools/TimeTable.shtml">Timetable</a>
+        <!--#include virtual="/help/en/parts/SidebarTools.shtml" -->
 
-            <li><a href="../../tools/index.shtml#systemSpecificTools">System-specific...</a>
-            </ul>
-		</dd>
-
-		<dt><h3 style="padding-left: 1em;"><a href="../../tools/automation/">Layout Automation</a></h3></dt>
-		<dd>
-		JMRI can be used to automate parts 
-		of your layout, from simply controlling a crossing gate
-		to running trains in the background.
-		    <ul>
-		    <li><a href="../../tools/signaling/index.shtml">Signaling</a>
-		    <li><a href="../../tools/EntryExit.shtml">Entry Exit (NX)</a>
-		    <li><a href="../../../package/jmri/jmrit/logix/Warrant.shtml">Warrants</a>
-		    <li><a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>
-		    <li><a href="../../tools/Routes.shtml">Routes</a>
-		    <li><a href="../../tools/fastclock/index.shtml">Fast Clocks</a>
-		    <li><a href="../../tools/uss/index.shtml">USS CTC</a>
-		    <li><a href="../../tools/scripting/index.shtml">Scripting</a>
-		    </ul>
-		</dd>
+        <!--#include virtual="/help/en/parts/SidebarLayoutAutomation.shtml" -->
+	    
 		
     </dl>
 
     <a href="/donations.shtml">
-     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" align="right" alt="Donate to JMRI" />
+     <img src="http://sourceforge.net/images/project-support.jpg" width="88" height="32" border="0" align="center" alt="Donate to JMRI" />
     </a>
 
 	</div> <!-- closes #side -->
@@ -170,4 +69,4 @@
     <script type="text/javascript" src="/web/js/here.js"></script>
     <!-- /Sidebar-Tail -->
 
-<!-- /Sidebar -->
+<!-- /Sidebar.shtml -->


### PR DESCRIPTION
Also, move DigitraxPower up a level in order to use same sidebar. {requires copy of /hardware/digitraxpower/index.shtml be made in /hardware/ directory with name digitraxpower.shtml.  Separate pull for that.