### PR TITLE
test: show running test on AppVeyor

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1518,7 +1518,7 @@
             <sysproperty key="user.country" value="US"/>
 
             <arg value="--scan-classpath"/>
-            <arg value="--details=none"/>
+            <arg value="--details=tree"/>
             <arg value="--include-engine=junit-jupiter"/>
 	    <arg value="--include-engine=junit-vintage"/>
 	    <arg line="-n '^(Test.*|.+[.$]Test.*|.*Tests?)$'" />

--- a/build.xml
+++ b/build.xml
@@ -1518,7 +1518,7 @@
             <sysproperty key="user.country" value="US"/>
 
             <arg value="--scan-classpath"/>
-            <arg value="--details=tree"/>
+            <arg value="--details=verbose"/>
             <arg value="--include-engine=junit-jupiter"/>
 	    <arg value="--include-engine=junit-vintage"/>
 	    <arg line="-n '^(Test.*|.+[.$]Test.*|.*Tests?)$'" />


### PR DESCRIPTION
AppVeyor is timing out too frequently to be considered reliable.  This change makes AppVeyor report the test being run as it is run, so we can identify if tests are hanging on AppVeyor.