### PR TITLE
Enable assertions during testing.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -759,6 +759,7 @@
             <arg line="-n ${test.includes}"/>
             <arg line="--reports-dir '${testreport}'" />
             <jvmarg value="-Xmx1536m"/>
+            <jvmarg value="-ea"/>
 	    <jvmarg line="${test-single.jvmargs}"/>
         </java>    
 	<fail>
@@ -797,6 +798,7 @@
             <arg line="-n ${test.includes}"/>
             <arg line="--reports-dir ${testreport}" />
             <jvmarg value="-Xmx1536m"/>
+            <jvmarg value="-ea"/>
             <jvmarg value="${jacocoagent}"/>
 	    <jvmarg line="${test-single.jvmargs}"/>
         </java>    


### PR DESCRIPTION
In other PR a test failed in Travis on `assert`. I think that assertions should be always enabled in test targets. `test-single` target is used by IDEs and also can be used from the commandline. 