### PR TITLE
Show error message when programmer cannot set desired mode

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle.properties
+++ b/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle.properties
@@ -276,3 +276,12 @@ Comment     = Comment
 CV          = CV
 Mask        = Mask
 State       = State
+
+#Error message when desired mode isn't available
+ErrorCannotSetModeTitle = Error: Cannot set desired mode
+
+ErrorCannotSetMode  =   <html>Cannot set mode {0}<br>\
+                        <br>\
+                        The programmer cannot set the desired mode. Some modes can only<br>\
+                        be used while programming on main. Some other modes requires a<br>\
+                        particular connection type, for example LocoNet.</html>

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
@@ -587,9 +587,12 @@ abstract public class PaneProgFrame extends JmriJFrame
             }
         }
 
+        StringBuilder desiredModes = new StringBuilder();
         // first try specified modes
         for (Element el1 : programming.getChildren("mode")) {
             String name = el1.getText();
+            if (desiredModes.length() > 0) desiredModes.append(", ");
+            desiredModes.append(name);
             if (log.isDebugEnabled()) {
                 log.debug(" mode {} was specified", name);
             }
@@ -619,6 +622,11 @@ abstract public class PaneProgFrame extends JmriJFrame
             mProgrammer.setMode(ProgrammingMode.REGISTERMODE);
             log.debug("Set to REGISTERMODE");
         } else {
+            JOptionPane.showMessageDialog(
+                    this,
+                    Bundle.getMessage("ErrorCannotSetMode", desiredModes.toString()),
+                    Bundle.getMessage("ErrorCannotSetModeTitle"),
+                    JOptionPane.OK_OPTION);
             log.warn("No acceptable mode found, leave as found");
         }
 


### PR DESCRIPTION
If the programmer cannot set the desired mode, for example LOCONETSV2MODE, show an error message dialog to inform the user about the problem and possible causes.