### PR TITLE
Organize LayoutEditor.HitPointType interface

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -444,6 +444,8 @@
             <fileset file="release.zip"/>
             <fileset file="spotbugs.html"/>
             <fileset file="spotbugs-check.html"/>
+            <fileset file="spotbugs.xml"/>
+            <fileset file="spotbugs-check.xml"/>
             <fileset dir="." includes="hs_err_pid*.log"/>
         </delete>
     </target>
@@ -464,8 +466,6 @@
             <fileset file="junit-results.xml"/>
             <fileset file="findbugs.html"/>
             <fileset file="findbugs.xml"/>
-            <fileset file="spotbugs.html"/>
-            <fileset file="spotbugs.xml"/>
             <fileset file="jacoco.exec"/>
             <fileset file="jmri-fb.html"/>
             <fileset file="coveragereport"/>

--- a/build.xml
+++ b/build.xml
@@ -442,6 +442,8 @@
             <fileset file=".ant-targets-build.xml"/>
             <fileset file=".run.sh"/>
             <fileset file="release.zip"/>
+            <fileset file="spotbugs.html"/>
+            <fileset file="spotbugs-check.html"/>
             <fileset dir="." includes="hs_err_pid*.log"/>
         </delete>
     </target>

--- a/java/src/jmri/jmrit/display/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryIcon.java
@@ -395,7 +395,7 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
                     setText(((Reportable)val).toReportString());
                     setIcon(null);
                 } else {
-                    log.warn("can't display current value of {}, val= {} of Class ",
+                    log.warn("can't display current value of {}, val= {} of Class {}",
                             getNameString(), val, val.getClass().getName());
                 }
             } else {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -2839,11 +2839,10 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
      * Provide an output to the console of all our neighbouring blocks.
      */
     public void printAdjacencies() {
-        log.info("");
-        log.info("Adjacencies for block " + this.getDisplayName());
+        log.info("Adjacencies for block {}", this.getDisplayName());
         log.info("Neighbour, Direction, mutual, relationship, metric");
         for (Adjacencies neighbour : neighbours) {
-            log.info(neighbour.getBlock().getDisplayName() + ", " + Path.decodeDirection(neighbour.getDirection()) + ", " + neighbour.isMutual() + ", " + decodePacketFlow(neighbour.getPacketFlow()) + ", " + neighbour.getMetric());
+            log.info("{}, {}, {}, {}, {}",neighbour.getBlock().getDisplayName(), Path.decodeDirection(neighbour.getDirection()), neighbour.isMutual(), decodePacketFlow(neighbour.getPacketFlow()), neighbour.getMetric());
         }
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -244,9 +244,9 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
         try {
             new BlockValueFile().readBlockValues();
         } catch (org.jdom2.JDOMException jde) {
-            log.error("JDOM Exception when retreiving block values {}", jde);
+            log.error("JDOM Exception when retreiving block values", jde);
         } catch (java.io.IOException ioe) {
-            log.error("I/O Exception when retreiving block values {}", ioe);
+            log.error("I/O Exception when retreiving block values", ioe);
         }
 
         //special tests for getFacingSignalHead method - comment out next three lines unless using LayoutEditorTests

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutConnectivity.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutConnectivity.java
@@ -226,7 +226,7 @@ public class LayoutConnectivity {
         hash = 37 * hash + direction;
         hash = 37 * hash + (this.track1 != null ? this.track1.hashCode() : 0);
         hash = 37 * hash + (this.connect2 != null ? this.connect2.hashCode() : 0);
-        hash = 37 * hash + typeConnect2.getXmlValue();
+        hash = 37 * hash + typeConnect2.hashCode();
         hash = 37 * hash + (this.xover != null ? this.xover.hashCode() : 0);
         hash = 37 * hash + (this.anchor != null ? this.anchor.hashCode() : 0);
         return hash;

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -397,13 +397,13 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         }   // isPopupHitType
        
        // *****************************************************************
-       //    Turntable Ray support
+       //    TURNTABLE_RAY support
        // *****************************************************************
        
        /**
         * Find the 0-63 index with respect to TURNTABLE_RAY_0
         * of a given enum entry.  Throws {@link IllegalArgumentException} if
-        * the given enum value isn't one of the TURNTABLE_RAY entries.
+        * the given enum value isn't one of the TURNTABLE_RAY_n entries.
         * <p>
         * Ideally, this would be replaced by turntable code that works
         * directly with the enum values as a step toward using objects
@@ -450,13 +450,13 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         }
 
        // *****************************************************************
-       //    Shape Point support
+       //    SHAPE_POINT support
        // *****************************************************************
        
        /**
         * Find the 0-9 index with respect to SHAPE_POINT_0
         * of a given enum entry.  Throws {@link IllegalArgumentException} if
-        * the given enum value isn't one of the SHAPE_POINT_0 entries.
+        * the given enum value isn't one of the SHAPE_POINT_n entries.
         * <p>
         * Ideally, this would be replaced by shape code that works
         * directly with the enum values as a step toward using objects
@@ -500,8 +500,46 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                     && (t.compareTo(SHAPE_POINT_9) <= 0));
         }
 
+        // limited use, remove?
+        public final static int NUM_SHAPE_POINTS = 10;
 
 
+       // *****************************************************************
+       //    BEZIER_CONTROL_POINT support
+       // *****************************************************************
+       
+       /**
+        * Find the 0-8 index with respect to BEZIER_CONTROL_POINT_0
+        * of a given enum entry.  Throws {@link IllegalArgumentException} if
+        * the given enum value isn't one of the BEZIER_CONTROL_POINT_n entries.
+        * <p>
+        * Ideally, this would be replaced by bezier code that works
+        * directly with the enum values as a step toward using objects
+        * to implement hit points.
+        */
+        protected int bezierPointIndex() {
+            int result = this.xmlValue - HitPointType.BEZIER_CONTROL_POINT_0.xmlValue;
+            if (result < 0) throw new IllegalArgumentException(this.toString()+ "is not a valid BEZIER_CONTROL_POINT");
+            if (result > 8) throw new IllegalArgumentException(this.toString()+ "is not a valid BEZIER_CONTROL_POINT");
+            return result;
+        }
+
+       /**
+        * Return a specific SHAPE_POINT from its 0-8 index.
+        * Throws {@link IllegalArgumentException} if
+        * the given index value isn't valid for the SHAPE_POINT entries.
+        * <p>
+        * Ideally, this would be replaced by shape code that works
+        * directly with the enum values as a step toward using objects
+        * to implement hit points.
+        */
+        protected static HitPointType bezierPointIndexedValue(int i) {
+            if (i<0 || i>8 ) throw new IllegalArgumentException(i+ "is not a valid BEZIER_CONTROL_POINT index");
+            return getValue(BEZIER_CONTROL_POINT_0.xmlValue+i);
+        }
+        
+        // limited use, remove?
+        public final static int NUM_BEZIER_CONTROL_POINTS = 9;
     }
 
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -379,7 +379,58 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             }
             return result;
         }   // isPopupHitType
+       
+       /**
+        * Find the 0-63 index with respect to TURNTABLE_RAY_0
+        * of a given enum entry.  Throws {@link IllegalArgumentException} if
+        * the given enum value isn't one of the TURNTABLE_RAY entries.
+        * <p>
+        * Ideally, this would be replaced by turntable code that works
+        * directly with the enum values as a step toward using objects
+        * to implement hit points.
+        */
+        protected int turntableTrackIndex() {
+            int result = this.xmlValue - HitPointType.TURNTABLE_RAY_0.xmlValue;
+            if (result < 0) throw new IllegalArgumentException(this.toString()+ "is not a valid TURNTABLE_RAY");
+            return result;
+        }
+
+       /**
+        * Return a specific TURNTABLE_RAY from its 0-63 index.
+        * Throws {@link IllegalArgumentException} if
+        * the given index value isn't valid for the TURNTABLE_RAY entries.
+        * <p>
+        * Ideally, this would be replaced by turntable code that works
+        * directly with the enum values as a step toward using objects
+        * to implement hit points.
+        */
+        protected static HitPointType turntableTrackIndexedValue(int i) {
+            if (i<0 || i>63 ) throw new IllegalArgumentException(i+ "is not a valid TURNTABLE_RAY index");
+            return getValue(TURNTABLE_RAY_0.xmlValue+i);
+        }
+        
+        
+       /**
+        * Return an array of the valid TURNTABLE_RAY enum values.
+        * Meant for interations over the set of rays.  Order is 
+        * from 0 to 63.
+        */
+        protected static HitPointType[] turntableValues() {
+            return new HitPointType[]{
+                     TURNTABLE_RAY_0,  TURNTABLE_RAY_1,  TURNTABLE_RAY_2,  TURNTABLE_RAY_3,  TURNTABLE_RAY_4,  TURNTABLE_RAY_5,  TURNTABLE_RAY_6,  TURNTABLE_RAY_7,
+                     TURNTABLE_RAY_8,  TURNTABLE_RAY_9, TURNTABLE_RAY_10, TURNTABLE_RAY_11, TURNTABLE_RAY_12, TURNTABLE_RAY_13, TURNTABLE_RAY_14, TURNTABLE_RAY_15,
+                    TURNTABLE_RAY_16, TURNTABLE_RAY_17, TURNTABLE_RAY_18, TURNTABLE_RAY_19, TURNTABLE_RAY_20, TURNTABLE_RAY_21, TURNTABLE_RAY_22, TURNTABLE_RAY_23,
+                    TURNTABLE_RAY_24, TURNTABLE_RAY_25, TURNTABLE_RAY_26, TURNTABLE_RAY_27, TURNTABLE_RAY_28, TURNTABLE_RAY_29, TURNTABLE_RAY_30, TURNTABLE_RAY_31,
+                    TURNTABLE_RAY_32, TURNTABLE_RAY_33, TURNTABLE_RAY_34, TURNTABLE_RAY_35, TURNTABLE_RAY_36, TURNTABLE_RAY_37, TURNTABLE_RAY_38, TURNTABLE_RAY_39,
+                    TURNTABLE_RAY_40, TURNTABLE_RAY_41, TURNTABLE_RAY_42, TURNTABLE_RAY_43, TURNTABLE_RAY_44, TURNTABLE_RAY_45, TURNTABLE_RAY_46, TURNTABLE_RAY_47,
+                    TURNTABLE_RAY_48, TURNTABLE_RAY_49, TURNTABLE_RAY_50, TURNTABLE_RAY_51, TURNTABLE_RAY_52, TURNTABLE_RAY_53, TURNTABLE_RAY_54, TURNTABLE_RAY_55,
+                    TURNTABLE_RAY_56, TURNTABLE_RAY_57, TURNTABLE_RAY_58, TURNTABLE_RAY_59, TURNTABLE_RAY_60, TURNTABLE_RAY_61, TURNTABLE_RAY_62, TURNTABLE_RAY_63
+                };
+        }
     }
+
+
+
 
     //Operational instance variables - not saved to disk
     private transient JmriJFrame floatingEditToolBoxFrame = null;
@@ -3657,7 +3708,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                     && !event.isShiftDown() && !event.isControlDown()) {
                 //controlling turntable, in edit mode
                 LayoutTurntable t = (LayoutTurntable) selectedObject;
-                t.setPosition(selectedHitPointType.getXmlValue() - HitPointType.TURNTABLE_RAY_0.getXmlValue());
+                t.setPosition(selectedHitPointType.turntableTrackIndex());
             } else if ((selectedObject != null) && ((selectedHitPointType == HitPointType.TURNOUT_CENTER)
                     || (selectedHitPointType == HitPointType.SLIP_CENTER)
                     || (selectedHitPointType == HitPointType.SLIP_LEFT)
@@ -3706,7 +3757,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 && !event.isShiftDown() && (!delayedPopupTrigger)) {
             // controlling turntable out of edit mode
             LayoutTurntable t = (LayoutTurntable) selectedObject;
-            t.setPosition(selectedHitPointType.getXmlValue() - HitPointType.TURNTABLE_RAY_0.getXmlValue());
+            t.setPosition( selectedHitPointType.turntableTrackIndex() );
         } else if ((event.isPopupTrigger() || delayedPopupTrigger) && (!isDragging)) {
             // requesting marker popup out of edit mode
             LocoIcon lo = checkMarkerPopUps(dLoc);
@@ -3798,7 +3849,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             } else if (HitPointType.isTurntableRayHitType(foundHitPointType)) {
                 LayoutTurntable t = (LayoutTurntable) foundTrack;
                 if (t.isTurnoutControlled()) {
-                    ((LayoutTurntable) foundTrack).showRayPopUp(event, foundHitPointType.getXmlValue() - HitPointType.TURNTABLE_RAY_0.getXmlValue());
+                    ((LayoutTurntable) foundTrack).showRayPopUp(event, foundHitPointType.turntableTrackIndex());
                 }
             } else if (HitPointType.isPopupHitType(foundHitPointType)) {
                 foundTrack.showPopup(event);
@@ -4128,7 +4179,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 default: {
                     if (HitPointType.isTurntableRayHitType(foundHitPointType)) {
                         LayoutTurntable tt = (LayoutTurntable) foundTrack;
-                        int ray = foundHitPointType.getXmlValue() - HitPointType.TURNTABLE_RAY_0.getXmlValue();
+                        int ray = foundHitPointType.turntableTrackIndex();
 
                         if (tt.getRayConnectIndexed(ray) == null) {
                             tt.setRayConnect(t, ray);
@@ -4954,7 +5005,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                             } else if (HitPointType.isTurntableRayHitType(selectedHitPointType)) {
                                 LayoutTurntable turn = (LayoutTurntable) selectedObject;
                                 turn.setRayCoordsIndexed(currentPoint.getX(), currentPoint.getY(),
-                                        selectedHitPointType.getXmlValue() - HitPointType.TURNTABLE_RAY_0.getXmlValue());
+                                        selectedHitPointType.turntableTrackIndex());
                             }
                             break;
                         }
@@ -5481,7 +5532,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             default: {
                 if (HitPointType.isTurntableRayHitType(fromPointType)) {
                     ((LayoutTurntable) fromObject).setRayConnect((TrackSegment) toObject,
-                            fromPointType.getXmlValue() - HitPointType.TURNTABLE_RAY_0.getXmlValue());
+                            fromPointType.turntableTrackIndex() );
                 }
                 break;
             }
@@ -6362,7 +6413,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
 
             default: {
                 if (HitPointType.isTurntableRayHitType(type)) {
-                    ((LayoutTurntable) o).setRayConnect(null, type.getXmlValue() - HitPointType.TURNTABLE_RAY_0.getXmlValue());
+                    ((LayoutTurntable) o).setRayConnect(null, type.turntableTrackIndex());
                 }
                 break;
             }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -183,7 +183,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         TURNTABLE_RAY_62(112), // /
         TURNTABLE_RAY_63(113); // offset for turntable connection points (maximum)
 
-        private final transient Integer xmlValue;
+        private final transient Integer xmlValue;  // access to this should be replaced by ordinal()
 
         /** 
          * @deprecated 4.19.6 - we are migrating away from integer access
@@ -194,10 +194,10 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         }
 
         /** 
-         * @deprecated 4.19.6 - we are migrating away from integer access
+         * @deprecated 4.19.6 - we are migrating away from integer access, prefer .ordinal() for tests
          */
-        @Deprecated  // 4.19.6 - we are migrating away from integer access
-        public static HitPointType getValue(Integer xmlValue) {
+        @Deprecated  // 4.19.6 - we are migrating away from integer access, prefer .ordinal() for tests
+        private static HitPointType getValue(Integer xmlValue) {
             HitPointType result = null;
             for (HitPointType instance : HitPointType.values()) {
                 if (instance.xmlValue.equals(xmlValue)) {
@@ -209,25 +209,11 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         }
 
         /** 
-         * @deprecated 4.19.6 - we are migrating away from integer access
+         * @deprecated 4.19.6 - we are migrating away from integer access, prefer .ordinal() for tests
          */
-        @Deprecated  // 4.19.6 - we are migrating away from integer access
-        private static HitPointType XgetValue(String name) {
-            HitPointType result = null;
-            for (HitPointType instance : HitPointType.values()) {
-                if (instance.name().equals(name)) {
-                    result = instance;
-                }
-            }
-            return result;
-        }
-
-        /** 
-         * @deprecated 4.19.6 - we are migrating away from integer access
-         */
-        @Deprecated  // 4.19.6 - we are migrating away from integer access
-        protected Integer getXmlValue() {
-            return xmlValue;
+        @Deprecated  // 4.19.6 - we are migrating away from integer access, prefer .ordinal() for tests
+        Integer getXmlValue() {
+           return xmlValue;
         }
 
         /**
@@ -235,7 +221,6 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
          * @return true if this is for a connection to a LayoutTrack
          */
         protected static boolean isConnectionHitType(HitPointType hitType) {
-            boolean result = false; // assume failure (pessimist!)
             switch (hitType) {
                 case POS_POINT:
                 case TURNOUT_A:
@@ -251,8 +236,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 case SLIP_B:
                 case SLIP_C:
                 case SLIP_D:
-                    result = true;  // these are all connection types
-                    break;
+                    return true;  // these are all connection types
                 case NONE:
                 case TURNOUT_CENTER:
                 case LEVEL_XING_CENTER:
@@ -265,17 +249,17 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 case SLIP_CENTER:
                 case SLIP_LEFT:
                 case SLIP_RIGHT:
+                    return false; // these are not
                 default:
-                    result = false; // these are not
                     break;
             }
             if (isBezierHitType(hitType)) {
-                result = false; // these are not
+                return false; // these are not
             } else if (isTurntableRayHitType(hitType)) {
-                result = true;  // these are all connection types
+                return true;  // these are all connection types
             }
-            return result;
-        }   // isConnectionHitType
+            return false;  // This is unexpected
+        }
 
         /**
          * @param hitType the hit point type
@@ -288,8 +272,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 case SLIP_CENTER:
                 case SLIP_LEFT:
                 case SLIP_RIGHT:
-                    result = true;  // these are all control types
-                    break;
+                    return true;  // these are all control types
                 case POS_POINT:
                 case TURNOUT_A:
                 case TURNOUT_B:
@@ -312,17 +295,17 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 case MULTI_SENSOR:
                 case MARKER:
                 case TRACK_CIRCLE_CENTRE:
+                    return false; // these are not
                 default:
-                    result = false; // these are not
                     break;
             }
             if (isBezierHitType(hitType)) {
-                result = false; // these are not control types
+                return false; // these are not control types
             } else if (isTurntableRayHitType(hitType)) {
-                result = true;  // these are all control types
+                return true;  // these are all control types
             }
-            return result;
-        }   // isControlHitType
+            return false;   // This is unexpected
+        }
 
         protected static boolean isTurnoutHitType(HitPointType hitType) {
             return ((hitType.compareTo(HitPointType.TURNOUT_A) >= 0)
@@ -365,8 +348,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 case TRACK_CIRCLE_CENTRE:
                 case TURNOUT_CENTER:
                 case TURNTABLE_CENTER:
-                    result = true;  // these are all popup hit types
-                    break;
+                    return true;
                 case LAYOUT_POS_JCOMP:
                 case LAYOUT_POS_LABEL:
                 case LEVEL_XING_A:
@@ -384,17 +366,17 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 case TURNOUT_B:
                 case TURNOUT_C:
                 case TURNOUT_D:
+                    return false; // these are not
                 default:
-                    result = false; // these are not
                     break;
             }
             if (isBezierHitType(hitType)) {
-                result = true; // these are all popup hit types
+                return true; // these are all popup hit types
             } else if (isTurntableRayHitType(hitType)) {
-                result = true;  // these are all popup hit types
+                return true;  // these are all popup hit types
             }
-            return result;
-        }   // isPopupHitType
+            return false;
+        }
        
        // *****************************************************************
        //    TURNTABLE_RAY support
@@ -5108,7 +5090,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
 
                         default: {
                             if (HitPointType.isBezierHitType(foundHitPointType)) {
-                                int index = selectedHitPointType.getXmlValue() - HitPointType.BEZIER_CONTROL_POINT_0.getXmlValue();
+                                int index = selectedHitPointType.bezierPointIndex();
                                 ((TrackSegment) selectedObject).setBezierControlPoint(currentPoint, index);
                             } else if ((selectedHitPointType == HitPointType.SHAPE_CENTER)) {
                                 ((LayoutShape) selectedObject).setCoordsCenter(currentPoint);

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -185,10 +185,18 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
 
         private final transient Integer xmlValue;
 
-        HitPointType(Integer xmlValue) {
+        /** 
+         * @deprecated 4.19.6 - we are migrating away from integer access
+         */
+        @Deprecated  // 4.19.6 - we are migrating away from integer access
+        private HitPointType(Integer xmlValue) {
             this.xmlValue = xmlValue;
         }
 
+        /** 
+         * @deprecated 4.19.6 - we are migrating away from integer access
+         */
+        @Deprecated  // 4.19.6 - we are migrating away from integer access
         public static HitPointType getValue(Integer xmlValue) {
             HitPointType result = null;
             for (HitPointType instance : HitPointType.values()) {
@@ -200,7 +208,11 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             return result;
         }
 
-        public static HitPointType getValue(String name) {
+        /** 
+         * @deprecated 4.19.6 - we are migrating away from integer access
+         */
+        @Deprecated  // 4.19.6 - we are migrating away from integer access
+        private static HitPointType XgetValue(String name) {
             HitPointType result = null;
             for (HitPointType instance : HitPointType.values()) {
                 if (instance.name().equals(name)) {
@@ -210,7 +222,11 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             return result;
         }
 
-        public Integer getXmlValue() {
+        /** 
+         * @deprecated 4.19.6 - we are migrating away from integer access
+         */
+        @Deprecated  // 4.19.6 - we are migrating away from integer access
+        protected Integer getXmlValue() {
             return xmlValue;
         }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -266,7 +266,6 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
          * @return true if this hit type is for a layout control
          */
         protected static boolean isControlHitType(HitPointType hitType) {
-            boolean result = false; // assume failure (pessimist!)
             switch (hitType) {
                 case TURNOUT_CENTER:
                 case SLIP_CENTER:
@@ -337,7 +336,6 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
          * @return true if this is for a popup menu
          */
         protected static boolean isPopupHitType(HitPointType hitType) {
-            boolean result = false; // assume failure (pessimist!)
             switch (hitType) {
                 case LEVEL_XING_CENTER:
                 case POS_POINT:

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -380,6 +380,10 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             return result;
         }   // isPopupHitType
        
+       // *****************************************************************
+       //    Turntable Ray support
+       // *****************************************************************
+       
        /**
         * Find the 0-63 index with respect to TURNTABLE_RAY_0
         * of a given enum entry.  Throws {@link IllegalArgumentException} if
@@ -391,7 +395,8 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         */
         protected int turntableTrackIndex() {
             int result = this.xmlValue - HitPointType.TURNTABLE_RAY_0.xmlValue;
-            if (result < 0) throw new IllegalArgumentException(this.toString()+ "is not a valid TURNTABLE_RAY");
+            if (result < 0)  throw new IllegalArgumentException(this.toString()+ "is not a valid TURNTABLE_RAY");
+            if (result > 63) throw new IllegalArgumentException(this.toString()+ "is not a valid TURNTABLE_RAY");
             return result;
         }
 
@@ -427,6 +432,60 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                     TURNTABLE_RAY_56, TURNTABLE_RAY_57, TURNTABLE_RAY_58, TURNTABLE_RAY_59, TURNTABLE_RAY_60, TURNTABLE_RAY_61, TURNTABLE_RAY_62, TURNTABLE_RAY_63
                 };
         }
+
+       // *****************************************************************
+       //    Shape Point support
+       // *****************************************************************
+       
+       /**
+        * Find the 0-9 index with respect to SHAPE_POINT_0
+        * of a given enum entry.  Throws {@link IllegalArgumentException} if
+        * the given enum value isn't one of the SHAPE_POINT_0 entries.
+        * <p>
+        * Ideally, this would be replaced by shape code that works
+        * directly with the enum values as a step toward using objects
+        * to implement hit points.
+        */
+        protected int shapePointIndex() {
+            int result = this.xmlValue - HitPointType.SHAPE_POINT_0.xmlValue;
+            if (result < 0) throw new IllegalArgumentException(this.toString()+ "is not a valid SHAPE_POINT");
+            if (result > 9) throw new IllegalArgumentException(this.toString()+ "is not a valid SHAPE_POINT");
+            return result;
+        }
+
+       /**
+        * Return a specific SHAPE_POINT from its 0-9 index.
+        * Throws {@link IllegalArgumentException} if
+        * the given index value isn't valid for the SHAPE_POINT entries.
+        * <p>
+        * Ideally, this would be replaced by shape code that works
+        * directly with the enum values as a step toward using objects
+        * to implement hit points.
+        */
+        protected static HitPointType shapePointIndexedValue(int i) {
+            if (i<0 || i>9 ) throw new IllegalArgumentException(i+ "is not a valid SHAPE_POINT index");
+            return getValue(SHAPE_POINT_0.xmlValue+i);
+        }
+        
+        
+       /**
+        * Return an array of the valid SHAPE_POINT enum values.
+        * Meant for interations over the set of points.  Order is 
+        * from 0 to 9.
+        */
+        protected static HitPointType[] shapePointValues() {
+            return new HitPointType[]{
+                     SHAPE_POINT_0, SHAPE_POINT_1, SHAPE_POINT_2, SHAPE_POINT_3, SHAPE_POINT_4, SHAPE_POINT_5, SHAPE_POINT_6, SHAPE_POINT_7, SHAPE_POINT_8, SHAPE_POINT_9
+                };
+        }
+
+        protected static boolean isShapePointOffsetHitPointType(LayoutEditor.HitPointType t) {
+            return ((t.compareTo(SHAPE_POINT_0) >= 0)
+                    && (t.compareTo(SHAPE_POINT_9) <= 0));
+        }
+
+
+
     }
 
 
@@ -3269,7 +3328,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 selectedObject = null;  // assume we're adding...
                 for (LayoutShape ls : layoutShapes) {
                     selectedHitPointType = ls.findHitPointType(dLoc, true);
-                    if (LayoutShape.isShapePointOffsetHitPointType(selectedHitPointType)) {
+                    if (LayoutEditor.HitPointType.isShapePointOffsetHitPointType(selectedHitPointType)) {
                         //log.warn("extend selectedObject: ", lt);
                         selectedObject = ls;    // nope, we're extending
                         beginLocation.setLocation(dLoc);
@@ -3675,7 +3734,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                         _targetPanel.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
                     } else {
                         LayoutShape ls = (LayoutShape) selectedObject;
-                        ls.addPoint(currentPoint, selectedHitPointType.getXmlValue() - HitPointType.SHAPE_POINT_0.getXmlValue());
+                        ls.addPoint(currentPoint, selectedHitPointType.shapePointIndex());
                     }
                 } else if (leToolBarPanel.signalMastButton.isSelected()) {
                     addSignalMast();
@@ -4999,8 +5058,8 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                                 ((TrackSegment) selectedObject).setBezierControlPoint(currentPoint, index);
                             } else if ((selectedHitPointType == HitPointType.SHAPE_CENTER)) {
                                 ((LayoutShape) selectedObject).setCoordsCenter(currentPoint);
-                            } else if (LayoutShape.isShapePointOffsetHitPointType(selectedHitPointType)) {
-                                int index = selectedHitPointType.getXmlValue() - HitPointType.SHAPE_POINT_0.getXmlValue();
+                            } else if (LayoutEditor.HitPointType.isShapePointOffsetHitPointType(selectedHitPointType)) {
+                                int index = selectedHitPointType.shapePointIndex();
                                 ((LayoutShape) selectedObject).setPoint(index, currentPoint);
                             } else if (HitPointType.isTurntableRayHitType(selectedHitPointType)) {
                                 LayoutTurntable turn = (LayoutTurntable) selectedObject;

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
@@ -292,7 +292,7 @@ public class LayoutShape {
      * @return the maximum number of points
      */
     public int getMaxNumberPoints() {
-        return LayoutEditor.HitPointType.SHAPE_POINT_9.getXmlValue() - LayoutEditor.HitPointType.SHAPE_POINT_0.getXmlValue() + 1;
+        return LayoutEditor.HitPointType.shapePointValues().length;
     }
 
     /**
@@ -330,7 +330,7 @@ public class LayoutShape {
             }
             for (int idx = 0; idx < shapePoints.size(); idx++) {
                 if (r.contains(shapePoints.get(idx).getPoint())) {
-                    result = LayoutEditor.HitPointType.getValue(LayoutEditor.HitPointType.SHAPE_POINT_0.getXmlValue() + idx);
+                    result = LayoutEditor.HitPointType.shapePointIndexedValue(idx);
                     break;
                 }
             }
@@ -340,7 +340,7 @@ public class LayoutShape {
                 distance = MathUtil.distance(shapePoints.get(idx).getPoint(), hitPoint);
                 if (distance < minDistance) {
                     minDistance = distance;
-                    result = LayoutEditor.HitPointType.getValue(LayoutEditor.HitPointType.SHAPE_POINT_0.getXmlValue() + idx);
+                    result = LayoutEditor.HitPointType.shapePointIndexedValue(idx);
                 }
             }
         }
@@ -349,12 +349,7 @@ public class LayoutShape {
 
     public static boolean isShapeHitPointType(LayoutEditor.HitPointType t) {
         return ((t == LayoutEditor.HitPointType.SHAPE_CENTER)
-                || isShapePointOffsetHitPointType(t));
-    }
-
-    public static boolean isShapePointOffsetHitPointType(LayoutEditor.HitPointType t) {
-        return ((t.compareTo(LayoutEditor.HitPointType.SHAPE_POINT_0) >= 0)
-                && (t.compareTo(LayoutEditor.HitPointType.SHAPE_POINT_9) <= 0));
+                || LayoutEditor.HitPointType.isShapePointOffsetHitPointType(t));
     }
 
     /**
@@ -428,7 +423,7 @@ public class LayoutShape {
             popup = new JPopupMenu();
         }
         if (layoutEditor.isEditable()) {
-            int pointIndex = hitPointType.getXmlValue() - LayoutEditor.HitPointType.SHAPE_POINT_0.getXmlValue();
+            int pointIndex = hitPointType.shapePointIndex();
 
             //JMenuItem jmi = popup.add(Bundle.getMessage("MakeLabel", Bundle.getMessage("LayoutShape")) + getName());
             JMenuItem jmi = popup.add(Bundle.getMessage("ShapeNameMenuItemTitle", getName()));

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
@@ -292,7 +292,7 @@ public class LayoutShape {
      * @return the maximum number of points
      */
     public int getMaxNumberPoints() {
-        return LayoutEditor.HitPointType.shapePointValues().length;
+        return LayoutEditor.HitPointType.NUM_SHAPE_POINTS;
     }
 
     /**

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTrack.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTrack.java
@@ -49,9 +49,6 @@ public abstract class LayoutTrack {
 //     public static final int BEZIER_CONTROL_POINT_OFFSET_MIN = 30; // offset for TrackSegment Bezier control points (minimum)
 //     public static final int BEZIER_CONTROL_POINT_OFFSET_MAX = 38; // offset for TrackSegment Bezier control points (maximum)
 //     public static final int SHAPE_CENTER = 39;
-//     public static final int SHAPE_POINT_OFFSET_MIN = 40; // offset for Shape points (minimum)
-//     public static final int SHAPE_POINT_OFFSET_MAX = 49; // offset for Shape points (maximum)
-//     public static final int TURNTABLE_RAY_OFFSET = 50; // offset for turntable connection points
     // operational instance variables (not saved between sessions)
     protected LayoutEditor layoutEditor = null;
     protected String ident = "";

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntable.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntable.java
@@ -161,7 +161,7 @@ public class LayoutTurntable extends LayoutTrack {
      * Get the connection for the ray with this index.
      *
      * @param index the index
-     * @return the connection for the ray with this index
+     * @return the connection for the ray with this value of getConnectionIndex
      */
     public TrackSegment getRayConnectIndexed(int index) {
         TrackSegment result = null;
@@ -178,7 +178,7 @@ public class LayoutTurntable extends LayoutTrack {
      * Get the connection for the ray at the index in the rayList.
      *
      * @param i the index in the rayList
-     * @return the connection for the ray at that index in the rayList
+     * @return the connection for the ray at that index in the rayList or null
      */
     public TrackSegment getRayConnectOrdered(int i) {
         TrackSegment result = null;
@@ -466,8 +466,7 @@ public class LayoutTurntable extends LayoutTrack {
             // nothing to see here, move along...
             // (results are already correct)
         } else if (LayoutEditor.HitPointType.isTurntableRayHitType(connectionType)) {
-            result = getRayCoordsIndexed(connectionType.getXmlValue()
-                    - LayoutEditor.HitPointType.TURNTABLE_RAY_0.getXmlValue());
+            result = getRayCoordsIndexed(connectionType.turntableTrackIndex());
         } else {
             log.error("{}.getCoordsForConnectionType({}); Invalid connection type",
                     getName(), connectionType); // NOI18N
@@ -482,7 +481,7 @@ public class LayoutTurntable extends LayoutTrack {
     public LayoutTrack getConnection(LayoutEditor.HitPointType connectionType) throws jmri.JmriException {
         LayoutTrack result = null;
         if (LayoutEditor.HitPointType.isTurntableRayHitType(connectionType)) {
-            result = getRayConnectIndexed(connectionType.getXmlValue() - LayoutEditor.HitPointType.TURNTABLE_RAY_0.getXmlValue());
+            result = getRayConnectIndexed(connectionType.turntableTrackIndex());
         } else {
             String errString = MessageFormat.format("{0}.getCoordsForConnectionType({1}); Invalid connection type",
                     getName(), connectionType); // NOI18N
@@ -505,7 +504,7 @@ public class LayoutTurntable extends LayoutTrack {
         }
         if (LayoutEditor.HitPointType.isTurntableRayHitType(connectionType)) {
             if ((o == null) || (o instanceof TrackSegment)) {
-                setRayConnect((TrackSegment) o, connectionType.getXmlValue() - LayoutEditor.HitPointType.TURNTABLE_RAY_0.getXmlValue());
+                setRayConnect((TrackSegment) o, connectionType.turntableTrackIndex());
             } else {
                 String errString = MessageFormat.format("{0}.setConnection({1}, {2}, {3}); Invalid object: {4}",
                         getName(), connectionType, o.getName(),
@@ -643,7 +642,7 @@ public class LayoutTurntable extends LayoutTrack {
                 if (distance < minDistance) {
                     minDistance = distance;
                     minPoint = p;
-                    result = LayoutEditor.HitPointType.getValue(LayoutEditor.HitPointType.TURNTABLE_RAY_0.getXmlValue() + getRayIndex(k));
+                    result = LayoutEditor.HitPointType.turntableTrackIndexedValue(k);
                 }
             }
         }
@@ -1212,10 +1211,11 @@ public class LayoutTurntable extends LayoutTrack {
      */
     @Override
     protected void highlightUnconnected(Graphics2D g2, LayoutEditor.HitPointType specificType) {
-        int specificTypeValue = specificType.getXmlValue();
         for (int j = 0; j < getNumberRays(); j++) {
-            if ((specificType == LayoutEditor.HitPointType.NONE)
-                    || (specificTypeValue == (LayoutEditor.HitPointType.TURNTABLE_RAY_0.getXmlValue() + j))) {
+            if (  (specificType == LayoutEditor.HitPointType.NONE)
+                    || (specificType == (LayoutEditor.HitPointType.turntableTrackIndexedValue(j)))
+                ) 
+            {
                 if (getRayConnectOrdered(j) == null) {
                     Point2D pt = getRayCoordsOrdered(j);
                     g2.fill(trackControlCircleAt(pt));
@@ -1294,7 +1294,7 @@ public class LayoutTurntable extends LayoutTrack {
 
         for (int k = 0; k < getNumberRays(); k++) {
             if (getRayConnectOrdered(k) == null) {
-                result.add(LayoutEditor.HitPointType.getValue(LayoutEditor.HitPointType.TURNTABLE_RAY_0.getXmlValue() + getRayIndex(k)));
+                result.add(LayoutEditor.HitPointType.turntableTrackIndexedValue(k));
             }
         }
         return result;

--- a/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
@@ -1043,7 +1043,7 @@ public class LevelXing extends LayoutTrack {
                     lb.incrementUse();
                 }
             } else {
-                log.error("{}.setObjects(); bad blockname BD ''{}''", tLayoutBlockNameBD);
+                log.error("{}.setObjects(); bad blockname BD ''{}''", this, tLayoutBlockNameBD);
                 namedLayoutBlockBD = null;
             }
             tLayoutBlockNameBD = null; //release this memory

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -694,7 +694,7 @@ public class TrackSegment extends LayoutTrack {
                     if (distance < minDistance) {
                         minDistance = distance;
                         minPoint = p;
-                        result = LayoutEditor.HitPointType.getValue(LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_0.getXmlValue() + index);
+                        result = LayoutEditor.HitPointType.bezierPointIndexedValue(index);
                     }
                 }
             }
@@ -726,18 +726,9 @@ public class TrackSegment extends LayoutTrack {
         if (connectionType == LayoutEditor.HitPointType.TRACK_CIRCLE_CENTRE) {
             result = getCoordsCenterCircle();
         } else if (LayoutEditor.HitPointType.isBezierHitType(connectionType)) {
-            result = getBezierControlPoint(connectionType.getXmlValue() - LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_0.getXmlValue());
+            result = getBezierControlPoint(connectionType.bezierPointIndex());
         }
         return result;
-    }
-
-    /**
-     * get the maximum number of bezier points
-     *
-     * @return the maximum number of points
-     */
-    public int getMaxNumberBezierPoints() {
-        return LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_8.getXmlValue() - LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_0.getXmlValue() + 1;
     }
 
     /**
@@ -1792,7 +1783,7 @@ public class TrackSegment extends LayoutTrack {
      * Display popup menu for information and editing.
      */
     protected void showBezierPopUp(MouseEvent e, LayoutEditor.HitPointType hitPointType) {
-        int bezierControlPointIndex = hitPointType.getXmlValue() - LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_0.getXmlValue();
+        int bezierControlPointIndex = hitPointType.bezierPointIndex();
         if (popupMenu != null) {
             popupMenu.removeAll();
         } else {
@@ -1803,7 +1794,7 @@ public class TrackSegment extends LayoutTrack {
         jmi.setEnabled(false);
         popupMenu.add(new JSeparator(JSeparator.HORIZONTAL));
 
-        if (bezierControlPoints.size() <= getMaxNumberBezierPoints()) {
+        if (bezierControlPoints.size() <= LayoutEditor.HitPointType.NUM_BEZIER_CONTROL_POINTS) {
             popupMenu.add(new AbstractAction(Bundle.getMessage("AddBezierControlPointAfter")) {
 
                 @Override

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutBlockManagerXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutBlockManagerXml.java
@@ -57,7 +57,7 @@ public class LayoutBlockManagerXml extends jmri.managers.configurexml.AbstractNa
             if (sname == null) {
                 log.error("System name null during LayoutBlock store");
             } else {
-                log.debug("layoutblock system name is " + sname);
+                log.debug("layoutblock system name is {}", sname);
                 LayoutBlock b = tm.getBySystemName(sname);
                 // save only those LayoutBlocks that are in use--skip abandoned ones
                 if (b!=null && b.getUseCount() > 0) {
@@ -133,15 +133,13 @@ public class LayoutBlockManagerXml extends jmri.managers.configurexml.AbstractNa
 
         List<Element> layoutblockList = layoutblocks.getChildren("layoutblock");
         if (log.isDebugEnabled()) {
-            log.debug("Found " + layoutblockList.size() + " layoutblocks");
+            log.debug("Found {} layoutblocks" + layoutblockList.size());
         }
 
         for (Element e : layoutblockList) {
             String sysName = getSystemName(e);
             if (sysName == null) {
-                log.warn("unexpected null in systemName "
-                        + e + " "
-                        + e.getAttributes());
+                log.warn("unexpected null in systemName {} {}", e, e.getAttributes());
                 break;
             }
 
@@ -198,7 +196,7 @@ public class LayoutBlockManagerXml extends jmri.managers.configurexml.AbstractNa
                     try {
                         b.setBlockMetric(Integer.parseInt(stMetric));
                     } catch (java.lang.NumberFormatException ex) {
-                        log.error("failed to convert metric attribute for block " + b.getDisplayName());
+                        log.error("failed to convert metric attribute for block {}", b.getDisplayName());
                     }
                 }
             }

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutEditorXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutEditorXml.java
@@ -133,7 +133,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
                 panel.addContent(e);
             }
         } catch (Exception e) {
-            log.error("Error storing contents element: " + e);
+            log.error("Error storing contents element: {}", e);
         }
 
         // note: moving zoom attribute into per-window user preference
@@ -150,7 +150,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
                         panel.addContent(e);
                     }
                 } catch (Exception e) {
-                    log.error("Error storing contents element: " + e);
+                    log.error("Error storing contents element: {}", e);
                 }
             } else {
                 log.warn("Null entry found when storing panel contents.");
@@ -161,7 +161,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
         List<LayoutTrack> layoutTracks = p.getLayoutTracks();
         num = layoutTracks.size();
         if (log.isDebugEnabled()) {
-            log.debug("N LayoutTrack elements: " + num);
+            log.debug("N LayoutTrack elements: {}", num);
         }
 
         // uncomment this (!!!temporarly!!!) to save alphanumerically sorted by ID
@@ -211,7 +211,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
                     panel.addContent(e);
                 }
             } catch (Exception e) {
-                log.error("Error storing layoutturnout element: " + e);
+                log.error("Error storing layoutturnout element: {}", e);
             }
         }
 
@@ -223,7 +223,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
                     panel.addContent(e);
                 }
             } catch (Exception e) {
-                log.error("Error storing layout shape element: " + e);
+                log.error("Error storing layout shape element: {}", e);
             }
         }
 
@@ -302,7 +302,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
             try {
                 xScale = (Float.parseFloat(a.getValue()));
             } catch (NumberFormatException e) {
-                log.error("failed to convert xscale attribute to float - " + a.getValue());
+                log.error("failed to convert xscale attribute to float - {}", a.getValue());
                 result = false;
             }
         }
@@ -310,7 +310,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
             try {
                 yScale = (Float.parseFloat(a.getValue()));
             } catch (NumberFormatException e) {
-                log.error("failed to convert yscale attribute to float - " + a.getValue());
+                log.error("failed to convert yscale attribute to float - {}", a.getValue());
                 result = false;
             }
         }
@@ -437,7 +437,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
             try {
                 panel.setTurnoutBX(Float.parseFloat(a.getValue()));
             } catch (NumberFormatException e) {
-                log.error("failed to convert turnoutbx to float - " + a.getValue());
+                log.error("failed to convert turnoutbx to float - {}", a.getValue());
                 result = false;
             }
         }
@@ -446,7 +446,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
             try {
                 panel.setTurnoutCX(Float.parseFloat(a.getValue()));
             } catch (NumberFormatException e) {
-                log.error("failed to convert turnoutcx to float - " + a.getValue());
+                log.error("failed to convert turnoutcx to float - {}", a.getValue());
                 result = false;
             }
         }
@@ -455,7 +455,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
             try {
                 panel.setTurnoutWid(Float.parseFloat(a.getValue()));
             } catch (NumberFormatException e) {
-                log.error("failed to convert turnoutwid to float - " + a.getValue());
+                log.error("failed to convert turnoutwid to float - {}", a.getValue());
                 result = false;
             }
         }
@@ -464,7 +464,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
             try {
                 panel.setXOverLong(Float.parseFloat(a.getValue()));
             } catch (NumberFormatException e) {
-                log.error("failed to convert xoverlong to float - " + a.getValue());
+                log.error("failed to convert xoverlong to float - {}", a.getValue());
                 result = false;
             }
         }
@@ -472,7 +472,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
             try {
                 panel.setXOverHWid(Float.parseFloat(a.getValue()));
             } catch (NumberFormatException e) {
-                log.error("failed to convert xoverhwid to float - " + a.getValue());
+                log.error("failed to convert xoverhwid to float - {}", a.getValue());
                 result = false;
             }
         }
@@ -480,7 +480,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
             try {
                 panel.setXOverShort(Float.parseFloat(a.getValue()));
             } catch (NumberFormatException e) {
-                log.error("failed to convert xovershort to float - " + a.getValue());
+                log.error("failed to convert xovershort to float - {}", a.getValue());
                 result = false;
             }
         }
@@ -489,7 +489,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
             try {
                 panel.setGridSize(Integer.parseInt(a.getValue()));
             } catch (NumberFormatException e) {
-                log.error("failed to convert gridSize to int - " + a.getValue());
+                log.error("failed to convert gridSize to int - {}", a.getValue());
                 result = false;
             }
         }
@@ -499,7 +499,7 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
             try {
                 panel.setGridSize2nd(Integer.parseInt(a.getValue()));
             } catch (NumberFormatException e) {
-                log.error("failed to convert gridSize2nd to int - " + a.getValue());
+                log.error("failed to convert gridSize2nd to int - {}", a.getValue());
                 result = false;
             }
         }
@@ -647,9 +647,10 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
                 String id = "<null>";
                 try {
                     id = item.getAttribute("name").getValue();
-                    log.debug("Load " + id + " for [" + panel.getName() + "] via " + adapterName);
+                    log.debug("Load {} for [{}] via {}", id, panel.getName(), adapterName);
                 } catch (NullPointerException e) {
                     log.debug("Load layout object for [" + panel.getName() + "] via " + adapterName);
+                    log.debug("Load layout object for [{}] via {}", panel.getName(), adapterName);
                 } catch (RuntimeException e) {
                     throw e;
                 } catch (Exception e) {

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutTurnoutXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutTurnoutXml.java
@@ -22,8 +22,8 @@ import org.slf4j.LoggerFactory;
  */
 public class LayoutTurnoutXml extends AbstractXmlAdapter {
 
-    EnumIO<LayoutTurnout.LinkType> linkEnumMap = new EnumIoOrdinals<>(LayoutTurnout.LinkType.class);
-    EnumIO<LayoutTurnout.TurnoutType> tTypeEnumMap = new EnumIoOrdinals<>(LayoutTurnout.TurnoutType.class);
+    static final EnumIO<LayoutTurnout.LinkType> linkEnumMap = new EnumIoOrdinals<>(LayoutTurnout.LinkType.class);
+    static final EnumIO<LayoutTurnout.TurnoutType> tTypeEnumMap = new EnumIoOrdinals<>(LayoutTurnout.TurnoutType.class);
     
     public LayoutTurnoutXml() {
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentXml.java
@@ -45,9 +45,9 @@ public class TrackSegmentXml extends AbstractXmlAdapter {
             element.setAttribute("blockname", p.getBlockName());
         }
         element.setAttribute("connect1name", p.getConnect1Name());
-        element.setAttribute("type1", "" + p.getType1().name());
+        element.setAttribute("type1", "" + htpMap.outputFromEnum(p.getType1()) );
         element.setAttribute("connect2name", p.getConnect2Name());
-        element.setAttribute("type2", "" + p.getType2().name());
+        element.setAttribute("type2", "" + htpMap.outputFromEnum(p.getType2()) );
         element.setAttribute("dashed", "" + (p.isDashed() ? "yes" : "no"));
         element.setAttribute("mainline", "" + (p.isMainline() ? "yes" : "no"));
         element.setAttribute("hidden", "" + (p.isHidden() ? "yes" : "no"));
@@ -249,8 +249,8 @@ public class TrackSegmentXml extends AbstractXmlAdapter {
                 if (attribute == null) {
                     throw new NullPointerException();
                 }
-                type1 = LayoutEditor.HitPointType.getValue(attribute.getIntValue());
-            } catch (DataConversionException | NullPointerException e1) {
+                type1 = htpMap.inputFromAttribute(attribute);
+            } catch (NullPointerException e1) {
                 log.error("failed to convert tracksegment type1 attribute");
             }
         }
@@ -264,8 +264,8 @@ public class TrackSegmentXml extends AbstractXmlAdapter {
                 if (attribute == null) {
                     throw new NullPointerException();
                 }
-                type2 = LayoutEditor.HitPointType.getValue(attribute.getIntValue());
-            } catch (DataConversionException | NullPointerException e1) {
+                type2 = htpMap.inputFromAttribute(attribute);
+            } catch (NullPointerException e1) {
                 log.error("failed to convert tracksegment type2 attribute");
             }
         }
@@ -619,6 +619,24 @@ public class TrackSegmentXml extends AbstractXmlAdapter {
         }
 
         p.getLayoutTracks().add(l);
+    }
+
+    // create the maps programmatically
+    static final EnumIO<LayoutEditor.HitPointType> htpMap;
+    
+    static {
+        // from map is names and numbers
+        HashMap<String, LayoutEditor.HitPointType> fromMap = new HashMap<>();
+        // to map is names
+        HashMap<LayoutEditor.HitPointType, String> toMap = new HashMap<>();
+
+        for (LayoutEditor.HitPointType h : LayoutEditor.HitPointType.values()) {
+            fromMap.put(h.toString(), h);
+            fromMap.put(""+h.ordinal(), h);  // tests insure equality
+            toMap.put(h, h.toString());
+        }
+        
+        htpMap = new EnumIoMapped<>(LayoutEditor.HitPointType.class, fromMap, toMap);
     }
 
     private final static Logger log = LoggerFactory.getLogger(TrackSegmentXml.class);

--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -56,20 +56,19 @@ public class Log4JUtil {
     // Goal is to be lightweight and fast; this will only be used in a few places,
     // and only those should appear in data structure.
     static public boolean warnOnce(@Nonnull Logger logger, @Nonnull String msg, Object... args) {
-        // the  Map<String, Boolean> is just being checked for existence; it's never False
-        Map<String, Boolean> loggerMap = warnedOnce.get(logger);
-        if (loggerMap == null) {  // if it exists, there was a prior warning given
-            loggerMap = new HashMap<>();
-            warnedOnce.put(logger, loggerMap);
-        } else {
-            if (Boolean.TRUE.equals(loggerMap.get(msg))) return false;
+        Set<String> loggerSet = warnedOnce.get(logger);
+        if (loggerSet == null) { 
+            loggerSet = new HashSet<>();
+            warnedOnce.put(logger, loggerSet);
+        } else {  // if it exists, there was a prior warning given
+            if (loggerSet.contains(msg)) return false;
         }
         warnOnceHasWarned = true;
-        loggerMap.put(msg, Boolean.TRUE);
+        loggerSet.add(msg);
         logger.warn(msg, args);
         return true;
     }
-    static private Map<Logger, Map<String, Boolean>> warnedOnce = new HashMap<>();
+    static private Map<Logger, Set<String>> warnedOnce = new HashMap<>();
     static private boolean warnOnceHasWarned = false;
     
     /**

--- a/java/test/jmri/configurexml/valid/WarrantFileIssue3751.xml
+++ b/java/test/jmri/configurexml/valid/WarrantFileIssue3751.xml
@@ -5035,6 +5035,7 @@
     <tracksegment ident="TUR2011-S-61" connect1name="TUR2011" type1="111" connect2name="A143" type2="1" dashed="no" mainline="no" hidden="no" arc="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="TUR2011-S-62" connect1name="TUR2011" type1="112" connect2name="EB634" type2="1" dashed="no" mainline="no" hidden="no" arc="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="TUR2011-S-63" connect1name="TUR2011" type1="113" connect2name="EB635" type2="1" dashed="no" mainline="no" hidden="no" arc="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+<!-- This 2.9.6 file has a turntable with more than 63 rays (!) which the code no longer supports
     <tracksegment ident="TUR2011-S-64" connect1name="TUR2011" type1="114" connect2name="A142" type2="1" dashed="no" mainline="no" hidden="no" arc="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="TUR2011-S-65" connect1name="TUR2011" type1="115" connect2name="EB636" type2="1" dashed="no" mainline="no" hidden="no" arc="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="TUR2011-S-66" connect1name="TUR2011" type1="116" connect2name="EB637" type2="1" dashed="no" mainline="no" hidden="no" arc="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
@@ -5043,6 +5044,7 @@
     <tracksegment ident="TUR2011-S-69" connect1name="TUR2011" type1="119" connect2name="EB639" type2="1" dashed="no" mainline="no" hidden="no" arc="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="TUR2011-S-70" connect1name="TUR2011" type1="120" connect2name="A112" type2="1" dashed="no" mainline="no" hidden="no" arc="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="TUR2011-S-71" connect1name="TUR2011" type1="121" connect2name="EB640" type2="1" dashed="no" mainline="no" hidden="no" arc="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+ -->
     <tracksegment ident="TS2195" connect1name="A95" type1="1" connect2name="A128" type2="1" dashed="no" mainline="no" hidden="no" arc="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="TC1358" connect1name="A350" type1="1" connect2name="A52" type2="1" dashed="no" mainline="no" hidden="no" arc="yes" flip="no" circle="yes" angle="45.0" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="T-I-TOR2048" blockname="St Blazey Jct Up" connect1name="TOR2048" type1="2" connect2name="A344" type2="1" dashed="no" mainline="no" hidden="no" arc="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -194,19 +194,54 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
         }
     }
 
-    public void testHPTisShapePointOffsetHitPointType() {
-        Assert.assertTrue(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.SHAPE_POINT_0));
-        Assert.assertTrue(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.SHAPE_POINT_1));
+       // *****************************************************************
+       //    Bezier Point support
+       // *****************************************************************
+       
+    @Test
+    public void testHPTbezierPointIndexOK() {
+        Assert.assertEquals(0, LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_0.bezierPointIndex());
+        Assert.assertEquals(1, LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_1.bezierPointIndex());
+        Assert.assertEquals(2, LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_2.bezierPointIndex());
         // ..
-        Assert.assertTrue(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.SHAPE_POINT_8));
-        Assert.assertTrue(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.SHAPE_POINT_9));
-        
-        Assert.assertFalse(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.NONE));
-        Assert.assertFalse(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.SHAPE_CENTER));
-        // ..
-        Assert.assertFalse(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.TURNTABLE_RAY_0));
-        Assert.assertFalse(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.TURNTABLE_RAY_63));
+        Assert.assertEquals(7, LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_7.bezierPointIndex());
+        Assert.assertEquals(8, LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_8.bezierPointIndex());        
     }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTbezierPointIndexBad1() {
+        LayoutEditor.HitPointType.POS_POINT.bezierPointIndex();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTbezierPointIndexBad2() {
+        LayoutEditor.HitPointType.TURNTABLE_RAY_0.bezierPointIndex();
+    }
+
+    @Test
+    public void testHPTbezierPointIndexedValueOK() {
+        Assert.assertEquals(LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_0, LayoutEditor.HitPointType.bezierPointIndexedValue(0));
+        Assert.assertEquals(LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_1, LayoutEditor.HitPointType.bezierPointIndexedValue(1));
+        Assert.assertEquals(LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_2, LayoutEditor.HitPointType.bezierPointIndexedValue(2));
+        // ..
+        Assert.assertEquals(LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_6, LayoutEditor.HitPointType.bezierPointIndexedValue(6));
+        Assert.assertEquals(LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_7, LayoutEditor.HitPointType.bezierPointIndexedValue(7));
+        Assert.assertEquals(LayoutEditor.HitPointType.BEZIER_CONTROL_POINT_8, LayoutEditor.HitPointType.bezierPointIndexedValue(8));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTbezierPointIndexedValueBad1() throws IllegalArgumentException {
+        LayoutEditor.HitPointType.bezierPointIndexedValue(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTbezierPointIndexedValueBad2() {
+        LayoutEditor.HitPointType.bezierPointIndexedValue(9);
+    }
+    
+        // *****************************************************************
+        // General Enum tests
+        // *****************************************************************
     
     /**
      * Ensure that assigned integer values (xmlValue) and ordinal values are actually the same

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -72,6 +72,10 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
         JUnitUtil.dispose(e);
     }
 
+       // *****************************************************************
+       //    Turntable Ray support
+       // *****************************************************************
+       
     @Test
     public void testHPTturntableTrackIndexOK() {
         Assert.assertEquals(0, LayoutEditor.HitPointType.TURNTABLE_RAY_0.turntableTrackIndex());
@@ -114,7 +118,7 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
     }
 
     @Test
-    public void turntableValues() {
+    public void testHPTturntableValues() {
         LayoutEditor.HitPointType[] array = LayoutEditor.HitPointType.turntableValues();
         Assert.assertEquals(64, array.length);
         Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_0, array[0]);
@@ -124,8 +128,93 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
         Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_63, array[63]);
         
         // while available, use the indexing operations to test content
-        for (int i = 0; i<=63; i++) {
+        for (int i = 0; i<array.length; i++) {
             Assert.assertEquals(LayoutEditor.HitPointType.turntableTrackIndexedValue(i),array[i]);
+        }
+    }
+
+       // *****************************************************************
+       //    Shape Point support
+       // *****************************************************************
+       
+    @Test
+    public void testHPTshapePointIndexOK() {
+        Assert.assertEquals(0, LayoutEditor.HitPointType.SHAPE_POINT_0.shapePointIndex());
+        Assert.assertEquals(1, LayoutEditor.HitPointType.SHAPE_POINT_1.shapePointIndex());
+        Assert.assertEquals(2, LayoutEditor.HitPointType.SHAPE_POINT_2.shapePointIndex());
+        // ..
+        Assert.assertEquals(8, LayoutEditor.HitPointType.SHAPE_POINT_8.shapePointIndex());
+        Assert.assertEquals(9, LayoutEditor.HitPointType.SHAPE_POINT_9.shapePointIndex());        
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTshapePointIndexBad1() {
+        LayoutEditor.HitPointType.POS_POINT.shapePointIndex();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTshapePointIndexBad2() {
+        LayoutEditor.HitPointType.TURNTABLE_RAY_0.shapePointIndex();
+    }
+
+    @Test
+    public void testHPTshapePointIndexedValueOK() {
+        Assert.assertEquals(LayoutEditor.HitPointType.SHAPE_POINT_0, LayoutEditor.HitPointType.shapePointIndexedValue(0));
+        Assert.assertEquals(LayoutEditor.HitPointType.SHAPE_POINT_1, LayoutEditor.HitPointType.shapePointIndexedValue(1));
+        Assert.assertEquals(LayoutEditor.HitPointType.SHAPE_POINT_2, LayoutEditor.HitPointType.shapePointIndexedValue(2));
+        // ..
+        Assert.assertEquals(LayoutEditor.HitPointType.SHAPE_POINT_7, LayoutEditor.HitPointType.shapePointIndexedValue(7));
+        Assert.assertEquals(LayoutEditor.HitPointType.SHAPE_POINT_8, LayoutEditor.HitPointType.shapePointIndexedValue(8));
+        Assert.assertEquals(LayoutEditor.HitPointType.SHAPE_POINT_9, LayoutEditor.HitPointType.shapePointIndexedValue(9));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTshapePointIndexedValueBad1() throws IllegalArgumentException {
+        LayoutEditor.HitPointType.shapePointIndexedValue(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTshapePointIndexedValueBad2() {
+        LayoutEditor.HitPointType.shapePointIndexedValue(10);
+    }
+
+    @Test
+    public void testHPTshapePointValues() {
+        LayoutEditor.HitPointType[] array = LayoutEditor.HitPointType.shapePointValues();
+        Assert.assertEquals(10, array.length);
+        Assert.assertEquals(LayoutEditor.HitPointType.SHAPE_POINT_0, array[0]);
+        Assert.assertEquals(LayoutEditor.HitPointType.SHAPE_POINT_1, array[1]);
+        // ..
+        Assert.assertEquals(LayoutEditor.HitPointType.SHAPE_POINT_8, array[8]);
+        Assert.assertEquals(LayoutEditor.HitPointType.SHAPE_POINT_9, array[9]);
+        
+        // while available, use the indexing operations to test content
+        for (int i = 0; i<array.length; i++) {
+            Assert.assertEquals(LayoutEditor.HitPointType.shapePointIndexedValue(i),array[i]);
+        }
+    }
+
+    public void testHPTisShapePointOffsetHitPointType() {
+        Assert.assertTrue(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.SHAPE_POINT_0));
+        Assert.assertTrue(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.SHAPE_POINT_1));
+        // ..
+        Assert.assertTrue(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.SHAPE_POINT_8));
+        Assert.assertTrue(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.SHAPE_POINT_9));
+        
+        Assert.assertFalse(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.NONE));
+        Assert.assertFalse(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.SHAPE_CENTER));
+        // ..
+        Assert.assertFalse(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.TURNTABLE_RAY_0));
+        Assert.assertFalse(LayoutEditor.HitPointType.isShapePointOffsetHitPointType(LayoutEditor.HitPointType.TURNTABLE_RAY_63));
+    }
+    
+    /**
+     * Ensure that assigned integer values (xmlValue) and ordinal values are actually the same
+     */
+    @Test
+    public void testHPTesureOrdinalValuesSameAsAssigned() {
+        for (LayoutEditor.HitPointType instance : LayoutEditor.HitPointType.values()) {
+            Assert.assertEquals(Integer.valueOf(instance.ordinal()), instance.getXmlValue());
         }
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -73,7 +73,70 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
     }
 
     @Test
-    public void testEnums() {
+    public void testHPTturntableTrackIndexOK() {
+        Assert.assertEquals(0, LayoutEditor.HitPointType.TURNTABLE_RAY_0.turntableTrackIndex());
+        Assert.assertEquals(1, LayoutEditor.HitPointType.TURNTABLE_RAY_1.turntableTrackIndex());
+        Assert.assertEquals(2, LayoutEditor.HitPointType.TURNTABLE_RAY_2.turntableTrackIndex());
+        // ..
+        Assert.assertEquals(62, LayoutEditor.HitPointType.TURNTABLE_RAY_62.turntableTrackIndex());
+        Assert.assertEquals(63, LayoutEditor.HitPointType.TURNTABLE_RAY_63.turntableTrackIndex());        
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTturntableTrackIndexBad1() {
+        LayoutEditor.HitPointType.POS_POINT.turntableTrackIndex();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTturntableTrackIndexBad2() {
+        LayoutEditor.HitPointType.SHAPE_POINT_9.turntableTrackIndex();
+    }
+
+    @Test
+    public void testHPTturntableTrackIndexedValueOK() {
+        Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_0, LayoutEditor.HitPointType.turntableTrackIndexedValue(0));
+        Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_1, LayoutEditor.HitPointType.turntableTrackIndexedValue(1));
+        Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_2, LayoutEditor.HitPointType.turntableTrackIndexedValue(2));
+        // ..
+        Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_61, LayoutEditor.HitPointType.turntableTrackIndexedValue(61));
+        Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_62, LayoutEditor.HitPointType.turntableTrackIndexedValue(62));
+        Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_63, LayoutEditor.HitPointType.turntableTrackIndexedValue(63));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTturntableTrackIndexedValueBad1() throws IllegalArgumentException {
+        LayoutEditor.HitPointType.turntableTrackIndexedValue(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHPTturntableTrackIndexedValueBad2() {
+        LayoutEditor.HitPointType.turntableTrackIndexedValue(64);
+    }
+
+    @Test
+    public void turntableValues() {
+        LayoutEditor.HitPointType[] array = LayoutEditor.HitPointType.turntableValues();
+        Assert.assertEquals(64, array.length);
+        Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_0, array[0]);
+        Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_1, array[1]);
+        // ..
+        Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_62, array[62]);
+        Assert.assertEquals(LayoutEditor.HitPointType.TURNTABLE_RAY_63, array[63]);
+        
+        // while available, use the indexing operations to test content
+        for (int i = 0; i<=63; i++) {
+            Assert.assertEquals(LayoutEditor.HitPointType.turntableTrackIndexedValue(i),array[i]);
+        }
+    }
+
+    /** 
+     * The specific values are tested for historical i/O compatibility
+     * and because some internal operations do arithmetic with them.
+     * For now, it's sufficient for this test to ensure they don't change,
+     * hence this test.
+     */
+    @Test
+    public void testEnumIntegerValues() {
         Assert.assertEquals("HitPointTypes.NONE.getValue() == 0", LayoutEditor.HitPointType.NONE.getXmlValue(), Integer.valueOf(0));
         Assert.assertEquals("HitPointTypes.POS_POINT.getValue() == 1", LayoutEditor.HitPointType.POS_POINT.getXmlValue(), Integer.valueOf(1));
         Assert.assertEquals("HitPointTypes.TURNOUT_A.getValue() == 2", LayoutEditor.HitPointType.TURNOUT_A.getXmlValue(), Integer.valueOf(2));

--- a/java/test/jmri/jmrit/display/layoutEditor/configurexml/LayoutTurnoutXmlTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/configurexml/LayoutTurnoutXmlTest.java
@@ -26,7 +26,7 @@ public class LayoutTurnoutXmlTest {
 
     @Test
     public void testFromEnum() {
-        LayoutTurnoutXml.EnumIO<LayoutTurnout.LinkType> enumMap = (new LayoutTurnoutXml()).linkEnumMap;
+        LayoutTurnoutXml.EnumIO<LayoutTurnout.LinkType> enumMap = LayoutTurnoutXml.linkEnumMap;
 
         Assert.assertEquals("0", enumMap.outputFromEnum(LayoutTurnout.LinkType.NO_LINK));
         Assert.assertEquals("2", enumMap.outputFromEnum(LayoutTurnout.LinkType.SECOND_3_WAY));
@@ -34,7 +34,7 @@ public class LayoutTurnoutXmlTest {
     
     @Test
     public void testToEnum() {
-        LayoutTurnoutXml.EnumIO<LayoutTurnout.LinkType> enumMap = (new LayoutTurnoutXml()).linkEnumMap;
+        LayoutTurnoutXml.EnumIO<LayoutTurnout.LinkType> enumMap = LayoutTurnoutXml.linkEnumMap;
         
         Assert.assertEquals(LayoutTurnout.LinkType.NO_LINK, enumMap.inputFromString("0"));
         Assert.assertEquals(LayoutTurnout.LinkType.SECOND_3_WAY, enumMap.inputFromString("2"));

--- a/java/test/jmri/jmrit/display/layoutEditor/invalid/TrkSegType1.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/invalid/TrkSegType1.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-2-9-6.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>17</minor>
+    <test>5</test>
+    <modifier>ish</modifier>
+  </jmriversion>
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Wed Apr 18 12:38:07 PDT 2018" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <LayoutEditor class="jmri.jmrit.display.layoutEditor.configurexml.LayoutEditorXml" name="Decorations Testing" x="0" y="23" windowheight="772" windowwidth="1028" panelheight="580" panelwidth="1000" sliders="no" scrollable="none" editable="yes" positionable="yes" controlling="yes" animating="yes" showhelpbar="no" drawgrid="yes" snaponadd="yes" snaponmove="yes" antialiasing="yes" turnoutcircles="yes" tooltipsnotedit="no" tooltipsinedit="yes" mainlinetrackwidth="4" xscale="1.0" yscale="1.0" sidetrackwidth="2" defaulttrackcolor="darkGray" defaultoccupiedtrackcolor="red" defaultalternativetrackcolor="white" defaulttextcolor="black" turnoutcirclecolor="pink" turnoutcirclethrowncolor="black" turnoutcirclesize="2" turnoutdrawunselectedleg="no" turnoutbx="20.0" turnoutcx="20.0" turnoutwid="10.0" xoverlong="30.0" xoverhwid="10.0" xovershort="10.0" autoblkgenerate="yes" redBackground="150" greenBackground="86" blueBackground="150" gridSize="10" gridSize2nd="10" openDispatcher="no" useDirectTurnoutControl="no">
+    <layoutTrackDrawingOptions name="Decorations Testing" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTrackDrawingOptionsXml">
+      <mainBallastColor>#000000</mainBallastColor>
+      <mainBallastWidth>0</mainBallastWidth>
+      <mainBlockLineDashPercentageX10>0</mainBlockLineDashPercentageX10>
+      <mainBlockLineWidth>4</mainBlockLineWidth>
+      <mainRailColor>#404040</mainRailColor>
+      <mainRailCount>1</mainRailCount>
+      <mainRailGap>0</mainRailGap>
+      <mainRailWidth>2</mainRailWidth>
+      <mainTieColor>#000000</mainTieColor>
+      <mainTieGap>0</mainTieGap>
+      <mainTieLength>0</mainTieLength>
+      <mainTieWidth>0</mainTieWidth>
+      <sideBallastColor>#000000</sideBallastColor>
+      <sideBallastWidth>0</sideBallastWidth>
+      <sideBlockLineDashPercentageX10>0</sideBlockLineDashPercentageX10>
+      <sideBlockLineWidth>2</sideBlockLineWidth>
+      <sideRailColor>#404040</sideRailColor>
+      <sideRailCount>1</sideRailCount>
+      <sideRailGap>0</sideRailGap>
+      <sideRailWidth>1</sideRailWidth>
+      <sideTieColor>#000000</sideTieColor>
+      <sideTieGap>0</sideTieGap>
+      <sideTieLength>0</sideTieLength>
+      <sideTieWidth>0</sideTieWidth>
+    </layoutTrackDrawingOptions>
+    <tracksegment ident="T1" blockname="RM Block" connect1name="EB1" type1="120" connect2name="A3" type2="1" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="left" end="entry" color="#FF00FF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <bumper end="start" color="#FF0000" linewidth="3" length="15" />
+      </decorations>
+    </tracksegment>
+    <positionablepoint ident="A3" type="1" x="300.0" y="140.0" connect1name="T1" connect2name="T3" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB1" type="2" x="100.0" y="100.0" connect1name="T1" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+  </LayoutEditor>
+  <filehistory>
+    <operation>
+      <type>app</type>
+      <date>Wed Oct 09 09:25:27 PDT 2019</date>
+      <filename>JMRI program</filename>
+    </operation>
+    <operation>
+      <type>Store</type>
+      <date>Wed Oct 09 09:26:26 PDT 2019</date>
+      <filename />
+    </operation>
+  </filehistory>
+  <!--Written by JMRI version 4.17.5ish+geowar+20191009T1625Z+Rada842a26e on Wed Oct 09 09:26:26 PDT 2019-->
+</layout-config>

--- a/java/test/jmri/jmrit/display/layoutEditor/invalid/TrkSegType2.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/invalid/TrkSegType2.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-2-9-6.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>17</minor>
+    <test>5</test>
+    <modifier>ish</modifier>
+  </jmriversion>
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Wed Apr 18 12:38:07 PDT 2018" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <LayoutEditor class="jmri.jmrit.display.layoutEditor.configurexml.LayoutEditorXml" name="Decorations Testing" x="0" y="23" windowheight="772" windowwidth="1028" panelheight="580" panelwidth="1000" sliders="no" scrollable="none" editable="yes" positionable="yes" controlling="yes" animating="yes" showhelpbar="no" drawgrid="yes" snaponadd="yes" snaponmove="yes" antialiasing="yes" turnoutcircles="yes" tooltipsnotedit="no" tooltipsinedit="yes" mainlinetrackwidth="4" xscale="1.0" yscale="1.0" sidetrackwidth="2" defaulttrackcolor="darkGray" defaultoccupiedtrackcolor="red" defaultalternativetrackcolor="white" defaulttextcolor="black" turnoutcirclecolor="pink" turnoutcirclethrowncolor="black" turnoutcirclesize="2" turnoutdrawunselectedleg="no" turnoutbx="20.0" turnoutcx="20.0" turnoutwid="10.0" xoverlong="30.0" xoverhwid="10.0" xovershort="10.0" autoblkgenerate="yes" redBackground="150" greenBackground="86" blueBackground="150" gridSize="10" gridSize2nd="10" openDispatcher="no" useDirectTurnoutControl="no">
+    <layoutTrackDrawingOptions name="Decorations Testing" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTrackDrawingOptionsXml">
+      <mainBallastColor>#000000</mainBallastColor>
+      <mainBallastWidth>0</mainBallastWidth>
+      <mainBlockLineDashPercentageX10>0</mainBlockLineDashPercentageX10>
+      <mainBlockLineWidth>4</mainBlockLineWidth>
+      <mainRailColor>#404040</mainRailColor>
+      <mainRailCount>1</mainRailCount>
+      <mainRailGap>0</mainRailGap>
+      <mainRailWidth>2</mainRailWidth>
+      <mainTieColor>#000000</mainTieColor>
+      <mainTieGap>0</mainTieGap>
+      <mainTieLength>0</mainTieLength>
+      <mainTieWidth>0</mainTieWidth>
+      <sideBallastColor>#000000</sideBallastColor>
+      <sideBallastWidth>0</sideBallastWidth>
+      <sideBlockLineDashPercentageX10>0</sideBlockLineDashPercentageX10>
+      <sideBlockLineWidth>2</sideBlockLineWidth>
+      <sideRailColor>#404040</sideRailColor>
+      <sideRailCount>1</sideRailCount>
+      <sideRailGap>0</sideRailGap>
+      <sideRailWidth>1</sideRailWidth>
+      <sideTieColor>#000000</sideTieColor>
+      <sideTieGap>0</sideTieGap>
+      <sideTieLength>0</sideTieLength>
+      <sideTieWidth>0</sideTieWidth>
+    </layoutTrackDrawingOptions>
+    <tracksegment ident="T1" blockname="RM Block" connect1name="EB1" type1="1" connect2name="A3" type2="FOAM" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="left" end="entry" color="#FF00FF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <bumper end="start" color="#FF0000" linewidth="3" length="15" />
+      </decorations>
+    </tracksegment>
+    <positionablepoint ident="A3" type="1" x="300.0" y="140.0" connect1name="T1" connect2name="T3" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB1" type="2" x="100.0" y="100.0" connect1name="T1" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+  </LayoutEditor>
+  <filehistory>
+    <operation>
+      <type>app</type>
+      <date>Wed Oct 09 09:25:27 PDT 2019</date>
+      <filename>JMRI program</filename>
+    </operation>
+    <operation>
+      <type>Store</type>
+      <date>Wed Oct 09 09:26:26 PDT 2019</date>
+      <filename />
+    </operation>
+  </filehistory>
+  <!--Written by JMRI version 4.17.5ish+geowar+20191009T1625Z+Rada842a26e on Wed Oct 09 09:26:26 PDT 2019-->
+</layout-config>

--- a/xml/schema/types/editors.xsd
+++ b/xml/schema/types/editors.xsd
@@ -1535,9 +1535,9 @@
       </xs:attribute>
       <xs:attribute name="blockname" type="beanNameType"></xs:attribute>  <!-- required in DTD, missing from some files -->
       <xs:attribute name="connect1name" type="beanNameType" use="required"></xs:attribute>
-      <xs:attribute name="type1" type="xs:string" use="required"></xs:attribute>
+      <xs:attribute name="type1" type="HitPointType" use="required"></xs:attribute>
       <xs:attribute name="connect2name" type="beanNameType" use="required"></xs:attribute>
-      <xs:attribute name="type2" type="xs:string" use="required"></xs:attribute>
+      <xs:attribute name="type2" type="HitPointType" use="required"></xs:attribute>
       <xs:attribute name="dashed" type="yesNoType"></xs:attribute>
       <xs:attribute name="mainline" type="yesNoType"></xs:attribute>
       <xs:attribute name="hidden" type="yesNoType"></xs:attribute>
@@ -1548,6 +1548,141 @@
       <xs:attribute name="angle" type="xs:float"></xs:attribute>
       <xs:attribute name="hideConLines" type="yesNoType"></xs:attribute>
     </xs:complexType>
+
+    <xs:simpleType name="HitPointType">
+      <xs:annotation>
+        <xs:documentation>
+          Represents values of LayoutEditor.HitPointType enum,
+          both as 0-63 and as String names.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:union>
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="113"/>
+          </xs:restriction>
+        </xs:simpleType>
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="NONE"></xs:enumeration>
+            <xs:enumeration value="POS_POINT"></xs:enumeration>
+            <xs:enumeration value="TURNOUT_A"></xs:enumeration>
+            <xs:enumeration value="TURNOUT_B"></xs:enumeration>
+            <xs:enumeration value="TURNOUT_C"></xs:enumeration>
+            <xs:enumeration value="TURNOUT_D"></xs:enumeration>
+            <xs:enumeration value="LEVEL_XING_A"></xs:enumeration>
+            <xs:enumeration value="LEVEL_XING_B"></xs:enumeration>
+            <xs:enumeration value="LEVEL_XING_C"></xs:enumeration>
+            <xs:enumeration value="LEVEL_XING_D"></xs:enumeration>
+            <xs:enumeration value="TRACK"></xs:enumeration>
+            <xs:enumeration value="TURNOUT_CENTER"></xs:enumeration>
+            <xs:enumeration value="LEVEL_XING_CENTER"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_CENTER"></xs:enumeration>
+            <xs:enumeration value="LAYOUT_POS_LABEL"></xs:enumeration>
+            <xs:enumeration value="LAYOUT_POS_JCOMP"></xs:enumeration>
+            <xs:enumeration value="MULTI_SENSOR"></xs:enumeration>
+            <xs:enumeration value="MARKER"></xs:enumeration>
+            <xs:enumeration value="TRACK_CIRCLE_CENTRE"></xs:enumeration>
+            <xs:enumeration value="UNUSED_19"></xs:enumeration>
+            <xs:enumeration value="SLIP_CENTER"></xs:enumeration>
+            <xs:enumeration value="SLIP_A"></xs:enumeration>
+            <xs:enumeration value="SLIP_B"></xs:enumeration>
+            <xs:enumeration value="SLIP_C"></xs:enumeration>
+            <xs:enumeration value="SLIP_D"></xs:enumeration>
+            <xs:enumeration value="SLIP_LEFT"></xs:enumeration>
+            <xs:enumeration value="SLIP_RIGHT"></xs:enumeration>
+            <xs:enumeration value="UNUSED_27"></xs:enumeration>
+            <xs:enumeration value="UNUSED_28"></xs:enumeration>
+            <xs:enumeration value="UNUSED_29"></xs:enumeration>
+            <xs:enumeration value="BEZIER_CONTROL_POINT_0"></xs:enumeration>
+            <xs:enumeration value="BEZIER_CONTROL_POINT_1"></xs:enumeration>
+            <xs:enumeration value="BEZIER_CONTROL_POINT_2"></xs:enumeration>
+            <xs:enumeration value="BEZIER_CONTROL_POINT_3"></xs:enumeration>
+            <xs:enumeration value="BEZIER_CONTROL_POINT_4"></xs:enumeration>
+            <xs:enumeration value="BEZIER_CONTROL_POINT_5"></xs:enumeration>
+            <xs:enumeration value="BEZIER_CONTROL_POINT_6"></xs:enumeration>
+            <xs:enumeration value="BEZIER_CONTROL_POINT_7"></xs:enumeration>
+            <xs:enumeration value="BEZIER_CONTROL_POINT_8"></xs:enumeration>
+            <xs:enumeration value="SHAPE_CENTER"></xs:enumeration>
+            <xs:enumeration value="SHAPE_POINT_0"></xs:enumeration>
+            <xs:enumeration value="SHAPE_POINT_1"></xs:enumeration>
+            <xs:enumeration value="SHAPE_POINT_2"></xs:enumeration>
+            <xs:enumeration value="SHAPE_POINT_3"></xs:enumeration>
+            <xs:enumeration value="SHAPE_POINT_4"></xs:enumeration>
+            <xs:enumeration value="SHAPE_POINT_5"></xs:enumeration>
+            <xs:enumeration value="SHAPE_POINT_6"></xs:enumeration>
+            <xs:enumeration value="SHAPE_POINT_7"></xs:enumeration>
+            <xs:enumeration value="SHAPE_POINT_8"></xs:enumeration>
+            <xs:enumeration value="SHAPE_POINT_9"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_0"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_1"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_2"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_3"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_4"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_5"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_6"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_7"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_8"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_9"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_10"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_11"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_12"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_13"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_14"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_15"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_16"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_17"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_18"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_19"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_20"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_21"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_22"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_23"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_24"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_25"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_26"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_27"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_28"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_29"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_30"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_31"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_32"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_33"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_34"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_35"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_36"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_37"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_38"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_39"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_40"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_41"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_42"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_43"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_44"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_45"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_46"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_47"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_48"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_49"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_50"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_51"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_52"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_53"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_54"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_55"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_56"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_57"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_58"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_59"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_60"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_61"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_62"></xs:enumeration>
+            <xs:enumeration value="TURNTABLE_RAY_63"></xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:union>
+    </xs:simpleType>
 
     <xs:complexType name="EditorLevelXingType">
       <xs:annotation>


### PR DESCRIPTION
 - Make HitPointType sections for TURNTABLE_RAY_n, SHAPE_POINT_n, BEZIER_CONTROL_POINT_n self-contained as a step toward eventually making them separate enums, perhaps separate classes
 - Add tests of new code, and to confirm use of ordinals
 - deprecate access as int or String and remove almost all occurrences in main (not test, not persistence) code