### PR TITLE
VSDecoder: partly undo and fix

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/VSDecoder.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoder.java
@@ -461,7 +461,17 @@ public class VSDecoder implements PropertyChangeListener {
             return;
         }
 
-        if (property.equals(Train.TRAIN_LOCATION_CHANGED_PROPERTY)) {
+        if (property.equals(VSDManagerFrame.MUTE)) {
+            // GUI Mute button
+            log.debug("VSD: Mute change. value: {}", evt.getNewValue());
+            Boolean b = (Boolean) evt.getNewValue();
+            this.mute(b.booleanValue());
+        } else if (property.equals(VSDManagerFrame.VOLUME_CHANGE)) {
+            // GUI Volume slider
+            log.debug("VSD: Volume change. value: {}", evt.getNewValue());
+            // Slider gives integer 0-100. Need to change that to a float 0.0-1.0
+            this.setMasterVolume((1.0f * (Integer) evt.getNewValue()) / 100.0f);
+        } else if (property.equals(Train.TRAIN_LOCATION_CHANGED_PROPERTY)) {
             // Train Location Move (either GUI)
             PhysicalLocation p = getTrainPosition((Train) evt.getSource());
             if (p != null) {
@@ -470,7 +480,6 @@ public class VSDecoder implements PropertyChangeListener {
                 log.debug("Train has null position");
                 this.setPosition(new PhysicalLocation());
             }
-
         } else if (property.equals(Train.STATUS_CHANGED_PROPERTY)) {
             // Train Status change (either GUI)
             String status = (String) evt.getNewValue();

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoder.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoder.java
@@ -468,11 +468,11 @@ public class VSDecoder implements PropertyChangeListener {
             this.mute(b.booleanValue());
         } else if (property.equals(VSDManagerFrame.VOLUME_CHANGE)) {
             // GUI Volume slider
-            log.debug("VSD: Volume change. value: {}", evt.getNewValue());
+            log.debug("VSD: Volume change. value: {}", evt.getOldValue());
             // Slider gives integer 0-100. Need to change that to a float 0.0-1.0
-            this.setMasterVolume((1.0f * (Integer) evt.getNewValue()) / 100.0f);
+            this.setMasterVolume((1.0f * (Integer) evt.getOldValue()) / 100.0f);
         } else if (property.equals(Train.TRAIN_LOCATION_CHANGED_PROPERTY)) {
-            // Train Location Move (either GUI)
+            // Train Location Move
             PhysicalLocation p = getTrainPosition((Train) evt.getSource());
             if (p != null) {
                 this.setPosition(getTrainPosition((Train) evt.getSource()));
@@ -481,8 +481,8 @@ public class VSDecoder implements PropertyChangeListener {
                 this.setPosition(new PhysicalLocation());
             }
         } else if (property.equals(Train.STATUS_CHANGED_PROPERTY)) {
-            // Train Status change (either GUI)
-            String status = (String) evt.getNewValue();
+            // Train Status change
+            String status = (String) evt.getOldValue();
             log.debug("Train status changed: {}", status);
             log.debug("New Location: {}", getTrainPosition((Train) evt.getSource()));
             if ((status.startsWith(Train.BUILT)) || (status.startsWith(Train.PARTIAL_BUILT))) {

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
@@ -594,7 +594,7 @@ public class VSDecoderManager implements PropertyChangeListener {
             if (evt.getPropertyName().equals(VSDManagerFrame.REMOVE_DECODER)) {
                 // Shut down the requested decoder and remove it from the manager's hash maps. 
                 // Unless there are "illegal" handles, this should put the decoder on the garbage heap.  I think.
-                String sa = (String) evt.getNewValue();
+                String sa = (String) evt.getOldValue();
                 VSDecoder d = this.getVSDecoderByAddress(sa);
                 log.debug("Removing Decoder {} ... {}", sa, d.getAddress());
                 stopSoundPositionTimer(d);

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
@@ -287,7 +287,7 @@ public class VSDConfigDialog extends JDialog {
                 config.setRosterEntry(null);
             }
 
-            firePropertyChange(CONFIG_PROPERTY, null, config);
+            firePropertyChange(CONFIG_PROPERTY, config, null);
             dispose();
         }
     }

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDControl.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDControl.java
@@ -257,7 +257,7 @@ public class VSDControl extends JPanel {
      */
     protected void deleteButtonPressed(ActionEvent e) {
         log.debug("({}) Delete Button Pressed", address);
-        firePropertyChange(DELETE, null, address);
+        firePropertyChange(DELETE, address, null);
     }
 
     /**
@@ -265,7 +265,7 @@ public class VSDControl extends JPanel {
      */
     protected void optionsDialogPropertyChange(PropertyChangeEvent event) {
         log.debug("internal options dialog handler");
-        firePropertyChange(OPTION_CHANGE, event.getOldValue(), event.getNewValue());
+        firePropertyChange(OPTION_CHANGE, null, event.getNewValue());
     }
 
     // VSDecoderManager Events

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDControl.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDControl.java
@@ -257,7 +257,7 @@ public class VSDControl extends JPanel {
      */
     protected void deleteButtonPressed(ActionEvent e) {
         log.debug("({}) Delete Button Pressed", address);
-        firePropertyChange(DELETE, address, address);
+        firePropertyChange(DELETE, null, address);
     }
 
     /**

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
@@ -35,9 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * class VSDManagerFrame
- *
- * Main frame for the new GUI VSDecoder Manager Frame
+ * Main frame for the GUI VSDecoder Manager.
  *
  * <hr>
  * This file is part of JMRI.
@@ -349,7 +347,7 @@ public class VSDManagerFrame extends JmriJFrame {
     protected void volumeChange(ChangeEvent e) {
         JSlider v = (JSlider) e.getSource();
         log.debug("Volume slider moved. value: {}", v.getValue());
-        firePropertyChange(VOLUME_CHANGE, v.getValue(), v.getValue());
+        firePropertyChange(VOLUME_CHANGE, null, v.getValue());
     }
 
     private void buildMenu() {

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
@@ -301,7 +301,7 @@ public class VSDManagerFrame extends JmriJFrame {
             this.pack();
             //this.setVisible(true);
             // Do we need to make newControl a listener to newDecoder?
-            //firePropertyChange(ADD_DECODER, null, newDecoder);
+            //firePropertyChange(ADD_DECODER, newDecoder, null);
         }
     }
 
@@ -312,14 +312,13 @@ public class VSDManagerFrame extends JmriJFrame {
         String property = event.getPropertyName();
         if (property.equals(VSDControl.DELETE)) {
             String ov = (String) event.getOldValue();
-            String nv = (String) event.getNewValue();
-            VSDecoder vsd = VSDecoderManager.instance().getVSDecoderByAddress(nv);
+            VSDecoder vsd = VSDecoderManager.instance().getVSDecoderByAddress(ov);
             if (vsd == null) {
                 log.debug("VSD is null.");
             }
             this.removePropertyChangeListener(vsd);
-            log.debug("vsdControlPropertyChange. ID: {}, old: {}, new: {}", REMOVE_DECODER, ov, nv);
-            firePropertyChange(REMOVE_DECODER, ov, nv);
+            log.debug("vsdControlPropertyChange. ID: {}, old: {}", REMOVE_DECODER, ov);
+            firePropertyChange(REMOVE_DECODER, ov, null);
             decoderPane.remove((VSDControl) event.getSource());
             if (decoderPane.getComponentCount() == 0) {
                 decoderPane.add(decoderBlank);
@@ -347,7 +346,7 @@ public class VSDManagerFrame extends JmriJFrame {
     protected void volumeChange(ChangeEvent e) {
         JSlider v = (JSlider) e.getSource();
         log.debug("Volume slider moved. value: {}", v.getValue());
-        firePropertyChange(VOLUME_CHANGE, null, v.getValue());
+        firePropertyChange(VOLUME_CHANGE, v.getValue(), null);
     }
 
     private void buildMenu() {

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDOptionsDialog.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDOptionsDialog.java
@@ -28,7 +28,7 @@ import jmri.jmrit.operations.trains.TrainManager;
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
  * for more details.
  *
- * @author   Mark Underwood Copyright (C) 2011
+ * @author Mark Underwood Copyright (C) 2011
  */
 public class VSDOptionsDialog extends JDialog {
 
@@ -71,6 +71,6 @@ public class VSDOptionsDialog extends JDialog {
         dispose();
     }
 
-    // Log not used... yet...
     //    private static final Logger log = LoggerFactory.getLogger(VSDOptionsDialog.class);
+
 }


### PR DESCRIPTION
Follow-up to PR #8293 and PR #8286.
When I removed the old GUI I removed a couple of lines to much. This stopped MUTE and VOLUME. The first commit brings the lines back.
But VOLUME still didn't work, and DELETE as well. The second commit is required to make the two responsible ```firePropertyChange```-calls functioning again.
