### PR TITLE
Change name presentation in Sections, Transits and Dispatcher

### DIFF
--- a/java/src/jmri/EntryPoint.java
+++ b/java/src/jmri/EntryPoint.java
@@ -82,13 +82,9 @@ public class EntryPoint {
         if (needsInitialize) {
             initialize();
         }
-        String s = mFromBlock.getSystemName();
-        String u = mFromBlock.getUserName();
-        if ((u != null) && (!u.equals(""))) {
-            s = s + "( " + u + " )";
-        }
+        String s = mFromBlock.getDisplayName();
         if ((mFromBlockDirection != null) && (!mFromBlockDirection.equals(""))) {
-            s = s + "( " + mFromBlockDirection + " )";
+            s = s + " ( " + mFromBlockDirection + " )";
         }
         return s;
     }

--- a/java/src/jmri/Section.java
+++ b/java/src/jmri/Section.java
@@ -756,12 +756,7 @@ public class Section extends AbstractNamedBean {
         if (mFirstBlock == null) {
             return "unknown";
         }
-        String s = mFirstBlock.getSystemName();
-        String uName = mFirstBlock.getUserName();
-        if ((uName != null) && !uName.isEmpty()) {
-            return (s + "( " + uName + " )");
-        }
-        return s;
+        return mFirstBlock.getDisplayName();
     }
 
     public String getEndBlockName() {
@@ -771,12 +766,7 @@ public class Section extends AbstractNamedBean {
         if (mLastBlock == null) {
             return "unknown";
         }
-        String s = mLastBlock.getSystemName();
-        String uName = mLastBlock.getUserName();
-        if ((uName != null) && (!uName.equals(""))) {
-            return (s + "( " + uName + " )");
-        }
-        return s;
+        return mLastBlock.getDisplayName();
     }
 
     public void addToForwardList(EntryPoint ep) {

--- a/java/src/jmri/jmrit/beantable/SectionTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SectionTableAction.java
@@ -43,6 +43,7 @@ import jmri.jmrit.display.PanelMenu;
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import jmri.util.JmriJFrame;
 import jmri.swing.NamedBeanComboBox;
+import jmri.util.swing.JComboBoxUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -330,7 +331,7 @@ public class SectionTableAction extends AbstractTableAction<Section> {
 
     // add/create variables
     JmriJFrame addFrame = null;
-    JTextField sysName = new JTextField(5);
+    JTextField sysName = new JTextField(15);
     JTextField userName = new JTextField(17);
     JLabel sysNameLabel = new JLabel(Bundle.getMessage("LabelSystemName"));
     JLabel userNameLabel = new JLabel(Bundle.getMessage("LabelUserName"));
@@ -549,6 +550,8 @@ public class SectionTableAction extends AbstractTableAction<Section> {
             reverseSensorBox = new NamedBeanComboBox<>(InstanceManager.sensorManagerInstance());
             reverseSensorBox.setAllowNull(true);
             reverseSensorBox.setSelectedItem(null);
+            JComboBoxUtil.setupComboBoxMaxRows(forwardSensorBox);
+            JComboBoxUtil.setupComboBoxMaxRows(reverseSensorBox);
             JPanel p20 = new JPanel();
             p20.setLayout(new FlowLayout());
             p20.add(new JLabel(rbx.getString("DirectionSensorLabel")));
@@ -571,6 +574,8 @@ public class SectionTableAction extends AbstractTableAction<Section> {
             reverseStopSensorBox = new NamedBeanComboBox<>(InstanceManager.sensorManagerInstance());
             reverseStopSensorBox.setAllowNull(true);
             reverseStopSensorBox.setSelectedItem(null);
+            JComboBoxUtil.setupComboBoxMaxRows(forwardStopSensorBox);
+            JComboBoxUtil.setupComboBoxMaxRows(reverseStopSensorBox);
             JPanel p40 = new JPanel();
             p40.setLayout(new FlowLayout());
             p40.add(new JLabel(rbx.getString("StoppingSensorLabel")));
@@ -809,78 +814,21 @@ public class SectionTableAction extends AbstractTableAction<Section> {
                     JOptionPane.ERROR_MESSAGE);
             return false;
         }
+
         // check direction sensors
-        String choiceName = forwardSensorBox.getSelectedItemDisplayName();
-        if ((choiceName == null) || (choiceName.equals(""))) {
-            fSensor = null;
-        } else {
-            try {
-                fSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(choiceName);
-                if (!choiceName.equals(fSensor.getUserName())) {
-                    forwardSensorBox.setSelectedItem(fSensor);
-                }
-            } catch (IllegalArgumentException ex) {
-                JOptionPane.showMessageDialog(addFrame, rbx
-                        .getString("Message7"), Bundle.getMessage("ErrorTitle"),
-                        JOptionPane.ERROR_MESSAGE);
-                return false;
-            }
-        }
-        choiceName = reverseSensorBox.getSelectedItemDisplayName();
-        if ((choiceName == null) || (choiceName.equals(""))) {
-            rSensor = null;
-        } else {
-            try {
-                rSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(choiceName);
-                if (!choiceName.equals(rSensor.getUserName())) {
-                    reverseSensorBox.setSelectedItem(rSensor);
-                }
-            } catch (IllegalArgumentException ex) {
-                JOptionPane.showMessageDialog(addFrame, rbx
-                        .getString("Message8"), Bundle.getMessage("ErrorTitle"),
-                        JOptionPane.ERROR_MESSAGE);
-                return false;
-            }
-        }
-        if ((fSensor != null) && (fSensor == rSensor)) {
+        fSensor = forwardSensorBox.getSelectedItem();
+        rSensor = reverseSensorBox.getSelectedItem();
+        if ((fSensor != null) && (fSensor.equals(rSensor))) {
             JOptionPane.showMessageDialog(addFrame, rbx
                     .getString("Message9"), Bundle.getMessage("ErrorTitle"),
                     JOptionPane.ERROR_MESSAGE);
             return false;
         }
+
         // check stopping sensors
-        choiceName = forwardStopSensorBox.getSelectedItemDisplayName();
-        if ((choiceName == null) || (choiceName.equals(""))) {
-            fStopSensor = null;
-        } else {
-            try {
-                fStopSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(choiceName);
-                if (!choiceName.equals(fStopSensor.getUserName())) {
-                    forwardStopSensorBox.setSelectedItem(fStopSensor);
-                }
-            } catch (IllegalArgumentException ex) {
-                JOptionPane.showMessageDialog(addFrame, rbx
-                        .getString("Message7"), Bundle.getMessage("ErrorTitle"),
-                        JOptionPane.ERROR_MESSAGE);
-                return false;
-            }
-        }
-        choiceName = reverseStopSensorBox.getSelectedItemDisplayName();
-        if ((choiceName == null) || (choiceName.equals(""))) {
-            rStopSensor = null;
-        } else {
-            try {
-                rStopSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(choiceName);
-                if (!choiceName.equals(rStopSensor.getUserName())) {
-                    reverseStopSensorBox.setSelectedItem(rStopSensor);
-                }
-            } catch (IllegalArgumentException ex) {
-                JOptionPane.showMessageDialog(addFrame, rbx
-                        .getString("Message8"), Bundle.getMessage("ErrorTitle"),
-                        JOptionPane.ERROR_MESSAGE);
-                return false;
-            }
-        }
+        fStopSensor = forwardStopSensorBox.getSelectedItem();
+        rStopSensor = reverseStopSensorBox.getSelectedItem();
+
         return true;
     }
 
@@ -980,28 +928,19 @@ public class SectionTableAction extends AbstractTableAction<Section> {
         if (blockList.size() == 0) {
             // No blocks selected, all blocks are eligible
             for (Block b : blockManager.getNamedBeanSet()) {
-                String bName = b.getSystemName();
-                String uname = b.getUserName();
-                if ((uname != null) && (!uname.equals(""))) {
-                    bName = bName + " ( " + uname + " )";
-                }
-                blockBox.addItem(bName);
+                blockBox.addItem(b.getDisplayName());
                 blockBoxList.add(b);
             }
         } else {
             // limit combo list to Blocks bonded to the currently selected Block that are not already in the Section
             for (Block b : blockManager.getNamedBeanSet()) {
-                String bName = b.getSystemName();
                 if ((!inSection(b)) && connected(b, endBlock)) {
-                    String uname = b.getUserName();
-                    if ((uname != null) && (!uname.equals(""))) {
-                        bName = bName + " ( " + uname + " )";
-                    }
-                    blockBox.addItem(bName);
+                    blockBox.addItem(b.getDisplayName());
                     blockBoxList.add(b);
                 }
             }
         }
+        JComboBoxUtil.setupComboBoxMaxRows(blockBox);
     }
 
     private boolean inSection(Block b) {
@@ -1534,12 +1473,7 @@ public class SectionTableAction extends AbstractTableAction<Section> {
                     return entryPointList.get(rx).getFromBlockName();
 
                 case TO_BLOCK_COLUMN:
-                    String s = entryPointList.get(rx).getBlock().getSystemName();
-                    String u = entryPointList.get(rx).getBlock().getUserName();
-                    if ((u != null) && (!u.equals(""))) {
-                        s = s + " ( " + u + " )";
-                    }
-                    return s;
+                    return entryPointList.get(rx).getBlock().getDisplayName();
 
                 case DIRECTION_COLUMN: //
                     if (entryPointList.get(rx).isForwardType()) {

--- a/java/src/jmri/jmrit/beantable/TransitTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TransitTableAction.java
@@ -48,6 +48,7 @@ import jmri.TransitSectionAction;
 import jmri.NamedBean.DisplayOptions;
 import jmri.util.JmriJFrame;
 import jmri.swing.NamedBeanComboBox;
+import jmri.util.swing.JComboBoxUtil;
 import jmri.util.table.ButtonEditor;
 import jmri.util.table.ButtonRenderer;
 import org.slf4j.Logger;
@@ -358,7 +359,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
 
     // add/create variables
     JmriJFrame addFrame = null;
-    JTextField sysName = new JTextField(5);
+    JTextField sysName = new JTextField(15);
     JLabel sysNameFixed = new JLabel("");
     JTextField userName = new JTextField(17);
     JLabel sysNameLabel = new JLabel(Bundle.getMessage("LabelSystemName"));
@@ -516,6 +517,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
             JPanel p13A = new JPanel();
             p13A.add(new JLabel(Bundle.getMessage("PauseAllocationOnSensorActive")));
             p13A.add(stopAllocatingSensorBox = new JComboBox<>(sensorList));
+            JComboBoxUtil.setupComboBoxMaxRows(stopAllocatingSensorBox);
             p13.add(p13A);
             stopAllocatingSensorBox.setToolTipText(Bundle.getMessage("PauseAllocationOnSensorActiveHint"));
             addNextSection.addActionListener(new ActionListener() {
@@ -933,26 +935,18 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
         List<Section> possibles = new ArrayList<>();
         int[] possiblesDirection = new int[150];
         List<String> possibleNames = new ArrayList<>();
-        
+
         for (Section s : sectionManager.getNamedBeanSet()) {
             Section mayBeSection = null;
-            String mayBeName = s.getSystemName();
+            String mayBeName = s.getDisplayName();
             int mayBeDirection = 0;
             if ((s != sOld) && (s != beforeSection)
                     && (s != afterSection) && (!inSectionList(s, altOldList))) {
                 if (beforeSection != null) {
                     if (forwardConnected(s, beforeSection, beforeSectionDirection)) {
-                        String uname = s.getUserName();
-                        if ((uname != null) && (!uname.equals(""))) {
-                            mayBeName = mayBeName + "( " + uname + " )";
-                        }
                         mayBeSection = s;
                         mayBeDirection = Section.FORWARD;
                     } else if (reverseConnected(s, beforeSection, beforeSectionDirection)) {
-                        String uname = s.getUserName();
-                        if ((uname != null) && (!uname.equals(""))) {
-                            mayBeName = mayBeName + "( " + uname + " )";
-                        }
                         mayBeSection = s;
                         mayBeDirection = Section.REVERSE;
                     }
@@ -969,17 +963,9 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
                     }
                 } else if (afterSection != null) {
                     if (forwardConnected(s, afterSection, afterSectionDirection)) {
-                        String uname = s.getUserName();
-                        if ((uname != null) && (!uname.equals(""))) {
-                            mayBeName = mayBeName + "( " + uname + " )";
-                        }
                         mayBeSection = s;
                         mayBeDirection = Section.REVERSE;
                     } else if (reverseConnected(s, afterSection, afterSectionDirection)) {
-                        String uname = s.getUserName();
-                        if ((uname != null) && (!uname.equals(""))) {
-                            mayBeName = mayBeName + "( " + uname + " )";
-                        }
                         mayBeSection = s;
                         mayBeDirection = Section.FORWARD;
                     }
@@ -1154,17 +1140,9 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
                     && (s != afterSection) && (!inSectionList(s, altOldList))) {
                 if (beforeSection != null) {
                     if (forwardConnected(s, beforeSection, beforeSectionDirection)) {
-                        String uname = s.getUserName();
-                        if ((uname != null) && (!uname.equals(""))) {
-                            mayBeName = mayBeName + "( " + uname + " )";
-                        }
                         mayBeSection = s;
                         mayBeDirection = Section.FORWARD;
                     } else if (reverseConnected(s, beforeSection, beforeSectionDirection)) {
-                        String uname = s.getUserName();
-                        if ((uname != null) && (!uname.equals(""))) {
-                            mayBeName = mayBeName + "( " + uname + " )";
-                        }
                         mayBeSection = s;
                         mayBeDirection = Section.REVERSE;
                     }
@@ -1181,17 +1159,9 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
                     }
                 } else if (afterSection != null) {
                     if (forwardConnected(s, afterSection, afterSectionDirection)) {
-                        String uname = s.getUserName();
-                        if ((uname != null) && (!uname.equals(""))) {
-                            mayBeName = mayBeName + "( " + uname + " )";
-                        }
                         mayBeSection = s;
                         mayBeDirection = Section.REVERSE;
                     } else if (reverseConnected(s, afterSection, afterSectionDirection)) {
-                        String uname = s.getUserName();
-                        if ((uname != null) && (!uname.equals(""))) {
-                            mayBeName = mayBeName + "( " + uname + " )";
-                        }
                         mayBeSection = s;
                         mayBeDirection = Section.FORWARD;
                     }
@@ -1387,11 +1357,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
         if (sectionList.size() == 0) {
             // no Sections currently in Transit - all Sections and all Directions OK
             for (Section s : sectionManager.getNamedBeanSet()) {
-                String sName = s.getSystemName();
-                String uname = s.getUserName();
-                if ((uname != null) && (!uname.equals(""))) {
-                    sName = sName + "( " + uname + " )";
-                }
+                String sName = s.getDisplayName();
                 primarySectionBox.addItem(sName);
                 primarySectionBoxList.add(s);
                 priSectionDirection[primarySectionBoxList.size() - 1] = Section.FORWARD;
@@ -1399,20 +1365,12 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
         } else {
             // limit to Sections that connect to the current Section and are not the previous Section
             for (Section s : sectionManager.getNamedBeanSet()) {
-                String sName = s.getSystemName();
+                String sName = s.getDisplayName();
                 if ((s != prevSection) && (forwardConnected(s, curSection, curSectionDirection))) {
-                    String uname = s.getUserName();
-                    if ((uname != null) && (!uname.equals(""))) {
-                        sName = sName + "( " + uname + " )";
-                    }
                     primarySectionBox.addItem(sName);
                     primarySectionBoxList.add(s);
                     priSectionDirection[primarySectionBoxList.size() - 1] = Section.FORWARD;
                 } else if ((s != prevSection) && (reverseConnected(s, curSection, curSectionDirection))) {
-                    String uname = s.getUserName();
-                    if ((uname != null) && (!uname.equals(""))) {
-                        sName = sName + "( " + uname + " )";
-                    }
                     primarySectionBox.addItem(sName);
                     primarySectionBoxList.add(s);
                     priSectionDirection[primarySectionBoxList.size() - 1] = Section.REVERSE;
@@ -1421,22 +1379,14 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
             // check if there are any alternate Section choices
             if (prevSection != null) {
                 for (Section s : sectionManager.getNamedBeanSet()) {
-                    String sName = s.getSystemName();
+                    String sName = s.getDisplayName();
                     if ((notIncludedWithSeq(s, curSequenceNum))
                             && forwardConnected(s, prevSection, prevSectionDirection)) {
-                        String uname = s.getUserName();
-                        if ((uname != null) && (!uname.equals(""))) {
-                            sName = sName + "( " + uname + " )";
-                        }
                         alternateSectionBox.addItem(sName);
                         alternateSectionBoxList.add(s);
                         altSectionDirection[alternateSectionBoxList.size() - 1] = Section.FORWARD;
                     } else if (notIncludedWithSeq(s, curSequenceNum)
                             && reverseConnected(s, prevSection, prevSectionDirection)) {
-                        String uname = s.getUserName();
-                        if ((uname != null) && (!uname.equals(""))) {
-                            sName = sName + "( " + uname + " )";
-                        }
                         alternateSectionBox.addItem(sName);
                         alternateSectionBoxList.add(s);
                         altSectionDirection[alternateSectionBoxList.size() - 1] = Section.REVERSE;
@@ -1450,26 +1400,21 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
                 testDirection = Section.REVERSE;
             }
             for (Section s : sectionManager.getNamedBeanSet()) {
-                String sName = s.getSystemName();
+                String sName = s.getDisplayName();
                 if ((s != firstSection) && (forwardConnected(s, firstSection, testDirection))) {
-                    String uname = s.getUserName();
-                    if ((uname != null) && (!uname.equals(""))) {
-                        sName = sName + "( " + uname + " )";
-                    }
                     insertAtBeginningBox.addItem(sName);
                     insertAtBeginningBoxList.add(s);
                     insertAtBeginningDirection[insertAtBeginningBoxList.size() - 1] = Section.REVERSE;
                 } else if ((s != firstSection) && (reverseConnected(s, firstSection, testDirection))) {
-                    String uname = s.getUserName();
-                    if ((uname != null) && (!uname.equals(""))) {
-                        sName = sName + "( " + uname + " )";
-                    }
                     insertAtBeginningBox.addItem(sName);
                     insertAtBeginningBoxList.add(s);
                     insertAtBeginningDirection[insertAtBeginningBoxList.size() - 1] = Section.FORWARD;
                 }
             }
         }
+        JComboBoxUtil.setupComboBoxMaxRows(primarySectionBox);
+        JComboBoxUtil.setupComboBoxMaxRows(alternateSectionBox);
+        JComboBoxUtil.setupComboBoxMaxRows(insertAtBeginningBox);
     }
 
     @SuppressWarnings("unused")
@@ -1738,6 +1683,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
             panel1.setLayout(new FlowLayout());
             panel1.add(new JLabel(rbx.getString("WhenText")));
             initializeWhenBox();
+            JComboBoxUtil.setupComboBoxMaxRows(whenBox);
             panel1.add(whenBox);
             whenBox.addActionListener(new ActionListener() {
                 @Override
@@ -1747,9 +1693,11 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
                 }
             });
             whenBox.setToolTipText(rbx.getString("WhenBoxTip"));
+            JComboBoxUtil.setupComboBoxMaxRows(whenSensorComboBox);
             panel1.add(whenSensorComboBox);
             whenSensorComboBox.setAllowNull(true);
             initializeBlockBox();
+            JComboBoxUtil.setupComboBoxMaxRows(blockBox);
             panel1.add(blockBox);
             panelx.add(panel1);
             // to set optional delay setting
@@ -1769,6 +1717,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
             panel2.setLayout(new FlowLayout());
             panel2.add(new JLabel(rbx.getString("WhatText")));
             initializeWhatBox();
+            JComboBoxUtil.setupComboBoxMaxRows(whatBox);
             panel2.add(whatBox);
             whatBox.setToolTipText(rbx.getString("WhatBoxTip"));
             whatBox.addActionListener(new ActionListener() {
@@ -1793,6 +1742,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
             signalPanel = new JPanel();
             signalPanel.setBorder(border);
             signalPanel.add(new JLabel(rbx.getString("MastLabel")));
+            JComboBoxUtil.setupComboBoxMaxRows(signalMastComboBox);
             signalPanel.add(signalMastComboBox);
             signalMastComboBox.setAllowNull(true);
             signalMastComboBox.addActionListener(new ActionListener() {
@@ -1804,6 +1754,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
                 }
             });
             signalPanel.add(new JLabel(rbx.getString("HeadLabel")));
+            JComboBoxUtil.setupComboBoxMaxRows(signalHeadComboBox);
             signalPanel.add(signalHeadComboBox);
             signalHeadComboBox.setAllowNull(true);
             signalHeadComboBox.addActionListener(new ActionListener() {
@@ -1825,6 +1776,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
             panel21.add(offButton);
             panel21.add(doneSensorLabel);
             panel21.add(doneSensorComboBox);
+            JComboBoxUtil.setupComboBoxMaxRows(doneSensorComboBox);
             doneSensorComboBox.setAllowNull(true);
             panelx.add(panel21);
             contentPane.add(panelx);
@@ -2374,11 +2326,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
         blockList = sectionList.get(activeRow).getBlockList();
         blockBox.removeAllItems();
         for (int i = 0; i < blockList.size(); i++) {
-            String s = blockList.get(i).getSystemName();
-            String uname = blockList.get(i).getUserName();
-            if ((uname != null) && (!uname.equals(""))) {
-                s = s + "(" + uname + ")";
-            }
+            String s = blockList.get(i).getDisplayName();
             blockBox.addItem(s);
         }
     }
@@ -2553,12 +2501,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
     }
 
     private String getSectionNameByRow(int r) {
-        String s = sectionList.get(r).getSystemName();
-        String u = sectionList.get(r).getUserName();
-        if ((u != null) && (!u.equals(""))) {
-            return (s + " ( " + u + " )");
-        }
-        return s;
+        return sectionList.get(r).getDisplayName();
     }
 
     /**
@@ -2708,6 +2651,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
                 case STOPALLOCATING_SENSOR:
                     String sensor = sensorStopAllocation[rx];
                     JComboBox<String> cb = new JComboBox<>(sensorList);
+                    JComboBoxUtil.setupComboBoxMaxRows(cb);
                     String name = "";
                     if (sensor != null) {
                         name = sensor;
@@ -2748,7 +2692,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
                 displayList[i++] = nBean.getDisplayName();
             }
         }
-        java.util.Arrays.sort(displayList);
+        java.util.Arrays.sort(displayList, new jmri.util.AlphanumComparator());
         sensorList = new String[displayList.length + 1];
         sensorList[0] = "";
         i = 1;

--- a/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
@@ -36,6 +36,7 @@ import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.swing.NamedBeanComboBox;
 import jmri.util.JmriJFrame;
+import jmri.util.swing.JComboBoxUtil;
 
 /**
  * Displays the Activate New Train dialog and processes information entered
@@ -193,10 +194,10 @@ public class ActivateTrainFrame {
         if (initiateFrame == null) {
             initiateFrame = new JmriJFrame(Bundle.getMessage("AddTrainTitle"), false, true);
             initiateFrame.addHelpMenu("package.jmri.jmrit.dispatcher.NewTrain", true);
-            
+
             initiatePane = new JPanel();
             initiatePane.setLayout(new BoxLayout(initiatePane, BoxLayout.Y_AXIS));
-            
+
             // add buttons to load and save train information
             JPanel p0 = new JPanel();
             p0.setLayout(new FlowLayout());
@@ -451,7 +452,7 @@ public class ActivateTrainFrame {
                 }
             });
             addNewTrainButton.setToolTipText(Bundle.getMessage("AddNewTrainButtonHint"));
-            
+
             JPanel mainPane = new JPanel();
             mainPane.setLayout(new BoxLayout(mainPane, BoxLayout.Y_AXIS));
             JScrollPane scrPane = new JScrollPane(initiatePane);
@@ -459,7 +460,7 @@ public class ActivateTrainFrame {
             mainPane.add(scrPane);
             mainPane.add(p7);
             initiateFrame.setContentPane(mainPane);
-            
+
         }
         if (_TrainsFromRoster || _TrainsFromOperations) {
             trainBoxLabel.setVisible(true);
@@ -822,15 +823,12 @@ public class ActivateTrainFrame {
                 }
             }
             if (free) {
-                String tName = t.getSystemName();
+                String tName = t.getDisplayName();
                 transitBoxList.add(t);
-                String uname = t.getUserName();
-                if ((uname != null) && (!uname.equals("")) && (!uname.equals(tName))) {
-                    tName = tName + "(" + uname + ")";
-                }
                 transitSelectBox.addItem(tName);
             }
         }
+        JComboBoxUtil.setupComboBoxMaxRows(transitSelectBox);
         if (transitBoxList.size() > 0) {
             transitSelectBox.setSelectedIndex(0);
             selectedTransit = transitBoxList.get(0);
@@ -966,6 +964,7 @@ public class ActivateTrainFrame {
                 found = true;
             }
         }
+        JComboBoxUtil.setupComboBoxMaxRows(startingBlockBox);
     }
 
     private void initializeDestinationBlockCombo() {
@@ -988,16 +987,12 @@ public class ActivateTrainFrame {
             }
             destinationBlockBox.addItem(bName);
         }
+        JComboBoxUtil.setupComboBoxMaxRows(destinationBlockBox);
     }
 
     private String getBlockName(Block b) {
         if (b != null) {
-            String sName = b.getSystemName();
-            String uName = b.getUserName();
-            if ((uName != null) && (!uName.equals("")) && (!uName.equals(sName))) {
-                return (sName + "(" + uName + ")");
-            }
-            return sName;
+            return b.getDisplayName();
         }
         return " ";
     }


### PR DESCRIPTION
Change the name presentation to be more consistent with other JMRI tools.

- Use `displayName` instead of `systemName (userName)`.
- Set combo dropdown list size based on content instead of defaulting to 8 rows.