### PR TITLE
chore: Use GitHub Actions for Static Analysis

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,32 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: |
+        # SpotBugs configuration is in pom.xml
+        mvn clean test -U -P travis-spotbugs --batch-mode --file=pom.xml
+        # run Javadoc
+        mvn javadoc:javadoc -U --batch-mode --file=pom.xml
+        # check html
+        mvn exec:exec -P travis-scanhelp --file=pom.xml
+        #run Architecture tests
+        mvn -Dtest=jmri.ArchitectureTest,jmri.util.FileLineEndingsTest test --file=pom.xml

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -28,7 +28,10 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
       run: |
-        # SpotBugs configuration is in pom.xml
+        # compile with ECJ for warnings or errors
+        #mvn -P test-warnings-check clean compile 
+        mvn antrun:run -Danttarget=tests-warnings-check
+        # run Spotbugs and Checkstyle
         mvn clean test -U -P travis-spotbugs --batch-mode --file=pom.xml
         # run Javadoc
         mvn javadoc:javadoc -U --batch-mode --file=pom.xml

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven
+name: Static Analysis with Maven
 
 on:
   push:
@@ -20,6 +20,12 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Cache Maven packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
       run: |
         # SpotBugs configuration is in pom.xml


### PR DESCRIPTION
This adds yet another CI service (GitHub Actions) and runs the same Static Analysis services on it as we run in the Static Analysis job on Travis CI.

If this is successful, it would allow either macOS-based testing or Java 11-based testing to run on Travis CI. I am not sure how GitHub Actions work in terms of maximum number of concurrent jobs, automatic cancellation of jobs, or what the real limits are, so Travis CI is also performing static analysis (eventually either this job will be removed, or the static analysis from Travis CI will be removed).