### PR TITLE
Documentation and test updates

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1909,6 +1909,8 @@
             <link href="https://commons.apache.org/proper/commons-csv/apidocs/"/>
             <link href="http://logging.apache.org/log4j/1.2/apidocs/"/>
             <link href="https://commons.apache.org/proper/commons-lang/javadocs/api-release"/>
+            <link href="https://javadoc.io/static/com.github.spotbugs/spotbugs-annotations/3.1.7/"/>
+            <link href="https://javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/"/>
             <!-- marking this one offline as it doesn't currently serve the 'package-list' document -->
             <link offline="true" href="https://jogamp.org/deployment/jogamp-next/javadoc/joal/javadoc/" packagelistLoc="lib/joal-2.3.1-packagelist"/>
             <!-- The following Javadocs were built with JDK 11+ and can't be directly linked -->
@@ -1998,6 +2000,8 @@
             <link href="https://commons.apache.org/proper/commons-csv/apidocs/"/>
             <link href="http://logging.apache.org/log4j/1.2/apidocs/"/>
             <link href="https://commons.apache.org/proper/commons-lang/javadocs/api-release"/>
+            <link href="https://javadoc.io/static/com.github.spotbugs/spotbugs-annotations/3.1.7/"/>
+            <link href="https://javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/"/>
             <!-- marking this one offline as it doesn't currently serve the 'package-list' document -->
             <link offline="true" href="https://jogamp.org/deployment/jogamp-next/javadoc/joal/javadoc/" packagelistLoc="lib/joal-2.3.1-packagelist"/>
             <!-- The following Javadocs were built with JDK 11+ and can't be directly linked -->
@@ -2105,6 +2109,8 @@
             <link href="https://commons.apache.org/proper/commons-csv/apidocs/"/>
             <link href="http://logging.apache.org/log4j/1.2/apidocs/"/>
             <link href="https://commons.apache.org/proper/commons-lang/javadocs/api-release"/>
+            <link href="https://javadoc.io/static/com.github.spotbugs/spotbugs-annotations/3.1.7/"/>
+            <link href="https://javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/"/>
             <!-- marking this one offline as it doesn't currently serve the 'package-list' document -->
             <link offline="true" href="https://jogamp.org/deployment/jogamp-next/javadoc/joal/javadoc/" packagelistLoc="lib/joal-2.3.1-packagelist"/>
             <!-- The following Javadocs were built with JDK 11+ and can't be directly linked -->

--- a/help/en/html/doc/Technical/Javadoc.shtml
+++ b/help/en/html/doc/Technical/Javadoc.shtml
@@ -62,15 +62,26 @@
       <code>package-info.java</code></a> file 
       to contain any needed
       package-level documentation. 
-      (It can also contain any 
+      It can also contain any 
       <a href="http://java.sun.com/docs/books/tutorial/java/javaOO/annotations.html">annotations</a>
-      you want to apply to all classes in the package)
+      you want to apply to all classes in the package.
+      If you don't have any annotations you want to include, please include
+
+<pre style="font-family: monospace;">      
+      @edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
+</pre>
+
+      which helps some of our build systems minimize recompilation.
+      (For more on that annotation, see 
+      <a href="https://javadoc.io/static/com.github.spotbugs/spotbugs-annotations/3.1.7/edu/umd/cs/findbugs/annotations/DefaultAnnotation.html">here</a>)
+      
+      <p>
       Previously, we used <code>package.html</code> files 
       for this. It's not a
       high priority to replace existing <code>package.html</code>
       files, but new packages should include a
       <code>package-info.java</code> copied from
-      <code>java/package-info.java</code>.</p>
+      <code>java/package-info.java</code> instead, see above.</p>
 
       <p>A nice discussion of how to use the "deprecated" label in
       documentation is available on the <a href=

--- a/help/en/html/hardware/arduino/ArduinoCMRIByteComm.shtml
+++ b/help/en/html/hardware/arduino/ArduinoCMRIByteComm.shtml
@@ -69,7 +69,7 @@
         current speed (perhaps 1 to 8) by encoding that number in several bits to be
         sent as part of the CMRINet transmission. A <a href="../../tools/scripting/index.shtml">
         JMRI script</a> can be <a href="../../tools/scripting/HowTo.shtml#multturnouts">listening
-        to changes</a> in these “speed” bits and use them to create a decimal number in a
+        to changes</a> in these "speed" bits and use them to create a decimal number in a
         <a href="../../tools/Memories.shtml"></a>JMRI memory variable for display on a panel,
         as illustrated in a <a href="https://www.jmri.org/jython/CmriBitsToBytes.py" target="_blank">
         this example script.</a> The image here shows sensors 0, 1, 2, and 3 active which
@@ -110,7 +110,7 @@
             as you need to tell the arduino to perform some task. Controlling whether 
             a motor is on or off can be done with a single light (INACTIVE (which sends a
             0) for OFF, ACTIVE (which sends a 1) for ON). Controlling its speed requires
-            two lights – one to tell it to increase, one to tell it to decrease, neither on
+            two lights - one to tell it to increase, one to tell it to decrease, neither on
             to stay the same speed.</p>
 		    </dd>
 
@@ -126,7 +126,7 @@
             
             <p class="note">While JMRI sends and receives a 0 or 1 in the
             CMRI bit steam, it translates a zero into a sensor INACTIVE state, which is
-            actually stored as 4 (requesting “state” and printing it as a number in a script
+            actually stored as 4 (requesting "state" and printing it as a number in a script
             will return a 4) and ACTIVE as a 2.  This is important in writing your JMRI
             script to translate received sensor states as binary bits.]</p>
 		    </dd>

--- a/java/test/jmri/managers/ManagerDefaultSelectorTest.java
+++ b/java/test/jmri/managers/ManagerDefaultSelectorTest.java
@@ -13,6 +13,7 @@ import jmri.util.JUnitUtil;
 import jmri.util.prefs.InitializationException;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -77,6 +78,8 @@ public class ManagerDefaultSelectorTest {
 
     @Test
     public void testSingleSystemPreferencesValid() throws InitializationException {
+        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
+
         ManagerDefaultSelector mds = new ManagerDefaultSelector();
         // assert default state
         Assert.assertFalse(mds.isAllInternalDefaultsValid());
@@ -128,6 +131,8 @@ public class ManagerDefaultSelectorTest {
 
     @Test
     public void testAuxInternalPreferencesValid() throws InitializationException {
+        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
+
         ManagerDefaultSelector mds = new ManagerDefaultSelector();
         Profile profile = ProfileManager.getDefault().getActiveProfile();
 
@@ -192,6 +197,8 @@ public class ManagerDefaultSelectorTest {
 
     @Test
     public void testTwoLoconetPreferencesValid() throws InitializationException {
+        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
+
         ManagerDefaultSelector mds = new ManagerDefaultSelector();
         Profile profile = ProfileManager.getDefault().getActiveProfile();
 

--- a/pom.xml
+++ b/pom.xml
@@ -636,6 +636,8 @@
                         <link>http://download.java.net/media/java3d/javadoc/1.3.2/</link>
                         <link>https://static.javadoc.io/org.openlcb/openlcb/${openlcb.version}/</link>
                         <link>https://commons.apache.org/proper/commons-lang/javadocs/api-release/</link>
+                        <link>https://javadoc.io/static/com.github.spotbugs/spotbugs-annotations/3.1.7/</link>
+                        <link>https://javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/</link>
                         <link>https://jogamp.org/deployment/jogamp-next/javadoc/joal/javadoc/</link>
                         <link>https://static.javadoc.io/com.github.purejavacomm/purejavacomm/1.0.1.RELEASE/</link>
                         <link>https://static.javadoc.io/com.alexandriasoftware.swing/jsplitbutton/1.3.1/</link>


### PR DESCRIPTION
 - Add a reference to keeping an annotation in package-info files (see #8277) in developer help
 - Link Javadoc creation to proper source for SpotBugs, JSR-305 (note that there are no Javadocs for the JSR-305 3.0.0 we use, so I linked it to 3.0.1)
 - Mark three tests that require graphics as requiring graphics.
 - Fix some invalid character codes in a .shtml file; not sure why those were caught by CI, found in Jenkins