### PR TITLE
Handle late running timer in test

### DIFF
--- a/java/src/jmri/jmrix/sprog/update/SprogIIUpdateFrame.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogIIUpdateFrame.java
@@ -284,6 +284,10 @@ public class SprogIIUpdateFrame
             log.debug("Request bootloader version");
         }
         // allow parsing of bootloader replies
+        if (tc == null) {
+            log.warn("requestBoot with null tc, ignored");
+            return;
+        }
         tc.setSprogState(SprogState.SIIBOOTMODE);
         bootState = BootState.VERREQSENT;
         msg = SprogMessage.getReadBootVersion();

--- a/java/src/jmri/jmrix/sprog/update/SprogUpdateFrame.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogUpdateFrame.java
@@ -369,7 +369,7 @@ abstract public class SprogUpdateFrame
     /**
      * Internal routine to stop timer, as all is well.
      */
-    synchronized protected void stopTimer() {
+    synchronized void stopTimer() {
         if (timer != null) {
             timer.stop();
         }

--- a/java/test/jmri/jmrix/sprog/update/SprogIIUpdateFrameTest.java
+++ b/java/test/jmri/jmrix/sprog/update/SprogIIUpdateFrameTest.java
@@ -26,12 +26,13 @@ public class SprogIIUpdateFrameTest extends jmri.util.JmriJFrameTestBase {
         m.configureCommandStation();
         if(!GraphicsEnvironment.isHeadless()){
            frame = new SprogIIUpdateFrame(m);
-	}
+	    }
     }
 
     @After
     @Override
     public void tearDown() {
+        ((SprogIIUpdateFrame)frame).stopTimer();
         // frame.dispose() called in super class
         m.getSlotThread().interrupt();
         JUnitUtil.waitFor(() -> {return m.getSlotThread().getState() == Thread.State.TERMINATED;}, "Slot thread failed to stop");

--- a/java/test/jmri/jmrix/sprog/update/SprogIIUpdateFrameTest.java
+++ b/java/test/jmri/jmrix/sprog/update/SprogIIUpdateFrameTest.java
@@ -32,7 +32,7 @@ public class SprogIIUpdateFrameTest extends jmri.util.JmriJFrameTestBase {
     @After
     @Override
     public void tearDown() {
-        ((SprogIIUpdateFrame)frame).stopTimer();
+        if (frame!=null) ((SprogIIUpdateFrame)frame).stopTimer();
         // frame.dispose() called in super class
         m.getSlotThread().interrupt();
         JUnitUtil.waitFor(() -> {return m.getSlotThread().getState() == Thread.State.TERMINATED;}, "Slot thread failed to stop");


### PR DESCRIPTION
We've been seeing occasionally failures due to SprogIIUpdateFrame emitting warnings that other tests don't expect.  This is because a timer is left running, which when it fires causes an NPE

 - Improve the cleanup a bit to try to kill the timer
 - bypass the NPE