### PR TITLE
Add method JUnitUtil.deregisterBlockManagerShutdownTask()

### DIFF
--- a/java/test/apps/gui3/tabbedpreferences/EditConnectionPreferencesDialogTest.java
+++ b/java/test/apps/gui3/tabbedpreferences/EditConnectionPreferencesDialogTest.java
@@ -36,7 +36,7 @@ public class EditConnectionPreferencesDialogTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/apps/gui3/tabbedpreferences/TabbedPreferencesFrameTest.java
+++ b/java/test/apps/gui3/tabbedpreferences/TabbedPreferencesFrameTest.java
@@ -35,7 +35,7 @@ public class TabbedPreferencesFrameTest {
     
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/apps/gui3/tabbedpreferences/TabbedPreferencesTest.java
+++ b/java/test/apps/gui3/tabbedpreferences/TabbedPreferencesTest.java
@@ -30,7 +30,7 @@ public class TabbedPreferencesTest extends jmri.util.swing.JmriPanelTest {
     @After
     @Override
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/BlockManagerTest.java
+++ b/java/test/jmri/BlockManagerTest.java
@@ -169,7 +169,7 @@ public class BlockManagerTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/ConditionalVariableTest.java
+++ b/java/test/jmri/ConditionalVariableTest.java
@@ -957,7 +957,7 @@ public class ConditionalVariableTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/InstanceManagerTest.java
+++ b/java/test/jmri/InstanceManagerTest.java
@@ -370,7 +370,7 @@ public class InstanceManagerTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/SectionManagerTest.java
+++ b/java/test/jmri/SectionManagerTest.java
@@ -26,7 +26,7 @@ public class SectionManagerTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/TransitManagerTest.java
+++ b/java/test/jmri/TransitManagerTest.java
@@ -26,7 +26,7 @@ public class TransitManagerTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/configurexml/SectionManagerXmlTest.java
+++ b/java/test/jmri/configurexml/SectionManagerXmlTest.java
@@ -541,7 +541,7 @@ public class SectionManagerXmlTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/configurexml/TransitManagerXmlTest.java
+++ b/java/test/jmri/configurexml/TransitManagerXmlTest.java
@@ -58,7 +58,7 @@ public class TransitManagerXmlTest {
 
    @After
    public void tearDown(){
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
    }
 

--- a/java/test/jmri/implementation/ActiveLogixTest.java
+++ b/java/test/jmri/implementation/ActiveLogixTest.java
@@ -183,7 +183,7 @@ public class ActiveLogixTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/implementation/DefaultCabSignalIT.java
+++ b/java/test/jmri/implementation/DefaultCabSignalIT.java
@@ -189,7 +189,7 @@ public class DefaultCabSignalIT {
     public void tearDown() {
         cs.dispose(); // verify no exceptions
         cs = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/implementation/DefaultCabSignalTest.java
+++ b/java/test/jmri/implementation/DefaultCabSignalTest.java
@@ -66,7 +66,7 @@ public class DefaultCabSignalTest {
     public void tearDown() {
         cs.dispose(); // verify no exceptions
         cs = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/implementation/DefaultConditionalTest.java
+++ b/java/test/jmri/implementation/DefaultConditionalTest.java
@@ -818,7 +818,7 @@ public class DefaultConditionalTest {
     @After
     public void tearDown() {
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/automat/JythonSigletTest.java
+++ b/java/test/jmri/jmrit/automat/JythonSigletTest.java
@@ -55,7 +55,7 @@ public class JythonSigletTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/beantable/BlockTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/BlockTableActionTest.java
@@ -319,7 +319,7 @@ public class BlockTableActionTest extends AbstractTableActionBase<Block> {
     public void tearDown() {
         a = null;
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/beantable/LRouteTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LRouteTableActionTest.java
@@ -164,7 +164,7 @@ public class LRouteTableActionTest {
         if (_lRouteTable.f != null) {
             _lRouteTable.f.dispose();
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/beantable/LogixTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixTableActionTest.java
@@ -240,7 +240,7 @@ public class LogixTableActionTest extends AbstractTableActionBase<Logix> {
     @Override
     public void tearDown() {
         a = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/beantable/MaintenanceTest.java
+++ b/java/test/jmri/jmrit/beantable/MaintenanceTest.java
@@ -156,7 +156,7 @@ public class MaintenanceTest {
     @After
     public void tearDown() {
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/beantable/OBlockTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/OBlockTableActionTest.java
@@ -58,7 +58,7 @@ public class OBlockTableActionTest {
     @After
     public void tearDown() throws Exception {
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/beantable/SectionTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/SectionTableActionTest.java
@@ -129,7 +129,7 @@ public class SectionTableActionTest extends AbstractTableActionBase<Section> {
     @Override
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/beantable/SignalMastLogicTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/SignalMastLogicTableActionTest.java
@@ -274,7 +274,7 @@ public class SignalMastLogicTableActionTest extends AbstractTableActionBase<Sign
     @After
     public void tearDown() {
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/beantable/TransitTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/TransitTableActionTest.java
@@ -127,7 +127,7 @@ public class TransitTableActionTest extends AbstractTableActionBase<Transit> {
     @Override
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/beantable/oblock/TableFramesTest.java
+++ b/java/test/jmri/jmrit/beantable/oblock/TableFramesTest.java
@@ -83,7 +83,7 @@ public class TableFramesTest {
     @After
     public void tearDown() {
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/beantable/usermessagepreferences/UserMessagePreferencesPaneTest.java
+++ b/java/test/jmri/jmrit/beantable/usermessagepreferences/UserMessagePreferencesPaneTest.java
@@ -31,7 +31,7 @@ public class UserMessagePreferencesPaneTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/conditional/ConditionalEditBaseTest.java
+++ b/java/test/jmri/jmrit/conditional/ConditionalEditBaseTest.java
@@ -95,7 +95,7 @@ public class ConditionalEditBaseTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/conditional/ConditionalListEditTest.java
+++ b/java/test/jmri/jmrit/conditional/ConditionalListEditTest.java
@@ -79,7 +79,7 @@ public class ConditionalListEditTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/conditional/ConditionalTreeEditTest.java
+++ b/java/test/jmri/jmrit/conditional/ConditionalTreeEditTest.java
@@ -154,7 +154,7 @@ public class ConditionalTreeEditTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/dispatcher/ActivateTrainFrameTest.java
+++ b/java/test/jmri/jmrit/dispatcher/ActivateTrainFrameTest.java
@@ -39,7 +39,7 @@ public class ActivateTrainFrameTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/dispatcher/AllocatedSectionTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AllocatedSectionTest.java
@@ -40,7 +40,7 @@ public class AllocatedSectionTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/dispatcher/AllocationPlanTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AllocationPlanTest.java
@@ -39,7 +39,7 @@ public class AllocationPlanTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/dispatcher/AutoTurnoutsTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AutoTurnoutsTest.java
@@ -38,7 +38,7 @@ public class AutoTurnoutsTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/dispatcher/DispatcherFrameTest.java
+++ b/java/test/jmri/jmrit/dispatcher/DispatcherFrameTest.java
@@ -181,7 +181,7 @@ public class DispatcherFrameTest {
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/dispatcher/OptionsFileTest.java
+++ b/java/test/jmri/jmrit/dispatcher/OptionsFileTest.java
@@ -52,7 +52,7 @@ public class OptionsFileTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/dispatcher/OptionsMenuTest.java
+++ b/java/test/jmri/jmrit/dispatcher/OptionsMenuTest.java
@@ -51,7 +51,7 @@ public class OptionsMenuTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/CoordinateEditTest.java
+++ b/java/test/jmri/jmrit/display/CoordinateEditTest.java
@@ -40,7 +40,7 @@ public class CoordinateEditTest extends jmri.util.JmriJFrameTestBase {
     @After
     @Override
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/EditorIconFrameTest.java
+++ b/java/test/jmri/jmrit/display/EditorIconFrameTest.java
@@ -93,7 +93,7 @@ public class EditorIconFrameTest {
           JUnitUtil.dispose(e);
        }
        e = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+       JUnitUtil.deregisterBlockManagerShutdownTask();
        JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/IconEditorWindowTest.java
+++ b/java/test/jmri/jmrit/display/IconEditorWindowTest.java
@@ -438,7 +438,7 @@ public class IconEditorWindowTest {
         _editor = null;
         
         JUnitUtil.resetWindows(false, false); // don't log existing windows here, should just be from this class
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/MemoryIconCoordinateEditTest.java
+++ b/java/test/jmri/jmrit/display/MemoryIconCoordinateEditTest.java
@@ -47,7 +47,7 @@ public class MemoryIconCoordinateEditTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/MemoryIconTest.java
+++ b/java/test/jmri/jmrit/display/MemoryIconTest.java
@@ -333,7 +333,7 @@ public class MemoryIconTest extends PositionableTestBase {
     @After
     public void tearDown() {
         to = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/PanelEditorTest.java
+++ b/java/test/jmri/jmrit/display/PanelEditorTest.java
@@ -60,7 +60,7 @@ public class PanelEditorTest {
     @After
     public void tearDown() {
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/PositionablePopupUtilTest.java
+++ b/java/test/jmri/jmrit/display/PositionablePopupUtilTest.java
@@ -63,7 +63,7 @@ public class PositionablePopupUtilTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/PositionablePropertiesUtilTest.java
+++ b/java/test/jmri/jmrit/display/PositionablePropertiesUtilTest.java
@@ -61,7 +61,7 @@ public class PositionablePropertiesUtilTest {
     @After
     public void tearDown() {
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/PositionableTestBase.java
+++ b/java/test/jmri/jmrit/display/PositionableTestBase.java
@@ -62,7 +62,7 @@ abstract public class PositionableTestBase {
         JUnitUtil.resetWindows(false, false);  // don't log here.  should be from this class.
         editor = null;
         p = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/SensorIconWindowTest.java
+++ b/java/test/jmri/jmrit/display/SensorIconWindowTest.java
@@ -146,7 +146,7 @@ public class SensorIconWindowTest {
     @After
     public void tearDown() throws Exception {
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/SensorTextEditTest.java
+++ b/java/test/jmri/jmrit/display/SensorTextEditTest.java
@@ -41,7 +41,7 @@ public class SensorTextEditTest extends jmri.util.JmriJFrameTestBase {
     @After
     @Override
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/SignalSystemTest.java
+++ b/java/test/jmri/jmrit/display/SignalSystemTest.java
@@ -192,7 +192,7 @@ public class SignalSystemTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
     

--- a/java/test/jmri/jmrit/display/SlipTurnoutTextEditTest.java
+++ b/java/test/jmri/jmrit/display/SlipTurnoutTextEditTest.java
@@ -41,7 +41,7 @@ public class SlipTurnoutTextEditTest extends jmri.util.JmriJFrameTestBase {
     @After
     @Override
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
+++ b/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
@@ -153,7 +153,7 @@ public class TurnoutIconWindowTest {
     @After
     public void tearDown() throws Exception {
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/CircuitBuilderTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/CircuitBuilderTest.java
@@ -210,7 +210,7 @@ public class CircuitBuilderTest {
         if (cpe != null) {
             cpe.dispose();
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
     private final static Logger log = LoggerFactory.getLogger(CircuitBuilderTest.class);

--- a/java/test/jmri/jmrit/display/controlPanelEditor/ControlPanelEditorTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/ControlPanelEditorTest.java
@@ -51,7 +51,7 @@ public class ControlPanelEditorTest extends AbstractEditorTestBase<ControlPanelE
             JUnitUtil.dispose(e);
             e = null;
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/ConvertDialogTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/ConvertDialogTest.java
@@ -76,7 +76,7 @@ public class ConvertDialogTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitFrameTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitFrameTest.java
@@ -48,7 +48,7 @@ public class EditCircuitFrameTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitPathsTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitPathsTest.java
@@ -59,7 +59,7 @@ public class EditCircuitPathsTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawCircleTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawCircleTest.java
@@ -57,7 +57,7 @@ public class DrawCircleTest {
     public void tearDown() {
         editor = null;
         jmri.util.JUnitUtil.resetWindows(false, false);  // don't log here.  should be from this class.
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawEllipseTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawEllipseTest.java
@@ -58,7 +58,7 @@ public class DrawEllipseTest {
     public void tearDown() {
         editor = null;
         jmri.util.JUnitUtil.resetWindows(false, false);  // don't log here.  should be from this class.
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawPolygonTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawPolygonTest.java
@@ -58,7 +58,7 @@ public class DrawPolygonTest {
     public void tearDown() {
         editor = null;
         jmri.util.JUnitUtil.resetWindows(false, false);  // don't log here.  should be from this class.
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawRectangleTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawRectangleTest.java
@@ -58,7 +58,7 @@ public class DrawRectangleTest {
     public void tearDown() {
         editor = null;
         jmri.util.JUnitUtil.resetWindows(false, false);  // don't log here.  should be from this class.
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawRoundRectTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawRoundRectTest.java
@@ -58,7 +58,7 @@ public class DrawRoundRectTest {
     public void tearDown() {
         editor = null;
         jmri.util.JUnitUtil.resetWindows(false, false);  // don't log here.  should be from this class.
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/LocoLabelTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/LocoLabelTest.java
@@ -33,7 +33,7 @@ public class LocoLabelTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/BlockValueFileTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/BlockValueFileTest.java
@@ -30,7 +30,7 @@ public class BlockValueFileTest {
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
     // private final static Logger log = LoggerFactory.getLogger(BlockValueFileTest.class);

--- a/java/test/jmri/jmrit/display/layoutEditor/ConnectivityUtilTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/ConnectivityUtilTest.java
@@ -36,7 +36,7 @@ public class ConnectivityUtilTest {
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutBlockTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutBlockTest.java
@@ -128,7 +128,7 @@ public class LayoutBlockTest {
     @After
     public void tearDown() throws Exception {
         layoutBlock = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
     // private final static Logger log = LoggerFactory.getLogger(LayoutBlockTest.class);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorAuxToolsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorAuxToolsTest.java
@@ -36,7 +36,7 @@ public class LayoutEditorAuxToolsTest {
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorChecksTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorChecksTest.java
@@ -38,7 +38,7 @@ public class LayoutEditorChecksTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorComponentTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorComponentTest.java
@@ -37,7 +37,7 @@ public class LayoutEditorComponentTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorConnectivityTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorConnectivityTest.java
@@ -311,7 +311,7 @@ public class LayoutEditorConnectivityTest {
     @After
     public void tearDown() throws Exception {
         cm = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/EnterGridSizesDialogTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/EnterGridSizesDialogTest.java
@@ -59,7 +59,7 @@ public class EnterGridSizesDialogTest {
             layoutEditor = null;
             enterGridSizesDialog = null;
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/EnterReporterDialogTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/EnterReporterDialogTest.java
@@ -61,7 +61,7 @@ public class EnterReporterDialogTest {
             layoutEditor = null;
             enterReporterDialog = null;
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackDrawingOptionsDialogTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackDrawingOptionsDialogTest.java
@@ -4,6 +4,7 @@ import java.awt.GraphicsEnvironment;
 import jmri.BlockManager;
 import jmri.InstanceManager;
 import jmri.ShutDownManager;
+import jmri.util.JUnitUtil;
 
 import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
@@ -29,8 +30,8 @@ public class LayoutTrackDrawingOptionsDialogTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
+        JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager();
         if(!GraphicsEnvironment.isHeadless()) {
             le = new LayoutEditor("Layout Track Drawing Options Dialog Test Layout");
             le.setVisible(true);
@@ -43,8 +44,8 @@ public class LayoutTrackDrawingOptionsDialogTest {
             EditorFrameOperator efo = new EditorFrameOperator(le);
             efo.closeFrameWithConfirmations();
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
-        jmri.util.JUnitUtil.tearDown();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackEditorsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackEditorsTest.java
@@ -918,7 +918,7 @@ public class LayoutTrackEditorsTest {
         layoutTrackEditors = null;
 
         JUnitUtil.resetWindows(false, false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/MoveSelectionDialogTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/MoveSelectionDialogTest.java
@@ -59,7 +59,7 @@ public class MoveSelectionDialogTest {
             layoutEditor = null;
             moveSelectionDialog = null;
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/ScaleTrackDiagramDialogTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/ScaleTrackDiagramDialogTest.java
@@ -59,7 +59,7 @@ public class ScaleTrackDiagramDialogTest {
             layoutEditor = null;
             scaleTrackDiagramDialog = null;
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorFindItemsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorFindItemsTest.java
@@ -35,7 +35,7 @@ public class LayoutEditorFindItemsTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorFloatingToolBarPanelTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorFloatingToolBarPanelTest.java
@@ -30,7 +30,7 @@ public class LayoutEditorFloatingToolBarPanelTest {
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
     // private final static Logger log = LoggerFactory.getLogger(LayoutEditorFloatingToolBarPanelTest.class);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorHorizontalToolBarPanelTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorHorizontalToolBarPanelTest.java
@@ -30,7 +30,7 @@ public class LayoutEditorHorizontalToolBarPanelTest {
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
     // private final static Logger log = LoggerFactory.getLogger(LayoutEditorHorizontalToolBarPanelTest.class);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -52,7 +52,7 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
             jfo.closeFrameWithConfirmations();
             e = null;
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
@@ -646,7 +646,7 @@ public class LayoutEditorToolsTest {
         turnouts = null;
         signalHeads = null;
         sensors = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorVerticalToolBarPanelTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorVerticalToolBarPanelTest.java
@@ -30,7 +30,7 @@ public class LayoutEditorVerticalToolBarPanelTest {
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
     // private final static Logger log = LoggerFactory.getLogger(LayoutEditorVerticalToolBarPanelTest.class);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorWindowTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorWindowTest.java
@@ -52,7 +52,7 @@ public class LayoutEditorWindowTest {
     @After
     public void tearDown() throws Exception {
         cm = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutShapeTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutShapeTest.java
@@ -190,7 +190,7 @@ public class LayoutShapeTest {
             JUnitUtil.dispose(layoutEditor);
             layoutEditor = null;
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutSlipTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutSlipTest.java
@@ -714,7 +714,7 @@ public class LayoutSlipTest {
             JUnitUtil.dispose(layoutEditor);
         }
         layoutEditor = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutTrackExpectedStateTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutTrackExpectedStateTest.java
@@ -6,6 +6,7 @@ import java.awt.geom.Point2D;
 import jmri.BlockManager;
 import jmri.InstanceManager;
 import jmri.ShutDownManager;
+import jmri.util.JUnitUtil;
 
 /**
  *
@@ -22,20 +23,20 @@ public class LayoutTrackExpectedStateTest {
         TrackSegment s = new TrackSegment("test", p1, LayoutEditor.HitPointType.POS_POINT, p2, LayoutEditor.HitPointType.POS_POINT, false, true, le);
         LayoutTrackExpectedState<LayoutTrack> t = new LayoutTrackExpectedState<LayoutTrack>(s, 0);
         Assert.assertNotNull("exists", t);
-        jmri.util.JUnitUtil.dispose(le);
+        JUnitUtil.dispose(le);
     }
 
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
+        JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager();
     }
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
-        jmri.util.JUnitUtil.tearDown();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutTurnoutTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutTurnoutTest.java
@@ -1094,7 +1094,7 @@ public class LayoutTurnoutTest {
             JUnitUtil.dispose(layoutEditor);
         }
         layoutEditor = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutTurntableTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutTurntableTest.java
@@ -59,7 +59,7 @@ public class LayoutTurntableTest {
         }
         lt = null;
         layoutEditor = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LevelXingTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LevelXingTest.java
@@ -37,7 +37,7 @@ public class LevelXingTest {
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/MemoryIconTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/MemoryIconTest.java
@@ -50,7 +50,7 @@ public class MemoryIconTest extends jmri.jmrit.display.MemoryIconTest {
            p = null;
         }
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/MultiSensorIconFrameTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/MultiSensorIconFrameTest.java
@@ -35,7 +35,7 @@ public class MultiSensorIconFrameTest extends jmri.util.JmriJFrameTestBase {
            JUnitUtil.dispose(e);
         }
         e = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/PositionablePointTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/PositionablePointTest.java
@@ -392,7 +392,7 @@ public class PositionablePointTest {
             JUnitUtil.dispose(le);
         }
         le = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/TrackNodeTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/TrackNodeTest.java
@@ -42,7 +42,7 @@ public class TrackNodeTest {
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentTest.java
@@ -598,7 +598,7 @@ public class TrackSegmentTest {
     public void tearDownEach() throws Exception {
         // release refereces to track segment
         trackSegment = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/palette/ColorDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/ColorDialogTest.java
@@ -228,7 +228,7 @@ public class ColorDialogTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/palette/DecoratorPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/DecoratorPanelTest.java
@@ -53,7 +53,7 @@ public class DecoratorPanelTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/palette/DetectionPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/DetectionPanelTest.java
@@ -45,7 +45,7 @@ public class DetectionPanelTest {
     @After
     public void tearDown() {
         ip = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/palette/IconDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/IconDialogTest.java
@@ -44,7 +44,7 @@ public class IconDialogTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/palette/ItemPaletteTest.java
+++ b/java/test/jmri/jmrit/display/palette/ItemPaletteTest.java
@@ -42,7 +42,7 @@ public class ItemPaletteTest {
     @After
     public void tearDown() {
         ip = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/palette/MemoryItemPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/MemoryItemPanelTest.java
@@ -46,7 +46,7 @@ public class MemoryItemPanelTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/palette/MultiSensorIconDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/MultiSensorIconDialogTest.java
@@ -45,7 +45,7 @@ public class MultiSensorIconDialogTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/palette/SignalHeadIconDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/SignalHeadIconDialogTest.java
@@ -43,7 +43,7 @@ public class SignalHeadIconDialogTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/palette/TextItemPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/TextItemPanelTest.java
@@ -45,7 +45,7 @@ public class TextItemPanelTest {
     @After
     public void tearDown() {
         ip = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/panelEditor/PanelEditorTest.java
+++ b/java/test/jmri/jmrit/display/panelEditor/PanelEditorTest.java
@@ -52,7 +52,7 @@ public class PanelEditorTest extends AbstractEditorTestBase<PanelEditor> {
             JUnitUtil.dispose(e);
             e = null;
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/switchboardEditor/BeanSwitchTest.java
+++ b/java/test/jmri/jmrit/display/switchboardEditor/BeanSwitchTest.java
@@ -39,7 +39,7 @@ public class BeanSwitchTest {
             swe = null;
         }
         JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
+++ b/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
@@ -98,7 +98,7 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
              JUnitUtil.dispose(e);
             e = null;
         }
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }		         
 

--- a/java/test/jmri/jmrit/entryexit/AddEntryExitPairActionTest.java
+++ b/java/test/jmri/jmrit/entryexit/AddEntryExitPairActionTest.java
@@ -36,7 +36,7 @@ public class AddEntryExitPairActionTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
+++ b/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
@@ -92,7 +92,7 @@ public class AddEntryExitPairPanelTest {
     public static void tearDown() {
         panels.forEach((name, panel) -> JUnitUtil.dispose(panel));
         panels = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/entryexit/DestinationPointsTest.java
+++ b/java/test/jmri/jmrit/entryexit/DestinationPointsTest.java
@@ -140,7 +140,7 @@ public class DestinationPointsTest {
         eep = null;
         panels = null;
         tools = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/entryexit/EntryExitPairsTest.java
+++ b/java/test/jmri/jmrit/entryexit/EntryExitPairsTest.java
@@ -121,7 +121,7 @@ public class EntryExitPairsTest {
         tm = null;
         panels = null;
         tools = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/entryexit/PointDetailsTest.java
+++ b/java/test/jmri/jmrit/entryexit/PointDetailsTest.java
@@ -90,7 +90,7 @@ public class PointDetailsTest {
     @AfterClass
     public static void tearDown() {
         panels.forEach((name, panel) -> JUnitUtil.dispose(panel));
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/entryexit/SourceTest.java
+++ b/java/test/jmri/jmrit/entryexit/SourceTest.java
@@ -122,7 +122,7 @@ public class SourceTest {
     @AfterClass
     static public void tearDown() {
         panels.forEach((name, panel) -> JUnitUtil.dispose(panel));
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/jython/InputWindowTest.java
+++ b/java/test/jmri/jmrit/jython/InputWindowTest.java
@@ -30,7 +30,7 @@ public class InputWindowTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/jython/JythonWindowsTest.java
+++ b/java/test/jmri/jmrit/jython/JythonWindowsTest.java
@@ -75,7 +75,7 @@ public class JythonWindowsTest {
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/jython/SampleScriptTest.java
+++ b/java/test/jmri/jmrit/jython/SampleScriptTest.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import jmri.BlockManager;
 import jmri.InstanceManager;
 import jmri.ShutDownManager;
+import jmri.util.JUnitUtil;
 
 import org.junit.*;
 import org.junit.runner.RunWith;
@@ -66,27 +67,27 @@ public class SampleScriptTest {
     
     @Before
     public void setUp() throws Exception {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
         
         // it's not really understood why, but doing these inside of the 
         // sample Python script doesn't always work; it's as if that
         // is working with a different InstanceManager. So we 
         // include a comprehensive set here.
-        jmri.util.JUnitUtil.resetInstanceManager();
-        jmri.util.JUnitUtil.resetProfileManager();
-        jmri.util.JUnitUtil.initConfigureManager();
-        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
-        jmri.util.JUnitUtil.initDebugPowerManager();
-        jmri.util.JUnitUtil.initInternalSensorManager();
-        jmri.util.JUnitUtil.initInternalTurnoutManager();
-        jmri.util.JUnitUtil.initDebugThrottleManager();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initDefaultUserMessagePreferences();
+        JUnitUtil.initDebugPowerManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initDebugThrottleManager();
     }
         
     @After 
     public void tearDown() throws Exception {
-        jmri.util.JUnitUtil.resetWindows(false,false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
-        jmri.util.JUnitUtil.tearDown();
+        JUnitUtil.resetWindows(false,false);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
     }
 
     @AfterClass

--- a/java/test/jmri/jmrit/logix/SpeedProfilePanelTest.java
+++ b/java/test/jmri/jmrit/logix/SpeedProfilePanelTest.java
@@ -6,6 +6,7 @@ import jmri.InstanceManager;
 import jmri.ShutDownManager;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.jmrit.roster.RosterSpeedProfile;
+import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -29,13 +30,13 @@ public class SpeedProfilePanelTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
     }
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
-        jmri.util.JUnitUtil.tearDown();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(SpeedProfilePanelTest.class);

--- a/java/test/jmri/jmrit/operations/OperationsTestCase.java
+++ b/java/test/jmri/jmrit/operations/OperationsTestCase.java
@@ -86,7 +86,7 @@ public class OperationsTestCase {
             }
         }
         
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         if (InstanceManager.containsDefault(ShutDownManager.class)) {
             ShutDownManager sm = InstanceManager.getDefault(jmri.ShutDownManager.class);
             List<ShutDownTask> list = sm.tasks();

--- a/java/test/jmri/jmrit/operations/trains/TrainIconTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainIconTest.java
@@ -91,7 +91,7 @@ public class TrainIconTest extends OperationsTestCase {
         }
         editor = null;
         trainicon = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/picker/PickFrameTest.java
+++ b/java/test/jmri/jmrit/picker/PickFrameTest.java
@@ -74,7 +74,7 @@ public class PickFrameTest extends JmriJFrameTestBase {
     @After
     @Override
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/picker/PickPanelTest.java
+++ b/java/test/jmri/jmrit/picker/PickPanelTest.java
@@ -43,7 +43,7 @@ public class PickPanelTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/roster/swing/speedprofile/SpeedProfileFrameTest.java
+++ b/java/test/jmri/jmrit/roster/swing/speedprofile/SpeedProfileFrameTest.java
@@ -28,7 +28,7 @@ public class SpeedProfileFrameTest extends jmri.util.JmriJFrameTestBase {
     @After
     @Override
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanelTest.java
+++ b/java/test/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanelTest.java
@@ -31,7 +31,7 @@ public class SpeedProfilePanelTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/sensorgroup/SensorGroupActionTest.java
+++ b/java/test/jmri/jmrit/sensorgroup/SensorGroupActionTest.java
@@ -50,7 +50,7 @@ public class SensorGroupActionTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/sensorgroup/SensorGroupFrameTest.java
+++ b/java/test/jmri/jmrit/sensorgroup/SensorGroupFrameTest.java
@@ -27,7 +27,7 @@ public class SensorGroupFrameTest extends jmri.util.JmriJFrameTestBase {
     @After
     @Override
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/signalling/SignallingPanelTest.java
+++ b/java/test/jmri/jmrit/signalling/SignallingPanelTest.java
@@ -79,7 +79,7 @@ public class SignallingPanelTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/ussctc/OsIndicatorTest.java
+++ b/java/test/jmri/jmrit/ussctc/OsIndicatorTest.java
@@ -6,6 +6,7 @@ import jmri.JmriException;
 import jmri.Sensor;
 import jmri.ShutDownManager;
 import jmri.Turnout;
+import jmri.util.JUnitUtil;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -134,17 +135,17 @@ public class OsIndicatorTest {
 
     @Before
     public void setUp() throws Exception {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
 
-        jmri.util.JUnitUtil.resetInstanceManager();
-        jmri.util.JUnitUtil.initInternalTurnoutManager();
-        jmri.util.JUnitUtil.initInternalSensorManager();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initInternalSensorManager();
     }
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
-        jmri.util.JUnitUtil.tearDown();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/Diesel3SoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/Diesel3SoundTest.java
@@ -30,7 +30,7 @@ public class Diesel3SoundTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/VSDManagerEventTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDManagerEventTest.java
@@ -31,7 +31,7 @@ public class VSDManagerEventTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/VSDecoderManagerTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDecoderManagerTest.java
@@ -30,7 +30,7 @@ public class VSDecoderManagerTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/swing/ManageLocationsFrameTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/swing/ManageLocationsFrameTest.java
@@ -9,6 +9,7 @@ import jmri.ShutDownManager;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.vsdecoder.listener.ListeningSpot;
+import jmri.util.JUnitUtil;
 import org.junit.*;
 
 /**
@@ -20,7 +21,7 @@ public class ManageLocationsFrameTest extends jmri.util.JmriJFrameTestBase {
     @Before
     @Override
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
         ListeningSpot s = new ListeningSpot();
         ReporterManager rmgr = jmri.InstanceManager.getDefault(jmri.ReporterManager.class);
         Object[][] reporterTable = new Object[rmgr.getObjectCount()][6];
@@ -41,7 +42,7 @@ public class ManageLocationsFrameTest extends jmri.util.JmriJFrameTestBase {
     @After
     @Override
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/swing/VSDManagerFrameTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/swing/VSDManagerFrameTest.java
@@ -29,7 +29,7 @@ public class VSDManagerFrameTest extends jmri.util.JmriJFrameTestBase {
 
         // this created an audio manager, clean that up
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/whereused/WhereUsedCollectorsTest.java
+++ b/java/test/jmri/jmrit/whereused/WhereUsedCollectorsTest.java
@@ -112,7 +112,7 @@ public class WhereUsedCollectorsTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/whereused/WhereUsedFrameTest.java
+++ b/java/test/jmri/jmrit/whereused/WhereUsedFrameTest.java
@@ -198,7 +198,7 @@ public class WhereUsedFrameTest {
 
     @After
     public  void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/can/cbus/CbusCabSignalIT.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusCabSignalIT.java
@@ -55,7 +55,7 @@ public class CbusCabSignalIT extends jmri.implementation.DefaultCabSignalIT {
         tc = null;
         cs.dispose();
         cs = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
 
     }

--- a/java/test/jmri/jmrix/can/cbus/CbusCabSignalTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusCabSignalTest.java
@@ -77,7 +77,7 @@ public class CbusCabSignalTest extends jmri.implementation.DefaultCabSignalTest 
         tc = null;
         cs.dispose();
         cs = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/CsOpSwAccessTest.java
+++ b/java/test/jmri/jmrix/loconet/CsOpSwAccessTest.java
@@ -1477,6 +1477,7 @@ public class CsOpSwAccessTest {
     public void tearDown() {
         memo.dispose();
         lnis = null;
+		JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/CsOpSwAccessTest.java
+++ b/java/test/jmri/jmrix/loconet/CsOpSwAccessTest.java
@@ -1477,7 +1477,7 @@ public class CsOpSwAccessTest {
     public void tearDown() {
         memo.dispose();
         lnis = null;
-		JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/LnCabSignalIT.java
+++ b/java/test/jmri/jmrix/loconet/LnCabSignalIT.java
@@ -74,7 +74,7 @@ public class LnCabSignalIT extends jmri.implementation.DefaultCabSignalIT {
     public void tearDown() {
         cs.dispose(); // verify no exceptions
         cs = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/LnCabSignalTest.java
+++ b/java/test/jmri/jmrix/loconet/LnCabSignalTest.java
@@ -61,7 +61,7 @@ public class LnCabSignalTest extends jmri.implementation.DefaultCabSignalTest {
     public void tearDown() {
         cs.dispose(); // verify no exceptions
         cs = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/rps/RpsPositionIconTest.java
+++ b/java/test/jmri/jmrix/rps/RpsPositionIconTest.java
@@ -53,7 +53,7 @@ public class RpsPositionIconTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/managers/DefaultConditionalManagerTest.java
+++ b/java/test/jmri/managers/DefaultConditionalManagerTest.java
@@ -3,17 +3,17 @@ package jmri.managers;
 import static org.junit.Assert.assertNotNull;
 
 import jmri.BlockManager;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import jmri.Conditional;
 import jmri.ConditionalManager;
 import jmri.InstanceManager;
 import jmri.Logix;
 import jmri.ShutDownManager;
 import jmri.jmrix.internal.InternalSystemConnectionMemo;
+import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests for the jmri.managers.DefaultConditionalManager class.
@@ -51,14 +51,14 @@ public class DefaultConditionalManagerTest extends AbstractManagerTestBase<jmri.
 
     @Before
     public void setUp() throws Exception {
-        jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
-        jmri.util.JUnitUtil.initInternalTurnoutManager();
-        jmri.util.JUnitUtil.initInternalLightManager();
-        jmri.util.JUnitUtil.initInternalSensorManager();
-        jmri.util.JUnitUtil.initIdTagManager();
-        jmri.util.JUnitUtil.initLogixManager();
-        jmri.util.JUnitUtil.initConditionalManager();
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initInternalLightManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initIdTagManager();
+        JUnitUtil.initLogixManager();
+        JUnitUtil.initConditionalManager();
 
         Logix x1 = new jmri.implementation.DefaultLogix("IX01");
         assertNotNull("Logix x1 is null!", x1);
@@ -73,7 +73,7 @@ public class DefaultConditionalManagerTest extends AbstractManagerTestBase<jmri.
     @After
     public void tearDown() throws Exception {
         l = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
-        jmri.util.JUnitUtil.tearDown();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/managers/DefaultLogixManagerTest.java
+++ b/java/test/jmri/managers/DefaultLogixManagerTest.java
@@ -2,6 +2,7 @@ package jmri.managers;
 
 import jmri.BlockManager;
 import jmri.InstanceManager;
+import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -73,19 +74,19 @@ public class DefaultLogixManagerTest extends AbstractManagerTestBase<jmri.LogixM
 
     @Before
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
-        jmri.util.JUnitUtil.initInternalTurnoutManager();
-        jmri.util.JUnitUtil.initInternalLightManager();
-        jmri.util.JUnitUtil.initInternalSensorManager();
-        jmri.util.JUnitUtil.initIdTagManager();
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initInternalLightManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initIdTagManager();
         l = new DefaultLogixManager(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
     }
 
     @After
     public void tearDown() {
         l = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
-        jmri.util.JUnitUtil.tearDown();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/managers/LogixSystemTest.java
+++ b/java/test/jmri/managers/LogixSystemTest.java
@@ -1,6 +1,7 @@
 package jmri.managers;
 
 import jmri.*;
+import jmri.util.JUnitUtil;
 import org.junit.Test;
 import org.junit.After;
 import org.junit.Assert;
@@ -55,17 +56,17 @@ public class LogixSystemTest {
 
     @Before
     public void setUp() throws Exception {
-        jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
-        jmri.util.JUnitUtil.initInternalTurnoutManager();
-        jmri.util.JUnitUtil.initInternalLightManager();
-        jmri.util.JUnitUtil.initInternalSensorManager();
-        jmri.util.JUnitUtil.initIdTagManager();
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initInternalLightManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initIdTagManager();
     }
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
-        jmri.util.JUnitUtil.tearDown();
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/script/JmriScriptEngineManagerTest.java
+++ b/java/test/jmri/script/JmriScriptEngineManagerTest.java
@@ -295,7 +295,7 @@ public class JmriScriptEngineManagerTest {
     @After
     public void tearDown() {
         jsem = null;
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/script/ScriptFileChooserTest.java
+++ b/java/test/jmri/script/ScriptFileChooserTest.java
@@ -29,7 +29,7 @@ public class ScriptFileChooserTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/server/json/JsonClientHandlerTest.java
+++ b/java/test/jmri/server/json/JsonClientHandlerTest.java
@@ -48,7 +48,7 @@ public class JsonClientHandlerTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/server/json/block/JsonBlockHttpServiceTest.java
+++ b/java/test/jmri/server/json/block/JsonBlockHttpServiceTest.java
@@ -51,7 +51,7 @@ public class JsonBlockHttpServiceTest extends JsonNamedBeanHttpServiceTestBase<B
     @After
     @Override
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/server/json/block/JsonBlockSocketServiceTest.java
+++ b/java/test/jmri/server/json/block/JsonBlockSocketServiceTest.java
@@ -128,7 +128,7 @@ public class JsonBlockSocketServiceTest {
 
     @After
     public void tearDown() throws Exception {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/server/json/layoutblock/JsonLayoutBlockSocketServiceTest.java
+++ b/java/test/jmri/server/json/layoutblock/JsonLayoutBlockSocketServiceTest.java
@@ -46,7 +46,7 @@ public class JsonLayoutBlockSocketServiceTest {
 
     @After
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/server/json/util/JsonUtilSocketServiceTest.java
+++ b/java/test/jmri/server/json/util/JsonUtilSocketServiceTest.java
@@ -59,7 +59,7 @@ public class JsonUtilSocketServiceTest {
     @After
     public void tearDown() {
         JUnitUtil.resetWindows(false, false);
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/spi/JsonServiceFactoryTest.java
+++ b/java/test/jmri/spi/JsonServiceFactoryTest.java
@@ -62,7 +62,7 @@ public class JsonServiceFactoryTest {
 
     @AfterEach
     public void tearDown() {
-        InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -729,6 +729,12 @@ public class JUnitUtil {
         }
     }
 
+    public static void deregisterBlockManagerShutdownTask() {
+        InstanceManager
+                .getDefault(ShutDownManager.class)
+                .deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
+    }
+
     public static void initWarrantManager() {
         WarrantManager w = new WarrantManager();
         if (InstanceManager.getNullableDefault(ConfigureManager.class) != null) {


### PR DESCRIPTION
Follow up of #8367.

So many tests needed to call

```
InstanceManager.getDefault(ShutDownManager.class).deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);
```
that I thought it would be better to add a method to JUnitUtil for this call.