### PR TITLE
CBUS Light - Do not resend when heard on network

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusLight.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLight.java
@@ -104,10 +104,9 @@ public class CbusLight extends AbstractLight implements CanListener, CbusEventIn
             return;
         }
         if (addrOn.match(f)) {
-            setState(ON);
-        //    this.set
+            notifyStateChange(getState(), ON);
         } else if (addrOff.match(f)) {
-            setState(OFF);
+            notifyStateChange(getState(), OFF);
         }
     }
 
@@ -120,9 +119,9 @@ public class CbusLight extends AbstractLight implements CanListener, CbusEventIn
         // convert response events to normal
         f = CbusMessage.opcRangeToStl(f);
         if (addrOn.match(f)) {
-            setState(ON);
+            notifyStateChange(getState(), ON);
         } else if (addrOff.match(f)) {
-            setState(OFF);
+            notifyStateChange(getState(), OFF);
         }
     }
     

--- a/java/test/jmri/jmrix/can/cbus/CbusLightTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightTest.java
@@ -337,6 +337,7 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
         m.setElement(0, 0x91); // ACOF OPC
         ((CbusLight)t).message(m);
         Assert.assertTrue(t.getState() == Light.OFF);
+        Assert.assertTrue(tcis.outbound.isEmpty());
  
     }
     
@@ -366,6 +367,7 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
         m.setRtr(false);
         ((CbusLight)t).message(m);
         Assert.assertTrue(t.getState() == Light.ON);
+        Assert.assertTrue(tcis.outbound.isEmpty());
         
     }
     
@@ -394,6 +396,7 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
         
         ((CbusLight) t).reply(r);
         Assert.assertTrue(t.getState() == Light.ON);
+        Assert.assertTrue(tcis.outbound.isEmpty());
         
     }
     
@@ -419,6 +422,7 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
         r.setElement(0, 0x91); // ACOF OPC
         ((CbusLight) t).reply(r);
         Assert.assertTrue(t.getState() == Light.OFF);
+        Assert.assertTrue(tcis.outbound.isEmpty());
   
     }
 
@@ -443,6 +447,7 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
         m.setElement(0, 0x99); // ASOF OPC
         ((CbusLight)t).message(m);
         Assert.assertTrue(t.getState() == Light.OFF);
+        Assert.assertTrue(tcis.outbound.isEmpty());
         
     }
     
@@ -467,6 +472,8 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
         r.setElement(0, 0x99); // ASOF OPC
         ((CbusLight) t).reply(r);
         Assert.assertTrue(t.getState() == Light.OFF);
+        
+        Assert.assertTrue(tcis.outbound.isEmpty());
         
     }
 


### PR DESCRIPTION
Stops CBUS Lights sending status to network whenever a matching event is heard