### PR TITLE
Run gui on gui thread

### DIFF
--- a/java/test/jmri/jmrix/AbstractConnectionConfigTestBase.java
+++ b/java/test/jmri/jmrix/AbstractConnectionConfigTestBase.java
@@ -2,6 +2,7 @@ package jmri.jmrix;
 
 import org.junit.*;
 import javax.swing.JPanel;
+import jmri.util.ThreadingUtil;
 
 /**
  * Base tests for ConnectionConfig objects.
@@ -19,8 +20,10 @@ abstract public class AbstractConnectionConfigTestBase {
 
     @Test
     public void testLoadDetails(){
-        // verify no exceptions thrown
-        cc.loadDetails(new JPanel());
+        ThreadingUtil.runOnGUI(() -> {
+            // verify no exceptions thrown
+            cc.loadDetails(new JPanel());
+        });
     }
 
     @Test

--- a/java/test/jmri/jmrix/AbstractConnectionConfigTestBase.java
+++ b/java/test/jmri/jmrix/AbstractConnectionConfigTestBase.java
@@ -1,8 +1,8 @@
 package jmri.jmrix;
 
+import org.assertj.swing.edt.GuiActionRunner;
 import org.junit.*;
 import javax.swing.JPanel;
-import jmri.util.ThreadingUtil;
 
 /**
  * Base tests for ConnectionConfig objects.
@@ -20,7 +20,7 @@ abstract public class AbstractConnectionConfigTestBase {
 
     @Test
     public void testLoadDetails(){
-        ThreadingUtil.runOnGUI(() -> {
+        GuiActionRunner.execute(() -> {
             // verify no exceptions thrown
             cc.loadDetails(new JPanel());
         });

--- a/java/test/jmri/jmrix/AbstractSerialConnectionConfigTestBase.java
+++ b/java/test/jmri/jmrix/AbstractSerialConnectionConfigTestBase.java
@@ -1,8 +1,8 @@
 package jmri.jmrix;
 
+import org.assertj.swing.edt.GuiActionRunner;
 import org.junit.*;
 import javax.swing.JPanel;
-import jmri.util.ThreadingUtil;
 
 /**
  * Base tests for SerialConnectionConfig objects.
@@ -14,7 +14,7 @@ abstract public class AbstractSerialConnectionConfigTestBase extends jmri.jmrix.
     @Test
     @Override
     public void testLoadDetails(){
-        ThreadingUtil.runOnGUI(() -> {
+        GuiActionRunner.execute(() -> {
             // verify no exceptions thrown
             cc.loadDetails(new JPanel());
             // load details MAY produce an error message if no ports are found.

--- a/java/test/jmri/jmrix/AbstractSerialConnectionConfigTestBase.java
+++ b/java/test/jmri/jmrix/AbstractSerialConnectionConfigTestBase.java
@@ -2,6 +2,7 @@ package jmri.jmrix;
 
 import org.junit.*;
 import javax.swing.JPanel;
+import jmri.util.ThreadingUtil;
 
 /**
  * Base tests for SerialConnectionConfig objects.
@@ -13,9 +14,11 @@ abstract public class AbstractSerialConnectionConfigTestBase extends jmri.jmrix.
     @Test
     @Override
     public void testLoadDetails(){
-        // verify no exceptions thrown
-        cc.loadDetails(new JPanel());
-        // load details MAY produce an error message if no ports are found.
-        jmri.util.JUnitAppender.suppressErrorMessage("No usable ports returned");
+        ThreadingUtil.runOnGUI(() -> {
+            // verify no exceptions thrown
+            cc.loadDetails(new JPanel());
+            // load details MAY produce an error message if no ports are found.
+            jmri.util.JUnitAppender.suppressErrorMessage("No usable ports returned");
+        });
     }
 }

--- a/java/test/jmri/jmrix/AbstractStreamConnectionConfigTestBase.java
+++ b/java/test/jmri/jmrix/AbstractStreamConnectionConfigTestBase.java
@@ -1,7 +1,7 @@
 package jmri.jmrix;
 
-import jmri.util.junit.annotations.*;
-import org.junit.*;
+// import jmri.util.junit.annotations.*;
+// import org.junit.*;
 
 /**
  * Base tests for StreamConnectionConfig objects.
@@ -10,10 +10,10 @@ import org.junit.*;
  */
 abstract public class AbstractStreamConnectionConfigTestBase extends jmri.jmrix.AbstractConnectionConfigTestBase {
 
-    @Test
-    @Ignore("Stream connections don't (currently) load details")
-    @ToDo("modify Stream port Connections so they load details, then remove this test so parent class test can run or re-implement the test here")
-    @Override
-    public void testLoadDetails(){
-    }
+//    @Test
+//    @Ignore("Stream connections don't (currently) load details")
+//    @ToDo("modify Stream port Connections so they load details, then remove this test so parent class test can run or re-implement the test here")
+//    @Override
+//    public void testLoadDetails(){
+//    }
 }

--- a/java/test/jmri/jmrix/AbstractStreamConnectionConfigTestBase.java
+++ b/java/test/jmri/jmrix/AbstractStreamConnectionConfigTestBase.java
@@ -1,7 +1,7 @@
 package jmri.jmrix;
 
-// import jmri.util.junit.annotations.*;
-// import org.junit.*;
+import jmri.util.junit.annotations.*;
+import org.junit.*;
 
 /**
  * Base tests for StreamConnectionConfig objects.
@@ -10,10 +10,10 @@ package jmri.jmrix;
  */
 abstract public class AbstractStreamConnectionConfigTestBase extends jmri.jmrix.AbstractConnectionConfigTestBase {
 
-//    @Test
-//    @Ignore("Stream connections don't (currently) load details")
-//    @ToDo("modify Stream port Connections so they load details, then remove this test so parent class test can run or re-implement the test here")
-//    @Override
-//    public void testLoadDetails(){
-//    }
+    @Test
+    @Ignore("Stream connections don't (currently) load details")
+    @ToDo("modify Stream port Connections so they load details, then remove this test so parent class test can run or re-implement the test here")
+    @Override
+    public void testLoadDetails(){
+    }
 }


### PR DESCRIPTION
Run swing code on GUI thread.

@pabender 
The test `AbstractStreamConnectionConfigTestBase.testLoadDetails()` is ignored with the comment `Stream connections don't (currently) load details`. But `AbstractStreamConnectionConfig.loadDetails()` has 50 lines of code. Is the comment not relevant any more?

I tried to comment the AbstractStreamConnectionConfigTestBase test to run the test in the parent class, but that requires `adapter` to be set in `Z21XNetConnectionConfigTest.setUp()`.