### PR TITLE
Add missing debug info for Audio Sources

### DIFF
--- a/java/src/jmri/jmrit/beantable/AudioTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AudioTableAction.java
@@ -349,7 +349,11 @@ public class AudioTableAction extends AbstractTableAction<Audio> {
         @Override
         public String getValue(String systemName) {
             Object m = InstanceManager.getDefault(jmri.AudioManager.class).getBySystemName(systemName);
-            return (m != null) ? m.toString() : "";
+            if (subType == Audio.SOURCE) {
+                return (m != null) ? ((jmri.jmrit.audio.AudioSource) m).getDebugString() : "";
+            } else {
+                return (m != null) ? m.toString() : "";
+            }
         }
 
         @Override


### PR DESCRIPTION
PanelPro >> Tools >> Tables >> Audio >> Tab "Audio Sources" >> column "Description"
Before [PR 6463](https://github.com/JMRI/JMRI/pull/6463) lines like ```Pos: (-15.356011, 0.0, 0.0), bound to: IAB1, loops: (min=3 max=6)``` were displayed.
After the mentioned PR the ```systemName``` of the ```AudioSource``` is displayed.
(for an example run the Jython script ```AudioExample.py```).

This PR intends to make use of the new ```AbstractAudioSource.getDebugString()``` method to bring the ```debug info``` back.

Review appreciated!
