### PR TITLE
Javadoc for NamedBean#toString

### DIFF
--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -123,6 +123,12 @@ public interface NamedBean extends Comparable<NamedBean>, PropertyChangeProvider
 
     /**
      * Display the system-specific name.
+     * <p>Note that this is a firm contract:  toString() in
+     * all implementing classes must return the system name.
+     * At some point in the future we may choose to extend this to include additional
+     * information, 
+     * but using code can assume that the result of toString() will always be 
+     * or start with the system name followed by a separator character.
      *
      * @return the system-specific name
      */

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -258,10 +258,20 @@ public abstract class AbstractNamedBean implements NamedBean {
         return mSystemName;
     }
 
-    /** {@inheritDoc} */
+    /** {@inheritDoc}
+    */
     @Nonnull
     @Override
     final public String toString() {
+        /*
+         * Implementation note:  This method is final to ensure that the
+         * contract for toString is properly implemented.  See the 
+         * comment in NamedBean#toString() for more info.
+         * If you ever do decide to allow extension:
+         *  - Consider just making that change here instead of releasing the final condition
+         *  - Add a JUnit or ArchUnit check or @OverridingMethodsMustInvokeSuper (which might not be being checked)
+         * to ensure that new code doesn't inadvertantly violate the contract
+         */
         return getSystemName();
     }
 


### PR DESCRIPTION
Add Javadoc & comments to document the contract for NamedBean#toString and discuss future paths.