### PR TITLE
Add speed step dropdown to throttles

### DIFF
--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -208,6 +208,16 @@ ProgrammingShort                 = Short circuit on programming track (309);
 SequenceError                    = Programming Operation Sequence Error (310);
 CommError                        = Communications Error Between PC and command station (311);
 
+# Speed Step Names
+SpeedStep128            = 128 SS
+SpeedStep28             = 28 SS
+SpeedStep27             = 27 SS
+SpeedStep14             = 14 SS
+SpeedStepUnknown        = Unknown
+SpeedStep32TMCC         = 32 SS (TMCC)
+SpeedStep28Motorola     = 28 SS (Motorola)
+SpeedStepIncremental    = Incremental
+
 # Protocol names
 ProtocolDCC                      = DCC
 ProtocolDCC_Long                 = DCC Long

--- a/java/src/jmri/NamedBeanBundle_ca.properties
+++ b/java/src/jmri/NamedBeanBundle_ca.properties
@@ -172,6 +172,16 @@ ProgrammingShort        = Curt-circuit a la via de programaci\u00f3 (309);
 SequenceError           = Error de programaci\u00f3 (310);
 CommError               = Error de comunicaci\u00f3 entre la central i l'ordinador (311);
 
+# Speed Step Names
+SpeedStep128            = 128 passos
+SpeedStep28             = 28 passos
+SpeedStep27             = 27 passos
+SpeedStep14             = 14 passos
+SpeedStepUnknown        = Desconegut
+SpeedStep32TMCC         = 32 passos (TMCC)
+SpeedStep28Motorola     = 28 passos (Motorola)
+SpeedStepIncremental    = Increment
+
 # Protocol names
 ProtocolDCC             = DCC
 ProtocolDCC_Long        = DCC llarg

--- a/java/src/jmri/NamedBeanBundle_cs.properties
+++ b/java/src/jmri/NamedBeanBundle_cs.properties
@@ -149,6 +149,16 @@ ProgrammingShort = Zkrat na programovac\u00ed koleji (309);
 SequenceError = Chyba po\u0159ad\u00ed programovac\u00edch operac\u00ed (310);
 CommError = Chyba komunikace mezi PC a centr\u00e1lou (311);
 
+# Speed Step Names
+SpeedStep128            = 128 stup\u0148\u016f
+SpeedStep28             = 28 stup\u0148\u016f
+SpeedStep27             = 27 Sstup\u0148\u016fS
+SpeedStep14             = 14 Sstup\u0148\u016fS
+SpeedStepUnknown        = Nezn\u00e1m\u00fd
+SpeedStep32TMCC         = 32 stup\u0148\u016f (TMCC)
+SpeedStep28Motorola     = 28 stup\u0148\u016f (Motorola)
+SpeedStepIncremental    = P\u0159\u00edr\u016fstkov\u00e9
+
 # Protocol names
 ProtocolDCC = DCC
 ProtocolDCC_Long = DCC dlouh\u00e1

--- a/java/src/jmri/NamedBeanBundle_da.properties
+++ b/java/src/jmri/NamedBeanBundle_da.properties
@@ -170,6 +170,16 @@ ProgrammingShort = Kortslutning p\u00e5 programerings sporet (309);
 SequenceError = Programming operations r\u00e6kkef\u00f8lge fejl(310);
 CommError = Komunikationsfejl mellem PC og Kommando Station (311);
 
+# Speed Step Names
+SpeedStep128            = 128 SS
+SpeedStep28             = 28 SS
+SpeedStep27             = 27 SS
+SpeedStep14             = 14 SS
+SpeedStepUnknown        = Ukendt
+SpeedStep32TMCC         = 32 SS (TMCC)
+SpeedStep28Motorola     = 28 SS (Motorola)
+SpeedStepIncremental    = Trinvis
+
 # Protocol names
 ProtocolDCC = DCC
 ProtocolDCC_Long = DCC Lang

--- a/java/src/jmri/NamedBeanBundle_de.properties
+++ b/java/src/jmri/NamedBeanBundle_de.properties
@@ -196,6 +196,16 @@ SignalHeads     = Signalschirme
 Reporters       = Melder
 Lights          = Lichte
 
+# Speed Step Names
+SpeedStep128            = 128 SS
+SpeedStep28             = 28 SS
+SpeedStep27             = 27 SS
+SpeedStep14             = 14 SS
+SpeedStepUnknown        = Unbekannt
+SpeedStep32TMCC         = 32 SS (TMCC)
+SpeedStep28Motorola     = 28 SS (Motorola)
+SpeedStepIncremental    = Inkrementell
+
 ProtocolDCC      = DCC
 ProtocolDCC_Long = DCC Lang
 ProtocolDCC_Short = DCC Kurz

--- a/java/src/jmri/NamedBeanBundle_fr.properties
+++ b/java/src/jmri/NamedBeanBundle_fr.properties
@@ -178,6 +178,16 @@ ProgrammingShort        = Court circuit sur voie de programmation (309);
 SequenceError           = Erreur de programmation (310);
 CommError               = Erreur de communication entre l'ordinateur et la centrale (311);
 
+# Speed Step Names
+SpeedStep128            = 128 Crans
+SpeedStep28             = 28 Crans
+SpeedStep27             = 27 Crans
+SpeedStep14             = 14 Crans
+SpeedStepUnknown        = Inconnue
+SpeedStep32TMCC         = 32 Crans (TMCC)
+SpeedStep28Motorola     = 28 Crans (Motorola)
+SpeedStepIncremental    = Incr\u00e9mentale
+
 # Protocol names
 ProtocolDCC             = DCC
 ProtocolDCC_Long        = DCC Long

--- a/java/src/jmri/NamedBeanBundle_it.properties
+++ b/java/src/jmri/NamedBeanBundle_it.properties
@@ -149,6 +149,16 @@ ProgrammingShort = Corto circuito in binario di programmazione (309);
 SequenceError = Errore Sequenza di Programmazione (310);
 CommError = Errore di Comunicazione tra PC e Centrale (311);
 
+# Speed Step Names
+SpeedStep128            = 128 step
+SpeedStep28             = 28 step
+SpeedStep27             = 27 step
+SpeedStep14             = 14 step
+SpeedStepUnknown        = Lo sconosciuto
+SpeedStep32TMCC         = 32 step (TMCC)
+SpeedStep28Motorola     = 28 step (Motorola)
+SpeedStepIncremental    = Incrementale
+
 # Protocol names
 ProtocolDCC = DCC
 ProtocolDCC_Long = DCC Esteso

--- a/java/src/jmri/NamedBeanBundle_ja_JP.properties
+++ b/java/src/jmri/NamedBeanBundle_ja_JP.properties
@@ -158,3 +158,13 @@ Magenta         = \u7d2b\u8272
 Cyan            = \u7d3a\u8272
 Pink            = \u6843\u8272
 ColumnHeadEnabled= \u6709\u52b9
+
+# Speed Step Names
+SpeedStep128            = 128\u6bb5\u5909\u901f
+SpeedStep28             = 28\u6bb5\u5909\u901f
+SpeedStep27             = 27\u6bb5\u5909\u901f
+SpeedStep14             = 14\u6bb5\u5909\u901f
+SpeedStepUnknown        = \u4e0d\u660e
+SpeedStep32TMCC         = 32\u6bb5\u5909\u901f (TMCC)
+SpeedStep28Motorola     = 28\u6bb5\u5909\u901f (Motorola)
+SpeedStepIncremental    = \u5897\u5206

--- a/java/src/jmri/NamedBeanBundle_nl.properties
+++ b/java/src/jmri/NamedBeanBundle_nl.properties
@@ -175,6 +175,16 @@ ProgrammingShort        = Kortsluiting op het Programmeerspoor (309);
 SequenceError           = Fout in de volgorde van programmeeracties (310);
 CommError               = Communicatiefout tussen PC en centrale (311);
 
+# Speed Step Names
+SpeedStep128            = 128 SS
+SpeedStep28             = 28 SS
+SpeedStep27             = 27 SS
+SpeedStep14             = 14 SS
+SpeedStepUnknown        = Onbekend
+SpeedStep32TMCC         = 32 SS (TMCC)
+SpeedStep28Motorola     = 28 SS (Motorola)
+SpeedStepIncremental    = Incrementeel
+
 # Protocol names
 ProtocolDCC             = DCC
 ProtocolDCC_Long        = DCC Lang

--- a/java/src/jmri/SpeedStepMode.java
+++ b/java/src/jmri/SpeedStepMode.java
@@ -20,30 +20,38 @@ import java.util.EnumSet;
  */
 @javax.annotation.concurrent.Immutable
 public enum SpeedStepMode {
-    UNKNOWN("unknown", 1, 0.0f),
+    // NOTE: keep these up to date with xml/schema/locomotive-config.xsd
+    UNKNOWN("unknown", 1, 0.0f, "SpeedStepUnknown"),
     // NMRA DCC standard speed step modes.
-    NMRA_DCC_128("128", 126), // Remember there are only 126 non-stop values in 128 speed.
-    NMRA_DCC_28("28", 28),
-    NMRA_DCC_27("27", 27),
-    NMRA_DCC_14("14", 14),
+    NMRA_DCC_128("128", 126, "SpeedStep128"), // Remember there are only 126 non-stop values in 128 speed.
+    NMRA_DCC_28("28", 28, "SpeedStep28"),
+    NMRA_DCC_27("27", 27, "SpeedStep27"),
+    NMRA_DCC_14("14", 14, "SpeedStep14"),
     // Non-DCC speed step modes.
-    MOTOROLA_28("motorola_28", 28), // Motorola 28 speed step mode.
-    TMCC_32("tmcc_32", 32), // Lionel TMCC 32 speed step mode.
-    INCREMENTAL("incremental", 1, 1.0f);
+    MOTOROLA_28("motorola_28", 28, "SpeedStep28Motorola"), // Motorola 28 speed step mode.
+    TMCC_32("tmcc_32", 32, "SpeedStep32TMCC"), // Lionel TMCC 32 speed step mode.
+    INCREMENTAL("incremental", 1, 1.0f, "SpeedStepIncremental");
 
-    SpeedStepMode(String name, int numSteps) {
-        this(name, numSteps, 1.0f / numSteps);
+    SpeedStepMode(String name, int numSteps, String description) {
+        this(name, numSteps, 1.0f / numSteps, description);
     }
 
-    SpeedStepMode(String name, int numSteps, float increment) {
+    SpeedStepMode(String name, int numSteps, float increment, String description) {
         this.name = name;
         this.numSteps = numSteps;
         this.increment = increment;
+        this.description = Bundle.getMessage(description);
     }
 
     public final String name;
     public final int numSteps;
     public final float increment;
+    public final String description;
+
+    @Override
+    public String toString() {
+        return description;
+    }
 
     /**
      * Convert a human-readable string to a DCC speed step mode.
@@ -55,6 +63,22 @@ public enum SpeedStepMode {
     static public SpeedStepMode getByName(String name) {
         for(SpeedStepMode s : SpeedStepMode.values()) {
             if(s.name.equals(name)) {
+                return s;
+            }
+        }
+        throw new IllegalArgumentException("Invalid speed step mode: " + name);
+    }
+
+    /**
+     * Convert a localized name string to a DCC speed step mode.
+     *
+     * @param name localized string version of speed step mode; example "128"
+     * @return matching SpeedStepMode
+     * @throws IllegalArgumentException if name does not correspond to a valid speed step mode.
+     */
+    static public SpeedStepMode getByDescription(String name) {
+        for(SpeedStepMode s : SpeedStepMode.values()) {
+            if(s.description.equals(name)) {
                 return s;
             }
         }
@@ -73,19 +97,69 @@ public enum SpeedStepMode {
             EnumSet<SpeedStepMode> command_station_modes,
             EnumSet<SpeedStepMode> decoder_modes) {
         EnumSet<SpeedStepMode> result = getCompatibleModes(command_station_modes, decoder_modes);
-        if(result.contains(NMRA_DCC_128)) {
+        return bestMode(result);
+    }
+
+    static public SpeedStepMode bestMode(EnumSet<SpeedStepMode> modes) {
+        if(modes.contains(NMRA_DCC_128)) {
             return NMRA_DCC_128;
-        } else if(result.contains(TMCC_32)) {
+        } else if(modes.contains(TMCC_32)) {
             return TMCC_32;
-        } else if(result.contains(NMRA_DCC_28)) {
+        } else if(modes.contains(NMRA_DCC_28)) {
             return NMRA_DCC_28;
-        } else if(result.contains(MOTOROLA_28)) {
+        } else if(modes.contains(MOTOROLA_28)) {
             return MOTOROLA_28;
-        } else if(result.contains(NMRA_DCC_27)) {
+        } else if(modes.contains(NMRA_DCC_27)) {
             return NMRA_DCC_27;
-        } else if(result.contains(NMRA_DCC_14)) {
+        } else if(modes.contains(NMRA_DCC_14)) {
             return NMRA_DCC_14;
         }
         return UNKNOWN;
+    }
+
+    static public EnumSet<SpeedStepMode> getCompatibleModesForProtocol(LocoAddress.Protocol protocol) {
+        switch (protocol) {
+            case DCC:
+            case DCC_LONG:
+            case DCC_SHORT:
+                return EnumSet.of(
+                        // NMRA Speed step modes.
+                        SpeedStepMode.NMRA_DCC_128,
+                        SpeedStepMode.NMRA_DCC_28,
+                        SpeedStepMode.NMRA_DCC_27,
+                        SpeedStepMode.NMRA_DCC_14,
+                        // Incremental speed step mode, used by LENZ XPA
+                        // XpressNet Phone Adapter.
+                        SpeedStepMode.INCREMENTAL,
+                        // TMCC mode, since some NMRA decoder models are used
+                        // for TMCC locomotives.
+                        SpeedStepMode.TMCC_32);
+            case MFX:
+                return EnumSet.of(
+                        // NMRA Speed step modes.
+                        SpeedStepMode.NMRA_DCC_128,
+                        SpeedStepMode.NMRA_DCC_28,
+                        SpeedStepMode.NMRA_DCC_27,
+                        SpeedStepMode.NMRA_DCC_14,
+                        // Incremental speed step mode, used by LENZ XPA
+                        // XpressNet Phone Adapter.
+                        SpeedStepMode.INCREMENTAL,
+                        // MFX decoders also support Motorola speed step mode.
+                        SpeedStepMode.MOTOROLA_28);
+            case MOTOROLA:
+                return EnumSet.of(SpeedStepMode.MOTOROLA_28);
+            case SELECTRIX:
+            case M4:
+            case OPENLCB:
+            case LGB:
+                // No compatible speed step modes for these protocols.
+                // NOTE: these protocols only appear to be used in conjunction
+                // with ECOS.
+                break;
+            default:
+                // Unhandled case; no compatible speed step mode.
+                break;
+        }
+        return EnumSet.noneOf(SpeedStepMode.class);
     }
 }

--- a/java/src/jmri/jmrit/Bundle.properties
+++ b/java/src/jmri/jmrit/Bundle.properties
@@ -111,10 +111,6 @@ Collect_Memory  = Collect Memory
 Update          = Update
 
 # common throttle strings among throttle and logix packages
-Button128SS     = 128 SS
-Button28SS      = 28 SS
-Button27SS      = 27 SS
-Button14SS      = 14 SS
 ButtonForward   = Forward
 ButtonReverse   = Reverse
 ButtonDisplaySpeedSlider = Display speed slider (from 0 to 100)

--- a/java/src/jmri/jmrit/Bundle_ca.properties
+++ b/java/src/jmri/jmrit/Bundle_ca.properties
@@ -112,10 +112,6 @@ Collect_Memory = Verifica la mem\u00f2ria
 Update = Actualitza
 
 # common throttle strings among throttle and logix packages
-Button128SS = 128 passos
-Button28SS = 28 passos
-Button27SS = 27 passos
-Button14SS = 14 passos
 ButtonForward = Endavant
 ButtonReverse = Endarrere
 ButtonDisplaySpeedSlider = Visualitza lliscant de velocitat (de 0 a 100)

--- a/java/src/jmri/jmrit/Bundle_cs.properties
+++ b/java/src/jmri/jmrit/Bundle_cs.properties
@@ -108,10 +108,6 @@ Collect_Memory = Pro\u010distit pam\u011b\u0165
 Update = Aktualizovat
 
 # common throttle strings among throttle and logix packages
-Button128SS = 128 stup\u0148\u016f
-Button28SS = 28 stup\u0148\u016f
-Button27SS = 27 stup\u0148\u016f
-Button14SS = 14 stup\u0148\u016f
 ButtonForward = Vp\u0159ed
 ButtonReverse = Vzad
 ButtonDisplaySpeedSlider = Zobrazit posuvn\u00edk rychlosti (od 0 do 100)

--- a/java/src/jmri/jmrit/Bundle_da.properties
+++ b/java/src/jmri/jmrit/Bundle_da.properties
@@ -111,10 +111,6 @@ Collect_Memory = Indsaml Hukommelse
 Update = Opdater
 
 # common throttle strings among throttle and logix packages
-Button128SS = 128 SS
-Button28SS = 28 SS
-Button27SS = 27 SS
-Button14SS = 14 SS
 ButtonForward = Frem
 ButtonReverse = Bak
 ButtonDisplaySpeedSlider = Vis hastigheds slider (fra 0 til 100)

--- a/java/src/jmri/jmrit/Bundle_de.properties
+++ b/java/src/jmri/jmrit/Bundle_de.properties
@@ -101,10 +101,6 @@ Collect_Memory = Komprimiere Speicher
 Update = Aktualisiere
 
 # ControlPanel
-Button128SS = 128 SS
-Button28SS = 28 SS
-Button27SS = 27 SS
-Button14SS = 14 SS
 ButtonForward = Vorw\u00e4rts
 ButtonReverse = R\u00fcckw\u00e4rts
 ButtonIdle = Ruhezustand

--- a/java/src/jmri/jmrit/Bundle_fr.properties
+++ b/java/src/jmri/jmrit/Bundle_fr.properties
@@ -112,10 +112,6 @@ Collect_Memory  = Recueillir M\u00e9moire
 Update          = Mise \u00e0 Jour
 
 # common throttle strings among throttle and logix packages
-Button128SS     = 128 Crans
-Button28SS      = 28 Crans
-Button27SS      = 27 Crans
-Button14SS      = 14 Crans
 ButtonForward   = Avant
 ButtonReverse   = Inverse
 ButtonDisplaySpeedSlider = Afficher curseur vitesse (de 0 \u00e0 100)

--- a/java/src/jmri/jmrit/Bundle_it.properties
+++ b/java/src/jmri/jmrit/Bundle_it.properties
@@ -107,10 +107,6 @@ Collect_Memory                      = Verifica Memoria
 Update                              = Aggiorna
 
 # common throttle strings among throttle and logix packages
-Button128SS                         = 128 step
-Button28SS                          = 28 step
-Button27SS                          = 27 step
-Button14SS                          = 14 step
 ButtonForward                       = Avanti
 ButtonReverse                       = Indietro
 ButtonDisplaySpeedSlider            = Visualizza slider Velocit\u00e0 (da 0 a 100)

--- a/java/src/jmri/jmrit/Bundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/Bundle_ja_JP.properties
@@ -85,10 +85,6 @@ Collect_Memory = \u30e1\u30e2\u30ea\u53ce\u96c6
 Update = \u66f4\u65b0
 
 # ControlPanel
-Button128SS = 128\u6bb5\u5909\u901f
-Button28SS = 28\u6bb5\u5909\u901f
-Button27SS = 27\u6bb5\u5909\u901f
-Button14SS = 14\u6bb5\u5909\u901f
 ButtonForward = \u524d\u9032
 ButtonReverse = \u5f8c\u9032
 ButtonIdle = \u4f11\u6b62

--- a/java/src/jmri/jmrit/Bundle_nl.properties
+++ b/java/src/jmri/jmrit/Bundle_nl.properties
@@ -110,10 +110,6 @@ Collect_Memory  = Schoon geheugen op
 Update          = Werk bij
 
 # common throttle strings among throttle and logix packages
-Button128SS     = 128 SS
-Button28SS      = 28 SS
-Button27SS      = 27 SS
-Button14SS      = 14 SS
 ButtonForward   = Vooruit
 ButtonReverse   = Achteruit
 ButtonDisplaySpeedSlider = Toon snelheidsregelaar (van 0 tot 100)

--- a/java/src/jmri/jmrit/logix/ControlPanel.java
+++ b/java/src/jmri/jmrit/logix/ControlPanel.java
@@ -80,10 +80,10 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         speedSpinner.setModel(speedSpinnerModel);
         speedSpinner.setFocusable(false);
 
-        speedStep128Button = new JRadioButton(Bundle.getMessage("Button128SS"));
-        speedStep28Button = new JRadioButton(Bundle.getMessage("Button28SS"));
-        speedStep27Button = new JRadioButton(Bundle.getMessage("Button27SS"));
-        speedStep14Button = new JRadioButton(Bundle.getMessage("Button14SS"));
+        speedStep128Button = new JRadioButton(SpeedStepMode.NMRA_DCC_128.description);
+        speedStep28Button = new JRadioButton(SpeedStepMode.NMRA_DCC_28.description);
+        speedStep27Button = new JRadioButton(SpeedStepMode.NMRA_DCC_27.description);
+        speedStep14Button = new JRadioButton(SpeedStepMode.NMRA_DCC_14.description);
 
         initGUI();
         pack();

--- a/java/src/jmri/jmrit/throttle/ControlPanel.java
+++ b/java/src/jmri/jmrit/throttle/ControlPanel.java
@@ -17,10 +17,13 @@ import java.awt.event.MouseListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.util.EnumSet;
+
+import javax.swing.AbstractButton;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
+import javax.swing.JComboBox;
 import javax.swing.JInternalFrame;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
@@ -47,7 +50,6 @@ import org.jdom2.Element;
  * A JInternalFrame that contains a JSlider to control loco speed, and buttons
  * for forward, reverse and STOP.
  * <p>
- * TODO: fix speed increments (14, 28)
  *
  * @author glen Copyright (C) 2002
  * @author Bob Jacobsen Copyright (C) 2007
@@ -60,10 +62,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
     private JSlider speedSliderContinuous;
     private JSpinner speedSpinner;
     private SpinnerNumberModel speedSpinnerModel;
-    private JRadioButton speedStep128Button;
-    private JRadioButton speedStep28Button;
-    private JRadioButton speedStep27Button;
-    private JRadioButton speedStep14Button;
+    private JComboBox<SpeedStepMode> speedStepBox;
     private JRadioButton forwardButton, reverseButton;
     private JButton stopButton;
     private JButton idleButton;
@@ -157,16 +156,9 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
      */
     @Override
     public void setEnabled(boolean isEnabled) {
-        //super.setEnabled(isEnabled);
         forwardButton.setEnabled(isEnabled);
         reverseButton.setEnabled(isEnabled);
-        speedStep128Button.setEnabled(isEnabled);
-        speedStep28Button.setEnabled(isEnabled);
-        speedStep27Button.setEnabled(isEnabled);
-        speedStep14Button.setEnabled(isEnabled);
-        if (isEnabled) {
-            configureAvailableSpeedStepModes();
-        }
+        speedStepBox.setEnabled(isEnabled);
         stopButton.setEnabled(isEnabled);
         idleButton.setEnabled(isEnabled);
         speedControllerEnable = isEnabled;
@@ -243,6 +235,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
      *                      SpeedStepMode.NMRA_DCC_14 step mode
      */
     private void setSpeedStepsMode(SpeedStepMode speedStepMode) {
+        final ThrottlesPreferences preferences =
+                InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences();
         internalAdjust = true;
         int maxSpeedPCT = 100;
         if (addressPanel.getRosterEntry() != null) {
@@ -252,31 +246,10 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         // Save the old speed as a float
         float oldSpeed = (speedSlider.getValue() / (maxSpeed * 1.0f));
 
-        if (speedStepMode == SpeedStepMode.NMRA_DCC_14) {
-            speedStep14Button.setSelected(true);
-            speedStep27Button.setSelected(false);
-            speedStep28Button.setSelected(false);
-            speedStep128Button.setSelected(false);
-            intSpeedSteps = 14;
-        } else if (speedStepMode == SpeedStepMode.NMRA_DCC_27) {
-            speedStep14Button.setSelected(false);
-            speedStep27Button.setSelected(true);
-            speedStep28Button.setSelected(false);
-            speedStep128Button.setSelected(false);
-            intSpeedSteps = 27;
-        } else if (speedStepMode == SpeedStepMode.NMRA_DCC_28) {
-            speedStep14Button.setSelected(false);
-            speedStep27Button.setSelected(false);
-            speedStep28Button.setSelected(true);
-            speedStep128Button.setSelected(false);
-            intSpeedSteps = 28;
-        } else {
-            speedStep14Button.setSelected(false);
-            speedStep27Button.setSelected(false);
-            speedStep28Button.setSelected(false);
-            speedStep128Button.setSelected(true);
-            intSpeedSteps = 126;
-        }
+        speedStepBox.setSelectedItem(speedStepMode);
+
+        intSpeedSteps = speedStepMode.numSteps;
+
         /* Set maximum speed based on the max speed stored in the roster as a percentage of the maximum */
         maxSpeed = (int) ((float) intSpeedSteps * ((float) maxSpeedPCT) / 100);
 
@@ -290,8 +263,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         labelTable.put(Integer.valueOf(0), new JLabel(Bundle.getMessage("ButtonStop")));
         speedSlider.setLabelTable(labelTable);
         
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
+        if (preferences.isUsingIcons()) {
             speedSlider.setPaintTicks(false);
             speedSlider.setPaintLabels(false);
         } else {
@@ -317,8 +289,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
             labelTable.put(Integer.valueOf(-maxSpeed), new JLabel("-100%"));
             speedSliderContinuous.setLabelTable(labelTable);
             speedSlider.setLabelTable(labelTable);
-            if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                    && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
+            if (preferences.isUsingIcons()) {
                 speedSliderContinuous.setPaintTicks(false);
                 speedSliderContinuous.setPaintLabels(false);
             } else {
@@ -340,6 +311,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
      * @param displaySlider integer value. possible values: SLIDERDISPLAY = use
      *                      speed slider display STEPDISPLAY = use speed step
      *                      display
+     * @return true if speed controller of the selected type is available.
      */
     public boolean isSpeedControllerAvailable(int displaySlider) {
         switch (displaySlider) {
@@ -412,6 +384,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
     /**
      * Get the value indicating what speed input we're displaying
      *
+     * @return SLIDERDISPLAY, STEPDISPLAY or SLIDERDISPLAYCONTINUOUS
      */
     public int getDisplaySlider() {
         return _displaySlider;
@@ -428,6 +401,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
 
     /**
      * Get status of real-time speed slider tracking
+     * 
+     * @return true if slider is tracking.
      */
     public boolean getTrackSlider() {
         return trackSlider;
@@ -463,13 +438,114 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         internalAdjust = false;
     }
 
+    private GridBagConstraints makeDefaultGridBagConstraints() {
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.anchor = GridBagConstraints.CENTER;
+        constraints.fill = GridBagConstraints.BOTH;
+        constraints.gridheight = 1;
+        constraints.gridwidth = 1;
+        constraints.ipadx = 0;
+        constraints.ipady = 0;
+        Insets insets = new Insets(2, 2, 2, 2);
+        constraints.insets = insets;
+        constraints.weightx = 1;
+        constraints.weighty = 1;
+        constraints.gridx = 0;
+        constraints.gridy = 0;
+
+        return constraints;
+    }
+
+    private void layoutButtonPanel() {
+        final ThrottlesPreferences preferences =
+                InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences();
+                
+        GridBagConstraints constraints = makeDefaultGridBagConstraints();
+
+        constraints.fill = GridBagConstraints.NONE;
+
+        constraints.gridy = 1;
+        if (preferences.isUsingIcons()) {
+            constraints.gridx = 3;
+        }
+        buttonPanel.add(forwardButton, constraints);
+
+        if (preferences.isUsingIcons()) {
+            constraints.gridx = 1;
+        } else {
+            constraints.gridy = 2;
+        }
+        buttonPanel.add(reverseButton, constraints);
+
+        if (preferences.isUsingIcons()) {
+            // TODO(trainman419): determine positioning for icon throttle mode.
+        } else {
+            constraints.gridy = 3;
+            buttonPanel.add(speedStepBox, constraints);
+        }
+
+        if (preferences.isUsingIcons()) {
+            constraints.gridx = 2;
+        }
+
+        constraints.gridy = 4;
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        buttonPanel.add(stopButton, constraints);
+
+        if (preferences.isUsingIcons()) {
+            constraints.gridy = 1;
+        } else {
+            constraints.gridy = 5;
+        }
+        buttonPanel.add(idleButton, constraints);
+    }
+
+    private void layoutSliderPanel() {
+        sliderPanel.setLayout(new GridBagLayout());
+
+        GridBagConstraints constraints = makeDefaultGridBagConstraints();
+
+        sliderPanel.add(speedSlider, constraints);
+    }
+
+    private void layoutSpeedSliderContinuous() {
+        speedSliderContinuousPanel.setLayout(new GridBagLayout());
+
+        GridBagConstraints constraints = makeDefaultGridBagConstraints();
+
+        speedSliderContinuousPanel.add(speedSliderContinuous, constraints);
+    }
+
+    private void layoutSpinnerPanel() {
+        spinnerPanel.setLayout(new GridBagLayout());
+        GridBagConstraints constraints = makeDefaultGridBagConstraints();
+
+        spinnerPanel.add(speedSpinner, constraints);
+    }
+
+    private void setupButton(AbstractButton button, final ThrottlesPreferences preferences, final String iconPath,
+        final String selectedIconPath, final String message) {
+        if (preferences.isUsingIcons()) {
+            button.setBorderPainted(false);
+            button.setContentAreaFilled(false);
+            button.setText(null);
+            button.setIcon(new ImageIcon(FileUtil.findURL(iconPath)));
+            button.setSelectedIcon(new ImageIcon(FileUtil.findURL(selectedIconPath)));
+            button.setPreferredSize(new Dimension(BUTTON_SIZE, BUTTON_SIZE));
+            button.setToolTipText(Bundle.getMessage(message));
+        } else {
+            button.setText(Bundle.getMessage(message));
+        }
+    }
+
     /**
      * Create, initialize and place GUI components.
      */
     private void initGUI() {
-        mainPanel = new JPanel();
+        final ThrottlesPreferences preferences =
+                InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences();
+        mainPanel = new JPanel(new BorderLayout());
         this.setContentPane(mainPanel);
-        mainPanel.setLayout(new BorderLayout());
         this.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 
         speedControlPanel = new JPanel();
@@ -477,12 +553,10 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         speedControlPanel.setOpaque(false);
         mainPanel.add(speedControlPanel, BorderLayout.CENTER);
         sliderPanel = new JPanel();
-        sliderPanel.setLayout(new GridBagLayout());
         sliderPanel.setOpaque(false);
         
         speedSlider = new JSlider(0, intSpeedSteps);
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
+        if (preferences.isUsingIcons()) {
             speedSlider.setUI(new ControlPanelCustomSliderUI(speedSlider));
         }
         speedSlider.setOpaque(false);
@@ -506,8 +580,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         });
 
         speedSliderContinuous = new JSlider(-intSpeedSteps, intSpeedSteps);
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
+        if (preferences.isUsingIcons()) {
             speedSliderContinuous.setUI(new ControlPanelCustomSliderUI(speedSlider));
         }
         speedSliderContinuous.setValue(0);
@@ -536,57 +609,21 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         speedSpinner.setModel(speedSpinnerModel);
         speedSpinner.setFocusable(false);
 
-        speedStep128Button = new JRadioButton(Bundle.getMessage("Button128SS"));
-        speedStep28Button = new JRadioButton(Bundle.getMessage("Button28SS"));
-        speedStep27Button = new JRadioButton(Bundle.getMessage("Button27SS"));
-        speedStep14Button = new JRadioButton(Bundle.getMessage("Button14SS"));
+        EnumSet<SpeedStepMode> speedStepModes = InstanceManager.throttleManagerInstance().supportedSpeedModes();
+
+        speedStepBox = new JComboBox<SpeedStepMode>(speedStepModes.toArray(new SpeedStepMode[speedStepModes.size()]));
 
         forwardButton = new JRadioButton();
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
-            forwardButton.setBorderPainted(false);
-            forwardButton.setContentAreaFilled(false);
-            forwardButton.setText(null);
-            forwardButton.setIcon(new ImageIcon(FileUtil.findURL("resources/icons/throttles/up-red.png")));
-            forwardButton.setSelectedIcon(new ImageIcon(FileUtil.findURL("resources/icons/throttles/up-green.png")));
-            forwardButton.setPreferredSize(new Dimension(BUTTON_SIZE, BUTTON_SIZE));
-            forwardButton.setToolTipText(Bundle.getMessage("ButtonForward"));
-        } else {
-            forwardButton.setText(Bundle.getMessage("ButtonForward"));
-        }
+        setupButton(forwardButton, preferences, "resources/icons/throttles/up-red.png",
+            "resources/icons/throttles/up-green.png", "ButtonForward");
 
         reverseButton = new JRadioButton();
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
-            reverseButton.setBorderPainted(false);
-            reverseButton.setContentAreaFilled(false);
-            reverseButton.setText(null);
-            reverseButton.setIcon(new ImageIcon(FileUtil.findURL("resources/icons/throttles/down-red.png")));
-            reverseButton.setSelectedIcon(new ImageIcon(FileUtil.findURL("resources/icons/throttles/down-green.png")));
-            reverseButton.setPreferredSize(new Dimension(BUTTON_SIZE, BUTTON_SIZE));
-            reverseButton.setToolTipText(Bundle.getMessage("ButtonReverse"));
-        } else {
-            reverseButton.setText(Bundle.getMessage("ButtonReverse"));
-        }
+        setupButton(reverseButton, preferences, "resources/icons/throttles/down-red.png",
+            "resources/icons/throttles/down-green.png", "ButtonReverse");
 
         propertiesPopup = new JPopupMenu();
 
-        GridBagConstraints constraints = new GridBagConstraints();
-        constraints.anchor = GridBagConstraints.CENTER;
-        constraints.fill = GridBagConstraints.BOTH;
-        constraints.gridheight = 1;
-        constraints.gridwidth = 1;
-        constraints.ipadx = 0;
-        constraints.ipady = 0;
-        Insets insets = new Insets(2, 2, 2, 2);
-        constraints.insets = insets;
-        constraints.weightx = 1;
-        constraints.weighty = 1;
-        constraints.gridx = 0;
-        constraints.gridy = 0;
-
-        sliderPanel.add(speedSlider, constraints);
-        //this.getContentPane().add(sliderPanel,BorderLayout.CENTER);
+        layoutSliderPanel();
         speedControlPanel.add(sliderPanel);
         speedSlider.setOrientation(JSlider.VERTICAL);
         speedSlider.setMajorTickSpacing(maxSpeed / 2);
@@ -595,8 +632,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         labelTable.put(Integer.valueOf(maxSpeed), new JLabel("100%"));
         labelTable.put(Integer.valueOf(0), new JLabel(Bundle.getMessage("ButtonStop")));
         speedSlider.setLabelTable(labelTable);
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
+        if (preferences.isUsingIcons()) {
             speedSlider.setPaintTicks(false);
             speedSlider.setPaintLabels(false);
         } else {
@@ -642,24 +678,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 });
 
         speedSliderContinuousPanel = new JPanel();
-        speedSliderContinuousPanel.setLayout(new GridBagLayout());
+        layoutSpeedSliderContinuous();
 
-        constraints = new GridBagConstraints();
-        constraints.anchor = GridBagConstraints.CENTER;
-        constraints.fill = GridBagConstraints.BOTH;
-        constraints.gridheight = 1;
-        constraints.gridwidth = 1;
-        constraints.ipadx = 0;
-        constraints.ipady = 0;
-        insets = new Insets(2, 2, 2, 2);
-        constraints.insets = insets;
-        constraints.weightx = 1;
-        constraints.weighty = 1;
-        constraints.gridx = 0;
-        constraints.gridy = 0;
-
-        speedSliderContinuousPanel.add(speedSliderContinuous, constraints);
-        //this.getContentPane().add(sliderPanel,BorderLayout.CENTER);
         speedControlPanel.add(speedSliderContinuousPanel);
         speedSliderContinuous.setOrientation(JSlider.VERTICAL);
         speedSliderContinuous.setMajorTickSpacing(maxSpeed / 2);
@@ -670,8 +690,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         labelTable.put(Integer.valueOf(-maxSpeed / 2), new JLabel("-50%"));
         labelTable.put(Integer.valueOf(-maxSpeed), new JLabel("-100%"));
         speedSliderContinuous.setLabelTable(labelTable);
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
+        if (preferences.isUsingIcons()) {
             speedSliderContinuous.setPaintTicks(false);
             speedSliderContinuous.setPaintLabels(false);
         } else {
@@ -717,9 +736,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 });
 
         spinnerPanel = new JPanel();
-        spinnerPanel.setLayout(new GridBagLayout());
-
-        spinnerPanel.add(speedSpinner, constraints);
+        layoutSpinnerPanel();
 
         speedControlPanel.add(spinnerPanel);
 
@@ -729,8 +746,6 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                     @Override
                     public void stateChanged(ChangeEvent e) {
                         if (!internalAdjust) {
-                            //if (!speedSpinner.getValueIsAdjusting())
-                            //{
                             float newSpeed = ((Integer) speedSpinner.getValue()).floatValue() / (intSpeedSteps * 1.0f);
                             if (log.isDebugEnabled()) {
                                 log.debug("stateChanged: spinner pos: " + speedSpinner.getValue() + " speed: " + newSpeed);
@@ -750,59 +765,18 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                             } else {
                                 log.warn("no throttle object in stateChanged, ignoring change of speed to " + newSpeed);
                             }
-                            //}
                         }
                     }
                 });
 
-        ButtonGroup speedStepButtons = new ButtonGroup();
-        speedStepButtons.add(speedStep128Button);
-        speedStepButtons.add(speedStep28Button);
-        speedStepButtons.add(speedStep27Button);
-        speedStepButtons.add(speedStep14Button);
-        constraints.fill = GridBagConstraints.NONE;
-        constraints.gridy = 1;
-        spinnerPanel.add(speedStep128Button, constraints);
-        constraints.gridy = 2;
-        spinnerPanel.add(speedStep28Button, constraints);
-        constraints.gridy = 3;
-        spinnerPanel.add(speedStep27Button, constraints);
-        constraints.gridy = 4;
-        spinnerPanel.add(speedStep14Button, constraints);
 
-        speedStep14Button.addActionListener(
+        speedStepBox.addActionListener(
                 new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(SpeedStepMode.NMRA_DCC_14);
-                        throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_14);
-                    }
-                });
-
-        speedStep27Button.addActionListener(
-                new ActionListener() {
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(SpeedStepMode.NMRA_DCC_27);
-                        throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_27);
-                    }
-                });
-
-        speedStep28Button.addActionListener(
-                new ActionListener() {
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(SpeedStepMode.NMRA_DCC_28);
-                        throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_28);
-                    }
-                });
-
-        speedStep128Button.addActionListener(
-                new ActionListener() {
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(SpeedStepMode.NMRA_DCC_128);
-                        throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_128);
+                        SpeedStepMode s = (SpeedStepMode)speedStepBox.getSelectedItem();
+                        setSpeedStepsMode(s);
+                        throttle.setSpeedStepMode(s);
                     }
                 });
 
@@ -815,27 +789,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         directionButtons.add(reverseButton);
         forwardButton.setFocusable(false);
         reverseButton.setFocusable(false);
-        constraints.fill = GridBagConstraints.NONE;
 
-        constraints.gridy = 1;
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
-            constraints.gridx = 3;
-        }
-        buttonPanel.add(forwardButton, constraints);
-
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
-            constraints.gridx = 1;
-        } else {
-            constraints.gridy = 2;
-        }
-        buttonPanel.add(reverseButton, constraints);
-
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
-            constraints.gridx = 2;
-        }
         forwardButton.addActionListener(
                 new ActionListener() {
                     @Override
@@ -859,21 +813,9 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 });
 
         stopButton = new JButton();
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
-            stopButton.setBorderPainted(false);
-            stopButton.setContentAreaFilled(false);
-            stopButton.setText(null);
-            stopButton.setIcon(new ImageIcon(FileUtil.findURL("resources/icons/throttles/estop.png")));
-            stopButton.setPressedIcon(new ImageIcon(FileUtil.findURL("resources/icons/throttles/estop24.png")));
-            stopButton.setPreferredSize(new Dimension(BUTTON_SIZE, BUTTON_SIZE));
-            stopButton.setToolTipText(Bundle.getMessage("ButtonEStop"));
-        } else {
-            stopButton.setText(Bundle.getMessage("ButtonEStop"));
-        }
-        constraints.gridy = 4;
-        constraints.fill = GridBagConstraints.HORIZONTAL;
-        buttonPanel.add(stopButton, constraints);
+        setupButton(stopButton, preferences, "resources/icons/throttles/estop.png",
+            "resources/icons/throttles/estop24.png", "ButtonEStop");
+
         stopButton.addActionListener(
                 new ActionListener() {
                     @Override
@@ -906,26 +848,9 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                     }
                 });
         idleButton = new JButton();
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
-            idleButton.setBorderPainted(false);
-            idleButton.setContentAreaFilled(false);
-            idleButton.setText(null);
-            idleButton.setIcon(new ImageIcon(FileUtil.findURL("resources/icons/throttles/stop.png")));
-            idleButton.setPressedIcon(new ImageIcon(FileUtil.findURL("resources/icons/throttles/stop24.png")));
-            idleButton.setPreferredSize(new Dimension(BUTTON_SIZE, BUTTON_SIZE));
-            idleButton.setToolTipText(Bundle.getMessage("ButtonIdle"));
-        } else {
-            idleButton.setText(Bundle.getMessage("ButtonIdle"));
-        }
+        setupButton(idleButton, preferences, "resources/icons/throttles/stop.png",
+            "resources/icons/throttles/stop24.png", "ButtonIdle");
 
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
-            constraints.gridy = 1;
-        } else {
-            constraints.gridy = 3;
-        }
-        buttonPanel.add(idleButton, constraints);
         idleButton.addActionListener(
                 new ActionListener() {
                     @Override
@@ -948,6 +873,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                         changeOrientation();
                     }
                 });
+
+        layoutButtonPanel();
 
         JMenuItem propertiesItem = new JMenuItem(Bundle.getMessage("ControlPanelProperties"));
         propertiesItem.addActionListener(this);
@@ -1145,6 +1072,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
 
     /**
      * Intended for throttle scripting
+     * 
+     * @param fwd direction: true for forward; false for reverse.
      */
     public void setForwardDirection(boolean fwd) {
         if (fwd) {
@@ -1164,6 +1093,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
 
     /**
      * Intended for throttle scripting
+     * 
+     * @return The speed splider.
      */
     public JSlider getSpeedSlider() {
         return speedSlider;
@@ -1225,35 +1156,6 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         ControlPanelPropertyEditor editor
                 = new ControlPanelPropertyEditor(this);
         editor.setVisible(true);
-    }
-
-    /**
-     * Configure the active Speed Step modes based on what is supported by the
-     * DCC system
-     */
-    private void configureAvailableSpeedStepModes() {
-        EnumSet<SpeedStepMode> modes = jmri.InstanceManager.throttleManagerInstance()
-                .supportedSpeedModes();
-        if (modes.contains(SpeedStepMode.NMRA_DCC_128)) {
-            speedStep128Button.setEnabled(true);
-        } else {
-            speedStep128Button.setEnabled(false);
-        }
-        if (modes.contains(SpeedStepMode.NMRA_DCC_28)) {
-            speedStep28Button.setEnabled(true);
-        } else {
-            speedStep28Button.setEnabled(false);
-        }
-        if (modes.contains(SpeedStepMode.NMRA_DCC_27)) {
-            speedStep27Button.setEnabled(true);
-        } else {
-            speedStep27Button.setEnabled(false);
-        }
-        if (modes.contains(SpeedStepMode.NMRA_DCC_14)) {
-            speedStep14Button.setEnabled(true);
-        } else {
-            speedStep14Button.setEnabled(false);
-        }
     }
 
     /**

--- a/java/src/jmri/jmrit/throttle/FunctionPanel.java
+++ b/java/src/jmri/jmrit/throttle/FunctionPanel.java
@@ -390,6 +390,7 @@ public class FunctionPanel extends JInternalFrame implements FunctionListener, j
      * loaded from a roster entry, update buttons accordingly
      */
     public void resetFnButtons() {
+        final ThrottlesPreferences preferences = InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences();
         // Buttons names, ids,
         for (int i = 0; i < NUM_FUNCTION_BUTTONS; i++) {
             functionButton[i].setIdentity(i);
@@ -401,9 +402,7 @@ public class FunctionPanel extends JInternalFrame implements FunctionListener, j
             }
 
             functionButton[i].setDisplay(true);
-            if ((i < 3)
-                    && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                    && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
+            if ((i < 3) && preferences.isUsingIcons()) {
                 switch (i) {
                     case 0:
                         functionButton[i].setIconPath("resources/icons/throttles/Light.png");
@@ -469,6 +468,7 @@ public class FunctionPanel extends JInternalFrame implements FunctionListener, j
 
     // Update buttons value from slot + load buttons definition from roster if any
     private void setFnButtons() {
+        final ThrottlesPreferences preferences = InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences();
         if (mThrottle != null) {
             if (addressPanel == null) {
                 return;
@@ -499,8 +499,7 @@ public class FunctionPanel extends JInternalFrame implements FunctionListener, j
                     if (text != null) {
                         functionButton[i].setDisplay(true);
                         functionButton[i].setButtonLabel(text);
-                        if ((InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle())
-                                && (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon())) {
+                        if (preferences.isUsingIcons()) {
                             functionButton[i].setIconPath(rosterEntry.getFunctionImage(i));
                             functionButton[i].setSelectedIconPath(rosterEntry.getFunctionSelectedImage(i));
                         } else {
@@ -513,10 +512,8 @@ public class FunctionPanel extends JInternalFrame implements FunctionListener, j
                             functionButton[i].setVisible(true);
                         }
                         maxi++; // bump number of buttons shown
-                    } else if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences()
-                            .isUsingExThrottle()
-                            && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences()
-                            .isHidingUndefinedFuncButt()) {
+                    } else if (preferences.isUsingExThrottle()
+                            && preferences.isHidingUndefinedFuncButt()) {
                         functionButton[i].setDisplay(false);
                         functionButton[i].setVisible(false);
                     }
@@ -524,11 +521,8 @@ public class FunctionPanel extends JInternalFrame implements FunctionListener, j
             }
             // hide alt buttons if not required
             if ((rosterEntry != null) && (maxi < NUM_FUNC_BUTTONS_INIT
-                    && InstanceManager.getDefault(ThrottleFrameManager.class)
-                    .getThrottlesPreferences().isUsingExThrottle()
-                    && InstanceManager.getDefault(ThrottleFrameManager.class)
-                    .getThrottlesPreferences()
-                    .isHidingUndefinedFuncButt())) {
+                    && preferences.isUsingExThrottle()
+                    && preferences.isHidingUndefinedFuncButt())) {
                 alt1Button.setVisible(false);
                 alt2Button.setVisible(false);
             }

--- a/java/src/jmri/jmrit/throttle/ThrottleFrame.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleFrame.java
@@ -271,6 +271,8 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
      * </ul>
      */
     private void initGUI() {
+        final ThrottlesPreferences preferences =
+            InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences();
         frameListener = new FrameListener();
 
         controlPanel = new ControlPanel();
@@ -295,8 +297,7 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
         int width = 3 * (FunctionButton.BUT_WDTH) + 2 * 3 * 5 + 10;   // = 192
         int height = 6 * (FunctionButton.BUT_HGHT) + 2 * 6 * 5 + 20; // = 240 (but there seems to be another 10 needed for some LAFs)
 
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
+        if (preferences.isUsingIcons()) {
             width = FunctionButton.BUT_WDTH * 3 + 2 * 3 * 5 + 10;
             height = FunctionButton.BUT_IMG_SIZE * 2 + FunctionButton.BUT_HGHT * 4 + 2 * 6 * 5 + 20;
         }
@@ -334,14 +335,13 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
         if (controlPanel.getHeight() > functionPanel.getHeight() + addressPanel.getHeight()) {
             addressPanel.setSize(addressPanel.getWidth(), controlPanel.getHeight() - functionPanel.getHeight());
         }
-        if (!(InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle() && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon())
+        if (!(preferences.isUsingIcons())
                 && (functionPanel.getWidth() < addressPanel.getWidth())) {
             functionPanel.setSize(addressPanel.getWidth(), functionPanel.getHeight());
         }
         // SpotBugs flagged the following (apparently correctly) as a
         // useless control statement, so it has been commented out.
-        //if (!(InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-        //        && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon())
+        //if (!(preferences.isUsingIcons())
         //        && (functionPanel.getWidth() < addressPanel.getWidth())) {
         //}
 
@@ -359,13 +359,13 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
         add(addressPanel, PANEL_LAYER_FRAME);
         add(speedPanel, PANEL_LAYER_FRAME);
 
-        if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()) {
-            /*         if ( InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingTransparentCtl() ) {
+        if (preferences.isUsingExThrottle()) {
+            /*         if ( preferences.isUsingTransparentCtl() ) {
              setTransparent(functionPanel);
              setTransparent(addressPanel);
              setTransparent(controlPanel);
              }*/
-            if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingRosterImage()) {
+            if (preferences.isUsingRosterImage()) {
                 backgroundPanel = new BackgroundPanel();
                 backgroundPanel.setAddressPanel(addressPanel); // reusing same way to do it than existing thing in functionPanel
                 addComponentListener(backgroundPanel); // backgroudPanel warned when desktop resized

--- a/java/src/jmri/jmrit/throttle/ThrottlesPreferences.java
+++ b/java/src/jmri/jmrit/throttle/ThrottlesPreferences.java
@@ -138,7 +138,7 @@ public class ThrottlesPreferences {
         setWindowDimension(tp.getWindowDimension());
         setUseExThrottle(tp.isUsingExThrottle());
         setUsingToolBar(tp.isUsingToolBar());
-        setUsingFunctionIcon(tp.isUsingFunctionIcon());
+        setUsingFunctionIcon(tp._useFunctionIcon);
         setResizeWindow(tp.isResizingWindow());
         setSaveThrottleOnLayoutSave(tp.isSavingThrottleOnLayoutSave());
         setUseRosterImage(tp.isUsingRosterImage());
@@ -243,6 +243,11 @@ public class ThrottlesPreferences {
         this.dirty = true;
     }
 
+    /**
+     * Check if function icons are in use.
+     * 
+     * @return user preference to use function icons.
+     */
     public boolean isUsingFunctionIcon() {
         return _useFunctionIcon;
     }
@@ -250,6 +255,16 @@ public class ThrottlesPreferences {
     public void setUsingFunctionIcon(boolean useFunctionIcon) {
         _useFunctionIcon = useFunctionIcon;
         this.dirty = true;
+    }
+
+    /**
+     * Retrun true if throttle icons should be shown; this returns
+     * isUsingExThrottle() &quot;&quot; isUsingFunctionIcon()
+     * 
+     * @return true if throttle icons should be used.
+     */
+    public boolean isUsingIcons() {
+        return (isUsingExThrottle() && isUsingFunctionIcon());
     }
 
     public boolean isResizingWindow() {

--- a/java/src/jmri/jmrit/throttle/ThrottlesTableCellRenderer.java
+++ b/java/src/jmri/jmrit/throttle/ThrottlesTableCellRenderer.java
@@ -65,12 +65,12 @@ public class ThrottlesTableCellRenderer implements TableCellRenderer {
         retPanel.add(locoID, BorderLayout.CENTER);
 
         if (tf.getAddressPanel().getThrottle() != null) {
+            final ThrottlesPreferences preferences = InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences();
             JPanel ctrlPanel = new JPanel();
             ctrlPanel.setLayout(new BorderLayout());
             Throttle thr = tf.getAddressPanel().getThrottle();
             JLabel dir = new JLabel();
-            if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                    && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
+            if (preferences.isUsingIcons()) {
                 if (thr.getIsForward()) {
                     dir.setIcon(fwdIcon);
                 } else {
@@ -85,8 +85,7 @@ public class ThrottlesTableCellRenderer implements TableCellRenderer {
             }
             dir.setVerticalAlignment(JLabel.CENTER);
             ctrlPanel.add(dir, BorderLayout.WEST);
-            if (InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingExThrottle()
-                    && InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().isUsingFunctionIcon()) {
+            if (preferences.isUsingIcons()) {
                 if (thr.getSpeedSetting() == -1) {
                     JLabel estop = new JLabel();
                     estop.setPreferredSize(new Dimension(64, height - 8));

--- a/java/test/jmri/SpeedStepModeTest.java
+++ b/java/test/jmri/SpeedStepModeTest.java
@@ -1,0 +1,28 @@
+package jmri;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test simple functioning of SpeedStepMode
+ *
+ * @author Austin Hendrix Copyright (C) 2019
+ */
+public class SpeedStepModeTest {
+
+    @Test
+    public void testValidValues() {
+        for( SpeedStepMode mode : SpeedStepMode.values()) {
+            Assert.assertNotNull(mode.name);
+            Assert.assertTrue(mode.name.length() > 0);
+
+            Assert.assertNotNull(mode.description);
+            Assert.assertTrue(mode.description.length() > 0);
+
+            Assert.assertTrue(mode.numSteps > 0);
+
+            Assert.assertTrue(mode.increment >= 0);
+        }
+    }
+
+}

--- a/java/test/jmri/jmrit/throttle/ControlPanelPropertyEditorTest.java
+++ b/java/test/jmri/jmrit/throttle/ControlPanelPropertyEditorTest.java
@@ -27,6 +27,7 @@ public class ControlPanelPropertyEditorTest {
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
+        JUnitUtil.initDebugThrottleManager();
     }
 
     @After

--- a/java/test/jmri/jmrit/throttle/ControlPanelTest.java
+++ b/java/test/jmri/jmrit/throttle/ControlPanelTest.java
@@ -1,7 +1,16 @@
 package jmri.jmrit.throttle;
 
+import java.awt.Container;
+import java.awt.Component;
 import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
+
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+
 import jmri.util.JUnitUtil;
+import jmri.InstanceManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -14,22 +23,135 @@ import org.junit.Test;
  * @author	Paul Bender Copyright (C) 2016
  */
 public class ControlPanelTest {
+    ControlPanel panel;
+    JFrame frame;
+
+    private void setupControlPanel() {
+        panel = new ControlPanel();
+        Assert.assertNotNull("exists", panel);
+        
+        frame = new JFrame("ControlPanelTest");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setVisible(true);
+        frame.setSize(200, 400);
+        
+        JPanel mainPanel = new JPanel();
+        mainPanel.setOpaque(true);
+        mainPanel.add(new JDesktopPane());
+        mainPanel.add(panel);
+
+        panel.toFront();
+        panel.setVisible(true);
+
+        frame.add(mainPanel);
+    }
+
+    private void checkFrameOverlap(Container f) {
+        synchronized(f.getTreeLock()) {
+            int count = f.getComponentCount();
+            for (int i1 =0 ; i1 < count; i1++) {
+                Component c1 = f.getComponent(i1);
+                for (int i2 = i1+1; i2 < count; i2++ ) {
+                    Component c2 = f.getComponent(i2);
+                    if (c1 == c2) {
+                        continue;
+                    }
+                    if (!c1.isVisible()) {
+                        continue;
+                    }
+                    if (!c2.isVisible()) {
+                        continue;
+                    }
+                    Rectangle r1 = c1.getBounds();
+                    Rectangle r2 = c2.getBounds();
+                    if (r1.intersects(r2)) {
+                        System.out.printf("Components %s(%s) and %s(%s) overlap%n",
+                            c1.getName(), c1.getClass().getName(),
+                            c2.getName(), c2.getClass().getName());
+                    }
+                    Assert.assertFalse(r1.intersects(r2));
+                }
+                
+                if (c1 instanceof Container) {
+                    checkFrameOverlap((Container)c1);
+                }
+            }
+        }
+    }
 
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        ControlPanel panel = new ControlPanel();
-        Assert.assertNotNull("exists", panel);
+        setupControlPanel();
+
+        checkFrameOverlap(panel.getContentPane());
+    }
+
+    @Test
+    public void testExtendedThrottle() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().setUsingFunctionIcon(false);
+        setupControlPanel();
+        //checkFrameOverlap(panel.getContentPane());
+
+        try {
+            Thread.sleep(1000);
+            checkFrameOverlap(panel.getContentPane());
+            panel.setSpeedController(ControlPanel.STEPDISPLAY);
+            Thread.sleep(1000);
+            checkFrameOverlap(panel.getContentPane());
+            panel.setSpeedController(ControlPanel.SLIDERDISPLAY);
+            Thread.sleep(1000);
+            checkFrameOverlap(panel.getContentPane());
+            panel.setSpeedController(ControlPanel.SLIDERDISPLAYCONTINUOUS);
+            Thread.sleep(1000);
+            checkFrameOverlap(panel.getContentPane());
+        } catch (InterruptedException e) {
+            // Ignore.
+        }
+    }
+
+    @Test
+    public void testIconThrottle() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().setUsingFunctionIcon(true);
+        setupControlPanel();
+        checkFrameOverlap(panel.getContentPane());
+
+        try {
+            Thread.sleep(1000);
+            checkFrameOverlap(panel.getContentPane());
+            panel.setSpeedController(ControlPanel.STEPDISPLAY);
+            Thread.sleep(1000);
+            checkFrameOverlap(panel.getContentPane());
+            panel.setSpeedController(ControlPanel.SLIDERDISPLAY);
+            Thread.sleep(1000);
+            checkFrameOverlap(panel.getContentPane());
+            panel.setSpeedController(ControlPanel.SLIDERDISPLAYCONTINUOUS);
+            Thread.sleep(1000);
+            checkFrameOverlap(panel.getContentPane());
+        } catch (InterruptedException e) {
+            // Ignore.
+        }
     }
 
     @Before
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
+        JUnitUtil.initDebugThrottleManager();
+        if (!GraphicsEnvironment.isHeadless()) {
+            InstanceManager.getDefault(ThrottleFrameManager.class).getThrottlesPreferences().setUseExThrottle(true);
+        }
     }
 
     @After
     public void tearDown() {
+        if( frame != null ) {
+            JUnitUtil.dispose(frame);
+            frame = null;
+        }
+
         JUnitUtil.resetWindows(false,false);
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/throttle/ThrottleFramePropertyEditorTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottleFramePropertyEditorTest.java
@@ -31,6 +31,7 @@ public class ThrottleFramePropertyEditorTest {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
         JUnitUtil.initRosterConfigManager();
+        JUnitUtil.initDebugThrottleManager();
     }
 
     @After

--- a/java/test/jmri/jmrit/throttle/ThrottleWindowTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottleWindowTest.java
@@ -17,6 +17,7 @@ public class ThrottleWindowTest extends jmri.util.JmriJFrameTestBase {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
         JUnitUtil.initRosterConfigManager();
+        JUnitUtil.initDebugThrottleManager();
         if (!GraphicsEnvironment.isHeadless()) {
             frame = new ThrottleWindow();
         }

--- a/java/test/jmri/jmrit/throttle/ThrottlesPreferencesTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottlesPreferencesTest.java
@@ -2,8 +2,11 @@ package jmri.jmrit.throttle;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.awt.Dimension;
 
 /**
  * Test simple functioning of ThrottlesPreferences
@@ -11,17 +14,79 @@ import org.junit.Test;
  * @author Paul Bender Copyright (C) 2016
  */
 public class ThrottlesPreferencesTest {
+    private ThrottlesPreferences preferences;
 
     @Test
     public void testCtor() {
-        ThrottlesPreferences panel = new ThrottlesPreferences();
-        Assert.assertNotNull("exists", panel);
+        Assert.assertNotNull("exists", preferences);
+        Assert.assertFalse("default preferences not dirty", preferences.isDirty());
+    }
+
+    @Test
+    public void testIsUsingIcons() {
+        Assume.assumeNotNull(preferences);
+        Assume.assumeFalse(preferences.isDirty());
+
+        Assert.assertTrue("default using extended throttle", preferences.isUsingExThrottle());
+        Assert.assertFalse("default not using icons", preferences.isUsingIcons());
+
+        preferences.setUsingFunctionIcon(true);
+        Assert.assertTrue("preferences dirty after setting icons", preferences.isDirty());
+        Assert.assertTrue("use icons after setting setUsingFunctionIcon", preferences.isUsingIcons());
+
+        preferences.setUseExThrottle(false);
+        Assert.assertFalse("don't use icons after disabled extended throttle", preferences.isUsingIcons());
+    }
+
+    @Test
+    public void testWindowDimension() {
+        Assume.assumeNotNull(preferences);
+        Assume.assumeFalse(preferences.isDirty());
+
+        Dimension d = new Dimension(800, 600);
+        Assert.assertEquals("default window dimensions", preferences.getWindowDimension(), d);
+
+        d.width = 640;
+        d.height = 480;
+        preferences.setWindowDimension(d);
+        Assert.assertTrue("preferences dirty after setting window dimensions",
+            preferences.isDirty());
+
+        Dimension d2 = new Dimension(640, 480);
+        Assert.assertEquals("test sanity", d, d2);
+        Assert.assertEquals("new window dimensions", preferences.getWindowDimension(), d2);
+    }
+
+    @Test
+    public void testUseExThrottle() {
+        Assume.assumeNotNull(preferences);
+        Assume.assumeFalse(preferences.isDirty());
+
+        Assert.assertTrue("default extended throttle to true", preferences.isUsingExThrottle());
+
+        preferences.setUseExThrottle(false);
+
+        Assert.assertFalse("ex throttle setting was updated", preferences.isUsingExThrottle());
+        Assert.assertTrue("preferences dirty after changing extened throttle setting", preferences.isDirty());
+    }
+
+    @Test
+    public void testUsingToolbar() {
+        Assume.assumeNotNull(preferences);
+        Assume.assumeFalse(preferences.isDirty());
+
+        Assert.assertTrue("default is using toolbar to true", preferences.isUsingToolBar());
+
+        preferences.setUsingToolBar(false);
+
+        Assert.assertFalse("using toolbar setting was updated", preferences.isUsingToolBar());
+        Assert.assertTrue("preferences dirty after toolbar setting update", preferences.isDirty());
     }
 
     @Before
     public void setUp() throws Exception {
         jmri.util.JUnitUtil.setUp();
-
+        preferences = new ThrottlesPreferences();
     }
 
     @After


### PR DESCRIPTION
Add a speed step dropdown to the extended throttle; this makes it easier to select the speed step mode and makes it possible to select the less common speed step modes exposed by some systems. I've also consolidated the throttle layout code, centralized the logic for determining if throttle icons should be shown, and added unit tests for the control panel layout and some preferences.

Slider:
![extended_slider](https://user-images.githubusercontent.com/103991/76286116-84a3da00-625e-11ea-9044-385aec3b924a.png)

Shunting:
![extended_shunting](https://user-images.githubusercontent.com/103991/76286113-84a3da00-625e-11ea-9e30-c28e39892b2b.png)

Step display (previously speed step):
![extended_step](https://user-images.githubusercontent.com/103991/76286117-853c7080-625e-11ea-95d5-963113e7c644.png)