### PR TITLE
Throttle layout also save throttle window mode

### DIFF
--- a/java/src/jmri/jmrit/throttle/ThrottleFrame.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleFrame.java
@@ -83,6 +83,10 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
 
     private String title;
     private String lastUsedSaveFile = null;
+
+    private boolean isEditMode = true;
+    private boolean willSwitch = false;
+
     private static final String DEFAULT_THROTTLE_FILENAME = "JMRI_ThrottlePreference.xml";
 
     public static String getDefaultThrottleFolder() {
@@ -219,7 +223,7 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
 
         boolean switchAfter = false;
         if (!isEditMode) {
-            switchMode();
+            setEditMode(true);
             switchAfter = true;
         }
 
@@ -256,7 +260,7 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
         }
 //     checkPosition();
         if (switchAfter) {
-            switchMode();
+            setEditMode(false);
         }
     }
 
@@ -546,20 +550,19 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
         }
     }
 
-    private boolean isEditMode = true;
-    private boolean willSwitch = false;
-
-    public void switchMode() {
+    public void setEditMode(boolean mode) {
+        if (mode == isEditMode)
+            return;
         if (isVisible()) {
-            if (isEditMode) {
+            if (!mode) {
                 playRendering();
             } else {
                 editRendering();
             }
-            isEditMode = !isEditMode;
+            isEditMode = mode;
             willSwitch = false;
         } else {
-            willSwitch = !willSwitch;
+            willSwitch = true;
         }
         throttleWindow.updateGUI();
     }
@@ -680,7 +683,7 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
     public Element getXml() {
         boolean switchAfter = false;
         if (!isEditMode) {
-            switchMode();
+            setEditMode(true);
             switchAfter = true;
         }
 
@@ -728,7 +731,7 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
         }
         me.setContent(children);
         if (switchAfter) {
-            switchMode();
+            setEditMode(false);
         }
         return me;
     }
@@ -768,7 +771,7 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
 
         boolean switchAfter = false;
         if (!isEditMode) {
-            switchMode();
+            setEditMode(true);
             switchAfter = true;
         }
 
@@ -827,7 +830,7 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
         }
         setFrameTitle();
         if (switchAfter) {
-            switchMode();
+            setEditMode(false);
         }
     }
 
@@ -874,7 +877,7 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
     public void componentShown(ComponentEvent e) {
         throttleWindow.setCurrentThrottleFrame(this);
         if (willSwitch) {
-            switchMode();
+            setEditMode(this.throttleWindow.getEditMode());
             repaint();
         }
         throttleWindow.updateGUI();

--- a/java/src/jmri/jmrit/throttle/ThrottleFrame.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleFrame.java
@@ -567,6 +567,14 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
         throttleWindow.updateGUI();
     }
 
+    public boolean getEditMode() {
+        return isEditMode;
+    }
+
+    public void switchMode() {
+        setEditMode(!isEditMode);
+    }
+
     /**
      * Handle my own destruction.
      * <ol>

--- a/java/src/jmri/jmrit/throttle/ThrottleFrame.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleFrame.java
@@ -571,6 +571,10 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
         return isEditMode;
     }
 
+    /**
+     * @deprecated since 4.19.5; use {@link #setEditMode(boolean)} instead
+     */
+    @Deprecated
     public void switchMode() {
         setEditMode(!isEditMode);
     }

--- a/java/src/jmri/jmrit/throttle/ThrottleWindow.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleWindow.java
@@ -763,7 +763,7 @@ public class ThrottleWindow extends JmriJFrame {
             setTitleTextType(e.getAttribute("titleType").getValue());
         }
         if (e.getAttribute("isEditMode") != null) {
-            isEditMode = new Boolean(e.getAttribute("isEditMode").getValue());
+            isEditMode = Boolean.valueOf(e.getAttribute("isEditMode").getValue());
         }
 
         Element window = e.getChild("window");

--- a/java/src/jmri/jmrit/throttle/ThrottleWindow.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleWindow.java
@@ -3,7 +3,6 @@ package jmri.jmrit.throttle;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Component;
-import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
@@ -12,7 +11,6 @@ import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.io.File;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -65,6 +63,8 @@ public class ThrottleWindow extends JmriJFrame {
 
     private String titleText = "";
     private String titleTextType = "rosterID";
+    private boolean isEditMode = true;
+
 
     private PowerManager powerMgr = null;
 
@@ -272,7 +272,7 @@ public class ThrottleWindow extends JmriJFrame {
         jbMode.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                switchMode();
+                setEditMode( !isEditMode );
             }
         });
         throttleToolBar.add(jbMode);
@@ -300,16 +300,20 @@ public class ThrottleWindow extends JmriJFrame {
         add(throttleToolBar, BorderLayout.PAGE_START);
     }
 
-    private boolean isEditMode = true;
-
-    private void switchMode() {
-        isEditMode = !isEditMode;
+    public void setEditMode(boolean mode) {
+        if (mode == isEditMode)
+            return;
+        isEditMode = mode;
         if (!throttleFrames.isEmpty()) {
             for (Iterator<ThrottleFrame> tfi = throttleFrames.values().iterator(); tfi.hasNext();) {
-                tfi.next().switchMode();
+                tfi.next().setEditMode(isEditMode);
             }
         }
         updateGUI();
+    }
+
+    public boolean getEditMode() {
+        return isEditMode;
     }
 
     public Jynstrument ynstrument(String path) {
@@ -433,7 +437,7 @@ public class ThrottleWindow extends JmriJFrame {
 
             @Override
             public void actionPerformed(ActionEvent ev) {
-                switchMode();
+                setEditMode(!isEditMode);
             }
         });
         JMenuItem viewThrottlesList = new JMenuItem(Bundle.getMessage("ThrottleMenuViewViewThrottleList"));
@@ -657,7 +661,7 @@ public class ThrottleWindow extends JmriJFrame {
         throttlesPanel.add(tp, txt);
         throttlesLayout.show(throttlesPanel, txt);
         if (!isEditMode) {
-            tp.switchMode();
+            tp.setEditMode(isEditMode);
         }
         updateGUI();
     }
@@ -696,6 +700,7 @@ public class ThrottleWindow extends JmriJFrame {
         Element me = new Element("ThrottleWindow");
         me.setAttribute("title", titleText);
         me.setAttribute("titleType", titleTextType);
+        me.setAttribute("isEditMode",  String.valueOf(isEditMode));
 
         java.util.ArrayList<Element> children = new java.util.ArrayList<Element>(1);
         children.add(WindowPreferences.getPreferences(this));
@@ -757,6 +762,9 @@ public class ThrottleWindow extends JmriJFrame {
         if (e.getAttribute("titleType") != null) {
             setTitleTextType(e.getAttribute("titleType").getValue());
         }
+        if (e.getAttribute("isEditMode") != null) {
+            isEditMode = new Boolean(e.getAttribute("isEditMode").getValue());
+        }
 
         Element window = e.getChild("window");
         if (window != null) {
@@ -773,6 +781,7 @@ public class ThrottleWindow extends JmriJFrame {
                     tf = addThrottleFrame();
                 }
                 tf.setXml(tfes.get(i));
+                tf.setEditMode(isEditMode);
             }
         }
 

--- a/java/src/jmri/jmrit/throttle/ThrottleWindow.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleWindow.java
@@ -316,6 +316,10 @@ public class ThrottleWindow extends JmriJFrame {
         return isEditMode;
     }
 
+    public void switchMode() {
+        setEditMode(!isEditMode);
+    }
+
     public Jynstrument ynstrument(String path) {
         Jynstrument it = JynstrumentFactory.createInstrument(path, this);
         if (it == null) {

--- a/java/src/jmri/jmrit/throttle/ThrottleWindow.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleWindow.java
@@ -316,6 +316,10 @@ public class ThrottleWindow extends JmriJFrame {
         return isEditMode;
     }
 
+    /**
+     * @deprecated since 4.19.5; use {@link #setEditMode(boolean)} instead
+     */
+    @Deprecated
     public void switchMode() {
         setEditMode(!isEditMode);
     }


### PR DESCRIPTION
When saving a throttle window layout, also save the edit/play mode. Will restore accordingly.
Refactored code (clean, add getter/setter, removed ambiguous mzthod).