### PR TITLE
fix: do not start logging console if headless

### DIFF
--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -1,5 +1,7 @@
 package jmri.util;
 
+import java.awt.GraphicsEnvironment;
+
 import apps.SystemConsole;
 
 import java.io.File;
@@ -172,7 +174,9 @@ public class Log4JUtil {
         // Initialise JMRI System Console
         // Need to do this before initialising log4j so that the new
         // stdout and stderr streams are set up and usable by the ConsoleAppender
-        SystemConsole.create();
+        if (!GraphicsEnvironment.isHeadless()) {
+            SystemConsole.create();
+        }
         log4JSetUp = true;
 
         // initialize the java.util.logging to log4j bridge


### PR DESCRIPTION
Does not create an `apps.SystemConsole` instance if a JMRI app is running without a GUI.

Cherry-picked from #8269 because it seems to be a useful addition.