### PR TITLE
./runtest selects PackageTest

### DIFF
--- a/java/test/jmri/util/junit/TestClassMainMethod.java
+++ b/java/test/jmri/util/junit/TestClassMainMethod.java
@@ -43,8 +43,14 @@ public class TestClassMainMethod {
                 run(cl);
             }
         } catch (ClassNotFoundException e) {
-            // log error
-            System.err.println("Unable to locate class " + className);
+            // try for a PackageTest
+            try {
+                run(Class.forName(className+".PackageTest"));
+            } catch (ClassNotFoundException ex) {
+                System.err.println("Did not find class "+className);
+            } catch (Exception ex) {
+                System.err.println(ex);
+            }
         }
     }
 


### PR DESCRIPTION
When running tests individually from the command line with ./runtest.sh, if you give just the name of a package, it will try to find and run the PackageTest in that package.  This saves a bit of typing time when e.g. cutting and pasting from an error message.