### PR TITLE
Fix debug single test in NetBeans broken by 4d323f8

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -95,9 +95,6 @@
             <isset property="jvm.args"/>
         </not>
     </condition>
-    <condition property="test-single.jvmargs" value="">
-        <not><isset property="test-single.jvmargs"/></not>
-    </condition>
     <condition property="cp.append" value="">
         <not>
             <isset property="cp.append"/>
@@ -735,7 +732,7 @@
     <target depends="-test-single-src,-test-single-test,tests,runtime-library-selection" description="Run single unit test." name="test-single">
         <mkdir dir="${tempdir}"/>
         <mkdir dir="${testreport}"/>
-
+        <property name="test-single.jvmargs" value=""/>
         <java classpathref="test.class.path" classname="org.junit.platform.console.ConsoleLauncher" fork="true" failonerror="true"  >
             <sysproperty key="wdm.forceCache" value="true"/>
             <!-- wdm.targetPath specifies the locaion of the web drivers on appveyor. -->
@@ -773,7 +770,7 @@
         <mkdir dir="${tempdir}"/>
         <mkdir dir="${testreport}"/>
         <jacoco:agent property="jacocoagent" destfile="${jacocoexec}" excludes="org.slf4j.*" />
-
+        <property name="test-single.jvmargs" value=""/>
         <java classpathref="test.class.path" classname="org.junit.platform.console.ConsoleLauncher" fork="true" failonerror="true"  >
             <sysproperty key="wdm.forceCache" value="true"/>
             <!-- wdm.targetPath specifies the locaion of the web drivers on appveyor. -->


### PR DESCRIPTION
I am unable to run individual testclasses in NetBeans - the culprit is the change in commit 4d323f8, lines 97-95.
These lines are outside of all tasks, so execute unconditionally, upon import of the `build.xml` file. The `nbproject/ide-targets.xml` imports it - and when it tries to define the task-specific `test-single.jvmargs` property, the value is ignored as the property is already defined (defaulted to empty string).

The proper approach is IMHO to use Ant's immutable property behaviour: default the property in the task that requires it. If the property is defined earlier, i.e. in `local.properties`, that value prevails. If undefined, the task will default it to none.