### PR TITLE
fix: Remove EntryExitPairs binding from scripts

### DIFF
--- a/help/en/html/tools/scripting/Start.shtml
+++ b/help/en/html/tools/scripting/Start.shtml
@@ -242,8 +242,6 @@ variables, and by shortening certain method calls.
 
         <li>warrants</li>
 
-        <li>entryExitPairs <span class="since">since 4.19.2</span></li>
-        
       </ul>These can then be referenced directly in Jython as
       <pre style="font-family: monospace;">t2 = turnouts.provideTurnout("12");
 </pre>Note that the variable t2 did not need to be declared.

--- a/java/src/jmri/script/JmriScriptEngineManager.java
+++ b/java/src/jmri/script/JmriScriptEngineManager.java
@@ -44,7 +44,6 @@ import jmri.SignalMastManager;
 import jmri.Turnout;
 import jmri.TurnoutManager;
 import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
-import jmri.jmrit.entryexit.EntryExitPairs;
 import jmri.jmrit.logix.WarrantManager;
 import jmri.util.FileUtil;
 import jmri.util.FileUtilSupport;
@@ -136,7 +135,6 @@ public final class JmriScriptEngineManager implements InstanceManagerAutoDefault
         bindings.put("shutdown", InstanceManager.getNullableDefault(ShutDownManager.class));
         bindings.put("layoutblocks", InstanceManager.getNullableDefault(LayoutBlockManager.class));
         bindings.put("warrants", InstanceManager.getNullableDefault(WarrantManager.class));
-        bindings.put("entryExitPairs", InstanceManager.getNullableDefault(EntryExitPairs.class));
         bindings.put("CLOSED", Turnout.CLOSED);
         bindings.put("THROWN", Turnout.THROWN);
         bindings.put("CABLOCKOUT", Turnout.CABLOCKOUT);


### PR DESCRIPTION
Partly reverts #7864 to allow the ScriptEngineManager to be used without invoking the EDT. JMRI users can use `eep = jmri.InstanceManager.getDefault(jmri.jmrit.entryexitEntryExitPairs)` to get the EntryExitPairs in Jython as [discussed in the user's group](https://groups.io/g/jmriusers/topic/32465975#161705)