### PR TITLE
Make test file more standard

### DIFF
--- a/java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest.xml
@@ -7,6 +7,15 @@
     <test>4</test>
     <modifier>ish</modifier>
   </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor inverted="false">
+      <systemName>IS0</systemName>
+    </sensor>
+    <sensor systemName="ISCLOCKRUNNING" inverted="false">
+      <systemName>ISCLOCKRUNNING</systemName>
+    </sensor>
+  </sensors>
   <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
@@ -47,8 +56,6 @@
       <userName>XYZZY</userName>
     </memory>
   </memories>
-  <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
-  <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
     <block systemName="IB1">
@@ -172,7 +179,6 @@
       </path>
     </block>
   </blocks>
-  <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <layoutblocks class="jmri.jmrit.display.layoutEditor.configurexml.LayoutBlockManagerXml">
     <layoutblock systemName="ILB1" occupiedsense="2" trackcolor="black" occupiedcolor="red" extracolor="green" memory="XYZZY">
       <systemName>ILB1</systemName>
@@ -199,7 +205,6 @@
       <userName>North</userName>
     </layoutblock>
   </layoutblocks>
-  <warrants class="jmri.jmrit.logix.configurexml.WarrantManagerXml" />
   <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
     <logicDelay>500</logicDelay>
   </signalmastlogics>

--- a/java/test/jmri/jmrit/display/layoutEditor/loadref/LayoutEditorTest.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/loadref/LayoutEditorTest.xml
@@ -7,6 +7,15 @@
     <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor inverted="false">
+      <systemName>IS0</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>ISCLOCKRUNNING</systemName>
+    </sensor>
+  </sensors>
   <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />


### PR DESCRIPTION
The LoadAndStoreTest of java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest.xml has been intermittently failing.  This makes that file more standard, with sensors in the usual order, which seems to reduce the rate of failures.