### PR TITLE
fix: Fix static analysis failure in logger

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusClockControl.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusClockControl.java
@@ -216,8 +216,7 @@ public class CbusClockControl extends jmri.implementation.DefaultClockControl im
                 , month, day, hour, min, 0);
         }
         catch( java.time.DateTimeException e){
-            log.debug ("Unable to process FastClock date. {}  Incoming: {}"
-                ,e.getLocalizedMessage(),r);
+            log.debug ("Unable to process FastClock date. Incoming: {}", r, e);
         }
         if (specificDate==null) { // if unset, try just the times.
             try {


### PR DESCRIPTION
This static analysis failure is likely an artifact of the order of merging #8432 and #8424 into master.