### PR TITLE
VSDecoder: cleanup property LoadVSDDirectoryChooserFilterLabel

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle.properties
@@ -13,7 +13,6 @@ RosterSaveButtonToolTip = test
 # Load VSD File action messages
 VSDecoderFileMenuLoadVSDFile = Load VSD File
 LoadVSDFileChooserFilterLabel = VSD File/s
-LoadVSDDirectoryChooserFilterLabel = VSD Directory
 VSDFileError = Error Loading VSD File
 
 # VSD File Status Messages

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_ca.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_ca.properties
@@ -8,7 +8,6 @@
 # Load VSD File action messages
 VSDecoderFileMenuLoadVSDFile = Obre fitxer VSD
 LoadVSDFileChooserFilterLabel = Fitxers VSD
-LoadVSDDirectoryChooserFilterLabel = VSD Directory
 VSDFileError = Error llegint fitxer VSD
 
 # VSD File Status Messages

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_da.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_da.properties
@@ -17,7 +17,6 @@
 # Load VSD File action messages
 VSDecoderFileMenuLoadVSDFile = Load VSD File
 LoadVSDFileChooserFilterLabel = VSD Files
-LoadVSDDirectoryChooserFilterLabel = VSD Directory
 VSDFileError = Error Loading VSD File
 
 # VSD File Status Messages

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_de.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_de.properties
@@ -6,7 +6,6 @@
 # Load VSD File action messages
 VSDecoderFileMenuLoadVSDFile = Lade VSD Datei
 LoadVSDFileChooserFilterLabel = VSD Dateien
-LoadVSDDirectoryChooserFilterLabel = VSD Directory
 VSDFileError = Fehler beim Einlesen der VSD Datei
 
 # VSD File Status Messages

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_fr.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_fr.properties
@@ -19,7 +19,6 @@
 # Charge messages d'action de fichiers VSD
 VSDecoderFileMenuLoadVSDFile = Charge fichier VSD
 LoadVSDFileChooserFilterLabel = Fichiers VSD
-LoadVSDDirectoryChooserFilterLabel = VSD Directory
 VSDFileError = Erreur lors du chargement du fichier VSD
 
 # VSD Etat classer les messages

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_it.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_it.properties
@@ -19,7 +19,6 @@
 # Load VSD File action messages
 VSDecoderFileMenuLoadVSDFile = Carica file VSD
 LoadVSDFileChooserFilterLabel = Files VSD
-LoadVSDDirectoryChooserFilterLabel = VSD Directory
 VSDFileError = Errore caricamento file VSD
 
 # VSD File Status Messages


### PR DESCRIPTION
This PR is a follow-up to #8221. Due to a change in ```VSDecoderPreferencesPane.java``` the property ```LoadVSDDirectoryChooserFilterLabel``` becomes superfluous and can be removed.