### PR TITLE
fix: deprecate jmri.util.swing.SwingSettings

### DIFF
--- a/java/src/apps/GuiLafConfigPane.java
+++ b/java/src/apps/GuiLafConfigPane.java
@@ -29,7 +29,6 @@ import jmri.profile.Profile;
 import jmri.profile.ProfileManager;
 import jmri.swing.PreferencesPanel;
 import jmri.util.gui.GuiLafPreferencesManager;
-import jmri.util.swing.SwingSettings;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -94,7 +93,6 @@ public final class GuiLafConfigPane extends JPanel implements PreferencesPanel {
     void doClickSelection(JPanel panel) {
         panel.setLayout(new FlowLayout());
         mouseEvent = new JCheckBox(ConfigBundle.getMessage("GUIButtonNonStandardRelease"));
-        mouseEvent.setSelected(SwingSettings.getNonStandardMouseEvent());
         mouseEvent.addItemListener((ItemEvent e) -> {
             InstanceManager.getDefault(GuiLafPreferencesManager.class).setNonStandardMouseEvent(mouseEvent.isSelected());
         });

--- a/java/src/apps/configurexml/GuiLafConfigPaneXml.java
+++ b/java/src/apps/configurexml/GuiLafConfigPaneXml.java
@@ -108,7 +108,6 @@ public class GuiLafConfigPaneXml extends jmri.configurexml.AbstractXmlAdapter {
         Attribute clickAttr = shared.getAttribute("nonStandardMouseEvent");
         if (clickAttr != null) {
             boolean nonStandardMouseEvent = clickAttr.getValue().equals("yes");
-            jmri.util.swing.SwingSettings.setNonStandardMouseEvent(nonStandardMouseEvent);
             InstanceManager.getDefault(GuiLafPreferencesManager.class).setNonStandardMouseEvent(nonStandardMouseEvent);
         }
         Attribute graphicAttr = shared.getAttribute("graphicTableState");

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -74,6 +74,7 @@ import jmri.jmrit.display.palette.ItemPalette;
 import jmri.jmrit.logix.WarrantTableAction;
 import jmri.util.HelpUtil;
 import jmri.util.SystemType;
+import jmri.util.gui.GuiLafPreferencesManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1215,7 +1216,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
         _selectRect = null;
 
         // if not sending MouseClicked, do it here
-        if (jmri.util.swing.SwingSettings.getNonStandardMouseEvent()) {
+        if (InstanceManager.getDefault(GuiLafPreferencesManager.class).isNonStandardMouseEvent()) {
             mouseClicked(event);
         }
 
@@ -1232,7 +1233,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
 
     @Override
     public void mouseClicked(MouseEvent event) {
-        if (jmri.util.swing.SwingSettings.getNonStandardMouseEvent()) {
+        if (InstanceManager.getDefault(GuiLafPreferencesManager.class).isNonStandardMouseEvent()) {
             long time = System.currentTimeMillis();
             if (time - _clickTime < 20) {
                 return;

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -51,6 +51,7 @@ import jmri.jmrit.display.PositionablePopupUtil;
 import jmri.jmrit.display.ToolTip;
 import jmri.util.JmriJFrame;
 import jmri.util.SystemType;
+import jmri.util.gui.GuiLafPreferencesManager;
 import jmri.util.swing.JmriColorChooser;
 import org.jdom2.Element;
 import org.slf4j.Logger;
@@ -786,7 +787,7 @@ public class PanelEditor extends Editor implements ItemListener {
         _selectRect = null;
 
         // if not sending MouseClicked, do it here
-        if (jmri.util.swing.SwingSettings.getNonStandardMouseEvent()) {
+        if (InstanceManager.getDefault(GuiLafPreferencesManager.class).isNonStandardMouseEvent()) {
             mouseClicked(event);
         }
         _targetPanel.repaint(); // needed for ToolTip

--- a/java/src/jmri/util/gui/GuiLafPreferencesManager.java
+++ b/java/src/jmri/util/gui/GuiLafPreferencesManager.java
@@ -20,7 +20,6 @@ import jmri.profile.Profile;
 import jmri.profile.ProfileUtils;
 import jmri.spi.PreferencesManager;
 import jmri.util.prefs.InitializationException;
-import jmri.util.swing.SwingSettings;
 import org.openide.util.lookup.ServiceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -123,7 +122,6 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesManager
 
             this.applyLookAndFeel();
             this.applyFontSize();
-            SwingSettings.setNonStandardMouseEvent(this.isNonStandardMouseEvent());
             this.setDirty(migrate);
             this.initialized = true;
         }

--- a/java/src/jmri/util/swing/SwingSettings.java
+++ b/java/src/jmri/util/swing/SwingSettings.java
@@ -1,5 +1,8 @@
 package jmri.util.swing;
 
+import jmri.InstanceManager;
+import jmri.util.gui.GuiLafPreferencesManager;
+
 /**
  * Settings for workarounds in Swing API.
  * <p>
@@ -15,17 +18,35 @@ package jmri.util.swing;
  *
  * @author Bob Jacobsen Copyright 2010
  * @since 2.9.4
+ * @deprecated since 4.19.6; use {@link GuiLafPreferencesManager} instead
  */
+@Deprecated
 public class SwingSettings {
 
-    static private boolean nonStandardMouseEvent = false;
-
+    /**
+     * Get if non-standard mouse events are to be used.
+     *
+     * @return true if non-standard mouse events are to be used
+     * @deprecated since 4.19.6; use
+     * {@link GuiLafPreferencesManager#isNonStandardMouseEvent()} instead
+     */
+    @Deprecated
     static public boolean getNonStandardMouseEvent() {
-        return nonStandardMouseEvent;
+        return InstanceManager.getDefault(GuiLafPreferencesManager.class).isNonStandardMouseEvent();
     }
 
+    /**
+     * Has no effect; retained until class is removed following deprecation
+     * period.
+     *
+     * @param v ignored
+     * @deprecated since 4.19.6; use
+     * {@link GuiLafPreferencesManager#setNonStandardMouseEvent(boolean)}
+     * instead
+     */
+    @Deprecated
     static public void setNonStandardMouseEvent(boolean v) {
-        nonStandardMouseEvent = v;
+        // do nothing
     }
 
 }

--- a/java/test/jmri/util/swing/ScrollablePanelTest.java
+++ b/java/test/jmri/util/swing/ScrollablePanelTest.java
@@ -34,6 +34,6 @@ public class ScrollablePanelTest {
         JUnitUtil.tearDown();
     }
 
-    // private final static Logger log = LoggerFactory.getLogger(SwingSettingsTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ScrollablePanelTest.class);
 
 }


### PR DESCRIPTION
Deprecate SwingSettings; this class only maintained a poorly synced copy of the GuiLafPreferencesManager.isNonStandardMouseEvent property.

Closes #7963