### PR TITLE
test: execute column sizing test on EDT

### DIFF
--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeSingleEventTableDataModelTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeSingleEventTableDataModelTest.java
@@ -2,6 +2,8 @@ package jmri.jmrix.can.cbus.node;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.assertj.swing.edt.GuiActionRunner;
+
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -40,15 +42,16 @@ public class CbusNodeSingleEventTableDataModelTest {
 
         assertThat(t.isTableLoaded()).isFalse();
         
-        for (int i = 0; i <t.getColumnCount(); i++) {
-            assertThat(t.getColumnName(i)).isNotEmpty();
-            assertThat(CbusNodeSingleEventTableDataModel.getPreferredWidth(i)).isGreaterThan(0);
-        }
-        
-        assertThat(t.getColumnName(999)).isEqualTo("unknown 999");
-        
-        assertThat(CbusNodeSingleEventTableDataModel.getPreferredWidth(999)).isGreaterThan(0);
-                
+        GuiActionRunner.execute(() -> {
+            for (int i = 0; i <t.getColumnCount(); i++) {
+                assertThat(t.getColumnName(i)).isNotEmpty();
+                assertThat(CbusNodeSingleEventTableDataModel.getPreferredWidth(i)).isGreaterThan(0);
+            }
+            
+            assertThat(t.getColumnName(999)).isEqualTo("unknown 999");
+            
+            assertThat(CbusNodeSingleEventTableDataModel.getPreferredWidth(999)).isGreaterThan(0);
+        });
     }
 
     @Test


### PR DESCRIPTION
Determining the size of a column in Swing requires (re)painting it, so this test should run on the EDT.

Cherry-picked from #8269