### PR TITLE
#8021: width computation must respect localized text length.

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_cs.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_cs.properties
@@ -437,7 +437,7 @@ ButtonKeep = Zachovat
 #Delete = Vymazat
 Move = P\u0159esunout
 Rename = P\u0159ejmenovat
-Clear = Vymazat u\u017eivatelsk\u00fd n\u00e1zev
+Clear = Odstranit u\u017eivatelsk\u00fd n\u00e1zev
 CopyName = Kop\u00edrovat u\u017eivatelsk\u00fd n\u00e1zev
 
 #These are used with the renaming/move option

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_cs.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_cs.properties
@@ -437,7 +437,7 @@ ButtonKeep = Zachovat
 #Delete = Vymazat
 Move = P\u0159esunout
 Rename = P\u0159ejmenovat
-Clear = P\u0159ejmenovat u\u017eivatelsk\u00fd n\u00e1zev
+Clear = Vymazat u\u017eivatelsk\u00fd n\u00e1zev
 CopyName = Kop\u00edrovat u\u017eivatelsk\u00fd n\u00e1zev
 
 #These are used with the renaming/move option

--- a/java/src/jmri/jmrit/beantable/TransitTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TransitTableAction.java
@@ -496,11 +496,13 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
             actionColumn.setMinWidth(testButton.getPreferredSize().width);
             TableColumn directionColumn = sectionColumnModel.getColumn(SectionTableModel.SEC_DIRECTION_COLUMN);
             directionColumn.setResizable(true);
-            directionColumn.setMinWidth((int)new JLabel(rbx.getString("DirectionColName").substring(1,7)).getPreferredSize().getWidth());
+            String s = rbx.getString("DirectionColName");
+            directionColumn.setMinWidth((int)new JLabel(s.substring(1, Math.min(s.length(), 7))).getPreferredSize().getWidth());
             directionColumn.setMaxWidth((int)new JLabel(rbx.getString("DirectionColName").concat("WW")).getPreferredSize().getWidth());
             TableColumn alternateColumn = sectionColumnModel.getColumn(SectionTableModel.ALTERNATE_COLUMN);
             alternateColumn.setResizable(true);
-            alternateColumn.setMinWidth((int)new JLabel(rbx.getString("AlternateColName").substring(1,7)).getPreferredSize().getWidth());
+            s = rbx.getString("AlternateColName");
+            alternateColumn.setMinWidth((int)new JLabel(s.substring(1, Math.min(s.length(), 7))).getPreferredSize().getWidth());
             alternateColumn.setMaxWidth((int)new JLabel(rbx.getString("AlternateColName").concat("WW")).getPreferredSize().getWidth());
             JScrollPane sectionTableScrollPane = new JScrollPane(sectionTable);
             p12.add(sectionTableScrollPane, BorderLayout.CENTER);


### PR DESCRIPTION
The original code relied on the L10N strings to be a certain length.

I've added a slightly unrelated translation fix - "Clear" was translated incorrectly as equivalent of "Rename", which was misleading.