### PR TITLE
WIP: Attempt to get more attention to Codecov by reducing noisy threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,10 @@ coverage:
   status:
     project:
       default:
+        # allow a 1% project drop to reduce noise
+        threshold: 1%
+    patch:
+      default:
         # allow a 1% drop to reduce noise
         threshold: 1%
   

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,13 @@
 codecov:
   ci:
     - !appveyor # ignore CI builds by AppVeyor
-
+coverage:
+  precision: 1
+  round: up
+  status:
+    project:
+      default:
+        # allow a 1% drop to reduce noise
+        threshold: 1%
+  
 # see https://docs.codecov.io/docs/codecov-yaml#section-default-yaml for defaults


### PR DESCRIPTION
The numbers checked in the Codecov CI checks fluctuate a little, which means about 50% of the runs fail semi-spuriously.    This PR reduces the threshold for failure by 1% in hopes that only real problems will be marked as failures, so that we can learn to pay attention to those.

Marked as WIP so I can rerun it a couple times and get some statistics on the results.