### PR TITLE
rm tab

### DIFF
--- a/java/test/jmri/util/gui/GuiLafPreferencesManagerTest.java
+++ b/java/test/jmri/util/gui/GuiLafPreferencesManagerTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017 
  */
 public class GuiLafPreferencesManagerTest {
 


### PR DESCRIPTION
Remove a tab char that slipping in due to overlapping PRs (Checkstyle catches these now)

