### PR TITLE
Special function mapping table only appears on CV61=97

### DIFF
--- a/xml/decoders/zimo/PaneAltFunctionMap4+2.xml
+++ b/xml/decoders/zimo/PaneAltFunctionMap4+2.xml
@@ -8,17 +8,29 @@
   <name xml:lang="cs">Alternativní přiřazení funkcí</name>
   <name xml:lang="de">Alt. Funktionszuordnung</name>
   <column>
-    <display item="FO3 + FO4 directional setting"/>
-    <label>
-      <text> </text>
-    </label>
-    <display item="Special Function Mapping" format="radiobuttons"/>
-    <label>
-      <text> </text>
-    </label>
-    <label>
-      <text> </text>
-    </label>
+      <row>
+          <column>
+              <display item="FO3 + FO4 directional setting"/>
+              <label>
+                  <text> </text>
+              </label>
+              <display item="Special Function Mapping" format="radiobuttons"/>
+              <label>
+                  <text> </text>
+              </label>
+              <label>
+                  <text> </text>
+              </label>
+          </column>    
+      </row>
+      <row>
+          <column>
+              <group>
+                <qualifier>
+                  <variableref>Special Function Mapping</variableref>
+                  <relation>eq</relation>
+                  <value>97</value>
+                </qualifier>
     <label>
       <text>           Description                                      Output wire or operation</text>
       <text xml:lang="it">           Descrizione                                      Filo Uscita o operazione</text>
@@ -405,6 +417,9 @@
           <label/>
         </display>
       </column>
+    </row>
+            </group>
+        </column>
     </row>
   </column>
 </pane>

--- a/xml/decoders/zimo/PaneAltFunctionMap4+4.xml
+++ b/xml/decoders/zimo/PaneAltFunctionMap4+4.xml
@@ -8,17 +8,29 @@
   <name xml:lang="cs">Alternativní přiřazení funkcí</name>
   <name xml:lang="de">Alt. Funktionszuordnung</name>
   <column>
-    <display item="FO3 + FO4 directional setting"/>
-    <label>
-      <text> </text>
-    </label>
-    <display item="Special Function Mapping" format="radiobuttons"/>
-    <label>
-      <text> </text>
-    </label>
-    <label>
-      <text> </text>
-    </label>
+      <row>
+          <column>
+              <display item="FO3 + FO4 directional setting"/>
+              <label>
+                  <text> </text>
+              </label>
+              <display item="Special Function Mapping" format="radiobuttons"/>
+              <label>
+                  <text> </text>
+              </label>
+              <label>
+                  <text> </text>
+              </label>
+          </column>    
+      </row>
+      <row>
+          <column>
+              <group>
+                <qualifier>
+                  <variableref>Special Function Mapping</variableref>
+                  <relation>eq</relation>
+                  <value>97</value>
+                </qualifier>
     <label>
       <text>           Description                                      Output wire or operation</text>
       <text xml:lang="it">           Descrizione                                      Filo Uscita o operazione</text>
@@ -513,6 +525,9 @@
           <label> </label>
         </display>
       </column>
+    </row>
+            </group>
+        </column>
     </row>
   </column>
 </pane>

--- a/xml/decoders/zimo/PaneAltFunctionMap4.xml
+++ b/xml/decoders/zimo/PaneAltFunctionMap4.xml
@@ -8,17 +8,29 @@
   <name xml:lang="cs">Alternativní přiřazení funkcí</name>
   <name xml:lang="de">Alt. Funktionszuordnung</name>
   <column>
-    <display item="FO3 + FO4 directional setting"/>
-    <label>
-      <text> </text>
-    </label>
-    <display item="Special Function Mapping" format="radiobuttons"/>
-    <label>
-      <text> </text>
-    </label>
-    <label>
-      <text> </text>
-    </label>
+      <row>
+          <column>
+              <display item="FO3 + FO4 directional setting"/>
+              <label>
+                  <text> </text>
+              </label>
+              <display item="Special Function Mapping" format="radiobuttons"/>
+              <label>
+                  <text> </text>
+              </label>
+              <label>
+                  <text> </text>
+              </label>
+          </column>    
+      </row>
+      <row>
+          <column>
+              <group>
+                <qualifier>
+                  <variableref>Special Function Mapping</variableref>
+                  <relation>eq</relation>
+                  <value>97</value>
+                </qualifier>
     <label>
       <text>           Description                                      Output wire or operation</text>
       <text xml:lang="it">           Descrizione                                      Filo Uscita o operazione</text>
@@ -297,6 +309,9 @@
           <label/>
         </display>
       </column>
+    </row>
+            </group>
+        </column>
     </row>
   </column>
 </pane>

--- a/xml/decoders/zimo/PaneAltFunctionMap6.xml
+++ b/xml/decoders/zimo/PaneAltFunctionMap6.xml
@@ -8,17 +8,29 @@
   <name xml:lang="cs">Alternativní přiřazení funkcí</name>
   <name xml:lang="de">Alt. Funktionszuordnung</name>
   <column>
-    <display item="FO3 + FO4 directional setting"/>
-    <label>
-      <text> </text>
-    </label>
-    <display item="Special Function Mapping" format="radiobuttons"/>
-    <label>
-      <text> </text>
-    </label>
-    <label>
-      <text> </text>
-    </label>
+      <row>
+          <column>
+              <display item="FO3 + FO4 directional setting"/>
+              <label>
+                  <text> </text>
+              </label>
+              <display item="Special Function Mapping" format="radiobuttons"/>
+              <label>
+                  <text> </text>
+              </label>
+              <label>
+                  <text> </text>
+              </label>
+          </column>    
+      </row>
+      <row>
+          <column>
+              <group>
+                <qualifier>
+                  <variableref>Special Function Mapping</variableref>
+                  <relation>eq</relation>
+                  <value>97</value>
+                </qualifier>
     <label>
       <text>           Description                                      Output wire or operation</text>
       <text xml:lang="it">           Descrizione                                      Filo Uscita o operazione</text>
@@ -405,6 +417,9 @@
           <label/>
         </display>
       </column>
+    </row>
+            </group>
+        </column>
     </row>
   </column>
 </pane>

--- a/xml/decoders/zimo/PaneAltFunctionMap8+.xml
+++ b/xml/decoders/zimo/PaneAltFunctionMap8+.xml
@@ -8,15 +8,30 @@
   <name xml:lang="cs">Alternativní přiřazení funkcí</name>
   <name xml:lang="de">Alt. Funktionszuordnung</name>
   <column>
-    <display item="FO3 + FO4 directional setting"/>
-    <display item="FO9 directional setting"/>
-    <label>
-      <text> </text>
-    </label>
-    <display item="Special Function Mapping" format="radiobuttons"/>
-    <label>
-      <text> </text>
-    </label>
+      <row>
+          <column>
+              <display item="FO3 + FO4 directional setting"/>
+              <display item="FO9 directional setting"/>
+              <label>
+                  <text> </text>
+              </label>
+              <display item="Special Function Mapping" format="radiobuttons"/>
+              <label>
+                  <text> </text>
+              </label>
+              <label>
+                  <text> </text>
+              </label>
+          </column>    
+      </row>
+      <row>
+          <column>
+              <group>
+                <qualifier>
+                  <variableref>Special Function Mapping</variableref>
+                  <relation>eq</relation>
+                  <value>97</value>
+                </qualifier>
     <label>
       <text> </text>
     </label>
@@ -537,6 +552,9 @@
           <text xml:lang="de">   nicht eingestellt werden.</text>
         </label>
       </column>
+    </row>
+            </group>
+        </column>
     </row>
   </column>
 </pane>

--- a/xml/decoders/zimo/PaneAltFunctionMap8.xml
+++ b/xml/decoders/zimo/PaneAltFunctionMap8.xml
@@ -8,17 +8,29 @@
   <name xml:lang="cs">Alternativní přiřazení funkcí</name>
   <name xml:lang="de">Alt. Funktionszuordnung</name>
   <column>
-    <display item="FO3 + FO4 directional setting"/>
-    <label>
-      <text> </text>
-    </label>
-    <display item="Special Function Mapping" format="radiobuttons"/>
-    <label>
-      <text> </text>
-    </label>
-    <label>
-      <text> </text>
-    </label>
+      <row>
+          <column>
+              <display item="FO3 + FO4 directional setting"/>
+              <label>
+                  <text> </text>
+              </label>
+              <display item="Special Function Mapping" format="radiobuttons"/>
+              <label>
+                  <text> </text>
+              </label>
+              <label>
+                  <text> </text>
+              </label>
+          </column>    
+      </row>
+      <row>
+          <column>
+              <group>
+                <qualifier>
+                  <variableref>Special Function Mapping</variableref>
+                  <relation>eq</relation>
+                  <value>97</value>
+                </qualifier>
     <label>
       <text>           Description                                      Output wire or operation</text>
       <text xml:lang="it">           Descrizione                                      Filo Uscita o operazione</text>
@@ -513,6 +525,9 @@
           <label> </label>
         </display>
       </column>
+    </row>
+            </group>
+        </column>
     </row>
   </column>
 </pane>


### PR DESCRIPTION
An user has reported "strange thing" and "misunderstandings" of how DecoderPro displays his ZIMO decoder configuration. It turned out that the user was confused by the `Alternative function map` table. His setting for `CV#61` was `0`, but according to ZIMO manual, this alternative mapping of CVs only applies if `CV#61` equals `97`.

The patch should display the checkbox table only conditionally, if the `Alterantive` radio button is selected.

For reference see [ZIMO MX decoder manual](http://www.zimo.at/web2010/documents/MX-KleineDecoder_E.pdf), page 26 near the end.

Note: to be included **after** 4.19.5 to give some extra testing time.