### PR TITLE
document slf4j plugin for spotbugs

### DIFF
--- a/help/en/html/doc/Technical/SpotBugs.shtml
+++ b/help/en/html/doc/Technical/SpotBugs.shtml
@@ -262,6 +262,9 @@ scanning through the code.
     <pre style="font-family: monospace;">
     spotbugs.home = /Users/jake/.spotbugs/spotbugs-3.1.7
     </pre>
+        <li>In order to check for spotbugs issues in logging statements, we use the <a
+            href="https://www.kengo-toda.jp/findbugs-slf4j/">Findbugs-slf4j</a> plugin by KengoTODA. To use this
+        plugin in ant builds, download the plugin and install it in the plugin directory of your spotbugs installation.
       <li>Then run SpotBugs in ant via:
     <pre style="font-family: monospace;">
     ant spotbugs
@@ -351,6 +354,13 @@ scanning through the code.
         serialization. JMRI doesn't used serialization, and is
         unlikely to do so in the future, so we suppress these to
         raise the average quality of the issued warnings.</dd>
+
+        <dt>SLF4J_LOGGER_SHOULD_BE_NON_STATIC</dt>
+
+        <dd>This warning indicates that loggers should be non-static variables,
+        but the JMRI standard is for the logger to be a static final variable, so
+        every logger would be flagged if this were enabled.</dd>
+
       </dl>
 
      <h4>Status and Counts</h4>


### PR DESCRIPTION
@bobjacobsen Since spotbugs is optional for developers to install, and ant uses the instalation if it is found, it turns out the way to install the plugin for slf4j is by adding it to a directory in the spotbugs installation.

I tried getting this to work using our lib directory and ant, but nothing in the spotbugs-ant configuration allows you to specify a plugin.

So this PR just updates the documentation indicating how to run it with ant.