### PR TITLE
Bugfix for VIA can't find route

### DIFF
--- a/java/src/jmri/jmrit/logix/RouteFinder.java
+++ b/java/src/jmri/jmrit/logix/RouteFinder.java
@@ -103,9 +103,6 @@ public class RouteFinder implements Runnable {
                 log.debug("level {} has {} nodes. quit= {}", level, nodes.size(), _quit);
             }
             level++;
-            if (_quit) {
-                break;
-            }
         }
         jmri.util.ThreadingUtil.runOnLayout(() -> {
             if (_destNodes.isEmpty()) {
@@ -175,10 +172,10 @@ public class RouteFinder implements Runnable {
                                 && _dEntryName.equals(pName)) {
                             _destNodes.add(child);
                         }
-                        children.add(child);
-                        if (_quit) {
-                            break;
-                        }
+                    }
+                    children.add(child);
+                    if (_quit) {
+                        break;
                     }
                 }
             } else {

--- a/java/test/jmri/util/PlaceWindowTest.java
+++ b/java/test/jmri/util/PlaceWindowTest.java
@@ -27,7 +27,7 @@ public class PlaceWindowTest {
     }
 
     @Test
-    @Ignore("Placement point dependent on GUI used by system")
+//    @Ignore("Placement point dependent on GraphicsEnvironment and test screen size")
     public void testNextTo() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         JFrame w1 = new JFrame();
@@ -44,12 +44,14 @@ public class PlaceWindowTest {
 
         PlaceWindow pw = new PlaceWindow();
         Point pt = pw.nextTo(w1,  null,  w2);        // w2 to the right of w1
-        Assert.assertEquals("pt.x=", 616, pt.x);
+        // weaken assertion for test environments with different screen environment
+        Assert.assertTrue("pt.x=", pt.x >= 600);
         Assert.assertEquals("pt.y=", 300, pt.y);
         
         w1.setLocation(300, 200);
         pt = pw.nextTo(w1,  null,  w2);        // w2 to the left of w1
-        Assert.assertEquals("pt.x=", 84, pt.x);
+        // weaken assertion for different screen sizes
+        Assert.assertTrue("pt.x=", pt.x <= 100);
         Assert.assertEquals("pt.y=", 300, pt.y);
         
         w1.dispose();


### PR DESCRIPTION
Fix bug where a VIA condition in an NW warrant would not find a route.
Also relaxed an assertion in PlaceWindow test to gain more coverage.