### PR TITLE
fix: Update serial ports docs for macOS and Linux

### DIFF
--- a/help/en/html/doc/Technical/StartUpScripts.shtml
+++ b/help/en/html/doc/Technical/StartUpScripts.shtml
@@ -207,9 +207,8 @@
 
         <dt><code>--serial-ports=<em>SERIAL_PORTS</em></code></dt>
 
-        <dd>Set the names of usable serial ports to the comma
-        separated list of ports in <em>SERIAL_PORTS</em> excluding the root
-        of the device tree (typically "/dev/").</dd>
+        <dd>Set the names of (not the paths to) usable serial ports to the comma
+        separated list of ports in <em>SERIAL_PORTS</em>.</dd>
 
         <dt><code>--settingsdir=<em>SETTINGS_DIR</em></code></dt>
 

--- a/help/en/html/doc/Technical/StartUpScripts.shtml
+++ b/help/en/html/doc/Technical/StartUpScripts.shtml
@@ -208,8 +208,8 @@
         <dt><code>--serial-ports=<em>SERIAL_PORTS</em></code></dt>
 
         <dd>Set the names of usable serial ports to the comma
-        separated list of ports in <em>SERIAL_PORTS</em>. This is
-        ignored on macOS.</dd>
+        separated list of ports in <em>SERIAL_PORTS</em> excluding the root
+        of the device tree (typically "/dev/").</dd>
 
         <dt><code>--settingsdir=<em>SETTINGS_DIR</em></code></dt>
 

--- a/jmri.conf
+++ b/jmri.conf
@@ -24,15 +24,16 @@
 # -d, --debug                    Add verbose output to this script
 # -JOPTION                       Pass the option OPTION to the JVM
 # -p PROFILE, --profile=PROFILE  Start JMRI with the profile PROFILE
-# --serial-ports=SERIAL_PORTS    Use the serial ports in SERIAL_PORTS
+# --serial-ports=SERIAL_PORTS    Use the serial ports in SERIAL_PORTS, excluding
+#                                the "/dev/" prefix if on Linux and macOS
 #
 # Examples:
 # - Set the maximum memory JMRI is allowed to use to 2 GB (2048 MB):
 #   default_options="-J-Xmx2048m"
 # - Set the serial ports to /dev/loconet and /dev/cmri:
-#   default_options="--serial-ports=/dev/loconet,/dev/cmri"
+#   default_options="--serial-ports=loconet,cmri"
 # - Combine the two examples above:
-#   default_options="-J-Xmx2048m --serial-ports=/dev/loconet,/dev/cmri"
+#   default_options="-J-Xmx2048m --serial-ports=loconet,cmri"
 #
 # See jmri.org/help/en/html/doc/Technical/StartUpScripts.shtml for more details.
 default_options=""

--- a/jmri.conf
+++ b/jmri.conf
@@ -24,16 +24,18 @@
 # -d, --debug                    Add verbose output to this script
 # -JOPTION                       Pass the option OPTION to the JVM
 # -p PROFILE, --profile=PROFILE  Start JMRI with the profile PROFILE
-# --serial-ports=SERIAL_PORTS    Use the serial ports in SERIAL_PORTS, excluding
-#                                the "/dev/" prefix if on Linux and macOS
+# --serial-ports=SERIAL_PORTS    Use the serial ports in SERIAL_PORTS by name
+#                                Multiple names are separated with commas (,)
 #
 # Examples:
 # - Set the maximum memory JMRI is allowed to use to 2 GB (2048 MB):
 #   default_options="-J-Xmx2048m"
-# - Set the serial ports to /dev/loconet and /dev/cmri:
+# - Set the serial ports to /dev/loconet and /dev/cmri (on Linux or macOS):
 #   default_options="--serial-ports=loconet,cmri"
 # - Combine the two examples above:
 #   default_options="-J-Xmx2048m --serial-ports=loconet,cmri"
+# - Set the serial ports to COM5 and COM11 (on Windows):
+#   default_options="--serial-ports=COM5,COM11"
 #
 # See jmri.org/help/en/html/doc/Technical/StartUpScripts.shtml for more details.
 default_options=""

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -21,9 +21,8 @@
 # options, this one cannot be set in the jmri.conf file, since it determines
 # from where the jmri.conf file is read).
 #
-# If your serial ports are not in the default list, include them in the
-# command line argument --serial-ports separated by commas excluding the root
-# of the device tree (typically "/dev/"):
+# If your serial ports are not in the default list, include the names in the
+# command line argument --serial-ports separated by commas:
 #    --serial-ports=locobuffer,cmri
 #
 # You can run separate instances of the program with their own preferences
@@ -60,8 +59,8 @@ Usage: $( basename $0 ) [--help] [OPTIONS] [--] [ARGUMENTS]
   -JOPTION                       Pass the option OPTION to the JVM
   -m MAIN, --main=MAIN           Use main() method in class MAIN to start JMRI
   -p PROFILE, --profile=PROFILE  Start JMRI with the profile PROFILE
-  --serial-ports=SERIAL_PORTS    Use the serial ports in SERIAL_PORTS, excluding
-                                 the root of the device tree (typically "/dev/")
+  --serial-ports=SERIAL_PORTS    Use the serial ports in SERIAL_PORTS by name
+                                 Multiple names are separated with commas (,)
   --settingsdir=SETTINGS_DIR     Use SETTINGS_DIR as the settings directory
   --                             Do not process anything following as an option,
                                  even if it matches one of the above options

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -22,8 +22,9 @@
 # from where the jmri.conf file is read).
 #
 # If your serial ports are not in the default list, include them in the
-# command line argument --serial-ports separated by commas:
-#    --serial-ports=/dev/locobuffer,/dev/cmri
+# command line argument --serial-ports separated by commas excluding the root
+# of the device tree (typically "/dev/"):
+#    --serial-ports=locobuffer,cmri
 #
 # You can run separate instances of the program with their own preferences
 # if you
@@ -59,7 +60,8 @@ Usage: $( basename $0 ) [--help] [OPTIONS] [--] [ARGUMENTS]
   -JOPTION                       Pass the option OPTION to the JVM
   -m MAIN, --main=MAIN           Use main() method in class MAIN to start JMRI
   -p PROFILE, --profile=PROFILE  Start JMRI with the profile PROFILE
-  --serial-ports=SERIAL_PORTS    Use the serial ports in SERIAL_PORTS
+  --serial-ports=SERIAL_PORTS    Use the serial ports in SERIAL_PORTS, excluding
+                                 the root of the device tree (typically "/dev/")
   --settingsdir=SETTINGS_DIR     Use SETTINGS_DIR as the settings directory
   --                             Do not process anything following as an option,
                                  even if it matches one of the above options


### PR DESCRIPTION
- [x] Fix examples to not include "/dev/"
- [x] Update documentation to clarify that the name of the port, not the path to it, must be used
- [x] Remove erroneous documentation that macOS ignores `--serial-port` parameter 

Fixes #8336