### PR TITLE
intermediate colors not added to recentColors 

### DIFF
--- a/java/src/jmri/jmrit/display/palette/ColorDialog.java
+++ b/java/src/jmri/jmrit/display/palette/ColorDialog.java
@@ -135,6 +135,7 @@ public class ColorDialog extends JDialog implements ChangeListener {
             _chooser = JmriColorChooser.extendColorChooser(new JColorChooser(_saveColor));
             _chooser.getSelectionModel().addChangeListener(this);
             _chooser.setPreviewPanel(new JPanel());
+            JmriColorChooser.suppressAddRecentColor(true);
             panel.add(_chooser);
             panel.add(Box.createVerticalStrut(STRUT));
 
@@ -206,6 +207,7 @@ public class ColorDialog extends JDialog implements ChangeListener {
                     if (_util != null) {
                         _util.setSuppressRecentColor(false);
                     }
+                    JmriColorChooser.suppressAddRecentColor(false);
                     JmriColorChooser.addRecentColor(_chooser.getColor());
                     dispose();
             });

--- a/java/src/jmri/jmrit/display/palette/ColorDialog.java
+++ b/java/src/jmri/jmrit/display/palette/ColorDialog.java
@@ -60,7 +60,7 @@ public class ColorDialog extends JDialog implements ChangeListener {
          * 
          * @param client Window holding the component
          * @param t target whose color may be changed
-         * @param type whicd attribute is being changed
+         * @param type which attribute is being changed
          * @param ca callback to tell client the component's color was changed. 
          * May be null if client doesen't care.
          */

--- a/java/src/jmri/jmrit/display/palette/ColorDialog.java
+++ b/java/src/jmri/jmrit/display/palette/ColorDialog.java
@@ -148,13 +148,11 @@ public class ColorDialog extends JDialog implements ChangeListener {
                     cancel();
                 }
             });
-            
-            
             setContentPane(panel);
-            InstanceManager.getDefault(jmri.util.PlaceWindow.class).nextTo(client, t, this);
 
             pack();
             setVisible(true);
+            InstanceManager.getDefault(jmri.util.PlaceWindow.class).nextTo(client, t, this);
         }
 
         JPanel makePanel(JPanel p) {
@@ -200,16 +198,7 @@ public class ColorDialog extends JDialog implements ChangeListener {
             panel.setLayout(new FlowLayout());
             JButton doneButton = new JButton(Bundle.getMessage("ButtonDone"));
             doneButton.addActionListener((ActionEvent event) -> {
-                    log.debug("Done button: color= {}", _chooser.getColor());
-                    if (_colorAction != null) {
-                        _colorAction.actionPerformed(null);
-                    }
-                    if (_util != null) {
-                        _util.setSuppressRecentColor(false);
-                    }
-                    JmriColorChooser.suppressAddRecentColor(false);
-                    JmriColorChooser.addRecentColor(_chooser.getColor());
-                    dispose();
+                done();
             });
             panel.add(doneButton);
 
@@ -219,8 +208,20 @@ public class ColorDialog extends JDialog implements ChangeListener {
                 });
 
             panel.add(cancelButton);
-
             return panel;
+        }
+
+        void done() {
+            log.debug("Done button: color= {}", _chooser.getColor());
+            if (_colorAction != null) {
+                _colorAction.actionPerformed(null);
+            }
+            if (_util != null) {
+                _util.setSuppressRecentColor(false);
+            }
+            JmriColorChooser.suppressAddRecentColor(false);
+            JmriColorChooser.addRecentColor(_chooser.getColor());
+            dispose();
         }
 
         void cancel() {

--- a/java/src/jmri/jmrit/display/palette/ColorDialog.java
+++ b/java/src/jmri/jmrit/display/palette/ColorDialog.java
@@ -237,6 +237,7 @@ public class ColorDialog extends JDialog implements ChangeListener {
             }
             _target.setOpaque(_saveOpaque);
             log.debug("Cancel: color= {}", _saveColor);
+            JmriColorChooser.suppressAddRecentColor(false);
             dispose();
         }
 

--- a/java/src/jmri/util/PlaceWindow.java
+++ b/java/src/jmri/util/PlaceWindow.java
@@ -5,6 +5,7 @@ import java.awt.Dimension;
 import java.awt.DisplayMode;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
+import java.awt.IllegalComponentStateException;
 import java.awt.Point;
 import java.awt.Window;
 //import java.util.ArrayList;
@@ -91,13 +92,18 @@ public class PlaceWindow implements InstanceManagerAutoDefault {
             }
         }*/
         int x = 0;
-        for (int i = 0;  i < _screenSize.length; i++) {
-            x += _screenSize[i].width;
-            if (window.getLocationOnScreen().x < x) {
-                return i;
+        try {
+            for (int i = 0;  i < _screenSize.length; i++) {
+                x += _screenSize[i].width;
+                if (window.getLocationOnScreen().x < x) {
+                    return i;
+                }
             }
+            
+        } catch (IllegalComponentStateException icse) {
+            return 0;
         }
-        return -1;
+        return 0;
     }
 
     public Dimension getScreenSize(int screenNum) {
@@ -144,7 +150,12 @@ public class PlaceWindow implements InstanceManagerAutoDefault {
         Dimension compDim;
         int margin;
         if (comp != null) {
-            compLoc = new Point(comp.getLocationOnScreen());
+            try {
+                compLoc = new Point(comp.getLocationOnScreen());
+            } catch (IllegalComponentStateException icse) {
+                compLoc = comp.getLocation();
+                compLoc = new Point(compLoc.x + parentLoc.x, compLoc.y + parentLoc.y);
+            }
             compDim = comp.getSize();
             margin = 20;
         } else {

--- a/java/src/jmri/util/swing/JmriColorChooser.java
+++ b/java/src/jmri/util/swing/JmriColorChooser.java
@@ -111,6 +111,7 @@ public class JmriColorChooser {
             }
         }
         chooser.setChooserPanels(newPanels);
+        _suppressAdd = false;
         return chooser;
     }
 }

--- a/java/src/jmri/util/swing/JmriColorChooser.java
+++ b/java/src/jmri/util/swing/JmriColorChooser.java
@@ -111,7 +111,7 @@ public class JmriColorChooser {
             }
         }
         chooser.setChooserPanels(newPanels);
-        _suppressAdd = false;
+        _suppressAdd = false;   // reset to default
         return chooser;
     }
 }

--- a/java/src/jmri/util/swing/JmriColorChooser.java
+++ b/java/src/jmri/util/swing/JmriColorChooser.java
@@ -25,6 +25,7 @@ public class JmriColorChooser {
      * subsequent activity will add new colors.
      */
     static private ArrayList<Color> recentColors = new ArrayList<>();
+    static private boolean _suppressAdd = false;
 
     /**
      * Add a new color to the recent list.
@@ -32,13 +33,23 @@ public class JmriColorChooser {
      * @param color The color object to be added.
      */
     static public void addRecentColor(Color color) {
-        if (color == null || !color.toString().contains("java.awt.Color")) {
+        if (color == null || _suppressAdd || !color.toString().contains("java.awt.Color")) {
             // Ignore null or default system colors
             return;
         }
         if (!recentColors.contains(color)) {
             recentColors.add(color);
         }
+    }
+
+    /**
+     * Suppress adding colors while temporarily displaying colors to
+     * wysiwyg applications of JmriColorChooser - e.g. use of RGB
+     * tab while editing colors on CPE panels.
+     * @param set if true, previewed color is not added.
+     */
+    static public void suppressAddRecentColor(boolean set) {
+        _suppressAdd = set;
     }
 
     /**

--- a/java/test/jmri/jmrit/display/palette/ColorDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/ColorDialogTest.java
@@ -1,11 +1,13 @@
 package jmri.jmrit.display.palette;
 
+import java.awt.Color;
 import java.awt.GraphicsEnvironment;
 import javax.swing.JComponent;
 import jmri.jmrit.display.PositionableLabel;
 import jmri.jmrit.display.controlPanelEditor.ControlPanelEditor;
 import jmri.util.JUnitUtil;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,16 +22,29 @@ public class ColorDialogTest {
 
     ControlPanelEditor _cpe;
     PositionableLabel _pos;
+    boolean _done;
     
     @Test
     public void testCTor1() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         startEditor();
-        BlockedThread th = new BlockedThread(_cpe, _cpe.getTargetPanel(), ColorDialog.ONLY);
-        th.start();
-        JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("PanelColor"));
-        JButtonOperator jbo = new JButtonOperator(jdo , jmri.jmrit.display.palette.Bundle.getMessage("ButtonDone"));
-        jbo.push();     // why does it not push - ??
+        _cpe.setBackgroundColor(Color.GREEN);
+        Assert.assertEquals("panel color is green", Color.GREEN, _cpe.getTargetPanel().getBackground());
+
+        _done = false;
+        DialogRunner dr = new DialogRunner(ColorDialog.ONLY, "PanelColor", Color.RED, "ButtonDone");
+        dr.start();
+        Thread t = new Thread(() -> {
+            new ColorDialog(_cpe, _cpe.getTargetPanel(), ColorDialog.ONLY, null);
+        });
+        t.start();
+        
+        jmri.util.JUnitUtil.waitFor(() -> {
+            return _done;
+        }, "Dialog done.");
+        new org.netbeans.jemmy.QueueTool().waitEmpty(100);  // allow some time for button push
+
+        Assert.assertEquals("panel color is red", Color.RED, _cpe.getTargetPanel().getBackground());
         JUnitUtil.dispose(_cpe);
     }
 
@@ -37,11 +52,23 @@ public class ColorDialogTest {
     public void testCTor2() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         startEditor();
-        BlockedThread th = new BlockedThread(_cpe, _pos, ColorDialog.BORDER);
-        th.start();
-        JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("SetBorderSizeColor"));
-        JButtonOperator jbo = new JButtonOperator(jdo , jmri.jmrit.display.palette.Bundle.getMessage("ButtonDone"));
-        jbo.push();     // why does it not push - ??
+        _cpe.setBackgroundColor(Color.GREEN);
+        Assert.assertEquals("panel color is green", Color.GREEN, _cpe.getTargetPanel().getBackground());
+
+        _done = false;
+        DialogRunner dr = new DialogRunner(ColorDialog.ONLY, "PanelColor", Color.RED, "ButtonCancel");
+        dr.start();
+        Thread t = new Thread(() -> {
+            new ColorDialog(_cpe, _cpe.getTargetPanel(), ColorDialog.ONLY, null);
+        });
+        t.start();
+        
+        jmri.util.JUnitUtil.waitFor(() -> {
+            return _done;
+        }, "Dialog done.");
+        new org.netbeans.jemmy.QueueTool().waitEmpty(100);  // allow some time for button push
+
+        Assert.assertEquals("panel color is green", Color.GREEN, _cpe.getTargetPanel().getBackground());
         JUnitUtil.dispose(_cpe);
     }
 
@@ -49,11 +76,20 @@ public class ColorDialogTest {
     public void testCTor3() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         startEditor();
-        BlockedThread th = new BlockedThread(_cpe, _pos, ColorDialog.MARGIN);
-        th.start();
-        JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("SetMarginSizeColor"));
-        JButtonOperator jbo = new JButtonOperator(jdo , jmri.jmrit.display.palette.Bundle.getMessage("ButtonDone"));
-        jbo.push();     // why does it not push - ??
+        _done = false;
+        DialogRunner dr = new DialogRunner(ColorDialog.BORDER, "SetBorderSizeColor", Color.BLUE, "ButtonDone");
+        dr.start();
+        Thread t = new Thread(() -> {
+            new ColorDialog(_cpe, _pos, ColorDialog.BORDER, null);
+        });
+        t.start();
+        
+        jmri.util.JUnitUtil.waitFor(() -> {
+            return _done;
+        }, "Dialog done.");
+        new org.netbeans.jemmy.QueueTool().waitEmpty(100);  // allow some time for button push
+
+        Assert.assertEquals("border color is blue", Color.BLUE, _pos.getPopupUtility().getBorderColor());
         JUnitUtil.dispose(_cpe);
     }
 
@@ -61,11 +97,23 @@ public class ColorDialogTest {
     public void testCTor4() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         startEditor();
-        BlockedThread th = new BlockedThread(_cpe, _pos, ColorDialog.FONT);
-        th.start();
-        JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("SetFontSizeColor"));
-        JButtonOperator jbo = new JButtonOperator(jdo , jmri.jmrit.display.palette.Bundle.getMessage("ButtonDone"));
-        jbo.push();     // why does it not push - ??
+        _pos.getPopupUtility().setBackgroundColor(Color.GREEN);
+        Assert.assertEquals("margin color is green", Color.GREEN, _pos.getPopupUtility().getBackground());
+
+        _done = false;
+        DialogRunner dr = new DialogRunner(ColorDialog.MARGIN, "SetMarginSizeColor", Color.RED, "ButtonCancel");
+        dr.start();
+        Thread t = new Thread(() -> {
+            new ColorDialog(_cpe, _pos, ColorDialog.MARGIN, null);
+        });
+        t.start();
+        
+        jmri.util.JUnitUtil.waitFor(() -> {
+            return _done;
+        }, "Dialog done.");
+        new org.netbeans.jemmy.QueueTool().waitEmpty(100);  // allow some time for button push
+
+        Assert.assertEquals("margin color is green", Color.GREEN, _pos.getPopupUtility().getBackground());
         JUnitUtil.dispose(_cpe);
     }
 
@@ -73,11 +121,43 @@ public class ColorDialogTest {
     public void testCTor5() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         startEditor();
-        BlockedThread th = new BlockedThread(_cpe, _pos, ColorDialog.TEXT);
-        th.start();
-        JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("SetTextSizeColor"));
-        JButtonOperator jbo = new JButtonOperator(jdo , jmri.jmrit.display.palette.Bundle.getMessage("ButtonDone"));
-        jbo.push();     // why does it not push - ??
+
+        _done = false;
+        DialogRunner dr = new DialogRunner(ColorDialog.FONT, "SetFontSizeColor", Color.RED, "ButtonDone");
+        dr.start();
+        Thread t = new Thread(() -> {
+            new ColorDialog(_cpe, _pos, ColorDialog.FONT, null);
+        });
+        t.start();
+        
+        jmri.util.JUnitUtil.waitFor(() -> {
+            return _done;
+        }, "Dialog done.");
+        new org.netbeans.jemmy.QueueTool().waitEmpty(100);  // allow some time for button push
+
+        Assert.assertEquals("font color is red", Color.RED, _pos.getPopupUtility().getForeground());
+        JUnitUtil.dispose(_cpe);
+    }
+
+    @Test
+    public void testCTor6() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        startEditor();
+
+        _done = false;
+        DialogRunner dr = new DialogRunner(ColorDialog.TEXT, "SetTextSizeColor", Color.BLUE, "ButtonDone");
+        dr.start();
+        Thread t = new Thread(() -> {
+            new ColorDialog(_cpe, _pos, ColorDialog.TEXT, null);
+        });
+        t.start();
+        
+        jmri.util.JUnitUtil.waitFor(() -> {
+            return _done;
+        }, "Dialog done.");
+        new org.netbeans.jemmy.QueueTool().waitEmpty(100);  // allow some time for button push
+
+        Assert.assertEquals("font color is red", Color.BLUE, _pos.getPopupUtility().getForeground());
         JUnitUtil.dispose(_cpe);
     }
 
@@ -87,22 +167,52 @@ public class ColorDialogTest {
         _cpe.putItem(_pos);
     }
 
-    class BlockedThread extends Thread {
-        ColorDialog _cd;
-        ControlPanelEditor _cpe;
-        JComponent _target;
+    class DialogRunner extends Thread {
+        // constructor for jdo will wait until the dialog is visible
+        String _dialogTitle;
+        String _buttonTitle;
         int _type;
-        
-        BlockedThread(ControlPanelEditor ed, JComponent target, int type) {
-            _cpe = ed;
-            _target = target;
+        Color _color;
+
+        DialogRunner(int type, String dialogTitle, Color color, String buttonTitle) {
+            super();
             _type = type;
+            _color = color;
+            _dialogTitle = dialogTitle;
+            _buttonTitle = buttonTitle;
         }
 
         @Override
         public void run() {
-            _cd = new ColorDialog(_cpe, _target, _type, null);
+            // constructor for jdo will wait until the dialog is visible
+            JDialogOperator jdo = new JDialogOperator(Bundle.getMessage(_dialogTitle));
+            JButtonOperator jbo = new JButtonOperator(jdo, Bundle.getMessage(_buttonTitle));
+            ColorDialog cd = (ColorDialog)jdo.getSource();
+            cd._chooser.setColor(_color);
+
+            Color c;
+            switch (_type) {
+                case ColorDialog.ONLY: 
+                    c = _cpe.getTargetPanel().getBackground();
+                    break;
+                case ColorDialog.BORDER:
+                    c = _pos.getPopupUtility().getBorderColor();
+                    break;
+                case ColorDialog.MARGIN:
+                    c = _pos.getPopupUtility().getBackground();
+                    break;
+                case ColorDialog.TEXT:
+                case ColorDialog.FONT:
+                    c = _pos.getPopupUtility().getForeground();
+                    break;
+                default:
+                    c = Color.BLACK;
+            }
+            Assert.assertEquals(_dialogTitle + " set color", _color, c);
+            jbo.pushNoBlock();
+            _done = true;
         }
+
     }
 
     // The minimal setup for log4J


### PR DESCRIPTION
Add suppressAddRecentColor() method so wysiwyg use of JMRIColorChooser does not add intermediate colors when using RGB tab. (previously recentColors array overwhelmed)