### PR TITLE
Make Travis verbose temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ dist: xenial
 env:
   global:
   # false to silence most maven output; true to catch tests that do not complete
-  - PRINT_SUMMARY=false
+  - PRINT_SUMMARY=true
   - MAVEN_OPTS=-Xmx1536m
   # see http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder for valid values
   - RUN_ORDER=filesystem


### PR DESCRIPTION
Travis graphical CI currently runs out of time in about 5% of runs. This PR turns on verbose logging so we can isolate why.  Once that’s done, we can turn it off again. 

If you do see a 50 minute timeout in Travis, please capture the _complete_ log and append it here. Thanks in advance. 