### PR TITLE
Remove background execution of CatalogPanel.makeDefaultCatalog during panel loading

### DIFF
--- a/java/src/jmri/CatalogTreeManager.java
+++ b/java/src/jmri/CatalogTreeManager.java
@@ -86,9 +86,13 @@ public interface CatalogTreeManager extends Manager<CatalogTree> {
     public CatalogTree newCatalogTree(@Nonnull String systemName, String userName);
 
     public void storeImageIndex();
-        
+
+    public void loadImageIndex();
+
     public boolean isIndexChanged();
-    
+
+    public boolean isIndexLoaded();
+
     public void indexChanged(boolean changed);
 
     @SuppressFBWarnings(value = "MS_MUTABLE_ARRAY",

--- a/java/src/jmri/configurexml/LoadXmlConfigAction.java
+++ b/java/src/jmri/configurexml/LoadXmlConfigAction.java
@@ -54,7 +54,6 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
                         // insure logix etc fire up
                         InstanceManager.getDefault(jmri.LogixManager.class).activateAllLogixs();
                         InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class).initializeLayoutBlockPaths();
-                        new jmri.jmrit.catalog.configurexml.DefaultCatalogTreeManagerXml().readCatalogTrees();
                     }
                 }
             } catch (JmriException e) {

--- a/java/src/jmri/jmrit/catalog/CatalogPanel.java
+++ b/java/src/jmri/jmrit/catalog/CatalogPanel.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
 public class CatalogPanel extends JPanel {
 
     private static final Object _lock = new Object();
-    
+
     public static final double ICON_SCALE = 0.020;
     public static final int ICON_WIDTH = 100;
     public static final int ICON_HEIGHT = 100;
@@ -85,7 +85,7 @@ public class CatalogPanel extends JPanel {
 
     /**
      * Constructor
-     * 
+     *
      * The constructor is private to force using the method makeCatalogPanel
      */
     private CatalogPanel() {
@@ -94,7 +94,7 @@ public class CatalogPanel extends JPanel {
 
     /**
      * Ctor for a named icon catalog split pane. Make sure both properties keys exist.
-     * 
+     *
      * The constructor is private to force using the method makeCatalogPanel
      *
      * @param label1 properties key to be used as the label for the icon tree
@@ -118,7 +118,7 @@ public class CatalogPanel extends JPanel {
 
     /**
      * Ctor for a named icon catalog split pane. Make sure both properties keys exist.
-     * 
+     *
      * The constructor is private to force using the method makeCatalogPanel
      *
      * @param label1 properties key to be used as the label for the icon tree
@@ -127,7 +127,7 @@ public class CatalogPanel extends JPanel {
     private CatalogPanel(String label1, String label2) {
         this(label1, label2, true);
     }
-    
+
     @Override
     public void setToolTipText(String tip) {
         if (_dTree != null) {
@@ -168,11 +168,11 @@ public class CatalogPanel extends JPanel {
         _dTree.setExpandsSelectedPaths(true);
         _treePane.setViewportView(_dTree);
     }
-    
+
     public void setParent(IconItemPanel p) {
         _parent = p;
     }
-    
+
     public void updatePanel() {
         log.debug("updatePanel: _dTree.isSelectionEmpty()= {} _dTree.getSelectionPath() is {}null",
                 _dTree.isSelectionEmpty(), (_dTree.getSelectionPath() == null) ? "" : "not ");
@@ -394,7 +394,7 @@ public class CatalogPanel extends JPanel {
         }
         return false;
     }
-    
+
     private void addLeaf(CatalogTreeNode node, NamedIcon icon) {
         node.addLeaf(icon.getName(), icon.getURL());
 
@@ -530,7 +530,7 @@ public class CatalogPanel extends JPanel {
     // called by palette.IconItemPanel to get user's selection from catalog
     public NamedIcon getIcon() {
         if (_selectedImage != null) {
-            return _selectedImage.getIcon();            
+            return _selectedImage.getIcon();
         }
         return null;
     }
@@ -542,10 +542,10 @@ public class CatalogPanel extends JPanel {
             _selectedImage = null;
         }
     }
-    
+
     protected void setSelection(IconDisplayPanel panel) {
         if (_parent == null) {
-            return;            
+            return;
         }
         if (_selectedImage != null && !panel.equals(_selectedImage)) {
             deselectIcon();
@@ -556,7 +556,7 @@ public class CatalogPanel extends JPanel {
         } else {
             deselectIcon();
         }
-        _parent.deselectIcon();            
+        _parent.deselectIcon();
     }
 
     public class MemoryExceptionHandler implements Thread.UncaughtExceptionHandler {
@@ -703,6 +703,7 @@ public class CatalogPanel extends JPanel {
             CatalogPanel catalog = new CatalogPanel("catalogs", "selectNode", addButtonPanel);
             catalog.init(treeDrop, dragIcon);
             CatalogTreeManager manager = InstanceManager.getDefault(jmri.CatalogTreeManager.class);
+            manager.loadImageIndex();
             for (CatalogTree tree : manager.getNamedBeanSet()) {
                 String systemName = tree.getSystemName();
                 if (systemName.charAt(0) == 'I') {
@@ -718,7 +719,7 @@ public class CatalogPanel extends JPanel {
 
     /**
      * Create a named icon catalog split pane. Make sure both properties keys exist.
-     * 
+     *
      * @param label1 properties key to be used as the label for the icon tree
      * @param label2 properties key to be used as the instruction
      * @param addButtonPanel adds background select comboBox
@@ -800,7 +801,7 @@ public class CatalogPanel extends JPanel {
             log.debug("setSelectedNode node: {}", node);
         }
         if (node != null) {
-            _dTree.setSelectionPath(new TreePath(node.getPath()));            
+            _dTree.setSelectionPath(new TreePath(node.getPath()));
         } else {
             _dTree.setSelectionRow(0);
         }
@@ -954,7 +955,7 @@ public class CatalogPanel extends JPanel {
             return false;
         }
     }
-    
+
     class DropJTree extends JTree implements DropTargetListener {
 
         DataFlavor dataFlavor;
@@ -1032,7 +1033,7 @@ public class CatalogPanel extends JPanel {
             }
             addMouseListener(new IconListener());
         }
-        
+
         NamedIcon getIcon() {
             return _icon;
         }
@@ -1052,7 +1053,7 @@ public class CatalogPanel extends JPanel {
                 image.setOpaque(false);
                 image.setName(_name);
                 image.setToolTipText(icon.getName());
-                double scale; 
+                double scale;
                 if (icon.getIconWidth() < 1 || icon.getIconHeight() < 1) {
                     image.setText(Bundle.getMessage("invisibleIcon"));
                     image.setForeground(Color.lightGray);
@@ -1064,7 +1065,7 @@ public class CatalogPanel extends JPanel {
                 image.setHorizontalAlignment(SwingConstants.CENTER);
                 image.addMouseListener(new IconListener());
                 add(image, BorderLayout.NORTH);
-                
+
                 String scaleMessage = Bundle.getMessage("scale", CatalogPanel.printDbl(scale, 2));
                 JLabel label = new JLabel(scaleMessage);
                 label.setOpaque(false);
@@ -1106,7 +1107,7 @@ public class CatalogPanel extends JPanel {
             // no handling provided for mouseExited events
         }
     }
-    
+
 
     private static final Logger log = LoggerFactory.getLogger(CatalogPanel.class);
 

--- a/java/src/jmri/jmrit/catalog/DefaultCatalogTreeManager.java
+++ b/java/src/jmri/jmrit/catalog/DefaultCatalogTreeManager.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 public class DefaultCatalogTreeManager extends AbstractManager<CatalogTree> implements CatalogTreeManager {
 
     private boolean _indexChanged = false;
+    private boolean _indexLoaded = false;
     private ShutDownTask _shutDownTask;
 
     public DefaultCatalogTreeManager() {
@@ -206,9 +207,26 @@ public class DefaultCatalogTreeManager extends AbstractManager<CatalogTree> impl
         }
     }
 
+    /**
+     * Load the index file, one time per session.
+     */
+    @Override
+    public void loadImageIndex() {
+        if (!isIndexLoaded()) {
+            new jmri.jmrit.catalog.configurexml.DefaultCatalogTreeManagerXml().readCatalogTrees();
+            _indexLoaded = true;
+            log.debug("loadImageIndex: catalog file loaded");
+        }
+    }
+
     @Override
     public boolean isIndexChanged() {
         return _indexChanged;
+    }
+
+    @Override
+    public boolean isIndexLoaded() {
+        return _indexLoaded;
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -182,30 +182,8 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
         }
         pack();
         setVisible(true);
-        makeCatalogWorker = new MakeCatalog();
-        makeCatalogWorker.execute();
-        log.debug("Init SwingWorker launched");
     }
-    static class MakeCatalog extends SwingWorker<CatalogPanel, Object> {
 
-        @Override
-        public CatalogPanel doInBackground() {
-            return CatalogPanel.makeDefaultCatalog();
-        }
-        /**
-         * Minimal implementation to catch and log errors
-         */
-        @Override
-        protected void done() {
-            try {
-                get();  // called to get errors
-            } catch (InterruptedException | java.util.concurrent.ExecutionException e) {
-                log.error("Exception while in MakeCatalog", e);
-            }
-        }
-    }
-    MakeCatalog makeCatalogWorker;
-    
     protected void makeIconMenu() {
         _iconMenu = new JMenu(Bundle.getMessage("MenuIcon"));
         _menuBar.add(_iconMenu, 0);
@@ -343,7 +321,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
             int idx = _menuBar.getComponentIndex(oldMenu);
             _menuBar.remove(oldMenu);
             _menuBar.add(_warrantMenu, idx);
-            
+
         }
         _menuBar.revalidate();
     }
@@ -1001,7 +979,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
     ////////////////// Overridden methods of Editor //////////////////
     private boolean _manualSelection = false;
 
-    @Override 
+    @Override
     public void deselectSelectionGroup() {
         _circuitBuilder.hidePortalIcons();
         super.deselectSelectionGroup();

--- a/java/src/jmri/jmrit/display/palette/ItemPalette.java
+++ b/java/src/jmri/jmrit/display/palette/ItemPalette.java
@@ -207,7 +207,7 @@ public class ItemPalette extends DisplayFrame implements ChangeListener {
     public static void loadIcons(Editor ed) {
         if (_iconMaps == null) {
             // long t = System.currentTimeMillis();
-            new jmri.jmrit.catalog.configurexml.DefaultCatalogTreeManagerXml().readCatalogTrees();
+            InstanceManager.getDefault(jmri.CatalogTreeManager.class).loadImageIndex();
             _iconMaps = new HashMap<>();
             _indicatorTOMaps = new HashMap<>();
 
@@ -423,12 +423,12 @@ public class ItemPalette extends DisplayFrame implements ChangeListener {
         instance.setVisible(true);
         return instance;
     }
-    
+
     public ItemPalette(String title, Editor ed) {
         super(false, false);
         init(title, ed);
     }
-    
+
     private void init(String title, Editor ed) {
         this.setTitle(title);
         loadIcons(ed);
@@ -515,7 +515,7 @@ public class ItemPalette extends DisplayFrame implements ChangeListener {
 
         _tabPane.addChangeListener(palette);
     }
-    
+
     static void addItemTab(ItemPanel itemPanel, String key, String tabTitle) {
         JScrollPane scrollPane = new JScrollPane(itemPanel);
         _tabPane.add(scrollPane, Bundle.getMessage(tabTitle));
@@ -555,7 +555,7 @@ public class ItemPalette extends DisplayFrame implements ChangeListener {
         if (log.isDebugEnabled()) {
             deltaDim = new Dimension(totalDim.width - oldTabDim.width, totalDim.height - oldTabDim.height);
             log.debug(" old _tabPane Dim= ({}, {}) oldType=({})= ({}, {})newType=({})= ({}, {}). diff= ({}, {})",
-                    totalDim.width, totalDim.height, _currentItemPanel._itemType, oldTabDim.width, oldTabDim.height,  
+                    totalDim.width, totalDim.height, _currentItemPanel._itemType, oldTabDim.width, oldTabDim.height,
                     p._itemType, newTabDim.width, newTabDim.height, deltaDim.width, deltaDim.height);
         }
         deltaDim = p.shellDimension(p);
@@ -770,7 +770,7 @@ public class ItemPalette extends DisplayFrame implements ChangeListener {
     }
 
     ///////////////////////////////////////////////////////////////////////////////
-    
+
     static protected HashMap<String, NamedIcon> cloneMap(HashMap<String, NamedIcon> map) {
         HashMap<String, NamedIcon> clone = new HashMap<>();
         if (map != null) {

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -138,7 +138,6 @@ public class PanelEditor extends Editor implements ItemListener {
 
     @Override
     protected void init(String name) {
-        initCatalogTree();
         java.awt.Container contentPane = this.getContentPane();
         contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
         // common items
@@ -427,25 +426,6 @@ public class PanelEditor extends Editor implements ItemListener {
         getTargetFrame().setVisible(true);
         log.debug("PanelEditor ctor done.");
     }  // end ctor
-
-    protected void initCatalogTree() {
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    // Build resource catalog and load CatalogTree.xml now
-                    CatalogPanel catalog = CatalogPanel.makeDefaultCatalog();
-                    catalog.createNewBranch("IFJAR", "Program Directory", "resources");
-                    // log.debug("init run created (var=catalog)"); // where's this used, just a test run?
-                } catch (Exception ex) {
-                    log.error("Error trying to set up preferences {}", ex);
-                }
-            }
-        };
-        Thread thr = new Thread(r);
-        thr.setName("PanelEditor init");
-        thr.start();
-    }
 
     /**
      * Initializes the hiddencheckbox and its listener. This has been taken out

--- a/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
@@ -334,17 +334,6 @@ public class SwitchboardEditor extends Editor {
         setupEditorPane(); // re-layout all the toolbar items
         updatePressed();   // refresh default Switchboard, updates all buttons
         pack();
-
-        // TODO choose your own icons
-//        class makeCatalog extends SwingWorker<CatalogPanel, Object> {
-//
-//            @Override
-//            public CatalogPanel doInBackground() {
-//                return CatalogPanel.makeDefaultCatalog();
-//            }
-//        }
-//        (new makeCatalog()).execute();
-//        log.debug("Init SwingWorker launched");
     }
 
     /**

--- a/java/test/jmri/jmrit/display/controlPanelEditor/CircuitBuilderTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/CircuitBuilderTest.java
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Test simple functioning of the CircuitBuilder class.
  *
- * @author  Paul Bender Copyright (C) 2017 
- * @author  Pete Cressman Copyright (C) 2019 
+ * @author  Paul Bender Copyright (C) 2017
+ * @author  Pete Cressman Copyright (C) 2019
  */
 public class CircuitBuilderTest {
 
@@ -42,7 +42,6 @@ public class CircuitBuilderTest {
         CircuitBuilder builder = new CircuitBuilder(f);
         Assert.assertNotNull("exists", builder);
         f.dispose();
-        if (f.makeCatalogWorker != null) JUnitUtil.waitFor(() -> {return f.makeCatalogWorker.isDone();}, "wait for catalog SwingWorker failed");
         JUnitUtil.dispose(f);
     }
 
@@ -52,10 +51,10 @@ public class CircuitBuilderTest {
 
         OBlock ob3 = InstanceManager.getDefault(OBlockManager.class).getOBlock("OB3");
         cb.setCurrentBlock(ob3);
-        
+
         cb.editCircuit("editCircuitItem", false);
         Assert.assertNotNull("exists", cb.getEditFrame());
-/*        
+/*
         cb.editCircuit("editCircuitItem", true);
         JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("editCircuitItem"));
         JTableOperator table = new JTableOperator(jdo);
@@ -73,7 +72,7 @@ public class CircuitBuilderTest {
         getCPEandCB();
 
         cb.editCircuitError("OB1");
-        
+
         JFrameOperator nfo = new JFrameOperator(cb.getEditFrame());
         JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonDone"));
     }
@@ -84,9 +83,9 @@ public class CircuitBuilderTest {
 
         OBlock ob3 = InstanceManager.getDefault(OBlockManager.class).getOBlock("OB2");
         cb.setCurrentBlock(ob3);
-        
+
         cb.editPortals("editPortalsItem", false);
-        
+
         JFrameOperator nfo = new JFrameOperator(cb.getEditFrame());
         JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonDone"));
     }
@@ -97,9 +96,9 @@ public class CircuitBuilderTest {
 
         OBlock ob3 = InstanceManager.getDefault(OBlockManager.class).getOBlock("OB3");
         cb.setCurrentBlock(ob3);
-        
+
         cb.editCircuitPaths("editCircuitPathsItem", false);
-        
+
         JFrameOperator nfo = new JFrameOperator(cb.getEditFrame());
         JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonDone"));
     }
@@ -110,9 +109,9 @@ public class CircuitBuilderTest {
 
         OBlock ob3 = InstanceManager.getDefault(OBlockManager.class).getOBlock("OB5");
         cb.setCurrentBlock(ob3);
-        
+
         cb.editPortalDirection("editDirectionItem", false);
-        
+
         JFrameOperator nfo = new JFrameOperator(cb.getEditFrame());
         JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonDone"));
     }
@@ -123,9 +122,9 @@ public class CircuitBuilderTest {
 
         OBlock ob3 = InstanceManager.getDefault(OBlockManager.class).getOBlock("OB4");
         cb.setCurrentBlock(ob3);
-        
+
         cb.editSignalFrame("editSignalItem", false);
-        
+
         JFrameOperator nfo = new JFrameOperator(cb.getEditFrame());
         JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonDone"));
     }
@@ -143,7 +142,7 @@ public class CircuitBuilderTest {
         }).start();
 
         cb.editPortalError("EastExit-EastJunction");
-        
+
         JFrameOperator nfo = new JFrameOperator(cb.getEditFrame());
         JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonDone"));
         new org.netbeans.jemmy.QueueTool().waitEmpty(100);
@@ -164,7 +163,7 @@ public class CircuitBuilderTest {
         }).start();
 
         cb.editPortalError(block, portal, null);
-        
+
         JFrameOperator nfo = new JFrameOperator(cb.getEditFrame());
         JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonDone"));
     }
@@ -174,7 +173,7 @@ public class CircuitBuilderTest {
     public void testNoBlock() {
         getCPEandCB();
         cb.editCircuitPaths("editCircuitPathsItem", false);
-        
+
 //        JFrameOperator frame = new JFrameOperator(cb.getEditFrame());
 //        JDialogOperator jdo = new JDialogOperator(frame, Bundle.getMessage("NeedDataTitle"));
         JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("NeedDataTitle"));

--- a/java/test/jmri/jmrit/display/controlPanelEditor/ControlPanelEditorTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/ControlPanelEditorTest.java
@@ -23,7 +23,6 @@ public class ControlPanelEditorTest extends AbstractEditorTestBase<ControlPanelE
         ControlPanelEditor f = new ControlPanelEditor();
         Assert.assertNotNull("exists", f);
         f.dispose();
-        if (f.makeCatalogWorker != null) JUnitUtil.waitFor(() -> {return f.makeCatalogWorker.isDone();}, "wait for catalog SwingWorker failed");
     }
 
     @Test
@@ -47,8 +46,6 @@ public class ControlPanelEditorTest extends AbstractEditorTestBase<ControlPanelE
     public void tearDown() {
         if (e != null) {
             JUnitUtil.dispose(e);
-            if (e.makeCatalogWorker != null) 
-                JUnitUtil.waitFor(() -> {return e.makeCatalogWorker.isDone();}, "wait for catalog SwingWorker failed");
             e = null;
         }
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/display/controlPanelEditor/ConvertDialogTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/ConvertDialogTest.java
@@ -27,7 +27,7 @@ import org.netbeans.jemmy.operators.JDialogOperator;
 //import org.netbeans.jemmy.*;
 /**
  *
- * @author Pete Cressman Copyright (C) 2019   
+ * @author Pete Cressman Copyright (C) 2019
  */
 public class ConvertDialogTest {
 
@@ -61,7 +61,6 @@ public class ConvertDialogTest {
 
         dialog.dispose();
         frame.dispose();
-        if (frame.makeCatalogWorker != null) JUnitUtil.waitFor(() -> {return frame.makeCatalogWorker.isDone();}, "wait for catalog SwingWorker failed");
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrit/display/controlPanelEditor/PortalIconTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/PortalIconTest.java
@@ -48,8 +48,6 @@ public class PortalIconTest extends PositionableIconTest {
     public void tearDown() {
         if (editor != null) {
             JUnitUtil.dispose(editor);
-            if (((ControlPanelEditor)editor).makeCatalogWorker != null) 
-                JUnitUtil.waitFor(() -> {return ((ControlPanelEditor)editor).makeCatalogWorker.isDone();}, "wait for catalog SwingWorker failed");
         }
         super.tearDown();
     }


### PR DESCRIPTION
Panel Editor and Control Panel Editor where creating a catalog panel during editor creation but were never capturing or using the resulting panel.  

As described in issue #8252, the locks added to makeDefaultCatalog by PR #8112 can result in a JMRI deadlock if a panel references a missing icon file.