### PR TITLE
remove an unnecessary queuetool wait

### DIFF
--- a/java/test/jmri/jmrix/AbstractMonPaneTestBase.java
+++ b/java/test/jmri/jmrix/AbstractMonPaneTestBase.java
@@ -148,7 +148,6 @@ public abstract class AbstractMonPaneTestBase extends jmri.util.swing.JmriPanelT
 
     protected void setAndCheckFilterTextEntry(String entryText, String resultText, String errorMessage) {
         ThreadingUtil.runOnGUI( () -> pane.setFilterText(entryText));
-        new org.netbeans.jemmy.QueueTool().waitEmpty(100);
         assertThat(resultText).withFailMessage(errorMessage)
                 .isEqualTo(ThreadingUtil.runOnGUIwithReturn( () -> pane.getFilterText()));
     }


### PR DESCRIPTION
After some recent work, the operations before and after this are both run on the EDT, so the wait for the queue to be empty is no longer required.  This has lead to some extended test times for this particular test.