### PR TITLE
Add debug for NoClassDefFoundError of NCE classes

### DIFF
--- a/java/src/jmri/jmrix/AbstractMRMessage.java
+++ b/java/src/jmri/jmrix/AbstractMRMessage.java
@@ -87,13 +87,19 @@ abstract public class AbstractMRMessage extends AbstractMessage {
     // accessors to the bulk data
 
     // state info
-    int mNeededMode;
+    private int mNeededMode;
 
-    public void setNeededMode(int pMode) {
+    /**
+     * final so that it can be called in constructors
+     */
+    final public void setNeededMode(int pMode) {
         mNeededMode = pMode;
     }
 
-    public int getNeededMode() {
+    /**
+     * final so that it can be called in constructors
+     */
+    final public int getNeededMode() {
         return mNeededMode;
     }
 
@@ -111,13 +117,19 @@ abstract public class AbstractMRMessage extends AbstractMessage {
     }
 
     // mode accessors
-    boolean _isBinary;
+    private boolean _isBinary;
 
-    public boolean isBinary() {
+    /**
+     * final so that it can be called in constructors
+     */
+    final public boolean isBinary() {
         return _isBinary;
     }
 
-    public void setBinary(boolean b) {
+    /**
+     * final so that it can be called in constructors
+     */
+    final public void setBinary(boolean b) {
         _isBinary = b;
     }
 
@@ -132,13 +144,20 @@ abstract public class AbstractMRMessage extends AbstractMessage {
      */
     static protected final int SHORT_TIMEOUT = 2000;
     static protected final int LONG_TIMEOUT = 60000;  // e.g. for programming options
-    int mTimeout;  // in milliseconds
+    
+    private int mTimeout;  // in milliseconds
 
-    public void setTimeout(int t) {
+    /**
+     * final so that it can be called in constructors
+     */
+    final public void setTimeout(int t) {
         mTimeout = t;
     }
 
-    public int getTimeout() {
+    /**
+     * final so that it can be called in constructors
+     */
+    final public int getTimeout() {
         return mTimeout;
     }
 
@@ -146,11 +165,17 @@ abstract public class AbstractMRMessage extends AbstractMessage {
      isn't ready for them. */
     private int mRetries = 0; // number of retries, default = 0;
 
-    public void setRetries(int i) {
+    /**
+     * final so that it can be called in constructors
+     */
+    final public void setRetries(int i) {
         mRetries = i;
     }
 
-    public int getRetries() {
+    /**
+     * final so that it can be called in constructors
+     */
+    final public int getRetries() {
         return mRetries;
     }
 
@@ -170,6 +195,10 @@ abstract public class AbstractMRMessage extends AbstractMessage {
         setElement(offset + 2, s.charAt(2));
     }
 
+    /**
+     * Put an int value into the message as 
+     * two ASCII upper-case hex characters.
+     */
     public void addIntAsTwoHex(int val, int offset) {
         String s = ("" + Integer.toHexString(val)).toUpperCase();
         if (s.length() < 2) {
@@ -182,6 +211,10 @@ abstract public class AbstractMRMessage extends AbstractMessage {
         setElement(offset + 1, s.charAt(1));
     }
 
+    /**
+     * Put an int value into the message as 
+     * three ASCII upper-case hex characters.
+     */
     public void addIntAsThreeHex(int val, int offset) {
         String s = ("" + Integer.toHexString(val)).toUpperCase();
         if (s.length() > 3) {
@@ -198,6 +231,10 @@ abstract public class AbstractMRMessage extends AbstractMessage {
         setElement(offset + 2, s.charAt(2));
     }
 
+    /**
+     * Put an int value into the message as 
+     * four ASCII upper-case hex characters.
+     */
     public void addIntAsFourHex(int val, int offset) {
         String s = ("" + Integer.toHexString(val)).toUpperCase();
         if (s.length() > 4) {

--- a/java/src/jmri/jmrix/nce/NceConsist.java
+++ b/java/src/jmri/jmrix/nce/NceConsist.java
@@ -198,7 +198,8 @@ public class NceConsist extends jmri.implementation.DccConsist implements jmri.j
     private synchronized void stopReadNCEconsistThread() {
         if (mb != null) {
             try {
-                mb.stop();
+                mb.interrupt();
+                //mb.stop();
                 mb.join();
             } catch (InterruptedException ex) {
                 log.warn("stopReadNCEconsistThread interrupted");
@@ -348,8 +349,12 @@ public class NceConsist extends jmri.implementation.DccConsist implements jmri.j
                 readConsistMemory(_consistNum, REAR);
                 readConsistMemory(_consistNum, MID);
                 setValid(true);
+            } catch (InterruptedException e) {
+                return; // we're done!
             } catch (Throwable t) {
-                log.error("NceReadConsist.run caught ", t);
+                if ( ! (t instanceof java.lang.ThreadDeath) ) {
+                    log.error("NceReadConsist.run caught ", t);
+                }
                 throw t;
             }
         }
@@ -358,7 +363,7 @@ public class NceConsist extends jmri.implementation.DccConsist implements jmri.j
          * Reads 16 bytes of NCE consist memory based on consist number and loco
          * number 0=lead 1=rear 2=mid
          */
-        private void readConsistMemory(int consistNum, int eNum) {
+        private void readConsistMemory(int consistNum, int eNum) throws InterruptedException { // throw interrupt upward
             if (consistNum > CONSIST_MAX || consistNum < CONSIST_MIN) {
                 log.error("Requesting consist " + consistNum + " out of range");
                 return;
@@ -390,15 +395,11 @@ public class NceConsist extends jmri.implementation.DccConsist implements jmri.j
         }
 
         // wait up to 30 sec per read
-        private boolean readWait() {
+        private boolean readWait() throws InterruptedException { // throw interrupt upward
             int waitcount = 30;
             while (_busy > 0) {
                 synchronized (this) {
-                    try {
-                        wait(1000);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt(); // retain if needed later
-                    }
+                    wait(1000);
                 }
                 if (waitcount-- < 0) {
                     log.error("read timeout");

--- a/java/src/jmri/jmrix/nce/NceConsist.java
+++ b/java/src/jmri/jmrix/nce/NceConsist.java
@@ -194,12 +194,10 @@ public class NceConsist extends jmri.implementation.DccConsist implements jmri.j
         }
     }
 
-    @SuppressWarnings("deprecation") // Thread.stop not likely to be removed
     private synchronized void stopReadNCEconsistThread() {
         if (mb != null) {
             try {
                 mb.interrupt();
-                //mb.stop();
                 mb.join();
             } catch (InterruptedException ex) {
                 log.warn("stopReadNCEconsistThread interrupted");

--- a/java/src/jmri/jmrix/nce/NceConsist.java
+++ b/java/src/jmri/jmrix/nce/NceConsist.java
@@ -183,7 +183,7 @@ public class NceConsist extends jmri.implementation.DccConsist implements jmri.j
 
     private NceReadConsist mb = null;
 
-    private void startReadNCEconsistThread(boolean check) {
+    private synchronized void startReadNCEconsistThread(boolean check) {
         // read command station memory to get the current consist (can't be a USB, only PH)
         if (tc.getUsbSystem() == NceTrafficController.USB_SYSTEM_NONE) {
             mb = new NceReadConsist();
@@ -195,7 +195,7 @@ public class NceConsist extends jmri.implementation.DccConsist implements jmri.j
     }
 
     @SuppressWarnings("deprecation") // Thread.stop not likely to be removed
-    private void stopReadNCEconsistThread() {
+    private synchronized void stopReadNCEconsistThread() {
         if (mb != null) {
             try {
                 mb.stop();

--- a/java/src/jmri/jmrix/nce/NceConsist.java
+++ b/java/src/jmri/jmrix/nce/NceConsist.java
@@ -202,6 +202,9 @@ public class NceConsist extends jmri.implementation.DccConsist implements jmri.j
                 mb.join();
             } catch (InterruptedException ex) {
                 log.warn("stopReadNCEconsistThread interrupted");
+            } catch (Throwable t) {
+                log.error("stopReadNCEconsistThread caught ", t);
+                throw t;
             } finally {
                 mb = null;
             }
@@ -340,10 +343,15 @@ public class NceConsist extends jmri.implementation.DccConsist implements jmri.j
         // load up the consist lists by lead, rear, and then mid
         @Override
         public void run() {
-            readConsistMemory(_consistNum, LEAD);
-            readConsistMemory(_consistNum, REAR);
-            readConsistMemory(_consistNum, MID);
-            setValid(true);
+            try{
+                readConsistMemory(_consistNum, LEAD);
+                readConsistMemory(_consistNum, REAR);
+                readConsistMemory(_consistNum, MID);
+                setValid(true);
+            } catch (Throwable t) {
+                log.error("NceReadConsist.run caught ", t);
+                throw t;
+            }
         }
 
         /**

--- a/java/src/jmri/jmrix/nce/NceMessage.java
+++ b/java/src/jmri/jmrix/nce/NceMessage.java
@@ -3,8 +3,6 @@ package jmri.jmrix.nce;
 import java.util.Arrays;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Encodes a message to an NCE command station.
@@ -622,5 +620,5 @@ public class NceMessage extends jmri.jmrix.AbstractMRMessage {
 	    return nceMon.displayMessage(this);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(NceMessage.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NceMessage.class);
 }

--- a/java/src/jmri/jmrix/nce/NceMessage.java
+++ b/java/src/jmri/jmrix/nce/NceMessage.java
@@ -32,8 +32,16 @@ import javax.annotation.Nonnull;
  */
 public class NceMessage extends jmri.jmrix.AbstractMRMessage {
  
-    protected static final jmri.jmrix.nce.ncemon.NceMonBinary nceMon = new jmri.jmrix.nce.ncemon.NceMonBinary();
-
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NceMessage.class); // called in static block
+    protected static final jmri.jmrix.nce.ncemon.NceMonBinary nceMon;
+    static {
+        try {
+            nceMon = new jmri.jmrix.nce.ncemon.NceMonBinary();
+        } catch (Throwable t) {
+            log.error("Thrown in NceMessage static init ",t);
+            throw t;
+        }
+    }
     public static final int NOP_CMD = 0x80; //NCE NOP command
     public static final int ASSIGN_CAB_CMD = 0x81; // NCE Assign loco to cab command, NCE-USB no
     public static final int READ_CLOCK_CMD = 0x82; // NCE read clock command, NCE-USB no
@@ -619,6 +627,4 @@ public class NceMessage extends jmri.jmrix.AbstractMRMessage {
     public String toMonitorString(){
 	    return nceMon.displayMessage(this);
     }
-
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NceMessage.class);
 }

--- a/java/src/jmri/jmrix/nce/NceMessage.java
+++ b/java/src/jmri/jmrix/nce/NceMessage.java
@@ -33,15 +33,8 @@ import javax.annotation.Nonnull;
 public class NceMessage extends jmri.jmrix.AbstractMRMessage {
  
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NceMessage.class); // called in static block
-    protected static final jmri.jmrix.nce.ncemon.NceMonBinary nceMon;
-    static {
-        try {
-            nceMon = new jmri.jmrix.nce.ncemon.NceMonBinary();
-        } catch (Throwable t) {
-            log.error("Thrown in NceMessage static init ",t);
-            throw t;
-        }
-    }
+    protected static final jmri.jmrix.nce.ncemon.NceMonBinary nceMon = new jmri.jmrix.nce.ncemon.NceMonBinary();
+
     public static final int NOP_CMD = 0x80; //NCE NOP command
     public static final int ASSIGN_CAB_CMD = 0x81; // NCE Assign loco to cab command, NCE-USB no
     public static final int READ_CLOCK_CMD = 0x82; // NCE read clock command, NCE-USB no

--- a/java/src/jmri/jmrix/nce/NceMessage.java
+++ b/java/src/jmri/jmrix/nce/NceMessage.java
@@ -33,7 +33,7 @@ import javax.annotation.Nonnull;
 public class NceMessage extends jmri.jmrix.AbstractMRMessage {
  
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NceMessage.class); // called in static block
-    protected static final jmri.jmrix.nce.ncemon.NceMonBinary nceMon = new jmri.jmrix.nce.ncemon.NceMonBinary();
+    private static final jmri.jmrix.nce.ncemon.NceMonBinary nceMon = new jmri.jmrix.nce.ncemon.NceMonBinary();
 
     public static final int NOP_CMD = 0x80; //NCE NOP command
     public static final int ASSIGN_CAB_CMD = 0x81; // NCE Assign loco to cab command, NCE-USB no

--- a/java/src/jmri/jmrix/nce/NceReply.java
+++ b/java/src/jmri/jmrix/nce/NceReply.java
@@ -12,7 +12,7 @@ package jmri.jmrix.nce;
 public class NceReply extends jmri.jmrix.AbstractMRReply {
 
     NceTrafficController tc;
-    protected static final jmri.jmrix.nce.ncemon.NceMonBinary nceMon = new jmri.jmrix.nce.ncemon.NceMonBinary();
+    private static final jmri.jmrix.nce.ncemon.NceMonBinary nceMon = new jmri.jmrix.nce.ncemon.NceMonBinary();
 
     // create a new one
     public NceReply(NceTrafficController tc) {

--- a/java/src/jmri/jmrix/nce/ncemon/NceMonBinary.java
+++ b/java/src/jmri/jmrix/nce/ncemon/NceMonBinary.java
@@ -18,8 +18,6 @@ public class NceMonBinary {
 
     private static final Logger log = LoggerFactory.getLogger(NceMonBinary.class);
 
-    private int replyType = REPLY_UNKNOWN;
-
     private static final int REPLY_UNKNOWN = 0;
     private static final int REPLY_STANDARD = 1;
     private static final int REPLY_DATA = 2;
@@ -32,6 +30,8 @@ public class NceMonBinary {
     private static final int REPLY_THREE = '3';// CV address or data out of range
     private static final int REPLY_FOUR = '4'; // byte count out of range
     private static final int REPLY_OK = '!';   // command completed successfully
+
+    private int replyType = REPLY_UNKNOWN;
 
     /**
      * Creates a command message for the log, in a human-friendly form if

--- a/java/test/jmri/jmrix/nce/NceMessageTest.java
+++ b/java/test/jmri/jmrix/nce/NceMessageTest.java
@@ -21,7 +21,11 @@ public class NceMessageTest extends jmri.jmrix.AbstractMessageTestBase {
         JUnitUtil.setUp();
         tc = new NceTrafficController();
         saveCommandOptions = tc.getCommandOptions();
-        m = msg = new NceMessage(1);
+        try {
+            m = msg = new NceMessage(1);
+        } catch (Throwable t) { // debug for "Could not initialize class jmri.jmrix.nce.NceMessage"
+            log.error("caught in NceMesssage ctor", t);
+        }
     }
 
     @After
@@ -165,5 +169,7 @@ public class NceMessageTest extends jmri.jmrix.AbstractMessageTestBase {
         msg = NceMessage.sendPacketMessage(tc, new byte[]{(byte) 0x81, (byte) 0xff, (byte) 0x7e});
         Assert.assertEquals("content", "93 02 81 FF 7E", msg.toString());
     }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NceMessageTest.class);
 
 }


### PR DESCRIPTION
This is a fix for the repeated cases of
```
java.lang.NoClassDefFoundError: Could not initialize class jmri.jmrix.nce.NceMessage
```

during Travis testing. They (well, at least a bunch of them) were due to the use of `Thread.stop()` in the `NceConsist.dispose()` method. That would (occasionally, but given the work load often enough) hit the thread while is loading _and_ _initializing_ various `jmrix.nce` classes, leaving them loaded but without their static members fully initialized.

 - Switch `NceConsist.dispose()` to use `Thread.interrupt()` instead
 - Add some debugging in case it comes back
 - Some Javadoc added to `AbstractMRMessage`; set some accessor methods final so they can be used in constructors.


