### PR TITLE
Add clearShutDownManager to reduce intermittent error rate

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -429,6 +429,7 @@
         <delete dir="release"/>
         <delete dir="dist"/>
         <delete dir="temp"/>
+        <delete dir="test"/>
         <delete dir="web/TrainCrew"/>
         <delete dir="lib/cachedir"/>
         <delete dir="java/tmp"/>

--- a/java/test/jmri/jmrit/dispatcher/AutoAllocateTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AutoAllocateTest.java
@@ -47,6 +47,7 @@ public class AutoAllocateTest {
 
     @After
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();  // only needed intermittently; better to find and remove, but that would require lots o' refactoring
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalDirectionTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalDirectionTest.java
@@ -59,6 +59,7 @@ public class EditPortalDirectionTest {
 
     @After
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();  // only needed intermittently; better to find and remove, but that would require lots o' refactoring
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalFrameTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalFrameTest.java
@@ -58,6 +58,7 @@ public class EditPortalFrameTest {
 
     @After
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();  // only needed intermittently; better to find and remove, but that would require lots o' refactoring
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
This adds a `clearShutDownManager` to `tearDown` in three tests classes that are intermittently showing ERROR due to a left-over ShutDownManager from during tests.  Left comments so that perhaps somebody will try to find and fix the underlying cause some day.