### PR TITLE
Use ID Tag UserNames in Block / Memory Tables

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -431,7 +431,8 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li></li>
+            <li>The Block Table and Memory Table attempt to use UserName for Reportable objects ( eg. ID Tags )</li>
+            <li>ID Tag Table attempts to use Reporter UserName for Location</li>
         </ul>
 
     <h3>Scripting</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -431,8 +431,8 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li>The Block Table and Memory Table attempt to use UserName for Reportable objects ( eg. ID Tags )</li>
-            <li>ID Tag Table attempts to use Reporter UserName for Location</li>
+            <li>The Block Table and Memory Table use the User Name for ID Tag if it is available.</li>
+            <li>The ID Tag Table uses the Reporter User Name for location if it is available.</li>
         </ul>
 
     <h3>Scripting</h3>

--- a/java/src/jmri/jmrit/beantable/BlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/BlockTableAction.java
@@ -139,7 +139,12 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                 }
                 Object m = b.getValue();
                 if (m != null) {
-                    return m.toString();
+                    if ( m instanceof jmri.Reportable) {
+                        return ((jmri.Reportable) m).toReportString();
+                    }
+                    else {
+                        return m.toString();
+                    }
                 } else {
                     return "";
                 }

--- a/java/src/jmri/jmrit/beantable/IdTagTableAction.java
+++ b/java/src/jmri/jmrit/beantable/IdTagTableAction.java
@@ -183,7 +183,13 @@ public class IdTagTableAction extends AbstractTableAction<IdTag> implements Prop
                     case WHERECOL:
                         Reporter r;
                         t = getBySystemName(sysNameList.get(row));
-                        return (t != null) ? (((r = t.getWhereLastSeen()) != null) ? r.getSystemName() : null) : null;
+                        if ( t !=null ){
+                            r = t.getWhereLastSeen();
+                            if (r!=null){
+                                return r.getDisplayName();                            
+                            }
+                        }
+                        return null;
                     case WHENCOL:
                         Date d;
                         t = getBySystemName(sysNameList.get(row));

--- a/java/src/jmri/jmrit/beantable/MemoryTableAction.java
+++ b/java/src/jmri/jmrit/beantable/MemoryTableAction.java
@@ -65,7 +65,12 @@ public class MemoryTableAction extends AbstractTableAction<Memory> {
                 }
                 Object m = mem.getValue();
                 if (m != null) {
-                    return m.toString();
+                    if ( m instanceof jmri.Reportable) {
+                        return ((jmri.Reportable) m).toReportString();
+                    }
+                    else {
+                        return m.toString();
+                    }
                 } else {
                     return "";
                 }


### PR DESCRIPTION
Attempt to use ID Tag UserNames in Block / Memory Tables
ID Tag Table attempts to use Reporter UserName
Fixes possible deference in IDTagTable

See #8088 