### PR TITLE
Cross reference use of Raspberry Pi

### DIFF
--- a/help/en/html/hardware/pi/index.shtml
+++ b/help/en/html/hardware/pi/index.shtml
@@ -44,20 +44,20 @@
       "Pi2 model B (&copy; www.raspberrypi.org)"> <a name=
       "hardware" id="hardware"></a>
 
-      <p class="noted">The Raspberry Pi can also be used to run a full version of JMRI under the
-      Raspian operating system. See <a href="../../../../../install/Raspbian.shtml">here for information </a>
-      on how to install JMRI on a Raspberry Pi.</p>
+      <p class="noted">See <a href="../../../../../install/Raspbian.shtml">here for information </a>
+      on how to install JMRI on a Raspberry Pi under the Raspian operating system.  This must be done before
+      using Raspberry Pi GPIO pins with JMRI objects.</p>
 
       <h2>Supported Hardware</h2>
 
       <p>Theoretically, any Raspberry Pi supported by <a href=
-      "http://pi4j.com/">Pi4J</a> is supported by JMRI.<br>
+      "http://pi4j.com/" target="_blank">Pi4J</a> is supported by JMRI.<br>
       JMRI support has been tested with the Models B, B+, 2B, and 3.
       There's also a <a href=
-      "http://jmri.org/install/Raspbian.shtml">JMRI install help
-      page for the Pi</a>.</p><a name="connecting" id=
-      "connecting"></a>
-
+      "../../../../../install/Raspbian.shtml">JMRI install help
+      page for the Pi</a>.</p>
+      
+      <a name="connecting" id="connecting"></a>
       <h2>Connecting</h2>
 
       <p>Underlying support for the Raspberry Pi's GPIO connections
@@ -84,7 +84,8 @@
       <p><b>This environment varialbe must be set prior to executing 
       JMRI</b></p>.  
      <p>For more information, please see the relavent portions of 
-     <a href="http://www.savagehomeautomation.com/projects/pi4j-now-supports-non-privileged-access-no-more-rootsudo.html">the pi4j web page</a>.</p>
+     <a href="http://www.savagehomeautomation.com/projects/pi4j-now-supports-non-privileged-access-no-more-rootsudo.html" target="_blank">
+     the pi4j web page</a>.</p>
 
       <h3>Pi4j 1.1 and Raspbian Stretch</h3>
 
@@ -156,7 +157,9 @@
         Manufacturer selection box.</li>
 
         <li>Select "Raspberry Pi GPIO" from the System Connection
-        selection box. <!--
+        selection box. 
+        
+<!--
   <li> The "Connection Prefix" is used to help JMRI communicate 
   separately with multiple "connections" to layout hardware. Each 
   "connection" must have a unique identifier, which is specified as
@@ -177,19 +180,21 @@
         program to quit, click "Yes".</li>
 
         <li>Restart the program. You should be up and running.</li>
-      </ol><a name="documentation" id="documentation"></a>
-
+      </ol>
+      
+      <a name="documentation" id="documentation"></a>
       <h2>Documentation</h2>
 
       <h3>JMRI Help</h3>
 
-      <p><a href="http://jmri.org/install/Raspbian.shtml">JMRI
+      <p><a href="../../../../../install/Raspbian.shtml">JMRI
       installation on Pi/Raspbian</a>.</p>
 
       <h3>Third Party info</h3>
 
-      <p>The <a href="http://pi4j.com/">Pi4J website</a> provides
+      <p>The <a href="http://pi4j.com/" target="_blank">Pi4J website</a> provides
       model specific Java I/O information.</p>
+      
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/html/hardware/pi/index.shtml
+++ b/help/en/html/hardware/pi/index.shtml
@@ -30,7 +30,7 @@
 
       <h1>Hardware Setup Support: Raspberry Pi via GPIO</h1>
 
-      <p>The <a href="http://www.raspberrypi.org">Raspberry Pi</a>
+      <p>The <a href="http://www.raspberrypi.org" target="_blank">Raspberry Pi</a>
       is a family of inexpensive credit card size single board
       computers that have many applications in embedded
       electronics. This page describes the use of the Raspberry
@@ -43,6 +43,10 @@
       "528" height="300" align="right" title=
       "Pi2 model B (&copy; www.raspberrypi.org)"> <a name=
       "hardware" id="hardware"></a>
+
+      <p class="noted">The Raspberry Pi can also be used to run a full version of JMRI under the
+      Raspian operating system. See <a href="../../../../../install/Raspbian.shtml">here for information </a>
+      on how to install JMRI on a Raspberry Pi.</p>
 
       <h2>Supported Hardware</h2>
 


### PR DESCRIPTION
This is the hardware page related to using Raspberry Pi's GPIO pins.  There is also a separate page for installing JMRI on a Raspberry Pi in the /install directory in the web repository.  I have put in links to cross-reference so that naive user (e.g. me) will realize that these are different and both are possible.