### PR TITLE
Small corrections

### DIFF
--- a/java/src/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetMetricsFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetMetricsFrame.java
@@ -268,7 +268,6 @@ public class CMRInetMetricsFrame extends jmri.util.JmriJFrame {
      * Save Metrics button handler Metric data is saved to a text file named
      * CMRInetMetrics_YYYYMMDD_HHMMSS The file is text lines, one for each
      * metric displayed and the count
-     * <p>
      */
     public void saveMetricsButtonActionPerformed(ActionEvent e) {
         String fileName = "CMRInetMetrics_";

--- a/java/src/jmri/jmrix/tams/TamsReply.java
+++ b/java/src/jmri/jmrix/tams/TamsReply.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Carries the reply to a TamsMessage
  * <p>
- * <p>
  * Based on work by Bob Jacobsen and Kevin Dickerson
  *
  * @author Jan Boen - version 151220 - 1211

--- a/java/test/apps/FileLocationPaneTest.java
+++ b/java/test/apps/FileLocationPaneTest.java
@@ -1,10 +1,7 @@
 package apps;
 
 import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 /**
  *
@@ -14,7 +11,7 @@ public class FileLocationPaneTest {
 
     @Test
     public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
         
         FileLocationPane t = new FileLocationPane();
         Assert.assertNotNull("exists",t);

--- a/java/test/apps/FileLocationPaneTest.java
+++ b/java/test/apps/FileLocationPaneTest.java
@@ -14,6 +14,8 @@ public class FileLocationPaneTest {
 
     @Test
     public void testCTor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
         FileLocationPane t = new FileLocationPane();
         Assert.assertNotNull("exists",t);
     }


### PR DESCRIPTION
 - fix two hanging `<p>` tags in Javadoc
 - Mark a test for not-headless as it won't work if the AWT thread is active