### PR TITLE
Restore "stop" behavior to DP bulk programming operations

### DIFF
--- a/java/src/jmri/util/BusyGlassPane.java
+++ b/java/src/jmri/util/BusyGlassPane.java
@@ -145,10 +145,22 @@ public class BusyGlassPane extends JComponent {
                         glassPanePoint,
                         component);
                 parentFrame.setCursor(Cursor.getDefaultCursor());
+                
                 component.dispatchEvent(new MouseEvent(component,
                         eventID,
                         e.getWhen(),
-                        e.getModifiersEx(),
+                        
+                        // The Java8 Javadoc 
+                        //  https://docs.oracle.com/javase/8/docs/api/java/awt/event/MouseEvent.html#MouseEvent-java.awt.Component-int-long-int-int-int-int-boolean-
+                        // says the following should reference
+                        // getModifiersEx()
+                        // but that makes it impossible to cancel
+                        // ReadAll, WriteAll etc in DecoderPro.
+                        // When it fails, getModifier is 0x10 BUTTON1_MASK
+                        // and 
+                        // getModifierEx is 0x400 BUTTON1_DOWN_MASK
+                        
+                        e.getModifiers(),
                         componentPoint.x,
                         componentPoint.y,
                         e.getClickCount(),


### PR DESCRIPTION
This restores the ability to stop a "Real All ..." or "Write All..." operation in DecoderPro

The `BusyGlassPane` was preventing access to the button.

The problem was that `BusyGlassPane` recreates a `MouseEvent` and propagates it.  The [Java8 Javadoc for MouseEvent](https://docs.oracle.com/javase/8/docs/api/java/awt/event/MouseEvent.html#MouseEvent-java.awt.Component-int-long-int-int-int-int-boolean-) says that the value of `getModifiersEx()` should be provided in the constructor.  That's what the code was doing, but it didn't work.  Instead, providing the (more recently deprecated) `getModifiers()` did work.  When the operation fails, `getModifierEx()` was 0x400 `BUTTON1_DOWN_MASK`, while `getModifier()` was 0x10 `BUTTON1_MASK`. A comment was left in the code explaining all this so it can be worked out later when it's time to handle the deprecation.
