### PR TITLE
Fix Loconet Throttle Functions

### DIFF
--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -430,16 +430,18 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
         }
         int addr = -1;
         // check long address
-        if ((m.getElement(5) & 0x40) != 0) {
-            addr = (m.getElement(5) & 0x3F) * 256 + (m.getElement(6) & 0xFF);
-            if ((m.getElement(4) & 0x02) != 0) {
-                addr += 128;  // and high bit
-            }
-        } else {
+        if ((m.getElement(4) & 0x01) == 0) { //bit 7=0 short
             addr = (m.getElement(5) & 0xFF);
             if ((m.getElement(4) & 0x01) != 0) {
                 addr += 128;  // and high bit
             }
+        } else if ((m.getElement(5) & 0x40) == 0x40) { // bit 7 = 1 if bit 6 = 1 then long
+            addr = (m.getElement(5) & 0x3F) * 256 + (m.getElement(6) & 0xFF);
+            if ((m.getElement(4) & 0x02) != 0) {
+                addr += 128;  // and high bit
+            }
+        } else { // accessory decoder or extended accessory decoder
+            addr = (m.getElement(5) & 0x3F);
         }
         return addr;
     }
@@ -472,11 +474,11 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
         int start;
         int high = m.getElement(4);
         // check long or short address
-        if ((m.getElement(5) & 0x40) != 0) {
+        if ((m.getElement(4) & 0x01) == 1 && (m.getElement(5) & 0x40) == 0x40 ) {  //long address bit 7 im1 = 1 and bit6 im1 = 1
             start = 7;
             high = high >> 2;
             n = n - 2;
-        } else {
+         } else {  //short or accessory
             start = 6;
             high = high >> 1;
             n = n - 1;

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -39,6 +39,11 @@ public class SlotManagerTest {
         Assert.assertEquals("short 3 sets F9", 3,
                 slotmanager.getDirectFunctionAddress(m1));
 
+        // test  top half of short 65
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x24, 0x02, 0x42, 0x21, 0x00, 0x00, 0x23});
+        Assert.assertEquals("long 65 sets F9", 66,
+                slotmanager.getDirectFunctionAddress(m1));
+
         m1 = new LocoNetMessage(11);
         m1.setElement(0, 0xED);  // long 513 sets F9
         m1.setElement(1, 0x0B);
@@ -53,7 +58,15 @@ public class SlotManagerTest {
         m1.setElement(10, 0x35);
         Assert.assertEquals("long 513 sets F9", 513,
                 slotmanager.getDirectFunctionAddress(m1));
-    }
+        //test mid high address 4097
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x34, 0x05, 0x50, 0x01, 0x21, 0x00, 0x00, 0x27});
+        Assert.assertEquals("long 4097 sets F9", 4097,
+                slotmanager.getDirectFunctionAddress(m1));
+        // test high high address 9983
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x34, 0x07, 0x66, 0x7F, 0x21, 0x00, 0x00, 0x6D});
+        Assert.assertEquals("long 9983 sets F9", 9983,
+                slotmanager.getDirectFunctionAddress(m1));
+   }
 
     @Test
     public void testGetDirectDccPacketOK() {
@@ -74,6 +87,11 @@ public class SlotManagerTest {
         Assert.assertEquals("short 3 sets F9", 0xA1,
                 slotmanager.getDirectDccPacket(m1));
 
+        // test  top half of short 65
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x24, 0x02, 0x42, 0x21, 0x00, 0x00, 0x23});
+        Assert.assertEquals("long 65 sets F9", 0xA1,
+                slotmanager.getDirectDccPacket(m1));
+
         m1 = new LocoNetMessage(11);
         m1.setElement(0, 0xED);  // long 513 sets F9
         m1.setElement(1, 0x0B);
@@ -88,6 +106,59 @@ public class SlotManagerTest {
         m1.setElement(10, 0x35);
         Assert.assertEquals("long 513 sets F9", 0xA1,
                 slotmanager.getDirectDccPacket(m1));
+        //test mid high address 4097
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x34, 0x05, 0x50, 0x01, 0x21, 0x00, 0x00, 0x27});
+        Assert.assertEquals("long 4097 sets F9", 0xA1,
+                slotmanager.getDirectDccPacket(m1));
+        // test high high address 9983
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x34, 0x07, 0x66, 0x7F, 0x21, 0x00, 0x00, 0x6D});
+        Assert.assertEquals("long 9983 sets F9", 0xA1,
+                slotmanager.getDirectDccPacket(m1));
+    }
+
+    @Test
+    public void testGetDirectFunctionAddressOK_F21_F28() {
+        LocoNetMessage m1;
+
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x34, 0x06, 0x03, 0x5F, 0x00, 0x00, 0x00, 0x08});
+        Assert.assertEquals("short 3 sets F28", 3,
+                slotmanager.getDirectFunctionAddress(m1));
+        // test  top half of short 66
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x24, 0x02, 0x42, 0x21, 0x00, 0x00, 0x23});
+        Assert.assertEquals("long 66 sets F28", 66,
+                slotmanager.getDirectFunctionAddress(m1));
+        // address 3
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x44, 0x0D, 0x42, 0x01, 0x5F, 0x00, 0x00, 0x33});
+        Assert.assertEquals("long 513 sets F28", 513,
+                slotmanager.getDirectFunctionAddress(m1));
+        //test mid high address 4097
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x44, 0x0D, 0x50, 0x01, 0x5F, 0x00, 0x00, 0x21});
+        Assert.assertEquals("long 4097 sets F28", 4097,
+                slotmanager.getDirectFunctionAddress(m1));
+        // test high high address 9983
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x44, 0x0F, 0x66, 0x7F, 0x5F, 0x00, 0x00, 0x6B});
+        Assert.assertEquals("long 9983 sets F9", 9983,
+                slotmanager.getDirectFunctionAddress(m1));
+   }
+
+    @Test
+    public void testisExtFunctionMessage_F21_F28() {
+        LocoNetMessage m1;
+
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x34, 0x06, 0x03, 0x5F, 0x00, 0x00, 0x00, 0x08});
+        Assert.assertTrue("short 3 sets F28",slotmanager.isExtFunctionMessage(m1));
+        // test  top half of short 66
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x24, 0x02, 0x42, 0x21, 0x00, 0x00, 0x23});
+        Assert.assertTrue("short 66 sets F28",slotmanager.isExtFunctionMessage(m1));
+        // address 3
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x44, 0x0D, 0x42, 0x01, 0x5F, 0x00, 0x00, 0x33});
+        Assert.assertTrue("short 513 sets F28",slotmanager.isExtFunctionMessage(m1));
+        //test mid high address 4097
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x44, 0x0D, 0x50, 0x01, 0x5F, 0x00, 0x00, 0x21});
+        Assert.assertTrue("short 4097 sets F28",slotmanager.isExtFunctionMessage(m1));
+        // test high high address 9983
+        m1 = new LocoNetMessage(new int[] {0xED, 0x0B, 0x7F, 0x44, 0x0F, 0x66, 0x7F, 0x5F, 0x7F, 0x00, 0x14});
+        Assert.assertTrue("short 9983 sets F28",slotmanager.isExtFunctionMessage(m1));
     }
 
     @Test


### PR DESCRIPTION
#7652
Check both bits 7 and 6 in imm packet to get length and address of decoder.