### PR TITLE
test: run CI tests in alphabetical order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ env:
   - PRINT_SUMMARY=false
   - MAVEN_OPTS=-Xmx1536m
   # see http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder for valid values
-  - RUN_ORDER=filesystem
+  - RUN_ORDER=alphabetical
   - CC_TEST_REPORTER_ID=1d1326c4dfaeede878b46588cda440432d1dd6ec605d2c99af7b240ac7db0477
   - SKIPINTERMITTENT=true
 


### PR DESCRIPTION
Run CI tests in a completely deterministic order, not relying on the order of commits in git to lay down onto a filesystem in a mostly consistent order.