### PR TITLE
disable the default maven compile on appveyor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,15 @@
         <profile>
             <id>appveyor</id>
             <build>
-                <plugins>
+	        <plugins>
+                <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                             <skipMain>true</skipMain>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
@@ -120,14 +128,14 @@
                         </executions>
                     </plugin>
                     <!-- use surefire (maven default test harness) only for line endings -->
-                    <plugin>
+		    <!--<plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${surefire.version}</version>
                         <configuration>
                             <test>jmri.util.FileLineEndingsTest</test>
                         </configuration>
-                    </plugin>
+		    </plugin> -->
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
While working on getting Appveyor to run JUnit 5 tests in ant as part of #8025, I discovered the Maven bootstrapping of ant runs the Maven complainer plug-in before running any ant tasks.  This is obviously not the behavior we want.

This PR also comments out running the FileLineEndings test on Appveyor.  This test is being replaced with a checkstyle check and the java file will soon be deleted ( in the meantime, this check is also run during a travis job ).

I let this set of changes run through Appveyor on my fork, and it cut the runtime down to 45 minutes.