### PR TITLE
Add link in ThrottleMain Help to WiThrottle

### DIFF
--- a/help/en/html/tools/throttle/ThrottleMain.shtml
+++ b/help/en/html/tools/throttle/ThrottleMain.shtml
@@ -78,6 +78,13 @@
         <li><a href="HowToJMRIOrientedThrottle.shtml">How to build
         a Throttle oriented JMRI</a></li>
       </ul>
+                  
+      <p>And for a related topic:</p>
+
+      <ul>
+        <li>Using <a href="../../../package/jmri/jmrit/withrottle/UserInterface.shtml">WiFi Throttles with JMRI</a></li>
+        <!-- Prior href will need to be changted when referenced page is split into a help page and a package page @jerryg2003 01-29-2020 -->
+      </ul>
       <hr>
 
       <p><a href="ThrottleChapter1.shtml">Throttles Help for JMRI v


### PR DESCRIPTION
Link to alert users to JMRI providing ability to go wireless.  [Part of continuing update of Help system.]