### PR TITLE
Add TimeoutReporter decorator for reporters.

### DIFF
--- a/java/src/jmri/implementation/AbstractIdTagReporter.java
+++ b/java/src/jmri/implementation/AbstractIdTagReporter.java
@@ -2,13 +2,8 @@ package jmri.implementation;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import jmri.DccLocoAddress;
-import jmri.IdTag;
-import jmri.IdTagListener;
-import jmri.InstanceManager;
-import jmri.LocoAddress;
-import jmri.PhysicalLocationReporter;
-import jmri.ReporterManager;
+
+import jmri.*;
 import jmri.util.PhysicalLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,12 +33,13 @@ public class AbstractIdTagReporter extends AbstractReporter
         log.debug("Notify: {}",mSystemName);
         if (id != null) {
             log.debug("Tag: {}",id);
-            AbstractIdTagReporter r;
-            if ((r = (AbstractIdTagReporter) id.getWhereLastSeen()) != null) {
-                log.debug("Previous reporter: {}",r.mSystemName);
-                if (!(r.equals(this)) && r.getCurrentReport() == id) {
+            Reporter r;
+            if ((r = id.getWhereLastSeen()) != null) {
+                log.debug("Previous reporter: {}",r.getSystemName());
+                if (!(r.equals(this)) && r.getCurrentReport() == id
+                   && (r instanceof IdTagListener)) {
                     log.debug("Notify previous");
-                    r.notify(null);
+                    ((IdTagListener)r).notify(null);
                 } else {
                     log.debug("Current report was: {}",r.getCurrentReport());
                 }

--- a/java/src/jmri/implementation/decorators/AbstractNamedBeanDecorator.java
+++ b/java/src/jmri/implementation/decorators/AbstractNamedBeanDecorator.java
@@ -1,0 +1,321 @@
+package jmri.implementation.decorators;
+
+import jmri.NamedBean;
+import jmri.beans.Beans;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Set;
+
+/**
+ * Abstract base for the NamedBean Decorators.
+ * <p>
+ *
+ * @author Bob Jacobsen Copyright (C) 2001
+ * @author Paul Bender Copyright (C) 2020
+ */
+public abstract class AbstractNamedBeanDecorator implements NamedBean {
+
+    private NamedBean decorated;
+
+    protected AbstractNamedBeanDecorator(NamedBean decorated){
+        this.decorated = decorated;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    final public String getComment() {
+        return decorated.getComment();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    final public void setComment(String comment) {
+        decorated.setComment(comment);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @CheckReturnValue
+    @Nonnull
+    final public String getDisplayName() {
+        return decorated.getDisplayName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @CheckReturnValue
+    @Nonnull
+    final public String getDisplayName(DisplayOptions displayOptions) {
+        return decorated.getDisplayName(displayOptions);
+    }
+
+    // implementing classes will typically have a function/listener to get
+    // updates from the layout, which will then call
+    //  public void firePropertyChange(String propertyName,
+    //             Object oldValue,
+    //      Object newValue)
+    // _once_ if anything has changed state
+    // since we can't do a "super(this)" in the ctor to inherit from PropertyChangeSupport, we'll
+    // reflect to it
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    protected final HashMap<PropertyChangeListener, String> register = new HashMap<>();
+    protected final HashMap<PropertyChangeListener, String> listenerRefs = new HashMap<>();
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public synchronized void addPropertyChangeListener(@Nonnull PropertyChangeListener l,
+                                                       String beanRef, String listenerRef) {
+        pcs.addPropertyChangeListener(l);
+        if (beanRef != null) {
+            register.put(l, beanRef);
+        }
+        if (listenerRef != null) {
+            listenerRefs.put(l, listenerRef);
+        }
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public synchronized void addPropertyChangeListener(@Nonnull String propertyName,
+                                                       @Nonnull PropertyChangeListener l, String beanRef, String listenerRef) {
+        pcs.addPropertyChangeListener(propertyName, l);
+        if (beanRef != null) {
+            register.put(l, beanRef);
+        }
+        if (listenerRef != null) {
+            listenerRefs.put(l, listenerRef);
+        }
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public synchronized void addPropertyChangeListener(PropertyChangeListener listener) {
+        pcs.addPropertyChangeListener(listener);
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public synchronized void addPropertyChangeListener(String propertyName, PropertyChangeListener listener) {
+        pcs.addPropertyChangeListener(propertyName, listener);
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public synchronized void removePropertyChangeListener(PropertyChangeListener listener) {
+        pcs.removePropertyChangeListener(listener);
+        if (listener != null && !Beans.contains(pcs.getPropertyChangeListeners(), listener)) {
+            register.remove(listener);
+            listenerRefs.remove(listener);
+        }
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public synchronized void removePropertyChangeListener(String propertyName, PropertyChangeListener listener) {
+        pcs.removePropertyChangeListener(propertyName, listener);
+        if (listener != null && !Beans.contains(pcs.getPropertyChangeListeners(), listener)) {
+            register.remove(listener);
+            listenerRefs.remove(listener);
+        }
+    }
+
+    @Override
+    @Nonnull
+    public synchronized PropertyChangeListener[] getPropertyChangeListenersByReference(@Nonnull String name) {
+        ArrayList<PropertyChangeListener> list = new ArrayList<>();
+        register.entrySet().forEach((entry) -> {
+            PropertyChangeListener l = entry.getKey();
+            if (entry.getValue().equals(name)) {
+                list.add(l);
+            }
+        });
+        return list.toArray(new PropertyChangeListener[list.size()]);
+    }
+
+    /**
+     * Get a meaningful list of places where the bean is in use.
+     *
+     * @return ArrayList of the listeners
+     */
+    @Override
+    public synchronized ArrayList<String> getListenerRefs() {
+        return new ArrayList<>(listenerRefs.values());
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public synchronized void updateListenerRef(PropertyChangeListener l, String newName) {
+        if (listenerRefs.containsKey(l)) {
+            listenerRefs.put(l, newName);
+        }
+    }
+
+    @Override
+    public synchronized String getListenerRef(PropertyChangeListener l) {
+        return listenerRefs.get(l);
+    }
+
+    /**
+     * Get the number of current listeners.
+     *
+     * @return -1 if the information is not available for some reason.
+     */
+    @Override
+    public synchronized int getNumPropertyChangeListeners() {
+        return pcs.getPropertyChangeListeners().length;
+    }
+
+    @Override
+    @Nonnull
+    public synchronized PropertyChangeListener[] getPropertyChangeListeners() {
+        return pcs.getPropertyChangeListeners();
+    }
+
+    @Override
+    @Nonnull
+    public synchronized PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
+        return pcs.getPropertyChangeListeners(propertyName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Nonnull
+    final public String getSystemName() {
+        return decorated.getSystemName();
+    }
+
+    /** {@inheritDoc}
+    */
+    @Nonnull
+    @Override
+    final public String toString() {
+        return decorated.getSystemName();
+    }
+
+    @Override
+    final public String getUserName() {
+        return decorated.getUserName();
+    }
+
+    @Nonnull
+    @Override
+    public String getBeanType() {
+        return decorated.getBeanType();
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void setUserName(String s) throws BadUserNameException {
+        decorated.setUserName(s);
+    }
+
+    @OverridingMethodsMustInvokeSuper
+    protected void firePropertyChange(String p, Object old, Object n) {
+        pcs.firePropertyChange(p, old, n);
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void dispose() {
+        PropertyChangeListener[] listeners = pcs.getPropertyChangeListeners();
+        for (PropertyChangeListener l : listeners) {
+            pcs.removePropertyChangeListener(l);
+            register.remove(l);
+            listenerRefs.remove(l);
+        }
+    }
+
+    @Override
+    @Nonnull
+    public String describeState(int state) {
+        return decorated.describeState(state);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void setProperty(@Nonnull String key,Object value){
+        decorated.setProperty(key,value);
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public Object getProperty(@Nonnull String key) {
+        return decorated.getProperty(key);
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    @Nonnull
+    public Set<String> getPropertyKeys() {
+        return decorated.getPropertyKeys();
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void removeProperty(String key) {
+        decorated.removeProperty(key);
+    }
+
+    @Override
+    public void vetoableChange(java.beans.PropertyChangeEvent evt) throws java.beans.PropertyVetoException {
+        decorated.vetoableChange(evt);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This implementation tests that
+     * {@link NamedBean#getSystemName()}
+     * is equal for this and obj.
+     *
+     * @param obj the reference object with which to compare.
+     * @return {@code true} if this object is the same as the obj argument;
+     *         {@code false} otherwise.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;  // for efficiency
+        if (obj == null) return false; // by contract
+
+        if (obj instanceof AbstractNamedBeanDecorator) {  // NamedBeans are not equal to things of other types
+            AbstractNamedBeanDecorator b = (AbstractNamedBeanDecorator) obj;
+            return this.getSystemName().equals(b.getSystemName());
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return this.getSystemName().hashCode();
+    }
+    
+    /**
+     * {@inheritDoc} 
+     */
+    @CheckReturnValue
+    @Override
+    public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull NamedBean n) {
+        return decorated.compareSystemNameSuffix(suffix1,suffix2,n);
+    }
+
+}

--- a/java/src/jmri/implementation/decorators/TimeoutReporter.java
+++ b/java/src/jmri/implementation/decorators/TimeoutReporter.java
@@ -1,0 +1,161 @@
+package jmri.implementation.decorators;
+
+import jmri.*;
+import jmri.implementation.AbstractReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyVetoException;
+import java.util.ArrayList;
+import java.util.Set;
+
+/**
+ * Timeout decorator implementation for reporters.
+ * <p>
+ * This decorator causes the current report to be reset to nullified after a
+ * preset time period.  This is to be used for reporter hardware that reports
+ * a value, but never reports the value is cleared (e.g. most RFID readers).
+ * <hr>
+ * This file is part of JMRI.
+ * <p>
+ * <p>
+ * based on TimeoutRfidReporter originally implemented by Matthew Harris
+ * <p>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * <p>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * Based
+ * @author Matthew Harris Copyright (C) 2014
+ * @author Paul Bender Copyright (C) 2020
+ * @since 4.19.4
+ */
+public class TimeoutReporter extends AbstractNamedBeanDecorator implements Reporter, IdTagListener,PropertyChangeListener {
+
+    /**
+     * The reporter this object is a decorator for
+     */
+    private Reporter reporter;
+
+
+    /**
+     * Timeout in ms
+     */
+    private static final int TIMEOUT = 2000;
+
+    /**
+     * Time when something was last reported by this object
+     */
+    private long whenLastReported = 0;
+
+    /**
+     * Reference to the timeout thread for this object
+     */
+    private TimeoutThread timeoutThread = null;
+
+    private final boolean logDebug = log.isDebugEnabled();
+
+    public TimeoutReporter(Reporter reporter) {
+        super(reporter);
+        this.reporter = reporter;
+        this.reporter.addPropertyChangeListener(this);
+    }
+
+    @Override
+    public Object getLastReport() {
+        return reporter.getLastReport();
+    }
+
+    @Override
+    public Object getCurrentReport() {
+        return reporter.getCurrentReport();
+    }
+
+    @Override
+    public void setReport(Object r) {
+        reporter.setReport(r);
+    }
+
+    @Override
+    public int getState() {
+        return reporter.getState();
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+        reporter.dispose();
+    }
+
+    @Override
+    public void setState(int i) throws JmriException {
+        reporter.setState(i);
+    }
+
+    @Override
+    public void notify(IdTag r) {
+        if(reporter instanceof IdTagListener ){
+            ((IdTagListener)reporter).notify(r);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     *  Intercepts property change events from the underlying reporter
+     *  and forwards them to property change listeners for this reporter.
+     */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        log.debug("event received {}",evt);
+         if(evt.getPropertyName().equals("currentReport") &&
+            evt.getNewValue()!=null ){
+                 whenLastReported = System.currentTimeMillis();
+                 if (timeoutThread == null) {
+                     timeoutThread = new TimeoutThread();
+                     timeoutThread.start();
+                 }
+         }
+         // fire off the property change for listeners of this TimeoutReporter.
+         firePropertyChange(evt.getPropertyName(),evt.getOldValue(),evt.getNewValue());
+    }
+
+    private void cleanUpTimeout() {
+        log.debug("Cleanup timeout thread for {}",getSystemName());
+        timeoutThread = null;
+    }
+
+    private class TimeoutThread extends Thread {
+
+        TimeoutThread() {
+            super();
+            this.setName("Timeout-" + getSystemName());
+        }
+
+        @Override
+        @SuppressWarnings("SleepWhileInLoop")
+        public void run() {
+            while ((whenLastReported + TIMEOUT) > System.currentTimeMillis()) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ex) {
+                }
+            }
+            reporter.setReport(null);
+            if (logDebug) {
+                log.debug("Timeout-" + getSystemName());
+            }
+            cleanUpTimeout();
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(TimeoutReporter.class);
+
+}

--- a/java/src/jmri/jmrix/rfid/TimeoutRfidReporter.java
+++ b/java/src/jmri/jmrix/rfid/TimeoutRfidReporter.java
@@ -26,7 +26,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author Matthew Harris Copyright (C) 2014
  * @since 3.9.2
+ * @deprecated since 4.19.4.  Use jmri.implementation.decorators.TimeoutReporter as a replacement.
  */
+@Deprecated
 public class TimeoutRfidReporter extends RfidReporter {
 
     /**

--- a/java/src/jmri/jmrix/rfid/generic/standalone/StandaloneReporterManager.java
+++ b/java/src/jmri/jmrix/rfid/generic/standalone/StandaloneReporterManager.java
@@ -5,12 +5,8 @@ import jmri.IdTag;
 import jmri.IdTagManager;
 import jmri.InstanceManager;
 import jmri.Reporter;
-import jmri.jmrix.rfid.RfidMessage;
-import jmri.jmrix.rfid.RfidReply;
-import jmri.jmrix.rfid.RfidReporterManager;
-import jmri.jmrix.rfid.RfidSystemConnectionMemo;
-import jmri.jmrix.rfid.RfidTrafficController;
-import jmri.jmrix.rfid.TimeoutRfidReporter;
+import jmri.implementation.decorators.TimeoutReporter;
+import jmri.jmrix.rfid.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +40,8 @@ public class StandaloneReporterManager extends RfidReporterManager {
             log.warn("Invalid Reporter name: " + systemName + " - out of supported range " + tc.getRange());
             throw new IllegalArgumentException("Invalid Reporter name: " + systemName + " - out of supported range " + tc.getRange());
         }
-        TimeoutRfidReporter r;
-        r = new TimeoutRfidReporter(systemName, userName);
+        Reporter r;
+        r = new TimeoutReporter( new RfidReporter(systemName, userName));
         r.addPropertyChangeListener(this);
         return r;
     }
@@ -72,7 +68,7 @@ public class StandaloneReporterManager extends RfidReporterManager {
             return;
         }
         IdTag idTag = InstanceManager.getDefault(IdTagManager.class).provideIdTag(tc.getAdapterMemo().getProtocol().getTag(r));
-        TimeoutRfidReporter report = (TimeoutRfidReporter) provideReporter(getSystemNamePrefix() + "1");
+        TimeoutReporter report = (TimeoutReporter) provideReporter(getSystemNamePrefix() + "1");
         report.notify(idTag);
     }
 

--- a/java/src/jmri/jmrix/rfid/merg/concentrator/ConcentratorReporterManager.java
+++ b/java/src/jmri/jmrix/rfid/merg/concentrator/ConcentratorReporterManager.java
@@ -5,12 +5,8 @@ import jmri.IdTag;
 import jmri.IdTagManager;
 import jmri.InstanceManager;
 import jmri.Reporter;
-import jmri.jmrix.rfid.RfidMessage;
-import jmri.jmrix.rfid.RfidReply;
-import jmri.jmrix.rfid.RfidReporterManager;
-import jmri.jmrix.rfid.RfidSystemConnectionMemo;
-import jmri.jmrix.rfid.RfidTrafficController;
-import jmri.jmrix.rfid.TimeoutRfidReporter;
+import jmri.implementation.decorators.TimeoutReporter;
+import jmri.jmrix.rfid.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +40,8 @@ public class ConcentratorReporterManager extends RfidReporterManager {
             log.warn("Invalid Reporter name: {}} - out of supported range {}", systemName, tc.getRange());
             throw new IllegalArgumentException("Invalid Reporter name: " + systemName + " - out of supported range " + tc.getRange());
         }
-        TimeoutRfidReporter r;
-        r = new TimeoutRfidReporter(systemName, userName);
+        Reporter r;
+        r = new TimeoutReporter( new RfidReporter(systemName, userName));
         r.addPropertyChangeListener(this);
         return r;
     }
@@ -76,7 +72,7 @@ public class ConcentratorReporterManager extends RfidReporterManager {
             return;
         }
         IdTag idTag = InstanceManager.getDefault(IdTagManager.class).provideIdTag(tc.getAdapterMemo().getProtocol().getTag(r));
-        TimeoutRfidReporter report = (TimeoutRfidReporter) provideReporter(getSystemNamePrefix() + r.getReaderPort());
+        TimeoutReporter report = (TimeoutReporter) provideReporter(getSystemNamePrefix() + r.getReaderPort());
         report.notify(idTag);
     }
 

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeTrickleFetchTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeTrickleFetchTest.java
@@ -1,12 +1,14 @@
 package jmri.jmrix.can.cbus.node;
 
 import jmri.jmrix.can.CanSystemConnectionMemo;
-import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.TrafficController;
 import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
@@ -18,30 +20,16 @@ public class CbusNodeTrickleFetchTest {
     @Test
     public void testCTor() {
         
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        TrafficControllerScaffold tcis = new TrafficControllerScaffold();
-        memo.setTrafficController(tcis);
+        CanSystemConnectionMemo memo = Mockito.mock(CanSystemConnectionMemo.class);
+        TrafficController tc = Mockito.mock(TrafficController.class);
+        CbusNodeTableDataModel model = Mockito.mock(CbusNodeTableDataModel.class);
+        Mockito.when(memo.getTrafficController()).thenReturn(tc);
         
-        CbusNodeTrickleFetch t = new CbusNodeTrickleFetch(memo,null,5L);
-        Assert.assertNotNull("exists",t);
+        CbusNodeTrickleFetch t = new CbusNodeTrickleFetch(memo,model,5L);
+        assertThat(t).isNotNull();
         
         t.dispose();
         
     }
-
-    // The minimal setup for log4J
-    @Before
-    public void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @After
-    public void tearDown() {
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
-        JUnitUtil.tearDown();
-
-    }
-
-    // private final static Logger log = LoggerFactory.getLogger(CbusNodeTrickleFetchTest.class);
 
 }

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeTrickleFetchTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeTrickleFetchTest.java
@@ -3,8 +3,6 @@ package jmri.jmrix.can.cbus.node;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficController;
 import jmri.util.JUnitUtil;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 


### PR DESCRIPTION
This is a different way of implementing the Timeout behavior of the TimeoutRFIDReporter using the decorator pattern.

This PR also fixes an unrelated test for the CBus code that threw an NPE In a timer event which cascaded to cause following tests that used the timer to fail.