### PR TITLE
chore: enable test coverage reporting in NetBeans

### DIFF
--- a/nbactions.xml
+++ b/nbactions.xml
@@ -68,4 +68,29 @@
                 <skipTests>true</skipTests>
             </properties>
         </action>
+        <action>
+            <actionName>test.single</actionName>
+            <packagings>
+                <packaging>*</packaging>
+            </packagings>
+            <goals>
+                <goal>test-compile</goal>
+                <goal>jacoco:prepare-agent</goal>
+                <goal>surefire:test</goal>
+                <goal>jacoco:report</goal>
+            </goals>
+            <properties>
+                <test>${packageClassName}</test>
+            </properties>
+        </action>
+        <action>
+            <actionName>test</actionName>
+            <packagings>
+                <packaging>*</packaging>
+            </packagings>
+            <goals>
+                <goal>test</goal>
+                <goal>jacoco:report</goal>
+            </goals>
+        </action>
     </actions>


### PR DESCRIPTION
This allows the coverage tools in NetBeans to display coverage in open files in NetBeans