### PR TITLE
Update NixieClockFrame.java and AmpMeterFrame.java

### DIFF
--- a/java/src/jmri/jmrit/ampmeter/AmpMeterFrame.java
+++ b/java/src/jmri/jmrit/ampmeter/AmpMeterFrame.java
@@ -35,9 +35,6 @@ public class AmpMeterFrame extends JmriJFrame implements java.beans.PropertyChan
     JLabel milliAmp;
     JLabel amp;
 
-    double aspect;
-    double iconAspect;
-
     private int startWidth;
     private int startHeight;
 
@@ -66,14 +63,6 @@ public class AmpMeterFrame extends JmriJFrame implements java.beans.PropertyChan
         milliAmpIcon = new NamedIcon("resources/icons/misc/LCD/milliampb.gif", "resources/icons/misc/LCD/milliampb.gif");
         ampIcon = new NamedIcon("resources/icons/misc/LCD/ampb.gif", "resources/icons/misc/LCD/ampb.gif");
 
-        // determine aspect ratio of a single digit graphic
-        iconAspect = 24. / 32.;
-
-        // determine the aspect ratio of the 4 digit base graphic plus a half digit for the colon
-        // this DOES NOT allow space for the Run/Stop button, if it is
-        // enabled.  When the Run/Stop button is enabled, the layout will have to be changed
-        aspect = (4.5 * 24.) / 32.; // used to be 4.5??
-
         // listen for changes to the meter parameters
         meter.addPropertyChangeListener(this);
 
@@ -89,6 +78,12 @@ public class AmpMeterFrame extends JmriJFrame implements java.beans.PropertyChan
 
         buildContents();
 
+        // Initially we want to scale the icons to fit the previously saved window size
+        startHeight = digits[0].getIconHeight();
+        startWidth = (int)(digits[0].getIconWidth() * 4.5);
+        scaleImage();
+        buildContents();
+        
         meter.enable();
 
         update();
@@ -111,9 +106,6 @@ public class AmpMeterFrame extends JmriJFrame implements java.beans.PropertyChan
                 scaleImage();
             }
         });
-
-        startHeight = this.getContentPane().getSize().height;
-        startWidth = this.getContentPane().getSize().width;
 
     }
 
@@ -162,11 +154,6 @@ public class AmpMeterFrame extends JmriJFrame implements java.beans.PropertyChan
                 getContentPane().add(percent);
                 break;
         }
-
-        getContentPane().add(b = new JButton(Bundle.getMessage("ButtonStop")));
-        b.addActionListener(new ButtonListener());
-        // since Run/Stop button looks crummy, don't display for now
-        b.setVisible(false);
 
         pack();
     }

--- a/java/src/jmri/jmrit/ampmeter/AmpMeterFrame.java
+++ b/java/src/jmri/jmrit/ampmeter/AmpMeterFrame.java
@@ -213,7 +213,7 @@ public class AmpMeterFrame extends JmriJFrame implements java.beans.PropertyChan
      */
     void getStartDimensions() {
         startHeight = digits[0].getIconHeight();
-        startWidth = (int)(digits[0].getIconWidth() * (displayLength + 1));
+        startWidth = digits[0].getIconWidth() * (displayLength + 1);
         if (displayDP) {
             startWidth += decimalIcon.getIconWidth();
         }

--- a/java/src/jmri/jmrit/ampmeter/AmpMeterFrame.java
+++ b/java/src/jmri/jmrit/ampmeter/AmpMeterFrame.java
@@ -1,12 +1,9 @@
 package jmri.jmrit.ampmeter;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.util.ArrayList;
 import javax.swing.BoxLayout;
-import javax.swing.JButton;
 import javax.swing.JLabel;
 import jmri.InstanceManager;
 import jmri.MultiMeter;
@@ -201,5 +198,7 @@ public class AmpMeterFrame extends JmriJFrame implements java.beans.PropertyChan
         }
          */
     }
+
+    private final static Logger log = LoggerFactory.getLogger(AmpMeterFrame.class);
 
 }

--- a/java/src/jmri/jmrit/ampmeter/AmpMeterFrame.java
+++ b/java/src/jmri/jmrit/ampmeter/AmpMeterFrame.java
@@ -202,22 +202,4 @@ public class AmpMeterFrame extends JmriJFrame implements java.beans.PropertyChan
          */
     }
 
-    JButton b;
-
-    static private class ButtonListener implements ActionListener {
-
-        @Override
-        public void actionPerformed(ActionEvent a) {
-            /*
-            boolean next = !clock.getRun();
-            clock.setRun(next);
-            if (next) {
-                b.setText("Stop");
-            } else {
-                b.setText("Run ");
-            }
-             */
-        }
-    }
-
 }

--- a/java/src/jmri/jmrit/ampmeter/AmpMeterFrame.java
+++ b/java/src/jmri/jmrit/ampmeter/AmpMeterFrame.java
@@ -123,6 +123,8 @@ public class AmpMeterFrame extends JmriJFrame implements java.beans.PropertyChan
         decimalIcon.scale(scale,this);
         ampIcon.scale(scale, this);
         milliAmpIcon.scale(scale,this);
+
+        this.getContentPane().revalidate();
     }
 
     private void buildContents(){
@@ -198,7 +200,5 @@ public class AmpMeterFrame extends JmriJFrame implements java.beans.PropertyChan
         }
          */
     }
-
-    private final static Logger log = LoggerFactory.getLogger(AmpMeterFrame.class);
 
 }

--- a/java/src/jmri/jmrit/nixieclock/NixieClockFrame.java
+++ b/java/src/jmri/jmrit/nixieclock/NixieClockFrame.java
@@ -142,8 +142,16 @@ public class NixieClockFrame extends JmriJFrame implements java.beans.PropertyCh
         }
         Image scaledImage = baseColon.getImage().getScaledInstance(iconWidth / 2, iconHeight, Image.SCALE_SMOOTH);
         colonIcon.setImage(scaledImage);
-        // update the images on screen
-        this.getContentPane().revalidate();
+
+//      Ugly hack to force frame to redo the layout.
+//      Without this the image is scaled but the label size and position doesn't change.
+//      doLayout() doesn't work either
+        this.setVisible(false);
+        this.remove(b);
+        if (clock.getShowStopButton()) {
+            this.getContentPane().add(b); // pick up clock prefs choice
+        }
+        this.setVisible(true);
         return;
     }
 

--- a/java/src/jmri/jmrit/nixieclock/NixieClockFrame.java
+++ b/java/src/jmri/jmrit/nixieclock/NixieClockFrame.java
@@ -142,16 +142,8 @@ public class NixieClockFrame extends JmriJFrame implements java.beans.PropertyCh
         }
         Image scaledImage = baseColon.getImage().getScaledInstance(iconWidth / 2, iconHeight, Image.SCALE_SMOOTH);
         colonIcon.setImage(scaledImage);
-
-//      Ugly hack to force frame to redo the layout.
-//      Without this the image is scaled but the label size and position doesn't change.
-//      doLayout() doesn't work either
-        this.setVisible(false);
-        this.remove(b);
-        if (clock.getShowStopButton()) {
-            this.getContentPane().add(b); // pick up clock prefs choice
-        }
-        this.setVisible(true);
+        // update the images on screen
+        this.getContentPane().revalidate();
         return;
     }
 


### PR DESCRIPTION
Replace the ugly hack with call to revalidate() as done in the LCD clock. Stops a nasty flickering effect for a few seconds when the window is resized on Windows 10 machines.