### PR TITLE
Split a testcase in two

### DIFF
--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -1207,15 +1207,6 @@ public class SlotManagerTest {
         JUnitUtil.waitFor(600);
         Assert.assertEquals("check no messages sent when DB150", 0, lnis.outbound.size());
 
-        slotmanager.commandStationType = LnCommandStationType.COMMAND_STATION_DCS240;
-        slotmanager.message(new LocoNetMessage(new int[] {0x8a, 0x75}));
-        JUnitUtil.waitFor(()->{return lnis.outbound.size() >126;},"testOpCode8a: slot managersent at least 127 LocoNet messages");
-        for (int i = 0; i < 127; ++i) {
-            Assert.assertEquals("testOpCode8a: loop "+i+" check sent opcode", 0xBB, lnis.outbound.get(i).getOpCode());
-            Assert.assertEquals("testOpCode8a: loop "+i+" check sent byte 1", i, lnis.outbound.get(i).getElement(1));
-            Assert.assertEquals("testOpCode8a: loop "+i+" check sent byte 2", 0, lnis.outbound.get(i).getElement(2));
-
-        }
     }
 
     @Test
@@ -1242,6 +1233,22 @@ public class SlotManagerTest {
             Assert.assertEquals("testOpCode8a DCS052: loop "+i+" check sent opcode", 0xBB, lnis.outbound.get(i).getOpCode());
             Assert.assertEquals("testOpCode8a DCS052: loop "+i+" check sent byte 1", i, lnis.outbound.get(i).getElement(1));
             Assert.assertEquals("testOpCode8a DCS052: loop "+i+" check sent byte 2", 0, lnis.outbound.get(i).getElement(2));
+
+        }
+    }
+
+    @Test
+    public void testYetMoreOpCode8a() {
+
+        LocoNetMessage m = new LocoNetMessage(new int[] {0x8a, 0x75});
+        
+        slotmanager.commandStationType = LnCommandStationType.COMMAND_STATION_DCS240;
+        slotmanager.message(new LocoNetMessage(new int[] {0x8a, 0x75}));
+        JUnitUtil.waitFor(()->{return lnis.outbound.size() >126;},"testOpCode8a: slot managersent at least 127 LocoNet messages");
+        for (int i = 0; i < 127; ++i) {
+            Assert.assertEquals("testOpCode8a: loop "+i+" check sent opcode", 0xBB, lnis.outbound.get(i).getOpCode());
+            Assert.assertEquals("testOpCode8a: loop "+i+" check sent byte 1", i, lnis.outbound.get(i).getElement(1));
+            Assert.assertEquals("testOpCode8a: loop "+i+" check sent byte 2", 0, lnis.outbound.get(i).getElement(2));
 
         }
     }

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -1185,23 +1185,23 @@ public class SlotManagerTest {
     public void testOpCode8a() {
 
         LocoNetMessage m = new LocoNetMessage(new int[] {0x8a, 0x75});
-        
+
         slotmanager.commandStationType = LnCommandStationType.COMMAND_STATION_DCS100;
         slotmanager.message(m);
         JUnitUtil.waitFor(600);
         Assert.assertEquals("check no messages sent when DCS100", 0, lnis.outbound.size());
-        
-        
+
+
         slotmanager.commandStationType = LnCommandStationType.COMMAND_STATION_DCS051;
         slotmanager.message(m);
         JUnitUtil.waitFor(600);
         Assert.assertEquals("check no messages sent when DCS051", 0, lnis.outbound.size());
-        
+
         slotmanager.commandStationType = LnCommandStationType.COMMAND_STATION_DCS050;
         slotmanager.message(m);
         JUnitUtil.waitFor(600);
         Assert.assertEquals("check no messages sent when DCS050", 0, lnis.outbound.size());
-        
+
         slotmanager.commandStationType = LnCommandStationType.COMMAND_STATION_DB150;
         slotmanager.message(m);
         JUnitUtil.waitFor(600);
@@ -1240,8 +1240,6 @@ public class SlotManagerTest {
     @Test
     public void testYetMoreOpCode8a() {
 
-        LocoNetMessage m = new LocoNetMessage(new int[] {0x8a, 0x75});
-        
         slotmanager.commandStationType = LnCommandStationType.COMMAND_STATION_DCS240;
         slotmanager.message(new LocoNetMessage(new int[] {0x8a, 0x75}));
         JUnitUtil.waitFor(()->{return lnis.outbound.size() >126;},"testOpCode8a: slot managersent at least 127 LocoNet messages");


### PR DESCRIPTION
Re: https://jmri-developers.groups.io/g/jmri/topic/slow_windows_tests/73177249?p=,,,20,0,0,0::recentpostdate%2Fsticky,,,20,2,0,73177249
 
Splitting one jmri.jmrix.loconet.SlotMonitorTest testcase into two to increase the number of testcases running in less than 5 seconds on CI.

(The other half of this testcase cannot be reduced to less than 5 seconds run time account nature of the functionality that is tested.)