### PR TITLE
Clean up some build warnings

### DIFF
--- a/java/acceptancetest/step_definitions/jmri/web/WebServerAcceptanceSteps.java
+++ b/java/acceptancetest/step_definitions/jmri/web/WebServerAcceptanceSteps.java
@@ -2,13 +2,11 @@ package jmri.web;
 
 import cucumber.api.java8.En;
 import java.io.File;
-import java.util.List;
 import jmri.InstanceManager;
 import jmri.ConfigureManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;

--- a/java/src/apps/AppsLaunchPane.java
+++ b/java/src/apps/AppsLaunchPane.java
@@ -6,7 +6,6 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.File;
 import java.net.URI;
 import java.util.Locale;
 import javax.swing.Box;
@@ -24,7 +23,6 @@ import jmri.jmrix.ConnectionStatus;
 import jmri.jmrix.JmrixConfigPane;
 import jmri.util.FileUtil;
 import jmri.util.iharder.dnd.URIDrop;
-import jmri.util.iharder.dnd.URIDrop.Listener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java/src/apps/startup/ScriptButtonPanel.java
+++ b/java/src/apps/startup/ScriptButtonPanel.java
@@ -53,6 +53,7 @@ public class ScriptButtonPanel extends javax.swing.JPanel {
 
         scriptButton.setText(bundle.getString("ScriptButtonPanel.scriptButton.text")); // NOI18N
         scriptButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 scriptButtonActionPerformed(evt);
             }

--- a/java/src/apps/startup/StartupActionsPreferencesPanel.java
+++ b/java/src/apps/startup/StartupActionsPreferencesPanel.java
@@ -109,6 +109,7 @@ public class StartupActionsPreferencesPanel extends JPanel implements Preference
         ResourceBundle bundle = ResourceBundle.getBundle("apps/startup/Bundle"); // NOI18N
         addBtn.setText(bundle.getString("StartupActionsPreferencesPanel.addBtn.text")); // NOI18N
         addBtn.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent evt) {
                 addBtnActionPerformed(evt);
             }
@@ -117,6 +118,7 @@ public class StartupActionsPreferencesPanel extends JPanel implements Preference
         removeBtn.setText(bundle.getString("StartupActionsPreferencesPanel.removeBtn.text")); // NOI18N
         removeBtn.setEnabled(false);
         removeBtn.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent evt) {
                 removeBtnActionPerformed(evt);
             }
@@ -127,6 +129,7 @@ public class StartupActionsPreferencesPanel extends JPanel implements Preference
         upBtn.setText(bundle.getString("StartupActionsPreferencesPanel.upBtn.text")); // NOI18N
         upBtn.setEnabled(false);
         upBtn.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent evt) {
                 upBtnActionPerformed(evt);
             }
@@ -135,6 +138,7 @@ public class StartupActionsPreferencesPanel extends JPanel implements Preference
         downBtn.setText(bundle.getString("StartupActionsPreferencesPanel.downBtn.text")); // NOI18N
         downBtn.setEnabled(false);
         downBtn.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent evt) {
                 downBtnActionPerformed(evt);
             }

--- a/java/src/jmri/AudioManager.java
+++ b/java/src/jmri/AudioManager.java
@@ -88,6 +88,7 @@ public interface AudioManager extends Manager<Audio> {
      * @param systemName Audio object system name (such as IAS1 or IAB4)
      * @return requested Audio object or null if none exists
      */
+    @Override
     @CheckForNull
     public Audio getBySystemName(@Nonnull String systemName);
 
@@ -98,6 +99,7 @@ public interface AudioManager extends Manager<Audio> {
      * @param userName Audio object user name
      * @return requested Audio object or null if none exists
      */
+    @Override
     @CheckForNull
     public Audio getByUserName(@Nonnull String userName);
 

--- a/java/src/jmri/CatalogTreeManager.java
+++ b/java/src/jmri/CatalogTreeManager.java
@@ -44,6 +44,7 @@ public interface CatalogTreeManager extends Manager<CatalogTree> {
      * @param systemName CatalogTree object to locate
      * @return requested CatalogTree object or null if none exists
      */
+    @Override
     public CatalogTree getBySystemName(@Nonnull String systemName);
 
     /**
@@ -53,6 +54,7 @@ public interface CatalogTreeManager extends Manager<CatalogTree> {
      * @param userName CatalogTree object to locate
      * @return requested CatalogTree object or null if none exists
      */
+    @Override
     public CatalogTree getByUserName(@Nonnull String userName);
 
     /**

--- a/java/src/jmri/ConditionalManager.java
+++ b/java/src/jmri/ConditionalManager.java
@@ -67,10 +67,12 @@ public interface ConditionalManager extends Manager<Conditional> {
 
     public Conditional getConditional(String name);
 
+    @Override
     public Conditional getByUserName(String s);
 
     public Conditional getByUserName(Logix x, String s);
 
+    @Override
     public Conditional getBySystemName(String s);
 
     /**

--- a/java/src/jmri/IdTagManager.java
+++ b/java/src/jmri/IdTagManager.java
@@ -76,6 +76,7 @@ public interface IdTagManager extends ProvidingManager<IdTag> {
      * @param systemName system name being requested
      * @return requested IdTag object or null if none exists
      */
+    @Override
     @CheckReturnValue
     @CheckForNull
     public IdTag getBySystemName(@Nonnull String systemName);
@@ -87,6 +88,7 @@ public interface IdTagManager extends ProvidingManager<IdTag> {
      * @param userName user name being requested
      * @return requested IdTag object or null if none exists
      */
+    @Override
     @CheckReturnValue
     @CheckForNull
     public IdTag getByUserName(@Nonnull String userName);

--- a/java/src/jmri/configurexml/StoreMenu.java
+++ b/java/src/jmri/configurexml/StoreMenu.java
@@ -1,6 +1,5 @@
 package jmri.configurexml;
 
-import java.util.ResourceBundle;
 import javax.swing.JMenu;
 
 /**

--- a/java/src/jmri/implementation/decorators/TimeoutReporter.java
+++ b/java/src/jmri/implementation/decorators/TimeoutReporter.java
@@ -1,17 +1,11 @@
 package jmri.implementation.decorators;
 
 import jmri.*;
-import jmri.implementation.AbstractReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.beans.PropertyVetoException;
-import java.util.ArrayList;
-import java.util.Set;
 
 /**
  * Timeout decorator implementation for reporters.

--- a/java/src/jmri/jmrit/beantable/oblock/PathTurnoutTableModel.java
+++ b/java/src/jmri/jmrit/beantable/oblock/PathTurnoutTableModel.java
@@ -264,6 +264,7 @@ public class PathTurnoutTableModel extends AbstractTableModel implements Propert
         return 5;
     }
 
+    @Override
     public void propertyChange(PropertyChangeEvent e) {
         if (_path.getBlock().equals(e.getSource())) {
             String property = e.getPropertyName();

--- a/java/src/jmri/jmrit/beantable/oblock/PortalTableModel.java
+++ b/java/src/jmri/jmrit/beantable/oblock/PortalTableModel.java
@@ -278,6 +278,7 @@ public class PortalTableModel extends AbstractTableModel implements PropertyChan
         return 5;
     }
 
+    @Override
     public void propertyChange(PropertyChangeEvent e) {
         String property = e.getPropertyName();
         if (log.isDebugEnabled()) {

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmAbout.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmAbout.java
@@ -52,6 +52,7 @@ public class FrmAbout extends javax.swing.JFrame {
 
         _mOK.setText(Bundle.getMessage("ButtonOK"));
         _mOK.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mOKActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmAddModifyCTCColumn.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmAddModifyCTCColumn.java
@@ -81,6 +81,7 @@ public class FrmAddModifyCTCColumn extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }
@@ -100,6 +101,7 @@ public class FrmAddModifyCTCColumn extends javax.swing.JFrame {
         _mGUIGeneratedAtLeastOnceAlready.setText(Bundle.getMessage("LabelDlgAddModGen")
         );
         _mGUIGeneratedAtLeastOnceAlready.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mGUIGeneratedAtLeastOnceAlreadyActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmCB.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmCB.java
@@ -132,6 +132,7 @@ public class FrmCB extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }
@@ -139,6 +140,7 @@ public class FrmCB extends javax.swing.JFrame {
 
         jButton2.setText(Bundle.getMessage("ButtonReapply"));
         jButton2.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButton2ActionPerformed(evt);
             }
@@ -147,6 +149,7 @@ public class FrmCB extends javax.swing.JFrame {
         _mOSSectionOccupiedExternalSensorPrompt.setText(Bundle.getMessage("LabelDlgCBPriSensor"));
 
         _mOSSectionSwitchSlavedToUniqueID.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mOSSectionSwitchSlavedToUniqueIDActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmCO.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmCO.java
@@ -189,6 +189,7 @@ public class FrmCO extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }
@@ -217,6 +218,7 @@ public class FrmCO extends javax.swing.JFrame {
         jLabel15.setText(Bundle.getMessage("InfoDlgCORow5B"));
 
         _mGroupingsList.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
+            @Override
             public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
                 _mGroupingsListValueChanged(evt);
             }
@@ -225,6 +227,7 @@ public class FrmCO extends javax.swing.JFrame {
 
         _mDelete.setText(Bundle.getMessage("ButtonDelete"));
         _mDelete.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mDeleteActionPerformed(evt);
             }
@@ -232,6 +235,7 @@ public class FrmCO extends javax.swing.JFrame {
 
         _mEditBelow.setText(Bundle.getMessage("ButtonEditBelow"));
         _mEditBelow.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEditBelowActionPerformed(evt);
             }
@@ -240,6 +244,7 @@ public class FrmCO extends javax.swing.JFrame {
         _mAddNew.setText(Bundle.getMessage("ButtonAddNew")
         );
         _mAddNew.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mAddNewActionPerformed(evt);
             }
@@ -252,6 +257,7 @@ public class FrmCO extends javax.swing.JFrame {
         _mGroupingListAddReplace.setText("      ");
         _mGroupingListAddReplace.setEnabled(false);
         _mGroupingListAddReplace.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mGroupingListAddReplaceActionPerformed(evt);
             }
@@ -259,6 +265,7 @@ public class FrmCO extends javax.swing.JFrame {
 
         jButton2.setText(Bundle.getMessage("ButtonReapply"));
         jButton2.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButton2ActionPerformed(evt);
             }
@@ -266,6 +273,7 @@ public class FrmCO extends javax.swing.JFrame {
 
         _mCancel.setText(Bundle.getMessage("ButtonCancel"));
         _mCancel.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mCancelActionPerformed(evt);
             }
@@ -282,6 +290,7 @@ public class FrmCO extends javax.swing.JFrame {
         jLabel14.setText(Bundle.getMessage("InfoDlgCOSelect"));
 
         _mSwitchIndicator1.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSwitchIndicator1ActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmDebugging.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmDebugging.java
@@ -73,6 +73,7 @@ public class FrmDebugging extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmDefaults.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmDefaults.java
@@ -126,6 +126,7 @@ public class FrmDefaults extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmFindAndReplace.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmFindAndReplace.java
@@ -114,6 +114,7 @@ public class FrmFindAndReplace extends javax.swing.JFrame {
 
         _mButtonDone.setText(Bundle.getMessage("ButtonDone"));
         _mButtonDone.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mButtonDoneActionPerformed(evt);
             }
@@ -127,6 +128,7 @@ public class FrmFindAndReplace extends javax.swing.JFrame {
 
         _mSearch.setText(Bundle.getMessage("ButtonDlgFindSearch"));
         _mSearch.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSearchActionPerformed(evt);
             }
@@ -151,6 +153,7 @@ public class FrmFindAndReplace extends javax.swing.JFrame {
 
         _mReplace.setText(Bundle.getMessage("ButtonDlgFindReplace"));
         _mReplace.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mReplaceActionPerformed(evt);
             }
@@ -188,6 +191,7 @@ public class FrmFindAndReplace extends javax.swing.JFrame {
 
         _mSelectDeselectAll.setText("?Select all");
         _mSelectDeselectAll.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSelectDeselectAllActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmFixErrors.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmFixErrors.java
@@ -58,6 +58,7 @@ public class FrmFixErrors extends javax.swing.JFrame {
 
         jButton1.setText(Bundle.getMessage("ButtonProceed"));
         jButton1.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButton1ActionPerformed(evt);
             }
@@ -65,6 +66,7 @@ public class FrmFixErrors extends javax.swing.JFrame {
 
         _mCancel.setText(Bundle.getMessage("ButtonCancel"));
         _mCancel.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mCancelActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmFleeting.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmFleeting.java
@@ -71,6 +71,7 @@ public class FrmFleeting extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmGUIDesign.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmGUIDesign.java
@@ -143,6 +143,7 @@ public class FrmGUIDesign extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }
@@ -181,6 +182,7 @@ public class FrmGUIDesign extends javax.swing.JFrame {
 
         _mGUIDesign_AnalogClockEtc.setText(Bundle.getMessage("LableDlgGUIClock"));
         _mGUIDesign_AnalogClockEtc.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mGUIDesign_AnalogClockEtcActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmIL.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmIL.java
@@ -162,6 +162,7 @@ public class FrmIL extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }
@@ -288,6 +289,7 @@ public class FrmIL extends javax.swing.JFrame {
 
         jButton1.setText(Bundle.getMessage("ButtonDlgILCompact"));
         jButton1.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButton1ActionPerformed(evt);
             }
@@ -307,6 +309,7 @@ public class FrmIL extends javax.swing.JFrame {
 
         BT_Replace.setText(Bundle.getMessage("ButtonDlgILReplace"));
         BT_Replace.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 BT_ReplaceActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmMainForm.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmMainForm.java
@@ -197,6 +197,7 @@ public class FrmMainForm extends JFrame {
 
         _mPresentlyDefinedColumns.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
         _mPresentlyDefinedColumns.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
+            @Override
             public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
                 _mPresentlyDefinedColumnsValueChanged(evt);
             }
@@ -205,6 +206,7 @@ public class FrmMainForm extends JFrame {
 
         addButton.setText(Bundle.getMessage("ButtonAdd"));
         addButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 addButtonActionPerformed(evt);
             }
@@ -212,6 +214,7 @@ public class FrmMainForm extends JFrame {
 
         deleteButton.setText(Bundle.getMessage("ButtonDelete"));
         deleteButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 deleteButtonActionPerformed(evt);
             }
@@ -219,6 +222,7 @@ public class FrmMainForm extends JFrame {
 
         _mSIDI_Enabled.setText(Bundle.getMessage("LabelEnabled"));
         _mSIDI_Enabled.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSIDI_EnabledActionPerformed(evt);
             }
@@ -226,6 +230,7 @@ public class FrmMainForm extends JFrame {
 
         _mEdit_SIDI.setText(Bundle.getMessage("ButtonEdit"));
         _mEdit_SIDI.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEdit_SIDIActionPerformed(evt);
             }
@@ -237,6 +242,7 @@ public class FrmMainForm extends JFrame {
 
         _mSIDL_Enabled.setText(Bundle.getMessage("LabelEnabled"));
         _mSIDL_Enabled.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSIDL_EnabledActionPerformed(evt);
             }
@@ -244,6 +250,7 @@ public class FrmMainForm extends JFrame {
 
         _mEdit_SIDL.setText(Bundle.getMessage("ButtonEdit"));
         _mEdit_SIDL.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEdit_SIDLActionPerformed(evt);
             }
@@ -253,6 +260,7 @@ public class FrmMainForm extends JFrame {
 
         _mSWDI_Enabled.setText(Bundle.getMessage("LabelEnabled"));
         _mSWDI_Enabled.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSWDI_EnabledActionPerformed(evt);
             }
@@ -260,6 +268,7 @@ public class FrmMainForm extends JFrame {
 
         _mEdit_SWDI.setText(Bundle.getMessage("ButtonEdit"));
         _mEdit_SWDI.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEdit_SWDIActionPerformed(evt);
             }
@@ -269,6 +278,7 @@ public class FrmMainForm extends JFrame {
 
         _mSWDL_Enabled.setText(Bundle.getMessage("LabelEnabled"));
         _mSWDL_Enabled.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSWDL_EnabledActionPerformed(evt);
             }
@@ -276,6 +286,7 @@ public class FrmMainForm extends JFrame {
 
         _mEdit_SWDL.setText(Bundle.getMessage("ButtonEdit"));
         _mEdit_SWDL.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEdit_SWDLActionPerformed(evt);
             }
@@ -285,6 +296,7 @@ public class FrmMainForm extends JFrame {
 
         _mCO_Enabled.setText(Bundle.getMessage("LabelEnabled"));
         _mCO_Enabled.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mCO_EnabledActionPerformed(evt);
             }
@@ -292,6 +304,7 @@ public class FrmMainForm extends JFrame {
 
         _mEdit_CO.setText(Bundle.getMessage("ButtonEdit"));
         _mEdit_CO.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEdit_COActionPerformed(evt);
             }
@@ -301,6 +314,7 @@ public class FrmMainForm extends JFrame {
 
         _mTUL_Enabled.setText(Bundle.getMessage("LabelEnabled"));
         _mTUL_Enabled.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mTUL_EnabledActionPerformed(evt);
             }
@@ -308,6 +322,7 @@ public class FrmMainForm extends JFrame {
 
         _mEdit_TUL.setText(Bundle.getMessage("ButtonEdit"));
         _mEdit_TUL.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEdit_TULActionPerformed(evt);
             }
@@ -317,6 +332,7 @@ public class FrmMainForm extends JFrame {
 
         _mIL_Enabled.setText(Bundle.getMessage("LabelEnabled"));
         _mIL_Enabled.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mIL_EnabledActionPerformed(evt);
             }
@@ -324,6 +340,7 @@ public class FrmMainForm extends JFrame {
 
         _mEdit_IL.setText(Bundle.getMessage("ButtonEdit"));
         _mEdit_IL.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEdit_ILActionPerformed(evt);
             }
@@ -331,6 +348,7 @@ public class FrmMainForm extends JFrame {
 
         reapplyPatternsButton.setText(Bundle.getMessage("ButtonReapplyItem"));
         reapplyPatternsButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 reapplyPatternsButtonActionPerformed(evt);
             }
@@ -340,6 +358,7 @@ public class FrmMainForm extends JFrame {
 
         _mTRL_Enabled.setText(Bundle.getMessage("LabelEnabled"));
         _mTRL_Enabled.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mTRL_EnabledActionPerformed(evt);
             }
@@ -347,6 +366,7 @@ public class FrmMainForm extends JFrame {
 
         _mEdit_TRL.setText(Bundle.getMessage("ButtonEdit"));
         _mEdit_TRL.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEdit_TRLActionPerformed(evt);
             }
@@ -356,6 +376,7 @@ public class FrmMainForm extends JFrame {
 
         _mEdit_CB.setText(Bundle.getMessage("ButtonEdit"));
         _mEdit_CB.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEdit_CBActionPerformed(evt);
             }
@@ -365,6 +386,7 @@ public class FrmMainForm extends JFrame {
 
         changeNumbersButton.setText(Bundle.getMessage("ButtonChange"));
         changeNumbersButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 changeNumbersButtonActionPerformed(evt);
             }
@@ -372,6 +394,7 @@ public class FrmMainForm extends JFrame {
 
         _mButtonWriteXMLFiles.setText(Bundle.getMessage("ButtonXmlFiles"));
         _mButtonWriteXMLFiles.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mButtonWriteXMLFilesActionPerformed(evt);
             }
@@ -379,6 +402,7 @@ public class FrmMainForm extends JFrame {
 
         _mMoveUp.setText(Bundle.getMessage("ButtonMoveUp"));
         _mMoveUp.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mMoveUpActionPerformed(evt);
             }
@@ -386,6 +410,7 @@ public class FrmMainForm extends JFrame {
 
         _mMoveDown.setText(Bundle.getMessage("ButtonMoveDown"));
         _mMoveDown.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mMoveDownActionPerformed(evt);
             }
@@ -393,6 +418,7 @@ public class FrmMainForm extends JFrame {
 
         _mCheckEverythingWithJMRI.setText(Bundle.getMessage("ButtonCheck"));
         _mCheckEverythingWithJMRI.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mCheckEverythingWithJMRIActionPerformed(evt);
             }
@@ -408,6 +434,7 @@ public class FrmMainForm extends JFrame {
         _mNew.setAccelerator(getAccelerator(KeyEvent.VK_N));
         _mNew.setText(Bundle.getMessage("MenuNew"));
         _mNew.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mNewActionPerformed(evt);
             }
@@ -417,6 +444,7 @@ public class FrmMainForm extends JFrame {
         _mSave.setAccelerator(getAccelerator(KeyEvent.VK_S));
         _mSave.setText(Bundle.getMessage("MenuSave"));
         _mSave.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveActionPerformed(evt);
             }
@@ -426,6 +454,7 @@ public class FrmMainForm extends JFrame {
         _mQuitWithoutSaving.setAccelerator(getAccelerator(KeyEvent.VK_E));
         _mQuitWithoutSaving.setText(Bundle.getMessage("MenuExit"));
         _mQuitWithoutSaving.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mQuitWithoutSavingActionPerformed(evt);
             }
@@ -439,6 +468,7 @@ public class FrmMainForm extends JFrame {
         _mFindAndReplace.setAccelerator(getAccelerator(KeyEvent.VK_F));
         _mFindAndReplace.setText(Bundle.getMessage("MenuFind"));
         _mFindAndReplace.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mFindAndReplaceActionPerformed(evt);
             }
@@ -447,6 +477,7 @@ public class FrmMainForm extends JFrame {
 
         _mFixErrors.setText(Bundle.getMessage("MenuFix"));
         _mFixErrors.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mFixErrorsActionPerformed(evt);
             }
@@ -459,6 +490,7 @@ public class FrmMainForm extends JFrame {
 
         _mDebugging.setText(Bundle.getMessage("MenuDebugging"));
         _mDebugging.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mDebuggingActionPerformed(evt);
             }
@@ -467,6 +499,7 @@ public class FrmMainForm extends JFrame {
 
         _mDefaults.setText(Bundle.getMessage("MenuDefaults"));
         _mDefaults.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mDefaultsActionPerformed(evt);
             }
@@ -475,6 +508,7 @@ public class FrmMainForm extends JFrame {
 
         _mFleeting.setText(Bundle.getMessage("MenuFleeting"));
         _mFleeting.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mFleetingActionPerformed(evt);
             }
@@ -483,6 +517,7 @@ public class FrmMainForm extends JFrame {
 
         _mPatterns.setText(Bundle.getMessage("MenuPatterns"));
         _mPatterns.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mPatternsActionPerformed(evt);
             }
@@ -491,6 +526,7 @@ public class FrmMainForm extends JFrame {
 
         _mGUIDesign.setText(Bundle.getMessage("MenuDesign"));
         _mGUIDesign.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mGUIDesignActionPerformed(evt);
             }
@@ -503,6 +539,7 @@ public class FrmMainForm extends JFrame {
 
         _mHelpAbout.setText(Bundle.getMessage("MenuAbout"));
         _mHelpAbout.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mHelpAboutActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmPatterns.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmPatterns.java
@@ -176,6 +176,7 @@ public class FrmPatterns extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmSIDI.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmSIDI.java
@@ -238,6 +238,7 @@ public class FrmSIDI extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }
@@ -504,6 +505,7 @@ public class FrmSIDI extends javax.swing.JFrame {
 
         jButton1.setText(Bundle.getMessage("ButtonSIDIBoth"));
         jButton1.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButton1ActionPerformed(evt);
             }
@@ -515,6 +517,7 @@ public class FrmSIDI extends javax.swing.JFrame {
 
         jButton2.setText(Bundle.getMessage("ButtonReapply"));
         jButton2.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButton2ActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmSIDL.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmSIDL.java
@@ -111,6 +111,7 @@ public class FrmSIDL extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }
@@ -127,6 +128,7 @@ public class FrmSIDL extends javax.swing.JFrame {
 
         jButton2.setText(Bundle.getMessage("ButtonReapply"));
         jButton2.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButton2ActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmSWDI.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmSWDI.java
@@ -138,6 +138,7 @@ public class FrmSWDI extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }
@@ -161,6 +162,7 @@ public class FrmSWDI extends javax.swing.JFrame {
 
         jButton2.setText(Bundle.getMessage("ButtonReapply"));
         jButton2.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButton2ActionPerformed(evt);
             }
@@ -175,6 +177,7 @@ public class FrmSWDI extends javax.swing.JFrame {
         _mSWDI_GUITurnoutType.add(_mTurnout);
         _mTurnout.setText(Bundle.getMessage("LabelSWDITurnout"));
         _mTurnout.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mTurnoutActionPerformed(evt);
             }
@@ -183,6 +186,7 @@ public class FrmSWDI extends javax.swing.JFrame {
         _mSWDI_GUITurnoutType.add(_mCrossover);
         _mCrossover.setText(Bundle.getMessage("LabelSWDIXOver"));
         _mCrossover.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mCrossoverActionPerformed(evt);
             }
@@ -191,6 +195,7 @@ public class FrmSWDI extends javax.swing.JFrame {
         _mSWDI_GUITurnoutType.add(_mDoubleCrossover);
         _mDoubleCrossover.setText(Bundle.getMessage("LabelSWDIDouble"));
         _mDoubleCrossover.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mDoubleCrossoverActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmSWDL.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmSWDL.java
@@ -91,6 +91,7 @@ public class FrmSWDL extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }
@@ -101,6 +102,7 @@ public class FrmSWDL extends javax.swing.JFrame {
 
         jButton2.setText(Bundle.getMessage("ButtonReapply"));
         jButton2.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButton2ActionPerformed(evt);
             }

--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmTRL_Rules.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmTRL_Rules.java
@@ -176,6 +176,7 @@ public class FrmTRL_Rules extends javax.swing.JFrame {
 
         _mSaveAndClose.setText(Bundle.getMessage("ButtonSaveClose"));
         _mSaveAndClose.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mSaveAndCloseActionPerformed(evt);
             }
@@ -184,6 +185,7 @@ public class FrmTRL_Rules extends javax.swing.JFrame {
         jLabel2.setText(Bundle.getMessage("LabelDlgTRLRulesRules"));
 
         _mTRL_TrafficLockingRulesSSVList.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
+            @Override
             public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
                 _mTRL_TrafficLockingRulesSSVListValueChanged(evt);
             }
@@ -192,6 +194,7 @@ public class FrmTRL_Rules extends javax.swing.JFrame {
 
         _mAddNew.setText(Bundle.getMessage("ButtonAddNew"));
         _mAddNew.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mAddNewActionPerformed(evt);
             }
@@ -199,6 +202,7 @@ public class FrmTRL_Rules extends javax.swing.JFrame {
 
         _mEditBelow.setText(Bundle.getMessage("ButtonEditBelow"));
         _mEditBelow.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEditBelowActionPerformed(evt);
             }
@@ -206,6 +210,7 @@ public class FrmTRL_Rules extends javax.swing.JFrame {
 
         _mDelete.setText(Bundle.getMessage("ButtonDelete"));
         _mDelete.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mDeleteActionPerformed(evt);
             }
@@ -214,6 +219,7 @@ public class FrmTRL_Rules extends javax.swing.JFrame {
         _mGroupingListAddReplace.setText(Bundle.getMessage("ButtonDlgTRLRulesUpdate"));
         _mGroupingListAddReplace.setEnabled(false);
         _mGroupingListAddReplace.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mGroupingListAddReplaceActionPerformed(evt);
             }
@@ -229,6 +235,7 @@ public class FrmTRL_Rules extends javax.swing.JFrame {
 
         _mCancel.setText(Bundle.getMessage("ButtonCancel"));
         _mCancel.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mCancelActionPerformed(evt);
             }
@@ -242,6 +249,7 @@ public class FrmTRL_Rules extends javax.swing.JFrame {
 
         _mEnableALLRules.setText(Bundle.getMessage("ButtonDlgTRLRulesEnable"));
         _mEnableALLRules.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mEnableALLRulesActionPerformed(evt);
             }
@@ -249,6 +257,7 @@ public class FrmTRL_Rules extends javax.swing.JFrame {
 
         _mDisableALLRules.setText(Bundle.getMessage("ButtonDlgTRLRulesDisable"));
         _mDisableALLRules.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mDisableALLRulesActionPerformed(evt);
             }
@@ -258,6 +267,7 @@ public class FrmTRL_Rules extends javax.swing.JFrame {
 
         _mDupToEnd.setText(Bundle.getMessage("ButtonDlgTRLRules"));
         _mDupToEnd.addActionListener(new java.awt.event.ActionListener() {
+            @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 _mDupToEndActionPerformed(evt);
             }


### PR DESCRIPTION
Remove some unused imports and add `@Override` tags in places where my IDE suggests them. This cleans up a few build warnings.