### PR TITLE
Test single target headless

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -805,48 +805,7 @@
         </fail>
     </target>
 
-    <target depends="-test-single-src,-test-single-test,tests,runtime-library-selection" description="Run single unit test non headless." name="test-single-coverage-head">
-        <mkdir dir="${tempdir}"/>
-        <mkdir dir="${testreport}"/>
-        <jacoco:agent property="jacocoagent" destfile="${jacocoexec}" excludes="org.slf4j.*" />
-        <property name="test-single.jvmargs" value=""/>
-        <java classpathref="test.class.path" classname="org.junit.platform.console.ConsoleLauncher" fork="true" failonerror="true"  >
-            <sysproperty key="wdm.forceCache" value="true"/>
-            <!-- wdm.targetPath specifies the locaion of the web drivers on appveyor. -->
-            <sysproperty key="wdm.targetPath" value="C:\Tools\WebDriver"/>
-
-            <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
-            <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
-            <sysproperty key="log4j.ignoreTCL" path="true/"/>
-            <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
-            <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
-            <sysproperty key="jmri.shutdownmanager" value="jmri.util.MockShutDownManager" />
-            <sysproperty key="jmri.skipTestsRequiringSeparateRunning" value="true"/><!-- skip intermittent tests -->
-            <sysproperty key="user.language" value="en"/>
-            <sysproperty key="user.country" value="US"/>
-            <sysproperty key="java.awt.headless" value="false"/>
-            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @Headed' --tags 'not @webtest'"/>
-
-            <arg value="--scan-classpath"/>
-            <arg value="--details=none"/>
-            <arg value="--include-engine=junit-jupiter"/>
-            <arg value="--include-engine=junit-vintage"/>
-            <arg line="-n ${test.includes}"/>
-            <arg line="--reports-dir ${testreport}" />
-            <jvmarg value="-Xmx1536m"/>
-            <jvmarg value="${jacocoagent}"/>
-	    <jvmarg line="${test-single.jvmargs}"/>
-        </java>    
-        <fail>
-            <condition>
-                <istrue value="${test.failed}" />
-            </condition>
-        </fail>
-    </target>
-
     <target name="single-test-coveragereport" depends="test-single-coverage, coveragereport" description="Generate Test Coverage Report from a single test" />
-
-    <target name="single-test-coveragereport-head" depends="test-single-coverage-head, coveragereport" description="Generate Test Coverage Report from a single test non-headless" />
 
     <target name="single-test-coveragecheck" depends="test-single-coverage, coveragecheck" description="Generate Test Coverage check from a single test" />
 

--- a/build.xml
+++ b/build.xml
@@ -749,8 +749,7 @@
             <sysproperty key="jmri.skipTestsRequiringSeparateRunning" value="true"/><!-- skip intermittent tests -->
             <sysproperty key="user.language" value="en"/>
             <sysproperty key="user.country" value="US"/>
-            <sysproperty key="java.awt.headless" value="true"/>
-            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @Headed' --tags 'not @webtest'"/>
+            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags --tags 'not @webtest'"/>
 
             <arg value="--scan-classpath"/>
             <arg value="--details=none"/>
@@ -768,7 +767,7 @@
         </fail>
     </target>
 
-    <target depends="-test-single-src,-test-single-test,tests,runtime-library-selection" description="Run single unit test." name="test-single-coverage">
+    <target depends="-test-single-src,-test-single-test,tests,runtime-library-selection" description="Run single unit test with Coverage." name="test-single-coverage">
         <mkdir dir="${tempdir}"/>
         <mkdir dir="${testreport}"/>
         <jacoco:agent property="jacocoagent" destfile="${jacocoexec}" excludes="org.slf4j.*" />
@@ -787,8 +786,7 @@
             <sysproperty key="jmri.skipTestsRequiringSeparateRunning" value="true"/><!-- skip intermittent tests -->
             <sysproperty key="user.language" value="en"/>
             <sysproperty key="user.country" value="US"/>
-            <sysproperty key="java.awt.headless" value="true"/>
-            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @Headed' --tags 'not @webtest'"/>
+            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @webtest'"/>
 
             <arg value="--scan-classpath"/>
             <arg value="--details=none"/>

--- a/build.xml
+++ b/build.xml
@@ -749,7 +749,7 @@
             <sysproperty key="jmri.skipTestsRequiringSeparateRunning" value="true"/><!-- skip intermittent tests -->
             <sysproperty key="user.language" value="en"/>
             <sysproperty key="user.country" value="US"/>
-            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags --tags 'not @webtest'"/>
+            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @webtest'"/>
 
             <arg value="--scan-classpath"/>
             <arg value="--details=none"/>

--- a/build.xml
+++ b/build.xml
@@ -746,7 +746,7 @@
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
             <sysproperty key="jmri.shutdownmanager" value="jmri.util.MockShutDownManager" />
-            <sysproperty key="jmri.skipTestsRequiringSeparateRunning" value="true"/><!-- skip intermittent tests -->
+            <sysproperty key="jmri.skipTestsRequiringSeparateRunning" value="false"/><!-- skip intermittent tests -->
             <sysproperty key="user.language" value="en"/>
             <sysproperty key="user.country" value="US"/>
             <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @webtest'"/>
@@ -783,7 +783,7 @@
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
             <sysproperty key="jmri.shutdownmanager" value="jmri.util.MockShutDownManager" />
-            <sysproperty key="jmri.skipTestsRequiringSeparateRunning" value="true"/><!-- skip intermittent tests -->
+            <sysproperty key="jmri.skipTestsRequiringSeparateRunning" value="false"/><!-- skip intermittent tests -->
             <sysproperty key="user.language" value="en"/>
             <sysproperty key="user.country" value="US"/>
             <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @webtest'"/>


### PR DESCRIPTION
Removes from test-single and test-single-coverage

```
<sysproperty key="java.awt.headless" value="true"/>
<sysproperty key="cucumber.options" value=" --tags 'not @Headed' '"/>
```

Enables separate running tests , changed from true to false

`<sysproperty key="jmri.skipTestsRequiringSeparateRunning" value="false"/>`

See #8342 

Removes test-single-coverage-head added in #8330  as the normal target can again be run headed.