### PR TITLE
Fix JavaDoc UML compile

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2066,19 +2066,24 @@
             <link href="https://docs.oracle.com/cd/E17802_01/products/products/javacomm/reference/api/" />
                         
             <!-- <link href="https://static.javadoc.io/com.fasterxml.jackson.core/jackson-databind/2.9.8/"/>  redirected to next line -->
-            <link href="https://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/2.9.8/" />
+            <!-- marking this offline as linking to JavaDoc hosted on javadoc.io seems to break the build -->
+            <!-- due to UmlGraph doclet attempting to interpret the injected Google Tag Manager script on javadoc.io -->
+            <link offline="true" href="https://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/2.9.8/" packagelistLoc="lib/jackson-databind-2.9.8-package-list"/>
                         
             <!-- <link href="http://download.java.net/media/java3d/javadoc/1.3.2/"/>  redirected to next line -->
             <link href="https://download.java.net/media/java3d/javadoc/1.3.2/" />
             
             <!-- <link href="https://static.javadoc.io/org.openlcb/openlcb/0.7.23/"/>  redirected to next line -->
-            <link href="https://www.javadoc.io/doc/org.openlcb/openlcb/0.7.23/" />
+            <!-- marking this offline as linking to JavaDoc hosted on javadoc.io seems to break the build -->
+            <link offline="true" href="https://www.javadoc.io/doc/org.openlcb/openlcb/0.7.23/" packagelistLoc="openlcb-0.7.23-package-list"/>
 
             <!-- <link href="https://static.javadoc.io/com.github.purejavacomm/purejavacomm/1.0.1.RELEASE/" packagelistLoc="lib/purejavacomm-1.0.1-package-list"/>  redirected to next line -->
-            <link href="https://www.javadoc.io/doc/com.github.purejavacomm/purejavacomm/1.0.1.RELEASE/" packagelistLoc="lib/purejavacomm-1.0.1-package-list"/>
+            <!-- marking this offline as linking to JavaDoc hosted on javadoc.io seems to break the build -->
+            <link offline="true" href="https://www.javadoc.io/doc/com.github.purejavacomm/purejavacomm/1.0.1.RELEASE/" packagelistLoc="lib/purejavacomm-1.0.1-package-list"/>
 
             <!-- <link href="https://static.javadoc.io/com.alexandriasoftware.swing/jsplitbutton/1.3.1/" packagelistLoc="lib/jsplitbutton-1.3.1-package-list"/>  redirected to next line -->
-            <link href="https://www.javadoc.io/doc/com.alexandriasoftware.swing/jsplitbutton/1.3.1/" packagelistLoc="lib/jsplitbutton-1.3.1-package-list"/>
+            <!-- marking this offline as linking to JavaDoc hosted on javadoc.io seems to break the build -->
+            <link offline="true" href="https://www.javadoc.io/doc/com.alexandriasoftware.swing/jsplitbutton/1.3.1/" packagelistLoc="lib/jsplitbutton-1.3.1-package-list"/>
             
             <link href="https://docs.oracle.com/javase/8/docs/api/"/>
             <link href="http://www.jdom.org/docs/apidocs/"/>


### PR DESCRIPTION
As noted, the `javadoc-uml` target doesn't seem to like live-linking to javadoc.io hosted content.