### PR TITLE
Reduce run time JmriFrame.reSizeToFitOnScreen() 

### DIFF
--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -259,6 +259,10 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      */
     private static ArrayList<ScreenDimensions> getInitialScreenDimensionsOnce() {
         ArrayList<ScreenDimensions> screenDimensions = new ArrayList<>();
+        if (GraphicsEnvironment.isHeadless()) {
+            // there are no screens
+            return screenDimensions;
+        }
         for (GraphicsDevice gd: GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()) {
             Rectangle bounds = new Rectangle();
             Insets insets = new Insets(0, 0, 0, 0);
@@ -631,6 +635,10 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
     @Override
     public Dimension getMaximumSize() {
         // adjust maximum size to full screen minus any toolbars
+        if (GraphicsEnvironment.isHeadless()) {
+            // there are no screens
+            return new Dimension(0,0);
+        }
         try {
             // Try our own algorithm. This throws null-pointer exceptions on
             // some Java installs, however, for unknown reasons, so be

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -240,13 +240,24 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         });
     }
 
+    private final static ArrayList<ScreenDimensions> screenDim = getInitialScreenDimensionsOnce();
+
+    /**
+     * returns the previously initialized array of screens. See getScreenDimensionsOnce()
+     * @return ArrayList of screen bounds and insets
+     */
+    public static ArrayList<ScreenDimensions> getScreenDimensions() {
+        return screenDim;
+    }
+
     /**
      * Iterates through the attached displays and retrieves bounds, insets
      * and id for each screen.
      * Size of returned ArrayList equals the number of detected displays.
+     * Used to initialize a static final array.
      * @return ArrayList of screen bounds and insets
      */
-    public static ArrayList<ScreenDimensions> getScreenDimensions() {
+    private static ArrayList<ScreenDimensions> getInitialScreenDimensionsOnce() {
         ArrayList<ScreenDimensions> screenDimensions = new ArrayList<>();
         for (GraphicsDevice gd: GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()) {
             Rectangle bounds = new Rectangle();
@@ -355,14 +366,18 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
     }
 
     /**
+     * Initialize only once the MaximumSize for the screen
+     */
+    private final Dimension maxSizeDimension = getMaximumSize();
+
+    /**
      * Tries to get window to fix entirely on screen. First choice is to move
      * the origin up and left as needed, then to make the window smaller
      */
     void reSizeToFitOnScreen() {
-        Dimension dim = getMaximumSize();
         int width = this.getPreferredSize().width;
         int height = this.getPreferredSize().height;
-        log.trace("reSizeToFitOnScreen of \"{}\" starts with maximum size {}", getTitle(), dim);
+        log.trace("reSizeToFitOnScreen of \"{}\" starts with maximum size {}", getTitle(), maxSizeDimension);
         log.trace("reSizeToFitOnScreen starts with preferred height {} width {}", height, width);
         log.trace("reSizeToFitOnScreen starts with location {},{}", getX(), getY());
         // Normalise the location
@@ -370,9 +385,9 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         Point locationOnDisplay = new Point(getLocation().x - sd.getBounds().x, getLocation().y - sd.getBounds().y);
         log.trace("reSizeToFitScreen normalises origin to {}, {}", locationOnDisplay.x, locationOnDisplay.y);
 
-        if ((width + locationOnDisplay.x) >= dim.getWidth()) {
+        if ((width + locationOnDisplay.x) >= maxSizeDimension.getWidth()) {
             // not fit in width, try to move position left
-            int offsetX = (width + locationOnDisplay.x) - (int) dim.getWidth(); // pixels too large
+            int offsetX = (width + locationOnDisplay.x) - (int) maxSizeDimension.getWidth(); // pixels too large
             log.trace("reSizeToFitScreen moves \"{}\" left {} pixels", getTitle(), offsetX);
             int positionX = locationOnDisplay.x - offsetX;
             if (positionX < 0) {
@@ -382,14 +397,14 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
             this.setLocation(positionX + sd.getBounds().x, this.getY());
             log.trace("reSizeToFitOnScreen during X calculation sets location {}, {}", positionX + sd.getBounds().x, this.getY());
             // try again to see if it doesn't fit
-            if ((width + locationOnDisplay.x) >= dim.getWidth()) {
-                width = width - (int) ((width + locationOnDisplay.x) - dim.getWidth());
+            if ((width + locationOnDisplay.x) >= maxSizeDimension.getWidth()) {
+                width = width - (int) ((width + locationOnDisplay.x) - maxSizeDimension.getWidth());
                 log.trace("reSizeToFitScreen sets \"{}\" width to {}", getTitle(), width);
             }
         }
-        if ((height + locationOnDisplay.y) >= dim.getHeight()) {
+        if ((height + locationOnDisplay.y) >= maxSizeDimension.getHeight()) {
             // not fit in height, try to move position up
-            int offsetY = (height + locationOnDisplay.y) - (int) dim.getHeight(); // pixels too large
+            int offsetY = (height + locationOnDisplay.y) - (int) maxSizeDimension.getHeight(); // pixels too large
             log.trace("reSizeToFitScreen moves \"{}\" up {} pixels", getTitle(), offsetY);
             int positionY = locationOnDisplay.y - offsetY;
             if (positionY < 0) {
@@ -399,8 +414,8 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
             this.setLocation(this.getX(), positionY + sd.getBounds().y);
             log.trace("reSizeToFitOnScreen during Y calculation sets location {}, {}", this.getX(), positionY + sd.getBounds().y);
             // try again to see if it doesn't fit
-            if ((height + this.getY()) >= dim.getHeight()) {
-                height = height - (int) ((height + locationOnDisplay.y) - dim.getHeight());
+            if ((height + this.getY()) >= maxSizeDimension.getHeight()) {
+                height = height - (int) ((height + locationOnDisplay.y) - maxSizeDimension.getHeight());
                 log.trace("reSizeToFitScreen sets \"{}\" height to {}", getTitle(), height);
             }
         }


### PR DESCRIPTION
from between 1200 and 200 milliseconds to zero millisecs.

Change getting the screen details to once not every time.

#8377 #8307