### PR TITLE
LE LayoutTurnout and LayoutSlip effectively types

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
@@ -61,7 +61,7 @@ public class LayoutSlip extends LayoutTurnout {
      * constructor method
      */
     public LayoutSlip(String id, Point2D c, double rot, LayoutEditor layoutEditor, TurnoutType type) {
-        super(id, c, layoutEditor);
+        super(id, c, layoutEditor, type);
 
         dispA = new Point2D.Double(-20.0, 0.0);
         pointA = MathUtil.add(center, dispA);
@@ -70,7 +70,17 @@ public class LayoutSlip extends LayoutTurnout {
         pointB = MathUtil.add(center, dispB);
         pointD = MathUtil.subtract(center, dispB);
 
-        setSlipType(type);
+        turnoutStates.put(STATE_AC, new TurnoutState(Turnout.CLOSED, Turnout.CLOSED));
+        turnoutStates.put(STATE_AD, new TurnoutState(Turnout.CLOSED, Turnout.THROWN));
+        turnoutStates.put(STATE_BD, new TurnoutState(Turnout.THROWN, Turnout.THROWN));
+        if (type == TurnoutType.SINGLE_SLIP) {
+            turnoutStates.remove(STATE_BC);
+        } else if (type == TurnoutType.DOUBLE_SLIP) {
+            turnoutStates.put(STATE_BC, new TurnoutState(Turnout.THROWN, Turnout.CLOSED));
+        } else {
+            log.error("{}.setSlipType({}); invalid slip type", getName(), type); //I18IN
+        }
+        
         rotateCoords(rot);
     }
 
@@ -78,26 +88,6 @@ public class LayoutSlip extends LayoutTurnout {
     @Override
     public String toString() {
         return String.format("LayoutSlip %s (%s)", getId(), getSlipStateString(getSlipState()));
-    }
-
-    public void setTurnoutType(LayoutTurnout.TurnoutType slipType) {
-        setSlipType(slipType);
-    }
-
-    public void setSlipType(TurnoutType slipType) {
-        if (type != slipType) {
-            type = slipType;
-            turnoutStates.put(STATE_AC, new TurnoutState(Turnout.CLOSED, Turnout.CLOSED));
-            turnoutStates.put(STATE_AD, new TurnoutState(Turnout.CLOSED, Turnout.THROWN));
-            turnoutStates.put(STATE_BD, new TurnoutState(Turnout.THROWN, Turnout.THROWN));
-            if (type == TurnoutType.SINGLE_SLIP) {
-                turnoutStates.remove(STATE_BC);
-            } else if (type == TurnoutType.DOUBLE_SLIP) {
-                turnoutStates.put(STATE_BC, new TurnoutState(Turnout.THROWN, Turnout.CLOSED));
-            } else {
-                log.error("{}.setSlipType({}); invalid slip type", getName(), slipType); //I18IN
-            }
-        }
     }
 
     public TurnoutType getSlipType() {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -260,6 +260,7 @@ public class LayoutTurnout extends LayoutTrack {
         THROAT_TO_THROAT  // this turnout is one of two throat-to-throat
         // turnouts - no signals at throat
     }
+    
     // operational instance variables (not saved between sessions)
     public static final int UNKNOWN = Turnout.UNKNOWN;
     public static final int INCONSISTENT = Turnout.INCONSISTENT;
@@ -337,7 +338,7 @@ public class LayoutTurnout extends LayoutTrack {
     protected NamedBeanHandle<Sensor> sensorCNamed = null; // diverging
     protected NamedBeanHandle<Sensor> sensorDNamed = null; // single or double crossover only
 
-    public TurnoutType type = TurnoutType.RH_TURNOUT;
+    protected final TurnoutType type;
 
     public LayoutTrack connectA = null;      // throat of LH, RH, RH Xover, LH Xover, and WYE turnouts
     public LayoutTrack connectB = null;      // straight leg of LH and RH turnouts
@@ -365,7 +366,14 @@ public class LayoutTurnout extends LayoutTrack {
 
     protected LayoutTurnout(@Nonnull String id,
             @Nonnull Point2D c, @Nonnull LayoutEditor layoutEditor) {
+        this(id, c, layoutEditor, TurnoutType.NONE);
+    }
+
+    protected LayoutTurnout(@Nonnull String id,
+            @Nonnull Point2D c, @Nonnull LayoutEditor layoutEditor, TurnoutType t) {
         super(id, c, layoutEditor);
+        
+        type = t;
     }
 
     public LayoutTurnout(@Nonnull String id, TurnoutType t,
@@ -376,7 +384,7 @@ public class LayoutTurnout extends LayoutTrack {
     }
 
     /**
-     * constructor method
+     * Main constructor method
      */
     public LayoutTurnout(@Nonnull String id, TurnoutType t, @Nonnull Point2D c, double rot,
             double xFactor, double yFactor, @Nonnull LayoutEditor layoutEditor, int v) {

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutSlipTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutSlipTest.java
@@ -68,42 +68,6 @@ public class LayoutSlipTest {
     }
 
     @Test
-    public void testSetSlipType() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertNotNull("LayoutEditor exists", layoutEditor);
-        Assert.assertNotNull("LayoutSlip single not null", lts);
-        Assert.assertNotNull("LayoutSlip double not null", ltd);
-
-        lts.setSlipType(LayoutTurnout.TurnoutType.NONE); // invalid type
-        JUnitAppender.assertErrorMessage("single.setSlipType(NONE); invalid slip type");
-        ltd.setSlipType(LayoutTurnout.TurnoutType.NONE); // invalid type
-        JUnitAppender.assertErrorMessage("double.setSlipType(NONE); invalid slip type");
-
-        lts.setSlipType(LayoutTurnout.TurnoutType.DOUBLE_SLIP);
-        Assert.assertTrue("lts.getSlipType() is DOUBLE_SLIP", lts.getSlipType() == LayoutTurnout.TurnoutType.DOUBLE_SLIP);
-        ltd.setSlipType(LayoutTurnout.TurnoutType.SINGLE_SLIP);
-        Assert.assertTrue("ltd.getSlipType() is SINGLE_SLIP", ltd.getSlipType() == LayoutTurnout.TurnoutType.SINGLE_SLIP);
-    }
-
-    @Test
-    public void testSetTurnoutType() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertNotNull("LayoutEditor exists", layoutEditor);
-        Assert.assertNotNull("LayoutSlip single not null", lts);
-        Assert.assertNotNull("LayoutSlip double not null", ltd);
-
-        lts.setTurnoutType(LayoutTurnout.TurnoutType.NONE); // invalid type
-        JUnitAppender.assertErrorMessage("single.setSlipType(NONE); invalid slip type");
-        ltd.setTurnoutType(LayoutTurnout.TurnoutType.NONE); // invalid type
-        JUnitAppender.assertErrorMessage("double.setSlipType(NONE); invalid slip type");
-
-        lts.setTurnoutType(LayoutTurnout.TurnoutType.DOUBLE_SLIP);
-        Assert.assertTrue("lts.getSlipType() is DOUBLE_SLIP", lts.getSlipType() == LayoutTurnout.TurnoutType.DOUBLE_SLIP);
-        ltd.setTurnoutType(LayoutTurnout.TurnoutType.SINGLE_SLIP);
-        Assert.assertTrue("ltd.getSlipType() is SINGLE_SLIP", ltd.getSlipType() == LayoutTurnout.TurnoutType.SINGLE_SLIP);
-    }
-
-    @Test
     public void testGetSlipState() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);


### PR DESCRIPTION
This changes the `type` variable in LayoutTurnout and LayoutSlip to `final`, which makes the classes into effectively types.

The next step is to break then out to real types by making LayoutTurnout and LayoutSlip with subtypes for Wye, etc.