### PR TITLE
fix: Always use system monospace font in console

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -87,7 +87,6 @@ import jmri.util.SystemType;
 import jmri.util.ThreadingUtil;
 import jmri.util.WindowMenu;
 import jmri.util.iharder.dnd.URIDrop;
-import jmri.util.swing.FontComboUtil;
 import jmri.util.swing.JFrameInterface;
 import jmri.util.swing.SliderSnap;
 import jmri.util.swing.WindowInterface;
@@ -132,10 +131,6 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
 
         // Enable proper snapping of JSliders
         SliderSnap.init();
-
-        // Prepare font lists
-        log.trace("prepareFontLists");
-        prepareFontLists();
 
         // Get configuration profile
         log.trace("start to get configuration profile - locate files");
@@ -1175,19 +1170,6 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
 
         // Log the startup information
         log.info(Log4JUtil.startupInfo(name));
-    }
-
-    private void prepareFontLists() {
-        // Prepare font lists
-        Thread fontThread = new Thread(() -> {
-            log.debug("Prepare font lists...");
-            FontComboUtil.prepareFontLists();
-            log.debug("...Font lists built");
-        }, "PrepareFontListsThread");
-
-        fontThread.setDaemon(true);
-        fontThread.setPriority(Thread.MIN_PRIORITY);
-        fontThread.start();
     }
 
     @Override

--- a/java/src/apps/SystemConsole.java
+++ b/java/src/apps/SystemConsole.java
@@ -89,7 +89,7 @@ public final class SystemConsole extends JTextArea {
 
     private int fontStyle = Font.PLAIN;
 
-    private String fontFamily = "Monospaced";  // NOI18N
+    private final String fontFamily = "Monospaced";  // NOI18N
 
     public static final int WRAP_STYLE_NONE = 0x00;
     public static final int WRAP_STYLE_LINE = 0x01;
@@ -478,10 +478,22 @@ public final class SystemConsole extends JTextArea {
         updateFont(fontFamily, fontStyle, fontSize);
     }
 
+    /**
+     * 
+     * @param family the new font family
+     * @deprecated since 4.19.6 without replacement
+     */
+    @Deprecated
     public void setFontFamily(String family) {
-        updateFont((fontFamily = family), fontStyle, fontSize);
+        // does nothing
     }
 
+    /**
+     * 
+     * @return the current font family
+     * @deprecated since 4.19.6 without replacement
+     */
+    @Deprecated
     public String getFontFamily() {
         return fontFamily;
     }

--- a/java/src/apps/SystemConsoleConfigPanel.java
+++ b/java/src/apps/SystemConsoleConfigPanel.java
@@ -16,7 +16,6 @@ import javax.swing.JToggleButton;
 import javax.swing.UIManager;
 import jmri.InstanceManager;
 import jmri.swing.PreferencesPanel;
-import jmri.util.swing.FontComboUtil;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -69,8 +68,6 @@ public class SystemConsoleConfigPanel extends JPanel implements PreferencesPanel
 
     private static final JComboBox<Scheme> schemes = new JComboBox<>(SystemConsole.getInstance().getSchemes());
 
-    private static final JComboBox<String> fontFamily = FontComboUtil.getFontCombo(FontComboUtil.MONOSPACED, 14);
-
     private static final JComboBox<Integer> fontSize = new JComboBox<>(fontSizes);
 
     public SystemConsoleConfigPanel() {
@@ -113,17 +110,6 @@ public class SystemConsoleConfigPanel extends JPanel implements PreferencesPanel
         add(p);
 
         p = new JPanel(new FlowLayout());
-        fontFamily.addActionListener((ActionEvent e) -> {
-            this.getPreferencesManager().setFontFamily((String) fontFamily.getSelectedItem());
-            schemes.repaint();
-        });
-        fontFamily.setSelectedItem(this.getPreferencesManager().getFontFamily());
-
-        JLabel fontFamilyLabel = new JLabel(rbc.getString("ConsoleFontStyle"));
-        fontFamilyLabel.setLabelFor(fontFamily);
-
-        p.add(fontFamilyLabel);
-        p.add(fontFamily);
 
         fontSize.addActionListener((ActionEvent e) -> {
             this.getPreferencesManager().setFontSize((int) fontSize.getSelectedItem());

--- a/java/src/apps/configurexml/SystemConsoleConfigPanelXml.java
+++ b/java/src/apps/configurexml/SystemConsoleConfigPanelXml.java
@@ -42,7 +42,6 @@ public class SystemConsoleConfigPanelXml extends jmri.configurexml.AbstractXmlAd
         e.setAttribute("class", this.getClass().getName());
         SystemConsolePreferencesManager manager = InstanceManager.getDefault(SystemConsolePreferencesManager.class);
         e.setAttribute("scheme", "" + manager.getScheme());
-        e.setAttribute("fontfamily", "" + manager.getFontFamily());
         e.setAttribute("fontsize", "" + manager.getFontSize());
         e.setAttribute("fontstyle", "" + manager.getFontStyle());
         e.setAttribute("wrapstyle", "" + manager.getWrapStyle());
@@ -71,10 +70,6 @@ public class SystemConsoleConfigPanelXml extends jmri.configurexml.AbstractXmlAd
         try {
             if ((value = shared.getAttributeValue("scheme")) != null) {
                 manager.setScheme(Integer.parseInt(value));
-            }
-
-            if ((value = shared.getAttributeValue("fontfamily")) != null) {
-                manager.setFontFamily(value);
             }
 
             if ((value = shared.getAttributeValue("fontsize")) != null) {

--- a/java/src/apps/gui3/Apps3.java
+++ b/java/src/apps/gui3/Apps3.java
@@ -35,7 +35,6 @@ import jmri.util.FileUtil;
 import jmri.util.HelpUtil;
 import jmri.util.JmriJFrame;
 import jmri.util.SystemType;
-import jmri.util.swing.FontComboUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,9 +89,6 @@ public abstract class Apps3 extends AppsBase {
     public Apps3(String applicationName, String configFileDef, String[] args) {
         // pre-GUI work
         super(applicationName, configFileDef, args);
-
-        // Prepare font lists
-        prepareFontLists();
 
         // create GUI
         initializeHelpSystem();
@@ -239,22 +235,6 @@ public abstract class Apps3 extends AppsBase {
         debugmsg = true;
 
         debugmsg = false;
-    }
-
-    private void prepareFontLists() {
-        // Prepare font lists
-        Thread fontThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                log.debug("Prepare font lists...");
-                FontComboUtil.prepareFontLists();
-                log.debug("...Font lists built");
-            }
-        });
-        
-        fontThread.setDaemon(true);
-        fontThread.setPriority(Thread.MIN_PRIORITY);
-        fontThread.start();
     }
 
     protected void initMacOSXMenus() {

--- a/java/src/apps/systemconsole/SystemConsolePreferencesManager.java
+++ b/java/src/apps/systemconsole/SystemConsolePreferencesManager.java
@@ -13,9 +13,7 @@ import jmri.beans.Bean;
 import jmri.profile.Profile;
 import jmri.profile.ProfileUtils;
 import jmri.spi.PreferencesManager;
-import jmri.util.ThreadingUtil;
 import jmri.util.prefs.InitializationException;
-import jmri.util.swing.FontComboUtil;
 import org.openide.util.lookup.ServiceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +36,7 @@ public class SystemConsolePreferencesManager extends Bean implements Preferences
     private int scheme = 0; // Green on Black
     private int fontSize = 12;
     private int fontStyle = Font.PLAIN;
-    private String fontFamily = "Monospaced";  // NOI18N
+    private final String fontFamily = "Monospaced";  // NOI18N
     private int wrapStyle = SystemConsole.WRAP_STYLE_WORD;
 
     /*
@@ -53,7 +51,6 @@ public class SystemConsolePreferencesManager extends Bean implements Preferences
     public void initialize(Profile profile) throws InitializationException {
         if (!this.initialized) {
             Preferences preferences = ProfileUtils.getPreferences(profile, this.getClass(), true);
-            this.setFontFamily(preferences.get(FONT_FAMILY, this.getFontFamily()));
             this.setFontSize(preferences.getInt(FONT_SIZE, this.getFontSize()));
             this.setFontStyle(preferences.getInt(FONT_STYLE, this.getFontStyle()));
             this.setScheme(preferences.getInt(SCHEME, this.getScheme()));
@@ -65,7 +62,6 @@ public class SystemConsolePreferencesManager extends Bean implements Preferences
     @Override
     public void savePreferences(Profile profile) {
         Preferences preferences = ProfileUtils.getPreferences(profile, this.getClass(), true);
-        preferences.put(FONT_FAMILY, this.getFontFamily());
         preferences.putInt(FONT_SIZE, this.getFontSize());
         preferences.putInt(FONT_STYLE, this.getFontStyle());
         preferences.putInt(SCHEME, this.getScheme());
@@ -161,29 +157,20 @@ public class SystemConsolePreferencesManager extends Bean implements Preferences
 
     /**
      * @return the fontFamily
+     * @deprecated since 4.19.6 without replacement
      */
+    @Deprecated
     public String getFontFamily() {
         return fontFamily;
     }
 
     /**
      * @param fontFamily the fontFamily to set
+     * @deprecated since 4.19.6 without replacement
      */
+    @Deprecated
     public void setFontFamily(String fontFamily) {
-        if (FontComboUtil.isReady()) {
-            if (FontComboUtil.getFonts(FontComboUtil.MONOSPACED).contains(fontFamily)) {
-                String oldFontFamily = this.fontFamily;
-                this.fontFamily = fontFamily;
-                this.firePropertyChange(FONT_FAMILY, oldFontFamily, fontFamily);
-                SystemConsole.getInstance().setFontFamily(this.getFontFamily());
-            } else {
-                log.warn("Incompatible console font \"{}\" - using \"{}\"", fontFamily, this.getFontFamily());
-            }
-        } else {
-            ThreadingUtil.runOnGUIDelayed(() -> {
-                this.setFontFamily(fontFamily);
-            }, 1000); // one second
-        }
+        // does nothing
     }
 
     /**

--- a/java/src/jmri/util/swing/FontComboUtil.java
+++ b/java/src/jmri/util/swing/FontComboUtil.java
@@ -6,6 +6,7 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.GraphicsEnvironment;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.swing.BoxLayout;
 import javax.swing.JComboBox;
@@ -44,19 +45,17 @@ public class FontComboUtil {
     public static final int CHARACTER = 3;
     public static final int SYMBOL = 4;
 
-    private static List<String> all = null;
-    private static List<String> monospaced = null;
-    private static List<String> proportional = null;
-    private static List<String> character = null;
-    private static List<String> symbol = null;
+    private static final List<String> all = new ArrayList<>();
+    private static final List<String> monospaced = new ArrayList<>();
+    private static final List<String> proportional = new ArrayList<>();
+    private static final List<String> character = new ArrayList<>();
+    private static final List<String> symbol = new ArrayList<>();
 
     private static volatile boolean prepared = false;
     private static volatile boolean preparing = false;
 
     public static List<String> getFonts(int which) {
-        if (!prepared && !preparing) { // prepareFontLists is synchronized; don't do it if you don't have to
-            prepareFontLists();
-        }
+        prepareFontLists();
 
         switch (which) {
             case MONOSPACED:
@@ -80,40 +79,35 @@ public class FontComboUtil {
      * @return true if a symbol font; false if not
      */
     public static boolean isSymbolFont(String font) {
-        if (!prepared && !preparing) { // prepareFontLists is synchronized; don't do it if you don't have to
-            prepareFontLists();
-        }
+        prepareFontLists();
         return symbol.contains(font);
     }
 
     /**
      * Method to initialise the font lists on first access
      */
-    public static synchronized void prepareFontLists() {
+    public static void prepareFontLists() {
         if (prepared || preparing) {
             // Normally we shouldn't get here except when the initialisation
             // thread has taken a bit longer than normal.
             log.debug("Subsequent call - no need to prepare");
             return;
         }
+        initFonts();
+    }
+        
+    private static synchronized void initFonts() {
         preparing = true;
 
         log.debug("Prepare font lists...");
 
         // Initialise the font lists
-        monospaced = new ArrayList<>();
-        proportional = new ArrayList<>();
-        character = new ArrayList<>();
-        symbol = new ArrayList<>();
-        all = new ArrayList<>();
+        initAllFonts();
 
         // Create a font render context to use for the comparison
         Canvas c = new Canvas();
         // Loop through all available font families
-        for (String s : GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames()) {
-
-            // Add to the 'all' fonts list
-            all.add(s);
+        all.forEach(s -> {
 
             // Retrieve a plain version of the current font family
             Font f = new Font(s, Font.PLAIN, 12);
@@ -140,12 +134,18 @@ public class FontComboUtil {
                 // It's a symbol font - add to the symbol font list
                 symbol.add(s);
             }
-        }
+        });
 
         log.debug("...font lists built");
         prepared = true;
     }
 
+    private static synchronized void initAllFonts() {
+        if (all.isEmpty()) {
+            all.addAll(Arrays.asList(GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames()));
+        }
+    }
+    
     /**
      * Return a JComboBox containing all available font families. The list is
      * displayed using a preview of the font at the standard size.
@@ -154,6 +154,7 @@ public class FontComboUtil {
      * @return List of all available font families as a {@link JComboBox}
      */
     public static JComboBox<String> getFontCombo() {
+        initAllFonts();
         return getFontCombo(ALL);
     }
 
@@ -168,6 +169,7 @@ public class FontComboUtil {
      * @return List of specified font families as a {@link JComboBox}
      */
     public static JComboBox<String> getFontCombo(boolean previewOnly) {
+        initAllFonts();
         return getFontCombo(ALL, previewOnly);
     }
 
@@ -252,6 +254,7 @@ public class FontComboUtil {
      * @return List of specified font families as a {@link JComboBox}
      */
     public static JComboBox<String> getFontCombo(int which, final int size, final boolean previewOnly) {
+        prepareFontLists();
         // Create a JComboBox containing the specified list of font families
         List<String> fonts = getFonts(which);
         JComboBox<String> fontList = new JComboBox<>(fonts.toArray(new String[fonts.size()]));


### PR DESCRIPTION
This should prevent initializing the FontComboUtil from impacting most users, since the remaining uses of FontComboUtil are related to printing, and I doubt someone has an automatic action to print from JMRI on startup.

Closes #8362; the difference between this PR and #8362 is that this PR allows other code that uses the FontComboUtil to get a list of fonts on the system to continue to do so while #8362 did not.
Fixes #5244 by not cataloging font families on startup.