### PR TITLE
Fixes running test, if CoS is enabled. Fixes Apply Changes in Debugger.

### DIFF
--- a/nbactions.xml
+++ b/nbactions.xml
@@ -75,10 +75,10 @@
             </packagings>
             <goals>
                 <goal>test</goal>
-                <goal>jacoco:report</goal>
             </goals>
             <properties>
                 <test>${packageClassName}</test>
+                <netbeans.jacoco.report>true</netbeans.jacoco.report>
             </properties>
         </action>
         <action>
@@ -88,7 +88,9 @@
             </packagings>
             <goals>
                 <goal>test</goal>
-                <goal>jacoco:report</goal>
             </goals>
+            <properties>
+                <netbeans.jacoco.report>true</netbeans.jacoco.report>
+            </properties>
         </action>
-    </actions>
+</actions>

--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,104 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!--
+                The profile disables if tests are run in debug mode, so Jacoco instrumentation
+                does not break debugging features.
+            -->
+            <id>jacoco-coverage-unit</id>
+            <activation>
+                <property>
+                    <name>!maven.surefire.debug</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!--
+                The profile disables if tests are run in debug mode, so Jacoco instrumentation
+                does not break debugging features.
+            -->
+            <id>jacoco-coverage-integration</id>
+            <activation>
+                <property>
+                    <name>!maven.surefire.debug</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent-integration</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!--
+                This profile is a workaround for NetBeans broken (?) support for multiple
+                maven goals on action where Compile-on-Save is enabled. Instead of running a
+                goal sequence, the IDE sets a property that activates this profile.
+            -->
+            <id>jacoco-coverage-ide-report</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>netbeans.jacoco.report</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
+                        <executions>
+                            <execution>
+                                <id>ide-report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <!-- Bind to the test phase. The Jacoco plugin is
+                                    configured AFTER surefire plugin in this POM, so starting with Maven 3.0.3
+                                    the Jacoco plugin goals will only run after surefire testing completes
+                                -->
+                                <phase>test</phase>
+                                <configuration>
+                                    <skip>${skipTests}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -662,15 +760,15 @@
                 </configuration>
             </plugin>
             <plugin>
+                <!-- Warning: do not put this plugin's configuration before surefire plugin one. The sequence
+                     in which the surefire and jacoco goals run is important -->
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
+                        <!-- Do not bind any goals, let a profile to do it conditionally -->
                         <configuration>
                             <append>true</append>
                             <destFile>${jacoco.reportDir}/jacoco-unit.exec</destFile>
@@ -679,9 +777,7 @@
                     </execution>
                     <execution>
                         <id>prepare-agent-integration</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
+                        <!-- Do not bind any goals, let a profile to do it conditionally -->
                         <configuration>
                             <append>true</append>
                             <destFile>${jacoco.reportDir}/jacoco-it.exec</destFile>
@@ -707,6 +803,24 @@
                     </execution>
                     <execution>
                         <id>default-cli</id>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <directory>${jacoco.reportDir}</directory>
+                                    <includes>
+                                        <File>**/*.exec</File>
+                                    </includes>
+                                </fileSet>
+                            </fileSets>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Do a merge after unit tests complete, to cover the case that only goals up to 'test' phase
+                             are executed. The post-integration-test will merge in integration tests' coverage -->
+                        <id>post-test-merge</id>
+                        <!-- Must explicitly bind to the phase. Since this plugin is configured AFTER surefire,
+                             it will bind later that surefire:test into the (same) test phase -->
+                        <phase>test</phase>
                         <goals>
                             <goal>merge</goal>
                         </goals>


### PR DESCRIPTION
Core ideas:

Disable `jacoco:prepare-agent` in debug-test mode; fixes "Apply changes" feature. Done by a profile that disables on `maven.surefire.debug` property.

Circumvent supposed NetBeans IDE bug with compile-on save: instead of adding goals to an action, the IDE defines a property that activates a Profile. That profile then binds the goal into the appropriate phase (`test`) executed by the IDE. The effect will be the same as if the explicit action was given.

Manually running `mvn test` only reaches `test` phase, while the `merge` was bound to `generate-resources` phase (too early, no tests were run), and `post-integration-test` is never reached with `test` goal. The fix is to bind `jacoco:merge` to the `test` phase -- since Maven 3.0.3, the order of plugins in POM should dictate the order of their goals contributed to a particular phase. So being in `test` textually later than Surefire, will run after tests are executed.

I would be grateful if someone tests this on his IDE/setup; there's a nonzero chance it works just in my local environment because of some forgotten setting/file (or similar human error).
