### PR TITLE
Improve Sidebar.shtml on Digitrax/LocoNet hardware page

### DIFF
--- a/help/en/html/hardware/loconet/Sidebar.shtml
+++ b/help/en/html/hardware/loconet/Sidebar.shtml
@@ -17,6 +17,7 @@
                     <ul>
                         <li><a href="DCS52.shtml">DCS52</a></li>
                         <li><a href="DCS240.shtml">DCS240</a></li>
+                        <li><a href="Digitrax.shtml#Setup">Other Command Stations</a></li>
                         <li><a href="CommandStationConfig.shtml">OpSw Configuration</a></li>
                     </ul>
                     <li>Programmers &amp; Adapters</li>

--- a/java/src/jmri/jmrix/loconet/LnConstants.java
+++ b/java/src/jmri/jmrix/loconet/LnConstants.java
@@ -368,10 +368,8 @@ public final class LnConstants {
     public final static int OPC_ALM_READ = 0xe6; // Undocumented name
     public final static int OPC_SL_RD_DATA = 0xe7;
     public final static int OPC_IMM_PACKET = 0xed;
-    //TODO Conflicts with OPC_EXP_WR_SL_DATA - or maybe length?
     public final static int OPC_IMM_PACKET_2 = 0xee;
     public final static int OPC_WR_SL_DATA = 0xef;
-    //TODO Conflicts with OPC_EXP_WR_SL_DATA - or maybe length?
     public final static int OPC_ALM_WRITE = 0xee; // Undocumented name
     public final static int OPC_MASK = 0x7f;  /* mask for acknowledge opcodes */
 


### PR DESCRIPTION
Current Sidebar shows two command stations.  Added link for "other command stations" (i.e. the ones which do not have integrated USB connectors).