### PR TITLE
Finish LayoutEditor track enum refactoring

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -346,7 +346,14 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
-	        <li></li>
+	        <li>
+	            Lots of internal work to improve Layout Editor structure
+	            so that new features can be added more reliably. Please
+	            keep an eye out for any new issues!
+	            <p>
+	            Note that files written by 4.19.6 may not be readable 
+	            by JMRI 4.19.5 and before.
+	        </li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>

--- a/help/en/releasenotes/current-draft-warnings.shtml
+++ b/help/en/releasenotes/current-draft-warnings.shtml
@@ -1,5 +1,7 @@
 
     <!-- contains new warnings for the release under development -->
     <li>
-        None yet
+        Layout Editor files stored by 4.19.6 may not be loadable 
+	    by JMRI 4.19.5 and before. This is in addition to the 
+	    changed in 4.19.5 that raised a similar issue for 4.19.4.
     </li>

--- a/java/src/jmri/configurexml/AbstractXmlAdapter.java
+++ b/java/src/jmri/configurexml/AbstractXmlAdapter.java
@@ -134,7 +134,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Nonnull
         public String outputFromEnum(@Nonnull T e) {
             int ordinal = e.ordinal();
-            return ""+ordinal;
+            return Integer.toString(ordinal);
         }
         
         /** {@inheritDoc} */
@@ -185,6 +185,27 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
                 T retval = mapToEnum.get(s);
                 log.trace("from String {} get {}} for {}", s, retval, clazz);
                 return retval;
+        }
+    }
+
+    /**
+     * Support for Enum I/O to XML using the enum's element names;
+     * for backward compatibility, it will also accept ordinal 
+     * numbers when reading.
+     */
+    public static class EnumIoNamesNumbers <T extends Enum<T>> extends EnumIoNames<T> { // public to be usable by adapters in other configXML packages
+    
+        /**
+         * This constructor converts to and from strings
+         * using the enum element names and, on read only, ordinal numbers
+         */
+        public EnumIoNamesNumbers(@Nonnull Class<T> clazz) {
+            super(clazz);
+            
+            for (T t : clazz.getEnumConstants() ) { // append to existing map
+                mapToEnum.put(Integer.toString(t.ordinal()), t);
+            }
+            
         }
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/ConnectivityUtil.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/ConnectivityUtil.java
@@ -295,10 +295,10 @@ public class ConnectivityUtil {
             }
             if (cType == HitPointType.POS_POINT) {
                 // reached anchor point or end bumper
-                if (((PositionablePoint) cObject).getType() == PositionablePoint.END_BUMPER) {
+                if (((PositionablePoint) cObject).getType() == PositionablePoint.PointType.END_BUMPER) {
                     // end of line
                     trackSegment = null;
-                } else if (((PositionablePoint) cObject).getType() == PositionablePoint.ANCHOR || (((PositionablePoint) cObject).getType() == PositionablePoint.EDGE_CONNECTOR)) {
+                } else if (((PositionablePoint) cObject).getType() == PositionablePoint.PointType.ANCHOR || (((PositionablePoint) cObject).getType() == PositionablePoint.PointType.EDGE_CONNECTOR)) {
                     // proceed to next track segment if within the same Block
                     if (((PositionablePoint) cObject).getConnect1() == trackSegment) {
                         trackSegment = ((PositionablePoint) cObject).getConnect2();
@@ -1312,7 +1312,7 @@ public class ConnectivityUtil {
             case POS_POINT:
                 if (currentNode instanceof PositionablePoint) {
                     PositionablePoint p = (PositionablePoint) currentNode;
-                    if (p.getType() == PositionablePoint.END_BUMPER) {
+                    if (p.getType() == PositionablePoint.PointType.END_BUMPER) {
                         log.warn("Attempt to search beyond end of track");
                         return null;
                     }
@@ -1695,7 +1695,7 @@ public class ConnectivityUtil {
 
             if (nextType == HitPointType.POS_POINT) {
                 PositionablePoint p = (PositionablePoint) nextLayoutTrack;
-                if (p.getType() == PositionablePoint.END_BUMPER) {
+                if (p.getType() == PositionablePoint.PointType.END_BUMPER) {
                     hitEnd = true;
                     hasNode = true;
                 } else {
@@ -2446,14 +2446,14 @@ public class ConnectivityUtil {
                 // this is a positionable point
                 if (conType == HitPointType.POS_POINT) {
                     // reached anchor point or end bumper
-                    if (((PositionablePoint) conLayoutTrack).getType() == PositionablePoint.END_BUMPER) {
+                    if (((PositionablePoint) conLayoutTrack).getType() == PositionablePoint.PointType.END_BUMPER) {
                         // end of line without reaching 'nextLayoutBlock'
                         if (log.isDebugEnabled()) {
                             log.info("end of line without reaching {}", nextLayoutBlock.getId());
                         }
                         curTrackSegment = null;
-                    } else if (((PositionablePoint) conLayoutTrack).getType() == PositionablePoint.ANCHOR
-                            || ((PositionablePoint) conLayoutTrack).getType() == PositionablePoint.EDGE_CONNECTOR) {
+                    } else if (((PositionablePoint) conLayoutTrack).getType() == PositionablePoint.PointType.ANCHOR
+                            || ((PositionablePoint) conLayoutTrack).getType() == PositionablePoint.PointType.EDGE_CONNECTOR) {
                         // proceed to next track segment if within the same Block
                         if (((PositionablePoint) conLayoutTrack).getConnect1() == curTrackSegment) {
                             curTrackSegment = (((PositionablePoint) conLayoutTrack).getConnect2());

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -1277,7 +1277,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
                 if (t.getType1() == HitPointType.POS_POINT) {
                     p = (PositionablePoint) t.getConnect1();
 
-                    if (p.getType() == PositionablePoint.END_BUMPER) {
+                    if (p.getType() == PositionablePoint.PointType.END_BUMPER) {
                         if (p.getEastBoundSignalMast() != null) {
                             return p.getEastBoundSignalMast();
                         }
@@ -1291,7 +1291,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
                 if (t.getType2() == HitPointType.POS_POINT) {
                     p = (PositionablePoint) t.getConnect2();
 
-                    if (p.getType() == PositionablePoint.END_BUMPER) {
+                    if (p.getType() == PositionablePoint.PointType.END_BUMPER) {
                         if (p.getEastBoundSignalMast() != null) {
                             return p.getEastBoundSignalMast();
                         }
@@ -1343,7 +1343,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
                 if (t.getType1() == HitPointType.POS_POINT) {
                     p = (PositionablePoint) t.getConnect1();
 
-                    if (p.getType() == PositionablePoint.END_BUMPER) {
+                    if (p.getType() == PositionablePoint.PointType.END_BUMPER) {
                         if (p.getEastBoundSensor() != null) {
                             return p.getEastBoundSensor();
                         }
@@ -1357,7 +1357,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
                 if (t.getType2() == HitPointType.POS_POINT) {
                     p = (PositionablePoint) t.getConnect2();
 
-                    if (p.getType() == PositionablePoint.END_BUMPER) {
+                    if (p.getType() == PositionablePoint.PointType.END_BUMPER) {
                         if (p.getEastBoundSensor() != null) {
                             return p.getEastBoundSensor();
                         }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -3766,7 +3766,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 case POS_POINT: {
                     PositionablePoint p2 = (PositionablePoint) foundTrack;
 
-                    if ((p2.getType() == PositionablePoint.ANCHOR) && p2.setTrackConnection(t)) {
+                    if ((p2.getType() == PositionablePoint.PointType.ANCHOR) && p2.setTrackConnection(t)) {
                         if (t.getConnect1() == p) {
                             t.setNewConnect1(p2, foundHitPointType);
                         } else {
@@ -4695,7 +4695,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
 
         //create object
         PositionablePoint o = new PositionablePoint(name,
-                PositionablePoint.ANCHOR, p, this);
+                PositionablePoint.PointType.ANCHOR, p, this);
 
         layoutTrackList.add(o);
         unionToPanelBounds(o.getBounds());
@@ -4713,7 +4713,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
 
         //create object
         PositionablePoint o = new PositionablePoint(name,
-                PositionablePoint.END_BUMPER, currentPoint, this);
+                PositionablePoint.PointType.END_BUMPER, currentPoint, this);
 
         layoutTrackList.add(o);
         unionToPanelBounds(o.getBounds());
@@ -4729,7 +4729,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
 
         //create object
         PositionablePoint o = new PositionablePoint(name,
-                PositionablePoint.EDGE_CONNECTOR, currentPoint, this);
+                PositionablePoint.PointType.EDGE_CONNECTOR, currentPoint, this);
 
         layoutTrackList.add(o);
         unionToPanelBounds(o.getBounds());

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorAuxTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorAuxTools.java
@@ -551,7 +551,7 @@ public class LayoutEditorAuxTools {
                     // skip further if positionable point (possible anchor point)
                     if (typeCurConnection == HitPointType.POS_POINT) {
                         PositionablePoint pt = (PositionablePoint) curConnection;
-                        if (pt.getType() == PositionablePoint.END_BUMPER) {
+                        if (pt.getType() == PositionablePoint.PointType.END_BUMPER) {
                             // reached end of track
                             curConnection = null;
                         } else {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorChecks.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorChecks.java
@@ -478,7 +478,7 @@ public class LayoutEditorChecks {
         List<PositionablePoint> aatzlts = new ArrayList<>();
         for (PositionablePoint pp : layoutEditor.getPositionablePoints()) {
             // has to be an anchor...
-            if (pp.getType() == PositionablePoint.ANCHOR) {
+            if (pp.getType() == PositionablePoint.PointType.ANCHOR) {
                 // adjacent track segments must be defined...
                 TrackSegment ts1 = pp.getConnect1();
                 TrackSegment ts2 = pp.getConnect2();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorFindItems.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorFindItems.java
@@ -60,7 +60,7 @@ public class LayoutEditorFindItems {
 
     public PositionablePoint findPositionableLinkPoint(LayoutBlock blk1) {
         for (PositionablePoint p : layoutEditor.getPositionablePoints()) {
-            if (p.getType() == PositionablePoint.EDGE_CONNECTOR) {
+            if (p.getType() == PositionablePoint.PointType.EDGE_CONNECTOR) {
                 if ((p.getConnect1() != null && p.getConnect1().getLayoutBlock() == blk1)
                         || (p.getConnect2() != null && p.getConnect2().getLayoutBlock() == blk1)) {
                     return p;

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
@@ -1487,7 +1487,7 @@ public class LayoutEditorTools {
             }
             if (type == HitPointType.POS_POINT) {
                 PositionablePoint p = (PositionablePoint) connect;
-                if (p.getType() == PositionablePoint.END_BUMPER) {
+                if (p.getType() == PositionablePoint.PointType.END_BUMPER) {
                     hitEndBumper = true;
                     return null;
                 }
@@ -1825,7 +1825,7 @@ public class LayoutEditorTools {
     *	"point" is an anchor point serving as a block boundary.
      */
     public static boolean isAtWestEndOfAnchor(TrackSegment t, PositionablePoint p) {
-        if (p.getType() == PositionablePoint.EDGE_CONNECTOR) {
+        if (p.getType() == PositionablePoint.PointType.EDGE_CONNECTOR) {
             if (p.getConnect1() == t) {
                 if (p.getConnect1Dir() == Path.NORTH || p.getConnect1Dir() == Path.WEST) {
                     return false;
@@ -1957,7 +1957,7 @@ public class LayoutEditorTools {
         boundary = p;
 
         //if this is an edge connector...
-        if ((p.getType() == PositionablePoint.EDGE_CONNECTOR) && ((p.getLinkedPoint() == null)
+        if ((p.getType() == PositionablePoint.PointType.EDGE_CONNECTOR) && ((p.getLinkedPoint() == null)
                 || (p.getLinkedPoint().getConnect1() == null))) {
             if (p.getConnect1Dir() == Path.EAST || p.getConnect1Dir() == Path.SOUTH) {
                 showWest = false;
@@ -2247,7 +2247,7 @@ public class LayoutEditorTools {
             }
             boundary = null;
             for (PositionablePoint p : layoutEditor.getPositionablePoints()) {
-                if (p.getType() == PositionablePoint.ANCHOR || p.getType() == PositionablePoint.EDGE_CONNECTOR) {
+                if (p.getType() == PositionablePoint.PointType.ANCHOR || p.getType() == PositionablePoint.PointType.EDGE_CONNECTOR) {
                     LayoutBlock bA = null;
                     LayoutBlock bB = null;
                     if (p.getConnect1() != null) {
@@ -2285,10 +2285,10 @@ public class LayoutEditorTools {
         }
         TrackSegment track2 = boundary.getConnect2();
 
-        if (boundary.getType() == PositionablePoint.END_BUMPER) {
+        if (boundary.getType() == PositionablePoint.PointType.END_BUMPER) {
             return true;
         }
-        if (boundary.getType() == PositionablePoint.EDGE_CONNECTOR) {
+        if (boundary.getType() == PositionablePoint.PointType.EDGE_CONNECTOR) {
             if (boundary.getConnect1Dir() == Path.EAST || boundary.getConnect1Dir() == Path.SOUTH) {
                 eastTrack = track2;
                 westTrack = track1;
@@ -2356,7 +2356,7 @@ public class LayoutEditorTools {
             }
         }
         if (!block.isOnPanel(layoutEditor)
-                && ((boundary == null) || boundary.getType() != PositionablePoint.EDGE_CONNECTOR)) {
+                && ((boundary == null) || boundary.getType() != PositionablePoint.PointType.EDGE_CONNECTOR)) {
             JOptionPane.showMessageDialog(setSignalsAtBlockBoundaryFrame,
                     Bundle.getMessage("SignalsError11",
                             new Object[]{theBlockName}), Bundle.getMessage("ErrorTitle"),
@@ -2414,7 +2414,7 @@ public class LayoutEditorTools {
             return;
         }
         PositionablePoint p = boundary;
-        if (boundary.getType() == PositionablePoint.EDGE_CONNECTOR && eastTrack != boundary.getConnect1()) {
+        if (boundary.getType() == PositionablePoint.PointType.EDGE_CONNECTOR && eastTrack != boundary.getConnect1()) {
             p = boundary.getLinkedPoint();
         }
         String newEastBoundSignalName = eastBoundSignalHeadComboBox.getSelectedItemDisplayName();
@@ -2458,7 +2458,7 @@ public class LayoutEditorTools {
             return;
         }
         PositionablePoint p = boundary;
-        if (boundary.getType() == PositionablePoint.EDGE_CONNECTOR && westTrack != boundary.getConnect1()) {
+        if (boundary.getType() == PositionablePoint.PointType.EDGE_CONNECTOR && westTrack != boundary.getConnect1()) {
             p = boundary.getLinkedPoint();
         }
         String newWestBoundSignalName = westBoundSignalHeadComboBox.getSelectedItemDisplayName();
@@ -7500,9 +7500,9 @@ public class LayoutEditorTools {
 
         sensorBlockPanel.removeAll();
 
-        if (boundary.getType() != PositionablePoint.END_BUMPER) {
+        if (boundary.getType() != PositionablePoint.PointType.END_BUMPER) {
             eastBoundSensor.setBoundaryTitle(Bundle.getMessage("East/SouthBound"));
-            if ((setSensorsAtBlockBoundaryFromMenuFlag) && (boundary.getType() == PositionablePoint.ANCHOR)) {
+            if ((setSensorsAtBlockBoundaryFromMenuFlag) && (boundary.getType() == PositionablePoint.PointType.ANCHOR)) {
                 if (isAtWestEndOfAnchor(boundary.getConnect1(), boundary)) {
                     eastBoundSensor.setBoundaryLabelText(Bundle.getMessage("ProtectingBlock") + boundary.getConnect2().getLayoutBlock().getDisplayName());
                 } else {
@@ -7560,7 +7560,7 @@ public class LayoutEditorTools {
                     + Bundle.getMessage("Name")));
         }
         //boundary should never be null... however, just in case...
-        boolean enable = ((boundary != null) && (boundary.getType() != PositionablePoint.END_BUMPER));
+        boolean enable = ((boundary != null) && (boundary.getType() != PositionablePoint.PointType.END_BUMPER));
         block2NameLabel.setVisible(enable);
 
         if (!setSensorsAtBlockBoundaryOpenFlag) {
@@ -7807,7 +7807,7 @@ public class LayoutEditorTools {
         eastBoundSensor.setTextField(boundary.getEastBoundSensorName());
         westBoundSensor.setTextField(boundary.getWestBoundSensorName());
 
-        if (boundary.getType() != PositionablePoint.END_BUMPER) {
+        if (boundary.getType() != PositionablePoint.PointType.END_BUMPER) {
             if (isAtWestEndOfAnchor(boundary.getConnect1(), boundary)) {
                 eastBoundSensor.setBoundaryLabelText(Bundle.getMessage("ProtectingBlock") + boundary.getConnect2().getLayoutBlock().getDisplayName());
             } else {
@@ -7986,7 +7986,7 @@ public class LayoutEditorTools {
             @Nonnull PositionablePoint p) {
         boundary = p;
         block1IDComboBox.setSelectedItem(boundary.getConnect1().getLayoutBlock().getBlock());
-        if (boundary.getType() != PositionablePoint.END_BUMPER) {
+        if (boundary.getType() != PositionablePoint.PointType.END_BUMPER) {
             block2IDComboBox.setSelectedItem(boundary.getConnect2().getLayoutBlock().getBlock());
         } else {
             block2IDComboBox.setSelectedItem(boundary.getConnect1().getLayoutBlock().getBlock());
@@ -8085,9 +8085,9 @@ public class LayoutEditorTools {
         westSignalMast.getCombo().setExcludedItems(new HashSet<>());
         signalMastBlockPanel.removeAll();
 
-        if (boundary.getType() != PositionablePoint.END_BUMPER) {   //Anchor points and Edge Connectors
+        if (boundary.getType() != PositionablePoint.PointType.END_BUMPER) {   //Anchor points and Edge Connectors
             eastSignalMast.setBoundaryTitle(Bundle.getMessage("East/SouthBound"));
-            if (boundary.getType() == PositionablePoint.EDGE_CONNECTOR) {
+            if (boundary.getType() == PositionablePoint.PointType.EDGE_CONNECTOR) {
                 eastSignalMast.setBoundaryTitle(Bundle.getMessage("West/NorthBound"));
             }
             if (setSignalMastsAtBlockBoundaryFromMenuFlag) {
@@ -8101,7 +8101,7 @@ public class LayoutEditorTools {
             signalMastBlockPanel.add(eastSignalMast.getDetailsPanel());
 
             westSignalMast.setBoundaryTitle(Bundle.getMessage("West/NorthBound"));
-            if (boundary.getType() == PositionablePoint.EDGE_CONNECTOR) {
+            if (boundary.getType() == PositionablePoint.PointType.EDGE_CONNECTOR) {
                 westSignalMast.setBoundaryTitle(Bundle.getMessage("East/SouthBound"));
             }
             if (setSignalMastsAtBlockBoundaryFromMenuFlag) {
@@ -8329,7 +8329,7 @@ public class LayoutEditorTools {
         eastSignalMast.setTextField(boundary.getEastBoundSignalMastName());
         westSignalMast.setTextField(boundary.getWestBoundSignalMastName());
 
-        if (boundary.getType() != PositionablePoint.END_BUMPER) {
+        if (boundary.getType() != PositionablePoint.PointType.END_BUMPER) {
             if (isAtWestEndOfAnchor(boundary.getConnect1(), boundary)) {
                 eastSignalMast.setBoundaryLabelText(Bundle.getMessage("ProtectingBlock") + boundary.getConnect2().getLayoutBlock().getDisplayName());
             } else {
@@ -8603,7 +8603,7 @@ public class LayoutEditorTools {
         //Track segment is used to determine the alignment, therefore this is opposite to the block that we are protecting
         TrackSegment t = boundary.getConnect2();
         boolean dir = true;
-        if (boundary.getType() == PositionablePoint.END_BUMPER) {
+        if (boundary.getType() == PositionablePoint.PointType.END_BUMPER) {
             t = boundary.getConnect1();
         } else {
             if (isAtWestEndOfAnchor(boundary.getConnect1(), boundary)) {
@@ -8627,7 +8627,7 @@ public class LayoutEditorTools {
         //Track segment is used to determine the alignment, therefore this is opposite to the block that we are protecting
         TrackSegment t = boundary.getConnect1();
         boolean dir = false;
-        if (boundary.getType() != PositionablePoint.END_BUMPER) {
+        if (boundary.getType() != PositionablePoint.PointType.END_BUMPER) {
             if (isAtWestEndOfAnchor(boundary.getConnect1(), boundary)) {
                 t = boundary.getConnect2();
             }
@@ -11620,7 +11620,7 @@ public class LayoutEditorTools {
             if (block2 == null || (block1 == block2)) {
                 //find the 1st positionablePoint that's connect1'ed to block1
                 for (PositionablePoint p : layoutEditor.getPositionablePoints()) {
-                    if (p.getType() == PositionablePoint.END_BUMPER) {
+                    if (p.getType() == PositionablePoint.PointType.END_BUMPER) {
                         if (p.getConnect1() != null && p.getConnect1().getLayoutBlock() == block1) {
                             boundary = p;
                             break;
@@ -11633,7 +11633,7 @@ public class LayoutEditorTools {
             //(if this fails boundary will still be set to the pp set if
             //block2 was null or equal to block1 above.)
             for (PositionablePoint p : layoutEditor.getPositionablePoints()) {
-                if (p.getType() != PositionablePoint.END_BUMPER) {
+                if (p.getType() != PositionablePoint.PointType.END_BUMPER) {
                     LayoutBlock bA = null;
                     LayoutBlock bB = null;
                     if (p.getConnect1() != null) {

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -45,13 +45,16 @@ import org.slf4j.*;
 public class PositionablePoint extends LayoutTrack {
 
     // defined constants
-    public static final int ANCHOR = 1;
-    public static final int END_BUMPER = 2;
-    public static final int EDGE_CONNECTOR = 3;
+    public enum PointType {
+        NONE,
+        ANCHOR,        // 1
+        END_BUMPER,    // 2
+        EDGE_CONNECTOR // 3
+    }
 
     // operational instance variables (not saved between sessions)
     // persistent instances variables (saved between sessions)
-    private int type = 0;
+    private PointType type = PointType.NONE;
     private TrackSegment connect1 = null;
     private TrackSegment connect2 = null;
 
@@ -65,14 +68,14 @@ public class PositionablePoint extends LayoutTrack {
     private NamedBeanHandle<Sensor> eastBoundSensorNamed = null;
     private NamedBeanHandle<Sensor> westBoundSensorNamed = null;
 
-    public PositionablePoint(String id, int t, Point2D c, LayoutEditor layoutEditor) {
+    public PositionablePoint(String id, PointType t, Point2D c, LayoutEditor layoutEditor) {
         super(id, c, layoutEditor);
 
-        if ((t == ANCHOR) || (t == END_BUMPER) || (t == EDGE_CONNECTOR)) {
+        if ((t == PointType.ANCHOR) || (t == PointType.END_BUMPER) || (t == PointType.EDGE_CONNECTOR)) {
             type = t;
         } else {
             log.error("Illegal type of PositionablePoint - " + t);
-            type = ANCHOR;
+            type = PointType.ANCHOR;
         }
     }
 
@@ -104,11 +107,11 @@ public class PositionablePoint extends LayoutTrack {
     /**
      * Accessor methods
      */
-    public int getType() {
+    public PointType getType() {
         return type;
     }
 
-    public void setType(int newType) {
+    public void setType(PointType newType) {
         if (type != newType) {
             switch (newType) {
                 default:
@@ -131,7 +134,7 @@ public class PositionablePoint extends LayoutTrack {
 
     private void setTypeAnchor() {
         ident = layoutEditor.getFinder().uniqueName("A", 1);
-        type = ANCHOR;
+        type = PointType.ANCHOR;
         if (connect1 != null) {
             if (connect1.getConnect1() == PositionablePoint.this) {
                 connect1.setArrowEndStart(false);
@@ -156,7 +159,7 @@ public class PositionablePoint extends LayoutTrack {
 
     private void setTypeEndBumper() {
         ident = layoutEditor.getFinder().uniqueName("EB", 1);
-        type = END_BUMPER;
+        type = PointType.END_BUMPER;
         if (connect1 != null) {
             if (connect1.getConnect1() == PositionablePoint.this) {
                 connect1.setArrowEndStart(false);
@@ -171,7 +174,7 @@ public class PositionablePoint extends LayoutTrack {
 
     private void setTypeEdgeConnector() {
         ident = layoutEditor.getFinder().uniqueName("EC", 1);
-        type = EDGE_CONNECTOR;
+        type = PointType.EDGE_CONNECTOR;
         if (connect1 != null) {
             if (connect1.getConnect1() == PositionablePoint.this) {
                 connect1.setBumperEndStart(false);
@@ -187,7 +190,7 @@ public class PositionablePoint extends LayoutTrack {
     }
 
     public TrackSegment getConnect2() {
-        if (type == EDGE_CONNECTOR && getLinkedPoint() != null) {
+        if (type == PointType.EDGE_CONNECTOR && getLinkedPoint() != null) {
             return getLinkedPoint().getConnect1();
         }
         return connect2;
@@ -310,7 +313,7 @@ public class PositionablePoint extends LayoutTrack {
     @CheckForNull
     @CheckReturnValue
     public SignalHead getEastBoundSignalHead() {
-        if (getType() == EDGE_CONNECTOR) {
+        if (getType() == PointType.EDGE_CONNECTOR) {
             int dir = getConnect1Dir();
             if (dir == Path.EAST || dir == Path.SOUTH || dir == Path.SOUTH_EAST) {
                 if (signalEastHeadNamed != null) {
@@ -333,7 +336,7 @@ public class PositionablePoint extends LayoutTrack {
     }
 
     public void setEastBoundSignal(String signalName) {
-        if (getType() == EDGE_CONNECTOR) {
+        if (getType() == PointType.EDGE_CONNECTOR) {
             int dir = getConnect1Dir();
             if (dir == Path.EAST || dir == Path.SOUTH || dir == Path.SOUTH_EAST) {
                 setEastBoundSignalName(signalName);
@@ -379,7 +382,7 @@ public class PositionablePoint extends LayoutTrack {
     @CheckForNull
     @CheckReturnValue
     public SignalHead getWestBoundSignalHead() {
-        if (getType() == EDGE_CONNECTOR) {
+        if (getType() == PointType.EDGE_CONNECTOR) {
             int dir = getConnect1Dir();
             if (dir == Path.WEST || dir == Path.NORTH || dir == Path.NORTH_WEST) {
                 if (signalWestHeadNamed != null) {
@@ -402,7 +405,7 @@ public class PositionablePoint extends LayoutTrack {
     }
 
     public void setWestBoundSignal(String signalName) {
-        if (getType() == EDGE_CONNECTOR) {
+        if (getType() == PointType.EDGE_CONNECTOR) {
             int dir = getConnect1Dir();
             if (dir == Path.WEST || dir == Path.NORTH || dir == Path.NORTH_WEST) {
                 setWestBoundSignalName(signalName);
@@ -515,7 +518,7 @@ public class PositionablePoint extends LayoutTrack {
 
     @CheckReturnValue
     private NamedBeanHandle<SignalMast> getEastBoundSignalMastNamed() {
-        if (getType() == EDGE_CONNECTOR) {
+        if (getType() == PointType.EDGE_CONNECTOR) {
             int dir = getConnect1Dir();
             if (dir == Path.SOUTH || dir == Path.EAST || dir == Path.SOUTH_EAST) {
                 return eastBoundSignalMastNamed;
@@ -542,7 +545,7 @@ public class PositionablePoint extends LayoutTrack {
             eastBoundSignalMastNamed = null;
             return;
         }
-        if (getType() == EDGE_CONNECTOR) {
+        if (getType() == PointType.EDGE_CONNECTOR) {
             int dir = getConnect1Dir();
             if (dir == Path.EAST || dir == Path.SOUTH || dir == Path.SOUTH_EAST) {
                 eastBoundSignalMastNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(signalMast, mast);
@@ -580,7 +583,7 @@ public class PositionablePoint extends LayoutTrack {
 
     @CheckReturnValue
     private NamedBeanHandle<SignalMast> getWestBoundSignalMastNamed() {
-        if (getType() == EDGE_CONNECTOR) {
+        if (getType() == PointType.EDGE_CONNECTOR) {
             int dir = getConnect1Dir();
             if (dir == Path.WEST || dir == Path.NORTH || dir == Path.NORTH_WEST) {
                 return westBoundSignalMastNamed;
@@ -607,7 +610,7 @@ public class PositionablePoint extends LayoutTrack {
             westBoundSignalMastNamed = null;
             return;
         }
-        if (getType() == EDGE_CONNECTOR) {
+        if (getType() == PointType.EDGE_CONNECTOR) {
             int dir = getConnect1Dir();
             if (dir == Path.WEST || dir == Path.NORTH || dir == Path.NORTH_WEST) {
                 westBoundSignalMastNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(signalMast, mast);
@@ -664,7 +667,7 @@ public class PositionablePoint extends LayoutTrack {
      */
     @Override
     public void setObjects(LayoutEditor p) {
-        if (type == EDGE_CONNECTOR) {
+        if (type == PointType.EDGE_CONNECTOR) {
             connect1 = p.getFinder().findTrackSegmentByName(trackSegment1Name);
             if (getConnect2() != null && getLinkedEditor() != null) {
                 //now that we have a connection we can fire off a change
@@ -737,7 +740,7 @@ public class PositionablePoint extends LayoutTrack {
             result = true;  // assume success (optimist!)
             if (connect1 == oldTrack) {
                 connect1 = newTrack;
-            } else if ((type == ANCHOR) && (connect2 == oldTrack)) {
+            } else if ((type == PointType.ANCHOR) && (connect2 == oldTrack)) {
                 connect2 = newTrack;
                 if (connect1.getLayoutBlock() == connect2.getLayoutBlock()) {
                     westBoundSignalMastNamed = null;
@@ -930,7 +933,7 @@ public class PositionablePoint extends LayoutTrack {
             popup.add(connectionsMenu);
         }
 
-        if (connect1 != null && (type == EDGE_CONNECTOR || type == END_BUMPER)) {
+        if (connect1 != null && (type == PointType.EDGE_CONNECTOR || type == PointType.END_BUMPER)) {
             //
             // decorations menu
             //
@@ -941,7 +944,7 @@ public class PositionablePoint extends LayoutTrack {
             popup.add(decorationsMenu);
 
             JCheckBoxMenuItem jcbmi;
-            if (type == EDGE_CONNECTOR) {
+            if (type == PointType.EDGE_CONNECTOR) {
                 JMenu arrowsMenu = new JMenu(Bundle.getMessage("ArrowsMenuTitle"));
                 decorationsMenu.setToolTipText(Bundle.getMessage("ArrowsMenuToolTip"));
                 decorationsMenu.add(arrowsMenu);
@@ -1132,7 +1135,7 @@ public class PositionablePoint extends LayoutTrack {
                 });
             } // if (type == EDGE_CONNECTOR)
 
-            if (type == END_BUMPER) {
+            if (type == PointType.END_BUMPER) {
                 JMenu endBumperMenu = new JMenu(Bundle.getMessage("EndBumperMenuTitle"));
                 decorationsMenu.setToolTipText(Bundle.getMessage("EndBumperMenuToolTip"));
                 decorationsMenu.add(endBumperMenu);
@@ -1207,7 +1210,7 @@ public class PositionablePoint extends LayoutTrack {
 
         popup.add(new JSeparator(JSeparator.HORIZONTAL));
 
-        if (getType() == ANCHOR) {
+        if (getType() == PointType.ANCHOR) {
             if (blockBoundary) {
                 jmi = popup.add(new JMenuItem(Bundle.getMessage("CanNotMergeAtBlockBoundary")));
                 jmi.setEnabled(false);
@@ -1329,11 +1332,11 @@ public class PositionablePoint extends LayoutTrack {
             }
         }));
 
-        jmi.setSelected(getType() == ANCHOR);
+        jmi.setSelected(getType() == PointType.ANCHOR);
 
         // you can't change it to an anchor if it has a 2nd connection
         // TODO: add error dialog if you try?
-        if ((getType() == EDGE_CONNECTOR) && (getConnect2() != null)) {
+        if ((getType() == PointType.EDGE_CONNECTOR) && (getConnect2() != null)) {
             jmi.setEnabled(false);
         }
 
@@ -1344,7 +1347,7 @@ public class PositionablePoint extends LayoutTrack {
             }
         }));
 
-        jmi.setSelected(getType() == END_BUMPER);
+        jmi.setSelected(getType() == PointType.END_BUMPER);
 
         jmi = lineType.add(new JCheckBoxMenuItem(new AbstractAction(Bundle.getMessage("EdgeConnector")) {
             @Override
@@ -1353,11 +1356,11 @@ public class PositionablePoint extends LayoutTrack {
             }
         }));
 
-        jmi.setSelected(getType() == EDGE_CONNECTOR);
+        jmi.setSelected(getType() == PointType.EDGE_CONNECTOR);
 
         popup.add(lineType);
 
-        if (!blockBoundary && getType() == EDGE_CONNECTOR) {
+        if (!blockBoundary && getType() == PointType.EDGE_CONNECTOR) {
             popup.add(new JSeparator(JSeparator.HORIZONTAL));
             popup.add(new AbstractAction(Bundle.getMessage("EdgeEditLink")) {
                 @Override
@@ -1369,7 +1372,7 @@ public class PositionablePoint extends LayoutTrack {
 
         if (blockBoundary) {
             popup.add(new JSeparator(JSeparator.HORIZONTAL));
-            if (getType() == EDGE_CONNECTOR) {
+            if (getType() == PointType.EDGE_CONNECTOR) {
                 popup.add(new AbstractAction(Bundle.getMessage("EdgeEditLink")) {
                     @Override
                     public void actionPerformed(ActionEvent e) {
@@ -1510,7 +1513,7 @@ public class PositionablePoint extends LayoutTrack {
     }
 
     void removeLinkedPoint() {
-        if (type == EDGE_CONNECTOR && getLinkedPoint() != null) {
+        if (type == PointType.EDGE_CONNECTOR && getLinkedPoint() != null) {
             if (getConnect2() != null && getLinkedEditor() != null) {
                 //as we have removed the point, need to force the update on the remote end.
                 LayoutEditor oldLinkedEditor = getLinkedEditor();
@@ -1632,7 +1635,7 @@ public class PositionablePoint extends LayoutTrack {
         linkPointsBox.setEnabled(true);
         LayoutEditor le = editorCombo.getItemAt(editorCombo.getSelectedIndex()).item();
         for (PositionablePoint p : le.getPositionablePoints()) {
-            if (p.getType() == EDGE_CONNECTOR) {
+            if (p.getType() == PointType.EDGE_CONNECTOR) {
                 if (p.getLinkedPoint() == this) {
                     pointList.add(p);
                     linkPointsBox.addItem(p.getName());
@@ -1704,7 +1707,7 @@ public class PositionablePoint extends LayoutTrack {
         double distance, minDistance = Float.POSITIVE_INFINITY;
 
         if (!requireUnconnected || (getConnect1() == null)
-                || ((getType() == ANCHOR) && (getConnect2() == null))) {
+                || ((getType() == PointType.ANCHOR) && (getConnect2() == null))) {
             // test point control rectangle
             p = getCoordsCenter();
             distance = MathUtil.distance(p, hitPoint);
@@ -1800,7 +1803,7 @@ public class PositionablePoint extends LayoutTrack {
         if (getConnect1() != null) {
             result = getConnect1().isMainline();
         }
-        if (getType() == ANCHOR) {
+        if (getType() == PointType.ANCHOR) {
             if (getConnect2() != null) {
                 result |= getConnect2().isMainline();
             }
@@ -1831,7 +1834,7 @@ public class PositionablePoint extends LayoutTrack {
     protected void highlightUnconnected(Graphics2D g2, HitPointType specificType) {
         if ((specificType == HitPointType.NONE) || (specificType == HitPointType.POS_POINT)) {
             if ((getConnect1() == null)
-                    || ((getType() == ANCHOR) && (getConnect2() == null))) {
+                    || ((getType() == PointType.ANCHOR) && (getConnect2() == null))) {
                 g2.fill(trackControlCircleAt(getCoordsCenter()));
             }
         }
@@ -1847,14 +1850,14 @@ public class PositionablePoint extends LayoutTrack {
             g2.setColor(Color.red);
         } else {
             TrackSegment ts2 = null;
-            if (getType() == ANCHOR) {
+            if (getType() == PointType.ANCHOR) {
                 ts2 = getConnect2();
-            } else if (getType() == EDGE_CONNECTOR) {
+            } else if (getType() == PointType.EDGE_CONNECTOR) {
                 if (getLinkedPoint() != null) {
                     ts2 = getLinkedPoint().getConnect1();
                 }
             }
-            if ((getType() != END_BUMPER) && (ts2 == null)) {
+            if ((getType() != PointType.END_BUMPER) && (ts2 == null)) {
                 g2.setColor(Color.yellow);
             } else {
                 g2.setColor(Color.green);
@@ -1877,7 +1880,7 @@ public class PositionablePoint extends LayoutTrack {
      */
     @Override
     public void reCheckBlockBoundary() {
-        if (type == END_BUMPER) {
+        if (type == PointType.END_BUMPER) {
             return;
         }
         if (getConnect1() == null && getConnect2() == null) {
@@ -1924,7 +1927,7 @@ public class PositionablePoint extends LayoutTrack {
         TrackSegment ts1 = getConnect1();
         Point2D p1, p2;
 
-        if (getType() == ANCHOR) {
+        if (getType() == PointType.ANCHOR) {
             TrackSegment ts2 = getConnect2();
             if ((ts1 != null) && (ts2 != null)) {
                 blk1 = ts1.getLayoutBlock();
@@ -1950,7 +1953,7 @@ public class PositionablePoint extends LayoutTrack {
                     results.add(lc);
                 }
             }
-        } else if (getType() == EDGE_CONNECTOR) {
+        } else if (getType() == PointType.EDGE_CONNECTOR) {
             TrackSegment ts2 = null;
             if (getLinkedPoint() != null) {
                 ts2 = getLinkedPoint().getConnect1();
@@ -1990,7 +1993,7 @@ public class PositionablePoint extends LayoutTrack {
         List<HitPointType> result = new ArrayList<>();
 
         if ((getConnect1() == null)
-                || ((getType() == ANCHOR) && (getConnect2() == null))) {
+                || ((getType() == PointType.ANCHOR) && (getConnect2() == null))) {
             result.add(HitPointType.POS_POINT);
         }
         return result;
@@ -2059,7 +2062,7 @@ public class PositionablePoint extends LayoutTrack {
             }
         }
 
-        if (getType() == ANCHOR) {
+        if (getType() == PointType.ANCHOR) {
             //check the 2nd connection points block
             TrackSegment ts2 = getConnect2();
             // this should never be null... but just in case...
@@ -2117,7 +2120,7 @@ public class PositionablePoint extends LayoutTrack {
                     }
                 }
             }
-            if (getType() == ANCHOR) {
+            if (getType() == PointType.ANCHOR) {
                 TrackSegment ts2 = getConnect2();
                 // this should never be null... but just in case...
                 if (ts2 != null) {

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -916,14 +916,14 @@ public class TrackSegment extends LayoutTrack {
         boolean hasEC1 = false;
         if (type1 == HitPointType.POS_POINT) {
             PositionablePoint pp = (PositionablePoint) connect1;
-            if (pp.getType() == PositionablePoint.EDGE_CONNECTOR) {
+            if (pp.getType() == PositionablePoint.PointType.EDGE_CONNECTOR) {
                 hasEC1 = true;
             }
         }
         boolean hasEC2 = false;
         if (type2 == HitPointType.POS_POINT) {
             PositionablePoint pp = (PositionablePoint) connect2;
-            if (pp.getType() == PositionablePoint.EDGE_CONNECTOR) {
+            if (pp.getType() == PositionablePoint.PointType.EDGE_CONNECTOR) {
                 hasEC2 = true;
             }
         }
@@ -951,8 +951,8 @@ public class TrackSegment extends LayoutTrack {
             arrowsCountMenu.add(jcbmi);
             jcbmi.setToolTipText(Bundle.getMessage("DecorationStyleMenuToolTip"));
             jcbmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-                setArrowEndStart((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.EDGE_CONNECTOR));
-                setArrowEndStop((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.EDGE_CONNECTOR));
+                setArrowEndStart((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.PointType.EDGE_CONNECTOR));
+                setArrowEndStop((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.PointType.EDGE_CONNECTOR));
                 setArrowStyle(1);
             });
             jcbmi.setSelected(arrowStyle == 1);
@@ -962,8 +962,8 @@ public class TrackSegment extends LayoutTrack {
             arrowsCountMenu.add(jcbmi);
             jcbmi.setToolTipText(Bundle.getMessage("DecorationStyleMenuToolTip"));
             jcbmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-                setArrowEndStart((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.EDGE_CONNECTOR));
-                setArrowEndStop((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.EDGE_CONNECTOR));
+                setArrowEndStart((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.PointType.EDGE_CONNECTOR));
+                setArrowEndStop((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.PointType.EDGE_CONNECTOR));
                 setArrowStyle(2);
             });
             jcbmi.setSelected(arrowStyle == 2);
@@ -973,8 +973,8 @@ public class TrackSegment extends LayoutTrack {
             arrowsCountMenu.add(jcbmi);
             jcbmi.setToolTipText(Bundle.getMessage("DecorationStyleMenuToolTip"));
             jcbmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-                setArrowEndStart((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.EDGE_CONNECTOR));
-                setArrowEndStop((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.EDGE_CONNECTOR));
+                setArrowEndStart((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.PointType.EDGE_CONNECTOR));
+                setArrowEndStop((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.PointType.EDGE_CONNECTOR));
                 setArrowStyle(3);
             });
             jcbmi.setSelected(arrowStyle == 3);
@@ -984,8 +984,8 @@ public class TrackSegment extends LayoutTrack {
             arrowsCountMenu.add(jcbmi);
             jcbmi.setToolTipText(Bundle.getMessage("DecorationStyleMenuToolTip"));
             jcbmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-                setArrowEndStart((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.EDGE_CONNECTOR));
-                setArrowEndStop((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.EDGE_CONNECTOR));
+                setArrowEndStart((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.PointType.EDGE_CONNECTOR));
+                setArrowEndStop((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.PointType.EDGE_CONNECTOR));
                 setArrowStyle(4);
             });
             jcbmi.setSelected(arrowStyle == 4);
@@ -995,8 +995,8 @@ public class TrackSegment extends LayoutTrack {
             arrowsCountMenu.add(jcbmi);
             jcbmi.setToolTipText(Bundle.getMessage("DecorationStyleMenuToolTip"));
             jcbmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-                setArrowEndStart((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.EDGE_CONNECTOR));
-                setArrowEndStop((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.EDGE_CONNECTOR));
+                setArrowEndStart((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.PointType.EDGE_CONNECTOR));
+                setArrowEndStop((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.PointType.EDGE_CONNECTOR));
                 setArrowStyle(5);
             });
             jcbmi.setSelected(arrowStyle == 5);
@@ -1252,14 +1252,14 @@ public class TrackSegment extends LayoutTrack {
         boolean hasEB1 = false;
         if (type1 == HitPointType.POS_POINT) {
             PositionablePoint pp = (PositionablePoint) connect1;
-            if (pp.getType() == PositionablePoint.END_BUMPER) {
+            if (pp.getType() == PositionablePoint.PointType.END_BUMPER) {
                 hasEB1 = true;
             }
         }
         boolean hasEB2 = false;
         if (type2 == HitPointType.POS_POINT) {
             PositionablePoint pp = (PositionablePoint) connect2;
-            if (pp.getType() == PositionablePoint.END_BUMPER) {
+            if (pp.getType() == PositionablePoint.PointType.END_BUMPER) {
                 hasEB2 = true;
             }
         }
@@ -1314,10 +1314,10 @@ public class TrackSegment extends LayoutTrack {
 
                 endBumperMenu.add(enableCheckBoxMenuItem);
                 enableCheckBoxMenuItem.addActionListener((java.awt.event.ActionEvent e3) -> {
-                    if ((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.END_BUMPER)) {
+                    if ((type1 == HitPointType.POS_POINT) && (((PositionablePoint) connect1).getType() == PositionablePoint.PointType.END_BUMPER)) {
                         setBumperEndStart(enableCheckBoxMenuItem.isSelected());
                     }
-                    if ((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.END_BUMPER)) {
+                    if ((type2 == HitPointType.POS_POINT) && (((PositionablePoint) connect2).getType() == PositionablePoint.PointType.END_BUMPER)) {
                         setBumperEndStop(enableCheckBoxMenuItem.isSelected());
                     }
                 });
@@ -1618,7 +1618,7 @@ public class TrackSegment extends LayoutTrack {
             if (!pt.getWestBoundSensorName().isEmpty()) {
                 result.add(pt.getWestBoundSensorName());
             }
-            if (pt.getType() == PositionablePoint.EDGE_CONNECTOR && pt.getLinkedPoint() != null) {
+            if (pt.getType() == PositionablePoint.PointType.EDGE_CONNECTOR && pt.getLinkedPoint() != null) {
                 result.add(Bundle.getMessage("DeleteECisActive"));   // NOI18N
             }
         }

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutShapeXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutShapeXml.java
@@ -25,9 +25,9 @@ public class LayoutShapeXml extends AbstractXmlAdapter {
     }
     
     // default mapping fine
-    EnumIoNames<LayoutShape.LayoutShapeType> sTypeEnumMap 
+    static final EnumIoNames<LayoutShape.LayoutShapeType> sTypeEnumMap 
             = new EnumIoNames<>(LayoutShape.LayoutShapeType.class);
-    EnumIoNames<LayoutShape.LayoutShapePointType> pTypeEnumMap 
+    static final EnumIoNames<LayoutShape.LayoutShapePointType> pTypeEnumMap 
             = new EnumIoNames<>(LayoutShape.LayoutShapePointType.class);
     
     /**

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutSlipXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutSlipXml.java
@@ -23,7 +23,7 @@ public class LayoutSlipXml extends AbstractXmlAdapter {
     public LayoutSlipXml() {
     }
 
-    final static EnumIoOrdinals<LayoutSlip.TurnoutType> tTypeEnumMap = new EnumIoOrdinals<>(LayoutSlip.TurnoutType.class);
+    final static EnumIO<LayoutSlip.TurnoutType> tTypeEnumMap = new EnumIoNamesNumbers<>(LayoutSlip.TurnoutType.class);
 
     /**
      * Default implementation for storing the contents of a LayoutSlip

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutSlipXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutSlipXml.java
@@ -23,7 +23,7 @@ public class LayoutSlipXml extends AbstractXmlAdapter {
     public LayoutSlipXml() {
     }
 
-    EnumIoOrdinals<LayoutSlip.TurnoutType> tTypeEnumMap = new EnumIoOrdinals<>(LayoutSlip.TurnoutType.class);
+    final static EnumIoOrdinals<LayoutSlip.TurnoutType> tTypeEnumMap = new EnumIoOrdinals<>(LayoutSlip.TurnoutType.class);
 
     /**
      * Default implementation for storing the contents of a LayoutSlip

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/PositionablePointXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/PositionablePointXml.java
@@ -20,6 +20,8 @@ import org.slf4j.LoggerFactory;
  */
 public class PositionablePointXml extends AbstractXmlAdapter {
 
+    static final EnumIO<PositionablePoint.PointType> pTypeEnumMap = new EnumIoOrdinals<>(PositionablePoint.PointType.class);
+
     public PositionablePointXml() {
     }
 
@@ -38,7 +40,7 @@ public class PositionablePointXml extends AbstractXmlAdapter {
 
         // include attributes
         element.setAttribute("ident", p.getId());
-        element.setAttribute("type", "" + p.getType());
+        element.setAttribute("type", pTypeEnumMap.outputFromEnum(p.getType()));
         Point2D coords = p.getCoordsCenter();
         element.setAttribute("x", "" + coords.getX());
         element.setAttribute("y", "" + coords.getY());
@@ -68,7 +70,7 @@ public class PositionablePointXml extends AbstractXmlAdapter {
         if (!p.getWestBoundSensorName().isEmpty()) {
             element.setAttribute("westboundsensor", p.getWestBoundSensorName());
         }
-        if (p.getType() == PositionablePoint.EDGE_CONNECTOR) {
+        if (p.getType() == PositionablePoint.PointType.EDGE_CONNECTOR) {
             element.setAttribute("linkedpanel", p.getLinkedEditorName());
             element.setAttribute("linkpointid", p.getLinkedPointId());
         }
@@ -97,13 +99,13 @@ public class PositionablePointXml extends AbstractXmlAdapter {
 
         // get attributes
         String name = element.getAttribute("ident").getValue();
-        int type = PositionablePoint.ANCHOR;
+        PositionablePoint.PointType type = PositionablePoint.PointType.ANCHOR;
         double x = 0.0;
         double y = 0.0;
         try {
             x = element.getAttribute("x").getFloatValue();
             y = element.getAttribute("y").getFloatValue();
-            type = element.getAttribute("type").getIntValue();
+            type = pTypeEnumMap.inputFromAttribute(element.getAttribute("type"));
         } catch (org.jdom2.DataConversionException e) {
             log.error("failed to convert positionablepoint attribute");
         }
@@ -145,13 +147,13 @@ public class PositionablePointXml extends AbstractXmlAdapter {
             l.setWestBoundSensor(a.getValue());
         }
 
-        if (type == PositionablePoint.EDGE_CONNECTOR && element.getAttribute("linkedpanel") != null && element.getAttribute("linkpointid") != null) {
+        if (type == PositionablePoint.PointType.EDGE_CONNECTOR && element.getAttribute("linkedpanel") != null && element.getAttribute("linkpointid") != null) {
             String linkedEditorName = element.getAttribute("linkedpanel").getValue();
             LayoutEditor linkedEditor = (LayoutEditor) InstanceManager.getDefault(PanelMenu.class).getEditorByName(linkedEditorName);
             if (linkedEditor != null) {
                 String linkedPoint = element.getAttribute("linkpointid").getValue();
                 for (PositionablePoint point : linkedEditor.getPositionablePoints()) {
-                    if (point.getType() == PositionablePoint.EDGE_CONNECTOR && point.getId().equals(linkedPoint)) {
+                    if (point.getType() == PositionablePoint.PointType.EDGE_CONNECTOR && point.getId().equals(linkedPoint)) {
                         point.setLinkedPoint(l);
                         l.setLinkedPoint(point);
                         break;

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/PositionablePointXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/PositionablePointXml.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PositionablePointXml extends AbstractXmlAdapter {
 
-    static final EnumIO<PositionablePoint.PointType> pTypeEnumMap = new EnumIoOrdinals<>(PositionablePoint.PointType.class);
+    static final EnumIO<PositionablePoint.PointType> pTypeEnumMap = new EnumIoNamesNumbers<>(PositionablePoint.PointType.class);
 
     public PositionablePointXml() {
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentXml.java
@@ -621,23 +621,7 @@ public class TrackSegmentXml extends AbstractXmlAdapter {
         p.getLayoutTracks().add(l);
     }
 
-    // create the maps programmatically
-    static final EnumIO<HitPointType> htpMap;
+    static final EnumIO<HitPointType> htpMap = new EnumIoNamesNumbers<>(HitPointType.class);
     
-    static {
-        // from map is names and numbers
-        HashMap<String, HitPointType> fromMap = new HashMap<>();
-        // to map is names
-        HashMap<HitPointType, String> toMap = new HashMap<>();
-
-        for (HitPointType h : HitPointType.values()) {
-            fromMap.put(h.toString(), h);
-            fromMap.put(""+h.ordinal(), h);  // tests insure equality
-            toMap.put(h, h.toString());
-        }
-        
-        htpMap = new EnumIoMapped<>(HitPointType.class, fromMap, toMap);
-    }
-
     private final static Logger log = LoggerFactory.getLogger(TrackSegmentXml.class);
 }

--- a/java/src/jmri/jmrit/display/layoutEditor/package-info.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/package-info.java
@@ -6,14 +6,14 @@
  * <h3>Connectivity</h3>
  * This is coded and stored as the following: (Some graphical attributes removed, reordered)<br>
 <pre>
-    &lt;layoutturnout ident="TO1" type="1" continuing="2" ver="1" connectaname="T3" connectbname="T2" connectcname="T1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" /&gt;
-    &lt;layoutturnout ident="TO2" type="2" continuing="2" ver="1" connectaname="T4" connectbname="T2" connectcname="T1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" /&gt;
+    &lt;layoutturnout ident="TO1" type="RH_TURNOUT" continuing="2" ver="1" connectaname="T3" connectbname="T2" connectcname="T1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" /&gt;
+    &lt;layoutturnout ident="TO2" type="LH_TURNOUT" continuing="2" ver="1" connectaname="T4" connectbname="T2" connectcname="T1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" /&gt;
     &lt;tracksegment ident="T1" connect1name="TO1" type1="TURNOUT_C" connect2name="TO2" type2="TURNOUT_C" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" /&gt;
     &lt;tracksegment ident="T2" connect1name="TO1" type1="TURNOUT_B" connect2name="TO2" type2="TURNOUT_B" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" /&gt;
     &lt;tracksegment ident="T3" connect1name="EB1" type1="POS_POINT" connect2name="TO1" type2="TURNOUT_A" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" /&gt;
     &lt;tracksegment ident="T4" connect1name="TO2" type1="TURNOUT_A" connect2name="EC1" type2="POS_POINT" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" /&gt;
-    &lt;positionablepoint ident="EB1" type="2" connect1name="T3" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" /&gt;
-    &lt;positionablepoint ident="EC1" type="3" connect1name="T4" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" /&gt;
+    &lt;positionablepoint ident="EB1" type="END_BUMPER" connect1name="T3" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" /&gt;
+    &lt;positionablepoint ident="EC1" type="EDGE_CONNECTOR" connect1name="T4" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" /&gt;
 </pre>
 <p>
  * <a href="doc-files/SidingConnections.png"><img src="doc-files/SidingConnections.png" alt="Example interconnections" height="33%" width="33%"></a>

--- a/java/src/jmri/jmrit/display/layoutEditor/package-info.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/package-info.java
@@ -44,7 +44,31 @@
  *      {@link jmri.jmrit.display.layoutEditor.MultiIconEditor}, and {@link jmri.jmrit.display.layoutEditor.MultiSensorIconFrame}, extend Swing or AWT components. 
  *      (Although {@link jmri.jmrit.display.layoutEditor.LayoutEditorComponent}
  *       sounds like a base class for others, it's not; it's part of the {@link jmri.jmrit.display.layoutEditor.LayoutEditor} implementation.)
+ * <li>Three subpackages provide specific services:
+ *   <ul>
+ *   <li>{@link jmri.jmrit.display.layoutEditor.blockRoutingTable}
+ *   <li>{@link jmri.jmrit.display.layoutEditor.LayoutEditorDialogs}
+ *   <li>{@link jmri.jmrit.display.layoutEditor.configurexml}
+ *   </ul>
  * </ul>
+ * 
+ * <h3>GUI</h3>
+ * The Layout Editor window consists of a menu bar and an upper tool-bar that are all made with 
+ * (basically) standard Swing components.  Below that is a JPane containing the 
+ * layout drawing itself.
+ * <p>
+ * The LayoutTrack tree defines <code>draw1</code> and <code>draw2</code> methods that 
+ * draw two different representations of the track elements.  These are only 
+ * invoked from {}@link jmri.jmrit.display.layoutEditor.LayoutEditorComponent}. LayoutEditorComponent is 
+ * a JComponent with a {@link jmri.jmrit.display.layoutEditor.LayoutEditorComponent#paint} public method
+ * that invokes a series of internal private methods to display the layers of the layout drawing. That in turn is invoked via the usual repaint() mechanism.
+ * Each of those layer private methods sets up graphics and method options, then
+ * calls {@link jmri.jmrit.display.layoutEditor.LayoutEditorComponent#draw1}
+ * or {@link jmri.jmrit.display.layoutEditor.LayoutEditorComponent#draw2}. Those in turn
+ * loop through a list from {@link jmri.jmrit.display.layoutEditor.LayoutEditor#getLayoutTracks()}
+ * calling their individual {@link jmri.jmrit.display.layoutEditor.LayoutTrack#draw1} and {@link jmri.jmrit.display.layoutEditor.LayoutTrack#draw1}
+ * methods.
+ * 
  * 
  * <h3>Persistance</h3>
  * The classes that have ConfigureXML partner classes are:

--- a/java/src/jmri/jmrit/entryexit/AddEntryExitPairPanel.java
+++ b/java/src/jmri/jmrit/entryexit/AddEntryExitPairPanel.java
@@ -493,7 +493,7 @@ public class AddEntryExitPairPanel extends jmri.util.swing.JmriPanel {
                     Object obj = nxPairs.getEndPointLocation((NamedBean) dest.get(row), panel);
                     if (obj instanceof PositionablePoint) {
                         PositionablePoint point = (PositionablePoint) obj;
-                        if (point.getType() == PositionablePoint.END_BUMPER) {
+                        if (point.getType() == PositionablePoint.PointType.END_BUMPER) {
                             JOptionPane.showMessageDialog(null, Bundle.getMessage("EndBumperPoint"));  // NOI18N
                             return false;
                         }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackEditorsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackEditorsTest.java
@@ -829,9 +829,9 @@ public class LayoutTrackEditorsTest {
             Point2D delta = new Point2D.Double(50.0, 10.0);
 
             // Track Segment
-            PositionablePoint pp1 = new PositionablePoint("a", PositionablePoint.ANCHOR, point, layoutEditor);
+            PositionablePoint pp1 = new PositionablePoint("a", PositionablePoint.PointType.ANCHOR, point, layoutEditor);
             point = MathUtil.add(point, delta);
-            PositionablePoint pp2 = new PositionablePoint("b", PositionablePoint.ANCHOR, point, layoutEditor);
+            PositionablePoint pp2 = new PositionablePoint("b", PositionablePoint.PointType.ANCHOR, point, layoutEditor);
             trackSegment = new TrackSegment("Segment", pp1, HitPointType.POS_POINT, pp2, HitPointType.POS_POINT, false, false, layoutEditor
             );
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
@@ -87,15 +87,15 @@ public class LayoutEditorToolsTest {
         Assert.assertNotNull("RH turnout for testSetSignalsAtTurnoutWithDone", layoutTurnout);
         layoutEditor.getLayoutTracks().add(layoutTurnout);
 
-        positionablePoint1 = new PositionablePoint("A1", PositionablePoint.ANCHOR, new Point2D.Double(250.0, 100.0), layoutEditor);
+        positionablePoint1 = new PositionablePoint("A1", PositionablePoint.PointType.ANCHOR, new Point2D.Double(250.0, 100.0), layoutEditor);
         Assert.assertNotNull("positionablePoint1 for testSetSignalsAtTurnoutWithDone", positionablePoint1);
         layoutEditor.getLayoutTracks().add(positionablePoint1);
 
-        positionablePoint2 = new PositionablePoint("A2", PositionablePoint.ANCHOR, new Point2D.Double(50.0, 100.0), layoutEditor);
+        positionablePoint2 = new PositionablePoint("A2", PositionablePoint.PointType.ANCHOR, new Point2D.Double(50.0, 100.0), layoutEditor);
         layoutEditor.getLayoutTracks().add(positionablePoint2);
         Assert.assertNotNull("positionablePoint2 for testSetSignalsAtTurnoutWithDone", positionablePoint2);
 
-        positionablePoint3 = new PositionablePoint("A3", PositionablePoint.ANCHOR, new Point2D.Double(250.0, 150.0), layoutEditor);
+        positionablePoint3 = new PositionablePoint("A3", PositionablePoint.PointType.ANCHOR, new Point2D.Double(250.0, 150.0), layoutEditor);
         layoutEditor.getLayoutTracks().add(positionablePoint3);
         Assert.assertNotNull("positionablePoint3 for testSetSignalsAtTurnoutWithDone", positionablePoint3);
 
@@ -298,7 +298,7 @@ public class LayoutEditorToolsTest {
         });
 
         //change anchor to end bumper
-        positionablePoints[idx].setType(PositionablePoint.END_BUMPER);
+        positionablePoints[idx].setType(PositionablePoint.PointType.END_BUMPER);
 
         //pressing "Done" should throw up a "blocks have not been defined around this item."  (InfoMessage6)
         //error dialog... dismiss it
@@ -363,9 +363,9 @@ public class LayoutEditorToolsTest {
         trackSegment.setLayoutBlock(null);
         layoutBlocks.get(lbIndex[idx]).setOccupancySensorName(null);
         //le.removeTrackSegment(trackSegment);
-        positionablePoint1.setType(PositionablePoint.ANCHOR);
-        positionablePoint2.setType(PositionablePoint.ANCHOR);
-        positionablePoint3.setType(PositionablePoint.ANCHOR);
+        positionablePoint1.setType(PositionablePoint.PointType.ANCHOR);
+        positionablePoint2.setType(PositionablePoint.PointType.ANCHOR);
+        positionablePoint3.setType(PositionablePoint.PointType.ANCHOR);
     }
 
     @Test

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutTrackExpectedStateTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutTrackExpectedStateTest.java
@@ -18,8 +18,8 @@ public class LayoutTrackExpectedStateTest {
     public void testCTor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor le = new LayoutEditor();
-        PositionablePoint p1 = new PositionablePoint("a", PositionablePoint.ANCHOR, new Point2D.Double(0.0, 0.0), le);
-        PositionablePoint p2 = new PositionablePoint("b", PositionablePoint.ANCHOR, new Point2D.Double(1.0, 1.0), le);
+        PositionablePoint p1 = new PositionablePoint("a", PositionablePoint.PointType.ANCHOR, new Point2D.Double(0.0, 0.0), le);
+        PositionablePoint p2 = new PositionablePoint("b", PositionablePoint.PointType.ANCHOR, new Point2D.Double(1.0, 1.0), le);
         TrackSegment s = new TrackSegment("test", p1, HitPointType.POS_POINT, p2, HitPointType.POS_POINT, false, true, le);
         LayoutTrackExpectedState<LayoutTrack> t = new LayoutTrackExpectedState<LayoutTrack>(s, 0);
         Assert.assertNotNull("exists", t);

--- a/java/test/jmri/jmrit/display/layoutEditor/PositionablePointTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/PositionablePointTest.java
@@ -23,7 +23,7 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.ANCHOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
     }
 
@@ -33,9 +33,9 @@ public class PositionablePointTest {
         Assert.assertNotNull("LayoutEditor exists", le);
 
         // 2nd parameter is illegal type
-        PositionablePoint pp = new PositionablePoint("test", 0, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.NONE, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
-        JUnitAppender.assertErrorMessage("Illegal type of PositionablePoint - 0");
+        JUnitAppender.assertErrorMessage("Illegal type of PositionablePoint - NONE");
     }
 
     @Test
@@ -43,15 +43,15 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint ppA = new PositionablePoint("test", PositionablePoint.ANCHOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint ppA = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", ppA);
         Assert.assertEquals("Anchor 'test'", ppA.toString());
 
-        PositionablePoint ppEB = new PositionablePoint("test", PositionablePoint.END_BUMPER, MathUtil.zeroPoint2D, le);
+        PositionablePoint ppEB = new PositionablePoint("test", PositionablePoint.PointType.END_BUMPER, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", ppEB);
         Assert.assertEquals("End Bumper 'test'", ppEB.toString());
 
-        PositionablePoint ppEC = new PositionablePoint("test", PositionablePoint.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint ppEC = new PositionablePoint("test", PositionablePoint.PointType.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", ppEC);
         Assert.assertEquals("Edge Connector 'test'", ppEC.toString());
     }
@@ -61,12 +61,12 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp1 = new PositionablePoint("test", PositionablePoint.ANCHOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp1 = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp1);
         Assert.assertEquals("getCoordsCenter equal to zeroPoint2D", MathUtil.zeroPoint2D, pp1.getCoordsCenter());
 
         Point2D point2 = new Point2D.Double(666.6, 999.9);
-        PositionablePoint pp2 = new PositionablePoint("test", PositionablePoint.ANCHOR, point2, le);
+        PositionablePoint pp2 = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, point2, le);
         Assert.assertNotNull("exists", pp2);
         Assert.assertEquals("getCoordsCenter equal to {666.6, 999.9}", point2, pp2.getCoordsCenter());
     }
@@ -76,7 +76,7 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.ANCHOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
         Assert.assertEquals("getCoordsCenter equal to zeroPoint2D", MathUtil.zeroPoint2D, pp.getCoordsCenter());
 
@@ -91,7 +91,7 @@ public class PositionablePointTest {
         Assert.assertNotNull("LayoutEditor exists", le);
 
         Point2D point = new Point2D.Double(666.6, 999.9);
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.ANCHOR, point, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, point, le);
         Assert.assertNotNull("exists", pp);
         pp.scaleCoords(2.F, 2.F);
         Point2D pointX2 = MathUtil.granulize(MathUtil.multiply(point, 2.0), 1.0);
@@ -104,7 +104,7 @@ public class PositionablePointTest {
         Assert.assertNotNull("LayoutEditor exists", le);
 
         Point2D point = new Point2D.Double(666.6, 999.9);
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.ANCHOR, point, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, point, le);
         Assert.assertNotNull("exists", pp);
         Point2D delta = new Point2D.Float(333.3F, 444.4F);
         pp.translateCoords((float) delta.getX(), (float) delta.getY());
@@ -118,7 +118,7 @@ public class PositionablePointTest {
         Assert.assertNotNull("LayoutEditor exists", le);
 
         Point2D point = new Point2D.Double(666.6, 999.9);
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.ANCHOR, point, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, point, le);
         Assert.assertNotNull("exists", pp);
         Rectangle2D bounds = new Rectangle2D.Double(point.getX() - 0.5, point.getY() - 0.5, 1.0, 1.0);
         Assert.assertEquals("getBounds equal to {666.6, 999.9, 0.0, 0.0}", bounds, pp.getBounds());
@@ -129,7 +129,7 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
 
         Assert.assertNull("Default linked Editor is null", pp.getLinkedEditor());
@@ -143,7 +143,7 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
 
         pp.setLinkedPoint(pp);
@@ -163,12 +163,12 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
 
         pp.setLinkedPoint(pp);
 
-        PositionablePoint pp2 = new PositionablePoint("test2", PositionablePoint.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp2 = new PositionablePoint("test2", PositionablePoint.PointType.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp2);
         pp.setLinkedPoint(pp2);
 
@@ -187,12 +187,12 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
 
         pp.setLinkedPoint(pp);
 
-        PositionablePoint pp2 = new PositionablePoint("test2", PositionablePoint.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp2 = new PositionablePoint("test2", PositionablePoint.PointType.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp2);
         pp.setLinkedPoint(pp2);
 
@@ -209,7 +209,7 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.EDGE_CONNECTOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
 
         Assert.assertTrue("maxWidth == 5", pp.maxWidth() == 5);
@@ -222,7 +222,7 @@ public class PositionablePointTest {
         Assert.assertNotNull("LayoutEditor exists", le);
 
         Point2D thePoint = new Point2D.Double(666.6, 999.9);
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.ANCHOR, thePoint, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, thePoint, le);
         Assert.assertNotNull("exists", pp);
 
         // first, try hit
@@ -240,7 +240,7 @@ public class PositionablePointTest {
         Assert.assertNotNull("LayoutEditor exists", le);
 
         Point2D thePoint = new Point2D.Double(666.6, 999.9);
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.ANCHOR, thePoint, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, thePoint, le);
         Assert.assertNotNull("exists", pp);
 
         // test failure
@@ -258,7 +258,7 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.ANCHOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
 
         try {
@@ -284,7 +284,7 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.ANCHOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
 
         try {
@@ -316,7 +316,7 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.ANCHOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
 
         // test Invalid Connection Type
@@ -334,7 +334,7 @@ public class PositionablePointTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", le);
 
-        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.ANCHOR, MathUtil.zeroPoint2D, le);
+        PositionablePoint pp = new PositionablePoint("test", PositionablePoint.PointType.ANCHOR, MathUtil.zeroPoint2D, le);
         Assert.assertNotNull("exists", pp);
 
         // test null track segment
@@ -342,10 +342,10 @@ public class PositionablePointTest {
                 pp.setTrackConnection(null));
         JUnitAppender.assertErrorMessage("test.replaceTrackConnection(null, null); Attempt to remove non-existant track connection");
 
-        PositionablePoint ppA = new PositionablePoint("A", PositionablePoint.ANCHOR, new Point2D.Double(0.0, 0.0), le);
-        PositionablePoint ppB = new PositionablePoint("B", PositionablePoint.ANCHOR, new Point2D.Double(10.0, 10.0), le);
-        PositionablePoint ppC = new PositionablePoint("C", PositionablePoint.ANCHOR, new Point2D.Double(20.0, 20.0), le);
-        PositionablePoint ppD = new PositionablePoint("D", PositionablePoint.ANCHOR, new Point2D.Double(30.0, 30.0), le);
+        PositionablePoint ppA = new PositionablePoint("A", PositionablePoint.PointType.ANCHOR, new Point2D.Double(0.0, 0.0), le);
+        PositionablePoint ppB = new PositionablePoint("B", PositionablePoint.PointType.ANCHOR, new Point2D.Double(10.0, 10.0), le);
+        PositionablePoint ppC = new PositionablePoint("C", PositionablePoint.PointType.ANCHOR, new Point2D.Double(20.0, 20.0), le);
+        PositionablePoint ppD = new PositionablePoint("D", PositionablePoint.PointType.ANCHOR, new Point2D.Double(30.0, 30.0), le);
         TrackSegment tsAB = new TrackSegment("testAB", ppA, HitPointType.POS_POINT, ppB, HitPointType.POS_POINT, false, false, le);
         Assert.assertNotNull("Track Segment AB exists", tsAB);
         TrackSegment tsBC = new TrackSegment("testBC", ppB, HitPointType.POS_POINT, ppC, HitPointType.POS_POINT, false, false, le);

--- a/java/test/jmri/jmrit/display/layoutEditor/TrackNodeTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/TrackNodeTest.java
@@ -25,8 +25,8 @@ public class TrackNodeTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor le = new LayoutEditor();
         LayoutTurnout lt = new LayoutTurnout("T", MathUtil.zeroPoint2D, le);
-        PositionablePoint p1 = new PositionablePoint("a", PositionablePoint.ANCHOR, new Point2D.Double(0.0, 0.0), le);
-        PositionablePoint p2 = new PositionablePoint("b", PositionablePoint.ANCHOR, new Point2D.Double(1.0, 1.0), le);
+        PositionablePoint p1 = new PositionablePoint("a", PositionablePoint.PointType.ANCHOR, new Point2D.Double(0.0, 0.0), le);
+        PositionablePoint p2 = new PositionablePoint("b", PositionablePoint.PointType.ANCHOR, new Point2D.Double(1.0, 1.0), le);
         TrackSegment ts = new TrackSegment("test", p1, HitPointType.POS_POINT, p2, HitPointType.POS_POINT, false, true, le);
         TrackNode tn = new TrackNode(lt, HitPointType.TURNOUT_A, ts, false, 0);
         Assert.assertNotNull("exists", tn);

--- a/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentTest.java
@@ -51,7 +51,7 @@ public class TrackSegmentTest {
             Assert.assertTrue("trackSegment.replaceTrackConnection(null, c1, t1) fail", trackSegment.replaceTrackConnection(null, c1, t1));
             Assert.assertEquals("trackSegment.replaceTrackConnection(null, c1, t1) fail", c1, trackSegment.getConnect1());
 
-            PositionablePoint a3 = new PositionablePoint("A3", PositionablePoint.ANCHOR, new Point2D.Double(10.0, 10.0), layoutEditor);
+            PositionablePoint a3 = new PositionablePoint("A3", PositionablePoint.PointType.ANCHOR, new Point2D.Double(10.0, 10.0), layoutEditor);
             Assert.assertTrue("trackSegment.replaceTrackConnection(c1, a3, POS_POINT) fail", trackSegment.replaceTrackConnection(c1, a3, HitPointType.POS_POINT));
         }
     }
@@ -580,8 +580,8 @@ public class TrackSegmentTest {
         jmri.util.JUnitUtil.resetProfileManager();
         if (!GraphicsEnvironment.isHeadless()) {
             if (layoutEditor != null) {
-                PositionablePoint p1 = new PositionablePoint("A1", PositionablePoint.ANCHOR, new Point2D.Double(10.0, 20.0), layoutEditor);
-                PositionablePoint p2 = new PositionablePoint("A2", PositionablePoint.ANCHOR, new Point2D.Double(20.0, 33.0), layoutEditor);
+                PositionablePoint p1 = new PositionablePoint("A1", PositionablePoint.PointType.ANCHOR, new Point2D.Double(10.0, 20.0), layoutEditor);
+                PositionablePoint p2 = new PositionablePoint("A2", PositionablePoint.PointType.ANCHOR, new Point2D.Double(20.0, 33.0), layoutEditor);
                 trackSegment = new TrackSegment("TS1", p1, HitPointType.POS_POINT, p2, HitPointType.POS_POINT, false, true, layoutEditor);
             }
         }

--- a/java/test/jmri/jmrit/display/layoutEditor/load/Decorations-4-19-6.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/load/Decorations-4-19-6.xml
@@ -1,0 +1,320 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-4-19-2.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-4-19-2.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>19</minor>
+    <test>6</test>
+    <modifier>ish</modifier>
+  </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor inverted="false">
+      <systemName>ISCLOCKRUNNING</systemName>
+    </sensor>
+  </sensors>
+  <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
+    <memory value="3:57 PM">
+      <systemName>IMCURRENTTIME</systemName>
+    </memory>
+    <memory value="1.0">
+      <systemName>IMRATEFACTOR</systemName>
+    </memory>
+  </memories>
+  <blocks class="jmri.configurexml.BlockManagerXml">
+    <defaultspeed>Normal</defaultspeed>
+    <block systemName="IB0">
+      <systemName>IB0</systemName>
+      <userName>RM Block</userName>
+    </block>
+    <block systemName="IB0" length="0.0" curve="0">
+      <systemName>IB0</systemName>
+      <userName>RM Block</userName>
+      <permissive>no</permissive>
+    </block>
+  </blocks>
+  <layoutblocks class="jmri.jmrit.display.layoutEditor.configurexml.LayoutBlockManagerXml">
+    <layoutblock systemName="IB0" occupiedsense="2" trackcolor="#33FF33" occupiedcolor="red" extracolor="orange">
+      <systemName>IB0</systemName>
+      <userName>RM Block</userName>
+    </layoutblock>
+  </layoutblocks>
+  <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
+    <logicDelay>500</logicDelay>
+  </signalmastlogics>
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Wed Apr 18 12:38:07 PDT 2018" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <LayoutEditor class="jmri.jmrit.display.layoutEditor.configurexml.LayoutEditorXml" name="Decorations Testing" x="0" y="23" windowheight="772" windowwidth="1028" panelheight="580" panelwidth="1000" sliders="no" scrollable="none" editable="yes" positionable="yes" controlling="yes" animating="yes" showhelpbar="no" drawgrid="yes" snaponadd="yes" snaponmove="yes" antialiasing="yes" turnoutcircles="yes" tooltipsnotedit="no" tooltipsinedit="yes" mainlinetrackwidth="4" xscale="1.0" yscale="1.0" sidetrackwidth="2" defaulttrackcolor="darkGray" defaultoccupiedtrackcolor="red" defaultalternativetrackcolor="white" defaulttextcolor="black" turnoutcirclecolor="pink" turnoutcirclethrowncolor="black" turnoutcirclesize="2" turnoutdrawunselectedleg="no" turnoutbx="20.0" turnoutcx="20.0" turnoutwid="10.0" xoverlong="30.0" xoverhwid="10.0" xovershort="10.0" autoblkgenerate="yes" redBackground="150" greenBackground="86" blueBackground="150" gridSize="10" gridSize2nd="10" openDispatcher="no" useDirectTurnoutControl="no">
+    <layoutTrackDrawingOptions name="Decorations Testing" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTrackDrawingOptionsXml">
+      <mainBallastColor>#000000</mainBallastColor>
+      <mainBallastWidth>0</mainBallastWidth>
+      <mainBlockLineDashPercentageX10>0</mainBlockLineDashPercentageX10>
+      <mainBlockLineWidth>4</mainBlockLineWidth>
+      <mainRailColor>#404040</mainRailColor>
+      <mainRailCount>1</mainRailCount>
+      <mainRailGap>0</mainRailGap>
+      <mainRailWidth>2</mainRailWidth>
+      <mainTieColor>#000000</mainTieColor>
+      <mainTieGap>0</mainTieGap>
+      <mainTieLength>0</mainTieLength>
+      <mainTieWidth>0</mainTieWidth>
+      <sideBallastColor>#000000</sideBallastColor>
+      <sideBallastWidth>0</sideBallastWidth>
+      <sideBlockLineDashPercentageX10>0</sideBlockLineDashPercentageX10>
+      <sideBlockLineWidth>2</sideBlockLineWidth>
+      <sideRailColor>#404040</sideRailColor>
+      <sideRailCount>1</sideRailCount>
+      <sideRailGap>0</sideRailGap>
+      <sideRailWidth>1</sideRailWidth>
+      <sideTieColor>#000000</sideTieColor>
+      <sideTieGap>0</sideTieGap>
+      <sideTieLength>0</sideTieLength>
+      <sideTieWidth>0</sideTieWidth>
+    </layoutTrackDrawingOptions>
+    <positionablelabel x="260" y="180" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" text="Lines" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
+    <positionablelabel x="720" y="50" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" text="Circles" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
+    <positionablelabel x="230" y="430" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" text="Ellipses" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
+    <positionablelabel x="670" y="420" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" text="Bezier" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
+    <positionablelabel x="357" y="309" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" text="The ugly colors are intentional (for testing)" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
+    <positionablelabel x="374" y="334" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" text="Everything drawn oversize (for testing)" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
+    <positionablelabel x="460" y="10" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" text="DECORATIONS" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
+    <tracksegment ident="T1" blockname="RM Block" connect1name="EB1" type1="POS_POINT" connect2name="A3" type2="POS_POINT" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="left" end="entry" color="#FF00FF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <bumper end="start" color="#FF0000" linewidth="3" length="15" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T3" blockname="RM Block" connect1name="A3" type1="POS_POINT" connect2name="EC10" type2="POS_POINT" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <arrow style="4" end="stop" direction="out" color="#0000FF" linewidth="1" length="6" gap="1" />
+        <bridge side="left" end="exit" color="#FF00FF" linewidth="1" approachwidth="8" deckwidth="20" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T5" blockname="RM Block" connect1name="EB6" type1="POS_POINT" connect2name="A15" type2="POS_POINT" dashed="yes" mainline="yes" hidden="no" arc="yes" flip="no" circle="yes" angle="90.0" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="left" end="entry" color="#FFFFFF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <bumper end="start" color="#FF0000" linewidth="3" length="15" />
+        <tunnel side="left" end="entry" color="#0000FF" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T7" blockname="RM Block" connect1name="A7" type1="POS_POINT" connect2name="EB2" type2="POS_POINT" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="right" end="exit" color="#FF00FF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <bumper end="stop" color="#FF0000" linewidth="3" length="15" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T11" blockname="RM Block" connect1name="EC1" type1="POS_POINT" connect2name="A7" type2="POS_POINT" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <arrow style="4" end="start" direction="out" color="#0000FF" linewidth="1" length="6" gap="1" />
+        <bridge side="right" end="entry" color="#FF00FF" linewidth="1" approachwidth="8" deckwidth="20" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T13" blockname="RM Block" connect1name="A15" type1="POS_POINT" connect2name="A19" type2="POS_POINT" dashed="yes" mainline="yes" hidden="no" arc="yes" flip="no" circle="yes" angle="45.00000000000001" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="left" end="exit" color="#FFFFFF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <tunnel side="left" end="exit" color="#0000FF" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T14" blockname="RM Block" connect1name="A16" type1="POS_POINT" connect2name="A1" type2="POS_POINT" dashed="yes" mainline="yes" hidden="no" arc="yes" flip="yes" circle="yes" angle="45.053445375816025" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="right" end="entry" color="#FFFFFF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <tunnel side="right" end="entry" color="#0000FF" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T18" blockname="RM Block" connect1name="EB4" type1="POS_POINT" connect2name="A9" type2="POS_POINT" dashed="yes" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bumper end="start" color="#FF0000" linewidth="3" length="15" />
+        <tunnel side="left" end="entry" color="#000000" linewidth="1" entrancewidth="26" floorwidth="20" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T19" blockname="RM Block" connect1name="A9" type1="POS_POINT" connect2name="EC2" type2="POS_POINT" dashed="yes" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <arrow style="4" end="stop" direction="out" color="#0000FF" linewidth="1" length="6" gap="1" />
+        <tunnel side="left" end="exit" color="#000000" linewidth="1" entrancewidth="26" floorwidth="20" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T22" blockname="RM Block" connect1name="EC3" type1="POS_POINT" connect2name="A14" type2="POS_POINT" dashed="yes" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <arrow style="4" end="start" direction="out" color="#0000FF" linewidth="1" length="6" gap="1" />
+        <tunnel side="right" end="entry" color="#000000" linewidth="1" entrancewidth="26" floorwidth="20" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T23" blockname="RM Block" connect1name="A14" type1="POS_POINT" connect2name="EB5" type2="POS_POINT" dashed="yes" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bumper end="stop" color="#FF0000" linewidth="3" length="15" />
+        <tunnel side="right" end="exit" color="#000000" linewidth="1" entrancewidth="26" floorwidth="20" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T27" blockname="RM Block" connect1name="EC7" type1="POS_POINT" connect2name="A23" type2="POS_POINT" dashed="yes" mainline="no" hidden="no" arc="yes" flip="no" circle="yes" angle="90.00000000000001" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <arrow style="4" end="start" direction="out" color="#0000FF" linewidth="1" length="6" gap="1" />
+        <bridge side="right" end="entry" color="#FFFFFF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <tunnel side="right" end="entry" color="#0000FF" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T28" blockname="RM Block" connect1name="A23" type1="POS_POINT" connect2name="A12" type2="POS_POINT" dashed="yes" mainline="no" hidden="no" arc="yes" flip="no" circle="yes" angle="45.0" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="right" end="exit" color="#FFFFFF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <tunnel side="right" end="exit" color="#0000FF" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T30" blockname="RM Block" connect1name="A25" type1="POS_POINT" connect2name="A11" type2="POS_POINT" dashed="yes" mainline="no" hidden="no" arc="yes" flip="yes" circle="yes" angle="45.261548845428074" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="left" end="entry" color="#FFFFFF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <tunnel side="left" end="entry" color="#0000FF" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T34" blockname="RM Block" connect1name="EB3" type1="POS_POINT" connect2name="A4" type2="POS_POINT" dashed="yes" mainline="yes" hidden="no" arc="yes" flip="yes" circle="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="right" end="entry" color="#FF0000" linewidth="1" approachwidth="8" deckwidth="20" />
+        <bumper end="start" color="#FF0000" linewidth="3" length="15" />
+        <tunnel side="right" end="entry" color="#663300" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T35" blockname="RM Block" connect1name="A31" type1="POS_POINT" connect2name="EC4" type2="POS_POINT" dashed="yes" mainline="yes" hidden="no" arc="yes" flip="no" circle="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <arrow style="4" end="stop" direction="out" color="#0000FF" linewidth="1" length="6" gap="1" />
+        <bridge side="left" end="exit" color="#FF0000" linewidth="1" approachwidth="8" deckwidth="20" />
+        <tunnel side="left" end="exit" color="#663300" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T38" blockname="RM Block" connect1name="EC9" type1="POS_POINT" connect2name="A2" type2="POS_POINT" dashed="yes" mainline="no" hidden="no" arc="yes" flip="yes" circle="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <arrow style="4" end="start" direction="out" color="#0000FF" linewidth="1" length="6" gap="1" />
+        <bridge side="left" end="entry" color="#FF0000" linewidth="1" approachwidth="8" deckwidth="20" />
+        <tunnel side="left" end="entry" color="#663300" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T39" blockname="RM Block" connect1name="A36" type1="POS_POINT" connect2name="EB8" type2="POS_POINT" dashed="yes" mainline="no" hidden="no" arc="yes" flip="no" circle="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="right" end="exit" color="#FF0000" linewidth="1" approachwidth="4" deckwidth="20" />
+        <bumper end="stop" color="#FF0000" linewidth="3" length="15" />
+        <tunnel side="right" end="exit" color="#663300" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T42" blockname="RM Block" connect1name="EB9" type1="POS_POINT" connect2name="A41" type2="POS_POINT" dashed="no" mainline="no" hidden="no" bezier="yes" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <controlpoints>
+        <controlpoint index="0" x="630.0" y="520.0" />
+        <controlpoint index="1" x="670.0" y="500.0" />
+        <controlpoint index="2" x="720.0" y="510.0" />
+      </controlpoints>
+      <decorations>
+        <bridge side="both" end="entry" color="#0000FF" linewidth="1" approachwidth="4" deckwidth="20" />
+        <bumper end="start" color="#FF0000" linewidth="3" length="15" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T43" blockname="RM Block" connect1name="A41" type1="POS_POINT" connect2name="EC5" type2="POS_POINT" dashed="yes" mainline="no" hidden="no" bezier="yes" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <controlpoints>
+        <controlpoint index="0" x="770.0" y="380.0" />
+        <controlpoint index="1" x="850.0" y="400.0" />
+      </controlpoints>
+      <decorations>
+        <arrow style="4" end="stop" direction="out" color="#0000FF" linewidth="1" length="6" gap="1" />
+        <tunnel side="both" end="exit" color="#FFC800" linewidth="1" entrancewidth="26" floorwidth="20" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T9" blockname="RM Block" connect1name="A1" type1="POS_POINT" connect2name="EC6" type2="POS_POINT" dashed="yes" mainline="yes" hidden="no" arc="yes" flip="yes" circle="yes" angle="47.550168505635206" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <arrow style="4" end="stop" direction="out" color="#0000FF" linewidth="1" length="6" gap="1" />
+        <bridge side="right" end="exit" color="#FFFFFF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <tunnel side="right" end="exit" color="#0000FF" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T12" blockname="RM Block" connect1name="A11" type1="POS_POINT" connect2name="EB7" type2="POS_POINT" dashed="yes" mainline="no" hidden="no" arc="yes" flip="yes" circle="yes" angle="47.01490956005987" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="left" end="exit" color="#FFFFFF" linewidth="1" approachwidth="8" deckwidth="20" />
+        <bumper end="stop" color="#FF0000" linewidth="3" length="15" />
+        <tunnel side="left" end="exit" color="#0000FF" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T16" blockname="RM Block" connect1name="A12" type1="POS_POINT" connect2name="A25" type2="POS_POINT" dashed="no" mainline="no" hidden="no" arc="yes" flip="no" circle="yes" angle="45.0" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T25" blockname="RM Block" connect1name="A19" type1="POS_POINT" connect2name="A16" type2="POS_POINT" dashed="no" mainline="yes" hidden="no" arc="yes" flip="no" circle="yes" angle="45.00000000000001" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T2" blockname="RM Block" connect1name="A2" type1="POS_POINT" connect2name="A36" type2="POS_POINT" dashed="yes" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="right" color="#FF0000" linewidth="1" approachwidth="8" deckwidth="20" />
+        <tunnel side="right" color="#663300" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <tracksegment ident="T4" blockname="RM Block" connect1name="A4" type1="POS_POINT" connect2name="A31" type2="POS_POINT" dashed="yes" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <decorations>
+        <bridge side="left" color="#FF0000" linewidth="1" approachwidth="8" deckwidth="20" />
+        <tunnel side="left" color="#663300" linewidth="1" entrancewidth="16" floorwidth="10" />
+      </decorations>
+    </tracksegment>
+    <positionablepoint ident="A3" type="ANCHOR" x="300.0" y="140.0" connect1name="T1" connect2name="T3" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB4" type="END_BUMPER" x="200.0" y="200.0" connect1name="T18" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A7" type="ANCHOR" x="290.0" y="160.0" connect1name="T11" connect2name="T7" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A9" type="ANCHOR" x="300.0" y="220.0" connect1name="T18" connect2name="T19" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC2" type="EDGE_CONNECTOR" x="400.0" y="240.0" connect1name="T19" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC3" type="EDGE_CONNECTOR" x="190.0" y="220.0" connect1name="T22" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A14" type="ANCHOR" x="290.0" y="240.0" connect1name="T22" connect2name="T23" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A15" type="ANCHOR" x="630.0" y="100.0" connect1name="T5" connect2name="T13" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A16" type="ANCHOR" x="730.0" y="120.0" connect1name="T25" connect2name="T14" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC6" type="EDGE_CONNECTOR" x="830.0" y="150.0" connect1name="T9" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB5" type="END_BUMPER" x="390.0" y="260.0" connect1name="T23" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB6" type="END_BUMPER" x="610.0" y="200.0" connect1name="T5" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB1" type="END_BUMPER" x="100.0" y="100.0" connect1name="T1" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC10" type="EDGE_CONNECTOR" x="500.0" y="180.0" connect1name="T3" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC1" type="EDGE_CONNECTOR" x="90.0" y="120.0" connect1name="T11" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB2" type="END_BUMPER" x="490.0" y="200.0" connect1name="T7" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC7" type="EDGE_CONNECTOR" x="620.0" y="190.0" connect1name="T27" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A23" type="ANCHOR" x="640.0" y="110.0" connect1name="T27" connect2name="T28" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A25" type="ANCHOR" x="720.0" y="130.0" connect1name="T16" connect2name="T30" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB7" type="END_BUMPER" x="840.0" y="160.0" connect1name="T12" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB3" type="END_BUMPER" x="150.0" y="300.0" connect1name="T34" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A31" type="ANCHOR" x="300.0" y="380.0" connect1name="T4" connect2name="T35" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC4" type="EDGE_CONNECTOR" x="450.0" y="480.0" connect1name="T35" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC9" type="EDGE_CONNECTOR" x="130.0" y="300.0" connect1name="T38" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A36" type="ANCHOR" x="300.0" y="400.0" connect1name="T2" connect2name="T39" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB8" type="END_BUMPER" x="430.0" y="480.0" connect1name="T39" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB9" type="END_BUMPER" x="560.0" y="490.0" connect1name="T42" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A41" type="ANCHOR" x="750.0" y="450.0" connect1name="T42" connect2name="T43" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC5" type="EDGE_CONNECTOR" x="910.0" y="420.0" connect1name="T43" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A1" type="ANCHOR" x="773.7868041992188" y="155.71067810058594" connect1name="T14" connect2name="T9" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A11" type="ANCHOR" x="773.7868041992188" y="169.85281372070312" connect1name="T30" connect2name="T12" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A12" type="ANCHOR" x="684.1421508789062" y="103.43145751953125" connect1name="T28" connect2name="T16" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A19" type="ANCHOR" x="684.1421508789062" y="89.28932189941406" connect1name="T13" connect2name="T25" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A2" type="ANCHOR" x="250.0" y="400.0" connect1name="T38" connect2name="T2" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A4" type="ANCHOR" x="250.0" y="380.0" connect1name="T34" connect2name="T4" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <layoutShape ident="Putting Green" type="Filled" level="3" linewidth="1" lineColor="#00FF00" fillColor="#338033" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutShapeXml">
+      <points>
+        <point type="Curve" x="457.5" y="47.5" />
+        <point type="Curve" x="517.5" y="77.5" />
+        <point type="Curve" x="517.5" y="147.5" />
+        <point type="Curve" x="387.5" y="87.5" />
+      </points>
+    </layoutShape>
+    <layoutShape ident="Pond-der-rosa" type="Filled" level="3" linewidth="5" lineColor="#FFFFA3" fillColor="#00FFFF" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutShapeXml">
+      <points>
+        <point type="Curve" x="740.0" y="360.0" />
+        <point type="Curve" x="840.0" y="340.0" />
+        <point type="Curve" x="900.0" y="250.0" />
+        <point type="Curve" x="720.0" y="210.0" />
+      </points>
+    </layoutShape>
+  </LayoutEditor>
+  <filehistory>
+    <operation>
+      <type>Load OK</type>
+      <date>Sun Apr 26 15:57:56 PDT 2020</date>
+      <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/java/test/jmri/jmrit/display/layoutEditor/load/Decorations.xml</filename>
+      <filehistory>
+        <operation>
+          <type>app</type>
+          <date>Wed Oct 09 09:25:27 PDT 2019</date>
+          <filename>JMRI program</filename>
+        </operation>
+        <operation>
+          <type>Store</type>
+          <date>Wed Oct 09 09:26:26 PDT 2019</date>
+          <filename />
+        </operation>
+      </filehistory>
+    </operation>
+    <operation>
+      <type>Store</type>
+      <date>Sun Apr 26 15:57:56 PDT 2020</date>
+      <filename />
+    </operation>
+  </filehistory>
+  <!--Written by JMRI version 4.19.6ish+jake+20200426T2255Z+R6c02d72f3a on Sun Apr 26 15:57:56 PDT 2020-->
+</layout-config>

--- a/java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest-4-19-6.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest-4-19-6.xml
@@ -1,0 +1,343 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-4-19-2.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-4-19-2.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>19</minor>
+    <test>6</test>
+    <modifier>ish</modifier>
+  </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor inverted="false">
+      <systemName>IS1</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS2</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>ISCLOCKRUNNING</systemName>
+    </sensor>
+  </sensors>
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
+    <operations automate="false">
+      <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
+    </operations>
+    <defaultclosedspeed>Normal</defaultclosedspeed>
+    <defaultthrownspeed>Restricted</defaultthrownspeed>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT1</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT2</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT3</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT4</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT5</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT6</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT7</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT8</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT9</systemName>
+    </turnout>
+  </turnouts>
+  <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
+    <memory value="U.P. #1167">
+      <systemName>IM1</systemName>
+      <userName>XYZZY</userName>
+    </memory>
+  </memories>
+  <blocks class="jmri.configurexml.BlockManagerXml">
+    <defaultspeed>Normal</defaultspeed>
+    <block systemName="IB1">
+      <systemName>IB1</systemName>
+      <userName>Yard</userName>
+    </block>
+    <block systemName="IB3">
+      <systemName>IB3</systemName>
+      <userName>West</userName>
+    </block>
+    <block systemName="IB4">
+      <systemName>IB4</systemName>
+      <userName>East</userName>
+    </block>
+    <block systemName="IB5">
+      <systemName>IB5</systemName>
+      <userName>SW Sliding</userName>
+    </block>
+    <block systemName="IB6">
+      <systemName>IB6</systemName>
+      <userName>SE Sliding</userName>
+    </block>
+    <block systemName="IB7">
+      <systemName>IB7</systemName>
+      <userName>North</userName>
+    </block>
+    <block systemName="IB1" length="0.0" curve="0">
+      <systemName>IB1</systemName>
+      <userName>Yard</userName>
+      <permissive>no</permissive>
+      <path todir="16" fromdir="32" block="IB3" />
+      <path todir="80" fromdir="160" block="IB4">
+        <beansetting setting="4">
+          <turnout systemName="IT3" />
+        </beansetting>
+      </path>
+      <path todir="64" fromdir="128" block="IB4" />
+      <path todir="128" fromdir="64" block="IB5">
+        <beansetting setting="2">
+          <turnout systemName="IT7" />
+        </beansetting>
+      </path>
+      <path todir="64" fromdir="128" block="IB6">
+        <beansetting setting="2">
+          <turnout systemName="IT9" />
+        </beansetting>
+      </path>
+      <path todir="144" fromdir="96" block="IB7">
+        <beansetting setting="4">
+          <turnout systemName="IT1" />
+        </beansetting>
+      </path>
+      <path todir="80" fromdir="160" block="IB7">
+        <beansetting setting="4">
+          <turnout systemName="IT2" />
+        </beansetting>
+      </path>
+    </block>
+    <block systemName="IB3" length="0.0" curve="0">
+      <systemName>IB3</systemName>
+      <userName>West</userName>
+      <permissive>no</permissive>
+      <path todir="32" fromdir="16" block="IB1" />
+      <path todir="16" fromdir="32" block="IB7" />
+    </block>
+    <block systemName="IB4" length="0.0" curve="0">
+      <systemName>IB4</systemName>
+      <userName>East</userName>
+      <permissive>no</permissive>
+      <path todir="160" fromdir="80" block="IB1">
+        <beansetting setting="4">
+          <turnout systemName="IT3" />
+        </beansetting>
+      </path>
+      <path todir="128" fromdir="64" block="IB1" />
+      <path todir="128" fromdir="64" block="IB7">
+        <beansetting setting="2">
+          <turnout systemName="IT3" />
+        </beansetting>
+      </path>
+    </block>
+    <block systemName="IB5" length="0.0" curve="0">
+      <systemName>IB5</systemName>
+      <userName>SW Sliding</userName>
+      <permissive>no</permissive>
+      <path todir="64" fromdir="128" block="IB1">
+        <beansetting setting="2">
+          <turnout systemName="IT7" />
+        </beansetting>
+      </path>
+    </block>
+    <block systemName="IB6" length="0.0" curve="0">
+      <systemName>IB6</systemName>
+      <userName>SE Sliding</userName>
+      <permissive>no</permissive>
+      <path todir="128" fromdir="64" block="IB1">
+        <beansetting setting="2">
+          <turnout systemName="IT9" />
+        </beansetting>
+      </path>
+    </block>
+    <block systemName="IB7" length="0.0" curve="0">
+      <systemName>IB7</systemName>
+      <userName>North</userName>
+      <permissive>no</permissive>
+      <path todir="96" fromdir="144" block="IB1">
+        <beansetting setting="4">
+          <turnout systemName="IT1" />
+        </beansetting>
+      </path>
+      <path todir="160" fromdir="80" block="IB1">
+        <beansetting setting="4">
+          <turnout systemName="IT2" />
+        </beansetting>
+      </path>
+      <path todir="32" fromdir="16" block="IB3" />
+      <path todir="64" fromdir="128" block="IB4">
+        <beansetting setting="2">
+          <turnout systemName="IT3" />
+        </beansetting>
+      </path>
+    </block>
+  </blocks>
+  <layoutblocks class="jmri.jmrit.display.layoutEditor.configurexml.LayoutBlockManagerXml">
+    <layoutblock systemName="ILB1" occupiedsense="2" trackcolor="black" occupiedcolor="red" extracolor="green" memory="XYZZY">
+      <systemName>ILB1</systemName>
+      <userName>Yard</userName>
+    </layoutblock>
+    <layoutblock systemName="ILB2" occupiedsense="2" trackcolor="black" occupiedcolor="red" extracolor="green">
+      <systemName>ILB2</systemName>
+      <userName>West</userName>
+    </layoutblock>
+    <layoutblock systemName="ILB3" occupiedsense="2" trackcolor="black" occupiedcolor="red" extracolor="green">
+      <systemName>ILB3</systemName>
+      <userName>East</userName>
+    </layoutblock>
+    <layoutblock systemName="ILB4" occupiedsense="2" trackcolor="black" occupiedcolor="red" extracolor="white">
+      <systemName>ILB4</systemName>
+      <userName>SW Sliding</userName>
+    </layoutblock>
+    <layoutblock systemName="ILB5" occupiedsense="2" trackcolor="black" occupiedcolor="red" extracolor="green">
+      <systemName>ILB5</systemName>
+      <userName>SE Sliding</userName>
+    </layoutblock>
+    <layoutblock systemName="ILB6" occupiedsense="2" trackcolor="black" occupiedcolor="red" extracolor="green">
+      <systemName>ILB6</systemName>
+      <userName>North</userName>
+    </layoutblock>
+  </layoutblocks>
+  <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
+    <logicDelay>500</logicDelay>
+  </signalmastlogics>
+  <LayoutEditor class="jmri.jmrit.display.layoutEditor.configurexml.LayoutEditorXml" name="Layout Editor Test" x="0" y="100" windowheight="360" windowwidth="670" panelheight="1054" panelwidth="1916" sliders="no" scrollable="none" editable="no" positionable="yes" controlling="yes" animating="yes" showhelpbar="no" drawgrid="yes" snaponadd="yes" snaponmove="yes" antialiasing="no" turnoutcircles="yes" tooltipsnotedit="no" tooltipsinedit="yes" mainlinetrackwidth="4" xscale="1.0" yscale="1.0" sidetrackwidth="2" defaulttrackcolor="black" defaultoccupiedtrackcolor="red" defaultalternativetrackcolor="white" defaulttextcolor="black" turnoutcirclecolor="magenta" turnoutcirclesize="3" turnoutdrawunselectedleg="yes" turnoutbx="20.0" turnoutcx="20.0" turnoutwid="10.0" xoverlong="30.0" xoverhwid="10.0" xovershort="10.0" autoblkgenerate="no" redBackground="192" greenBackground="192" blueBackground="192" gridSize="10" gridSize2nd="10" openDispatcher="no" useDirectTurnoutControl="no">
+    <layoutTrackDrawingOptions name="Layout Editor Test" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTrackDrawingOptionsXml">
+      <mainBallastColor>#000000</mainBallastColor>
+      <mainBallastWidth>0</mainBallastWidth>
+      <mainBlockLineDashPercentageX10>0</mainBlockLineDashPercentageX10>
+      <mainBlockLineWidth>4</mainBlockLineWidth>
+      <mainRailColor>#404040</mainRailColor>
+      <mainRailCount>1</mainRailCount>
+      <mainRailGap>0</mainRailGap>
+      <mainRailWidth>4</mainRailWidth>
+      <mainTieColor>#000000</mainTieColor>
+      <mainTieGap>0</mainTieGap>
+      <mainTieLength>0</mainTieLength>
+      <mainTieWidth>0</mainTieWidth>
+      <sideBallastColor>#000000</sideBallastColor>
+      <sideBallastWidth>0</sideBallastWidth>
+      <sideBlockLineDashPercentageX10>0</sideBlockLineDashPercentageX10>
+      <sideBlockLineWidth>2</sideBlockLineWidth>
+      <sideRailColor>#404040</sideRailColor>
+      <sideRailCount>1</sideRailCount>
+      <sideRailGap>0</sideRailGap>
+      <sideRailWidth>2</sideRailWidth>
+      <sideTieColor>#000000</sideTieColor>
+      <sideTieGap>0</sideTieGap>
+      <sideTieLength>0</sideTieLength>
+      <sideTieWidth>0</sideTieWidth>
+    </layoutTrackDrawingOptions>
+    <positionablelabel x="260" y="120" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="false" editable="false" text="Label Text" fontname="Georgia" size="16" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <tooltip>Text Label</tooltip>
+    </positionablelabel>
+    <memoryicon memory="XYZZY" x="300" y="160" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="false" editable="false" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="left" selectable="no" updateBlockValue="yes" class="jmri.jmrit.display.configurexml.MemoryIconXml" defaulticon="program:resources/icons/misc/X-green.gif">
+      <tooltip>XYZZY (IM1)</tooltip>
+    </memoryicon>
+    <BlockContentsIcon blockcontents="Yard" x="230" y="10" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="false" editable="false" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="left" selectable="no" class="jmri.jmrit.display.configurexml.BlockContentsIconXml">
+      <tooltip>Yard (IB1)</tooltip>
+    </BlockContentsIcon>
+    <positionablelabel x="450" y="90" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="false" editable="false" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <tooltip>Icon</tooltip>
+      <icon url="program:resources/icons/smallschematics/tracksegments/block.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <layoutturnout ident="TO4" type="1" hidden="no" disabled="yes" disableWhenOccupied="no" continuing="2" xcen="202.0" ycen="40.0" xa="184.0" ya="40.0" xb="220.0" yb="40.0" xc="220.0" yc="50.0" xd="184.0" yd="40.0" ver="1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" turnoutname="IT1" blockname="North" connectaname="T1" connectbname="T12" connectcname="T10" />
+    <layoutturnout ident="TO8" type="2" hidden="yes" disabled="no" disableWhenOccupied="no" continuing="2" xcen="320.0" ycen="40.0" xa="360.0" ya="40.0" xb="280.0" yb="40.0" xc="300.0" yc="50.0" xd="360.0" yd="40.0" ver="1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" turnoutname="IT2" blockname="North" connectaname="T15" connectbname="T12" connectcname="T11" />
+    <layoutturnout ident="TO1" type="5" hidden="no" disabled="no" disableWhenOccupied="yes" continuing="2" xcen="210.0" ycen="250.0" xa="180.0" ya="240.0" xb="219.99999" yb="240.0" xc="240.0" yc="260.0" xd="200.00001" yd="260.0" ver="1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" turnoutname="IT7" blockname="Yard" connectaname="T1" connectbname="T4" connectcname="T2" connectdname="T6" />
+    <layoutturnout ident="TO2" type="4" hidden="no" disabled="no" disableWhenOccupied="no" continuing="2" xcen="270.0" ycen="250.0" xa="240.0" ya="240.0" xb="300.0" yb="240.0" xc="300.0" yc="260.0" xd="240.0" yd="260.0" ver="1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" turnoutname="IT8" blockname="Yard" connectaname="T4" connectbname="T5" connectcname="T3" connectdname="T2" />
+    <layoutturnout ident="TO3" type="6" hidden="no" disabled="no" disableWhenOccupied="no" continuing="2" xcen="330.0" ycen="250.0" xa="320.0" ya="240.0" xb="360.0" yb="240.0" xc="340.0" yc="260.0" xd="300.0" yd="260.0" ver="1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" turnoutname="IT9" blockname="Yard" connectaname="T5" connectbname="T20" connectcname="T7" connectdname="T3" />
+    <layoutturnout ident="TO5" type="3" hidden="no" disabled="no" disableWhenOccupied="no" continuing="2" xcen="200.0" ycen="100.0" xa="216.13423843904454" ya="92.10246276855469" xb="180.0000015154656" yb="100.0" xc="187.7315216064453" yc="115.79507446289062" xd="219.9999984845344" yd="100.0" ver="1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" turnoutname="IT4" blockname="Yard" connectaname="T9" connectbname="T13" connectcname="T14" />
+    <layoutturnout ident="TO6" type="2" hidden="no" disabled="no" disableWhenOccupied="no" continuing="2" xcen="400.0" ycen="40.0" xa="420.0" ya="40.0" xb="380.0" yb="40.0" xc="380.0" yc="50.0" xd="420.0" yd="40.0" ver="1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" turnoutname="IT3" blockname="East" connectaname="T21" connectbname="T15" connectcname="T17" />
+    <tracksegment ident="T10" blockname="Yard" connect1name="TO4" type1="TURNOUT_C" connect2name="X1" type2="LEVEL_XING_A" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T11" blockname="Yard" connect1name="X1" type1="LEVEL_XING_D" connect2name="TO8" type2="TURNOUT_C" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T12" blockname="North" connect1name="TO4" type1="TURNOUT_B" connect2name="TO8" type2="TURNOUT_B" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T1" blockname="West" connect1name="TO4" type1="TURNOUT_A" connect2name="TO1" type2="TURNOUT_A" dashed="no" mainline="yes" hidden="no" arc="yes" flip="yes" circle="yes" angle="180.0" hideConLines="yes" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T2" blockname="Yard" connect1name="TO2" type1="TURNOUT_D" connect2name="TO1" type2="TURNOUT_C" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T3" blockname="Yard" connect1name="TO3" type1="TURNOUT_D" connect2name="TO2" type2="TURNOUT_C" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T4" blockname="Yard" connect1name="TO1" type1="TURNOUT_B" connect2name="TO2" type2="TURNOUT_A" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T5" blockname="Yard" connect1name="TO2" type1="TURNOUT_B" connect2name="TO3" type2="TURNOUT_A" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T6" blockname="SW Sliding" connect1name="EB1" type1="POS_POINT" connect2name="TO1" type2="TURNOUT_D" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T7" blockname="SE Sliding" connect1name="TO3" type1="TURNOUT_C" connect2name="EB2" type2="POS_POINT" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T9" blockname="Yard" connect1name="TO5" type1="TURNOUT_A" connect2name="X1" type2="LEVEL_XING_B" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T13" blockname="Yard" connect1name="A2" type1="POS_POINT" connect2name="TO5" type2="TURNOUT_B" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T14" blockname="Yard" connect1name="TO5" type1="TURNOUT_C" connect2name="A3" type2="POS_POINT" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T15" blockname="North" connect1name="TO6" type1="TURNOUT_B" connect2name="TO8" type2="TURNOUT_A" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T17" blockname="Yard" connect1name="SL1" type1="SLIP_D" connect2name="TO6" type2="TURNOUT_C" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T18" blockname="Yard" connect1name="SL1" type1="SLIP_B" connect2name="A4" type2="POS_POINT" dashed="no" mainline="no" hidden="no" bezier="yes" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <controlpoints>
+        <controlpoint index="0" x="220.0" y="130.0" />
+        <controlpoint index="1" x="180.0" y="170.0" />
+      </controlpoints>
+    </tracksegment>
+    <tracksegment ident="T20" blockname="East" connect1name="TO3" type1="TURNOUT_B" connect2name="A5" type2="POS_POINT" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T21" blockname="East" connect1name="TO6" type1="TURNOUT_A" connect2name="A5" type2="POS_POINT" dashed="no" mainline="yes" hidden="no" arc="yes" flip="no" circle="yes" angle="180.0" hideConLines="yes" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T22" blockname="Yard" connect1name="SL1" type1="SLIP_C" connect2name="A6" type2="POS_POINT" dashed="no" mainline="no" hidden="no" bezier="yes" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+      <controlpoints>
+        <controlpoint index="0" x="400.0" y="140.0" />
+        <controlpoint index="1" x="420.0" y="140.0" />
+      </controlpoints>
+    </tracksegment>
+    <positionablepoint ident="EB1" type="END_BUMPER" x="50.0" y="260.0" connect1name="T6" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB2" type="END_BUMPER" x="570.0" y="260.0" connect1name="T7" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A2" type="ANCHOR" x="110.0" y="100.0" connect1name="T13" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A3" type="ANCHOR" x="120.0" y="200.0" connect1name="T14" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A4" type="ANCHOR" x="150.0" y="220.0" connect1name="T18" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A5" type="ANCHOR" x="420.0" y="240.0" connect1name="T20" connect2name="T21" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A6" type="ANCHOR" x="500.0" y="140.0" connect1name="T22" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <levelxing ident="X1" blocknameac="Yard" blocknamebd="Yard" connectaname="T10" connectbname="T9" connectdname="T11" xcen="260.0" ycen="70.0" xa="240.0" ya="60.0" xb="240.0" yb="80.0" class="jmri.jmrit.display.layoutEditor.configurexml.LevelXingXml" />
+    <layoutSlip ident="SL1" slipType="DOUBLE_SLIP" hidden="yes" disabled="yes" disableWhenOccupied="yes" xcen="300.0" ycen="90.0" xa="280.0" ya="80.0" xb="280.0" yb="100.0" blockname="Yard" connectbname="T18" connectcname="T22" connectdname="T17" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutSlipXml">
+      <turnout>IT5</turnout>
+      <turnoutB>IT6</turnoutB>
+      <states>
+        <A-C>
+          <turnout>2</turnout>
+          <turnoutB>2</turnoutB>
+        </A-C>
+        <A-D>
+          <turnout>2</turnout>
+          <turnoutB>4</turnoutB>
+        </A-D>
+        <B-D>
+          <turnout>4</turnout>
+          <turnoutB>4</turnoutB>
+        </B-D>
+        <B-C>
+          <turnout>4</turnout>
+          <turnoutB>2</turnoutB>
+        </B-C>
+      </states>
+    </layoutSlip>
+    <layoutturntable ident="TUR1" radius="35.0" xcen="200.0" ycen="200.0" turnoutControlled="no" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurntableXml">
+      <raytrack angle="0.0" index="0" />
+      <raytrack angle="90.0" index="1" />
+      <raytrack angle="180.0" index="2" />
+      <raytrack angle="270.0" index="3" />
+    </layoutturntable>
+  </LayoutEditor>
+  <filehistory>
+    <operation>
+      <type>Load OK</type>
+      <date>Sun Apr 26 15:57:57 PDT 2020</date>
+      <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest.xml</filename>
+      <filehistory />
+    </operation>
+    <operation>
+      <type>Store</type>
+      <date>Sun Apr 26 15:57:57 PDT 2020</date>
+      <filename />
+    </operation>
+  </filehistory>
+  <!--Written by JMRI version 4.19.6ish+jake+20200426T2255Z+R6c02d72f3a on Sun Apr 26 15:57:57 PDT 2020-->
+</layout-config>

--- a/java/test/jmri/jmrit/display/layoutEditor/load/ThreeWay-Error-4-19-6.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/load/ThreeWay-Error-4-19-6.xml
@@ -1,0 +1,761 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-4-19-2.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-4-19-2.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>19</minor>
+    <test>6</test>
+    <modifier>ish</modifier>
+  </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor inverted="false">
+      <systemName>IS1</systemName>
+      <userName>West-F</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS2</systemName>
+      <userName>West-R</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS3</systemName>
+      <userName>Switch-F</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS4</systemName>
+      <userName>Switch-R</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS5</systemName>
+      <userName>SouthEast-F</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS6</systemName>
+      <userName>SouthEast-R</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS7</systemName>
+      <userName>CentralEast-F</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS8</systemName>
+      <userName>CentralEast-R</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS9</systemName>
+      <userName>NorthEast-F</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS10</systemName>
+      <userName>NorthEast-R</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS11</systemName>
+      <userName>StartTrain</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS12</systemName>
+      <userName>ResetTrain</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS17</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS18</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS19</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS20</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS21</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS22</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS23</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS24</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS25</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS26</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS27</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS28</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS29</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS30</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS31</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS32</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS33</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS34</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS35</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS36</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS37</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS38</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS39</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS40</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS121</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS122</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS123</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS124</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS125</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS126</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS127</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS128</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS249</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS250</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS251</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS252</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS253</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS254</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS255</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS256</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS257</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS258</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS259</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS260</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS261</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS262</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS263</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS264</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS265</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS266</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS267</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS268</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS269</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS270</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS271</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS272</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>ISCLOCKRUNNING</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>ISLT12_T_IH1</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>ISLT12_T_IH3</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>ISLT12_T_IH4</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>ISLT12_T_IH6</systemName>
+    </sensor>
+  </sensors>
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
+    <operations automate="false">
+      <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
+      <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
+      <operation name="Sensor" class="jmri.configurexml.turnoutoperations.SensorTurnoutOperationXml" interval="300" maxtries="3" />
+    </operations>
+    <defaultclosedspeed>Normal</defaultclosedspeed>
+    <defaultthrownspeed>Restricted</defaultthrownspeed>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT1</systemName>
+      <userName>EastSwitch</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT12</systemName>
+      <userName>WestSwitch</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>ITLT12</systemName>
+    </turnout>
+  </turnouts>
+  <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
+    <memory value="3:57 PM">
+      <systemName>IMCURRENTTIME</systemName>
+    </memory>
+    <memory value="1.0">
+      <systemName>IMRATEFACTOR</systemName>
+    </memory>
+  </memories>
+  <signalheads class="jmri.managers.configurexml.AbstractSignalHeadManagerXml">
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH1</systemName>
+      <userName>Switch-Th-C</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH2</systemName>
+      <userName>Switch-S</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH3</systemName>
+      <userName>Switch-C</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH4</systemName>
+      <userName>Switch-N</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH5</systemName>
+      <userName>Switch-Th-S</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH6</systemName>
+      <userName>Switch-Th-N</userName>
+    </signalhead>
+  </signalheads>
+  <blocks class="jmri.configurexml.BlockManagerXml">
+    <defaultspeed>Normal</defaultspeed>
+    <block systemName="IB:AUTO:0001">
+      <systemName>IB:AUTO:0001</systemName>
+      <userName>West-B</userName>
+    </block>
+    <block systemName="IB:AUTO:0002">
+      <systemName>IB:AUTO:0002</systemName>
+      <userName>SouthEast-B</userName>
+    </block>
+    <block systemName="IB:AUTO:0003">
+      <systemName>IB:AUTO:0003</systemName>
+      <userName>CentralEast-B</userName>
+    </block>
+    <block systemName="IB:AUTO:0004">
+      <systemName>IB:AUTO:0004</systemName>
+      <userName>NorthEast-B</userName>
+    </block>
+    <block systemName="IB:AUTO:0005">
+      <systemName>IB:AUTO:0005</systemName>
+      <userName>Switch-B</userName>
+    </block>
+    <block systemName="IB:AUTO:0001" length="0.0" curve="0">
+      <systemName>IB:AUTO:0001</systemName>
+      <userName>West-B</userName>
+      <permissive>no</permissive>
+      <occupancysensor>IS17</occupancysensor>
+      <path todir="64" fromdir="128" block="IB:AUTO:0005" />
+    </block>
+    <block systemName="IB:AUTO:0002" length="0.0" curve="0">
+      <systemName>IB:AUTO:0002</systemName>
+      <userName>SouthEast-B</userName>
+      <permissive>no</permissive>
+      <occupancysensor>IS19</occupancysensor>
+      <path todir="128" fromdir="64" block="IB:AUTO:0005">
+        <beansetting setting="4">
+          <turnout systemName="WestSwitch" />
+        </beansetting>
+      </path>
+    </block>
+    <block systemName="IB:AUTO:0003" length="0.0" curve="0">
+      <systemName>IB:AUTO:0003</systemName>
+      <userName>CentralEast-B</userName>
+      <permissive>no</permissive>
+      <occupancysensor>IS20</occupancysensor>
+      <path todir="128" fromdir="64" block="IB:AUTO:0005">
+        <beansetting setting="2">
+          <turnout systemName="EastSwitch" />
+        </beansetting>
+      </path>
+    </block>
+    <block systemName="IB:AUTO:0004" length="0.0" curve="0">
+      <systemName>IB:AUTO:0004</systemName>
+      <userName>NorthEast-B</userName>
+      <permissive>no</permissive>
+      <occupancysensor>IS21</occupancysensor>
+      <path todir="128" fromdir="64" block="IB:AUTO:0005">
+        <beansetting setting="4">
+          <turnout systemName="EastSwitch" />
+        </beansetting>
+      </path>
+    </block>
+    <block systemName="IB:AUTO:0005" length="0.0" curve="0">
+      <systemName>IB:AUTO:0005</systemName>
+      <userName>Switch-B</userName>
+      <permissive>no</permissive>
+      <occupancysensor>IS18</occupancysensor>
+      <path todir="128" fromdir="64" block="IB:AUTO:0001" />
+      <path todir="64" fromdir="128" block="IB:AUTO:0002">
+        <beansetting setting="4">
+          <turnout systemName="WestSwitch" />
+        </beansetting>
+      </path>
+      <path todir="64" fromdir="128" block="IB:AUTO:0003">
+        <beansetting setting="2">
+          <turnout systemName="EastSwitch" />
+        </beansetting>
+        <beansetting setting="2">
+          <turnout systemName="WestSwitch" />
+        </beansetting>
+      </path>
+      <path todir="64" fromdir="128" block="IB:AUTO:0004">
+        <beansetting setting="4">
+          <turnout systemName="EastSwitch" />
+        </beansetting>
+        <beansetting setting="2">
+          <turnout systemName="WestSwitch" />
+        </beansetting>
+      </path>
+    </block>
+  </blocks>
+  <layoutblocks class="jmri.jmrit.display.layoutEditor.configurexml.LayoutBlockManagerXml">
+    <layoutblock systemName="ILB1" occupancysensor="IS17" occupiedsense="2" trackcolor="darkGray" occupiedcolor="red" extracolor="white">
+      <systemName>ILB1</systemName>
+      <userName>West-B</userName>
+    </layoutblock>
+    <layoutblock systemName="ILB2" occupancysensor="IS19" occupiedsense="2" trackcolor="darkGray" occupiedcolor="red" extracolor="white">
+      <systemName>ILB2</systemName>
+      <userName>SouthEast-B</userName>
+    </layoutblock>
+    <layoutblock systemName="ILB3" occupancysensor="IS20" occupiedsense="2" trackcolor="darkGray" occupiedcolor="red" extracolor="white">
+      <systemName>ILB3</systemName>
+      <userName>CentralEast-B</userName>
+    </layoutblock>
+    <layoutblock systemName="ILB4" occupancysensor="IS21" occupiedsense="2" trackcolor="darkGray" occupiedcolor="red" extracolor="white">
+      <systemName>ILB4</systemName>
+      <userName>NorthEast-B</userName>
+    </layoutblock>
+    <layoutblock systemName="ILB5" occupancysensor="IS18" occupiedsense="2" trackcolor="darkGray" occupiedcolor="red" extracolor="white">
+      <systemName>ILB5</systemName>
+      <userName>Switch-B</userName>
+    </layoutblock>
+  </layoutblocks>
+  <sections class="jmri.configurexml.SectionManagerXml">
+    <section systemName="IY:AUTO:0001" userName="West-S" creationtype="userdefined" fsensorname="West-F" rsensorname="West-R">
+      <systemName>IY:AUTO:0001</systemName>
+      <userName>West-S</userName>
+      <blockentry sName="IB:AUTO:0001" order="0" />
+      <entrypoint fromblock="IB:AUTO:0005" toblock="IB:AUTO:0001" direction="8" fixed="no" fromblockdirection="West" />
+    </section>
+    <section systemName="IY:AUTO:0002" userName="Switch-S" creationtype="userdefined" fsensorname="Switch-F" rsensorname="Switch-R">
+      <systemName>IY:AUTO:0002</systemName>
+      <userName>Switch-S</userName>
+      <blockentry sName="IB:AUTO:0005" order="0" />
+      <entrypoint fromblock="IB:AUTO:0001" toblock="IB:AUTO:0005" direction="4" fixed="no" fromblockdirection="East" />
+      <entrypoint fromblock="IB:AUTO:0002" toblock="IB:AUTO:0005" direction="8" fixed="no" fromblockdirection="West" />
+      <entrypoint fromblock="IB:AUTO:0003" toblock="IB:AUTO:0005" direction="8" fixed="no" fromblockdirection="West" />
+      <entrypoint fromblock="IB:AUTO:0004" toblock="IB:AUTO:0005" direction="8" fixed="no" fromblockdirection="West" />
+    </section>
+    <section systemName="IY:AUTO:0003" userName="SouthEast-S" creationtype="userdefined" fsensorname="SouthEast-F" rsensorname="SouthEast-R">
+      <systemName>IY:AUTO:0003</systemName>
+      <userName>SouthEast-S</userName>
+      <blockentry sName="IB:AUTO:0002" order="0" />
+      <entrypoint fromblock="IB:AUTO:0005" toblock="IB:AUTO:0002" direction="4" fixed="no" fromblockdirection="East" />
+    </section>
+    <section systemName="IY:AUTO:0004" userName="CentralEast-S" creationtype="userdefined" fsensorname="CentralEast-F" rsensorname="CentralEast-R">
+      <systemName>IY:AUTO:0004</systemName>
+      <userName>CentralEast-S</userName>
+      <blockentry sName="IB:AUTO:0003" order="0" />
+      <entrypoint fromblock="IB:AUTO:0005" toblock="IB:AUTO:0003" direction="4" fixed="no" fromblockdirection="East" />
+    </section>
+    <section systemName="IY:AUTO:0005" userName="NorthEast-S" creationtype="userdefined" fsensorname="NorthEast-F" rsensorname="NorthEast-R">
+      <systemName>IY:AUTO:0005</systemName>
+      <userName>NorthEast-S</userName>
+      <blockentry sName="IB:AUTO:0004" order="0" />
+      <entrypoint fromblock="IB:AUTO:0005" toblock="IB:AUTO:0004" direction="4" fixed="no" fromblockdirection="East" />
+    </section>
+  </sections>
+  <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
+    <logicDelay>500</logicDelay>
+  </signalmastlogics>
+  <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
+    <logix enabled="yes">
+      <systemName>IXLT12_T_IH1</systemName>
+      <logixConditional systemName="IXLT12_T_IH1C1" order="0" />
+    </logix>
+    <logix enabled="yes">
+      <systemName>IXLT12_T_IH3</systemName>
+      <logixConditional systemName="IXLT12_T_IH3C1" order="0" />
+    </logix>
+    <logix enabled="yes">
+      <systemName>IXLT12_T_IH4</systemName>
+      <logixConditional systemName="IXLT12_T_IH4C1" order="0" />
+    </logix>
+    <logix enabled="yes">
+      <systemName>IXLT12_T_IH6</systemName>
+      <logixConditional systemName="IXLT12_T_IH6C1" order="0" />
+    </logix>
+  </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IXLT12_T_IH1C1" antecedent="" logicType="1" triggerOnChange="yes">
+      <systemName>IXLT12_T_IH1C1</systemName>
+      <conditionalStateVariable operator="1" negated="no" type="3" systemName="LT12" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="9" systemName="ISLT12_T_IH1" data="2" delay="0" string="" />
+      <conditionalAction option="2" type="9" systemName="ISLT12_T_IH1" data="4" delay="0" string="" />
+    </conditional>
+    <conditional systemName="IXLT12_T_IH3C1" antecedent="" logicType="1" triggerOnChange="yes">
+      <systemName>IXLT12_T_IH3C1</systemName>
+      <conditionalStateVariable operator="1" negated="no" type="3" systemName="LT12" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="9" systemName="ISLT12_T_IH3" data="2" delay="0" string="" />
+      <conditionalAction option="2" type="9" systemName="ISLT12_T_IH3" data="4" delay="0" string="" />
+    </conditional>
+    <conditional systemName="IXLT12_T_IH4C1" antecedent="" logicType="1" triggerOnChange="yes">
+      <systemName>IXLT12_T_IH4C1</systemName>
+      <conditionalStateVariable operator="1" negated="no" type="3" systemName="LT12" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="9" systemName="ISLT12_T_IH4" data="2" delay="0" string="" />
+      <conditionalAction option="2" type="9" systemName="ISLT12_T_IH4" data="4" delay="0" string="" />
+    </conditional>
+    <conditional systemName="IXLT12_T_IH6C1" antecedent="" logicType="1" triggerOnChange="yes">
+      <systemName>IXLT12_T_IH6C1</systemName>
+      <conditionalStateVariable operator="1" negated="no" type="3" systemName="LT12" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="9" systemName="ISLT12_T_IH6" data="2" delay="0" string="" />
+      <conditionalAction option="2" type="9" systemName="ISLT12_T_IH6" data="4" delay="0" string="" />
+    </conditional>
+  </conditionals>
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Apr 17 05:13:25 PDT 2020" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <LayoutEditor class="jmri.jmrit.display.layoutEditor.configurexml.LayoutEditorXml" name="My Layout" x="0" y="23" windowheight="1394" windowwidth="2560" panelheight="190" panelwidth="410" sliders="no" scrollable="none" editable="yes" positionable="yes" controlling="yes" animating="yes" showhelpbar="no" drawgrid="yes" snaponadd="yes" snaponmove="yes" antialiasing="yes" turnoutcircles="no" tooltipsnotedit="no" tooltipsinedit="yes" mainlinetrackwidth="4" xscale="1.0" yscale="1.0" sidetrackwidth="2" defaulttrackcolor="darkGray" defaultoccupiedtrackcolor="red" defaultalternativetrackcolor="white" defaulttextcolor="black" turnoutcirclecolor="black" turnoutcirclesize="4" turnoutdrawunselectedleg="yes" turnoutbx="20.0" turnoutcx="20.0" turnoutwid="10.0" xoverlong="30.0" xoverhwid="10.0" xovershort="10.0" autoblkgenerate="no" redBackground="192" greenBackground="192" blueBackground="192" gridSize="10" gridSize2nd="10" openDispatcher="no" useDirectTurnoutControl="no">
+    <layoutTrackDrawingOptions name="My Layout" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTrackDrawingOptionsXml">
+      <mainBallastColor>#000000</mainBallastColor>
+      <mainBallastWidth>0</mainBallastWidth>
+      <mainBlockLineDashPercentageX10>0</mainBlockLineDashPercentageX10>
+      <mainBlockLineWidth>4</mainBlockLineWidth>
+      <mainRailColor>#404040</mainRailColor>
+      <mainRailCount>1</mainRailCount>
+      <mainRailGap>0</mainRailGap>
+      <mainRailWidth>2</mainRailWidth>
+      <mainTieColor>#000000</mainTieColor>
+      <mainTieGap>0</mainTieGap>
+      <mainTieLength>0</mainTieLength>
+      <mainTieWidth>0</mainTieWidth>
+      <sideBallastColor>#000000</sideBallastColor>
+      <sideBallastWidth>0</sideBallastWidth>
+      <sideBlockLineDashPercentageX10>0</sideBlockLineDashPercentageX10>
+      <sideBlockLineWidth>2</sideBlockLineWidth>
+      <sideRailColor>#404040</sideRailColor>
+      <sideRailCount>1</sideRailCount>
+      <sideRailGap>0</sideRailGap>
+      <sideRailWidth>1</sideRailWidth>
+      <sideTieColor>#000000</sideTieColor>
+      <sideTieGap>0</sideTieGap>
+      <sideTieLength>0</sideTieLength>
+      <sideTieWidth>0</sideTieWidth>
+    </layoutTrackDrawingOptions>
+    <signalheadicon signalhead="Switch-Th-C" x="182" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" degrees="180" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="Switch-Th-S" x="162" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" degrees="180" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="Switch-Th-N" x="142" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" degrees="180" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-short.gif" degrees="180" scale="1.0">
+          <rotation>0</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="Switch-S" x="231" y="100" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" degrees="26" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-short.gif" degrees="26" scale="1.0">
+          <rotation>0</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-short.gif" degrees="26" scale="1.0">
+          <rotation>0</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-short.gif" degrees="26" scale="1.0">
+          <rotation>0</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-short.gif" degrees="26" scale="1.0">
+          <rotation>0</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-short.gif" degrees="26" scale="1.0">
+          <rotation>0</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-short.gif" degrees="26" scale="1.0">
+          <rotation>0</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-short.gif" degrees="26" scale="1.0">
+          <rotation>0</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-short.gif" degrees="26" scale="1.0">
+          <rotation>0</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="Switch-C" x="264" y="82" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" degrees="90" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-short.gif" degrees="90" scale="1.0">
+          <rotation>0</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-short.gif" degrees="90" scale="1.0">
+          <rotation>0</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-short.gif" degrees="90" scale="1.0">
+          <rotation>0</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-short.gif" degrees="90" scale="1.0">
+          <rotation>0</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-short.gif" degrees="90" scale="1.0">
+          <rotation>0</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-short.gif" degrees="90" scale="1.0">
+          <rotation>0</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-short.gif" degrees="90" scale="1.0">
+          <rotation>0</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-short.gif" degrees="90" scale="1.0">
+          <rotation>0</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="Switch-N" x="254" y="67" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" degrees="333" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-short.gif" degrees="333" scale="1.0">
+          <rotation>0</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-short.gif" degrees="333" scale="1.0">
+          <rotation>0</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-short.gif" degrees="333" scale="1.0">
+          <rotation>0</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-short.gif" degrees="333" scale="1.0">
+          <rotation>0</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-short.gif" degrees="333" scale="1.0">
+          <rotation>0</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-short.gif" degrees="333" scale="1.0">
+          <rotation>0</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-short.gif" degrees="333" scale="1.0">
+          <rotation>0</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-short.gif" degrees="333" scale="1.0">
+          <rotation>0</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <layoutturnout ident="TO1" type="1" hidden="no" disabled="no" disableWhenOccupied="no" continuing="2" xcen="200.0" ycen="100.0" xa="180.0" ya="100.0" xb="220.0" yb="100.0" xc="220.0" yc="110.0" xd="180.0" yd="100.0" ver="1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" turnoutname="WestSwitch" linkedturnoutname="EastSwitch" linktype="1" blockname="Switch-B" connectaname="T2" connectbname="T1" connectcname="T3" signala1name="Switch-Th-C" signala2name="Switch-Th-S" signala3name="Switch-Th-N" signalc1name="Switch-S" />
+    <layoutturnout ident="TO2" type="2" hidden="no" disabled="no" disableWhenOccupied="no" continuing="2" xcen="240.0" ycen="100.0" xa="220.0" ya="100.0" xb="260.0" yb="100.0" xc="260.0" yc="90.0" xd="220.0" yd="100.0" ver="1" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutTurnoutXml" turnoutname="EastSwitch" linkedturnoutname="WestSwitch" linktype="2" blockname="Switch-B" connectaname="T1" connectbname="T4" connectcname="T5" signalb1name="Switch-C" signalc1name="Switch-N" />
+    <tracksegment ident="T1" blockname="Switch-B" connect1name="TO2" type1="TURNOUT_A" connect2name="TO1" type2="TURNOUT_B" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T2" blockname="West-B" connect1name="EB1" type1="POS_POINT" connect2name="TO1" type2="TURNOUT_A" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T3" blockname="SouthEast-B" connect1name="TO1" type1="TURNOUT_C" connect2name="EB2" type2="POS_POINT" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T4" blockname="CentralEast-B" connect1name="TO2" type1="TURNOUT_B" connect2name="EB3" type2="POS_POINT" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <tracksegment ident="T5" blockname="NorthEast-B" connect1name="TO2" type1="TURNOUT_C" connect2name="EB4" type2="POS_POINT" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
+    <positionablepoint ident="EB1" type="END_BUMPER" x="40.0" y="100.0" connect1name="T2" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB2" type="END_BUMPER" x="360.0" y="140.0" connect1name="T3" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB3" type="END_BUMPER" x="360.0" y="100.0" connect1name="T4" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB4" type="END_BUMPER" x="360.0" y="60.0" connect1name="T5" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+  </LayoutEditor>
+  <filehistory>
+    <operation>
+      <type>Load OK</type>
+      <date>Sun Apr 26 15:57:58 PDT 2020</date>
+      <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/java/test/jmri/jmrit/display/layoutEditor/load/ThreeWay-Error.xml</filename>
+      <filehistory>
+        <operation>
+          <type>Load OK</type>
+          <date>Fri Apr 17 16:26:50 PDT 2020</date>
+          <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/java/test/jmri/jmrit/display/layoutEditor/load/ThreeWay-Error.xml</filename>
+          <filehistory>
+            <operation>
+              <type>app</type>
+              <date>Fri Apr 17 15:45:44 PDT 2020</date>
+              <filename>JMRI program</filename>
+            </operation>
+            <operation>
+              <type>Load OK</type>
+              <date>Fri Apr 17 15:46:08 PDT 2020</date>
+              <filename>/Users/jake/Downloads/ThreeWay-Error.xml</filename>
+              <filehistory>
+                <operation>
+                  <type>app</type>
+                  <date>Fri Apr 17 08:13:24 EDT 2020</date>
+                  <filename>JMRI program</filename>
+                </operation>
+                <operation>
+                  <type>Store</type>
+                  <date>Fri Apr 17 08:44:32 EDT 2020</date>
+                  <filename />
+                </operation>
+              </filehistory>
+            </operation>
+            <operation>
+              <type>Store</type>
+              <date>Fri Apr 17 15:46:32 PDT 2020</date>
+              <filename />
+            </operation>
+          </filehistory>
+        </operation>
+        <operation>
+          <type>Store</type>
+          <date>Fri Apr 17 16:26:50 PDT 2020</date>
+          <filename />
+        </operation>
+      </filehistory>
+    </operation>
+    <operation>
+      <type>Store</type>
+      <date>Sun Apr 26 15:57:58 PDT 2020</date>
+      <filename />
+    </operation>
+  </filehistory>
+  <!--Written by JMRI version 4.19.6ish+jake+20200426T2255Z+R6c02d72f3a on Sun Apr 26 15:57:58 PDT 2020-->
+</layout-config>

--- a/java/test/jmri/jmrit/display/layoutEditor/loadref/Decorations.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/loadref/Decorations.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>19</minor>
-    <test>5</test>
+    <test>6</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -14,7 +14,7 @@
     </sensor>
   </sensors>
   <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
-    <memory value="2:08 PM">
+    <memory value="3:57 PM">
       <systemName>IMCURRENTTIME</systemName>
     </memory>
     <memory value="1.0">
@@ -240,41 +240,41 @@
         <tunnel side="left" color="#663300" linewidth="1" entrancewidth="16" floorwidth="10" />
       </decorations>
     </tracksegment>
-    <positionablepoint ident="A3" type="1" x="300.0" y="140.0" connect1name="T1" connect2name="T3" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB4" type="2" x="200.0" y="200.0" connect1name="T18" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A7" type="1" x="290.0" y="160.0" connect1name="T11" connect2name="T7" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A9" type="1" x="300.0" y="220.0" connect1name="T18" connect2name="T19" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EC2" type="3" x="400.0" y="240.0" connect1name="T19" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EC3" type="3" x="190.0" y="220.0" connect1name="T22" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A14" type="1" x="290.0" y="240.0" connect1name="T22" connect2name="T23" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A15" type="1" x="630.0" y="100.0" connect1name="T5" connect2name="T13" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A16" type="1" x="730.0" y="120.0" connect1name="T25" connect2name="T14" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EC6" type="3" x="830.0" y="150.0" connect1name="T9" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB5" type="2" x="390.0" y="260.0" connect1name="T23" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB6" type="2" x="610.0" y="200.0" connect1name="T5" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB1" type="2" x="100.0" y="100.0" connect1name="T1" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EC10" type="3" x="500.0" y="180.0" connect1name="T3" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EC1" type="3" x="90.0" y="120.0" connect1name="T11" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB2" type="2" x="490.0" y="200.0" connect1name="T7" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EC7" type="3" x="620.0" y="190.0" connect1name="T27" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A23" type="1" x="640.0" y="110.0" connect1name="T27" connect2name="T28" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A25" type="1" x="720.0" y="130.0" connect1name="T16" connect2name="T30" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB7" type="2" x="840.0" y="160.0" connect1name="T12" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB3" type="2" x="150.0" y="300.0" connect1name="T34" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A31" type="1" x="300.0" y="380.0" connect1name="T4" connect2name="T35" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EC4" type="3" x="450.0" y="480.0" connect1name="T35" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EC9" type="3" x="130.0" y="300.0" connect1name="T38" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A36" type="1" x="300.0" y="400.0" connect1name="T2" connect2name="T39" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB8" type="2" x="430.0" y="480.0" connect1name="T39" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB9" type="2" x="560.0" y="490.0" connect1name="T42" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A41" type="1" x="750.0" y="450.0" connect1name="T42" connect2name="T43" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EC5" type="3" x="910.0" y="420.0" connect1name="T43" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A1" type="1" x="773.7868041992188" y="155.71067810058594" connect1name="T14" connect2name="T9" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A11" type="1" x="773.7868041992188" y="169.85281372070312" connect1name="T30" connect2name="T12" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A12" type="1" x="684.1421508789062" y="103.43145751953125" connect1name="T28" connect2name="T16" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A19" type="1" x="684.1421508789062" y="89.28932189941406" connect1name="T13" connect2name="T25" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A2" type="1" x="250.0" y="400.0" connect1name="T38" connect2name="T2" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A4" type="1" x="250.0" y="380.0" connect1name="T34" connect2name="T4" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A3" type="ANCHOR" x="300.0" y="140.0" connect1name="T1" connect2name="T3" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB4" type="END_BUMPER" x="200.0" y="200.0" connect1name="T18" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A7" type="ANCHOR" x="290.0" y="160.0" connect1name="T11" connect2name="T7" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A9" type="ANCHOR" x="300.0" y="220.0" connect1name="T18" connect2name="T19" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC2" type="EDGE_CONNECTOR" x="400.0" y="240.0" connect1name="T19" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC3" type="EDGE_CONNECTOR" x="190.0" y="220.0" connect1name="T22" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A14" type="ANCHOR" x="290.0" y="240.0" connect1name="T22" connect2name="T23" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A15" type="ANCHOR" x="630.0" y="100.0" connect1name="T5" connect2name="T13" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A16" type="ANCHOR" x="730.0" y="120.0" connect1name="T25" connect2name="T14" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC6" type="EDGE_CONNECTOR" x="830.0" y="150.0" connect1name="T9" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB5" type="END_BUMPER" x="390.0" y="260.0" connect1name="T23" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB6" type="END_BUMPER" x="610.0" y="200.0" connect1name="T5" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB1" type="END_BUMPER" x="100.0" y="100.0" connect1name="T1" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC10" type="EDGE_CONNECTOR" x="500.0" y="180.0" connect1name="T3" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC1" type="EDGE_CONNECTOR" x="90.0" y="120.0" connect1name="T11" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB2" type="END_BUMPER" x="490.0" y="200.0" connect1name="T7" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC7" type="EDGE_CONNECTOR" x="620.0" y="190.0" connect1name="T27" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A23" type="ANCHOR" x="640.0" y="110.0" connect1name="T27" connect2name="T28" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A25" type="ANCHOR" x="720.0" y="130.0" connect1name="T16" connect2name="T30" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB7" type="END_BUMPER" x="840.0" y="160.0" connect1name="T12" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB3" type="END_BUMPER" x="150.0" y="300.0" connect1name="T34" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A31" type="ANCHOR" x="300.0" y="380.0" connect1name="T4" connect2name="T35" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC4" type="EDGE_CONNECTOR" x="450.0" y="480.0" connect1name="T35" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC9" type="EDGE_CONNECTOR" x="130.0" y="300.0" connect1name="T38" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A36" type="ANCHOR" x="300.0" y="400.0" connect1name="T2" connect2name="T39" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB8" type="END_BUMPER" x="430.0" y="480.0" connect1name="T39" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB9" type="END_BUMPER" x="560.0" y="490.0" connect1name="T42" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A41" type="ANCHOR" x="750.0" y="450.0" connect1name="T42" connect2name="T43" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EC5" type="EDGE_CONNECTOR" x="910.0" y="420.0" connect1name="T43" linkedpanel="" linkpointid="" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A1" type="ANCHOR" x="773.7868041992188" y="155.71067810058594" connect1name="T14" connect2name="T9" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A11" type="ANCHOR" x="773.7868041992188" y="169.85281372070312" connect1name="T30" connect2name="T12" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A12" type="ANCHOR" x="684.1421508789062" y="103.43145751953125" connect1name="T28" connect2name="T16" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A19" type="ANCHOR" x="684.1421508789062" y="89.28932189941406" connect1name="T13" connect2name="T25" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A2" type="ANCHOR" x="250.0" y="400.0" connect1name="T38" connect2name="T2" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A4" type="ANCHOR" x="250.0" y="380.0" connect1name="T34" connect2name="T4" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
     <layoutShape ident="Putting Green" type="Filled" level="3" linewidth="1" lineColor="#00FF00" fillColor="#338033" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutShapeXml">
       <points>
         <point type="Curve" x="457.5" y="47.5" />
@@ -294,14 +294,9 @@
   </LayoutEditor>
   <filehistory>
     <operation>
-      <type>app</type>
-      <date>Mon Apr 13 14:07:38 PDT 2020</date>
-      <filename>JMRI program</filename>
-    </operation>
-    <operation>
       <type>Load OK</type>
-      <date>Mon Apr 13 14:07:41 PDT 2020</date>
-      <filename>/Volumes/Geo512GB/Users/Shared/Dropbox/Model%20Railroading/JMRI/GeoDebugging/GeoDebugging.xml</filename>
+      <date>Sun Apr 26 15:57:56 PDT 2020</date>
+      <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/java/test/jmri/jmrit/display/layoutEditor/load/Decorations.xml</filename>
       <filehistory>
         <operation>
           <type>app</type>
@@ -317,9 +312,9 @@
     </operation>
     <operation>
       <type>Store</type>
-      <date>Mon Apr 13 14:08:12 PDT 2020</date>
+      <date>Sun Apr 26 15:57:56 PDT 2020</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.19.5ish+geowar+20200413T2107Z+R4323a6e1be on Mon Apr 13 14:08:12 PDT 2020-->
+  <!--Written by JMRI version 4.19.6ish+jake+20200426T2255Z+R6c02d72f3a on Sun Apr 26 15:57:56 PDT 2020-->
 </layout-config>

--- a/java/test/jmri/jmrit/display/layoutEditor/loadref/LayoutEditorTest.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/loadref/LayoutEditorTest.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>19</minor>
-    <test>5</test>
+    <test>6</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -289,15 +289,15 @@
         <controlpoint index="1" x="420.0" y="140.0" />
       </controlpoints>
     </tracksegment>
-    <positionablepoint ident="EB1" type="2" x="50.0" y="260.0" connect1name="T6" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB2" type="2" x="570.0" y="260.0" connect1name="T7" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A2" type="1" x="110.0" y="100.0" connect1name="T13" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A3" type="1" x="120.0" y="200.0" connect1name="T14" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A4" type="1" x="150.0" y="220.0" connect1name="T18" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A5" type="1" x="420.0" y="240.0" connect1name="T20" connect2name="T21" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="A6" type="1" x="500.0" y="140.0" connect1name="T22" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB1" type="END_BUMPER" x="50.0" y="260.0" connect1name="T6" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB2" type="END_BUMPER" x="570.0" y="260.0" connect1name="T7" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A2" type="ANCHOR" x="110.0" y="100.0" connect1name="T13" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A3" type="ANCHOR" x="120.0" y="200.0" connect1name="T14" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A4" type="ANCHOR" x="150.0" y="220.0" connect1name="T18" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A5" type="ANCHOR" x="420.0" y="240.0" connect1name="T20" connect2name="T21" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="A6" type="ANCHOR" x="500.0" y="140.0" connect1name="T22" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
     <levelxing ident="X1" blocknameac="Yard" blocknamebd="Yard" connectaname="T10" connectbname="T9" connectdname="T11" xcen="260.0" ycen="70.0" xa="240.0" ya="60.0" xb="240.0" yb="80.0" class="jmri.jmrit.display.layoutEditor.configurexml.LevelXingXml" />
-    <layoutSlip ident="SL1" slipType="8" hidden="yes" disabled="yes" disableWhenOccupied="yes" xcen="300.0" ycen="90.0" xa="280.0" ya="80.0" xb="280.0" yb="100.0" blockname="Yard" connectbname="T18" connectcname="T22" connectdname="T17" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutSlipXml">
+    <layoutSlip ident="SL1" slipType="DOUBLE_SLIP" hidden="yes" disabled="yes" disableWhenOccupied="yes" xcen="300.0" ycen="90.0" xa="280.0" ya="80.0" xb="280.0" yb="100.0" blockname="Yard" connectbname="T18" connectcname="T22" connectdname="T17" class="jmri.jmrit.display.layoutEditor.configurexml.LayoutSlipXml">
       <turnout>IT5</turnout>
       <turnoutB>IT6</turnoutB>
       <states>
@@ -328,38 +328,16 @@
   </LayoutEditor>
   <filehistory>
     <operation>
-      <type>app</type>
-      <date>Mon Apr 13 14:12:12 PDT 2020</date>
-      <filename>JMRI program</filename>
-    </operation>
-    <operation>
       <type>Load OK</type>
-      <date>Mon Apr 13 14:12:15 PDT 2020</date>
-      <filename>/Volumes/Geo512GB/Users/Shared/Dropbox/Model%20Railroading/JMRI/GeoDebugging/GeoDebugging.xml</filename>
-      <filehistory>
-        <operation>
-          <type>app</type>
-      <date>Tue Sep 10 22:44:20 CEST 2019</date>
-      <filename>JMRI program</filename>
-    </operation>
-    <operation>
-      <type>Load OK</type>
-      <date>Tue Sep 10 22:46:01 CEST 2019</date>
-      <filename>/Users/egbertbroerse/Documents/Egbert/Computers/IntelliJ%20local/JMRI/java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest.xml</filename>
+      <date>Sun Apr 26 15:57:57 PDT 2020</date>
+      <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest.xml</filename>
       <filehistory />
     </operation>
     <operation>
       <type>Store</type>
-      <date>Tue Sep 10 22:46:23 CEST 2019</date>
+      <date>Sun Apr 26 15:57:57 PDT 2020</date>
       <filename />
     </operation>
   </filehistory>
-    </operation>
-    <operation>
-      <type>Store</type>
-      <date>Mon Apr 13 14:12:28 PDT 2020</date>
-      <filename />
-    </operation>
-  </filehistory>
-  <!--Written by JMRI version 4.19.5ish+geowar+20200413T2112Z+R4323a6e1be on Mon Apr 13 14:12:28 PDT 2020-->
+  <!--Written by JMRI version 4.19.6ish+jake+20200426T2255Z+R6c02d72f3a on Sun Apr 26 15:57:57 PDT 2020-->
 </layout-config>

--- a/java/test/jmri/jmrit/display/layoutEditor/loadref/ThreeWay-Error.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/loadref/ThreeWay-Error.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>19</minor>
-    <test>5</test>
+    <test>6</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -262,7 +262,7 @@
     </turnout>
   </turnouts>
   <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
-    <memory value="8:48 PM">
+    <memory value="3:57 PM">
       <systemName>IMCURRENTTIME</systemName>
     </memory>
     <memory value="1.0">
@@ -699,15 +699,15 @@
     <tracksegment ident="T3" blockname="SouthEast-B" connect1name="TO1" type1="TURNOUT_C" connect2name="EB2" type2="POS_POINT" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="T4" blockname="CentralEast-B" connect1name="TO2" type1="TURNOUT_B" connect2name="EB3" type2="POS_POINT" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="T5" blockname="NorthEast-B" connect1name="TO2" type1="TURNOUT_C" connect2name="EB4" type2="POS_POINT" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
-    <positionablepoint ident="EB1" type="2" x="40.0" y="100.0" connect1name="T2" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB2" type="2" x="360.0" y="140.0" connect1name="T3" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB3" type="2" x="360.0" y="100.0" connect1name="T4" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
-    <positionablepoint ident="EB4" type="2" x="360.0" y="60.0" connect1name="T5" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB1" type="END_BUMPER" x="40.0" y="100.0" connect1name="T2" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB2" type="END_BUMPER" x="360.0" y="140.0" connect1name="T3" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB3" type="END_BUMPER" x="360.0" y="100.0" connect1name="T4" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
+    <positionablepoint ident="EB4" type="END_BUMPER" x="360.0" y="60.0" connect1name="T5" class="jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml" />
   </LayoutEditor>
   <filehistory>
     <operation>
       <type>Load OK</type>
-      <date>Fri Apr 17 20:48:29 PDT 2020</date>
+      <date>Sun Apr 26 15:57:58 PDT 2020</date>
       <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/java/test/jmri/jmrit/display/layoutEditor/load/ThreeWay-Error.xml</filename>
       <filehistory>
         <operation>
@@ -753,9 +753,9 @@
     </operation>
     <operation>
       <type>Store</type>
-      <date>Fri Apr 17 20:48:29 PDT 2020</date>
+      <date>Sun Apr 26 15:57:58 PDT 2020</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.19.5ish+jake+20200417T2344Z+R918c4d1801 on Fri Apr 17 20:48:29 PDT 2020-->
+  <!--Written by JMRI version 4.19.6ish+jake+20200426T2255Z+R6c02d72f3a on Sun Apr 26 15:57:58 PDT 2020-->
 </layout-config>

--- a/xml/schema/types/editors.xsd
+++ b/xml/schema/types/editors.xsd
@@ -269,6 +269,31 @@
       <xs:attribute name="text" type="xs:string"></xs:attribute>
     </xs:complexType>
 
+    <xs:simpleType name="PositionablePointType">
+      <xs:annotation>
+        <xs:documentation>
+          Represents values of PositionablePoint.??? enum,
+          both as 0-3 and as String names.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:union>
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="3"/>
+          </xs:restriction>
+        </xs:simpleType>
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="NONE"></xs:enumeration>
+            <xs:enumeration value="ANCHOR"></xs:enumeration>
+            <xs:enumeration value="END_BUMPER"></xs:enumeration>
+            <xs:enumeration value="EDGE_CONNECTOR"></xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:union>
+    </xs:simpleType>
+
     <xs:complexType name="EditorPositionablePointType">
       <xs:annotation>
         <xs:documentation>
@@ -276,6 +301,7 @@
         </xs:documentation>
         <xs:appinfo>
           jmri.jmrit.display.configurexml.PositionablePointXml
+          jmri.jmrit.display.layoutEditor.configurexml.PositionablePointXml
         </xs:appinfo>
       </xs:annotation>
 
@@ -298,7 +324,7 @@
       <xs:attribute name="ident" type="beanNameType" use="required">
         <xs:annotation><xs:documentation>Identify this element, for reference in connect* attributes elsewhere</xs:documentation></xs:annotation>
       </xs:attribute>
-      <xs:attribute name="type" type="xs:int" use="required"></xs:attribute>
+      <xs:attribute name="type" type="PositionablePointType" use="required"></xs:attribute>
       <xs:attribute name="x" type="xs:float" use="required"></xs:attribute>
       <xs:attribute name="y" type="xs:float" use="required"></xs:attribute>
       <xs:attribute name="connect1name" type="xs:string"></xs:attribute>
@@ -1134,6 +1160,37 @@
     </xs:complexType>
 
 
+    <xs:simpleType name="LayoutTurnoutType">
+      <xs:annotation>
+        <xs:documentation>
+          Represents values of LayoutTurnout.TurnoutType enum,
+          both as 0-63 and as String names.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:union>
+        <xs:simpleType>
+          <xs:restriction base="xs:integer">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="8"/>
+          </xs:restriction>
+        </xs:simpleType>
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:enumeration value="NONE"></xs:enumeration>
+            <xs:enumeration value="RH_TURNOUT"></xs:enumeration>
+            <xs:enumeration value="LH_TURNOUT"></xs:enumeration>
+            <xs:enumeration value="WYE_TURNOUT"></xs:enumeration>
+            <xs:enumeration value="DOUBLE_XOVER"></xs:enumeration>
+            <xs:enumeration value="TURNOUT_D"></xs:enumeration>
+            <xs:enumeration value="RH_XOVER"></xs:enumeration>
+            <xs:enumeration value="LH_XOVER"></xs:enumeration>
+            <xs:enumeration value="SINGLE_SLIP"></xs:enumeration>
+            <xs:enumeration value="DOUBLE_SLIP"></xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:union>
+    </xs:simpleType>
+
     <xs:complexType name="EditorLayoutTurnoutType">
       <xs:annotation>
         <xs:documentation>
@@ -1159,7 +1216,7 @@
       <xs:attribute name="ident" type="beanNameType" use="required">
         <xs:annotation><xs:documentation>Identify this element, for reference in connect* attributes elsewhere</xs:documentation></xs:annotation>
       </xs:attribute>
-      <xs:attribute name="type" type="xs:int" use="required"></xs:attribute>
+      <xs:attribute name="type" type="LayoutTurnoutType" use="required"></xs:attribute>
       <xs:attribute name="continuing" type="xs:string" use="required"></xs:attribute>
 
       <xs:attribute name="xa" type="xs:float"></xs:attribute>

--- a/xml/schema/types/editors.xsd
+++ b/xml/schema/types/editors.xsd
@@ -1259,6 +1259,7 @@
       <xs:attribute name="linktype" type="xs:string"></xs:attribute>
     </xs:complexType>
 
+
     <xs:complexType name="EditorLayoutSlipType">
       <xs:annotation>
         <xs:documentation>
@@ -1332,7 +1333,7 @@
       <xs:attribute name="ident" type="beanNameType" use="required">
         <xs:annotation><xs:documentation>Identify this element, for reference in connect* attributes elsewhere</xs:documentation></xs:annotation>
       </xs:attribute>
-      <xs:attribute name="slipType" type="xs:string" use="required"></xs:attribute>
+      <xs:attribute name="slipType" type="LayoutTurnoutType" use="required"></xs:attribute>
 
       <xs:attribute name="xa" type="xs:float" use="required"></xs:attribute>
       <xs:attribute name="ya" type="xs:float" use="required"></xs:attribute>


### PR DESCRIPTION
The selection constants in LayoutTrack, LayoutTurnout, LayoutTurntable, LayoutSlip, TrackSegment and PositionablePoint are now enums which are stored and loaded via their text names.  The code and XML Schema accepts both the current names and numerical constants used earlier.