### PR TITLE
Add checks for logging issues to spotbugs

### DIFF
--- a/.spotbugs-check.xml
+++ b/.spotbugs-check.xml
@@ -5,12 +5,23 @@
          all cleared out. -->
          
     <!-- Suppress high bugs which we _don't_ want to fail CI until we can get them removed -->
+     <Match>
+        <Confidence value="1" /> <!-- 3 is low priority, 2 is medium priority, 1 is high priority -->
+        <Or>
+           <Bug pattern="SLF4J_FORMAT_SHOULD_BE_CONST" />
+	   <Bug pattern="SLF4J_PLACE_HOLDER_MISMATCH" />
+	   <Bug pattern="SLF4J_UNKNOWN_ARRAY" />
+        </Or>
+     </Match>
 
     <!-- Suppress medium bugs which we _don't_ want to fail CI until we can get them removed -->
      <Match>
         <Confidence value="2" /> <!-- 3 is low priority, 2 is medium priority, 1 is high priority -->
         <Or>
            <Bug pattern="IS2_INCONSISTENT_SYNC" />
+	   <Bug pattern="SLF4J_SIGN_ONLY_FORMAT" />
+	   <Bug pattern="SLF4J_MANUALLY_PROVIDED_MESSAGE" />
+	   <Bug pattern="SLF4J_LOGGER_SHOULD_BE_PRIVATE" />
         </Or>
      </Match>
 
@@ -79,6 +90,11 @@
      <Match>
        <!-- JMRI does not use serialization, permanently ignore -->
        <Bug code="Se,SnVI" />
+     </Match>
+
+     <Match>
+       <!-- JMRI code is written with static final loggers. -->
+       <Bug pattern="SLF4J_LOGGER_SHOULD_BE_NON_STATIC" />
      </Match>
 
 </FindBugsFilter>

--- a/.spotbugs.xml
+++ b/.spotbugs.xml
@@ -55,4 +55,10 @@
        <Bug code="Se,SnVI" />
      </Match>
 
+
+     <Match>
+       <!-- JMRI code is written with static final loggers. -->
+       <Bug pattern="SLF4J_LOGGER_SHOULD_BE_NON_STATIC" />
+     </Match>
+
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,15 @@
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
                         <version>3.1.12</version>
+                        <configuration>
+                            <plugins>
+                                <plugin>
+                                    <groupId>jp.skypencil.findbugs.slf4j</groupId>
+                                    <artifactId>bug-pattern</artifactId>
+                                    <version>1.5.0</version>
+                                </plugin>
+                            </plugins>
+                        </configuration>
                         <!-- configured to fail on Medium priority bugs during test phase (needs to be done two places) -->
                         <executions>
                             <execution>
@@ -402,6 +411,13 @@
                 <version>3.1.12</version>
                 <!-- configured to fail on medium priority bugs (needs to be done two places)-->
                 <configuration>
+                    <plugins>
+                        <plugin>
+                            <groupId>jp.skypencil.findbugs.slf4j</groupId>
+                            <artifactId>bug-pattern</artifactId>
+                            <version>1.5.0</version>
+                        </plugin>
+                    </plugins>
                     <excludeFilterFile>.spotbugs-check.xml</excludeFilterFile>
                     <effort>Max</effort>
                     <threshold>Low</threshold>


### PR DESCRIPTION
Adds the required dependencies to check logging issues as suggested by @rhwood in comments on #8417.

Tasks:
- [x] Configure maven for running plugin on travis
- [ ] configure Ant to run plugin on spotbugs targets
- [x] set ignores so we can work through issues that haven't been fixed