### PR TITLE
Fix JavaDoc compile error on JDK13

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/package.html
+++ b/java/src/jmri/jmrix/can/cbus/package.html
@@ -18,7 +18,7 @@
             More information on the protocols is available on the
             <a href="https://www.merg.org.uk/merg_resources/cbus.php">MERG CBUS web site</a>.
 
-        <h3>A note on terminology</h3>
+        <h2>A note on terminology</h2>
 
         CBUS refers to a 7-bit field in the standard CAN header 
         as the "ID", "Node ID", and "CAN ID", 

--- a/java/src/jmri/jmrix/can/package.html
+++ b/java/src/jmri/jmrix/can/package.html
@@ -42,7 +42,7 @@
         <!-- Put @see and @since tags down here. -->
         <!-- @see jmri.InstanceManager -->
 
-        <h3>A note on terminology</h3>
+        <h2>A note on terminology</h2>
 
         CBUS refers to a 7-bit field in the standard CAN header 
         as the "ID", "Node ID", and "CAN ID", 

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
  * methods.
  * <li>Maintains a list of existing JmriJFrames
  * </ul>
- * <h3>Window Closing</h3>
+ * <h2>Window Closing</h2>
  * Normally, a JMRI window wants to be disposed when it closes. This is what's
  * needed when each invocation of the corresponding action can create a new copy
  * of the window. To do this, you don't have to do anything in your subclass.


### PR DESCRIPTION
Seems that JDK13 JavaDoc is fussier about sequences of Header elements.

Error seen on Jenkins prior to this proposed fix:

```
  [javadoc] /var/lib/jenkins/workspace/development/versionchecks/jdk-13/java/src/jmri/util/JmriJFrame.java:58: error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>
  [javadoc]  * <h3>Window Closing</h3>
  [javadoc]    ^
  [javadoc] /var/lib/jenkins/workspace/development/versionchecks/jdk-13/java/src/jmri/jmrix/can/package.html:45: error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>
  [javadoc]         <h3>A note on terminology</h3>
  [javadoc]         ^
  [javadoc] /var/lib/jenkins/workspace/development/versionchecks/jdk-13/java/src/jmri/jmrix/can/cbus/package.html:21: error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>
  [javadoc]         <h3>A note on terminology</h3>
  [javadoc]         ^
  [javadoc] 3 errors
```