### PR TITLE
Page on example use of XSL to generate decoder xml contents.

### DIFF
--- a/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
+++ b/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
@@ -1275,7 +1275,13 @@ means that it doesn't.
       number is too low. Note that initially, before the values are
       read from the decoder, this display will depend on the
       default value from the file, which might be misleading to the
-      user.</p><!--#include virtual="/Footer.shtml" -->
+      user.</p>
+      <h3>Using XSL transformations</h3>
+      <p>
+          It is possible to generate complex, repeated decoder XML parts using XSL stylesheets.
+          For more information, please see <a href="TransformDecoder.shtml">Use XSLT Transformation for complex decoders</a>.
+      </p>
+      <!--#include virtual="/Footer" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->
 </body>

--- a/help/en/html/apps/DecoderPro/TransformDecoder.shtml
+++ b/help/en/html/apps/DecoderPro/TransformDecoder.shtml
@@ -358,7 +358,7 @@ xsltproc scom.xsl decoder-template.xml > decoder-gen.xml
       </p>
       <pre>
 &lt;xsl:template match="variables">
-    <variables>
+    &lt;variables>
       &lt;xsl:copy-of select="node()"/>
       &lt;!-- call-template instructions, that generate the content; example follows -->
       &lt;xsl:call-template name="generate-masts">

--- a/help/en/html/apps/DecoderPro/TransformDecoder.shtml
+++ b/help/en/html/apps/DecoderPro/TransformDecoder.shtml
@@ -1,0 +1,402 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+"http://www.w3.org/TR/html4/strict.dtd">
+
+<html lang="en">
+<head>
+  <!-- Copyright Bob Jacobsen 2008 -->
+
+  <title>JMRI: DecoderPro User Guide - Use XSLT Transformation for complex decoders
+  File</title>
+  <!-- Style -->
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=us-ascii">
+  <link rel="stylesheet" type="text/css" href="/css/default.css"
+  media="screen">
+  <link rel="stylesheet" type="text/css" href="/css/print.css"
+  media="print">
+  <link rel="icon" href="/images/jmri.ico" type="image/png">
+  <link rel="home" title="Home" href="/">
+  <!-- /Style -->
+</head>
+
+<body>
+  <!--#include virtual="/Header" -->
+  <div id="mBody">
+    <!--#include virtual="Sidebar.shtml" -->
+    <div id="mainContent">
+
+    <h1>JMRI: DecoderPro User Guide</h1>
+
+      <h2>Use XSLT Transformation for complex decoders</h2>
+
+      <p>
+          Some decoders contain <b>repeated blocks</b> of CVs, for example to
+          define behaviour of several accessories, each controlled by multiple
+          CVs. An advanced turnout decoder may for example define multiple paths,
+          each containing several turnouts and their desired position to form
+          the travel path on the layout.
+      </p>
+      <p>
+          Although the decoder file must define dozens or even hundreds of CVs
+          and their appearance on panes in total, only a fraction of the CVs or
+          displays are actually unique: the rest can be <b>generated from a template</b>.
+          While creating template, and the transformation recipe is <b>a lot more complex</b>
+          than copy-pasting CV definitions, the benefit is <b>a lot easier maintenance</b>
+          once the hard part is done: each change propagates consistently to
+          all generated parts.
+      </p>
+      <p>
+          To give some example of simplification possible - let's take the decoder file
+          <code>Public_Domain_dccdoma_ARD_SCOM_MX.xm</code>. It configures a decoder, capable
+          of displaying signal aspects on several signal masts. The configuration contains
+          over 500 of CVs - yet the basic idea behind the configuration is dead simple:
+     </p>
+          <ul>
+            <li>a default aspect for each signal mast</li>
+            <li>for each signal mast AND for each one of 32 possible aspects, the number of signal to be displayed, 
+                interpreted by the decoder itself</li>
+          </ul>
+     <p>
+          A few statistics:
+     </p>
+          <ul>
+              <li>original decoder's definition: <b>870 kByte</b> 20608 lines.</li>
+              <li>stylesheet file: <b>12 kByte</b>, 257 lines.</li>
+              <li>decoder file template: <b>18 kByte</b>, 390 lines.</li>
+          </ul>
+     <p>
+          For JMRI itself or the speed of DecoderPro operation, these two approaches are the same: the file template
+          is internally transformed (expanded) to the decode definition XML and processed as if it was written
+          entirely by hand. For <b>maintenance</b>, it is a way easier to maintain ~600 lines of XML than 20600.
+     </p>
+     <p>
+          JMRI provides an option to apply a <b>XSLT stylesheet</b> to a decoder file,
+          <b>before</b> the file is loaded into DecoderPro and before it is interpreted
+          as CV variables and panels. This allows to hand-write unique CV definitions
+          and their panes, and <b>add generated</b> content where appropriate. 
+      </p>
+      <h2>
+          Example files
+      </h2>
+      <p>
+          To illustrate the techniques described here, a few example files are provided; all the files are licensed under
+          GNU GPL.
+      </p>
+      <ul>
+          <li><b><a href="resources/decoder-template.xml">decoder-template.xml</a></b> - the decoder definition <b>template</b> 
+          <li><b><a href="resources/scom.xsl">scom.xsl</a></b> - the stylesheet</li>
+      </ul>
+      <p>
+          The decoder template should be placed into the <b>xml/decoders</b> folder of the JMRI installation. It is <b>based on Petr Sidlo's
+          dccdoma.cz - ARD-SCOM-MX decoder</b> - generates the same decoder panels as the original one (as of 12/2019). The stylesheet
+          (<b>scom.xsl</b>) should be placed also into <b><code>xml/decoder</code></b> folder of the JMRI installation.
+      </p>
+      <p>
+          The template can be processed from the commandline to generate the decoder XML, so you can inspect effects of changing the
+          stylesheet and/or data embedded in the decoder template. The commandline for Linux:
+      </p>
+      <pre>
+xsltproc scom.xsl decoder-template.xml > decoder-gen.xml
+      </pre>
+      <p>
+          Remember to replace the files with their actual names or locations; for experimenting from the commandline, 
+          the best is to place the decoder file template AND its stylesheet to some directory and work in there.
+          Later, move the stylesheet and the template to the folders as described above.
+      </p>
+      <h2>
+          Apply stylesheet to the decoder file.
+      </h2>
+      <p>
+          An <b>instruction to process the file as a template</b> must be present in the file, in order to act like a template. Otherwise
+          JMRI would pick it as just "ordinary" decoder definition - all the display items (see below) "misused" to hold data for template processing
+          would appear in the UI !
+      </p>
+      <p>
+          The processing instruction must appear at the start of the decoder definition:
+      </p>
+      <pre>
+&lt;?transform-xslt href="http://jmri.org/xml/decoders/scom.xsl"?>
+      </pre>
+      <p>
+          So the decoder template's header would look like:
+      </p>
+      <pre>
+&lt;?xml version="1.0" encoding="utf-8"?>
+&lt;?transform-xslt href="http://jmri.org/xml/decoders/scom.xsl"?>
+&lt;decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" showEmptyPanes="no" >
+
+    &lt;decoder>
+...
+      </pre>
+      <h2>
+          Provide metadata to the stylesheet
+      </h2>
+      <p>
+          One of the critical points is how to generate CV numbers or other variable
+          parts: XSLT language provides simple numeric computation, but more sophisticated
+          functions are typically not accessible (by default). Some generated content is
+          composed from a list of strings (i.e. signal aspect names are repeated for
+          each signal masts), and we have to provide such input to the stylesheet. 
+          The decoder file is <b>the only input</b> provided for the stylesheet by the
+          JMRI framework.
+      </p>
+      <p>
+          The decoder template file is <b>still interpreted as a decoder definition</b> and must
+          adhere strictly to the <code>decoder.xsd</code> XML schema. For parts that we want 
+          to generate from the template, the prescribed elements have to be <b>carefully misused</b> to provide
+      </p>
+        <ul>
+            <li>anchor points, where the generated content will be inserted</li>
+            <li>input data for the stylesheet</li>
+        </ul>
+      <p>
+        There is a number of ways how to approach the problem, I will present a way I see as more or less clean
+        (although it misuses elements to provide data different than they formally should !). The guide should
+        be seen as a recommendation to keep the generated decoders somewhat consistent. Please <b>do not hesitate
+        to contribute and provide simpler approaches</b>.
+      </p>
+      <h3>Adding Variables</h3>
+      <p>
+        Just adding variables is simple, and requires <b>no extra placeholder</b> in the decoder file. However, the
+        <b><code>&lt;variables></code></b> element must be present, so the technique described below for generating variables works.
+        The element could look like this example:
+      </p>
+      <pre>
+        &lt;variables>
+          &lt;variable CV="1" item="Short Address" default="100" >
+            &lt;splitVal highCV="9" upperMask="XXXXXVVV" factor="1" offset="0" />
+            &lt;label>Decoder Address:&lt;/label>
+            &lt;tooltip>Accessory decoder address. CV1 - LSB. CV9 - MSB.&lt;/tooltip>
+          &lt;/variable>
+        &lt;/variables>
+      </pre>
+      <p>
+          Additional generated content will be <b>appended</b> inside that element. 
+      </p>
+      <h3>Data holder pane</h3>
+      <p>
+          While <b><code>variable</code></b> element's definition is rather strict, UI definitions seems most relaxed, so we 
+          abuse them. The following section describes some typical kind of data, how they can be <b>represented</b> in decoder 
+          template file, so the text conforms to the mandatory <code>decoder.xsd</code> rules. And finally how they can be
+          <b>accessed</b> from the stylesheet.
+      </p>
+      <p>
+          <b>All the data</b> (not UI panel definitions) will be placed in a <b>single &lt;pane> element</b>. All panes must be named -
+          the name can be arbitrary, but should be <b>unique</b> so a system-defined pane or a custom <b>real</b> pane is not replaced
+          accidentally. In our example, <b>__Aspects</b> name is used. I recommend to prefix the panel name with two underscores. The
+          pane's name <b>must be used</b> in selectors - so if you invent your own name, replace the text in examples with whatever
+          name you choose.
+      </p>
+      <h4>
+          Passing root of the data
+      </h4>
+      <p>
+          Each time, a value needs to be read by the stylesheet, it must be <b>selected</b> by an XPath expression. For example:          
+      </p>
+      <pre>
+&lt;xsl:template name="generate-masts">
+      &lt;xsl:variable name="cvStart" select="string(//pane[name/text() ='__Aspects']/display[@item='mastcount']/@tooltip)"/>
+      &lt;xsl:variable name="outputs" select="string(//pane[name/text() ='__Aspects']/display[@item='outputs']/@label)"/>
+      &lt;xsl:for-each select="//pane[name/text() ='__Aspects']/display[@item='masts']/label">
+          ...
+      &lt;/xsl:for-each>
+&lt;/xsl:template>
+      </pre>
+      <p>
+          The selector always contains the common prefix part, which finds the "data holder" pane within the decoder template file.
+          We can save the typing by passing that element as a <b>parameter</b>:
+      </p>
+      <pre>
+&lt;xsl:template name="generate-masts">
+      &lt;xsl:param name="root"/>
+      &lt;xsl:variable name="cvStart" select="string($root/display[@item='mastcount']/@tooltip)"/>
+      &lt;xsl:variable name="outputs" select="string($root/display[@item='outputs']/@label)"/>
+      &lt;xsl:for-each select="$root/display[@item='masts']/label">
+          ...
+      &lt;/xsl:for-each>
+&lt;/xsl:template>
+      </pre>
+      <p>
+          The invocation of such a generating template <b>must pass the parameter</b>:
+      </p>
+      <pre>
+&lt;xsl:call-template name="generate-masts">
+      &lt;xsl:with-param name="root" select="//pane[name/text() ='__Aspects']//display[position() = 1]/.."/>
+&lt;/xsl:call-template> 
+      </pre>
+      <p>
+      Note the strange suffix. This is because the display items can not be nested directly in the <b>pane</b> element, they have
+      to be in some kind of column, row, group etc. The strange selector at the end will find <b>first nested display element</b> and
+      will take its <b>parent element</b> as the data root.
+      </p>
+      <p>
+          A <b>global variable</b> can be defined in a similar way - place this element directly as top-level element in the
+          stylesheet:
+      </p>
+      <pre>
+&lt;xsl:variable name="root" select="//pane[name/text() ='__Aspects']//display[position() = 1]/.."/>          
+      </pre>
+      <p>
+          The templates can now reference the root of data by just <b>$root</b> expression.
+      </p>
+      <h4>
+          Constants, max/min values, single values
+      </h4>
+      <p>
+        A constant can be used, e.g. as a maximum count of items, specific CV number, ... I recommend to use <b>display</b> element
+        to define a constant. That element has two free-form attributes: <b>label</b> and <b>tooltip</b>. So we can define actually
+        two constants in a single element ! This can be useful, if there are values closely tied together, for example. Constants, that
+        define maximum number of aspects handled by the UI and starting CV can be written as:
+      </p>
+      <pre>
+&lt;display item="mastcount" label="15" tooltip="128"/>
+      </pre>
+      <p>
+          The "<b>mastcount</b>" is an arbitrary (but unique) name. Name it so after the value's meaning to your decoder.
+          It will be used in <i>selectors</i> to access the value like this:
+      </p>
+      <pre>
+&lt;xsl:variable name="cvStart" select="string($root/display[@item='mastcount']/@tooltip)"/>          
+      </pre>
+      <ul>
+          <li><b>$root</b> is the parameter / variable that contains root of the data.</li>
+          <li><b>mastcount</b> is the name of the <b>display</b> element - your value.</li>
+          <li><b>@tooltip</b> means that the selector will read the <b>tooltip</b> attribute. You may use @label to access the othe one.
+      </ul>
+      
+      <h4>
+          Enumerations, sequences, lists
+      </h4>
+      <p>
+          Sometimes a CV (variable, display item) should be generated for e.g. each output idenfied by a name, or number. The list can be coded
+          as a series of <b>&lt;label></b> sub-elements of a <b>&lt;display></b> element:
+      </p>
+      <pre>
+&lt;display item="masts" tooltip="512">
+    &lt;label>0&lt;/label>&lt;label>1&lt;/label>&lt;label>2&lt;/label>&lt;label>3&lt;/label>&lt;label>4&lt;/label>&lt;label>5&lt;/label>&lt;label>6&lt;/label>&lt;label>7&lt;/label>
+    &lt;label>8&lt;/label>&lt;label>9&lt;/label>&lt;label>10&lt;/label>&lt;label>11&lt;/label>&lt;label>12&lt;/label>&lt;label>13&lt;/label>&lt;label>14&lt;/label>&lt;label>15&lt;/label>
+&lt;/display>
+      </pre>
+      <p>
+          We then may either iterate those items one by one, or access them by index/position as needed. The following examples selects the
+          <b>masts</b> data item under the data root (see above for data root). For <b>each of the items</b> it calls another template 
+          (not shown here), and passes the item's value (encoded into the label element content) to the template as <b>mast</b> parameter:
+      </p>
+      <pre>
+&lt;xsl:template name="generate-panes">
+    &lt;xsl:param name="root"/>
+
+    &lt;xsl:for-each select="$root/display[@item='masts']/label">
+        &lt;xsl:variable name="mast" select="string(./text())"/>
+        &lt;xsl:call-template name="mast-pane">
+            &lt;xsl:with-param name="root" select="$root"/>
+            &lt;xsl:with-param name="mast" select="$mast"/>
+        &lt;/xsl:call-template>
+    &lt;/xsl:for-each>
+&lt;/xsl:template>    
+      </pre>
+      <p>
+          Note, that element <b>content</b> is used as a value here - this allows to use all awkward characters like quotes, doublequotes,
+          ">" and other chars not permitted in attributes.
+      </p>
+      <p>
+          Individual items may be accessed by their index (which is passed as a parameter):
+      </p>
+      <pre>
+&lt;xsl:template name="generate-one-panes">
+    &lt;xsl:param name="root"/>
+    &lt;xsl:param name="index"/>
+
+    &lt;xsl:variable name="mast" select="string($root/display[@item='masts']/label[position() = $index]/text())"/>
+    &lt;xsl:call-template name="mast-pane">
+        &lt;xsl:with-param name="root" select="$root"/>
+        &lt;xsl:with-param name="mast" select="$mast"/>
+    &lt;/xsl:call-template>
+&lt;/xsl:template>    
+      </pre>
+      <h2>
+          Creating the stylesheet
+      </h2>
+      <h3>
+          A boilerplate
+      </h3>
+      <p>
+          The template is likely to have some boilerplate instructions. The following declarations should be at the top,
+          defining how output will be generated:
+      </p>
+      <pre>
+&lt;?xml version="1.0" encoding="utf-8"?>
+&lt;xsl:stylesheet	version="1.0" 
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:db="http://docbook.org/ns/docbook"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+
+    exclude-result-prefixes="db">
+
+
+    &lt;xsl:output method="xml" encoding="utf-8" indent="yes"/>
+    &lt;xsl:strip-space elements=""/>
+    &lt;xsl:preserve-space elements="text"/>
+&lt;/xsl:stylesheet>
+      </pre>
+      <p>
+          The following will <b>copy elements, and
+          their attributes</b> to the output:
+      </p>
+      <pre>
+&lt;xsl:template match="@*|node()">
+    &lt;xsl:copy>
+        &lt;xsl:apply-templates select="@*|node()"/>
+    &lt;/xsl:copy>
+&lt;/xsl:template>
+      </pre>
+      <h3>Generating content to the insertion points</h3>
+      <p>
+          Variable definitions are usually generated by the stylesheet. Basic and fixed variables should be provided, as usual,
+          in the <code>&lt;variables></code> element. The stylesheet can then <b>append generated variables</b> at the end:
+      </p>
+      <pre>
+&lt;xsl:template match="variables">
+    <variables>
+      &lt;xsl:copy-of select="node()"/>
+      &lt;!-- call-template instructions, that generate the content; example follows -->
+      &lt;xsl:call-template name="generate-masts">
+            &lt;xsl:with-param name="root" select="//pane[name/text() ='__Aspects']//display[position() = 1]/.."/>
+      &lt;/xsl:call-template> 
+
+      &lt;xsl:call-template name="generate-aspects">
+            &lt;xsl:with-param name="root" select="//pane[name/text() ='__Aspects']//display[position() = 1]/.."/>
+      &lt;/xsl:call-template> 
+    &lt;/variables>
+&lt;/xsl:template>
+      </pre>
+      <p>
+          Note that, in this example, the <code>pane</code> element with a special name (<code>__Aspects</code>) is used as a
+          holder for input data for generation. While <code>//pane[name/text() == '__Aspects']</code> selects the data holder, the
+          <code>//display[position() = 1]/..</code> selects an element <b>within</b> the holder pane XML element. <b>Pay attention to 
+          typos</b> in the strings, otherwise the select clauses select empty data, and nothing - or invalid content - will be generated.
+      </p>
+      <p>
+          For <b>UI Panels</b> I recommend to <b>replace</b> the data holder with the sequence of generated panels. In my example,
+          data is provided from panel named <b>__Aspects</b>, which we definitely <b>do not want</b> to be displayed in DecoderPro as
+          it ... isn't any UI panel, after all. The following will <b>replace</b> the data holder (a top-level Pane) with panels 
+          generated by the stylesheet:
+      </p>
+          <pre>
+&lt;xsl:template match="pane[name='__Aspects']" priority="100">
+    &lt;!-- call-template instructions for individual groups of panels to be generated; example follows -->
+    &lt;xsl:call-template name="generate-panes">
+            &lt;xsl:with-param name="root" select="//pane[name/text() ='__Aspects']//display[position() = 1]/.."/>
+    &lt;/xsl:call-template> 
+&lt;/xsl:template>
+          </pre>
+      <p>
+          The <code>match</code> clause will react on the <code>__Aspect</code> data holder pane element, but unlike the variables
+          insertion point, <b>no copy instruction is present</b>. So the old content will be thrown away (entire <code>&lt;pane></code> element!), 
+          replaced by whatever elements the <code>call-template</code> instructions generate.
+      </p>
+      </div><!-- close #mainContent -->
+    </div><!-- close #mBody -->
+</body>
+</html>

--- a/help/en/html/apps/DecoderPro/TransformDecoder.shtml
+++ b/help/en/html/apps/DecoderPro/TransformDecoder.shtml
@@ -315,6 +315,73 @@ xsltproc scom.xsl decoder-template.xml > decoder-gen.xml
     &lt;/xsl:call-template>
 &lt;/xsl:template>    
       </pre>
+      <p>
+          You can easily use the above label list to make a loop from 1 to 15, which directly not possible in XSLT. Instead of controlling the
+          loop by a <i>control index variable</i>, we control the loop by <i>the data that should apply in individual cycle iterations</i> and
+          derive the index variable from them. Here's the modified example:
+      </p>
+      <pre>
+&lt;xsl:template name="generate-panes">
+    &lt;xsl:param name="root"/>
+    <b>&lt;-- The loop count is controlled by the number of <i>label</i> variables --></b>
+    &lt;xsl:for-each select="$root/display[@item='masts']/label">
+        &lt;xsl:variable name="mast" select="string(./text())"/>
+        &lt;xsl:call-template name="mast-pane">
+            &lt;xsl:with-param name="root" select="$root"/>
+            &lt;xsl:with-param name="mast" select="$mast"/>
+            <b>&lt;-- We use the current label's element <i>position</i> to derive the
+               "loop control variable" value --></b>
+            &lt;xsl:with-param name="index" select="./position()"/>
+        &lt;/xsl:call-template>
+    &lt;/xsl:for-each>
+&lt;/xsl:template>    
+      </pre>
+      <h3>
+          Cycles and loops
+      </h3>
+      <p>
+          XSLT language is a declarative one, and variables, once assigned, cannot be changed - so it does not have a <b>loop construct</b> as
+          most programmig languages do. Sometimes, a cycle can be more illustratively replaced by iteration over the content. Sometimes it is
+          not possible: truly some fixed number of iterations need to be done, such as <b>generating sequential CVs</b> with the same structure -
+          just the sequence number and the represented function index will differ.
+      </p>
+      <p>
+          This can be done by <b>tail recursion</b>, which replaces loops by invoking a template from that template itself. The only caveat is 
+          that the number of iterations is <b>limited</b> to about 100 (?), before the stack space is exhausted. The example can be found in
+          <code><a href="https://github.com/JMRI/JMRI/blob/master/xml/decoders/TamValleyDepot_QuadLn_S_11.xsl">TamsValleyDepot_QuadLn_s_11.xsl</a></code>, 
+          look for template <code>AllLEDGroups</code>:
+      </p>
+      <pre>
+&lt;xsl:template name="AllLEDGroups">
+  <b>&lt;-- Use <i>select=""</i> attribute to pick an initial value for the cycle.
+      Applies if the template does not get parameter on (first) invocation --></b>
+  &lt;xsl:param name="CV1" select="633"/>
+  &lt;xsl:param name="CV2" select="513"/>
+  &lt;xsl:param name="CV3" select="537"/>
+  <b>&lt;-- This is the loop's control variable --></b>
+  &lt;xsl:param name="index" select="1"/>
+  <b>&lt;!-- next line controls count --></b>
+  &lt;xsl:if test="24 >= $index">
+    &lt;xsl:call-template name="OneLEDGroup">
+      &lt;xsl:with-param name="CV1" select="$CV1"/>
+      &lt;xsl:with-param name="CV2" select="$CV2"/>
+      &lt;xsl:with-param name="CV3" select="$CV3"/>
+      &lt;xsl:with-param name="index" select="$index"/>
+    &lt;/xsl:call-template>
+    &lt;!-- iterate until done -->
+    <b>&lt;-- The <i>if</i> a few lines above makes sure, this <i>call-template</i>
+        will not be executed for i > 24 --></b>
+    &lt;xsl:call-template name="AllLEDGroups">
+      &lt;xsl:with-param name="CV1" select="$CV1 +1"/>
+      &lt;xsl:with-param name="CV2" select="$CV2 +1"/>
+      &lt;xsl:with-param name="CV3" select="$CV3 +2"/>
+      <b>&lt;-- Call itself, but with control variable one higher, therefore counting
+          the number of cycles--></b>
+      &lt;xsl:with-param name="index" select="$index+1"/>
+    &lt;/xsl:call-template>
+  &lt;/xsl:if>
+&lt;/xsl:template>
+      </pre>
       <h2>
           Creating the stylesheet
       </h2>
@@ -395,6 +462,42 @@ xsltproc scom.xsl decoder-template.xml > decoder-gen.xml
           The <code>match</code> clause will react on the <code>__Aspect</code> data holder pane element, but unlike the variables
           insertion point, <b>no copy instruction is present</b>. So the old content will be thrown away (entire <code>&lt;pane></code> element!), 
           replaced by whatever elements the <code>call-template</code> instructions generate.
+      </p>
+      <h2>
+          Using XML fragments
+      </h2>
+      <p>
+          If part of the generated content <b>does not change</b> from place to place, it is possible to prepare it as a <b>XML fragment</b> to
+          be included: it won't be a part of XSL stylesheet with all those strange <i>xsl:xxx</i> instructions, but will stored as a separate,
+          small and clean bit of XML. This can be useful for <b>choice values</b>, or even repeated <b>UI panels</b> without variable content.
+          An example of the usage is again in <code><a href="https://github.com/JMRI/JMRI/blob/master/xml/decoders/TamValleyDepot_QuadLn_S_11.xsl">TamsValleyDepot_QuadLn_s_11.xsl</a></code>.
+          (LedPaneHeader) 
+      </p>
+      <p>
+          Individual variables are generates using <i>xsl:template</i>, but the value part, mostly a <i>choice</i> is included from a separate file. Note
+          that the <i>xi:include</i> will be generated into the resulting XML, so it is the DecoderPro  panel reader, who does the content inclusion,
+          not the generator. The template subsitutes the variable parts of the definition:
+      </p>
+      <pre>
+&lt;variable item="Aspect{$index} LED1 Out" CV="{$CV2}" mask="XXXVVVVV" default="0">
+    &lt;xi:include href="http://jmri.org/xml/decoders/tvd/LedOutput.xml"/>
+&lt;/variable>
+      </pre>
+      <p>
+          There are two important things. When using <i>xi:</i> prefix, that <b>prefix must be declared</b> at the top of the document (may be in any parent element,
+          but conventionally prefixes are collected at the start). Use exactly the same URL (attribute value), otherwise the instruction won't be recognized.
+      </p>
+      <pre>
+&lt;xsl:stylesheet	version="1.0" 
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:db="http://docbook.org/ns/docbook"
+    xmlns:xi="http://www.w3.org/2001/XInclude"      <b>-- this is the prefix declaration</b>
+    >
+      </pre>
+      <p>
+          The second issue is that the <i>xi:include</i> must use URLs that JMRI is able to <b>resolve locally</b>. Otherwise, the DecoderPro would attempt to download
+          parts of the definition from the Internet, which requires an online connection - and is slow. The prefix <b>http://jmri.org/xml</b> is guaranteed to resolve
+          to the <b>xml</b> directory of your local JMRI installation. For more mapping, please see other JMRI documentation.
       </p>
       </div><!-- close #mainContent -->
     </div><!-- close #mBody -->

--- a/help/en/html/apps/DecoderPro/resources/decoder-template.xml
+++ b/help/en/html/apps/DecoderPro/resources/decoder-template.xml
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?transform-xslt href="http://jmri.org/xml/decoders/scom.xsl"?>
+<!-- Copyright (C) JMRI 2002, 2004, 2020 All rights reserved -->
+<!-- $Id$ -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" showEmptyPanes="no" >
+    <version author="Petr Šídlo sidlo64@hotmail.com" version="1" lastUpdated="20181201"/>
+    <version author="Petr Šídlo sidlo64@hotmail.com" version="2" lastUpdated="20190220"/>
+    <version author="Petr Šídlo sidlo64@hotmail.com" version="3" lastUpdated="20190305"/>
+    <version author="Svata Dedic svatopluk.dedic@gmail.com" version="4" lastUpdated="20191211"/>
+    <!-- Accessory decoder  -->
+    <!-- Description of circuit diagram https://sites.google.com/site/sidloweb/elektrika/22-uni16ard -->
+    <!-- Program description https://sites.google.com/site/sidloweb/elektrika/29-ard-scom-mx -->
+    <!-- e-shop http://dccdoma.eshop-zdarma.cz/ -->
+    
+    <decoder>
+
+        <family name="dccdoma.cz" mfg="Public-domain and DIY" >
+            <model model="XSL - ARD-SCOM-MX" lowVersionID="10" highVersionID="19" productID="16843265" maxInputVolts="24V AC" maxTotalCurrent="0.2A peak 3.3A" numOuts="16" connector="other" />
+        </family>
+    
+        <programming direct="yes" paged="yes" register="no" ops="no" />
+        
+    <variables>
+    	
+      <variable CV="1" item="Short Address" default="100" >
+        <splitVal highCV="9" upperMask="XXXXXVVV" factor="1" offset="0" />
+        <label>Decoder Address:</label>
+        <label xml:lang="cs">Adresa dekodéru:</label>
+        <tooltip>Accessory decoder address. CV1 - LSB. CV9 - MSB.</tooltip>
+        <tooltip xml:lang="cs">Adresa dekodéru příslušenství. CV1 - LSB. CV9 - MSB.</tooltip>
+      </variable>
+
+      <variable CV="7" item="Decoder Version" readOnly="yes" >
+        <decVal/>
+        <label>Decoder Version:</label>
+        <label xml:lang="cs">Verze software:</label>
+      </variable>
+      
+      <variable CV="8" item="Manufacturer" readOnly="yes" default="13" >
+        <decVal/>
+        <label>Manufacturer:</label>
+        <label xml:lang="cs">Výrobce ID:</label>
+      </variable>
+    
+      <variable CV="15" item="Key" default="0">
+        <decVal/>
+        <label>Key:</label>
+        <label xml:lang="cs">Klíč:</label>
+        <tooltip>Key for lock. Universal key is 255.</tooltip>
+        <tooltip xml:lang="cs">Klíč k zámku. Univerzální klíč je 255.</tooltip>
+      </variable>
+    
+      <variable CV="16" item="Lock" default="0">
+        <decVal/>
+        <label>Lock:</label>
+        <label xml:lang="cs">Zámek:</label>
+        <tooltip>Value other than 0 lock the decoder.</tooltip>
+        <tooltip xml:lang="cs">Jiná hodnota než 0 zamkne dekodér.</tooltip>
+      </variable>
+    
+      <variable CV="34" item="Addressing" default="1">
+      	<enumVal>
+      		<enumChoice choice="NMRA"/>
+      		<enumChoice choice="ROCO"/>
+      	</enumVal>
+        <label>Addressing:</label>
+        <label xml:lang="cs">Adresování:</label>
+        <tooltip>ROCO addressing is NMRA addressing + 4.</tooltip>
+        <tooltip xml:lang="cs">ROCO adresování je NMRA adresování + 4.</tooltip>
+      </variable>
+    
+      <variable CV="41" item="Aspect lag" default="4" >
+        <decVal min="0" max="255" />
+        <label>Aspect lag:</label>
+        <label xml:lang="cs">Zpoždění návěsti:</label>
+        <tooltip>Signal delay after the last command. lag × 0.128 s</tooltip>
+        <tooltip xml:lang="cs">Zpoždění zobrazení návěsti po poslením příkazu. zpoždění × 0,128 s</tooltip>
+      </variable>
+        
+      <variable CV="42" item="Bit period" default="20" >
+        <decVal min="4" max="30" />
+        <label>Bit period:</label>
+        <label xml:lang="cs">Perioda bitu:</label>
+        <tooltip>Length of bit period in ms.</tooltip>
+        <tooltip xml:lang="cs">Délka periody bitu v ms.</tooltip>
+      </variable>
+        
+      <variable CV="43" item="Start delay" default="24" >
+        <decVal min="0" max="255" />
+        <label>Star delay:</label>
+        <label xml:lang="cs">Zpoždění startu:</label>
+        <tooltip>Delay of decoder after switching on. delay × 0.128 s</tooltip>
+        <tooltip xml:lang="cs">Zpoždění zahájení činnosti dekodéru po zapnutí. zpoždění × 0,128 s</tooltip>
+      </variable>
+        
+      <variable CV="44" item="Address order" default="0">
+      	<enumVal>
+            <enumChoice choice="All successively" value="0" >
+                <choice xml:lang="cs">Všechny postupně</choice>
+            </enumChoice>
+            <enumChoice choice="Only even" value="1" >
+                <choice xml:lang="cs">Pouze sudé</choice>
+            </enumChoice>
+      	</enumVal>
+        <label>Address order:</label>
+        <label xml:lang="cs">Pořadí adres:</label>
+        <tooltip>Use all addresses sequentially or only even.</tooltip>
+        <tooltip xml:lang="cs">Použití všech adres postupně nebo pouze sudé.</tooltip>
+      </variable>
+            
+      <variable CV="47" item="ProductID1" readOnly="yes" default="1" >
+        <decVal/>
+        <label>Product ID #1</label>
+        <label xml:lang="cs">Výrobek ID #1:</label>
+        <tooltip>Product ID #1</tooltip>
+        <tooltip xml:lang="cs">Výrobek ID #1</tooltip>
+      </variable>
+      
+      <variable CV="48" item="ProductID2" readOnly="yes" default="1" >
+        <decVal/>
+        <label>Product ID #2</label>
+        <label xml:lang="cs">Výrobek ID #2:</label>
+        <tooltip>Product ID #2</tooltip>
+        <tooltip xml:lang="cs">Výrobek ID #2</tooltip>
+      </variable>
+      
+      <variable CV="49" item="ProductID3" readOnly="yes" default="2" >
+        <decVal/>
+        <label>Product ID #3</label>
+        <label xml:lang="cs">Výrobek ID #3:</label>
+        <tooltip>Product ID #3</tooltip>
+        <tooltip xml:lang="cs">Výrobek ID #3</tooltip>
+      </variable>
+      
+      <variable CV="50" item="ProductID4" readOnly="yes" default="1" >
+        <decVal/>
+        <label>Product ID #4</label>
+        <label xml:lang="cs">Výrobek ID #4:</label>
+        <tooltip>Product ID #4</tooltip>
+        <tooltip xml:lang="cs">Výrobek ID #4</tooltip>
+      </variable>
+      
+<!--  Outputs ============================================================== -->      
+
+    </variables> 
+
+    <resets>
+      <factReset CV="8" default="1">
+        <label>Reset All CVs Settings 16×1</label>
+        <label xml:lang="cs">Reset všech CV Nastavení 16×1</label>
+      </factReset>
+      <factReset CV="8" default="2">
+        <label>Reset All CVs Settings 16×2</label>
+        <label xml:lang="cs">Reset všech CV Nastavení 16×2</label>
+      </factReset>
+      <factReset CV="8" default="3">
+        <label>Reset All CVs Settings 14×2 + 2×3</label>
+        <label xml:lang="cs">Reset všech CV Nastavení 14×2 + 2×3</label>
+      </factReset>
+      <factReset CV="8" default="4">
+        <label>Reset All CVs Settings 13×2 + 3×3</label>
+        <label xml:lang="cs">Reset všech CV Nastavení 13×2 + 3×3</label>
+      </factReset>
+      <factReset CV="8" default="5">
+        <label>Reset All CVs Settings 12×2 + 4×3</label>
+        <label xml:lang="cs">Reset všech CV Nastavení 12×2 + 4×3</label>
+      </factReset>
+    </resets>
+
+  </decoder>
+  
+    <pane>
+<!--  Pane Decoder ========================================================= -->      
+  	<name>Decoder</name>
+        <name xml:lang="cs">Dekodér</name>
+        <column>
+            <display item="Addressing" />
+            <display item="Address order" />
+            <display item="Start delay" />
+            <display item="Bit period" />
+            <display item="Aspect lag" />
+            <display item="Key" />
+            <display item="Lock" />
+        </column>
+        <column>
+            <display item="ProductID1" />
+            <display item="ProductID2" />
+            <display item="ProductID3" />
+            <display item="ProductID4" />
+        </column>
+    </pane>
+            
+            
+    <pane>
+        <!-- Definition of Aspects; do NOT change panel name -->
+        <name>__Aspects</name>
+        <column>
+            <!-- 
+                Metadata: variable definition
+                    label: is the highest number of mast, should be the same as number of labels in <display item="mast"/>
+                    tooltip: starting CV
+                    
+            	CVs are assigned sequentially, starting with mast(0)-aspect(0), going to mast(0)-aspect(31), then mast(1)-aspect(0)....
+            -->
+            <display item="mastcount" label="15" tooltip="128"/>
+
+            <!-- 
+                Metadata: output definition
+                    label contains as many characters as outputs = masts. Each character represents one output.
+            -->
+            <display item="outputs" label="ABCDEFGHIJKLMNOP"/>
+
+            <!--
+            	Metadata: mast names and default setup CVs
+                    tooltip: gives the starting CV number
+                    each label generates one mast; label's content is the mast name. 
+            	
+           	-->
+            <display item="masts" tooltip="512">
+            	<label>0</label><label>1</label><label>2</label><label>3</label><label>4</label><label>5</label><label>6</label><label>7</label>
+            	<label>8</label><label>9</label><label>10</label><label>11</label><label>12</label><label>13</label><label>14</label><label>15</label>
+            </display>
+            <!--
+            	Metadata: aspect names
+                    each label generates one aspect per mast; label's content is the aspect name. 
+           	-->
+            <display item="aspects">
+            	<label>0</label><label>1</label><label>2</label><label>3</label><label>4</label><label>5</label><label>6</label><label>7</label>
+            	<label>8</label><label>9</label><label>10</label><label>11</label><label>12</label><label>13</label><label>14</label><label>15</label>
+            	<label>16</label><label>17</label><label>18</label><label>19</label><label>20</label><label>21</label><label>22</label><label>23</label>
+            	<label>24</label><label>25</label><label>26</label><label>27</label><label>28</label><label>29</label><label>30</label><label>31</label>
+            </display>
+            
+            <!--
+                Metadata: minimum outputs allowed for certain aspects
+                    Each label represents an aspect of the same position (code). The label determines minimum of outputs for the
+                    aspect to be displayed.
+            -->
+            <display item="minOutputs">
+            	<label>1</label><label>1</label>
+            	<label>2</label><label>2</label>
+            	<label>3</label><label>3</label><label>3</label><label>3</label>
+            	
+            	<label>4</label><label>4</label><label>4</label><label>4</label><label>4</label><label>4</label><label>4</label><label>4</label>
+            	
+            	<label>5</label><label>5</label><label>5</label><label>5</label><label>5</label><label>5</label><label>5</label><label>5</label>
+            	<label>5</label><label>5</label><label>5</label><label>5</label><label>5</label><label>5</label><label>5</label><label>5</label>
+            </display>
+            
+            <!--
+                Metadata: binary representation table
+                    Each label represents a binary number 0x00 - 0x1f
+            -->
+            <display item="binary">
+            	<label>□</label>
+            	<label>√</label>
+            	<label>□√</label>
+            	<label>√√</label>
+            	<label>□□√</label>
+            	<label>√□√</label>
+            	<label>□√√</label>
+            	<label>√√√</label>
+            	<label>□□□√</label>
+            	<label>√□□√</label>
+            	<label>□√□√</label>
+            	<label>√√□√</label>
+            	<label>□□√√</label>
+            	<label>√□√√</label>
+            	<label>□√√√</label>
+            	<label>√√√√</label>
+            	<label>□□□□√</label>
+            	<label>√□□□√</label>
+            	<label>□√□□√</label>
+            	<label>√√□□√</label>
+            	<label>□□√□√</label>
+            	<label>√□√□√</label>
+            	<label>□√√□√</label>
+            	<label>√√√□√</label>
+            	<label>□□□√√</label>
+            	<label>√□□√√</label>
+            	<label>□√□√√</label>
+            	<label>√√□√√</label>
+            	<label>□□√√√</label>
+            	<label>√□√√√</label>
+            	<label>□√√√√</label>
+            	<label>√√√√√</label>
+            </display>
+            
+            <!-- Do not repmove this column, it's used to search for "aspectNames" template -->
+            <column>
+                <display item="aspectNames"/>
+                
+                <!-- 
+                    Blueprint:
+                        this column will be copied to the output pane with all its contents.
+                        No templates allowed.
+                -->
+                <column>
+                    <label>
+                        <text>0 – Stop</text>
+                        <text xml:lang="cs">0 – Stůj</text>
+                    </label>
+                    <label>
+                        <text>1 – Clear</text>
+                        <text xml:lang="cs">1 – Volno</text>
+                    </label>
+                    <label>
+                        <text>2 – Caution</text>
+                        <text xml:lang="cs">2 – Výstraha</text>
+                    </label>
+                    <label>
+                        <text>3 – Preparing to 40</text>
+                        <text xml:lang="cs">3 – Očekávej 40</text>
+                    </label>
+                    <label>
+                        <text>4 – 40 then clear</text>
+                        <text xml:lang="cs">4 – 40 a volno</text>
+                    </label>
+                    <label>
+                        <text>5 – ××××× test</text>
+                        <text xml:lang="cs">5 – ××××× test</text>
+                    </label>
+                    <label>
+                        <text>6 – 40 then caution</text>
+                        <text xml:lang="cs">6 – 40 a výstraha</text>
+                    </label>
+                    <label>
+                        <text>7 – 40 then preparing to 40</text>
+                        <text xml:lang="cs">7 – 40 a očekávej 40</text>
+                    </label>
+                    <label>
+                        <text>8 – Call-on</text>
+                        <text xml:lang="cs">8 – Opatrně na přivolávací návěst</text>
+                    </label>
+                    <label>
+                        <text>9 – Shunting allowed</text>
+                        <text xml:lang="cs">9 – Posun dovolen</text>
+                    </label>
+                    <label>
+                        <text>10 – Shunting allowed</text>
+                        <text xml:lang="cs">10 – Posun dovolen - nezabezpečený</text>
+                    </label>
+                    <label>
+                        <text>11 – Repeated clear</text>
+                        <text xml:lang="cs">11 – Opakovaná volno</text>
+                    </label>
+                    <label>
+                        <text>12 – Repeated caution</text>
+                        <text xml:lang="cs">12 – Opakovaná výstraha</text>
+                    </label>
+                    <label>
+                        <text>13 – Unlit</text>
+                        <text xml:lang="cs">13 – Zhasnuto</text>
+                    </label>
+                    <label>
+                        <text>14 – Repeated preparing to 40</text>
+                        <text xml:lang="cs">14 – Opakovaná očekávej 40</text>
+                    </label>
+                    <label>
+                        <text>15 – 40 and repeated caution</text>
+                        <text xml:lang="cs">15 – 40 a opakovaná výstraha</text>
+                    </label>
+                    <label>
+                        <text>16 – 40 and repeated preparing to 40</text>
+                        <text xml:lang="cs">16 – 40 a opakovaná očekávej 40</text>
+                    </label>
+                    <label>
+                        <text>17 – Proceed according to perspective possibilities</text>
+                        <text xml:lang="cs">17 – Jízda podle rozhledových poměrů</text>
+                    </label>
+                    <label>
+                        <text>18 – 40 and procced according to perspective possibilities</text>
+                        <text xml:lang="cs">18 – 40 a jízda podle rozhledových poměrů</text>
+                    </label>
+                </column>
+            </column>
+        </column>
+    </pane>
+
+            
+</decoder-config>

--- a/help/en/html/apps/DecoderPro/resources/scom.xsl
+++ b/help/en/html/apps/DecoderPro/resources/scom.xsl
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) JMRI 2002, 2004, 2020 All rights reserved -->
+<!-- $Id$ -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<xsl:stylesheet	version="1.0" 
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:db="http://docbook.org/ns/docbook"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    
+    exclude-result-prefixes="db"
+>
+    <xsl:output method="xml" encoding="utf-8" indent="yes"/>
+    <xsl:strip-space elements=""/>
+    <xsl:preserve-space elements="text"/>
+
+    <!--
+        Generates one mast definition
+    -->
+    <xsl:template name="mast-definition">
+        <xsl:param name="cvname"/>
+        <xsl:param name="mast"/>
+        <xsl:param name="output"/>
+
+        <variable CV="{$cvname}" item="Signal mast {$mast} Default aspect" default="0" >
+            <decVal min="0" max="31"></decVal>
+            <label>Default aspect code:</label>
+            <label xml:lang="cs">Kód výchozí návěsti:</label>
+            <tooltip>Default aspect code for Signal mast <xsl:value-of select="$mast"/> - output <xsl:value-of select="$output"/>.</tooltip>
+            <tooltip xml:lang="cs">Kód výchozí návěsti pro návěstidlo <xsl:value-of select="$mast"/> - výstup <xsl:value-of select="$output"/>.</tooltip>
+        </variable>
+
+        <variable CV="{$cvname + 1}" item="Signal mast {$mast} Number of addresses" default="1" >
+            <decVal min="1" max="5" />
+            <label>Number of DCC addresses:</label>
+            <label xml:lang="cs">Počet DCC adres:</label>
+            <tooltip>Number of DCC addresses 1 – 5</tooltip>
+            <tooltip xml:lang="cs">Počet DCC adres 1 – 5</tooltip>
+        </variable>
+    </xsl:template>
+
+    <!--
+        Generates all mast definitions. 
+        Iterates through labels in <display item="masts"/>, assigns CVs sequentially.
+    -->
+    <xsl:template name="generate-masts">
+    	  <xsl:param name="root"/>
+          <xsl:variable name="cvStart" select="string($root/display[@item='mastcount']/@tooltip)"/>
+          <xsl:variable name="outputs" select="string($root/display[@item='outputs']/@label)"/>
+          <xsl:for-each select="$root/display[@item='masts']/label">
+    		<xsl:variable name="mast" select="./text()"/>
+    		<xsl:variable name="mastIndex" select="position() - 1"/>
+                <xsl:call-template name="mast-definition">
+                    <xsl:with-param name="cvname" select="$cvStart + $mastIndex * 2"/>
+                    <xsl:with-param name="output" select="substring($outputs, position(), 1)"/>
+                    <xsl:with-param name="mast" select="$mastIndex"/>
+                </xsl:call-template>
+          </xsl:for-each>
+    </xsl:template>
+    
+    <!--
+        Generates <variable> for one aspect on a specific mast
+    -->
+    <xsl:template name="one-mast-aspect">
+    	<xsl:param name="mast"/>
+    	<xsl:param name="aspect"/>
+    	<xsl:param name="cvname"/>
+        <variable CV="{$cvname}" item="Signal mast {$mast} Aspect {$aspect}" default="{$aspect}" >
+            <decVal min="0" max="31" />
+            <label>Aspect number:</label>
+            <label xml:lang="cs">Číslo návěsti:</label>
+            <tooltip>Aspect number by S-com dccdoma.cz. Signal mast <xsl:value-of select="$mast"/> Aspect <xsl:value-of select="$aspect"/>.</tooltip>
+            <tooltip xml:lang="cs">Číslo návěst podle tabulky S-com dccdoma.cz. Návěstidlo <xsl:value-of select="$mast"/> Návěst <xsl:value-of select="$aspect"/>.</tooltip>
+        </variable>
+   	</xsl:template>
+    
+    <!--
+        Generates all aspects for all masts.
+    -->
+    <xsl:template name="generate-aspects">
+    	<xsl:param name="root"/>
+    	
+        <xsl:variable name="startCV" select="string($root/display[@item='masts']/@tooltip)"/>
+    	<xsl:variable name="aspectCount" select="count($root/display[@item='aspects']/label)"/>
+
+    	<xsl:for-each select="$root/display[@item='masts']/label">
+    		<xsl:variable name="mast" select="./text()"/>
+    		<xsl:variable name="mastIndex" select="position() - 1"/>
+    		<xsl:for-each select="$root/display[@item='aspects']/label">
+    			<xsl:variable name="aspectIndex" select="position() - 1"/>
+                        <xsl:variable name="aspectName" select="text()"/>
+    			<xsl:call-template name="one-mast-aspect">
+    				<xsl:with-param name="mast" select="$mast"/>
+    				<xsl:with-param name="aspect" select="$aspectName"/>
+    				<xsl:with-param name="cvname" select="$startCV + $mastIndex * $aspectCount + $aspectIndex"/>
+    			</xsl:call-template>
+    		</xsl:for-each>
+    	</xsl:for-each>
+    </xsl:template>
+
+    <!--
+        Generates conditionally a qualifier.
+        Outputs noting if min# of outputs is 1
+    -->
+    <xsl:template name="qualifier">
+    	<xsl:param name="min"/>
+    	<xsl:param name="mast"/>
+    	<xsl:if test="$min > 1">
+            <qualifier>
+                <variableref>Signal mast <xsl:value-of select="$mast"/> Number of addresses</variableref>
+                <relation>ge</relation>
+                <value><xsl:value-of select="$min"/></value>
+            </qualifier>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="mast-pane">
+        <xsl:param name="mast"/>
+        <xsl:param name="root"/>
+				
+        <xsl:variable name="minOutputs" select="$root/display[@item='minOutputs']"/>
+        <xsl:variable name="aspects" select="$root/display[@item='aspects']"/>
+        <xsl:variable name="binary" select="$root/display[@item='binary']"/>
+        <pane>
+            <xsl:comment>  Pane Signal mast <xsl:value-of select="$mast"/> =============================================== </xsl:comment>
+            <name>Signal mast <xsl:value-of select="$mast"/></name>
+            <name xml:lang="cs">Návěstidlo <xsl:value-of select="$mast"/></name>
+	   	
+            <column>
+                <display item="Signal mast {$mast} Number of addresses" />
+                <display item="Signal mast {$mast} Default aspect" />
+                <label>
+                    <text><xsl:value-of select="'    '"/></text>
+                    <text xml:lang="cs"><xsl:value-of select="'    '"/></text>
+                </label>
+
+                <grid>
+                    <!--  Hlavicka  -->
+                    <griditem gridx="0" gridy="0">
+                        <label>
+                            <text>Code</text>
+                            <text xml:lang="cs">Kód</text>
+                        </label>
+                    </griditem>
+                    <griditem gridx="1" gridy="0">
+                        <label>
+                            <text>Combination</text>
+                            <text xml:lang="cs">Kombinace</text>
+                        </label>
+                    </griditem>
+                    <griditem gridx="2" gridy="0">
+                        <label>
+                            <text>Aspect</text>
+                            <text xml:lang="cs">Návěst</text>
+                        </label>
+                    </griditem>
+		            
+                    <griditem gridx="0" gridy="1">
+                        <label>
+                            <text>of aspect</text>
+                            <text xml:lang="cs">návěsti</text>
+                        </label>
+                    </griditem>
+                    <griditem gridx="1" gridy="1">
+                        <label>
+                            <text>of outputs</text>
+                            <text xml:lang="cs">výstupů</text>
+                        </label>
+                    </griditem>
+                    <griditem gridx="2" gridy="1">
+                        <label>
+                            <text>S-com</text>
+                            <text xml:lang="cs">S-com</text>
+                        </label>
+                    </griditem>
+		            
+                    <xsl:for-each select="$aspects/label">
+                        <xsl:variable name="aspect" select="text()"/>
+                        <xsl:variable name="pos" select="position()"/>
+                        <xsl:variable name="index" select="position() - 1"/>
+						
+                        <!--  Radek  -->
+                        <griditem gridx="0" gridy="{$index + 2}">
+                            <xsl:call-template name="qualifier">
+                                <xsl:with-param name="mast" select="$mast"/>
+                                <xsl:with-param name="min" select="$minOutputs/label[$pos]/text()"/>
+                            </xsl:call-template>
+                            <label>
+                                <text><xsl:value-of select="$aspect"/></text>
+                            </label>
+                        </griditem>
+                        <griditem gridx="1" gridy="{$index + 2}" anchor="LINE_START">
+                            <xsl:call-template name="qualifier">
+                                <xsl:with-param name="mast" select="$mast"/>
+                                <xsl:with-param name="min" select="$minOutputs/label[$pos]/text()"/>
+                            </xsl:call-template>
+                            <label>
+                                <text><xsl:value-of select="$binary/label[$pos]/text()"/></text>
+                            </label>
+                        </griditem>
+                        <griditem gridx="2" gridy="{$index + 2}">
+                            <xsl:call-template name="qualifier" >
+                                <xsl:with-param name="mast" select="$mast"/>
+                                <xsl:with-param name="min" select="$minOutputs/label[$pos]/text()"/>
+                            </xsl:call-template>
+                            <display item="Signal mast {$mast} Aspect {$aspect}" label="" />
+                        </griditem>            
+                    </xsl:for-each>
+                </grid>
+            </column>
+                
+            <!-- Add aspect names from the template -->
+            <column>
+                <xsl:apply-templates select="$root/display[@item='aspectNames']/../column/*"/>
+            </column>
+        </pane>    
+    </xsl:template>
+	
+    <xsl:template name="generate-panes">
+        <xsl:param name="root"/>
+
+        <xsl:for-each select="$root/display[@item='masts']/label">
+            <xsl:variable name="mast" select="string(./text())"/>
+            <xsl:call-template name="mast-pane">
+                <xsl:with-param name="root" select="$root"/>
+                <xsl:with-param name="mast" select="$mast"/>
+            </xsl:call-template>
+        </xsl:for-each>
+    </xsl:template>    
+    
+    <!--
+        Copy <variables> content, and add generated variables at the end
+    -->
+    <xsl:template match="variables">
+        <variables>
+          <xsl:copy-of select="node()"/>
+          <xsl:call-template name="generate-masts">
+          	<xsl:with-param name="root" select="//pane[name/text() ='__Aspects']//display[position() = 1]/.."/>
+          </xsl:call-template> 
+
+          <xsl:call-template name="generate-aspects">
+          	<xsl:with-param name="root" select="//pane[name/text() ='__Aspects']//display[position() = 1]/.."/>
+          </xsl:call-template> 
+        </variables>
+    </xsl:template>
+    
+    <xsl:template match="pane[name='__Aspects']" priority="100">
+        <xsl:call-template name="generate-panes">
+        	<xsl:with-param name="root" select="//pane[name/text() ='__Aspects']//display[position() = 1]/.."/>
+        </xsl:call-template> 
+    </xsl:template>
+    
+    <!--Identity template copies content forward -->
+    <!-- - - - MATCH - - - -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Some months back, I've experimented with XSL transformation on decoder XMLs. After investing some time (actually created a full replacement for the decoder def), I've realized that the author is actually willing to use a custom commandline generator that somehow produces the resulting XML.

So while the stylesheet is not useful for production, it may be useful as an example on how to put data/template together to save typing with a complex decoder.

The text needs a review - especially if the recommended patterns are actually usable long term; or whether some other place in the decoder xml file structure would be more appropriate. 

Please share your feedback.
