### PR TITLE
fix: Beans may fire events on or off EDT

### DIFF
--- a/java/src/jmri/beans/Bean.java
+++ b/java/src/jmri/beans/Bean.java
@@ -2,8 +2,7 @@ package jmri.beans;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.beans.PropertyChangeSupport;
-import jmri.util.ThreadingUtil;
+import javax.swing.event.SwingPropertyChangeSupport;
 
 /**
  * Generic implementation of {@link jmri.beans.BeanInterface} with a complete
@@ -14,20 +13,37 @@ import jmri.util.ThreadingUtil;
  * <p>
  * This class is thread safe.
  *
- * @author Randall Wood (c) 2011, 2014, 2015, 2016
+ * @author Randall Wood (c) 2011, 2014, 2015, 2016, 2020
  * @see java.beans.PropertyChangeSupport
  */
-public abstract class Bean extends UnboundBean implements PropertyChangeProvider {
+public abstract class Bean extends UnboundBean implements PropertyChangeFirer, PropertyChangeProvider {
 
     /**
      * Provide a {@link java.beans.PropertyChangeSupport} helper.
      */
-    protected final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+    protected final SwingPropertyChangeSupport propertyChangeSupport;
 
     /**
-     * Add a PropertyChangeListener to the listener list.
-     *
-     * @param listener The PropertyChangeListener to be added
+     * Create a bean that notifies property change listeners on the event
+     * dispatch thread (EDT).
+     */
+    protected Bean() {
+        this(true);
+    }
+
+    /**
+     * Create a bean.
+     * 
+     * @param notifyOnEDT true to notify property change listeners on the EDT;
+     *                    false to notify listeners on the thread the event was
+     *                    generated on (which may or may not be the EDT)
+     */
+    protected Bean(boolean notifyOnEDT) {
+        propertyChangeSupport = new SwingPropertyChangeSupport(this, notifyOnEDT);
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public void addPropertyChangeListener(PropertyChangeListener listener) {
@@ -35,10 +51,7 @@ public abstract class Bean extends UnboundBean implements PropertyChangeProvider
     }
 
     /**
-     * Add a PropertyChangeListener for a specific property.
-     *
-     * @param propertyName The name of the property to listen on.
-     * @param listener     The PropertyChangeListener to be added
+     * {@inheritDoc}
      */
     @Override
     public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener) {
@@ -46,120 +59,102 @@ public abstract class Bean extends UnboundBean implements PropertyChangeProvider
     }
 
     /**
-     * Fire an indexed property change on the Event dispatch (Swing) thread. Use
-     * {@link java.beans.PropertyChangeSupport#fireIndexedPropertyChange(java.lang.String, int, boolean, boolean)}
-     * directly to fire this notification on another thread.
-     *
-     * @param propertyName the programmatic name of the property that was
-     *                     changed
-     * @param index        the index of the property element that was changed
-     * @param oldValue     the old value of the property
-     * @param newValue     the new value of the property
+     * {@inheritDoc}
      */
-    protected void fireIndexedPropertyChange(String propertyName, int index, boolean oldValue, boolean newValue) {
-        ThreadingUtil.runOnGUIEventually(() -> propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue));
+    @Override
+    public void fireIndexedPropertyChange(String propertyName, int index, boolean oldValue, boolean newValue) {
+        propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
     }
 
     /**
-     * Fire an indexed property change on the Event dispatch (Swing) thread. Use
-     * {@link java.beans.PropertyChangeSupport#fireIndexedPropertyChange(java.lang.String, int, int, int)}
-     * directly to fire this notification on another thread.
-     *
-     * @param propertyName the programmatic name of the property that was
-     *                     changed
-     * @param index        the index of the property element that was changed
-     * @param oldValue     the old value of the property
-     * @param newValue     the new value of the property
+     * {@inheritDoc}
      */
-    protected void fireIndexedPropertyChange(String propertyName, int index, int oldValue, int newValue) {
-        ThreadingUtil.runOnGUIEventually(() -> propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue));
+    @Override
+    public void fireIndexedPropertyChange(String propertyName, int index, int oldValue, int newValue) {
+        propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
     }
 
     /**
-     * Fire an indexed property change on the Event dispatch (Swing) thread. Use
-     * {@link java.beans.PropertyChangeSupport#fireIndexedPropertyChange(java.lang.String, int, java.lang.Object, java.lang.Object)}
-     * directly to fire this notification on another thread.
-     *
-     * @param propertyName the programmatic name of the property that was
-     *                     changed
-     * @param index        the index of the property element that was changed
-     * @param oldValue     the old value of the property
-     * @param newValue     the new value of the property
+     * {@inheritDoc}
      */
-    protected void fireIndexedPropertyChange(String propertyName, int index, Object oldValue, Object newValue) {
-        ThreadingUtil.runOnGUIEventually(() -> propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue));
+    @Override
+    public void fireIndexedPropertyChange(String propertyName, int index, Object oldValue, Object newValue) {
+        propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
     }
 
     /**
-     * Fire a property change on the Event dispatch (Swing) thread. Use
-     * {@link java.beans.PropertyChangeSupport#firePropertyChange(java.lang.String, boolean, boolean)}
-     * directly to fire this notification on another thread.
-     *
-     * @param propertyName the programmatic name of the property that was
-     *                     changed
-     * @param oldValue     the old value of the property
-     * @param newValue     the new value of the property
+     * {@inheritDoc}
      */
-    protected void firePropertyChange(String propertyName, boolean oldValue, boolean newValue) {
-        ThreadingUtil.runOnGUIEventually(() ->  propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue));
+    @Override
+    public void firePropertyChange(String propertyName, boolean oldValue, boolean newValue) {
+        propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
     }
 
     /**
-     * Fire a property change on the Event dispatch (Swing) thread. Use
-     * {@link java.beans.PropertyChangeSupport#firePropertyChange(java.beans.PropertyChangeEvent)}
-     * directly to fire this notification on another thread.
-     *
-     * @param event the PropertyChangeEvent to be fired
+     * {@inheritDoc}
      */
-    protected void firePropertyChange(PropertyChangeEvent event) {
-        ThreadingUtil.runOnGUIEventually(() -> propertyChangeSupport.firePropertyChange(event));
+    @Override
+    public void firePropertyChange(PropertyChangeEvent event) {
+        propertyChangeSupport.firePropertyChange(event);
     }
 
     /**
-     * Fire a property change on the Event dispatch (Swing) thread. Use
-     * {@link java.beans.PropertyChangeSupport#firePropertyChange(java.lang.String, int, int)}
-     * directly to fire this notification on another thread.
-     *
-     * @param propertyName the programmatic name of the property that was
-     *                     changed
-     * @param oldValue     the old value of the property
-     * @param newValue     the new value of the property
+     * {@inheritDoc}
      */
-    protected void firePropertyChange(String propertyName, int oldValue, int newValue) {
-        ThreadingUtil.runOnGUIEventually(() -> propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue));
+    @Override
+    public void firePropertyChange(String propertyName, int oldValue, int newValue) {
+        propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
     }
 
     /**
-     * Fire a property change on the Event dispatch (Swing) thread. Use
-     * {@link java.beans.PropertyChangeSupport#firePropertyChange(java.lang.String, java.lang.Object, java.lang.Object)}
-     * directly to fire this notification on another thread.
-     *
-     * @param propertyName the programmatic name of the property that was
-     *                     changed
-     * @param oldValue     the old value of the property
-     * @param newValue     the new value of the property
+     * {@inheritDoc}
      */
-    protected void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
-        ThreadingUtil.runOnGUIEventually(() ->  propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue));
+    @Override
+    public void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
+        propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public PropertyChangeListener[] getPropertyChangeListeners() {
         return propertyChangeSupport.getPropertyChangeListeners();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
         return propertyChangeSupport.getPropertyChangeListeners(propertyName);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void removePropertyChangeListener(PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(listener);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void removePropertyChangeListener(String propertyName, PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(propertyName, listener);
+    }
+    
+    /**
+     * Is this Bean assuring that all property change listeners will be notified
+     * on the EDT?
+     *
+     * @return true if notifying listeners of events on the EDT; false if
+     *         notifying listeners on the thread that the event was generated on
+     *         (which may or may not be the EDT)
+     */
+    public boolean isNotifyOnEDT() {
+        return propertyChangeSupport.isNotifyOnEDT();
     }
 }

--- a/java/src/jmri/beans/PreferencesBean.java
+++ b/java/src/jmri/beans/PreferencesBean.java
@@ -1,12 +1,13 @@
 package jmri.beans;
 
+import java.beans.PropertyChangeEvent;
 import javax.annotation.Nonnull;
 import jmri.profile.Profile;
 
 /**
  * Bean that implements some common code for preferences objects.
  *
- * @author Randall Wood (C) 2017
+ * @author Randall Wood (C) 2017, 2020
  */
 public abstract class PreferencesBean extends Bean {
 
@@ -33,6 +34,7 @@ public abstract class PreferencesBean extends Bean {
      * null is not associated with a Profile, but applies application wide
      */
     public PreferencesBean(Profile profile) {
+        super(false);
         this.profile = profile;
     }
 
@@ -82,31 +84,68 @@ public abstract class PreferencesBean extends Bean {
      */
     protected void setIsDirty(boolean value) {
         boolean old = this.isDirty;
-        if (old != value) {
-            this.isDirty = value;
-            this.firePropertyChange(DIRTY, old, value);
-        }
+        this.isDirty = value;
+        this.firePropertyChange(DIRTY, old, value);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * As a side effect, calls to {@link #isDirty} will return {@code true} if
+     * oldValue and newValue differ or are null.
+     */
     @Override
-    protected void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
-        this.propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
-        this.setIsDirty(true);
-    }
-
-    @Override
-    protected void firePropertyChange(String propertyName, boolean oldValue, boolean newValue) {
-        this.propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
-        // don't force dirty to true if we just changed dirty
-        if (!DIRTY.equals(propertyName)) {
+    public void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
+        if (oldValue == null || newValue == null || !oldValue.equals(newValue)) {
+            this.propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
             this.setIsDirty(true);
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * As a side effect, calls to {@link #isDirty} will return {@code true} if
+     * oldValue and newValue differ and propertyName is not {@value #DIRTY}.
+     */
     @Override
-    protected void firePropertyChange(String propertyName, int oldValue, int newValue) {
-        this.propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
-        this.setIsDirty(true);
+    public void firePropertyChange(String propertyName, boolean oldValue, boolean newValue) {
+        if (oldValue != newValue) {
+            this.propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
+            // don't force dirty to true if we just changed dirty
+            if (!DIRTY.equals(propertyName)) {
+                this.setIsDirty(true);
+            }
+        }
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * As a side effect, calls to {@link #isDirty} will return {@code true} if
+     * oldValue and newValue differ.
+     */
+    @Override
+    public void firePropertyChange(String propertyName, int oldValue, int newValue) {
+        if (oldValue != newValue) {
+            this.propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
+            this.setIsDirty(true);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * As a side effect, calls to {@link #isDirty} will return {@code true}. To
+     * avoid that side effect, call
+     * {@link PropertyChangeSupport#firePropertyChange(java.beans.PropertyChangeEvent)}
+     * on {@link #propertyChangeSupport} directly.
+     */
+    @Override
+    public void firePropertyChange(PropertyChangeEvent evt) {
+        this.propertyChangeSupport.firePropertyChange(evt);
+        if (!DIRTY.equals(evt.getPropertyName())) {
+            this.setIsDirty(true);
+        }
+    }
 }

--- a/java/src/jmri/jmrit/operations/locations/Pool.java
+++ b/java/src/jmri/jmrit/operations/locations/Pool.java
@@ -21,7 +21,7 @@ public class Pool extends Bean {
     private final static Logger log = LoggerFactory.getLogger(Pool.class);
 
     // stores tracks for this pool
-    protected List<Track> _tracks = new ArrayList<Track>();
+    protected List<Track> _tracks = new ArrayList<>();
 
     protected String _id = "";
 
@@ -57,13 +57,14 @@ public class Pool extends Bean {
     }
 
     public Pool(String id, String name) {
+        super(false);
         log.debug("New pool ({}) id: {}", name, id);
         _name = name;
         _id = id;
     }
 
     public void dispose() {
-        this.propertyChangeSupport.firePropertyChange(DISPOSE, null, DISPOSE);
+        firePropertyChange(DISPOSE, null, DISPOSE);
     }
 
     /**
@@ -77,7 +78,7 @@ public class Pool extends Bean {
             int oldSize = _tracks.size();
             _tracks.add(track);
 
-            this.propertyChangeSupport.firePropertyChange(LISTCHANGE_CHANGED_PROPERTY, Integer.valueOf(oldSize), Integer.valueOf(_tracks.size()));
+            firePropertyChange(LISTCHANGE_CHANGED_PROPERTY, oldSize, _tracks.size());
         }
     }
 
@@ -92,21 +93,17 @@ public class Pool extends Bean {
             int oldSize = _tracks.size();
             _tracks.remove(track);
 
-            this.propertyChangeSupport.firePropertyChange(LISTCHANGE_CHANGED_PROPERTY, Integer.valueOf(oldSize), Integer.valueOf(_tracks.size()));
+            firePropertyChange(LISTCHANGE_CHANGED_PROPERTY, oldSize, _tracks.size());
         }
     }
 
     public List<Track> getTracks() {
         // Return a copy to protect the internal list
-        return new ArrayList<Track>(_tracks);
+        return new ArrayList<>(_tracks);
     }
 
     public int getTotalLengthTracks() {
-        int total = 0;
-        for (Track track : getTracks()) {
-            total += track.getLength();
-        }
-        return total;
+        return getTracks().stream().map(track -> track.getLength()).reduce(0, Integer::sum);
     }
 
     /**

--- a/java/src/jmri/util/FileUtilSupport.java
+++ b/java/src/jmri/util/FileUtilSupport.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
  * they can be exposed to scripts as an object methods instead of as static
  * methods of a class.
  *
- * @author Randall Wood (C) 2015, 2016, 2019
+ * @author Randall Wood (C) 2015, 2016, 2019, 2020
  */
 public class FileUtilSupport extends Bean {
 
@@ -84,6 +84,10 @@ public class FileUtilSupport extends Bean {
     private static final Logger log = LoggerFactory.getLogger(FileUtilSupport.class);
     // default instance
     volatile private static FileUtilSupport defaultInstance = null;
+
+    public FileUtilSupport() {
+        super(false);
+    }
 
     /**
      * Get the {@link java.io.File} that path refers to. Throws a

--- a/java/test/jmri/beans/BeanTest.java
+++ b/java/test/jmri/beans/BeanTest.java
@@ -141,6 +141,17 @@ public class BeanTest {
         assertThat(changed).isTrue();
     }
 
+    /**
+     * Test that {@link Bean#isNotifyOnEDT()}, which provides access to a final
+     * value is returning the expected final value for all construction scenarios.
+     */
+    @Test
+    public void testIsNotifyOnEDT() {
+        assertThat(new Bean() {}.isNotifyOnEDT()).isTrue();
+        assertThat(new Bean(true) {}.isNotifyOnEDT()).isTrue();
+        assertThat(new Bean(false) {}.isNotifyOnEDT()).isFalse();
+    }
+
     @BeforeEach
     public void setup() {
         JUnitUtil.setUp();

--- a/java/test/jmri/beans/PreferencesBeanTest.java
+++ b/java/test/jmri/beans/PreferencesBeanTest.java
@@ -2,6 +2,7 @@ package jmri.beans;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.beans.PropertyChangeEvent;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -80,13 +81,17 @@ public class PreferencesBeanTest {
         bean.addPropertyChangeListener("boolean", (e) -> changed = true);
         assertThat(changed).isFalse();
         assertThat(bean.b).isFalse();
+        assertThat(bean.isDirty()).isFalse();
         bean.setBoolean(true);
         assertThat(changed).isTrue();
         assertThat(bean.b).isTrue();
+        assertThat(bean.isDirty()).isTrue();
         changed = false;
+        bean.setIsDirty(false);
         bean.setBoolean(true);
         assertThat(changed).isFalse();
         assertThat(bean.b).isTrue();
+        assertThat(bean.isDirty()).isFalse();
         changed = false;
         bean.setBoolean(false);
         assertThat(changed).isTrue();
@@ -98,13 +103,17 @@ public class PreferencesBeanTest {
         bean.addPropertyChangeListener("int", (e) -> changed = true);
         assertThat(changed).isFalse();
         assertThat(bean.i).isEqualTo(0);
+        assertThat(bean.isDirty()).isFalse();
         bean.setInt(1);
+        assertThat(bean.isDirty()).isTrue();
         assertThat(changed).isTrue();
         assertThat(bean.i).isEqualTo(1);
         changed = false;
+        bean.setIsDirty(false);
         bean.setInt(1);
         assertThat(changed).isFalse();
         assertThat(bean.i).isEqualTo(1);
+        assertThat(bean.isDirty()).isFalse();
         changed = false;
         bean.setInt(0);
         assertThat(changed).isTrue();
@@ -116,17 +125,31 @@ public class PreferencesBeanTest {
         bean.addPropertyChangeListener("Object", (e) -> changed = true);
         assertThat(changed).isFalse();
         assertThat(bean.o).isNull();
+        assertThat(bean.isDirty()).isFalse();
         bean.setObject(profilePath);
+        assertThat(bean.isDirty()).isTrue();
         assertThat(changed).isTrue();
         assertThat(bean.o).isEqualTo(profilePath);
         changed = false;
+        bean.setIsDirty(false);
         bean.setObject(profilePath);
         assertThat(changed).isFalse();
         assertThat(bean.o).isEqualTo(profilePath);
+        assertThat(bean.isDirty()).isFalse();
         changed = false;
         bean.setObject(null);
         assertThat(changed).isTrue();
         assertThat(bean.o).isNull();
+    }
+
+    @Test
+    public void testFirePropertyChange_PropertyChangeEvent() {
+        bean.addPropertyChangeListener("Event", e -> changed = true);
+        assertThat(changed).isFalse();
+        assertThat(bean.isDirty()).isFalse();
+        bean.firePropertyChange(new PropertyChangeEvent(bean, "Event", null, null));
+        assertThat(changed).isTrue();
+        assertThat(bean.isDirty()).isTrue();
     }
 
     private class PreferencesBeanImpl extends PreferencesBean {

--- a/java/test/jmri/jmrix/easydcc/networkdriver/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/easydcc/networkdriver/configurexml/ConnectionConfigXmlTest.java
@@ -33,7 +33,7 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractNet
     @After
     @Override
     public void tearDown() {
-        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;

--- a/java/test/jmri/jmrix/easydcc/networkdriver/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/easydcc/networkdriver/configurexml/ConnectionConfigXmlTest.java
@@ -28,14 +28,14 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractNet
         super.loadTest();
         // the port attribute for testing is "(none selected)", which isn't an int
         jmri.util.JUnitAppender.assertWarnMessage("Could not parse port attribute: [Attribute: port=\"(none selected)\"]");
-    }    
+    }
 
     @After
     @Override
     public void tearDown() {
-        xmlAdapter = null;
-        cc = null;
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
+        xmlAdapter = null;
+        cc = null;
     }
 }

--- a/java/test/jmri/jmrix/easydcc/networkdriver/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/easydcc/networkdriver/configurexml/ConnectionConfigXmlTest.java
@@ -33,8 +33,9 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractNet
     @After
     @Override
     public void tearDown() {
-        JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/easydcc/serialdriver/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/easydcc/serialdriver/configurexml/ConnectionConfigXmlTest.java
@@ -23,7 +23,7 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
     @After
     @Override
     public void tearDown() {
-        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;

--- a/java/test/jmri/jmrix/easydcc/serialdriver/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/easydcc/serialdriver/configurexml/ConnectionConfigXmlTest.java
@@ -23,9 +23,9 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
     @After
     @Override
     public void tearDown() {
-        xmlAdapter = null;
-        cc = null;
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
+        xmlAdapter = null;
+        cc = null;
     }
 }

--- a/java/test/jmri/jmrix/easydcc/serialdriver/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/easydcc/serialdriver/configurexml/ConnectionConfigXmlTest.java
@@ -23,8 +23,9 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
     @After
     @Override
     public void tearDown() {
-        JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/easydcc/simulator/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/easydcc/simulator/configurexml/ConnectionConfigXmlTest.java
@@ -23,8 +23,9 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSim
     @After
     @Override
     public void tearDown() {
-        JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/easydcc/simulator/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/easydcc/simulator/configurexml/ConnectionConfigXmlTest.java
@@ -23,9 +23,9 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSim
     @After
     @Override
     public void tearDown() {
-        xmlAdapter = null;
-        cc = null;
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
+        xmlAdapter = null;
+        cc = null;
     }
 }

--- a/java/test/jmri/jmrix/easydcc/simulator/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/easydcc/simulator/configurexml/ConnectionConfigXmlTest.java
@@ -23,7 +23,7 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSim
     @After
     @Override
     public void tearDown() {
-        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;


### PR DESCRIPTION
- `jmri.beans.Bean` uses SwingPropertyChangeSupport to allow a Bean to either always fire events on the EDT or to fire events on the thread that generated the event and have constructors to allow subclasses to set that
- `Bean` inherits from `PropertyChangeFirer` to avoid duplicating Javadocs
- add method to Bean to test if Bean is (not) firing events on EDT
- `jmri.util.FileUtilSupport` fires events on generating thread
- `PreferencesBean` fires events on generating thread
- `PreferencesBean` only sets the dirty property if a change really occurs

Fixes #8389