### PR TITLE
Update CI-Status page for new Jenkins

### DIFF
--- a/help/en/html/doc/Technical/CI-status.shtml
+++ b/help/en/html/doc/Technical/CI-status.shtml
@@ -23,40 +23,37 @@
 		
 		<table>
 		<tr><td align="right">
-		<a href="https://builds.jmri.org/jenkins/job/Development/">Development</a>:</td><td>
-		<a href='https://builds.jmri.org/jenkins/job/Development/job/AllTest/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Falltest'></a>
-		<a href='https://builds.jmri.org/jenkins/job/Development/job/Builds/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fbuilds' title="Builds"></a>
-		<a href='https://builds.jmri.org/jenkins/job/Development/job/Cucumber/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fcucumber' title="Cucumber"></a>
-		<a href='https://builds.jmri.org/jenkins/job/Development/job/Deprecations/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fdeprecations' title="Deprecations"></a>
-        <a href='https://builds.jmri.org/jenkins/job/Development/job/html-scan/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fhtml-scan' title="HTML scan"></a>
-		<a href='https://jmri.tagadab.com/jenkins/job/Development/job/ignored-test-scan/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fignored-test-scan' title="Ignored Test Scan"></a>
+		<a href="https://builds.jmri.org/jenkins/job/development/">Development</a>:</td><td>
+		<a href='https://builds.jmri.org/jenkins/job/development/job/alltest/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Falltest' title="AllTest"></a>
+		<a href='https://builds.jmri.org/jenkins/job/development/job/builds/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fbuilds' title="Builds"></a>
+		<a href='https://builds.jmri.org/jenkins/job/development/job/cucumber/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fcucumber' title="Cucumber"></a>
+		<a href='https://builds.jmri.org/jenkins/job/development/job/deprecations/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fdeprecations' title="Deprecations"></a>
+        <a href='https://builds.jmri.org/jenkins/job/development/job/html-scan/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fhtml-scan' title="HTML scan"></a>
+		<a href='https://jmri.tagadab.com/jenkins/job/development/job/ignored-test-scan/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fignored-test-scan' title="Ignored Test Scan"></a>
 		<br>
-		<a href='http://builds.jmri.org/jenkins/job/Development/job/JaCoCo/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fjacoco' title="JaCoCo"></a>
-		<a href='http://builds.jmri.org/jenkins/job/Development/job/Packages/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fpackages' title="Packages"></a>
-        <a href='http://builds.jmri.org/jenkins/job/Development/job/Separate_Tests/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fseparate-tests' title="Separate Tests"></a>
-		<a href='http://builds.jmri.org/jenkins/job/Development/job/SpotBugs/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fspotbugs' title="SpotBugs"></a>
+		<a href='http://builds.jmri.org/jenkins/job/development/job/jacoco/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fjacoco' title="JaCoCo"></a>
+		<a href='http://builds.jmri.org/jenkins/job/development/job/packages/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fpackages' title="Packages"></a>
+        <a href='http://builds.jmri.org/jenkins/job/development/job/separate-tests/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fseparate-tests' title="Separate Tests"></a>
+		<a href='http://builds.jmri.org/jenkins/job/development/job/spotbugs/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fspotbugs' title="SpotBugs"></a>
 		</td></tr><tr><td align="right">
-		<a href="http://builds.jmri.org/jenkins/job/Development/job/VersionChecks/">Version Checks</a>:</td><td>
+		<a href="http://builds.jmri.org/jenkins/job/development/job/versionchecks/">Version Checks</a>:</td><td>
 		    <table><tr>
 		    <td>JDK:</td>
 		    <td><table>
-                <tr><td align="right">11:</td><td><a href='http://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JDK%2011/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/VersionChecks/JDK%2011' title="JDK 11"></a>
+                <tr><td align="right">13:</td><td><a href='https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-13/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fversionchecks%2Fjdk-13'></a>
                     on JRE 8u181:
-                    <a href='http://jmri.tagadab.com/jenkins/job/Development/job/VersionChecks/job/JDK%2011%20to%20JRE%208/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development%2FVersionChecks%2FJDK+11+to+JRE+8'></a>
+                    <a href='https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-13-to-jre-8/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fversionchecks%2Fjdk-13-to-jre-8'></a>
                     </td></tr>
-                <tr><td align="right">10:</td><td><a href='http://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JDK%2010.0.1/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/VersionChecks/JDK%2010.0.1' title="JDK 10"></a>
-                    </td></tr>
-                <tr><td align="right"> 9:</td><td><a href='http://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JDK%209.0.4/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/VersionChecks/JDK%209.0.4' title="JDK 9"></a>
+                <tr><td align="right">11:</td><td><a href='https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-11/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fversionchecks%2Fjdk-11'></a>
                     on JRE 8u181:
-                    <a href='http://jmri.tagadab.com/jenkins/job/Development/job/VersionChecks/job/JDK%209.0.4%20to%20JRE%208/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development%2FVersionChecks%2FJDK+9.0.4+to+JRE+8'></a>
+                    <a href='https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-11-to-jre-8/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fversionchecks%2Fjdk-11-to-jre-8'></a>
                     </td></tr>
             </table></td>
             <td>JDK 8u151 on JRE:</td>
 		    <td><table>
-                <tr><td align="right">11:</td><td><a href='http://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JRE%2011/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/VersionChecks/JRE%2011' title="JRE 11"></a></td></tr>
-                <tr><td align="right">10:</td><td><a href='http://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JRE%2010.0.1/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/VersionChecks/JRE%2010.0.1' title="JRE 10"></a></td></tr>
-                <tr><td align="right">9:</td><td><a href='http://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JRE%209.0.4/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/VersionChecks/JRE%209.0.4' title="JRE 9"></a></td></tr>
-                <tr><td align="right">8u181:</td><td><a href='http://builds.jmri.org/jenkins/job/Development/VersionChecks/JRE%208u181'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/VersionChecks/JRE%208u181' title="JRE 8u181"></a></td></tr>
+                <tr><td align="right">13:</td><td><a href='https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jre-13/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fversionchecks%2Fjre-13' title="JRE 13"></a></td></tr>
+                <tr><td align="right">11:</td><td><a href='https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jre-11/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fversionchecks%2Fjre-11' title="JRE 13"></a></td></tr>
+                <tr><td align="right">8u181:</td><td><a href='https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jre-8u181/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fversionchecks%2Fjre-8u181' title="JRE 8u181"></a></td></tr>
             </table>
             </td>
             </table></td>
@@ -83,14 +80,14 @@
 		
 	<table>
 
-		<tr><td><a href="http://builds.jmri.org/jenkins/job/Development/job/SpotBugs/">SpotBugs</a><br>
+		<tr><td><a href="http://builds.jmri.org/jenkins/job/development/job/spotbugs/">SpotBugs</a><br>
         <a href="https://builds.jmri.org/jenkins/job/development/job/spotbugs/lastBuild/spotbugs/">
             <img src="http://builds.jmri.org/jenkins/job/Development/job/spotbugs/findbugs/trendGraph/png?url=PRIORITY">
         </a>
 		</td>
 		
-		<td><a href="https://builds.jmri.org/jenkins/job/Development/job/Deprecations/">Deprecations</a><br>
-        <a href="https://builds.jmri.org/jenkins/job/Development/job/Deprecations/lastBuild/warnings4Result/">
+		<td><a href="https://builds.jmri.org/jenkins/job/development/job/deprecations/">Deprecations</a><br>
+        <a href="https://builds.jmri.org/jenkins/job/development/job/deprecations/lastBuild/warnings4Result/">
             <img src="http://builds.jmri.org/jenkins/job/Development/job/Deprecations/warnings3/trendGraph/png?url=PRIORITY">
         </a>
         </td></tr>
@@ -112,9 +109,9 @@
 
         <tr>
             <td>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/JaCoCo/">JaCoCo</a><br>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/JaCoCo/lastBuild/">
-                    <img src="http://builds.jmri.org/jenkins/job/Development/job/JaCoCo/jacoco/graph">
+                <a href="https://builds.jmri.org/jenkins/job/development/job/jacoco/">JaCoCo</a><br>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/jacoco/lastBuild/">
+                    <img src="http://builds.jmri.org/jenkins/job/development/job/jacoco/jacoco/graph">
                 </a>
             </td>
             <td align="center">
@@ -126,110 +123,110 @@
 
         <tr>
             <td>
-                <a href="http://builds.jmri.org/jenkins/job/Development/job/Separate_Tests/">Separate Tests</a> - Runtime Warnings Results
-                    <br><a href='http://builds.jmri.org/jenkins/job/Development/job/Separate_Tests/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/Separate_Tests' title="Separate Tests"></a>
+                <a href="http://builds.jmri.org/jenkins/job/Development/job/separate-tests//">Separate Tests</a> - Runtime Warnings Results
+                    <br><a href='https://builds.jmri.org/jenkins/job/development/job/separate-tests/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fseparate-tests'></a>
                     <br>
-                <a href="http://builds.jmri.org/jenkins/job/Development/job/Separate_Tests/lastBuild/testReport/">
-                    <img src="http://builds.jmri.org/jenkins/job/Development/job/Separate_Tests/warnings5/trendGraph/png?url=PRIORITY">
+                <a href="http://builds.jmri.org/jenkins/job/development/job/separate-tests//lastBuild/testReport/">
+                    <img src="http://builds.jmri.org/jenkins/job/development/job/separate-tests//warnings5/trendGraph/png?url=PRIORITY">
                 </a>
             </td>
 
             <td>
-                <a href="http://builds.jmri.org/jenkins/job/Development/job/Ignored%20Test%20Scan/">Ignored Tests</a>
-                    <br><a href='http://jmri.tagadab.com/jenkins/job/Development/job/Ignored%20Test%20Scan/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/Ignored%20Test%20Scan' title="Ignored Test Scan"></a>
+                <a href="http://builds.jmri.org/jenkins/job/development/job/ignored-test-scan/">Ignored Tests</a>
+                    <br><a href='https://builds.jmri.org/jenkins/job/development/job/ignored-test-scan/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fignored-test-scan'></a>
                     <br>
-                <a href="http://builds.jmri.org/jenkins/job/Development/job/Ignored%20Test%20Scan/lastBuild/testReport/">
-                    <img src="http://builds.jmri.org/jenkins/job/Development/job/Ignored%20Test%20Scan/warnings6/trendGraph/png?url=PRIORITY">
+                <a href="http://builds.jmri.org/jenkins/job/development/job/ignored-test-scan/lastBuild/testReport/">
+                    <img src="http://builds.jmri.org/jenkins/job/development/job/ignored-test-scan/warnings6/trendGraph/png?url=PRIORITY">
                 </a>
             </td>
        </tr>
 
         <tr>
             <td>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/AllTest/">AllTest</a> - Unit Tests Run and Skipped
-                    <br><a href='https://builds.jmri.org/jenkins/job/Development/job/AllTest/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/AllTest' title="AllTest"></a>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/alltest/">AllTest</a> - Unit Tests Run and Skipped
+                    <br><a href='https://builds.jmri.org/jenkins/job/development/job/alltest/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Falltest' title="AllTest"></a>
                     <br>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/AllTest/lastBuild/testReport/">
-                    <img src="https://builds.jmri.org/jenkins/job/Development/job/AllTest/test/trend">
+                <a href="https://builds.jmri.org/jenkins/job/development/job/alltest/lastBuild/testReport/">
+                    <img src="https://builds.jmri.org/jenkins/job/development/job/alltest/test/trend">
                 </a>
             </td>
 
             <td>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/AllTest/">AllTest</a> - Unit Test Failures
-                    <br><a href='https://builds.jmri.org/jenkins/job/Development/job/AllTest/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/AllTest' title="AllTest"></a>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/alltest/">AllTest</a> - Unit Test Failures
+                    <br><a href='https://builds.jmri.org/jenkins/job/development/job/alltest/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Falltest' title="AllTest"></a>
                     <br>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/AllTest/lastBuild/testReport/">
-                    <img src="https://builds.jmri.org/jenkins/job/Development/job/AllTest/test/trend?failureOnly=true">
+                <a href="https://builds.jmri.org/jenkins/job/development/job/alltest/lastBuild/testReport/">
+                    <img src="https://builds.jmri.org/jenkins/job/development/job/alltest/test/trend?failureOnly=true">
                 </a>
             </td>
         </tr>
 
         <tr>
             <td>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/Builds/">Builds</a> - Unit Tests Run and Skipped<br>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/Builds/lastBuild/testReport/">
-                    <img src="https://builds.jmri.org/jenkins/job/Development/job/Builds/test/trend">
+                <a href="https://builds.jmri.org/jenkins/job/development/job/builds/">Builds</a> - Unit Tests Run and Skipped<br>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/builds/lastBuild/testReport/">
+                    <img src="https://builds.jmri.org/jenkins/job/development/job/builds/test/trend">
                 </a>
             </td>
 
             <td>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/Builds/">Builds</a> - Unit Test Failures<br>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/Builds/lastBuild/testReport/">
-                    <img src="https://builds.jmri.org/jenkins/job/Development/job/Builds/test/trend?failureOnly=true">
-                </a>
-            </td>
-        </tr>
-
-        <tr>
-            <td>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/Builds/">Builds</a> - Regular Java warnings<br>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/Builds/lastBuild/warnings10Result/NORMAL/">
-                    <img src="https://builds.jmri.org/jenkins/job/Development/job/Builds/warnings10/trendGraph/png?url=PRIORITY">
-                </a>
-            </td>
-
-            <td>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/Builds/">Builds</a> - ECJ Java warnings<br>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/Builds/lastBuild/warnings25Result/NORMAL/">
-                    <img src="https://builds.jmri.org/jenkins/job/Development/job/Builds/warnings24/trendGraph/png?url=PRIORITY">
+                <a href="https://builds.jmri.org/jenkins/job/development/job/builds/">Builds</a> - Unit Test Failures<br>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/builds/lastBuild/testReport/">
+                    <img src="https://builds.jmri.org/jenkins/job/development/job/builds/test/trend?failureOnly=true">
                 </a>
             </td>
         </tr>
 
         <tr>
             <td>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/Builds/">Builds</a> - Javadoc results<br>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/Builds/lastBuild/warnings42Result/NORMAL/">
-                    <img src="https://builds.jmri.org/jenkins/job/Development/job/Builds/warnings41/trendGraph/png?url=PRIORITY">
+                <a href="https://builds.jmri.org/jenkins/job/development/job/builds/">Builds</a> - Regular Java warnings<br>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/builds/lastBuild/warnings10Result/NORMAL/">
+                    <img src="https://builds.jmri.org/jenkins/job/development/job/builds/warnings10/trendGraph/png?url=PRIORITY">
                 </a>
             </td>
 
             <td>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/HTML%20Scan/">HTML Scan</a>
-                    <br><a href='http://jmri.tagadab.com/jenkins/job/Development/job/HTML%20Scan/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development%2FHTML+Scan'></a>
-                    <br>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/HTML%20Scan/lastBuild/warnings25Result/NORMAL/">
-                    <img src="https://builds.jmri.org/jenkins/job/Development/job/HTML%20Scan/warnings4/trendGraph/png?url=PRIORITY">
+                <a href="https://builds.jmri.org/jenkins/job/development/job/builds/">Builds</a> - ECJ Java warnings<br>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/builds/lastBuild/warnings25Result/NORMAL/">
+                    <img src="https://builds.jmri.org/jenkins/job/development/job/builds/warnings24/trendGraph/png?url=PRIORITY">
                 </a>
             </td>
         </tr>
 
         <tr>
             <td>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JDK%2011/">JDK 11 build</a> - Java warnings
-                    <br><a href='https://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JDK%2011/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/VersionChecks/JDK%2011' title="JDK 11"></a>
-                    <br>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JDK%2011/lastBuild/warnings10Result/">
-                    <img src="https://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JDK%2011/warnings10/trendGraph/png?url=PRIORITY">
+                <a href="https://builds.jmri.org/jenkins/job/development/job/builds/">Builds</a> - Javadoc results<br>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/builds/lastBuild/warnings42Result/NORMAL/">
+                    <img src="https://builds.jmri.org/jenkins/job/development/job/builds/warnings41/trendGraph/png?url=PRIORITY">
                 </a>
             </td>
 
             <td>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JDK%209.0.4//">Java 9 build</a> - Java warnings
-                    <br><a href='https://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JDK%209.0.4/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/VersionChecks/JDK%209.0.4' title="JDK 9"></a>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/html-scan/">HTML Scan</a>
+                    <br><a href='https://builds.jmri.org/jenkins/job/development/job/html-scan/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fhtml-scan' title="HTML scan"></a>
                     <br>
-                <a href="https://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JDK%209.0.4/lastBuild/">
-                    <img src="https://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JDK%209.0.4/warnings10/trendGraph/png?url=PRIORITY">
+                <a href="https://builds.jmri.org/jenkins/job/development/job/html-scan/lastBuild/warnings25Result/NORMAL/">
+                    <img src="https://builds.jmri.org/jenkins/job/development/job/html-scan/warnings4/trendGraph/png?url=PRIORITY">
+                </a>
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-13/">JDK 13 build</a> - Java warnings
+                    <br><a href='https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-13/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fversionchecks%2Fjdk-13'></a>
+                    <br>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-13/lastBuild/warnings10Result/">
+                    <img src="https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-13/warnings10/trendGraph/png?url=PRIORITY">
+                </a>
+            </td>
+
+            <td>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-11/">Java 11 build</a> - Java warnings
+                    <br><a href='https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-11/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=development%2Fversionchecks%2Fjdk-11'></a>
+                    <br>
+                <a href="https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-11/lastBuild/">
+                    <img src="https://builds.jmri.org/jenkins/job/development/job/versionchecks/job/jdk-11/warnings10/trendGraph/png?url=PRIORITY">
                 </a>
             </td>
         </tr>


### PR DESCRIPTION
Update the existing [CI status page](https://www.jmri.org/help/en/html/doc/Technical/CI-status.shtml) to reference the new Jenkins jobs.  Links and status tags are working.

The new Jenkins has [very nice interactive status graphs](https://builds.jmri.org/jenkins/job/Development/job/builds/) instead of images.  It's not clear how to include those on the CI page.  Until this is worked out, the links to the old image files will be showing as broken.