### PR TITLE
Do not run ArchitectureTest as a unit test under maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,8 @@
                         <exclude>**.PackageTest</exclude>
                         <!-- ignore since the test is not intended to be normally used -->
                         <exclude>jmri.util.FailTest</exclude>
+			<!-- exclude the archunit tests from automatic execution -->
+                        <exclude>jmri.ArchitectureTest</exclude>
                         <!-- ignore since base classes for other tests -->
                         <exclude>jmri.util.SwingTestCase</exclude>
                         <exclude>jmri.jmrit.operations.OperationsTestCase</exclude>
@@ -700,6 +702,8 @@
                                 <File>jmri/jmris/srcp/parser/SRCPParserTreeConstants.class</File>
                                 <File>jmri/jmrit/audio/AudioSource.class</File>
                                 <File>jmri/jmrix/srcp/parser/SRCPClientParserTreeConstants.class</File>
+                                <!-- exclude the archunit check -->
+				<File>jmri.ArchitectureCheck.class</File>
                                 <!-- deprecated classes -->
                                 <File>jmri/jmrix/loconet/AbstractAlmImplementation.class</File>
                                 <!-- Exclude files meant to check SpotBugs. -->

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -31,6 +31,8 @@ if [[ "${HEADLESS}" == "true" ]] ; then
         mvn javadoc:javadoc -U --batch-mode
         # check html
         mvn exec:exec -P travis-scanhelp
+        #run Architecture tests
+        mvn -Dtest=jmri.ArchitectureTest test
     else
         # run headless tests
         mvn test integration-test failsafe:verify -U -P travis-headless --batch-mode \


### PR DESCRIPTION
ArchitectureTest has been repeatedly erroring due to running out of memory when run on Jenkins as part of ‘mvn verify’. ( in the PIT job ).

This PR excluded ArchitectureTest from running as part of the standard unit tests under Maven while at the same time moving it to the Travis static tests job.