### PR TITLE
Added support for DIGI-CZ and fucik.name DIY decoders.

### DIFF
--- a/xml/decoders/Fucik_Servo4.xml
+++ b/xml/decoders/Fucik_Servo4.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2020 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" showEmptyPanes="no" >
+    <version version="1" author="Svata Dedic svatopluk.dedic@gmail.com" lastUpdated="20200201"/>
+    <decoder>
+        <!-- These decoders are registered / certified NMRA, and are/were sold by http://digi-cz.cz -->
+        <family name="fucik.name" mfg="Fucik" >
+            <model model="ServoDecoder v5.x" lowVersionID="53" highVersionID="55" numOuts="4" connector="other"/>
+        </family>
+        <programming direct="yes" paged="no" register="yes" ops="no" />
+        
+        <variables>
+            <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_vars_common.xml"/>
+            <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_vars_2_4.xml"/>
+        </variables>
+    </decoder>
+    <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_panels_basic.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_panels_2_4.xml"/>
+</decoder-config>

--- a/xml/decoders/Public_Domain_Fucik_1.xml
+++ b/xml/decoders/Public_Domain_Fucik_1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2002, 2019 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" showEmptyPanes="no" >
+    <version version="1" author="Svata Dedic svatopluk.dedic@gmail.com" lastUpdated="20200201"/>
+    <decoder>
+        <!-- These decoders are DIY and are documented at http://www.fucik.name" -->
+        <family name="fucik.name DIY" mfg="Public-domain and DIY" >
+            <model model="1 ServoDecoder v3.4" lowVersionID="34" highVersionID="34" numOuts="2" connector="other"/>
+        </family>
+        <programming direct="yes" paged="no" register="yes" ops="no" />
+        
+        <variables>
+            <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_vars_common.xml"/>
+            <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_vars_1.xml"/>
+        </variables>
+    </decoder>
+    <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_panels_basic.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_panels_1.xml"/>
+</decoder-config>

--- a/xml/decoders/Public_Domain_Fucik_2_4.xml
+++ b/xml/decoders/Public_Domain_Fucik_2_4.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2002, 2019 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" showEmptyPanes="no" >
+    <version version="1" author="Svata Dedic svatopluk.dedic@gmail.com" lastUpdated="20200201"/>
+    <decoder>
+        <!-- These decoders are DIY and are documented at http://www.fucik.name" -->
+        <family name="fucik.name DIY" mfg="Public-domain and DIY" >
+            <model model="4 ServoDecoder v3.0" lowVersionID="30" highVersionID="30" numOuts="4" connector="other"/>
+            <model model="2 ServoDecoder v3.2" lowVersionID="32" highVersionID="32" numOuts="2" connector="other"/>
+            <model model="4 ServoDecoder v3.5" lowVersionID="35" highVersionID="35" numOuts="4" connector="other"/>
+        </family>
+        <programming direct="yes" paged="no" register="yes" ops="no" />
+        
+        <variables>
+            <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_vars_common.xml"/>
+            <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_vars_2_4.xml"/>
+        </variables>
+    </decoder>
+    <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_panels_basic.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/fucik/servodecoder_panels_2_4.xml"/>
+</decoder-config>

--- a/xml/decoders/fucik/servodecoder_panels_1.xml
+++ b/xml/decoders/fucik/servodecoder_panels_1.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2020 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<pane xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+    <name>Servos</name>
+    <name xml:lang="cs">Serva</name>
+    <column>
+        <display item="Servo1_PosA"/>
+        <display item="Servo1_PosB"/>
+        <display item="Servo1_PosC"/>
+        <display item="Servo1_PosD"/>
+        <label>
+            <text>
+            </text>
+        </label>
+        <display item="Servo1_PosE"/>
+        <display item="Servo1_PosF"/>
+        <display item="Servo1_PosG"/>
+        <display item="Servo1_PosH"/>
+    </column>
+    <column>
+        <display item="Servo1_Speed">
+            <label>Speed:</label>
+            <label xml:lang="cs">Rychlost:</label>
+        </display>
+    </column>
+</pane>

--- a/xml/decoders/fucik/servodecoder_panels_2_4.xml
+++ b/xml/decoders/fucik/servodecoder_panels_2_4.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2020 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<pane xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+    <name>Servos</name>
+    <name xml:lang="cs">Serva</name>
+    <column>
+        <label>
+            <text>Servo 1</text>
+            <text xml:lang="cs">Servo 1</text>
+        </label>
+        <display item="Servo1_PosA">
+            <label>Position A:</label>
+            <label xml:lang="cs">Pozice A:</label>
+        </display>
+        <display item="Servo1_PosB">
+            <label>Position B:</label>
+            <label xml:lang="cs">Pozice B:</label>
+        </display>
+        <display item="Servo1_PosC">
+            <label>Position C:</label>
+            <label xml:lang="cs">Pozice C:</label>
+        </display>
+        <display item="Servo1_PosD">
+            <label>Position D:</label>
+            <label xml:lang="cs">Pozice D:</label>
+        </display>
+        <display item="Servo1_Speed">
+            <label>Speed:</label>
+            <label xml:lang="cs">Rychlost:</label>
+        </display>
+        <label>
+            <text> </text>
+        </label>
+        <separator/>
+        <label>
+            <text> </text>
+        </label>
+        <label>
+            <text>Servo 2</text>
+            <text xml:lang="cs">Servo 2</text>
+        </label>
+        <display item="Servo2_PosA">
+            <label>Position A:</label>
+            <label xml:lang="cs">Pozice A:</label>
+        </display>
+        <display item="Servo2_PosB">
+            <label>Position B:</label>
+            <label xml:lang="cs">Pozice B:</label>
+        </display>
+        <display item="Servo2_PosC">
+            <label>Position C:</label>
+            <label xml:lang="cs">Pozice C:</label>
+        </display>
+        <display item="Servo2_PosD">
+            <label>Position D:</label>
+            <label xml:lang="cs">Pozice D:</label>
+        </display>
+        <display item="Servo2_Speed">
+            <label>Speed:</label>
+            <label xml:lang="cs">Rychlost:</label>
+        </display>
+    </column>
+    <column>
+        <group>
+            <qualifier>
+                <variableref>Decoder Version</variableref>
+                <relation>ne</relation>
+                <value>32</value>
+            </qualifier>
+            <qualifier>
+                <variableref>Decoder Version</variableref>
+                <relation>ne</relation>
+                <value>34</value>
+            </qualifier>
+            <column>
+                <label>
+                    <text>Servo 3</text>
+                    <text xml:lang="cs">Servo 3</text>
+                </label>
+                <display item="Servo3_PosA">
+                    <label>Position A:</label>
+                    <label xml:lang="cs">Pozice A:</label>
+                </display>
+                <display item="Servo3_PosB">
+                    <label>Position B:</label>
+                    <label xml:lang="cs">Pozice B:</label>
+                </display>
+                <display item="Servo3_Speed">
+                    <label>Speed:</label>
+                    <label xml:lang="cs">Rychlost:</label>
+                </display>
+                <label>
+                    <text> </text>
+                </label>
+                <separator/>
+                <label>
+                    <text> </text>
+                </label>
+                <label>
+                    <text>Servo 4</text>
+                    <text xml:lang="cs">Servo 4</text>
+                </label>
+                <display item="Servo4_PosA">
+                    <label>Position A:</label>
+                    <label xml:lang="cs">Pozice A:</label>
+                </display>
+                <display item="Servo4_PosB">
+                    <label>Position B:</label>
+                    <label xml:lang="cs">Pozice B:</label>
+                </display>
+                <display item="Servo4_Speed">
+                    <label>Speed:</label>
+                    <label xml:lang="cs">Rychlost:</label>
+                </display>
+            </column>
+        </group>
+    </column>
+</pane>

--- a/xml/decoders/fucik/servodecoder_panels_basic.xml
+++ b/xml/decoders/fucik/servodecoder_panels_basic.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2020 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<pane xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+    <name>Basic</name>
+    <name xml:lang="cs">Základní</name>
+    <column>
+        <row>
+            <column>
+                <qualifier>
+                    <variableref>Decoder Version</variableref>
+                    <relation>ne</relation>
+                    <value>34</value>
+                </qualifier>
+                <label>
+                    <text><![CDATA[<html>
+                        The decoder occupies several DCC addresses, each for single output (servo). <br/>
+                        The group address is used to compute the first handled DCC address, using the <br/> 
+                        formula <br/><br/>
+                        &nbsp;&nbsp;&nbsp;<font color="blue">(Group-Address - 1) * Number-Outputs + 1</font> <br/><br/>
+                        Setting "2" for a 4-output decoder will handle addresses 5-8. Setting 5 for <br/>
+                        2-output decoder will handle DCC addresses 11,12.<br/>
+                        Going in the other direction, if youv want to set up a 4-servo decoder to handle specific DCC addresses,<br/>
+                        you need to align the address block, so the <b>first address</b> is a multiply of 4 (number of outputs)<br/>
+                        plus one. For 4-servo decoder, you can start at DCC addresses 5, 9, 13, ... then the<br/>
+                        Group Address should be computed as<br/><br/>
+                        &nbsp;&nbsp;&nbsp;<font color="blue">(Starting DCC Address - 1) / Number-Outputs</font> <br/><br/>
+                        If a decoder (4 servos) should handle DCC addresses 17-20, its Group Address should be set to 4.<br/>
+                    </html>]]></text>
+                    <text xml:lang="cs"><![CDATA[<html>
+                        Dekodér obsluhuje několik po sobě jdoucích DCC adres, pro každý výstup jednu.<br/>
+                        Skupinová adresa se použije k výpočtu obsluhovaných adres příslušenství pomocí vzorce:<br/><br/>
+                        &nbsp;&nbsp;&nbsp;<font color="blue">(Skupinová-adresa - 1) * Počet-výstupů + 1</font> <br/><br/>
+                        Například nastavení "2" pro dekodér se 4 servy bude obsluhovat příslušenství s DCC adresami 5-8.<br/>
+                        Nastavení "5" pro dekodér pro 2 serva obslouží DCC adresy 11 a 12.<br/>
+                        Opačně, chcete-li nastavit dekodér pro 4 serva, aby obsluhoval konkrétní DCC adresy, musíte nejprve<br/>
+                        zvolit adresy tak, aby <b>první DCC adresa</b> byla násobkem 4 plus 1. Pro 4-servový dekodér mohou <br/>
+                        tedy obsluhované adresy začínat na 5, 9, 13, ... Skupinovou adresu pak spočítáte jako<br/><br/>
+                        &nbsp;&nbsp;&nbsp;<font color="blue">(Skupinová-adresa - 1) / Počet výstupů</font> <br/><br/>
+                        Tedy má-li dekodér (4 serva) obsluhovat adresy 17-20, musí být skupinová adresa 4.
+                    </html>]]></text>
+                </label>
+                <label>
+                    <text>
+                        
+                    </text>
+                </label>
+                <separator/>
+                <label>
+                    <text>
+                        
+                    </text>
+                </label>
+            </column>
+        </row>
+        <display item="Short Address" />
+        <display item="Save positions" />
+        <display item="PulsesReached" />
+    </column>
+</pane>

--- a/xml/decoders/fucik/servodecoder_vars_1.xml
+++ b/xml/decoders/fucik/servodecoder_vars_1.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2020 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+
+    
+    <variable CV="35" item="Servo1_PosA" default="100" >
+        <decVal min="90" max="210" />
+        <label>Position A:</label>
+        <label xml:lang="cs">Pozice A:</label>
+        <tooltip>Servo 1: Position "A"</tooltip>
+        <tooltip xml:lang="cs">Pozice "A"</tooltip>
+    </variable>
+    
+    <variable CV="36" item="Servo1_PosB" default="100">
+        <decVal min="90" max="210" />
+        <label>Position B:</label>
+        <label xml:lang="cs">Pozice B:</label>
+        <tooltip>Position "B"</tooltip>
+        <tooltip xml:lang="cs">Pozice "B"</tooltip>
+    </variable>
+    
+    <variable CV="37" item="Servo1_PosC" default="100">
+        <decVal min="90" max="210" />
+        <label>Position C:</label>
+        <label xml:lang="cs">Pozice C:</label>
+        <tooltip>Position "C"</tooltip>
+        <tooltip xml:lang="cs">Pozice "C"</tooltip>
+    </variable>
+    <variable CV="38" item="Servo1_PosD" default="100">
+        <decVal min="90" max="210" />
+        <label>Position D:</label>
+        <label xml:lang="cs">Pozice D:</label>
+        <tooltip>Position "D"</tooltip>
+        <tooltip xml:lang="cs">Pozice "D"</tooltip>
+    </variable>
+    
+    <variable CV="39" item="Servo1_PosE" default="200">
+        <decVal min="90" max="210" />
+        <label>Position E:</label>
+        <label xml:lang="cs">Pozice E:</label>
+        <tooltip>Position "E"</tooltip>
+        <tooltip xml:lang="cs">Pozice "E"</tooltip>
+    </variable>
+
+    <variable CV="40" item="Servo1_PosF" default="200">
+        <decVal min="90" max="210" />
+        <label>Position F:</label>
+        <label xml:lang="cs">Pozice F:</label>
+        <tooltip>Position "F"</tooltip>
+        <tooltip xml:lang="cs">Pozice "F"</tooltip>
+    </variable>
+
+    <variable CV="41" item="Servo1_PosG" default="200">
+        <decVal min="90" max="210" />
+        <label>Position G:</label>
+        <label xml:lang="cs">Pozice G:</label>
+        <tooltip>Position "G"</tooltip>
+        <tooltip xml:lang="cs">Pozice "G"</tooltip>
+    </variable>
+    <variable CV="42" item="Servo1_PosH" default="200">
+        <decVal min="90" max="210" />
+        <label>Position H:</label>
+        <label xml:lang="cs">Pozice H:</label>
+        <tooltip>Position "H"</tooltip>
+        <tooltip xml:lang="cs">Pozice "H"</tooltip>
+    </variable>
+
+</variables>

--- a/xml/decoders/fucik/servodecoder_vars_2_4.xml
+++ b/xml/decoders/fucik/servodecoder_vars_2_4.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2020 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+
+    
+    <variable CV="35" item="Servo1_PosA" default="100" >
+        <decVal min="90" max="210" />
+        <label>Position 1-A</label>
+        <label xml:lang="cs">Pozice 1-A</label>
+        <tooltip>Servo 1: Position "A"</tooltip>
+        <tooltip xml:lang="cs">Pozice "A" pro Servo 1</tooltip>
+    </variable>
+    <variable CV="39" item="Servo1_PosB" default="200">
+        <decVal min="90" max="210" />
+        <label>Position 1-B</label>
+        <label xml:lang="cs">Pozice 1-B</label>
+        <tooltip>Servo 1: Position "B"</tooltip>
+        <tooltip xml:lang="cs">Pozice "B" pro Servo 1</tooltip>
+    </variable>
+
+    <variable CV="36" item="Servo2_PosA" default="100" >
+        <decVal min="90" max="210" />
+        <label>Position 2-A</label>
+        <label xml:lang="cs">Pozice 2-A</label>
+        <tooltip>Servo 2: Position "A"</tooltip>
+        <tooltip xml:lang="cs">Pozice "A" pro Servo 2</tooltip>
+    </variable>
+
+    <variable CV="37" item="Servo3_PosA" default="100" minOut="4">
+        <decVal min="90" max="210" />
+        <label>Position 3-A</label>
+        <label xml:lang="cs">Pozice 3-A</label>
+        <tooltip>Servo 3: Position "A"</tooltip>
+        <tooltip xml:lang="cs">Pozice "A" pro Servo 3</tooltip>
+    </variable>
+    <variable CV="38" item="Servo4_PosA" default="100" minOut="4">
+        <decVal min="90" max="210" />
+        <label>Position 4-A</label>
+        <label xml:lang="cs">Pozice 4-A</label>
+        <tooltip>Servo 4: Position "A"</tooltip>
+        <tooltip xml:lang="cs">Pozice "A" pro Servo 4</tooltip>
+    </variable>
+    
+    <variable CV="40" item="Servo2_PosB" default="200">
+        <decVal min="90" max="210" />
+        <label>Position 2-B</label>
+        <label xml:lang="cs">Pozice 2-B</label>
+        <tooltip>Servo 2: Position "B"</tooltip>
+        <tooltip xml:lang="cs">Pozice "B" pro Servo 2</tooltip>
+    </variable>
+
+    <variable CV="41" item="Servo3_PosB" default="200" minOut="4">
+        <decVal min="90" max="210" />
+        <label>Position 3-B</label>
+        <label xml:lang="cs">Pozice 3-B</label>
+        <tooltip>Servo 3: Position "B"</tooltip>
+        <tooltip xml:lang="cs">Pozice "B" pro Servo 3</tooltip>
+    </variable>
+    <variable CV="42" item="Servo4_PosB" default="200" minOut="4">
+        <decVal min="90" max="210" />
+        <label>Position 4-B</label>
+        <label xml:lang="cs">Pozice 4-B</label>
+        <tooltip>Servo 4: Position "B"</tooltip>
+        <tooltip xml:lang="cs">Pozice "B" pro Servo 4</tooltip>
+    </variable>
+
+    <variable CV="35" item="Servo1_PosC" default="100" include="2 ServoDecoder v3.2">
+        <decVal min="90" max="210" />
+        <label>Position 1-C</label>
+        <label xml:lang="cs">Pozice 1-C</label>
+        <tooltip>Servo 1: Position "C"</tooltip>
+        <tooltip xml:lang="cs">Pozice "C" pro Servo 1</tooltip>
+    </variable>
+    <variable CV="36" item="Servo2_PosC" default="100" minOut="2" include="2 ServoDecoder v3.2">
+        <decVal min="90" max="210" />
+        <label>Position 2-C</label>
+        <label xml:lang="cs">Pozice 2-C</label>
+        <tooltip>Servo 2: Position "C"</tooltip>
+        <tooltip xml:lang="cs">Pozice "C" pro Servo 2</tooltip>
+    </variable>
+
+    <variable CV="35" item="Servo1_PosD" default="100" include="2 ServoDecoder v3.2">
+        <decVal min="90" max="210" />
+        <label>Position 1-D</label>
+        <label xml:lang="cs">Pozice 1-D</label>
+        <tooltip>Servo 1: Position "D"</tooltip>
+        <tooltip xml:lang="cs">Pozice "D" pro Servo 1</tooltip>
+    </variable>
+    <variable CV="36" item="Servo2_PosD" default="100" include="2 ServoDecoder v3.2">
+        <decVal min="90" max="210" />
+        <label>Position 2-D</label>
+        <label xml:lang="cs">Pozice 2-D</label>
+        <tooltip>Servo 2: Position "D"</tooltip>
+        <tooltip xml:lang="cs">Pozice "A" pro Servo 2</tooltip>
+    </variable>
+</variables>

--- a/xml/decoders/fucik/servodecoder_vars_common.xml
+++ b/xml/decoders/fucik/servodecoder_vars_common.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2020 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+    
+    <variable CV="1" item="Short Address" default="200" exclude="1 ServoDecoder v3.4">
+        <splitVal highCV="9" upperMask="XXXXXVVV" factor="1" offset="0" />
+        <label>Group Address:</label>
+        <label xml:lang="cs">Skupinová adresa:</label>
+        <tooltip>Address for the group of turnouts. The decoder listens to serval accessory addresses.</tooltip>
+        <tooltip xml:lang="cs">Dekodér obsluhuje několik po sobě následujících DCC adres. Skupinová adresa určuje první obsluhované příslušenství.</tooltip>
+    </variable>
+
+    <variable CV="1" item="Short Address" default="200" include="1 ServoDecoder v3.4">
+        <splitVal highCV="9" upperMask="XXXXXVVV" factor="1" offset="0" />
+        <label>Address:</label>
+        <label xml:lang="cs">Adresa:</label>
+    </variable>
+
+    <variable item="Decoder Version" CV="7" readOnly="yes" default="30" include="4 ServoDecoder v3.0,4 ServoDecoder v3.5,ServoDecoder v5.x">
+        <decVal/>
+        <label>Decoder Version:</label>
+        <label xml:lang="cs">Verze software:</label>
+    </variable>
+
+    <variable item="Decoder Version" CV="7" readOnly="yes" default="32" include="2 ServoDecoder v3.2">
+        <decVal/>
+        <label>Decoder Version:</label>
+        <label xml:lang="cs">Verze software:</label>
+    </variable>
+
+    <variable item="Decoder Version" CV="7" readOnly="yes" default="34" include="1 ServoDecoder v3.4">
+        <decVal/>
+        <label>Decoder Version:</label>
+        <label xml:lang="cs">Verze software:</label>
+    </variable>
+
+    <variable CV="8" item="Manufacturer" readOnly="yes" default="158" >
+        <decVal/>
+        <label>Manufacturer:</label>
+        <label xml:lang="cs">Výrobce ID:</label>
+    </variable>
+
+    <variable CV="29" mask="VXXXXXXX" item="Save positions" default="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>Save positions</label>
+        <label xml:lang="cs">Ukládat pozice:</label>  
+        <tooltip>Save servo positions, move servos to stored positions on power up</tooltip>
+        <tooltip xml:lang="cs">Ukládat pozice serva, přesunout na uložené pozice po zapnutí.</tooltip>
+    </variable>
+
+    <variable CV="3" item="Servo1_Speed" default="1" >
+        <decVal min="0" max="255" />
+        <label>Servo 1 Speed:</label>
+        <label xml:lang="cs">Rychlost Serva 1:</label>
+        <tooltip>Servo 1 Speed</tooltip>
+        <tooltip xml:lang="cs">Rychlost serva 1</tooltip>
+    </variable>
+    <variable CV="4" item="Servo2_Speed" default="1" minOut="2">
+        <decVal min="0" max="255" />
+        <label>Servo 2 Speed:</label>
+        <label xml:lang="cs">Rychlost Serva 2:</label>
+        <tooltip>Servo 2 Speed</tooltip>
+        <tooltip xml:lang="cs">Rychlost serva 2</tooltip>
+    </variable>
+    <variable CV="5" item="Servo3_Speed" default="1" minOut="4">
+        <decVal min="0" max="255" />
+        <label>Servo 3 Speed:</label>
+        <label xml:lang="cs">Rychlost Serva 3:</label>
+        <tooltip>Servo 3 Speed</tooltip>
+        <tooltip xml:lang="cs">Rychlost serva 3</tooltip>
+    </variable>
+    <variable CV="6" item="Servo4_Speed" default="1" minOut="4">
+        <decVal min="0" max="255" />
+        <label>Servo 4 Speed:</label>
+        <label xml:lang="cs">Rychlost Serva 4:</label>
+        <tooltip>Servo 4 Speed</tooltip>
+        <tooltip xml:lang="cs">Rychlost serva 4</tooltip>
+    </variable>
+    <variable CV="43" item="PulsesReached" default="4">
+        <decVal min="4" max="10"/>
+        <label>Final Pulses</label>
+        <label xml:lang="cs">Pulzy po nastavení</label>
+        <tooltip>Number of control pulses sent after the target position is reached</tooltip>
+        <tooltip xml:lang="cs">Počet řídících pulzů, které se pošlou po dosažení cílové pozice</tooltip>
+    </variable>
+    
+</variables>


### PR DESCRIPTION
Rudimentary support for locally (Czech Republic) produced and DIY servo decoders, described as DIY at http://www.fucik.name/masinky/servo/ or sold as completed electronics by http://www.digi-cz.cz/
