### PR TITLE
Update Digitrax Command Station Defs.

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnCommandStationType.java
+++ b/java/src/jmri/jmrix/loconet/LnCommandStationType.java
@@ -35,56 +35,56 @@ public enum LnCommandStationType {
     //  enum value(name, canRead, progEndOp, ThrottleManager, SlotManager, supportsIdle, supportsMultimeter
     COMMAND_STATION_DCS100("DCS100 (Chief)",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_TURNEDOFF_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.SUPPORTS_OPC_IDLE,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_DCS240("DCS240 (Advanced Command Station)",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.SUPPORTS_OPC_IDLE,
             MultiMeterSupport.SUPPORTS_MULTIMETER_FUNCTION,
             LocoResetSupport.SUPPORTS_LOCO_RESET_FUNCTION),
     COMMAND_STATION_DCS210("DCS210 (Evolution Command Station)",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_TURNEDOFF_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.SUPPORTS_OPC_IDLE,
             MultiMeterSupport.SUPPORTS_MULTIMETER_FUNCTION,
             LocoResetSupport.SUPPORTS_LOCO_RESET_FUNCTION),
     COMMAND_STATION_DCS200("DCS200",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_TURNEDOFF_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.SUPPORTS_OPC_IDLE,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_DCS050("DCS50 (Zephyr)",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_DCS051("DCS51 (Zephyr Xtra)",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_DCS052("DCS52 (Zephyr Express)", // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
-            MultiMeterSupport.NO_MULTIMETER_SUPPORT,
+            MultiMeterSupport.SUPPORTS_MULTIMETER_FUNCTION,
             LocoResetSupport.SUPPORTS_LOCO_RESET_FUNCTION),
     COMMAND_STATION_DB150("DB150 (Empire Builder)", // NOI18N
             ReadsFromServiceModeTrack.NO_SVC_MODE_READS,
-            ProgDepowersTrack.TRACK_ALIVE_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.SUPPORTS_OPC_IDLE,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
@@ -93,28 +93,28 @@ public enum LnCommandStationType {
     // the following command stations are assumed to not support "OPC_IDLE"
     COMMAND_STATION_LBPS("LocoBuffer (PS)",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_TURNEDOFF_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_MM("Mix-Master",  // NOI18N
             ReadsFromServiceModeTrack.NO_SVC_MODE_READS,
-            ProgDepowersTrack.TRACK_ALIVE_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_IBX_TYPE_1("Intellibox-I",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_ALIVE_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "Ib1ThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_IBX_TYPE_2("Intellibox-II",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_ALIVE_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "Ib2ThrottleManager", "UhlenbrockSlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
@@ -123,45 +123,45 @@ public enum LnCommandStationType {
     // the following command stations are known to not support "OPC_IDLE"
     COMMAND_STATION_PR3_ALONE("PR3 standalone programmer",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_PR2_ALONE("PR2 standalone programmer",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_TURNEDOFF_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_STANDALONE("Stand-alone LocoNet",  // NOI18N
             ReadsFromServiceModeTrack.NO_SVC_MODE_READS,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_TURNEDOFF_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_PR4_ALONE("PR4 standalone programmer",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
             MultiMeterSupport.NO_MULTIMETER_SUPPORT,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_USB_DCS240_ALONE("DCS240 USB interface as standalone programmer", // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",  // NOI18N
             IdleSupport.NO_OPC_IDLE_SUPPORT,
-            MultiMeterSupport.NO_MULTIMETER_SUPPORT,
+            MultiMeterSupport.SUPPORTS_MULTIMETER_FUNCTION,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT),
     COMMAND_STATION_USB_DCS52_ALONE("DCS52 USB interface as standalone programmer",  // NOI18N
             ReadsFromServiceModeTrack.CAN_READ_ON_SVC_TRACK,
-            ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING,
+            ProgDepowersTrack.TRACK_UNCHANGED_BY_PROGRAMMING,
             "LnThrottleManager", "SlotManager",
             IdleSupport.NO_OPC_IDLE_SUPPORT, // NOI18N
-            MultiMeterSupport.NO_MULTIMETER_SUPPORT,
+            MultiMeterSupport.SUPPORTS_MULTIMETER_FUNCTION,
             LocoResetSupport.NO_LOCO_RESET_SUPPORT);
 
     // Note that the convention is that the first word (space-separated token) of the name is the
@@ -212,7 +212,7 @@ public enum LnCommandStationType {
      * @return whether the programming operation turns track power off
      */
     public boolean getProgPowersOff() {
-        return progEndOp == ProgDepowersTrack.TRACK_OFF_WHEN_PROGRAMMING;
+        return progEndOp == ProgDepowersTrack.TRACK_TURNEDOFF_BY_PROGRAMMING;
     }
 
     static public LnCommandStationType getByName(String name) {
@@ -325,7 +325,7 @@ public enum LnCommandStationType {
     }
 
     protected enum ProgDepowersTrack {
-        TRACK_OFF_WHEN_PROGRAMMING, TRACK_ALIVE_WHEN_PROGRAMMING
+        TRACK_TURNEDOFF_BY_PROGRAMMING, TRACK_UNCHANGED_BY_PROGRAMMING
     }
 
     protected enum IdleSupport {


### PR DESCRIPTION
Correct whether power is removed by programming or not.
Correct which stations have multimeter support.

I have only updated the CS/Connections that I have access to.

Update enums to more accurate names.
Update DCS240, DCS50, DCS51, DCS52 characteristics..