### PR TITLE
chore: Make NetBeans use Line Feeds (LF) as line endings

### DIFF
--- a/nb-configuration.xml
+++ b/nb-configuration.xml
@@ -29,5 +29,8 @@ Any value defined here will override the pom.xml file value but is only applicab
         <org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>80</org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width>
         <netbeans.compile.on.save>none</netbeans.compile.on.save>
         <netbeans.hint.jdkPlatform>JDK_1.8</netbeans.hint.jdkPlatform>
+        <com-junichi11-netbeans-changelf.enable>true</com-junichi11-netbeans-changelf.enable>
+        <com-junichi11-netbeans-changelf.use-project>true</com-junichi11-netbeans-changelf.use-project>
+        <com-junichi11-netbeans-changelf.use-global>false</com-junichi11-netbeans-changelf.use-global>
     </properties>
 </project-shared-configuration>


### PR DESCRIPTION
This makes this project use a consistent line endings style if the NetBeans _Change Line Endings on Save_ plugin is installed in the IDE.