### PR TITLE
chore: Use a benign package annotation to avoid recompilation

### DIFF
--- a/java/package-info.java
+++ b/java/package-info.java
@@ -20,7 +20,6 @@
 */
 
 //@annotations for the entire package go here
-// include empty SuppressFBWarnings to avoid excessive recompilation unless
-// suppressing multiple warnings within the entire package
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri;

--- a/java/src/apps/TrainCrew/package-info.java
+++ b/java/src/apps/TrainCrew/package-info.java
@@ -6,5 +6,6 @@
  * and
  * <a href="https://github.com/ekapus/TrainCrew">https://github.com/ekapus/TrainCrew</a>.
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package apps.TrainCrew;

--- a/java/src/apps/gui3/tabbedpreferences/package-info.java
+++ b/java/src/apps/gui3/tabbedpreferences/package-info.java
@@ -50,5 +50,6 @@
  * @see jmri.swing.PreferencesPanel
  * @see apps.AppConfigBase
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package apps.gui3.tabbedpreferences;

--- a/java/src/jmri/beans/package-info.java
+++ b/java/src/jmri/beans/package-info.java
@@ -51,4 +51,6 @@
  * and discovering JMRI arbitrary properties.</dd>
  * </dl>
  */
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.beans;

--- a/java/src/jmri/jmris/json/package-info.java
+++ b/java/src/jmri/jmris/json/package-info.java
@@ -1,5 +1,6 @@
 /**
  * @see jmri.server.json
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmris.json;

--- a/java/src/jmri/jmrit/ctc/editor/package-info.java
+++ b/java/src/jmri/jmrit/ctc/editor/package-info.java
@@ -7,5 +7,6 @@
  */
 
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.ctc.editor;

--- a/java/src/jmri/jmrit/ctc/package-info.java
+++ b/java/src/jmri/jmrit/ctc/package-info.java
@@ -3,5 +3,6 @@
  */
 
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.ctc;

--- a/java/src/jmri/jmrit/display/package-info.java
+++ b/java/src/jmri/jmrit/display/package-info.java
@@ -14,7 +14,8 @@
  * @see jmri.jmrit.display.palette
  * @see jmri.jmrit.picker
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.display;
 
 /*

--- a/java/src/jmri/jmrit/display/palette/package-info.java
+++ b/java/src/jmri/jmrit/display/palette/package-info.java
@@ -10,7 +10,8 @@
  * @see jmri.jmrit.display
  * @see jmri.jmrit.picker
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.display.palette;
 
 /*

--- a/java/src/jmri/jmrit/entryexit/package-info.java
+++ b/java/src/jmri/jmrit/entryexit/package-info.java
@@ -7,5 +7,6 @@
  */
 
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.entryexit;

--- a/java/src/jmri/jmrit/logix/package-info.java
+++ b/java/src/jmri/jmrit/logix/package-info.java
@@ -26,5 +26,6 @@
 // See https://jmri.org/help/en/html/doc//Technical/Javadoc.shtml
 
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.logix;

--- a/java/src/jmri/jmrit/sample/package-info.java
+++ b/java/src/jmri/jmrit/sample/package-info.java
@@ -19,5 +19,6 @@
 */
 
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.sample;

--- a/java/src/jmri/jmrit/timetable/configurexml/package-info.java
+++ b/java/src/jmri/jmrit/timetable/configurexml/package-info.java
@@ -7,5 +7,6 @@
  */
 
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.timetable.configurexml;

--- a/java/src/jmri/jmrit/timetable/package-info.java
+++ b/java/src/jmri/jmrit/timetable/package-info.java
@@ -7,5 +7,6 @@
  */
 
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.timetable;

--- a/java/src/jmri/jmrit/timetable/swing/package-info.java
+++ b/java/src/jmri/jmrit/timetable/swing/package-info.java
@@ -7,5 +7,6 @@
  */
 
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.timetable.swing;

--- a/java/src/jmri/jmrit/ussctc/package-info.java
+++ b/java/src/jmri/jmrit/ussctc/package-info.java
@@ -51,5 +51,6 @@
 */
 
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.ussctc;

--- a/java/src/jmri/jmrit/vsdecoder/package-info.java
+++ b/java/src/jmri/jmrit/vsdecoder/package-info.java
@@ -10,5 +10,6 @@
 */
 
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.vsdecoder;

--- a/java/src/jmri/jmrit/whereused/package-info.java
+++ b/java/src/jmri/jmrit/whereused/package-info.java
@@ -17,5 +17,6 @@
  */
 
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrit.whereused;

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/sproggen5/package-info.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/sproggen5/package-info.java
@@ -26,5 +26,6 @@
  * <!-- Put @see and @since tags down here. -->
  * @since 4.19
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.can.adapters.gridconnect.sproggen5;

--- a/java/src/jmri/jmrix/can/cbus/swing/bootloader/package-info.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/bootloader/package-info.java
@@ -11,5 +11,6 @@
  * <!-- Put @see and @since tags down here. -->
  * @since 4.19
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.can.cbus.swing.bootloader;

--- a/java/src/jmri/jmrix/cmri/package-info.java
+++ b/java/src/jmri/jmrix/cmri/package-info.java
@@ -19,5 +19,6 @@
  *
  * @see jmri.jmrix.cmri.serial
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.cmri;

--- a/java/src/jmri/jmrix/cmri/serial/package-info.java
+++ b/java/src/jmri/jmrix/cmri/serial/package-info.java
@@ -14,5 +14,6 @@
  *
  * @see jmri.jmrix.cmri
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.cmri.serial;

--- a/java/src/jmri/jmrix/internal/package-info.java
+++ b/java/src/jmri/jmrix/internal/package-info.java
@@ -31,5 +31,6 @@
  * @see jmri.managers
  * @see jmri.implementation
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.internal;

--- a/java/src/jmri/jmrix/loconet/Intellibox/package-info.java
+++ b/java/src/jmri/jmrix/loconet/Intellibox/package-info.java
@@ -11,5 +11,6 @@
  * Uhlenbrock page</a>.
  */
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.loconet.Intellibox;

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/package-info.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/package-info.java
@@ -12,5 +12,6 @@
  * over TCP servers</a>
  * @since 1.3.6
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.loconet.loconetovertcp;

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/package-info.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/package-info.java
@@ -11,5 +11,6 @@
  * Uhlenbrock page</a>.
  */
 //@annotations for the entire package go here
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.loconet.uhlenbrock;

--- a/java/src/jmri/jmrix/mqtt/package-info.java
+++ b/java/src/jmri/jmrix/mqtt/package-info.java
@@ -32,5 +32,6 @@
  *
  * @since 3.9.6
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.mqtt;

--- a/java/src/jmri/jmrix/openlcb/package-info.java
+++ b/java/src/jmri/jmrix/openlcb/package-info.java
@@ -11,5 +11,6 @@
  * <!-- Put @see and @since tags down here. -->
  * @since 2.1.7
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.openlcb;

--- a/java/src/jmri/jmrix/openlcb/swing/downloader/package-info.java
+++ b/java/src/jmri/jmrix/openlcb/swing/downloader/package-info.java
@@ -23,5 +23,6 @@
  * @see jmri.managers
  * @see jmri.implementation
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.openlcb.swing.downloader;

--- a/java/src/jmri/jmrix/openlcb/swing/package-info.java
+++ b/java/src/jmri/jmrix/openlcb/swing/package-info.java
@@ -11,5 +11,6 @@
  * <!-- Put @see and @since tags down here. -->
  * @since 2.1.7
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.openlcb.swing;

--- a/java/src/jmri/jmrix/openlcb/swing/send/package-info.java
+++ b/java/src/jmri/jmrix/openlcb/swing/send/package-info.java
@@ -14,5 +14,6 @@
  * <!-- Put @see and @since tags down here. -->
  * @since 2.9.6
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.openlcb.swing.send;

--- a/java/src/jmri/jmrix/openlcb/swing/tie/package-info.java
+++ b/java/src/jmri/jmrix/openlcb/swing/tie/package-info.java
@@ -11,5 +11,6 @@
  * <li><a href="http://openlcb.org/">OpenLCB project overview page</a>
  * </ul>
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.openlcb.swing.tie;

--- a/java/src/jmri/jmrix/rps/Analytic_AAlgorithm.java
+++ b/java/src/jmri/jmrix/rps/Analytic_AAlgorithm.java
@@ -36,20 +36,11 @@ public class Analytic_AAlgorithm extends AbstractCalculator {
     }
 
     public Analytic_AAlgorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[3];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
+        this(new Point3d[]{sensor1, sensor2, sensor3}, vsound);
     }
 
     public Analytic_AAlgorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, Point3d sensor4, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[4];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
-        sensors[3] = sensor4;
+        this(new Point3d[]{sensor1, sensor2, sensor3, sensor4}, vsound);
     }
 
     double Vs;

--- a/java/src/jmri/jmrix/rps/Ash1_0Algorithm.java
+++ b/java/src/jmri/jmrix/rps/Ash1_0Algorithm.java
@@ -30,20 +30,11 @@ public class Ash1_0Algorithm implements Calculator {
     }
 
     public Ash1_0Algorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[3];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
+        this(new Point3d[]{sensor1, sensor2, sensor3}, vsound);
     }
 
     public Ash1_0Algorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, Point3d sensor4, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[4];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
-        sensors[3] = sensor4;
+        this(new Point3d[]{sensor1, sensor2, sensor3, sensor4}, vsound);
     }
 
     double Vs;

--- a/java/src/jmri/jmrix/rps/Ash1_1Algorithm.java
+++ b/java/src/jmri/jmrix/rps/Ash1_1Algorithm.java
@@ -132,20 +132,11 @@ public class Ash1_1Algorithm implements Calculator {
     }
 
     public Ash1_1Algorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[3];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
+        this(new Point3d[]{sensor1, sensor2, sensor3}, vsound);
     }
 
     public Ash1_1Algorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, Point3d sensor4, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[4];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
-        sensors[3] = sensor4;
+        this(new Point3d[]{sensor1, sensor2, sensor3, sensor4}, vsound);
     }
 
     double Vs;

--- a/java/src/jmri/jmrix/rps/Ash2_0Algorithm.java
+++ b/java/src/jmri/jmrix/rps/Ash2_0Algorithm.java
@@ -142,20 +142,11 @@ public class Ash2_0Algorithm extends AbstractCalculator {
     }
 
     public Ash2_0Algorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[3];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
+        this(new Point3d[]{sensor1, sensor2, sensor3}, vsound);
     }
 
     public Ash2_0Algorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, Point3d sensor4, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[4];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
-        sensors[3] = sensor4;
+        this(new Point3d[]{sensor1, sensor2, sensor3, sensor4}, vsound);
     }
 
     double Vs;

--- a/java/src/jmri/jmrix/rps/Ash2_1Algorithm.java
+++ b/java/src/jmri/jmrix/rps/Ash2_1Algorithm.java
@@ -37,20 +37,11 @@ public class Ash2_1Algorithm extends AbstractCalculator {
     }
 
     public Ash2_1Algorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[3];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
+        this(new Point3d[]{sensor1, sensor2, sensor3}, vsound);
     }
 
     public Ash2_1Algorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, Point3d sensor4, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[4];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
-        sensors[3] = sensor4;
+        this(new Point3d[]{sensor1, sensor2, sensor3, sensor4}, vsound);
     }
 
     double Vs;

--- a/java/src/jmri/jmrix/rps/Ash2_2Algorithm.java
+++ b/java/src/jmri/jmrix/rps/Ash2_2Algorithm.java
@@ -166,20 +166,11 @@ public class Ash2_2Algorithm extends AbstractCalculator {
     }
 
     public Ash2_2Algorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[3];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
+        this(new Point3d[]{sensor1, sensor2, sensor3}, vsound);
     }
 
     public Ash2_2Algorithm(Point3d sensor1, Point3d sensor2, Point3d sensor3, Point3d sensor4, double vsound) {
-        this(null, vsound);
-        sensors = new Point3d[4];
-        sensors[0] = sensor1;
-        sensors[1] = sensor2;
-        sensors[2] = sensor3;
-        sensors[3] = sensor4;
+        this(new Point3d[]{sensor1, sensor2, sensor3, sensor4}, vsound);
     }
 
     double Vs;

--- a/java/src/jmri/jmrix/rps/Measurement.java
+++ b/java/src/jmri/jmrix/rps/Measurement.java
@@ -68,7 +68,7 @@ public class Measurement {
         if (!valid) {
             return false;
         }
-        return !(Math.abs(x) > 1.E10 || Math.abs(x) > 1.E10 || Math.abs(x) > 1.E10);
+        return !(Math.abs(x) > 1.E10 || Math.abs(y) > 1.E10 || Math.abs(z) > 1.E10);
     }
 
     public void setValidPosition(boolean val) {

--- a/java/src/jmri/jmrix/rps/package-info.java
+++ b/java/src/jmri/jmrix/rps/package-info.java
@@ -44,6 +44,8 @@
  *        </ul>
  *        <!-- Put @see and @since tags down here. -->
  */
+// silence all warnings
+@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
 // include empty DefaultAnnotation to avoid excessive recompilation
 @edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.rps;

--- a/java/src/jmri/jmrix/rps/package-info.java
+++ b/java/src/jmri/jmrix/rps/package-info.java
@@ -44,5 +44,6 @@
  *        </ul>
  *        <!-- Put @see and @since tags down here. -->
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.jmrix.rps;

--- a/java/src/jmri/jmrix/rps/serial/SerialAdapter.java
+++ b/java/src/jmri/jmrix/rps/serial/SerialAdapter.java
@@ -375,12 +375,12 @@ public class SerialAdapter extends jmri.jmrix.AbstractSerialPortController {
             log.debug("Found {} receivers", n);
 
             // find max receiver number
-            int max = Integer.valueOf(r.get(r.size() - 1));
+            int max = Integer.parseInt(r.get(r.size() - 1));
             log.debug("Highest receiver address is {}", max);
 
             offsetArray = new int[n];
             for (int i = 0; i < n; i++) {
-                offsetArray[i] = Integer.valueOf(r.get(i + 2));
+                offsetArray[i] = Integer.parseInt(r.get(i + 2));
             }
 
         } catch (IOException e) {

--- a/java/src/jmri/jmrix/rps/swing/debugger/DebuggerFrame.java
+++ b/java/src/jmri/jmrix/rps/swing/debugger/DebuggerFrame.java
@@ -201,13 +201,13 @@ public class DebuggerFrame extends jmri.util.JmriJFrame
 
     void doLoadReadingFromFile() throws IOException {
         if (readingInput == null) {
-            getParser(readingInput, readingFileChooser);
+            readingInput = getParser(readingFileChooser);
         }
 
         // get and load a line
         if (readingInput.getRecords().isEmpty()) {
             // read failed, try once to get another file
-            getParser(readingInput, readingFileChooser);
+            readingInput = getParser(readingFileChooser);
             if (readingInput.getRecords().isEmpty()) {
                 throw new IOException("no valid file");
             }
@@ -224,17 +224,17 @@ public class DebuggerFrame extends jmri.util.JmriJFrame
      *
      * @throws IOException if unable to read file
      * @deprecated since 4.19.3; use
-     * {@link #getParser(org.apache.commons.csv.CSVParser, javax.swing.JFileChooser)}
+     * {@link #getParser(javax.swing.JFileChooser)}
      * instead
      */
     @Deprecated
     void setupReadingFile() throws IOException {
-        getParser(readingInput, readingFileChooser);
+        readingInput = getParser(readingFileChooser);
     }
 
-    private void getParser(CSVParser parser, JFileChooser chooser) throws IOException {
+    private CSVParser getParser(JFileChooser chooser) throws IOException {
         // get file
-        parser = null;
+        CSVParser parser = null;
 
         chooser.rescanCurrentDirectory();
         int retVal = chooser.showOpenDialog(this);
@@ -245,17 +245,18 @@ public class DebuggerFrame extends jmri.util.JmriJFrame
             Reader reader = new FileReader(chooser.getSelectedFile());
             parser = new CSVParser(reader, CSVFormat.DEFAULT.withSkipHeaderRecord());
         }
+        return parser;
     }
 
     void doLoadMeasurementFromFile() throws IOException {
         if (measurementInput == null) {
-            getParser(measurementInput, measurementFileChooser);
+            measurementInput = getParser(measurementFileChooser);
         }
 
         // get and load a line
         if (measurementInput.getRecords().isEmpty()) {
             // read failed, try once to get another file
-            getParser(measurementInput, measurementFileChooser);
+            measurementInput = getParser(measurementFileChooser);
             if (measurementInput.getRecords().isEmpty()) {
                 throw new IOException("no valid file");
             }
@@ -280,12 +281,12 @@ public class DebuggerFrame extends jmri.util.JmriJFrame
      *
      * @throws IOException if unable to read file
      * @deprecated since 4.19.3; use
-     * {@link #getParser(org.apache.commons.csv.CSVParser, javax.swing.JFileChooser)}
+     * {@link #getParser(javax.swing.JFileChooser)}
      * instead
      */
     @Deprecated
     void setupMeasurementFile() throws IOException {
-        getParser(measurementInput, measurementFileChooser);
+        measurementInput = getParser(measurementFileChooser);
     }
 
     Measurement lastPoint = null;

--- a/java/src/jmri/package-info.java
+++ b/java/src/jmri/package-info.java
@@ -17,5 +17,6 @@
  * @see jmri.managers
  * @see jmri.implementation
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri;

--- a/java/src/jmri/plaf/macosx/package-info.java
+++ b/java/src/jmri/plaf/macosx/package-info.java
@@ -6,5 +6,6 @@
  * which is expanded in JDK 9 to support OS X integration that once depended
  * upon the com.apple.eawt package.
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.plaf.macosx;

--- a/java/src/jmri/profile/package-info.java
+++ b/java/src/jmri/profile/package-info.java
@@ -8,5 +8,6 @@
  * {@link jmri.profile.ProfilePreferencesPanel}. This allows profiles to be
  * imported into a JMRI instance while that instance is not running.
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.profile;

--- a/java/src/jmri/server/json/message/package-info.java
+++ b/java/src/jmri/server/json/message/package-info.java
@@ -50,5 +50,6 @@
  * client's locale and the JMRI server's locale.</dd>
  * </dl>
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.server.json.message;

--- a/java/src/jmri/server/json/operations/package-info.java
+++ b/java/src/jmri/server/json/operations/package-info.java
@@ -32,5 +32,6 @@
  * 
  * @see jmri.server.json
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.server.json.operations;

--- a/java/src/jmri/server/json/package-info.java
+++ b/java/src/jmri/server/json/package-info.java
@@ -293,5 +293,6 @@
  * @see jmri.server.json.JsonServer
  * @see jmri.spi.JsonServiceFactory
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.server.json;

--- a/java/src/jmri/server/json/power/package-info.java
+++ b/java/src/jmri/server/json/power/package-info.java
@@ -17,5 +17,6 @@
  * default system connection, otherwise it returns the power state for the named
  * system connection.
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.server.json.power;

--- a/java/src/jmri/spi/package-info.java
+++ b/java/src/jmri/spi/package-info.java
@@ -17,5 +17,6 @@
  *
  * @see java.util.ServiceLoader
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.spi;

--- a/java/src/jmri/util/com/package-info.java
+++ b/java/src/jmri/util/com/package-info.java
@@ -5,5 +5,6 @@
  * repositories, etc.  Large bodies of code should be brought
  * in as libraries i.e. jar files.
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.util.com;

--- a/java/src/jmri/util/node/package-info.java
+++ b/java/src/jmri/util/node/package-info.java
@@ -3,5 +3,6 @@
  *
  * @since JMRI 3.7.1
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.util.node;

--- a/java/src/jmri/util/package-info.java
+++ b/java/src/jmri/util/package-info.java
@@ -9,5 +9,6 @@
  * The {@link jmri.util.com} package contains several sets of
  * imported code.
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.util;

--- a/java/src/jmri/util/prefs/package-info.java
+++ b/java/src/jmri/util/prefs/package-info.java
@@ -28,5 +28,6 @@
  * in any class in this package refer to the results of
 {@link jmri.profile.ProfileManager#getActiveProfile()}.
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings({})
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package jmri.util.prefs;


### PR DESCRIPTION
Addresses [group.io discussion](https://jmri-developers.groups.io/g/jmri/topic/72561538) by correcting changes made in #8245 to use a benign package annotation.

Also fixes high priority warnings in `jmri.jmrix.rps` package that have been long-standing crashers (which are obviously neither tested nor used in production, or they would have been caught by unit tests or reported by users).