### PR TITLE
fix: test frameworks should not log results to GUI

### DIFF
--- a/java/src/apps/SystemConsole.java
+++ b/java/src/apps/SystemConsole.java
@@ -113,6 +113,7 @@ public final class SystemConsole extends JTextArea {
      * Initialise the system console ensuring both System.out and System.err
      * streams are re-directed to the consoles JTextArea
      */
+    
     public static void create() {
 
         if (instance == null) {
@@ -147,7 +148,7 @@ public final class SystemConsole extends JTextArea {
         this.errorStream = new PrintStream(outStream(STD_ERR), true);
 
         // Then redirect to it
-        redirectSystemStreams();
+        redirectSystemStreams(outputStream, errorStream);
     }
 
     /**
@@ -160,6 +161,15 @@ public final class SystemConsole extends JTextArea {
             SystemConsole.create();
         }
         return instance;
+    }
+
+    /**
+     * Test if the default instance exists.
+     * 
+     * @return true if default instance exists; false otherwise
+     */
+    public static boolean isCreated() {
+        return instance != null;
     }
 
     /**
@@ -394,9 +404,9 @@ public final class SystemConsole extends JTextArea {
      */
     @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING",
             justification = "Can only be called from the same instance so default encoding OK")
-    private void redirectSystemStreams() {
-        System.setOut(this.getOutputStream());
-        System.setErr(this.getErrorStream());
+    private void redirectSystemStreams(PrintStream out, PrintStream err) {
+        System.setOut(out);
+        System.setErr(err);
     }
 
     /**
@@ -567,7 +577,20 @@ public final class SystemConsole extends JTextArea {
     public PrintStream getErrorStream() {
         return this.errorStream;
     }
-    
+
+    /**
+     * Stop logging System output and error streams to the console.
+     */
+    public void close() {
+        redirectSystemStreams(originalOut, originalErr);
+    }
+
+    /**
+     * Start logging System output and error streams to the console.
+     */
+    public void open() {
+        redirectSystemStreams(getOutputStream(), getErrorStream());
+    }
     /**
      * Retrieve the current console colour scheme
      *

--- a/java/src/apps/SystemConsole.java
+++ b/java/src/apps/SystemConsole.java
@@ -591,6 +591,7 @@ public final class SystemConsole extends JTextArea {
     public void open() {
         redirectSystemStreams(getOutputStream(), getErrorStream());
     }
+
     /**
      * Retrieve the current console colour scheme
      *

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -22,6 +22,7 @@ import org.netbeans.jemmy.operators.JDialogOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import apps.SystemConsole;
 import apps.gui.GuiLafPreferencesManager;
 import jmri.*;
 import jmri.implementation.JmriConfigurationManager;
@@ -178,6 +179,10 @@ public class JUnitUtil {
             isLoggingInitialized = true;
             String filename = System.getProperty("jmri.log4jconfigfilename", "tests.lcf");
             Log4JUtil.initLogging(filename);
+        }
+
+        if (SystemConsole.isCreated()) {
+            SystemConsole.getInstance().open();
         }
 
         // need to do this each time
@@ -338,6 +343,10 @@ public class JUnitUtil {
         // Optionally, check that the Swing queue is idle
         //new org.netbeans.jemmy.QueueTool().waitEmpty(250);
 
+        // remove SystemConsole log appenders so test framework output is not included
+        if (SystemConsole.isCreated()) {
+            SystemConsole.getInstance().close();
+        }
     }
 
     /**


### PR DESCRIPTION
The SystemConsole's redirection of STDOUT and STDERR so it could render those needs to be stopped at the end of tests to prevent attempts to modify a GUI window as the test completes. 

Since the SystemConsole is static and is not being reset after every test (we don't want to break STDOUT or STDERR by doing this incorrectly), this introduces the ability to close and (re)open the SystemConsole in the `@Before/@BeforeEach` and `@After/@AfterEach` annotated methods when testing.

This was pulled from #8269.