### PR TITLE
WIP: See how AppVeyor runs with more recent JDKs.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ skip_commits:
 install:
 # Available choices on https://www.appveyor.com/docs/windows-images-software/#java
 #  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-  - SET JAVA_HOME=C:\Program Files\Java\jdk11
+  - SET JAVA_HOME=C:\Program Files\Java\jdk9
 #  - echo JAVA_HOME %JAVA_HOME%
   - SET GECKODRIVER=C:\Tools\WebDriver
   - SET CHROMEDRIVER=C:\Tools\WebDriver\chromedriver.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # select image with Java 1.8 221
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 version: '{build}'
 clone_depth: 50
@@ -11,7 +11,7 @@ skip_commits:
 install:
 # Available choices on https://www.appveyor.com/docs/windows-images-software/#java
 #  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-  - SET JAVA_HOME=C:\Program Files\Java\jdk9
+  - SET JAVA_HOME=C:\Program Files\Java\jdk11
 #  - echo JAVA_HOME %JAVA_HOME%
   - SET GECKODRIVER=C:\Tools\WebDriver
   - SET CHROMEDRIVER=C:\Tools\WebDriver\chromedriver.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,8 @@ skip_commits:
   
 install:
 # Available choices on https://www.appveyor.com/docs/windows-images-software/#java
-  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+#  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+  - SET JAVA_HOME=C:\Program Files\Java\jdk11
 #  - echo JAVA_HOME %JAVA_HOME%
   - SET GECKODRIVER=C:\Tools\WebDriver
   - SET CHROMEDRIVER=C:\Tools\WebDriver\chromedriver.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # select image with Java 1.8 221
-image: Visual Studio 2019
+image: Visual Studio 2017
 
 version: '{build}'
 clone_depth: 50

--- a/build.xml
+++ b/build.xml
@@ -15,7 +15,10 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 
-<project name="JMRI" default="debug" basedir="." xmlns:jacoco="antlib:org.jacoco.ant">
+<project name="JMRI" default="debug" basedir="." 
+        xmlns:jacoco="antlib:org.jacoco.ant" 
+        xmlns:if="ant:if"
+        xmlns:unless="ant:unless">
 
     <!-- basedir="." means all paths are relative to the top level -->
     <!-- directory in the project.  We expect that lib et al will  -->
@@ -88,6 +91,11 @@
 
     <condition property="nsis.home" value="">
         <not><isset property="nsis.home"/></not>
+    </condition>
+
+    <!-- Check for Java 8 vs later -->
+    <condition property="java.version.eight" value="true" else="false">
+      <equals arg1="${ant.java.version}" arg2="1.8"/>
     </condition>
 
     <condition property="jvm.args" value="">
@@ -278,10 +286,12 @@
         <pathelement location="${testtarget}"/> <!-- test resources in classpath that collide with stock resources -->
     </path>
 
+    <!-- macro to reduce output -->
+    <!-- JavaScript not available in JDK 9 or later -->
     <macrodef name="quiet">
         <element name="body" implicit="yes"/>
         <sequential>
-            <script language="javascript" >
+            <script language="javascript" if:true="java.version.eight">
                 // to see type of 1st logger, uncomment the following
                 //echo = JMRI.createTask("echo");
                 //echo.setMessage(Object.prototype.toString.call(project.getBuildListeners().firstElement()));
@@ -294,7 +304,7 @@
                 }
             </script>
             <body/>
-            <script language="javascript" >
+            <script language="javascript" if:true="java.version.eight">
                 // TODO: restore last log level instead of going to fixed value "2"
                 if (Object.prototype.toString.call(project.getBuildListeners().firstElement()) == "[object org.apache.tools.ant.DefaultLogger]") {
                     project.getBuildListeners().firstElement().setMessageOutputLevel(2);


### PR DESCRIPTION
This is an attempt to see if the huge number of NPEs in AppVeyor runs also occur with other JDKs.

First check is JDK 11, the long term support version.