### PR TITLE
LayoutEditor:Bugfix-split decorations

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -2255,21 +2255,18 @@ public class TrackSegment extends LayoutTrack {
      * {@inheritDoc}
      */
     @Override
-    protected void draw1(Graphics2D g2, boolean isMain, boolean isBlock, boolean isMark) {
+    protected void draw1(Graphics2D g2, boolean isMain, boolean isBlock) {
 //   if (getName().equals("T15")) {
 //       log.debug("STOP");
 //   }
-        if (!isBlock && !isMark && isDashed() && getLayoutBlock() != null) {
+        if (!isBlock && isDashed() && getLayoutBlock() != null) {
             //Skip the dashed rail layer, the block layer will display the dashed track
             //This removes random rail fragments from between the block dashes
             return;
         }
-        if ((isMain == mainline) && (!isMark || marked)) {
+        if (isMain == mainline) {
             if (isBlock) {
                 setColorForTrackBlock(g2, getLayoutBlock());
-                if (isMark) {
-                    g2.setColor(ColorUtil.contrast(g2.getColor()));
-                }
             }
             if (isArc()) {
                 calculateTrackSegmentAngle();

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -1,21 +1,11 @@
 package jmri.jmrit.display.layoutEditor;
 
-import static java.lang.Float.POSITIVE_INFINITY;
-import static jmri.jmrit.display.layoutEditor.LayoutTrack.TRACK;
-import static jmri.jmrit.display.layoutEditor.PositionablePoint.EDGE_CONNECTOR;
-import static jmri.jmrit.display.layoutEditor.PositionablePoint.END_BUMPER;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
-import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
-import java.awt.geom.Arc2D;
-import java.awt.geom.GeneralPath;
-import java.awt.geom.Line2D;
-import java.awt.geom.Point2D;
-import java.awt.geom.Rectangle2D;
+import java.awt.event.*;
+import java.awt.geom.*;
 import java.util.*;
 import java.util.function.*;
 import javax.annotation.*;
@@ -24,8 +14,7 @@ import jmri.*;
 import jmri.jmrit.display.layoutEditor.blockRoutingTable.LayoutBlockRouteTableAction;
 import jmri.util.*;
 import jmri.util.swing.JmriColorChooser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.*;
 
 /**
  * TrackSegment is a segment of track on a layout linking two nodes of the
@@ -50,11 +39,11 @@ import org.slf4j.LoggerFactory;
  */
 public class TrackSegment extends LayoutTrack {
 
-    // defined constants
-    // operational instance variables (not saved between sessions)
+    //defined constants
+    //operational instance variables (not saved between sessions)
     private NamedBeanHandle<LayoutBlock> namedLayoutBlock = null;
 
-    // persistent instances variables (saved between sessions)
+    //persistent instances variables (saved between sessions)
     protected LayoutTrack connect1 = null;
     protected int type1 = 0;
     protected LayoutTrack connect2 = null;
@@ -68,8 +57,8 @@ public class TrackSegment extends LayoutTrack {
     private boolean changed = false;
     private boolean bezier = false;
 
-    // for Bezier
-    private ArrayList<Point2D> bezierControlPoints = new ArrayList<>(); // list of control point displacements
+    //for Bezier
+    private ArrayList<Point2D> bezierControlPoints = new ArrayList<>(); //list of control point displacements
 
     public TrackSegment(@Nonnull String id,
             @CheckForNull LayoutTrack c1, int t1,
@@ -78,7 +67,7 @@ public class TrackSegment extends LayoutTrack {
             @Nonnull LayoutEditor layoutEditor) {
         super(id, MathUtil.zeroPoint2D, layoutEditor);
 
-        // validate input
+        //validate input
         if ((c1 == null) || (c2 == null)) {
             log.error("Invalid object in TrackSegment constructor call - " + id);
         }
@@ -107,7 +96,7 @@ public class TrackSegment extends LayoutTrack {
         setupDefaultBumperSizes(layoutEditor);
     }
 
-    // alternate constructor for loading layout editor panels
+    //alternate constructor for loading layout editor panels
     public TrackSegment(@Nonnull String id,
             @CheckForNull String c1Name, int t1,
             @CheckForNull String c2Name, int t2,
@@ -198,12 +187,12 @@ public class TrackSegment extends LayoutTrack {
      * @return true if successful
      */
     public boolean replaceTrackConnection(@CheckForNull LayoutTrack oldTrack, @CheckForNull LayoutTrack newTrack, int newType) {
-        boolean result = false; // assume failure (pessimist!)
-        // trying to replace old track with null?
+        boolean result = false; //assume failure (pessimist!)
+        //trying to replace old track with null?
         if (newTrack == null) {
-            // (yes) remove old connection
+            //(yes) remove old connection
             if (oldTrack != null) {
-                result = true;  // assume success (optimist!)
+                result = true;  //assume success (optimist!)
                 if (connect1 == oldTrack) {
                     connect1 = null;
                     type1 = NONE;
@@ -218,10 +207,10 @@ public class TrackSegment extends LayoutTrack {
                 log.error("Can't replace null track connection with null");
                 result = false;
             }
-        } else // already connected to newTrack?
+        } else //already connected to newTrack?
         if ((connect1 != newTrack) && (connect2 != newTrack)) {
-            // (no) find a connection we can connect to
-            result = true;  // assume success (optimist!)
+            //(no) find a connection we can connect to
+            result = true;  //assume success (optimist!)
             if (connect1 == oldTrack) {
                 connect1 = newTrack;
                 type1 = newType;
@@ -413,10 +402,10 @@ public class TrackSegment extends LayoutTrack {
      * This implementation returns null because {@link #getConnect1} and
      * {@link #getConnect2} should be used instead.
      */
-    // only implemented here to suppress "does not override abstract method " error in compiler
+    //only implemented here to suppress "does not override abstract method " error in compiler
     @Override
     public LayoutTrack getConnection(int connectionType) throws jmri.JmriException {
-        // nothing to see here, move along
+        //nothing to see here, move along
         throw new jmri.JmriException("Use getConnect1() or getConnect2() instead.");
     }
 
@@ -426,10 +415,10 @@ public class TrackSegment extends LayoutTrack {
      * This implementation does nothing because {@link #setNewConnect1} and
      * {@link #setNewConnect2} should be used instead.
      */
-    // only implemented here to suppress "does not override abstract method " error in compiler
+    //only implemented here to suppress "does not override abstract method " error in compiler
     @Override
     public void setConnection(int connectionType, @CheckForNull LayoutTrack o, int type) throws jmri.JmriException {
-        // nothing to see here, move along
+        //nothing to see here, move along
         throw new jmri.JmriException("Use setConnect1() or setConnect2() instead.");
     }
 
@@ -468,7 +457,7 @@ public class TrackSegment extends LayoutTrack {
     public void setLayoutBlock(@CheckForNull LayoutBlock newLayoutBlock) {
         LayoutBlock layoutBlock = getLayoutBlock();
         if (layoutBlock != newLayoutBlock) {
-            // block has changed, if old block exists, decrement use
+            //block has changed, if old block exists, decrement use
             if (layoutBlock != null) {
                 layoutBlock.decrementUse();
             }
@@ -545,7 +534,7 @@ public class TrackSegment extends LayoutTrack {
         }
     }
 
-    // initialization instance variables (used when loading a LayoutEditor)
+    //initialization instance variables (used when loading a LayoutEditor)
     public String tConnect1Name = "";
     public String tConnect2Name = "";
 
@@ -558,7 +547,7 @@ public class TrackSegment extends LayoutTrack {
      */
     @SuppressWarnings("deprecation")
     //NOTE: findObjectByTypeAndName is @Deprecated;
-    // we're using it here for backwards compatibility until it can be removed
+    //we're using it here for backwards compatibility until it can be removed
     @Override
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Null check performed before using return value")
     public void setObjects(LayoutEditor p) {
@@ -577,14 +566,14 @@ public class TrackSegment extends LayoutTrack {
         }
 
         //NOTE: testing "type-less" connects
-        // (read comments for findObjectByName in LayoutEditorFindItems.java)
+        //(read comments for findObjectByName in LayoutEditorFindItems.java)
         connect1 = p.getFinder().findObjectByName(tConnect1Name);
-        if (null == connect1) { // findObjectByName failed... try findObjectByTypeAndName
+        if (null == connect1) { //findObjectByName failed... try findObjectByTypeAndName
             log.warn("Unknown connect1 object prefix: '{}' of type {}.", tConnect1Name, type1);
             connect1 = p.getFinder().findObjectByTypeAndName(type1, tConnect1Name);
         }
         connect2 = p.getFinder().findObjectByName(tConnect2Name);
-        if (null == connect2) { // findObjectByName failed; try findObjectByTypeAndName
+        if (null == connect2) { //findObjectByName failed; try findObjectByTypeAndName
             log.warn("Unknown connect2 object prefix: '{}' of type {}.", tConnect2Name, type2);
             connect2 = p.getFinder().findObjectByTypeAndName(type2, tConnect2Name);
         }
@@ -634,17 +623,17 @@ public class TrackSegment extends LayoutTrack {
      */
     @Override
     protected int findHitPointType(Point2D hitPoint, boolean useRectangles, boolean requireUnconnected) {
-        int result = NONE;  // assume point not on connection
+        int result = NONE;  //assume point not on connection
 
         if (!requireUnconnected) {
             //note: optimization here: instead of creating rectangles for all the
-            // points to check below, we create a rectangle for the test point
-            // and test if the points below are in that rectangle instead.
+            //points to check below, we create a rectangle for the test point
+            //and test if the points below are in that rectangle instead.
             Rectangle2D r = layoutEditor.layoutEditorControlCircleRectAt(hitPoint);
             Point2D p, minPoint = MathUtil.zeroPoint2D;
 
             double circleRadius = LayoutEditor.SIZE * layoutEditor.getTurnoutCircleSize();
-            double distance, minDistance = POSITIVE_INFINITY;
+            double distance, minDistance = Float.POSITIVE_INFINITY;
 
             if (isCircle()) {
                 p = getCoordsCenterCircle();
@@ -655,7 +644,7 @@ public class TrackSegment extends LayoutTrack {
                     result = TRACK_CIRCLE_CENTRE;
                 }
             } else if (isBezier()) {
-                // hit testing for the control points
+                //hit testing for the control points
                 for (int index = 0; index < bezierControlPoints.size(); index++) {
                     p = bezierControlPoints.get(index);
                     distance = MathUtil.distance(p, hitPoint);
@@ -672,12 +661,12 @@ public class TrackSegment extends LayoutTrack {
             }
             if (result == NONE) {
                 if (r.contains(getCentreSeg())) {
-                    result = TRACK;
+                    result = LayoutTrack.TRACK;
                 }
             }
         }
         return result;
-    }   // findHitPointType
+    }   //findHitPointType
 
     /**
      * Get the coordinates for a specified connection type.
@@ -765,7 +754,7 @@ public class TrackSegment extends LayoutTrack {
             int newValue = QuickPromptUtil.promptForInteger(layoutEditor,
                     Bundle.getMessage(titleKey),
                     Bundle.getMessage(titleKey),
-                    // getting again, maybe something changed from the menu construction ?
+                    //getting again, maybe something changed from the menu construction ?
                     val.get(), predicate);
             set.accept(newValue);
             layoutEditor.repaint();
@@ -807,16 +796,16 @@ public class TrackSegment extends LayoutTrack {
         }
         jmi.setEnabled(false);
 
-        // if there are any track connections
+        //if there are any track connections
         if ((connect1 != null) || (connect2 != null)) {
-            JMenu connectionsMenu = new JMenu(Bundle.getMessage("Connections")); // there is no pane opening (which is what ... implies)
+            JMenu connectionsMenu = new JMenu(Bundle.getMessage("Connections")); //there is no pane opening (which is what ... implies)
             if (connect1 != null) {
                 connectionsMenu.add(new AbstractAction(Bundle.getMessage("MakeLabel", "1") + connect1.getName()) {
                     @Override
                     public void actionPerformed(ActionEvent e) {
                         LayoutEditorFindItems lf = layoutEditor.getFinder();
                         LayoutTrack lt = lf.findObjectByName(connect1.getName());
-                        // this shouldn't ever be null... however...
+                        //this shouldn't ever be null... however...
                         if (lt != null) {
                             layoutEditor.setSelectionRect(lt.getBounds());
                             lt.showPopup();
@@ -830,7 +819,7 @@ public class TrackSegment extends LayoutTrack {
                     public void actionPerformed(ActionEvent e) {
                         LayoutEditorFindItems lf = layoutEditor.getFinder();
                         LayoutTrack lt = lf.findObjectByName(connect2.getName());
-                        // this shouldn't ever be null... however...
+                        //this shouldn't ever be null... however...
                         if (lt != null) {
                             layoutEditor.setSelectionRect(lt.getBounds());
                             lt.showPopup();
@@ -874,7 +863,7 @@ public class TrackSegment extends LayoutTrack {
         }
 
         //
-        // decorations menu
+        //decorations menu
         //
         JMenu decorationsMenu = new JMenu(Bundle.getMessage("DecorationMenuTitle"));
         decorationsMenu.setToolTipText(Bundle.getMessage("DecorationMenuToolTip"));
@@ -882,21 +871,21 @@ public class TrackSegment extends LayoutTrack {
         JCheckBoxMenuItem jcbmi;
 
         //
-        // arrows menus
+        //arrows menus
         //
-        // arrows can only be added at edge connector
+        //arrows can only be added at edge connector
         //
         boolean hasEC1 = false;
         if (type1 == POS_POINT) {
             PositionablePoint pp = (PositionablePoint) connect1;
-            if (pp.getType() == EDGE_CONNECTOR) {
+            if (pp.getType() == PositionablePoint.EDGE_CONNECTOR) {
                 hasEC1 = true;
             }
         }
         boolean hasEC2 = false;
         if (type2 == POS_POINT) {
             PositionablePoint pp = (PositionablePoint) connect2;
-            if (pp.getType() == EDGE_CONNECTOR) {
+            if (pp.getType() == PositionablePoint.EDGE_CONNECTOR) {
                 hasEC2 = true;
             }
         }
@@ -924,8 +913,8 @@ public class TrackSegment extends LayoutTrack {
             arrowsCountMenu.add(jcbmi);
             jcbmi.setToolTipText(Bundle.getMessage("DecorationStyleMenuToolTip"));
             jcbmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-                setArrowEndStart((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == EDGE_CONNECTOR));
-                setArrowEndStop((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == EDGE_CONNECTOR));
+                setArrowEndStart((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.EDGE_CONNECTOR));
+                setArrowEndStop((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.EDGE_CONNECTOR));
                 setArrowStyle(1);
             });
             jcbmi.setSelected(arrowStyle == 1);
@@ -935,8 +924,8 @@ public class TrackSegment extends LayoutTrack {
             arrowsCountMenu.add(jcbmi);
             jcbmi.setToolTipText(Bundle.getMessage("DecorationStyleMenuToolTip"));
             jcbmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-                setArrowEndStart((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == EDGE_CONNECTOR));
-                setArrowEndStop((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == EDGE_CONNECTOR));
+                setArrowEndStart((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.EDGE_CONNECTOR));
+                setArrowEndStop((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.EDGE_CONNECTOR));
                 setArrowStyle(2);
             });
             jcbmi.setSelected(arrowStyle == 2);
@@ -946,8 +935,8 @@ public class TrackSegment extends LayoutTrack {
             arrowsCountMenu.add(jcbmi);
             jcbmi.setToolTipText(Bundle.getMessage("DecorationStyleMenuToolTip"));
             jcbmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-                setArrowEndStart((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == EDGE_CONNECTOR));
-                setArrowEndStop((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == EDGE_CONNECTOR));
+                setArrowEndStart((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.EDGE_CONNECTOR));
+                setArrowEndStop((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.EDGE_CONNECTOR));
                 setArrowStyle(3);
             });
             jcbmi.setSelected(arrowStyle == 3);
@@ -957,8 +946,8 @@ public class TrackSegment extends LayoutTrack {
             arrowsCountMenu.add(jcbmi);
             jcbmi.setToolTipText(Bundle.getMessage("DecorationStyleMenuToolTip"));
             jcbmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-                setArrowEndStart((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == EDGE_CONNECTOR));
-                setArrowEndStop((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == EDGE_CONNECTOR));
+                setArrowEndStart((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.EDGE_CONNECTOR));
+                setArrowEndStop((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.EDGE_CONNECTOR));
                 setArrowStyle(4);
             });
             jcbmi.setSelected(arrowStyle == 4);
@@ -968,8 +957,8 @@ public class TrackSegment extends LayoutTrack {
             arrowsCountMenu.add(jcbmi);
             jcbmi.setToolTipText(Bundle.getMessage("DecorationStyleMenuToolTip"));
             jcbmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-                setArrowEndStart((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == EDGE_CONNECTOR));
-                setArrowEndStop((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == EDGE_CONNECTOR));
+                setArrowEndStart((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.EDGE_CONNECTOR));
+                setArrowEndStop((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.EDGE_CONNECTOR));
                 setArrowStyle(5);
             });
             jcbmi.setSelected(arrowStyle == 5);
@@ -1105,7 +1094,7 @@ public class TrackSegment extends LayoutTrack {
         }
 
         //
-        // bridge menus
+        //bridge menus
         //
         JMenu bridgeMenu = new JMenu(Bundle.getMessage("BridgeMenuTitle"));
         decorationsMenu.setToolTipText(Bundle.getMessage("BridgeMenuToolTip"));
@@ -1218,21 +1207,21 @@ public class TrackSegment extends LayoutTrack {
                 QuickPromptUtil.checkIntRange(1, MAX_BRIDGE_DECK_WIDTH, null));
 
         //
-        // end bumper menus
+        //end bumper menus
         //
-        // end bumper decorations can only be on end bumpers
+        //end bumper decorations can only be on end bumpers
         //
         boolean hasEB1 = false;
         if (type1 == POS_POINT) {
             PositionablePoint pp = (PositionablePoint) connect1;
-            if (pp.getType() == END_BUMPER) {
+            if (pp.getType() == PositionablePoint.END_BUMPER) {
                 hasEB1 = true;
             }
         }
         boolean hasEB2 = false;
         if (type2 == POS_POINT) {
             PositionablePoint pp = (PositionablePoint) connect2;
-            if (pp.getType() == END_BUMPER) {
+            if (pp.getType() == PositionablePoint.END_BUMPER) {
                 hasEB2 = true;
             }
         }
@@ -1287,10 +1276,10 @@ public class TrackSegment extends LayoutTrack {
 
                 endBumperMenu.add(enableCheckBoxMenuItem);
                 enableCheckBoxMenuItem.addActionListener((java.awt.event.ActionEvent e3) -> {
-                    if ((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == END_BUMPER)) {
+                    if ((type1 == POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.END_BUMPER)) {
                         setBumperEndStart(enableCheckBoxMenuItem.isSelected());
                     }
-                    if ((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == END_BUMPER)) {
+                    if ((type2 == POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.END_BUMPER)) {
                         setBumperEndStop(enableCheckBoxMenuItem.isSelected());
                     }
                 });
@@ -1353,7 +1342,7 @@ public class TrackSegment extends LayoutTrack {
         }
 
         //
-        // tunnel menus
+        //tunnel menus
         //
         JMenu tunnelMenu = new JMenu(Bundle.getMessage("TunnelMenuTitle"));
         decorationsMenu.setToolTipText(Bundle.getMessage("TunnelMenuToolTip"));
@@ -1552,7 +1541,7 @@ public class TrackSegment extends LayoutTrack {
         }
         popupMenu.show(mouseEvent.getComponent(), mouseEvent.getX(), mouseEvent.getY());
         return popupMenu;
-    }   // showPopup
+    }   //showPopup
 
     /**
      * {@inheritDoc}
@@ -1570,7 +1559,7 @@ public class TrackSegment extends LayoutTrack {
         itemList.addAll(getPointReferences(type2, conn2));
 
         if (!itemList.isEmpty()) {
-            displayRemoveWarningDialog(itemList, "TrackSegment");  // NOI18N
+            displayRemoveWarningDialog(itemList, "TrackSegment");  //NOI18N
         }
         return itemList.isEmpty();
     }
@@ -1598,56 +1587,56 @@ public class TrackSegment extends LayoutTrack {
             if (!pt.getWestBoundSensorName().isEmpty()) {
                 result.add(pt.getWestBoundSensorName());
             }
-            if (pt.getType() == EDGE_CONNECTOR && pt.getLinkedPoint() != null) {
-                result.add(Bundle.getMessage("DeleteECisActive"));   // NOI18N
+            if (pt.getType() == PositionablePoint.EDGE_CONNECTOR && pt.getLinkedPoint() != null) {
+                result.add(Bundle.getMessage("DeleteECisActive"));   //NOI18N
             }
         }
 
         if ((type == TURNOUT_A || type == TURNOUT_B || type == TURNOUT_C || type == TURNOUT_D) && conn instanceof LayoutTurnout) {
             LayoutTurnout lt = (LayoutTurnout) conn;
             if (type == TURNOUT_A) {
-                result = lt.getBeanReferences("A");  // NOI18N
+                result = lt.getBeanReferences("A");  //NOI18N
             }
             if (type == TURNOUT_B) {
-                result = lt.getBeanReferences("B");  // NOI18N
+                result = lt.getBeanReferences("B");  //NOI18N
             }
             if (type == TURNOUT_C) {
-                result = lt.getBeanReferences("C");  // NOI18N
+                result = lt.getBeanReferences("C");  //NOI18N
             }
             if (type == TURNOUT_D) {
-                result = lt.getBeanReferences("D");  // NOI18N
+                result = lt.getBeanReferences("D");  //NOI18N
             }
         }
 
         if ((type == LEVEL_XING_A || type == LEVEL_XING_B || type == LEVEL_XING_C || type == LEVEL_XING_D) && conn instanceof LevelXing) {
             LevelXing lx = (LevelXing) conn;
             if (type == LEVEL_XING_A) {
-                result = lx.getBeanReferences("A");  // NOI18N
+                result = lx.getBeanReferences("A");  //NOI18N
             }
             if (type == LEVEL_XING_B) {
-                result = lx.getBeanReferences("B");  // NOI18N
+                result = lx.getBeanReferences("B");  //NOI18N
             }
             if (type == LEVEL_XING_C) {
-                result = lx.getBeanReferences("C");  // NOI18N
+                result = lx.getBeanReferences("C");  //NOI18N
             }
             if (type == LEVEL_XING_D) {
-                result = lx.getBeanReferences("D");  // NOI18N
+                result = lx.getBeanReferences("D");  //NOI18N
             }
         }
 
         if ((type == SLIP_A || type == SLIP_B || type == SLIP_C || type == SLIP_D) && conn instanceof LayoutSlip) {
             LayoutSlip ls = (LayoutSlip) conn;
             if (type == SLIP_A) {
-                result = ls.getBeanReferences("A");  // NOI18N
+                result = ls.getBeanReferences("A");  //NOI18N
             }
             if (type == SLIP_B) {
-                result = ls.getBeanReferences("B");  // NOI18N
+                result = ls.getBeanReferences("B");  //NOI18N
             }
             if (type == SLIP_C) {
-                result = ls.getBeanReferences("C");  // NOI18N
+                result = ls.getBeanReferences("C");  //NOI18N
             }
             if (type == SLIP_D) {
-                result = ls.getBeanReferences("D");  // NOI18N
+                result = ls.getBeanReferences("D");  //NOI18N
             }
         }
 
@@ -1658,11 +1647,11 @@ public class TrackSegment extends LayoutTrack {
      * split track segment into two track segments with an anchor between
      */
     public void splitTrackSegment() {
-        // create a new anchor
+        //create a new anchor
         Point2D p = getCentreSeg();
         PositionablePoint newAnchor = layoutEditor.addAnchor(p);
-        // link it to me
-        layoutEditor.setLink(newAnchor, POS_POINT, this, TRACK);
+        //link it to me
+        layoutEditor.setLink(newAnchor, POS_POINT, this, LayoutTrack.TRACK);
 
         //get unique name for a new track segment
         String name = layoutEditor.getFinder().uniqueName("T", 1);
@@ -1672,30 +1661,51 @@ public class TrackSegment extends LayoutTrack {
                 newAnchor, POS_POINT,
                 connect2, type2,
                 isDashed(), isMainline(), layoutEditor);
-        // add it to known tracks
+        //add it to known tracks
         layoutEditor.getLayoutTracks().add(newTrackSegment);
         layoutEditor.setDirty();
 
-        // copy attributes to new track segment
+        //copy attributes to new track segment
         newTrackSegment.setLayoutBlock(this.getLayoutBlock());
         newTrackSegment.setArc(this.isArc());
         newTrackSegment.setCircle(this.isCircle());
+        //split any angle between the two new track segments
+        newTrackSegment.setAngle(this.getAngle() / 2.0);
+        this.setAngle(this.getAngle() / 2.0);
         //newTrackSegment.setBezier(this.isBezier());
         newTrackSegment.setFlip(this.isFlip());
-        newTrackSegment.setDecorations(this.getDecorations());
 
-        // link my connect2 to the new track segment
+        //copy over decorations
+        Map<String, String> d = new HashMap<>();
+        this.getDecorations().forEach((k, v) -> {
+            if (k.equals("arrow")) {                //if this is an arrow
+                if (this.isArrowEndStop()) {        //and it's on the stop end
+                    d.put(k, v);                    //copy it to new track
+                    this.setArrowEndStop(false);    //and remove it from this track
+                }
+            } else if (k.equals("bumper")) {        //if this is an end bumper
+                if (this.isBumperEndStop()) {       //amd it's on the stop end
+                    d.put(k, v);                    //copy it to new track
+                    this.setBumperEndStop(false);   //and remove it from this track
+                }
+            } else {                                //otherwise...
+                d.put(k, v);                        //copy to new track
+            }
+        });
+        newTrackSegment.setDecorations(d);
+
+        //link my connect2 to the new track segment
         if (connect2 instanceof PositionablePoint) {
             PositionablePoint pp = (PositionablePoint) connect2;
             pp.replaceTrackConnection(this, newTrackSegment);
         } else {
-            layoutEditor.setLink(connect2, type2, newTrackSegment, TRACK);
+            layoutEditor.setLink(connect2, type2, newTrackSegment, LayoutTrack.TRACK);
         }
 
-        // link the new anchor to the new track segment
-        layoutEditor.setLink(newAnchor, POS_POINT, newTrackSegment, TRACK);
+        //link the new anchor to the new track segment
+        layoutEditor.setLink(newAnchor, POS_POINT, newTrackSegment, LayoutTrack.TRACK);
 
-        // link me to the new newAnchor
+        //link me to the new newAnchor
         connect2 = newAnchor;
         type2 = POS_POINT;
 
@@ -1709,7 +1719,7 @@ public class TrackSegment extends LayoutTrack {
         }
         layoutEditor.setDirty();
         layoutEditor.redrawPanel();
-    }   // splitTrackSegment
+    }   //splitTrackSegment
 
     /**
      * Display popup menu for information and editing.
@@ -1793,48 +1803,48 @@ public class TrackSegment extends LayoutTrack {
 
     void changeType(int choice) {
         switch (choice) {
-            case 0: // plain track segment (line)
+            case 0: //plain track segment (line)
                 setArc(false);
                 setAngle(0.0D);
                 setCircle(false);
                 setBezier(false);
                 break;
-            case 1: // circle
+            case 1: //circle
                 setArc(true);
                 setAngle(90.0D);
                 setCircle(true);
                 setBezier(false);
                 break;
-            case 2: // arc
+            case 2: //arc
                 setArc(true);
                 setAngle(90.0D);
                 setCircle(false);
                 setBezier(false);
                 break;
             case 3:
-                setArc(false);  // bezier
+                setArc(false);  //bezier
                 setCircle(false);
                 if (bezierControlPoints.size() == 0) {
                     //TODO: Use MathUtil.intersect to find intersection of adjacent tracks
                     //TODO: and place the control points halfway between that and the two endpoints
 
-                    // set default control point displacements
+                    //set default control point displacements
                     Point2D ep1 = LayoutEditor.getCoords(getConnect1(), getType1());
                     Point2D ep2 = LayoutEditor.getCoords(getConnect2(), getType2());
 
-                    // compute orthogonal offset0 with length one third the distance from ep1 to ep2
+                    //compute orthogonal offset0 with length one third the distance from ep1 to ep2
                     Point2D offset = MathUtil.subtract(ep2, ep1);
                     offset = MathUtil.normalize(offset, MathUtil.length(offset) / 3.0);
                     offset = MathUtil.orthogonal(offset);
 
-                    // add orthogonal offset0 to 1/3rd and 2/3rd points
+                    //add orthogonal offset0 to 1/3rd and 2/3rd points
                     Point2D pt1 = MathUtil.add(MathUtil.oneThirdPoint(ep1, ep2), offset);
                     Point2D pt2 = MathUtil.subtract(MathUtil.twoThirdsPoint(ep1, ep2), offset);
 
                     bezierControlPoints.add(pt1);
                     bezierControlPoints.add(pt2);
                 }
-                setBezier(true);    // do this last (it calls reCenter())
+                setBezier(true);    //do this last (it calls reCenter())
                 break;
             default:
                 break;
@@ -1861,7 +1871,7 @@ public class TrackSegment extends LayoutTrack {
      * Remove this object from display and persistance.
      */
     public void remove() {
-        // remove from persistance by flagging inactive
+        //remove from persistance by flagging inactive
         active = false;
     }
 
@@ -1983,7 +1993,7 @@ public class TrackSegment extends LayoutTrack {
         this.startAdj = startAdj;
     }
 
-    // this is the center of the track segment (it is "on" the track segment)
+    //this is the center of the track segment (it is "on" the track segment)
     public double getCentreSegX() {
         return getCentreSeg().getX();
     }
@@ -2007,7 +2017,7 @@ public class TrackSegment extends LayoutTrack {
         Point2D result = MathUtil.zeroPoint2D;
 
         if ((connect1 != null) && (connect2 != null)) {
-            // get the end points
+            //get the end points
             Point2D ep1 = LayoutEditor.getCoords(getConnect1(), getType1());
             Point2D ep2 = LayoutEditor.getCoords(getConnect2(), getType2());
 
@@ -2021,7 +2031,7 @@ public class TrackSegment extends LayoutTrack {
                     ep2 = t;
                 }
                 Point2D delta = MathUtil.subtract(ep1, ep2);
-                // are they of the same sign?
+                //are they of the same sign?
                 if ((delta.getX() >= 0.0) != (delta.getY() >= 0.0)) {
                     delta = MathUtil.divide(delta, +5.0, -5.0);
                 } else {
@@ -2029,8 +2039,8 @@ public class TrackSegment extends LayoutTrack {
                 }
                 result = MathUtil.add(center, delta);
             } else if (isBezier()) {
-                // compute result Bezier point for (t == 0.5);
-                // copy all the control points (including end points) into an array
+                //compute result Bezier point for (t == 0.5);
+                //copy all the control points (including end points) into an array
                 int len = bezierControlPoints.size() + 2;
                 Point2D[] points = new Point2D[len];
                 points[0] = ep1;
@@ -2039,7 +2049,7 @@ public class TrackSegment extends LayoutTrack {
                 }
                 points[len - 1] = ep2;
 
-                // calculate midpoints of all points (len - 1 order times)
+                //calculate midpoints of all points (len - 1 order times)
                 for (int idx = len - 1; idx > 0; idx--) {
                     for (int jdx = 0; jdx < idx; jdx++) {
                         points[jdx] = MathUtil.midPoint(points[jdx], points[jdx + 1]);
@@ -2058,7 +2068,7 @@ public class TrackSegment extends LayoutTrack {
         center = p;
     }
 
-    // this is the center of the track segment when configured as a circle
+    //this is the center of the track segment when configured as a circle
     private double centreX;
 
     public double getCentreX() {
@@ -2149,7 +2159,7 @@ public class TrackSegment extends LayoutTrack {
             double a;
             double o;
             double la;
-            // Compute arc's chord
+            //Compute arc's chord
             a = pt2x - x;
             o = pt2y - y;
             la = Math.hypot(a, o);
@@ -2190,45 +2200,45 @@ public class TrackSegment extends LayoutTrack {
             } else {
                 setTmpAngle(getAngle());
             }
-            // Convert angle to radiants in order to speed up math
+            //Convert angle to radiants in order to speed up math
             double halfAngleRAD = Math.toRadians(getTmpAngle()) / 2.D;
 
-            // Compute arc's chord
+            //Compute arc's chord
             double a = pt2x - pt1x;
             double o = pt2y - pt1y;
             double chord = Math.hypot(a, o);
             setChordLength(chord);
 
-            // Make sure chord is not null
-            // In such a case (ep1 == ep2), there is no arc to draw
+            //Make sure chord is not null
+            //In such a case (ep1 == ep2), there is no arc to draw
             if (chord > 0.D) {
                 double radius = (chord / 2.D) / Math.sin(halfAngleRAD);
-                // Circle
+                //Circle
                 double startRad = Math.atan2(a, o) - halfAngleRAD;
                 setStartAdj(Math.toDegrees(startRad));
                 if (isCircle()) {
-                    // Circle - Compute center
+                    //Circle - Compute center
                     setCentreX(pt2x - Math.cos(startRad) * radius);
                     setCentreY(pt2y + Math.sin(startRad) * radius);
 
-                    // Circle - Compute rectangle required by Arc2D.Double
+                    //Circle - Compute rectangle required by Arc2D.Double
                     setCW(radius * 2.0D);
                     setCH(radius * 2.0D);
                     setCX(getCentreX() - radius);
                     setCY(getCentreY() - radius);
 
-                    // Compute where to locate the control circle on the circle segment
+                    //Compute where to locate the control circle on the circle segment
                     Point2D offset = new Point2D.Double(
                             +radius * Math.cos(startRad + halfAngleRAD),
                             -radius * Math.sin(startRad + halfAngleRAD));
                     setCentreSeg(MathUtil.add(getCentre(), offset));
                 } else {
-                    // Ellipse - Round start angle to the closest multiple of 90
+                    //Ellipse - Round start angle to the closest multiple of 90
                     setStartAdj(Math.round(getStartAdj() / 90.0D) * 90.0D);
-                    // Ellipse - Compute rectangle required by Arc2D.Double
+                    //Ellipse - Compute rectangle required by Arc2D.Double
                     setCW(Math.abs(a) * 2.0D);
                     setCH(Math.abs(o) * 2.0D);
-                    // Ellipse - Adjust rectangle corner, depending on quadrant
+                    //Ellipse - Adjust rectangle corner, depending on quadrant
                     if (o * a < 0.0D) {
                         a = -a;
                     } else {
@@ -2239,24 +2249,27 @@ public class TrackSegment extends LayoutTrack {
                 }
             }
         }
-    }   // calculateTrackSegmentAngle
+    }   //calculateTrackSegmentAngle
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected void draw1(Graphics2D g2, boolean isMain, boolean isBlock) {
-//        if (getName().equals("T5")) {
-//            log.debug("STOP");
-//        }
-        if (!isBlock && isDashed() && getLayoutBlock() != null) {
-            // Skip the dashed rail layer, the block layer will display the dashed track
-            // This removes random rail fragments from between the block dashes
+    protected void draw1(Graphics2D g2, boolean isMain, boolean isBlock, boolean isMark) {
+//   if (getName().equals("T15")) {
+//       log.debug("STOP");
+//   }
+        if (!isBlock && !isMark && isDashed() && getLayoutBlock() != null) {
+            //Skip the dashed rail layer, the block layer will display the dashed track
+            //This removes random rail fragments from between the block dashes
             return;
         }
-        if (isMain == mainline) {
+        if ((isMain == mainline) && (!isMark || marked)) {
             if (isBlock) {
                 setColorForTrackBlock(g2, getLayoutBlock());
+                if (isMark) {
+                    g2.setColor(ColorUtil.contrast(g2.getColor()));
+                }
             }
             if (isArc()) {
                 calculateTrackSegmentAngle();
@@ -2279,12 +2292,12 @@ public class TrackSegment extends LayoutTrack {
      */
     @Override
     protected void draw2(Graphics2D g2, boolean isMain, float railDisplacement) {
-//        if (getName().equals("T5")) {
-//            log.debug("STOP");
-//        }
+//   if (getName().equals("T5")) {
+//       log.debug("STOP");
+//   }
         if (isDashed() && getLayoutBlock() != null) {
-            // Skip the dashed rail layer, the block layer will display the dashed track
-            // This removes random rail fragments from between the block dashes
+            //Skip the dashed rail layer, the block layer will display the dashed track
+            //This removes random rail fragments from between the block dashes
             return;
         }
         if (isMain == mainline) {
@@ -2330,8 +2343,8 @@ public class TrackSegment extends LayoutTrack {
      */
     @Override
     protected void highlightUnconnected(Graphics2D g2, int selectedType) {
-        // TrackSegments are always connected
-        // nothing to see here... move along...
+        //TrackSegments are always connected
+        //nothing to see here... move along...
     }
 
     @Override
@@ -2341,12 +2354,12 @@ public class TrackSegment extends LayoutTrack {
             Point2D ep1 = LayoutEditor.getCoords(getConnect1(), getType1());
             Point2D ep2 = LayoutEditor.getCoords(getConnect2(), getType2());
             if (isCircle()) {
-                // draw radiuses
+                //draw radiuses
                 Point2D circleCenterPoint = getCoordsCenterCircle();
                 g2.draw(new Line2D.Double(circleCenterPoint, ep1));
                 g2.draw(new Line2D.Double(circleCenterPoint, ep2));
-                // Draw a circle and square at the circles centre, that
-                // allows the user to change the angle by dragging the mouse.
+                //Draw a circle and square at the circles centre, that
+                //allows the user to change the angle by dragging the mouse.
                 g2.draw(trackEditControlCircleAt(circleCenterPoint));
                 g2.draw(layoutEditor.layoutEditorControlRectAt(circleCenterPoint));
             } else if (isBezier()) {
@@ -2361,12 +2374,12 @@ public class TrackSegment extends LayoutTrack {
             }
         }
         g2.draw(trackEditControlCircleAt(getCentreSeg()));
-    }   // drawEditControls
+    }   //drawEditControls
 
     @Override
     protected void drawTurnoutControls(Graphics2D g2) {
-        // TrackSegments don't have turnout controls...
-        // nothing to see here... move along...
+        //TrackSegments don't have turnout controls...
+        //nothing to see here... move along...
     }
 
     /**
@@ -2374,7 +2387,7 @@ public class TrackSegment extends LayoutTrack {
      */
     @Override
     public void reCheckBlockBoundary() {
-        // nothing to see here... move along...
+        //nothing to see here... move along...
     }
 
     /**
@@ -2382,11 +2395,11 @@ public class TrackSegment extends LayoutTrack {
      */
     @Override
     protected void drawDecorations(Graphics2D g2) {
-//        if (getName().equals("T5")) {
-//            log.debug("STOP");
-//        }
+//   if (getName().equals("T5")) {
+//       log.debug("STOP");
+//   }
 
-        // get end points and calculate start/stop angles (in radians)
+        //get end points and calculate start/stop angles (in radians)
         Point2D ep1 = LayoutEditor.getCoords(getConnect1(), getType1());
         Point2D ep2 = LayoutEditor.getCoords(getConnect2(), getType2());
         Point2D p1, p2, p3, p4, p5, p6, p7;
@@ -2416,14 +2429,14 @@ public class TrackSegment extends LayoutTrack {
         }
 
         //
-        // arrow decorations
+        //arrow decorations
         //
         if (arrowStyle > 0) {
             g2.setStroke(new BasicStroke(arrowLineWidth,
                     BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1.F));
             g2.setColor(arrowColor);
 
-            // draw the start arrows
+            //draw the start arrows
             int offset = 1;
             if (arrowEndStart) {
                 if (arrowDirIn) {
@@ -2434,7 +2447,7 @@ public class TrackSegment extends LayoutTrack {
                 }
             }
 
-            // draw the stop arrows
+            //draw the stop arrows
             offset = 1;
             if (arrowEndStop) {
                 if (arrowDirIn) {
@@ -2444,10 +2457,10 @@ public class TrackSegment extends LayoutTrack {
                     offset = drawArrow(g2, ep2, stopAngleRAD, true, offset);
                 }
             }
-        }   // arrow decoration
+        }   //arrow decoration
 
         //
-        //  bridge decorations
+        //bridge decorations
         //
         if (bridgeSideLeft || bridgeSideRight) {
             float halfWidth = bridgeDeckWidth / 2.F;
@@ -2497,7 +2510,7 @@ public class TrackSegment extends LayoutTrack {
                     Point2D ep2L = MathUtil.subtract(ep2, vector);
                     g2.draw(new Line2D.Double(ep1L, ep2L));
                 }
-            }   // if isArc() {} else if isBezier() {} else...
+            }   //if isArc() {} else if isBezier() {} else...
 
             if (isFlip()) {
                 boolean temp = bridgeSideRight;
@@ -2538,7 +2551,7 @@ public class TrackSegment extends LayoutTrack {
                 }
             }
 
-            // if necessary flip these back
+            //if necessary flip these back
             if (isFlip()) {
                 boolean temp = bridgeSideRight;
                 bridgeSideRight = bridgeSideLeft;
@@ -2547,7 +2560,7 @@ public class TrackSegment extends LayoutTrack {
         }
 
         //
-        //  end bumper decorations
+        //end bumper decorations
         //
         if (bumperEndStart || bumperEndStop) {
             g2.setStroke(new BasicStroke(bumperLineWidth,
@@ -2562,26 +2575,26 @@ public class TrackSegment extends LayoutTrack {
                 stopAngleRAD = temp;
             }
 
-            // common points
+            //common points
             p1 = new Point2D.Double(0.F, -halfLength);
             p2 = new Point2D.Double(0.F, +halfLength);
 
             if (bumperEndStart) {
                 p1P = MathUtil.add(MathUtil.rotateRAD(p1, startAngleRAD), ep1);
                 p2P = MathUtil.add(MathUtil.rotateRAD(p2, startAngleRAD), ep1);
-                // draw cross tie
+                //draw cross tie
                 g2.draw(new Line2D.Double(p1P, p2P));
             }
             if (bumperEndStop) {
                 p1P = MathUtil.add(MathUtil.rotateRAD(p1, stopAngleRAD), ep2);
                 p2P = MathUtil.add(MathUtil.rotateRAD(p2, stopAngleRAD), ep2);
-                // draw cross tie
+                //draw cross tie
                 g2.draw(new Line2D.Double(p1P, p2P));
             }
-        }   // if (bumperEndStart || bumperEndStop)
+        }   //if (bumperEndStart || bumperEndStop)
 
         //
-        //  tunnel decorations
+        //tunnel decorations
         //
         if (tunnelSideRight || tunnelSideLeft) {
             float halfWidth = tunnelFloorWidth / 2.F;
@@ -2631,13 +2644,13 @@ public class TrackSegment extends LayoutTrack {
                     Point2D ep2R = MathUtil.subtract(ep2, vector);
                     g2.draw(new Line2D.Double(ep1R, ep2R));
                 }
-            }   // if isArc() {} else if isBezier() {} else...
+            }   //if isArc() {} else if isBezier() {} else...
 
             g2.setStroke(new BasicStroke(tunnelLineWidth,
                     BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 1.F));
             g2.setColor(tunnelColor);
 
-            // don't let tunnelEntranceWidth be less than tunnelFloorWidth + 6
+            //don't let tunnelEntranceWidth be less than tunnelFloorWidth + 6
             tunnelEntranceWidth = Math.max(tunnelEntranceWidth, tunnelFloorWidth + 6);
 
             double halfEntranceWidth = tunnelEntranceWidth / 2.0;
@@ -2759,14 +2772,14 @@ public class TrackSegment extends LayoutTrack {
                 }
             }
 
-            // if necessary, put these back
+            //if necessary, put these back
             if (isFlip()) {
                 boolean temp = tunnelSideRight;
                 tunnelSideRight = tunnelSideLeft;
                 tunnelSideLeft = temp;
             }
         }
-    }   // drawDecorations
+    }   //drawDecorations
 
     /*
      * getBezierPoints
@@ -2934,7 +2947,7 @@ public class TrackSegment extends LayoutTrack {
             }
         }
         return offset;
-    }   // drawArrow
+    }   //drawArrow
 
     /*======================*\
     |* decoration accessors *|
@@ -2959,16 +2972,16 @@ public class TrackSegment extends LayoutTrack {
         } //if (decorathions != null)
 
         //
-        // arrow decorations
+        //arrow decorations
         //
         if (arrowStyle > 0) {
-            // <decoration name="arrow" value="double;both;linewidth=1;length=12;gap=1" />
+            //<decoration name="arrow" value="double;both;linewidth=1;length=12;gap=1" />
             List<String> arrowValues = new ArrayList<String>();
 
             arrowValues.add("style=" + arrowStyle);
 
             if (arrowEndStart && arrowEndStop) {
-                // default behaviour is both
+                //default behaviour is both
             } else if (arrowEndStop) {
                 arrowValues.add("stop");
             } else {
@@ -2990,13 +3003,13 @@ public class TrackSegment extends LayoutTrack {
             arrowValues.add("length=" + arrowLength);
             arrowValues.add("gap=" + arrowGap);
             decorations.put("arrow", String.join(";", arrowValues));
-        }   // if (arrowCount > 0)
+        }   //if (arrowCount > 0)
 
         //
-        //  bridge decorations
+        //bridge decorations
         //
         if (bridgeSideLeft || bridgeSideRight) {
-            // <decoration name="bridge" value="both;linewidth=2;deckwidth=8" />
+            //<decoration name="bridge" value="both;linewidth=2;deckwidth=8" />
             List<String> bridgeValues = new ArrayList<String>();
 
             if (bridgeHasEntry && !bridgeHasExit) {
@@ -3017,13 +3030,13 @@ public class TrackSegment extends LayoutTrack {
             bridgeValues.add("deckwidth=" + bridgeDeckWidth);
 
             decorations.put("bridge", String.join(";", bridgeValues));
-        }   // if (bridgeSideLeft || bridgeSideRight)
+        }   //if (bridgeSideLeft || bridgeSideRight)
 
         //
-        //  end bumper decorations
+        //end bumper decorations
         //
         if (bumperEndStart || bumperEndStop) {
-            // <decoration name="bumper" value="double;linewidth=2;length=6;gap=2;flipped" />
+            //<decoration name="bumper" value="double;linewidth=2;length=6;gap=2;flipped" />
             List<String> bumperValues = new ArrayList<String>();
             if (bumperEndStart) {
                 bumperValues.add("start");
@@ -3039,13 +3052,13 @@ public class TrackSegment extends LayoutTrack {
             bumperValues.add("linewidth=" + bumperLineWidth);
 
             decorations.put("bumper", String.join(";", bumperValues));
-        }   // if (bumperCount > 0)
+        }   //if (bumperCount > 0)
 
         //
-        //  tunnel decorations
+        //tunnel decorations
         //
         if (tunnelSideLeft || tunnelSideRight) {
-            // <decoration name="tunnel" value="both;linewidth=2;floorwidth=8" />
+            //<decoration name="tunnel" value="both;linewidth=2;floorwidth=8" />
             List<String> tunnelValues = new ArrayList<String>();
 
             if (tunnelHasEntry && !tunnelHasExit) {
@@ -3067,9 +3080,9 @@ public class TrackSegment extends LayoutTrack {
             tunnelValues.add("floorwidth=" + tunnelFloorWidth);
 
             decorations.put("tunnel", String.join(";", tunnelValues));
-        }   // if (tunnelSideLeft || tunnelSideRight)
+        }   //if (tunnelSideLeft || tunnelSideRight)
         return decorations;
-    } // getDecorations
+    } //getDecorations
 
     /**
      * Set decorations.
@@ -3085,11 +3098,11 @@ public class TrackSegment extends LayoutTrack {
                 log.debug("Key = {}, Value = {}", entry.getKey(), entry.getValue());
                 String key = entry.getKey();
                 //
-                // arrow decorations
+                //arrow decorations
                 //
                 if (key.equals("arrow")) {
                     String arrowValue = entry.getValue();
-                    // <decoration name="arrow" value="double;both;linewidth=1;length=12;gap=1" />
+                    //<decoration name="arrow" value="double;both;linewidth=1;length=12;gap=1" />
                     boolean atStart = true, atStop = true;
                     boolean hasIn = false, hasOut = false;
                     int lineWidth = 1, length = 3, gap = 1, count = 1;
@@ -3133,9 +3146,9 @@ public class TrackSegment extends LayoutTrack {
                             log.debug("arrow value ignored: {}", value);
                         }
                     }
-                    hasIn |= !hasOut;   // if hasOut is false make hasIn true
-                    if (!atStart && !atStop) {   // if both false
-                        atStart = true; // set both true
+                    hasIn |= !hasOut;   //if hasOut is false make hasIn true
+                    if (!atStart && !atStop) {   //if both false
+                        atStart = true; //set both true
                         atStop = true;
                     }
                     setArrowEndStart(atStart);
@@ -3146,16 +3159,16 @@ public class TrackSegment extends LayoutTrack {
                     setArrowLineWidth(lineWidth);
                     setArrowLength(length);
                     setArrowGap(gap);
-                    // set count last so it will fix ends and dir (if necessary)
+                    //set count last so it will fix ends and dir (if necessary)
                     setArrowStyle(count);
-                } // if (key.equals("arrow")) {
+                } //if (key.equals("arrow")) {
                 //
-                //  bridge decorations
+                //bridge decorations
                 //
                 else if (key.equals("bridge")) {
                     String bridgeValue = entry.getValue();
-                    // <decoration name="bridge" value="both;linewidth=2;deckwidth=8" />
-                    // right/left default true; in/out default false
+                    //<decoration name="bridge" value="both;linewidth=2;deckwidth=8" />
+                    //right/left default true; in/out default false
                     boolean hasLeft = true, hasRight = true, hasEntry = false, hasExit = false;
                     int approachWidth = 4, lineWidth = 1, deckWidth = 2;
                     Color color = defaultTrackColor;
@@ -3190,7 +3203,7 @@ public class TrackSegment extends LayoutTrack {
                             log.debug("bridge value ignored: {}", value);
                         }
                     }
-                    // these both can't be false
+                    //these both can't be false
                     if (!hasLeft && !hasRight) {
                         hasLeft = true;
                         hasRight = true;
@@ -3203,16 +3216,16 @@ public class TrackSegment extends LayoutTrack {
                     setBridgeDeckWidth(deckWidth);
                     setBridgeLineWidth(lineWidth);
                     setBridgeApproachWidth(approachWidth);
-                } // if (key.equals("bridge")) {
+                } //if (key.equals("bridge")) {
                 //
-                //  bumper decorations
+                //bumper decorations
                 //
                 else if (key.equals("bumper")) {
                     String bumperValue = entry.getValue();
-//                    if (getName().equals("T15")) {
-//                        log.debug("STOP");
-//                    }
-                    // <decoration name="bumper" value="double;linewidth=2;length=6;gap=2;flipped" />
+//               if (getName().equals("T15")) {
+//                   log.debug("STOP");
+//               }
+                    //<decoration name="bumper" value="double;linewidth=2;length=6;gap=2;flipped" />
                     int lineWidth = 1, length = 4;
                     boolean isFlipped = false, atStart = true, atStop = true;
                     Color color = defaultTrackColor;
@@ -3225,7 +3238,7 @@ public class TrackSegment extends LayoutTrack {
                         } else if (value.equals("stop")) {
                             atStart = false;
                         } else if (value.equals("both")) {
-                            // this is the default behaviour; parameter ignored
+                            //this is the default behaviour; parameter ignored
                         } else if (value.equals("flip")) {
                             isFlipped = true;
                         } else if (value.startsWith("color=")) {
@@ -3241,21 +3254,21 @@ public class TrackSegment extends LayoutTrack {
                             log.debug("bumper value ignored: " + value);
                         }
                     }
-                    atStop |= !atStart;   // if atStart is false make atStop true
+                    atStop |= !atStart;   //if atStart is false make atStop true
                     setBumperEndStart(atStart);
                     setBumperEndStop(atStop);
                     setBumperColor(color);
                     setBumperLineWidth(lineWidth);
                     setBumperLength(length);
                     setBumperFlipped(isFlipped);
-                } // if (key.equals("bumper")) {
+                } //if (key.equals("bumper")) {
                 //
-                //  tunnel decorations
+                //tunnel decorations
                 //
                 else if (key.equals("tunnel")) {
                     String tunnelValue = entry.getValue();
-                    // <decoration name="tunnel" value="both;linewidth=2;floorwidth=8" />
-                    // right/left default true; in/out default false
+                    //<decoration name="tunnel" value="both;linewidth=2;floorwidth=8" />
+                    //right/left default true; in/out default false
                     boolean hasLeft = true, hasRight = true, hasIn = false, hasOut = false;
                     int entranceWidth = 4, lineWidth = 1, floorWidth = 2;
                     Color color = defaultTrackColor;
@@ -3290,7 +3303,7 @@ public class TrackSegment extends LayoutTrack {
                             log.debug("tunnel value ignored: " + value);
                         }
                     }
-                    // these both can't be false
+                    //these both can't be false
                     if (!hasLeft && !hasRight) {
                         hasLeft = true;
                         hasRight = true;
@@ -3303,16 +3316,16 @@ public class TrackSegment extends LayoutTrack {
                     setTunnelEntranceWidth(entranceWidth);
                     setTunnelLineWidth(lineWidth);
                     setTunnelFloorWidth(floorWidth);
-                } // if (tunnelValue != null)
+                } //if (tunnelValue != null)
                 else {
                     log.debug("Unknown decoration key: " + key + ", value: " + entry.getValue());
                 }
-            }   // for (Map.Entry<String, String> entry : decorations.entrySet())
+            }   //for (Map.Entry<String, String> entry : decorations.entrySet())
         } //if (decorathions != null)
-    }   // setDirections
+    }   //setDirections
 
     //
-    //  arrow decoration accessors
+    //arrow decoration accessors
     //
     public int getArrowStyle() {
         return arrowStyle;
@@ -3329,7 +3342,7 @@ public class TrackSegment extends LayoutTrack {
                     arrowDirOut = true;
                 }
             } else {
-                newVal = 0; // only positive styles allowed!
+                newVal = 0; //only positive styles allowed!
             }
             arrowStyle = newVal;
             layoutEditor.redrawPanel();
@@ -3464,7 +3477,7 @@ public class TrackSegment extends LayoutTrack {
     private int arrowGap = 1;
 
     //
-    //  bridge decoration accessors
+    //bridge decoration accessors
     //
     public boolean isBridgeSideRight() {
         return bridgeSideRight;
@@ -3538,7 +3551,7 @@ public class TrackSegment extends LayoutTrack {
 
     public void setBridgeDeckWidth(int newVal) {
         if (bridgeDeckWidth != newVal) {
-            bridgeDeckWidth = Math.max(6, newVal);   // don't let value be less than 6
+            bridgeDeckWidth = Math.max(6, newVal);   //don't let value be less than 6
             layoutEditor.redrawPanel();
             layoutEditor.setDirty();
         }
@@ -3551,7 +3564,7 @@ public class TrackSegment extends LayoutTrack {
 
     public void setBridgeLineWidth(int newVal) {
         if (bridgeLineWidth != newVal) {
-            bridgeLineWidth = Math.max(1, newVal);   // don't let value be less than 1
+            bridgeLineWidth = Math.max(1, newVal);   //don't let value be less than 1
             layoutEditor.redrawPanel();
             layoutEditor.setDirty();
         }
@@ -3564,7 +3577,7 @@ public class TrackSegment extends LayoutTrack {
 
     public void setBridgeApproachWidth(int newVal) {
         if (bridgeApproachWidth != newVal) {
-            bridgeApproachWidth = Math.max(8, newVal);   // don't let value be less than 8
+            bridgeApproachWidth = Math.max(8, newVal);   //don't let value be less than 8
             layoutEditor.redrawPanel();
             layoutEditor.setDirty();
         }
@@ -3572,7 +3585,7 @@ public class TrackSegment extends LayoutTrack {
     private int bridgeApproachWidth = 4;
 
     //
-    //  bumper decoration accessors
+    //bumper decoration accessors
     //
     public boolean isBumperEndStart() {
         return bumperEndStart;
@@ -3625,31 +3638,8 @@ public class TrackSegment extends LayoutTrack {
             layoutEditor.setDirty();
         }
     }
-    private int bumperLineWidth = 2;
 
-    private void setupDefaultBumperSizes(LayoutEditor layoutEditor) {
-        LayoutTrackDrawingOptions ltdo = layoutEditor.getLayoutTrackDrawingOptions();
-
-        // use these as default sizes for end bumpers
-        int tieLength = ltdo.getSideTieLength();
-        int tieWidth = ltdo.getSideTieWidth();
-        int railWidth = ltdo.getSideRailWidth();
-        int railGap = ltdo.getSideRailGap();
-        if (mainline) {
-            tieLength = ltdo.getMainTieLength();
-            tieWidth = ltdo.getMainTieWidth();
-            railWidth = ltdo.getMainRailWidth();
-            railGap = ltdo.getMainRailGap();
-        }
-        bumperLineWidth = railWidth;
-        bumperLength = (5 * (railGap + railWidth)) / 2;
-        if ((tieLength > 0) && (tieWidth > 0)) {
-            bumperLineWidth = tieWidth;
-            bumperLength = tieLength * 3 / 2;
-        }
-        bumperLineWidth = Math.min(1, bumperLineWidth);
-        bumperLength = Math.min(10, bumperLength);
-    }
+    private int bumperLineWidth = 3;
 
     public int getBumperLength() {
         return bumperLength;
@@ -3657,12 +3647,12 @@ public class TrackSegment extends LayoutTrack {
 
     public void setBumperLength(int newVal) {
         if (bumperLength != newVal) {
-            bumperLength = Math.max(8, newVal);   // don't let value be less than 8
+            bumperLength = Math.max(8, newVal);   //don't let value be less than 8
             layoutEditor.redrawPanel();
             layoutEditor.setDirty();
         }
     }
-    private int bumperLength = 10;
+    private int bumperLength = 20;
 
     public boolean isBumperFlipped() {
         return bumperFlipped;
@@ -3677,8 +3667,32 @@ public class TrackSegment extends LayoutTrack {
     }
     private boolean bumperFlipped = false;
 
+    private void setupDefaultBumperSizes(LayoutEditor layoutEditor) {
+        LayoutTrackDrawingOptions ltdo = layoutEditor.getLayoutTrackDrawingOptions();
+
+        //use these as default sizes for end bumpers
+        int tieLength = ltdo.getSideTieLength();
+        int tieWidth = ltdo.getSideTieWidth();
+        int railWidth = ltdo.getSideRailWidth();
+        int railGap = ltdo.getSideRailGap();
+        if (mainline) {
+            tieLength = ltdo.getMainTieLength();
+            tieWidth = ltdo.getMainTieWidth();
+            railWidth = ltdo.getMainRailWidth();
+            railGap = ltdo.getMainRailGap();
+        }
+        bumperLineWidth = Math.max(railWidth, ltdo.getMainBlockLineWidth()) * 2;
+        bumperLength = railGap + (2 * railWidth);
+        if ((tieLength > 0) && (tieWidth > 0)) {
+            bumperLineWidth = tieWidth;
+            bumperLength = tieLength * 3 / 2;
+        }
+        bumperLineWidth = Math.max(1, bumperLineWidth);
+        bumperLength = Math.max(10, bumperLength);
+    }
+
     //
-    //  tunnel decoration accessors
+    //tunnel decoration accessors
     //
     public boolean isTunnelSideRight() {
         return tunnelSideRight;
@@ -3752,7 +3766,7 @@ public class TrackSegment extends LayoutTrack {
 
     public void setTunnelFloorWidth(int newVal) {
         if (tunnelFloorWidth != newVal) {
-            tunnelFloorWidth = Math.max(4, newVal);   // don't let value be less than 4
+            tunnelFloorWidth = Math.max(4, newVal);   //don't let value be less than 4
             layoutEditor.redrawPanel();
             layoutEditor.setDirty();
         }
@@ -3765,7 +3779,7 @@ public class TrackSegment extends LayoutTrack {
 
     public void setTunnelLineWidth(int newVal) {
         if (tunnelLineWidth != newVal) {
-            tunnelLineWidth = Math.max(1, newVal);   // don't let value be less than 1
+            tunnelLineWidth = Math.max(1, newVal);   //don't let value be less than 1
             layoutEditor.redrawPanel();
             layoutEditor.setDirty();
         }
@@ -3778,7 +3792,7 @@ public class TrackSegment extends LayoutTrack {
 
     public void setTunnelEntranceWidth(int newVal) {
         if (tunnelEntranceWidth != newVal) {
-            tunnelEntranceWidth = Math.max(1, newVal);   // don't let value be less than 1
+            tunnelEntranceWidth = Math.max(1, newVal);   //don't let value be less than 1
             layoutEditor.redrawPanel();
             layoutEditor.setDirty();
         }
@@ -3794,17 +3808,17 @@ public class TrackSegment extends LayoutTrack {
 
         LayoutConnectivity lc = null;
         LayoutBlock lb1 = getLayoutBlock(), lb2 = null;
-        // ensure that block is assigned
+        //ensure that block is assigned
         if (lb1 != null) {
-            // check first connection for turnout or level crossing
+            //check first connection for turnout or level crossing
             if ((type1 >= TURNOUT_A) && (type1 <= LEVEL_XING_D)) {
-                // have connection to turnout or level crossing
+                //have connection to turnout or level crossing
                 if (type1 <= TURNOUT_D) {
-                    // have connection to a turnout, is block different
+                    //have connection to a turnout, is block different
                     LayoutTurnout lt = (LayoutTurnout) getConnect1();
                     lb2 = lt.getLayoutBlock();
                     if (lt.getTurnoutType() > LayoutTurnout.WYE_TURNOUT) {
-                        // not RH, LH, or WYE turnout - other blocks possible
+                        //not RH, LH, or WYE turnout - other blocks possible
                         if ((type1 == TURNOUT_B) && (lt.getLayoutBlockB() != null)) {
                             lb2 = lt.getLayoutBlockB();
                         }
@@ -3816,7 +3830,7 @@ public class TrackSegment extends LayoutTrack {
                         }
                     }
                     if ((lb2 != null) && (lb1 != lb2)) {
-                        // have a block boundary, create a LayoutConnectivity
+                        //have a block boundary, create a LayoutConnectivity
                         log.debug("Block boundary  ('{}'<->'{}') found at {}", lb1, lb2, this);
                         lc = new LayoutConnectivity(lb1, lb2);
                         lc.setConnections(this, lt, type1, null);
@@ -3826,7 +3840,7 @@ public class TrackSegment extends LayoutTrack {
                         results.add(lc);
                     }
                 } else {
-                    // have connection to a level crossing
+                    //have connection to a level crossing
                     LevelXing lx = (LevelXing) getConnect1();
                     if ((type1 == LEVEL_XING_A) || (type1 == LEVEL_XING_C)) {
                         lb2 = lx.getLayoutBlockAC();
@@ -3834,7 +3848,7 @@ public class TrackSegment extends LayoutTrack {
                         lb2 = lx.getLayoutBlockBD();
                     }
                     if ((lb2 != null) && (lb1 != lb2)) {
-                        // have a block boundary, create a LayoutConnectivity
+                        //have a block boundary, create a LayoutConnectivity
                         log.debug("Block boundary  ('{}'<->'{}') found at {}", lb1, lb2, this);
                         lc = new LayoutConnectivity(lb1, lb2);
                         lc.setConnections(this, lx, type1, null);
@@ -3845,11 +3859,11 @@ public class TrackSegment extends LayoutTrack {
                     }
                 }
             } else if ((type1 >= SLIP_A) && (type1 <= SLIP_D)) {
-                // have connection to a slip crossing
+                //have connection to a slip crossing
                 LayoutSlip ls = (LayoutSlip) getConnect1();
                 lb2 = ls.getLayoutBlock();
                 if ((lb2 != null) && (lb1 != lb2)) {
-                    // have a block boundary, create a LayoutConnectivity
+                    //have a block boundary, create a LayoutConnectivity
                     log.debug("Block boundary  ('{}'<->'{}') found at {}", lb1, lb2, this);
                     lc = new LayoutConnectivity(lb1, lb2);
                     lc.setConnections(this, ls, type1, null);
@@ -3858,15 +3872,15 @@ public class TrackSegment extends LayoutTrack {
                     results.add(lc);
                 }
             }
-            // check second connection for turnout or level crossing
+            //check second connection for turnout or level crossing
             if ((type2 >= TURNOUT_A) && (type2 <= LEVEL_XING_D)) {
-                // have connection to turnout or level crossing
+                //have connection to turnout or level crossing
                 if (type2 <= TURNOUT_D) {
-                    // have connection to a turnout
+                    //have connection to a turnout
                     LayoutTurnout lt = (LayoutTurnout) getConnect2();
                     lb2 = lt.getLayoutBlock();
                     if (lt.getTurnoutType() > LayoutTurnout.WYE_TURNOUT) {
-                        // not RH, LH, or WYE turnout - other blocks possible
+                        //not RH, LH, or WYE turnout - other blocks possible
                         if ((type2 == TURNOUT_B) && (lt.getLayoutBlockB() != null)) {
                             lb2 = lt.getLayoutBlockB();
                         }
@@ -3878,7 +3892,7 @@ public class TrackSegment extends LayoutTrack {
                         }
                     }
                     if ((lb2 != null) && (lb1 != lb2)) {
-                        // have a block boundary, create a LayoutConnectivity
+                        //have a block boundary, create a LayoutConnectivity
                         log.debug("Block boundary  ('{}'<->'{}') found at {}", lb1, lb2, this);
                         lc = new LayoutConnectivity(lb1, lb2);
                         lc.setConnections(this, lt, type2, null);
@@ -3888,7 +3902,7 @@ public class TrackSegment extends LayoutTrack {
                         results.add(lc);
                     }
                 } else {
-                    // have connection to a level crossing
+                    //have connection to a level crossing
                     LevelXing lx = (LevelXing) getConnect2();
                     if ((type2 == LEVEL_XING_A) || (type2 == LEVEL_XING_C)) {
                         lb2 = lx.getLayoutBlockAC();
@@ -3896,7 +3910,7 @@ public class TrackSegment extends LayoutTrack {
                         lb2 = lx.getLayoutBlockBD();
                     }
                     if ((lb2 != null) && (lb1 != lb2)) {
-                        // have a block boundary, create a LayoutConnectivity
+                        //have a block boundary, create a LayoutConnectivity
                         log.debug("Block boundary  ('{}'<->'{}') found at {}", lb1, lb2, this);
                         lc = new LayoutConnectivity(lb1, lb2);
                         lc.setConnections(this, lx, type2, null);
@@ -3907,11 +3921,11 @@ public class TrackSegment extends LayoutTrack {
                     }
                 }
             } else if ((type2 >= SLIP_A) && (type2 <= SLIP_D)) {
-                // have connection to a slip crossing
+                //have connection to a slip crossing
                 LayoutSlip ls = (LayoutSlip) getConnect2();
                 lb2 = ls.getLayoutBlock();
                 if ((lb2 != null) && (lb1 != lb2)) {
-                    // have a block boundary, create a LayoutConnectivity
+                    //have a block boundary, create a LayoutConnectivity
                     log.debug("Block boundary  ('{}'<->'{}') found at {}", lb1, lb2, this);
                     lc = new LayoutConnectivity(lb1, lb2);
                     lc.setConnections(this, ls, type2, null);
@@ -3921,12 +3935,12 @@ public class TrackSegment extends LayoutTrack {
                     results.add(lc);
                 }
             } else {
-                // this is routinely reached in normal operations
-                // (nothing to see here... move along)
+                //this is routinely reached in normal operations
+                //(nothing to see here... move along)
             }
-        }   // if (lb1 != null)
+        }   //if (lb1 != null)
         return results;
-    }   // getLayoutConnectivity()
+    }   //getLayoutConnectivity()
 
     /**
      * {@inheritDoc}
@@ -3934,8 +3948,8 @@ public class TrackSegment extends LayoutTrack {
     @Override
     public List<Integer> checkForFreeConnections() {
         List<Integer> result = new ArrayList<>();
-        // Track Segments always have all their connections so...
-        // (nothing to see here... move along)
+        //Track Segments always have all their connections so...
+        //(nothing to see here... move along)
         return result;
     }
 
@@ -3966,18 +3980,18 @@ public class TrackSegment extends LayoutTrack {
          *     (in blockNamesToTrackNameSetMap)
          */
         List<Set<String>> TrackNameSets = null;
-        Set<String> TrackNameSet = null;    // assume not found (pessimist!)
+        Set<String> TrackNameSet = null;    //assume not found (pessimist!)
         String blockName = getBlockName();
         if (!blockName.isEmpty()) {
             TrackNameSets = blockNamesToTrackNameSetsMap.get(blockName);
-            if (TrackNameSets != null) { // (#1)
+            if (TrackNameSets != null) { //(#1)
                 for (Set<String> checkTrackNameSet : TrackNameSets) {
-                    if (checkTrackNameSet.contains(getName())) { // (#2)
+                    if (checkTrackNameSet.contains(getName())) { //(#2)
                         TrackNameSet = checkTrackNameSet;
                         break;
                     }
                 }
-            } else {    // (#3)
+            } else {    //(#3)
                 log.debug("*New block ('{}') trackNameSets", blockName);
                 TrackNameSets = new ArrayList<>();
                 blockNamesToTrackNameSetsMap.put(blockName, TrackNameSets);
@@ -3989,11 +4003,11 @@ public class TrackSegment extends LayoutTrack {
             if (TrackNameSet.add(getName())) {
                 log.debug("*    Add track '{}' to TrackNameSets for block '{}'", getName(), blockName);
             }
-            // (#4)
+            //(#4)
             if (connect1 != null) {
                 connect1.collectContiguousTracksNamesInBlockNamed(blockName, TrackNameSet);
             }
-            if (connect2 != null) { // (#4)
+            if (connect2 != null) { //(#4)
                 connect2.collectContiguousTracksNamesInBlockNamed(blockName, TrackNameSet);
             }
         }
@@ -4006,14 +4020,14 @@ public class TrackSegment extends LayoutTrack {
     public void collectContiguousTracksNamesInBlockNamed(@Nonnull String blockName,
             @Nonnull Set<String> TrackNameSet) {
         if (!TrackNameSet.contains(getName())) {
-            // is this the blockName we're looking for?
+            //is this the blockName we're looking for?
             if (getBlockName().equals(blockName)) {
-                // if we are added to the TrackNameSet
+                //if we are added to the TrackNameSet
                 if (TrackNameSet.add(getName())) {
                     log.debug("*    Add track '{}'for block '{}'", getName(), blockName);
                 }
-                // these should never be null... but just in case...
-                // it's time to play... flood your neighbours!
+                //these should never be null... but just in case...
+                //it's time to play... flood your neighbours!
                 if (connect1 != null) {
                     connect1.collectContiguousTracksNamesInBlockNamed(blockName, TrackNameSet);
                 }

--- a/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentTest.java
@@ -419,7 +419,7 @@ public class TrackSegmentTest {
     public void testDefaultGetSetBumperLineWidth() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         if ((layoutEditor != null) && (trackSegment != null)) {
-            Assert.assertEquals("trackSegment.getBumperLineWidth() == 1 (default).", 1, trackSegment.getBumperLineWidth());
+            Assert.assertEquals("trackSegment.getBumperLineWidth() == 8 (default).", 8, trackSegment.getBumperLineWidth());
             trackSegment.setBumperLineWidth(-1);
             Assert.assertNotEquals("trackSegment.setBumperLineWidth(-1) not allowed.", -1, trackSegment.getBumperLineWidth());
             trackSegment.setBumperLineWidth(5);


### PR DESCRIPTION
When splitting a track segment decorations were being blindly copied to the new track segment… this resulted in arrow and end bumper decoration between the two split segments. This bugfix prevents that.