### PR TITLE
toString extension mechanism

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -497,6 +497,7 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>The toString() method is NamedBeans has been standardized to return the system name.
+            There's an extension mechanism to add additional information if needed.</li>
         </ul>
 

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -124,11 +124,10 @@ public interface NamedBean extends Comparable<NamedBean>, PropertyChangeProvider
     /**
      * Display the system-specific name.
      * <p>Note that this is a firm contract:  toString() in
-     * all implementing classes must return the system name.
-     * At some point in the future we may choose to extend this to include additional
-     * information, 
-     * but using code can assume that the result of toString() will always be 
-     * or start with the system name followed by a separator character.
+     * all implementing classes must return the system name
+     * followed by optional additional information.
+     * Using code can assume that the result of toString() will always be 
+     * or start with the system name followed by some kind of separator character.
      *
      * @return the system-specific name
      */

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -267,14 +267,19 @@ public abstract class AbstractNamedBean implements NamedBean {
          * Implementation note:  This method is final to ensure that the
          * contract for toString is properly implemented.  See the 
          * comment in NamedBean#toString() for more info.
-         * If you ever do decide to allow extension:
-         *  - Consider just making that change here instead of releasing the final condition
-         *  - Add a JUnit or ArchUnit check or @OverridingMethodsMustInvokeSuper (which might not be being checked)
-         * to ensure that new code doesn't inadvertantly violate the contract
+         * If a subclass wants to add extra info at the end of the
+         * toString output, extend {@link #toStringSuffix}.
          */
-        return getSystemName();
+        return getSystemName()+toStringSuffix();
     }
 
+    /**
+     * Overload this in a sub-class to add extra info to the results of toString()
+     */
+    protected String toStringSuffix() {
+        return "";
+    }
+    
     @Override
     final public String getUserName() {
         return mUserName;

--- a/java/test/jmri/implementation/AbstractSensorTest.java
+++ b/java/test/jmri/implementation/AbstractSensorTest.java
@@ -1,8 +1,8 @@
 package jmri.implementation;
 
+import jmri.*;
 import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.*;
 
 
 /**
@@ -25,6 +25,19 @@ public class AbstractSensorTest extends AbstractSensorTestBase {
     @Override
     public void checkStatusRequestMsgSent() {}
 
+    @Test
+    public void checkToString() {
+        Sensor nb = new AbstractSensor("Foo", "Bar"){
+            @Override
+            public void requestUpdateFromLayout(){} // for abstract class
+            
+            @Override
+            public String toStringSuffix(){ return " After";} // feature under test
+        };
+
+        Assert.assertEquals(nb.toString(), "Foo After");
+    }
+    
     // load t with actual object; create scaffolds as needed
     @Override
     @Before


### PR DESCRIPTION
This adds a safe extension mechanism for the toString() method of NamedBeans (at least the ones that extend from AbstractNamedBean, which all current ones do)