### PR TITLE
test: silence some NPEs forcably closing windows on AppVeyor

### DIFF
--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1253,10 +1253,14 @@ public class JUnitUtil {
      * @param window the window to dispose of
      */
     public static void dispose(@Nonnull Window window) {
-        java.util.Objects.requireNonNull(window, "Window cannot be null");
+        Objects.requireNonNull(window, "Window cannot be null");
         
         ThreadingUtil.runOnGUI(() -> {
-            window.dispose();
+            try {
+                window.dispose();
+            } catch (NullPointerException ex) {
+                // merely silencing error, so doing nothing
+            }
         });
     }
         


### PR DESCRIPTION
I have always wanted to make it a warning in `JunitUtil.tearDown()` that tearDown is being called with an open window, but until that's accepted, this just silences the NPEs disposing of Windows.