### PR TITLE
Signal Mast Logic and Routes: standardize table sorting; set max combo size

### DIFF
--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -42,11 +42,12 @@ import jmri.RouteManager;
 import jmri.Sensor;
 import jmri.Turnout;
 import jmri.implementation.DefaultConditionalAction;
+import jmri.swing.NamedBeanComboBox;
 import jmri.swing.RowSorterUtil;
 import jmri.util.AlphanumComparator;
 import jmri.util.FileUtil;
 import jmri.util.JmriJFrame;
-import jmri.swing.NamedBeanComboBox;
+import jmri.util.swing.JComboBoxUtil;
 
 /**
  * Swing action to create and register a Route Table.
@@ -486,6 +487,15 @@ public class RouteTableAction extends AbstractTableAction<Route> {
             sensor3 = new NamedBeanComboBox<>(InstanceManager.sensorManagerInstance());
             cTurnout = new NamedBeanComboBox<>(InstanceManager.turnoutManagerInstance());
             cLockTurnout = new NamedBeanComboBox<>(InstanceManager.turnoutManagerInstance());
+
+            // Set combo max rows
+            JComboBoxUtil.setupComboBoxMaxRows(turnoutsAlignedSensor);
+            JComboBoxUtil.setupComboBoxMaxRows(sensor1);
+            JComboBoxUtil.setupComboBoxMaxRows(sensor2);
+            JComboBoxUtil.setupComboBoxMaxRows(sensor3);
+            JComboBoxUtil.setupComboBoxMaxRows(cTurnout);
+            JComboBoxUtil.setupComboBoxMaxRows(cLockTurnout);
+
             addFrame = new JmriJFrame(Bundle.getMessage("TitleAddRoute"), false, true); // title later changed for Edit
             addFrame.addHelpMenu("package.jmri.jmrit.beantable.RouteAddEdit", true);
             addFrame.setLocation(100, 30);
@@ -561,10 +571,11 @@ public class RouteTableAction extends AbstractTableAction<Route> {
             JTable routeTurnoutTable = new JTable(_routeTurnoutModel);
             TableRowSorter<RouteTurnoutModel> rtSorter = new TableRowSorter<>(_routeTurnoutModel);
 
-            // use NamedBean's built-in Comparator interface for sorting the system name column
-            RowSorterUtil.setSortOrder(rtSorter, RouteTurnoutModel.SNAME_COLUMN, SortOrder.ASCENDING);
+            // Use AlphanumComparator for SNAME and UNAME columns.  Start with SNAME sort.
+            rtSorter.setComparator(RouteTurnoutModel.SNAME_COLUMN, new AlphanumComparator());
             rtSorter.setComparator(RouteTurnoutModel.UNAME_COLUMN, new AlphanumComparator());
-            RowSorterUtil.setSortOrder(rtSorter, RouteTurnoutModel.UNAME_COLUMN, SortOrder.ASCENDING);
+            RowSorterUtil.setSortOrder(rtSorter, RouteTurnoutModel.SNAME_COLUMN, SortOrder.ASCENDING);
+
             routeTurnoutTable.setRowSorter(rtSorter);
             routeTurnoutTable.setRowSelectionAllowed(false);
             routeTurnoutTable.setPreferredScrollableViewportSize(new java.awt.Dimension(480, 80));
@@ -616,10 +627,10 @@ public class RouteTableAction extends AbstractTableAction<Route> {
             JTable routeSensorTable = new JTable(_routeSensorModel);
             TableRowSorter<RouteSensorModel> rsSorter = new TableRowSorter<>(_routeSensorModel);
 
-            // use NamedBean's built-in Comparator interface for sorting the system name column
+            // Use AlphanumComparator for SNAME and UNAME columns.  Start with SNAME sort.
+            rsSorter.setComparator(RouteTurnoutModel.SNAME_COLUMN, new AlphanumComparator());
+            rsSorter.setComparator(RouteTurnoutModel.UNAME_COLUMN, new AlphanumComparator());
             RowSorterUtil.setSortOrder(rsSorter, RouteSensorModel.SNAME_COLUMN, SortOrder.ASCENDING);
-            rtSorter.setComparator(RouteTurnoutModel.UNAME_COLUMN, new AlphanumComparator());
-            RowSorterUtil.setSortOrder(rtSorter, RouteTurnoutModel.UNAME_COLUMN, SortOrder.ASCENDING);
             routeSensorTable.setRowSorter(rsSorter);
             routeSensorTable.setRowSelectionAllowed(false);
             routeSensorTable.setPreferredScrollableViewportSize(new java.awt.Dimension(480, 80));

--- a/java/src/jmri/jmrit/picker/PickListModel.java
+++ b/java/src/jmri/jmrit/picker/PickListModel.java
@@ -10,6 +10,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
+import javax.swing.SortOrder;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableRowSorter;
@@ -17,6 +18,7 @@ import jmri.*;
 import jmri.jmrit.beantable.BeanTableDataModel;
 import jmri.jmrit.entryexit.*;
 import jmri.jmrit.logix.*;
+import jmri.swing.RowSorterUtil;
 import jmri.util.*;
 import jmri.util.swing.XTableColumnModel;
 import org.slf4j.Logger;
@@ -320,6 +322,9 @@ public abstract class PickListModel<E extends NamedBean> extends BeanTableDataMo
                 }
             }
         };
+        _sorter.setComparator(SNAME_COLUMN, new jmri.util.AlphanumComparator());
+        _sorter.setComparator(UNAME_COLUMN, new jmri.util.AlphanumComparator());
+        RowSorterUtil.setSortOrder(_sorter, SNAME_COLUMN, SortOrder.ASCENDING);
         _table.setRowSorter(_sorter);
 
         _table.setRowSelectionAllowed(true);
@@ -351,6 +356,9 @@ public abstract class PickListModel<E extends NamedBean> extends BeanTableDataMo
 
     public void makeSorter(@Nonnull JTable table) {
         _sorter = new TableRowSorter<>(this);
+        _sorter.setComparator(SNAME_COLUMN, new jmri.util.AlphanumComparator());
+        _sorter.setComparator(UNAME_COLUMN, new jmri.util.AlphanumComparator());
+        RowSorterUtil.setSortOrder(_sorter, SNAME_COLUMN, SortOrder.ASCENDING);
         table.setRowSorter(_sorter);
     }
 

--- a/java/src/jmri/jmrit/sensorgroup/SensorGroupFrame.java
+++ b/java/src/jmri/jmrit/sensorgroup/SensorGroupFrame.java
@@ -16,8 +16,10 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
+import javax.swing.SortOrder;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
+import javax.swing.table.TableRowSorter;
 import jmri.Conditional;
 import jmri.ConditionalAction;
 import jmri.ConditionalVariable;
@@ -28,6 +30,8 @@ import jmri.RouteManager;
 import jmri.Sensor;
 import jmri.implementation.DefaultConditionalAction;
 import jmri.implementation.SensorGroupConditional;
+import jmri.swing.RowSorterUtil;
+import jmri.util.AlphanumComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,6 +88,12 @@ public class SensorGroupFrame extends jmri.util.JmriJFrame {
         p2xs.add(p21s);
         _sensorModel = new SensorTableModel();
         JTable sensorTable = new JTable(_sensorModel);
+
+        TableRowSorter<SensorTableModel> sorter = new TableRowSorter<>(_sensorModel);
+        sorter.setComparator(SensorTableModel.SNAME_COLUMN, new jmri.util.AlphanumComparator());
+        sorter.setComparator(SensorTableModel.UNAME_COLUMN, new jmri.util.AlphanumComparator());
+        RowSorterUtil.setSortOrder(sorter, SensorTableModel.SNAME_COLUMN, SortOrder.ASCENDING);
+        sensorTable.setRowSorter(sorter);
 
         sensorTable.setRowSelectionAllowed(false);
         sensorTable.setPreferredScrollableViewportSize(new java.awt.Dimension(450, 200));

--- a/java/src/jmri/jmrit/signalling/SignallingPanel.java
+++ b/java/src/jmri/jmrit/signalling/SignallingPanel.java
@@ -49,6 +49,8 @@ import jmri.jmrit.display.layoutEditor.LayoutBlockConnectivityTools;
 import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 import jmri.swing.NamedBeanComboBox;
 import jmri.swing.RowSorterUtil;
+import jmri.util.AlphanumComparator;
+import jmri.util.swing.JComboBoxUtil;
 import jmri.util.swing.JmriPanel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -152,6 +154,9 @@ public class SignallingPanel extends JmriPanel {
         sourceMastBox.setMaximumSize(sourceMastBox.getPreferredSize());
         destMastBox = new NamedBeanComboBox<>(smm, destMast, DisplayOptions.DISPLAYNAME);
         destMastBox.setMaximumSize(destMastBox.getPreferredSize());
+
+        JComboBoxUtil.setupComboBoxMaxRows(sourceMastBox);
+        JComboBoxUtil.setupComboBoxMaxRows(destMastBox);
 
         // directly add sub-panes onto JFrame's content pane to allow resizing (2018)
         Container contentPane = frame.getContentPane();
@@ -428,6 +433,8 @@ public class SignallingPanel extends JmriPanel {
         TableRowSorter<BlockModel> manualBlockSorter = new TableRowSorter<>(_blockModel);
         // configure row height for comboBox
         manualBlockTable.setRowHeight(sizer.getPreferredSize().height - 2); // row height has to be greater than for plain tables
+        manualBlockSorter.setComparator(BlockModel.SNAME_COLUMN, new jmri.util.AlphanumComparator());
+        manualBlockSorter.setComparator(BlockModel.UNAME_COLUMN, new jmri.util.AlphanumComparator());
         RowSorterUtil.setSortOrder(manualBlockSorter, BlockModel.SNAME_COLUMN, SortOrder.ASCENDING);
         _blockModel.configStateColumn(manualBlockTable); // create static comboBox in State column
         manualBlockTable.setRowSorter(manualBlockSorter);
@@ -446,7 +453,6 @@ public class SignallingPanel extends JmriPanel {
                 getColumn(BlockModel.SNAME_COLUMN);
         sNameColumnC.setResizable(true);
         sNameColumnC.setMinWidth(75);
-        sNameColumnC.setMaxWidth(95);
 
         TableColumn stateColumnC = _manualBlockColumnModel.
                 getColumn(BlockModel.STATE_COLUMN);
@@ -476,6 +482,8 @@ public class SignallingPanel extends JmriPanel {
         _autoBlockModel = new AutoBlockModel();
         JTable autoBlockTable = new JTable(_autoBlockModel);
         TableRowSorter<AutoBlockModel> autoBlockSorter = new TableRowSorter<>(_autoBlockModel);
+        autoBlockSorter.setComparator(AutoBlockModel.SNAME_COLUMN, new jmri.util.AlphanumComparator());
+        autoBlockSorter.setComparator(AutoBlockModel.UNAME_COLUMN, new jmri.util.AlphanumComparator());
         RowSorterUtil.setSortOrder(autoBlockSorter, AutoBlockModel.SNAME_COLUMN, SortOrder.ASCENDING);
         autoBlockTable.setRowSorter(autoBlockSorter);
         autoBlockTable.setRowSelectionAllowed(false);
@@ -486,7 +494,6 @@ public class SignallingPanel extends JmriPanel {
                 getColumn(AutoBlockModel.SNAME_COLUMN);
         sNameColumnA.setResizable(true);
         sNameColumnA.setMinWidth(75);
-        sNameColumnA.setMaxWidth(95);
 
         TableColumn stateColumnA = _autoBlockColumnModel.
                 getColumn(AutoBlockModel.STATE_COLUMN);
@@ -553,6 +560,8 @@ public class SignallingPanel extends JmriPanel {
         TableRowSorter<TurnoutModel> manualTurnoutSorter = new TableRowSorter<>(_turnoutModel);
         // configure row height for comboBox
         manualTurnoutTable.setRowHeight(sizer.getPreferredSize().height - 2); // row height has to be greater than for plain tables
+        manualTurnoutSorter.setComparator(TurnoutModel.SNAME_COLUMN, new AlphanumComparator());
+        manualTurnoutSorter.setComparator(TurnoutModel.UNAME_COLUMN, new AlphanumComparator());
         RowSorterUtil.setSortOrder(manualTurnoutSorter, TurnoutModel.SNAME_COLUMN, SortOrder.ASCENDING);
         _turnoutModel.configStateColumn(manualTurnoutTable); // create static comboBox in State column
         manualTurnoutTable.setRowSorter(manualTurnoutSorter);
@@ -571,7 +580,6 @@ public class SignallingPanel extends JmriPanel {
                 getColumn(TurnoutModel.SNAME_COLUMN);
         sNameColumnC.setResizable(true);
         sNameColumnC.setMinWidth(75);
-        sNameColumnC.setMaxWidth(95);
 
         TableColumn stateColumnC = _manualTurnoutColumnModel.
                 getColumn(TurnoutModel.STATE_COLUMN);
@@ -602,6 +610,8 @@ public class SignallingPanel extends JmriPanel {
         _autoTurnoutModel = new AutoTurnoutModel();
         JTable autoTurnoutTable = new JTable(_autoTurnoutModel);
         TableRowSorter<AutoTurnoutModel> autoTurnoutSorter = new TableRowSorter<>(_autoTurnoutModel);
+        autoTurnoutSorter.setComparator(AutoTurnoutModel.SNAME_COLUMN, new AlphanumComparator());
+        autoTurnoutSorter.setComparator(AutoTurnoutModel.UNAME_COLUMN, new AlphanumComparator());
         RowSorterUtil.setSortOrder(autoTurnoutSorter, AutoTurnoutModel.SNAME_COLUMN, SortOrder.ASCENDING);
         autoTurnoutTable.setRowSorter(autoTurnoutSorter);
         autoTurnoutTable.setRowSelectionAllowed(false);
@@ -612,7 +622,6 @@ public class SignallingPanel extends JmriPanel {
                 getColumn(AutoTurnoutModel.SNAME_COLUMN);
         sNameColumnA.setResizable(true);
         sNameColumnA.setMinWidth(75);
-        sNameColumnA.setMaxWidth(95);
 
         TableColumn stateColumnA = _autoTurnoutColumnModel.
                 getColumn(AutoTurnoutModel.STATE_COLUMN);
@@ -665,6 +674,8 @@ public class SignallingPanel extends JmriPanel {
         TableRowSorter<SensorModel> manualSensorSorter = new TableRowSorter<>(_sensorModel);
         // configure row height for comboBox
         manualSensorTable.setRowHeight(sizer.getPreferredSize().height - 2); // row height has to be greater than for plain tables
+        manualSensorSorter.setComparator(SensorModel.SNAME_COLUMN, new AlphanumComparator());
+        manualSensorSorter.setComparator(SensorModel.UNAME_COLUMN, new AlphanumComparator());
         RowSorterUtil.setSortOrder(manualSensorSorter, SensorModel.SNAME_COLUMN, SortOrder.ASCENDING);
         _sensorModel.configStateColumn(manualSensorTable); // create static comboBox in State column
         manualSensorTable.setRowSorter(manualSensorSorter);
@@ -683,7 +694,6 @@ public class SignallingPanel extends JmriPanel {
                 getColumn(SensorModel.SNAME_COLUMN);
         sNameColumnC.setResizable(true);
         sNameColumnC.setMinWidth(75);
-        sNameColumnC.setMaxWidth(95);
 
         TableColumn stateColumnC = _manualSensorColumnModel.
                 getColumn(SensorModel.STATE_COLUMN);
@@ -733,13 +743,16 @@ public class SignallingPanel extends JmriPanel {
         p2xm.add(p21c);
 
         _signalMastModel = new SignalMastModel();
-        TableRowSorter<SignalMastModel> sorter = new TableRowSorter<>(_signalMastModel);
+        TableRowSorter<SignalMastModel> manualMastSorter = new TableRowSorter<>(_signalMastModel);
         JTable manualSignalMastTable = new JTable(_signalMastModel);
         // configure (extra) row height for comboBox
         manualSignalMastTable.setRowHeight(sizer.getPreferredSize().height - 2);
         // row height has to be greater than plain tables to properly show comboBox shape, but tightened a bit over preferred
         _signalMastModel.configStateColumn(manualSignalMastTable); // create mast (row) specific comboBox in Aspect column
-        manualSignalMastTable.setRowSorter(sorter);
+        manualMastSorter.setComparator(SignalMastModel.SNAME_COLUMN, new jmri.util.AlphanumComparator());
+        manualMastSorter.setComparator(SignalMastModel.UNAME_COLUMN, new jmri.util.AlphanumComparator());
+        RowSorterUtil.setSortOrder(manualMastSorter, SignalMastModel.SNAME_COLUMN, SortOrder.ASCENDING);
+        manualSignalMastTable.setRowSorter(manualMastSorter);
         manualSignalMastTable.setRowSelectionAllowed(false);
         manualSignalMastTable.setPreferredScrollableViewportSize(TABLESIZEPREFERRED);
 
@@ -753,7 +766,6 @@ public class SignallingPanel extends JmriPanel {
                 getColumn(SignalMastModel.SNAME_COLUMN);
         sNameColumnC.setResizable(true);
         sNameColumnC.setMinWidth(75);
-        sNameColumnC.setMaxWidth(95);
 
         TableColumn stateColumnC = _manualSignalMastColumnModel.
                 getColumn(SensorModel.STATE_COLUMN);
@@ -782,6 +794,8 @@ public class SignallingPanel extends JmriPanel {
         _autoSignalMastModel = new AutoMastModel();
         JTable autoMastTable = new JTable(_autoSignalMastModel);
         TableRowSorter<AutoMastModel> autoMastSorter = new TableRowSorter<>(_autoSignalMastModel);
+        autoMastSorter.setComparator(AutoMastModel.SNAME_COLUMN, new jmri.util.AlphanumComparator());
+        autoMastSorter.setComparator(AutoMastModel.UNAME_COLUMN, new jmri.util.AlphanumComparator());
         RowSorterUtil.setSortOrder(autoMastSorter, AutoMastModel.SNAME_COLUMN, SortOrder.ASCENDING);
         autoMastTable.setRowSorter(autoMastSorter);
         autoMastTable.setRowSelectionAllowed(false);
@@ -792,7 +806,6 @@ public class SignallingPanel extends JmriPanel {
                 getColumn(AutoMastModel.SNAME_COLUMN);
         sNameColumnA.setResizable(true);
         sNameColumnA.setMinWidth(75);
-        sNameColumnA.setMaxWidth(95);
 
         TableColumn stateColumnA = _autoMastColumnModel.
                 getColumn(AutoMastModel.STATE_COLUMN);


### PR DESCRIPTION
- Use AlphanumComparator for system and user names.
- Set the initial sort to the system name column.
- Use `JComboBoxUtil` to set the max combo box size.