### PR TITLE
Reduce Travis 50 minute timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ dist: xenial
 env:
   global:
   # false to silence most maven output; true to catch tests that do not complete
-  - PRINT_SUMMARY=true
+  - PRINT_SUMMARY=false
   - MAVEN_OPTS=-Xmx1536m
   # see http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder for valid values
   - RUN_ORDER=filesystem

--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -1144,7 +1144,7 @@ setenv JMRI_OPTIONS -Djmri.util.JUnitUtil.checkRemnantThreads=true
             proceeding.  We're not sure what the best value is; see
             <a href="https://github.com/JMRI/JMRI/issues/5321">JMRI Issue #5321</a>
             and 
-            <a> href="https://netbeans.org/bugzilla/show_bug.cgi?id=36665">NetBeans bug tracker 36665</a>
+            <a href="https://netbeans.org/bugzilla/show_bug.cgi?id=36665">NetBeans bug tracker 36665</a>
             for some background discussion. Briefly, since things like 
             flashing cursors fire Swing events,
             the queue doesn't stay idle forever once the primary work is done.

--- a/java/src/jmri/ConfigureManager.java
+++ b/java/src/jmri/ConfigureManager.java
@@ -21,9 +21,10 @@ import jmri.jmrit.XmlFile;
  * <li>"Prefs" - handled first on read, these are the general preferences
  * controlling how the program starts up
  * <li>"Config" - layout configuration information, e.g. turnout, signal, etc
+ *   - generally, all NamedBeanManagers
  * <li>"Tool" - (Not really clear yet, but present)
  * <li>"User" - typically information about panels and windows, these are
- * handled last during startup
+ * handled last during startup - all the jmri.display panel types
  * </ol>
  * <p>
  * The configuration manager is generally located through the InstanceManager.
@@ -41,7 +42,9 @@ import jmri.jmrit.XmlFile;
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
- * @author Bob Jacobsen Copyright (C) 2002
+ * @author Bob Jacobsen Copyright (C) 2002, 2010, 2017, 2020
+ * @author Matthew Harris Copyright (C) 2010, 2016
+ * @author Randall Wood Coyright (C) 2013, 2015, 2017
  * @see jmri.InstanceManager
  * @see jmri.configurexml.ConfigXmlManager
  */

--- a/java/src/jmri/configurexml/Bundle_ca.properties
+++ b/java/src/jmri/configurexml/Bundle_ca.properties
@@ -4,7 +4,7 @@
 #Translation Joan de Castro [joan276dca@yahoo.es] 20/09/2014
 # Default properties for the jmri.configurexml.SaveMenuItem
 
-MenuItemSave   = Desa
+MenuItemStore   = Desa
 
 MenuItemStoreConfig     = Desa nom\u00e9s la configuraci\u00f3 al fitxer...
 MenuItemStoreUser    = Desa la configuraci\u00f3 i els panells al fitxer ...

--- a/java/src/jmri/configurexml/Bundle_cs.properties
+++ b/java/src/jmri/configurexml/Bundle_cs.properties
@@ -4,7 +4,7 @@
 #
 # Default properties for the jmri.configurexml.SaveMenuItem
 
-MenuItemSave   = Ulo\u017eit
+MenuItemStore   = Ulo\u017eit
 
 MenuItemStoreConfig  = Ulo\u017eit pouze konfiguraci do souboru...
 MenuItemStoreUser    = Ulo\u017eit konfiguraci a panely do souboru...

--- a/java/src/jmri/configurexml/Bundle_da.properties
+++ b/java/src/jmri/configurexml/Bundle_da.properties
@@ -4,7 +4,7 @@
 # Danish translation by Sonny Hansen
 # Overrides default properties for the jmri.configurexml.SaveMenuItem with danish
 
-MenuItemSave = Gem
+MenuItemStore = Gem
 
 MenuItemStoreConfig = Gem kun Konfigurationen i fil...
 MenuItemStoreUser = Gem Konfiguration og Panel i fil...

--- a/java/src/jmri/configurexml/Bundle_de.properties
+++ b/java/src/jmri/configurexml/Bundle_de.properties
@@ -3,7 +3,7 @@
 # by Simon Ginsburg
 # German properties for the jmri.configurexml.SaveMenuItem
 
-MenuItemSave = Speichern
+MenuItemStore = Speichern
 
 MenuItemStoreConfig = Nur Konfiguration abspeichern...
 MenuItemStoreUser = Konfiguration und Gleisstellbild abspeichern...

--- a/java/src/jmri/configurexml/Bundle_es.properties
+++ b/java/src/jmri/configurexml/Bundle_es.properties
@@ -4,7 +4,7 @@
 #
 # Default properties for the jmri.configurexml.SaveMenuItem
 
-MenuItemSave = Guardar
+MenuItemStore = Guardar
 
 MenuItemStoreConfig = Guardar solo configuracion al fichero...
 MenuItemStoreUser = Guardar configuracion y paneles al fichero...

--- a/java/src/jmri/configurexml/Bundle_fr.properties
+++ b/java/src/jmri/configurexml/Bundle_fr.properties
@@ -7,7 +7,7 @@
 # Translated by Herv\u00e9 BLOREC <bzh56420@yahoo.fr> le 2013-8-19
 
 
-MenuItemSave         =  Enregistrer
+MenuItemStore         =  Enregistrer
 
 MenuItemStoreConfig  = Enregistrer la Configuration seulement dans le Fichier...
 MenuItemStoreUser    = Enregistrer la Configuration et le Panneau dans le Fichier...

--- a/java/src/jmri/configurexml/Bundle_it.properties
+++ b/java/src/jmri/configurexml/Bundle_it.properties
@@ -6,7 +6,7 @@
 #
 # Default properties for the jmri.configurexml.SaveMenuItem
 
-MenuItemSave   = Salva
+MenuItemStore   = Salva
 
 MenuItemStoreConfig = Salva Configurazione Solo su File...
 MenuItemStoreUser   = Salva Configurazione e Pannelli su File...

--- a/java/src/jmri/configurexml/Bundle_ja_JP.properties
+++ b/java/src/jmri/configurexml/Bundle_ja_JP.properties
@@ -5,7 +5,7 @@
 # Japanese properties for the jmri.configurexml.SaveMenuItem
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>
 
-MenuItemSave = \u30b9\u30c8\u30a2
+MenuItemStore = \u30b9\u30c8\u30a2
 
 MenuItemStoreConfig = \u30d1\u30cd\u30eb\u3092\u9664\u304f\u8a2d\u5b9a\u3092\u4fdd\u5b58...
 MenuItemStoreUser = \u30d1\u30cd\u30eb\u3068\u8a2d\u5b9a\u3092\u30d5\u30a1\u30a4\u30eb\u306b\u4fdd\u5b58...

--- a/java/src/jmri/configurexml/Bundle_nl.properties
+++ b/java/src/jmri/configurexml/Bundle_nl.properties
@@ -2,7 +2,7 @@
 #
 # Dutch properties for the jmri.configurexml.SaveMenuItem
 
-MenuItemSave   = Bewaar
+MenuItemStore   = Bewaar
 
 MenuItemStoreConfig  = Bewaar alleen Configuratie naar bestand...
 MenuItemStoreUser    = Bewaar Configuratie en Panelen naar bestand...

--- a/java/src/jmri/configurexml/package.html
+++ b/java/src/jmri/configurexml/package.html
@@ -76,12 +76,13 @@
             There are four levels of information, a coarse measure to ensure
             that prerequisites are present during a load:
         <UL>
-            <LI>Pref
-            <LI>Config
-            <LI>Tool
-            <LI>User
+            <LI>Pref - program-level preferences
+            <LI>Config - NamedBeanManagers
+            <LI>Tool - not used
+            <LI>User - panels
         </UL>
-        
+            The level is specified via the call used when registering
+            with the {@link jmri.ConfigureManager}.
         <P>
             Additionally, the {@link jmri.Manager} class has a 
             {@link jmri.Manager#getXMLOrder} method that 

--- a/java/src/jmri/jmrit/display/controlPanelEditor/EditPortalDirection.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/EditPortalDirection.java
@@ -37,6 +37,10 @@ public class EditPortalDirection extends EditFrame implements ActionListener, Li
     public EditPortalDirection(String title, CircuitBuilder parent, OBlock block) {
         super(title, parent, block);
         pack();
+        contructorChecks(title, parent, block);
+    }
+
+    protected void contructorChecks(String title, CircuitBuilder parent, OBlock block) {
         String msg = _parent.checkForPortals(block, "DirectionArrow");
         if (msg == null) {
             msg = _parent.checkForPortalIcons(block, "DirectionArrow");
@@ -47,7 +51,7 @@ public class EditPortalDirection extends EditFrame implements ActionListener, Li
             _canEdit = false;
         }
     }
-
+    
     private JPanel makeArrowPanel() {
         JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalDirectionTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalDirectionTest.java
@@ -11,6 +11,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JDialogOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
@@ -24,8 +25,10 @@ public class EditPortalDirectionTest {
     OBlockManager blkMgr;
 
     @Test
-    public void testCTor() {
+    public void testSetup() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        
         ControlPanelEditor frame = new ControlPanelEditor("EditPortalDirectionTest");
         frame.makeCircuitMenu(true);
         CircuitBuilder cb = frame.getCircuitBuilder();
@@ -45,6 +48,24 @@ public class EditPortalDirectionTest {
         JUnitUtil.dispose(dFrame);
     }
 
+    @Test
+    public void testPart() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
+        ControlPanelEditor frame = new ControlPanelEditor("EditPortalDirectionTest");
+        frame.makeCircuitMenu(true);
+        CircuitBuilder cb = frame.getCircuitBuilder();
+        OBlock ob1 = blkMgr.createNewOBlock("OB1", "a");
+
+        EditPortalDirection dFrame = new EditPortalDirection("Edit Direction Arrows", cb, ob1){
+            protected void contructorChecks(String title, CircuitBuilder parent, OBlock block) {}
+        };
+        Assert.assertNotNull("exists", dFrame);
+        
+        JUnitUtil.dispose(frame);
+        JUnitUtil.dispose(dFrame);
+    }
+    
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest.xml
@@ -9,6 +9,12 @@
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
+    <sensor inverted="false">
+      <systemName>IS1</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS2</systemName>
+    </sensor>
     <sensor systemName="ISCLOCKRUNNING" inverted="false">
       <systemName>ISCLOCKRUNNING</systemName>
     </sensor>

--- a/java/test/jmri/jmrit/display/layoutEditor/loadref/LayoutEditorTest.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/loadref/LayoutEditorTest.xml
@@ -10,6 +10,12 @@
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor inverted="false">
+      <systemName>IS1</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS2</systemName>
+    </sensor>
+    <sensor inverted="false">
       <systemName>ISCLOCKRUNNING</systemName>
     </sensor>
   </sensors>

--- a/java/test/jmri/jmrit/operations/setup/OperationsSetupFrameTest.java
+++ b/java/test/jmri/jmrit/operations/setup/OperationsSetupFrameTest.java
@@ -33,8 +33,10 @@ public class OperationsSetupFrameTest extends OperationsTestCase {
 
     @Test
     public void testDirectionCheckBoxes() {
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         // it may be possible to make this a headless test by only initializing the panel, not the frame
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
         OperationsSetupFrame f = new OperationsSetupFrame();
         f.setLocation(0, 0); // entire panel must be visible for tests to work properly
         f.initComponents();


### PR DESCRIPTION
 - move EditPortalDirection test to separate running for intermittent tests
 - operations/setup/OperationsSetupFrameTest moved to separate running

Plus a couple things noticed in passing:
 - fix typo in Unit docs
 - I18N update
 - small doc and copyright updates
 - small refactor of EditPortalDirection to ease testing
 - update layoutEditor/loadref/LayoutEditorTest.xml to reduce spurious fails
