### PR TITLE
Cleanup of duplicate / inefficient code working with XNetReply feedback.

### DIFF
--- a/java/src/jmri/jmrix/lenz/FeedbackItem.java
+++ b/java/src/jmri/jmrix/lenz/FeedbackItem.java
@@ -1,0 +1,168 @@
+package jmri.jmrix.lenz;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import jmri.Turnout;
+
+/**
+ * Represents a single response from the XpressNet.
+ *
+ * @author svatopluk.dedic@gmail.com Copyright (C) 2020
+ *
+ */
+public class FeedbackItem {
+    private final int number;
+    private final int data;
+    private final XNetReply reply;
+
+    protected FeedbackItem(XNetReply reply, int number, int data) {
+        this.number = number;
+        this.data = data;
+        this.reply = reply;
+    }
+    
+    /**
+     * Determines if the feedback was solicited.
+     * @return {@code true}, if feedback was solicited.
+     */
+    public boolean isUnsolicited() {
+        return reply.isUnsolicited();
+    }
+
+    /**
+     * Resets the unsolicited flag in the reply.
+     * @see XNetReply#resetUnsolicited()
+     */
+    public void resetUnsolicited() {
+        reply.resetUnsolicited();
+    }
+    
+    /**
+     * Returns the (base) address of the item.
+     * For turnouts, return the reported address. For encoders,
+     * return the address of the first contained sensor
+     * @return the address.
+     */
+    public int getAddress() {
+        return number;
+    }
+
+    /**
+     * Determines if the feedback is for the given Turnout address
+     * @param address address to check
+     * @return {@code true}, if the item applies to the address.
+     */
+    public boolean matchesAddress(int address) {
+        if (isAccessory()) {
+            return number == address;
+        } else {
+            return ((address - 1) & ~0x03) + 1 == number;
+        }
+    }
+
+    /**
+     * Determines if the turnout motion has completed. Requires decoder/switch
+     * feedback to be processed by the command station; always {@code false} if not connected.
+     * @return {@code true} if the motion is complete.
+     */
+    public boolean isMotionComplete() {
+        return (data & 0x80) == 0;
+    }
+
+    /**
+     * Returns the feedback type.
+     * <ul>
+     * <li> 0: Turnout without feedback
+     * <li> 1: Turnout with feedback
+     * <li> 2: Feedback encoder
+     * <li> 3: reserved, invalid
+     * </ul>
+     * @return feedback type.
+     */
+    public int getType() {
+        return (data & 0b0110_0000) >> 5;
+    }
+
+    /**
+     * Translates raw value in {@link #getAccessoryStatus} into Turnout's CLOSED/THROWN
+     * values
+     * @return {@link Turnout#CLOSED}, {@link Turnout#THROWN} or -1 for inconsistent.s
+     */
+    public int getTurnoutStatus() {
+        int t = getType();
+        if (t > 1) {
+            return -1;
+        }
+        switch (getAccessoryStatus()) {
+            case 0x01: return Turnout.CLOSED;
+            case 0x02: return Turnout.THROWN;
+            default: // fall through
+        }
+        return -1;
+    }
+    
+    /**
+     * Returns true, if the feedback is from feedback encoder.
+     * @return {@code true} for encoder feedback.
+     */
+    public boolean isEncoder() {
+        return getType() == 2;
+    }
+    
+    /**
+     * Returns true, if the feedback is from turnout (accessory).
+     * @return {@code true} for turnout feedback.
+     */
+    public boolean isAccessory() {
+        return getType() < 2;
+    }
+
+    /**
+     * Gives status value as specified in XPressNet.
+     * <ul>
+     * <li> 0x00: turnout was not operated
+     * <li> 0x01: last command was "0", turnout left, CLOSED.
+     * <li> 0x02: last command was "1", turnout right, THROWN.
+     * <li> 0x03: reserved, invalid
+     * </ul>
+     * The method returns 0x03, if the feedback is not for accessory.
+     * @return accessory state.
+     */
+    public int getAccessoryStatus() {
+        if (!isAccessory()) {
+            return 0x03;    // invalid
+        }
+        return (number & 0x01) != 0 ? (data & 0b0011) : (data & 0b1100) >> 2;
+    }
+
+    /**
+     * Returns encoder feedback for the given sensor. The function return {@code null}
+     * if the sensor number is not within this FeedbackItem range, or the item does
+     * not represent an encoder feedback.
+     * @param sensorNumber sensor number, starting with 1.
+     * @return The sensor's reported bit value (true/false) or {@code null}, if 
+     * no encoder feedback for the sensor is found. 
+     */
+    @CheckForNull
+    public Boolean getEncoderStatus(int sensorNumber) {
+        if (!matchesAddress(number) || isAccessory()) {
+            return null;
+        } else {
+            return (data & (1 << ((sensorNumber -1) % 4))) > 0;
+        }
+    }
+
+    /**
+     * Returns a FeedbackItem instance for the other accessory address reported in the
+     * item. Returns {@code null} for non-accessory feedbacks.
+     * @return instance for the paired accessory, or {@code null}.
+     */
+    @Nullable
+    public FeedbackItem pairedAccessoryItem() {
+        if (!isAccessory()) {
+            return null;
+        }
+        int a = (number & 0x01) != 0 ? number + 1 : number - 1;
+        return new FeedbackItem(reply, a, data);
+    }
+}

--- a/java/src/jmri/jmrix/lenz/FeedbackItem.java
+++ b/java/src/jmri/jmrix/lenz/FeedbackItem.java
@@ -1,7 +1,6 @@
 package jmri.jmrix.lenz;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
 import jmri.Turnout;
 
 /**
@@ -157,7 +156,6 @@ public class FeedbackItem {
      * item. Returns {@code null} for non-accessory feedbacks.
      * @return instance for the paired accessory, or {@code null}.
      */
-    @Nullable
     public FeedbackItem pairedAccessoryItem() {
         if (!isAccessory()) {
             return null;

--- a/java/src/jmri/jmrix/lenz/XNetTurnout.java
+++ b/java/src/jmri/jmrix/lenz/XNetTurnout.java
@@ -1,10 +1,12 @@
 package jmri.jmrix.lenz;
 
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
 import jmri.implementation.AbstractTurnout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import javax.annotation.concurrent.GuardedBy;
-import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * Extend jmri.AbstractTurnout for XNet layouts
@@ -113,7 +115,7 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
     protected static final int STATUSREQUESTSENT = 4;
     protected static final int IDLE = 0;
     protected int internalState = IDLE;
-
+    
     /* Static arrays to hold Lenz specific feedback mode information */
     static String[] modeNames = null;
     static int[] modeValues = null;
@@ -132,7 +134,7 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
         _prefix = prefix;
         mNumber = pNumber;
 
-        requestList = new LinkedBlockingQueue<>();
+        requestList = new ArrayDeque<>();
 
         /* Add additiona feedback types information */
         _validFeedbackTypes |= MONITORING | EXACT | SIGNAL;
@@ -145,14 +147,14 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
         // set the mode names and values based on the static values.
         _validFeedbackNames = getModeNames();
         _validFeedbackModes = getModeValues();
-
+        
         // Register to get property change information from the superclass
         _stateListener = new XNetTurnoutStateListener(this);
         this.addPropertyChangeListener(_stateListener);
         // Finally, request the current state from the layout.
         tc.getFeedbackMessageCache().requestCachedStateFromLayout(this);
     }
-
+    
     /**
      * Set the mode information for XpressNet Turnouts.
      */
@@ -163,12 +165,8 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
             if (feedbackNames.length != feedbackModes.length) {
                 log.error("int and string feedback arrays different length");
             }
-            modeNames = new String[feedbackNames.length + 3];
-            modeValues = new int[feedbackNames.length + 3];
-            for (int i = 0; i < feedbackNames.length; i++) {
-                modeNames[i] = feedbackNames[i];
-                modeValues[i] = feedbackModes[i];
-            }
+            modeNames = Arrays.copyOf(feedbackNames, feedbackNames.length + 3);
+            modeValues = Arrays.copyOf(feedbackModes, feedbackNames.length + 3);
             modeNames[feedbackNames.length] = "MONITORING";
             modeValues[feedbackNames.length] = MONITORING;
             modeNames[feedbackNames.length + 1] = "EXACT";
@@ -385,35 +383,23 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
             l.resetUnsolicited();
         }
         if (getCommandedState() != getKnownState() || internalState == COMMANDSENT) {
-            if (l.isFeedbackBroadcastMessage()) {
-                int numDataBytes = l.getElement(0) & 0x0f;
-                for (int i = 1; i < numDataBytes; i += 2) {
-                    int messageType = l.getFeedbackMessageType(i);
-                    if (messageType == 0 || messageType == 1) {
-                        if ((mNumber % 2 != 0
-                                && (l.getTurnoutMsgAddr(i) == mNumber))
-                                || (((mNumber % 2) == 0)
-                                && (l.getTurnoutMsgAddr(i) == mNumber - 1))) {
-                            // This message includes feedback for this turnout
-                            log.debug("Turnout {} DIRECT feedback mode - directed reply received.", mNumber);
-                            // set the reply as being solicited
-                            if (l.isUnsolicited()) {
-                                l.resetUnsolicited();
-                            }
-                            sendOffMessage();
-                            // Explicitly send two off messages in Direct Mode
-                            sendOffMessage();
-                            break;
-                        }
-                    }
-                }
-            } else if (l.isOkMessage()) {
+            if (l.isOkMessage()) {
                 // Finally, we may just receive an OK message.
                 log.debug("Turnout {} DIRECT feedback mode - OK message triggering OFF message.", mNumber);
-                sendOffMessage();
-                // Explicitly send two off messages in Direct Mode
-                sendOffMessage();
+            } else {
+                // implicitly checks for isFeedbackBroadcastMessage()
+                if (!l.selectTurnoutFeedback(mNumber).isPresent()) {
+                    return;
+                }
+                log.debug("Turnout {} DIRECT feedback mode - directed reply received.", mNumber);
+                // set the reply as being solicited
+                if (l.isUnsolicited()) {
+                    l.resetUnsolicited();
+                }
             }
+            sendOffMessage();
+            // Explicitly send two off messages in Direct Mode
+            sendOffMessage();
         }
     }
 
@@ -435,41 +421,26 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
          */
         log.debug("Handle Message for turnout {} in MONITORING feedback mode ", mNumber);
         if (internalState == IDLE || internalState == STATUSREQUESTSENT) {
-            if (l.isFeedbackBroadcastMessage()) {
-                // This is a feedback message, we need to check and see if it
-                // indicates this turnout is to change state or if it is for
-                // another turnout.
-                int numDataBytes = l.getElement(0) & 0x0f;
-                for (int i = 1; i < numDataBytes; i += 2) {
-                    if (parseFeedbackMessage(l, i) != -1) {
-                        log.debug("Turnout {} MONITORING feedback mode - state change from feedback.", mNumber);
-                        break;
-                    }
-                }
+            if (l.onTurnoutFeedback(mNumber, this::parseFeedbackMessage)) {
+                log.debug("Turnout {} MONITORING feedback mode - state change from feedback.", mNumber);
             }
         } else if (getCommandedState() != getKnownState()
                 || internalState == COMMANDSENT) {
-            if (l.isFeedbackBroadcastMessage()) {
-                int numDataBytes = l.getElement(0) & 0x0f;
-                for (int i = 1; i < numDataBytes; i += 2) {
-                    int messageType = l.getFeedbackMessageType(i);
-                    if (messageType == 0 || messageType == 1) {
-                        // In Monitoring mode, treat both turnouts with feedback
-                        // and turnouts without feedback as turnouts without
-                        // feedback.  i.e. just interpret the feedback
-                        // message, don't check to see if the motion is complete
-                        if (parseFeedbackMessage(l, i) != -1) {
-                            // We need to tell the turnout to shut off the output.
-                            log.debug("Turnout {} MONITORING feedback mode - state change from feedback, CommandedState != KnownState.", mNumber);
-                            sendOffMessage();
-                            break;
-                        }
-                    }
-                }
-            } else if (l.isOkMessage()) {
+            if (l.isOkMessage()) {
                 // Finally, we may just receive an OK message.
                 log.debug("Turnout {} MONITORING feedback mode - OK message triggering OFF message.", mNumber);
                 sendOffMessage();
+            } else {
+                // In Monitoring mode, treat both turnouts with feedback
+                // and turnouts without feedback as turnouts without
+                // feedback.  i.e. just interpret the feedback
+                // message, don't check to see if the motion is complete
+                // implicitly checks for isFeedbackBroadcastMessage()
+                if (l.onTurnoutFeedback(mNumber, this::parseFeedbackMessage)) {
+                    // We need to tell the turnout to shut off the output.
+                    log.debug("Turnout {} MONITORING feedback mode - state change from feedback, CommandedState != KnownState.", mNumber);
+                    sendOffMessage();
+                }
             }
         }
     }
@@ -492,74 +463,62 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
         log.debug("Handle Message for turnout {} in EXACT feedback mode ", mNumber);
         if (getCommandedState() == getKnownState()
                 && (internalState == IDLE || internalState == STATUSREQUESTSENT)) {
-            if (reply.isFeedbackBroadcastMessage()) {
-                // This is a feedback message, we need to check and see if it
-                // indicates this turnout is to change state or if it is for
-                // another turnout.
-                int numDataBytes = reply.getElement(0) & 0x0f;
-                for (int i = 1; i < numDataBytes; i += 2) {
-                    if (parseFeedbackMessage(reply, i) != -1) {
-                        log.debug("Turnout {} EXACT feedback mode - state change from feedback.", mNumber);
-                    }
-                }
+            // This is a feedback message, we need to check and see if it
+            // indicates this turnout is to change state or if it is for
+            // another turnout.
+            if (reply.onTurnoutFeedback(mNumber, this::parseFeedbackMessage)) {
+                log.debug("Turnout {} EXACT feedback mode - state change from feedback.", mNumber);
             }
         } else if (getCommandedState() != getKnownState()
                 || internalState == COMMANDSENT
                 || internalState == STATUSREQUESTSENT) {
-            if (reply.isFeedbackBroadcastMessage()) {
-                int numDataBytes = reply.getElement(0) & 0x0f;
-                for (int i = 1; i < numDataBytes; i += 2) {
-                    if ((mNumber % 2 != 0
-                            && (reply.getTurnoutMsgAddr(i) == mNumber))
-                            || (((mNumber % 2) == 0)
-                            && (reply.getTurnoutMsgAddr(i) == mNumber - 1))) {
-                        // This message includes feedback for this turnout
-                        int messageType = reply.getFeedbackMessageType(i);
-                        if (messageType == 1) {
+            if (reply.isOkMessage()) {
+                // Finally, we may just receive an OK message.
+                log.debug("Turnout {} EXACT feedback mode - OK message triggering OFF message.", mNumber);
+                sendOffMessage();
+            } else {
+                // implicitly checks for isFeedbackBroadcastMessage()
+                reply.selectTurnoutFeedback(mNumber).ifPresent(l -> {
+                    int messageType = l.getType();
+                    switch (messageType) {
+                        case 1: {
                             // The first case is that we receive a message for
                             // this turnout and this turnout provides feedback.
                             // In this case, we want to check to see if the
                             // turnout has completed its movement before doing
                             // anything else.
-                            if (!motionComplete(reply, i)) {
+                            if (!l.isMotionComplete()) {
                                 log.debug("Turnout {} EXACT feedback mode - state change from feedback, CommandedState!=KnownState - motion not complete", mNumber);
                                 // If the motion is NOT complete, send a feedback
                                 // request for this nibble
                                 XNetMessage msg = XNetMessage.getFeedbackRequestMsg(
                                         mNumber, ((mNumber % 4) <= 1));
                                 queueMessage(msg,STATUSREQUESTSENT ,null); //status is returned via the manager.
+                                return;
                             } else {
                                 log.debug("Turnout {} EXACT feedback mode - state change from feedback, CommandedState!=KnownState - motion complete", mNumber);
-                                // If the motion is completed, behave as though
-                                // this is a turnout without feedback.
-                                parseFeedbackMessage(reply, i);
-                                // We need to tell the turnout to shut off the
-                                // output.
-                                sendOffMessage();
                             }
-                        } else if (messageType == 0) {
-                            log.debug("Turnout {} EXACT feedback mode - state change from feedback, CommandedState!=KnownState - Turnout does not provide feedback", mNumber);
+                            break;
+                        }
+                        case 0: 
+                            log.debug("Turnout {} EXACT feedback mode - state change from feedback, CommandedState!=KnownState - motion complete", mNumber);
                             // The second case is that we receive a message about
                             // this turnout, and this turnout does not provide
                             // feedback. In this case, we want to check the
                             // contents of the message and act accordingly.
-                            parseFeedbackMessage(reply, i);
-                            // We need to tell the turnout to shut off the output.
-                            sendOffMessage();
-                        }
-                        break;
+                            break;
+                        default: return;
                     }
-                }
-            } else if (reply.isOkMessage()) {
-                // Finally, we may just receive an OK message.
-                log.debug("Turnout {} EXACT feedback mode - OK message triggering OFF message.", mNumber);
-                sendOffMessage();
+                    parseFeedbackMessage(l);
+                    // We need to tell the turnout to shut off the output.
+                    sendOffMessage();
+                });
             }
         }
     }
-
+    
     /**
-     * Send an "Off" message to the decoder for this output.
+     * Send an "Off" message to the decoder for this output. 
      */
     protected synchronized void sendOffMessage() {
         // We need to tell the turnout to shut off the output.
@@ -569,26 +528,24 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
         }
         XNetMessage msg = getOffMessage();
         // Set the known state to the commanded state.
-        synchronized (this) {
-            // To avoid some of the command station busy
-            // messages, add a short delay before sending the
-            // first off message.
+        // To avoid some of the command station busy
+        // messages, add a short delay before sending the
+        // first off message.
             if (internalState != OFFSENT) {
-                jmri.util.ThreadingUtil.runOnLayoutDelayed( () ->
-                   tc.sendHighPriorityXNetMessage(msg, this), 30);
-                newKnownState(getCommandedState());
-                internalState = OFFSENT;
-                return;
-            }
+            jmri.util.ThreadingUtil.runOnLayoutDelayed( () ->
+               tc.sendHighPriorityXNetMessage(msg, this), 30);
             newKnownState(getCommandedState());
             internalState = OFFSENT;
+            return;
         }
+        newKnownState(getCommandedState());
+        internalState = OFFSENT;
         // Then send the message.
         tc.sendHighPriorityXNetMessage(msg, this);
     }
 
     protected synchronized XNetMessage getOffMessage(){
-         return ( XNetMessage.getTurnoutCommandMsg(mNumber,
+        return ( XNetMessage.getTurnoutCommandMsg(mNumber,
                 getCommandedState() == _mClosed,
                 getCommandedState() == _mThrown,
                 false) );
@@ -598,34 +555,23 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
      * Parse the feedback message, and set the status of the turnout
      * accordingly.
      *
-     * @param l  feedback broadcast message
-     * @param startByte  first Byte of message to check
-     *
+     * @param l  turnout feedback item
+     * 
      * @return 0 if address matches our turnout -1 otherwise
      */
-    private synchronized int parseFeedbackMessage(XNetReply l, int startByte) {
-        // check validity & addressing
-        // if this is an ODD numbered turnout, then we always get the
-        // right response from .getTurnoutMsgAddr.  If this is an even
-        // numbered turnout, we need to check the messages for the odd
-        // numbered turnout in the nibble as well.
-        if (mNumber % 2 != 0 && (l.getTurnoutMsgAddr(startByte) == mNumber)) {
-            // is for this object, parse the message
-            log.debug("Message for turnout {}", mNumber);
-            if (internalState != IDLE && l.isUnsolicited()) {
-                l.resetUnsolicited();
-            }
-            if (l.getTurnoutStatus(startByte, 1) == THROWN) {
-                synchronized (this) {
-                    newKnownState(_mThrown);
-                }
-                return (0);
-            } else if (l.getTurnoutStatus(startByte, 1) == CLOSED) {
-                synchronized (this) {
-                    newKnownState(_mClosed);
-                }
-                return (0);
-            } else {
+    private synchronized boolean parseFeedbackMessage(FeedbackItem l) {
+        log.debug("Message for turnout {}", mNumber);
+        if (internalState != IDLE && l.isUnsolicited()) {
+            l.resetUnsolicited();
+        }
+        switch (l.getTurnoutStatus()) {
+            case THROWN:
+                newKnownState(_mThrown);
+                return true;
+            case CLOSED:
+                newKnownState(_mClosed);
+                return true;
+            default:
                 // the state is unknown or inconsistent.  If the command state
                 // does not equal the known state, and the command repeat the
                 // last command
@@ -634,65 +580,10 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
                 } else {
                     sendQueuedMessage();
                 }
-                return -1;
-            }
-        } else if (((mNumber % 2) == 0)
-                && (l.getTurnoutMsgAddr(startByte) == mNumber - 1)) {
-            // is for this object, parse message type
-            log.debug("Message for turnout {}", mNumber);
-            if (internalState != IDLE && l.isUnsolicited()) {
-                l.resetUnsolicited();
-            }
-            if (l.getTurnoutStatus(startByte, 0) == THROWN) {
-                synchronized (this) {
-                    newKnownState(_mThrown);
-                }
-                return (0);
-            } else if (l.getTurnoutStatus(startByte, 0) == CLOSED) {
-                synchronized (this) {
-                    newKnownState(_mClosed);
-                }
-                return (0);
-            } else {
-                // the state is unknown or inconsistent.  If the command state
-                // does not equal the known state, and the command repeat the
-                // last command
-                if (getCommandedState() != getKnownState()) {
-                    forwardCommandChangeToLayout(getCommandedState());
-                } else {
-                    sendQueuedMessage();
-                }
-                return -1;
-            }
+                return false;
         }
-        return (-1);
     }
-
-    /**
-     * Determine if this feedback message says the turnout has completed
-     * its motion or not.  Returns true for mostion complete, false
-     * otherwise.
-     *
-     * @param l  feedback broadcast message
-     * @param startByte  first Byte of message to check
-     *
-     * @return true if motion complete, false otherwise
-     */
-    private synchronized boolean motionComplete(XNetReply l, int startByte) {
-        // check validity & addressing
-        // if this is an ODD numbered turnout, then we always get the
-        // right response from .getTurnoutMsgAddr.  If this is an even
-        // numbered turnout, we need to check the messages for the odd
-        // numbered turnout in the nibble as well.
-        if ((mNumber % 2 != 0 && (l.getTurnoutMsgAddr(startByte) == mNumber)) ||
-                ((mNumber % 2) == 0)
-                        && (l.getTurnoutMsgAddr(startByte) == mNumber - 1)) {
-            // is for this object, parse the message
-            return l.isFeedbackMotionComplete(startByte);
-        }
-        return (false);
-    }
-
+    
     @Override
     public void dispose() {
         this.removePropertyChangeListener(_stateListener);
@@ -763,7 +654,8 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
     XNetTurnoutStateListener _stateListener;  // Internal class object
 
     // A queue to hold outstanding messages
-    protected LinkedBlockingQueue<RequestMessage> requestList = null;
+    @GuardedBy("this")
+    protected final Deque<RequestMessage> requestList;
 
     /**
      * Send message from queue.
@@ -773,27 +665,21 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
         RequestMessage msg = null;
         // check to see if the queue has a message in it, and if it does,
         // remove the first message
-        if (!requestList.isEmpty()) {
+        msg = requestList.poll();
+        // if the queue is not empty, remove the first message
+        // from the queue, send the message, and set the state machine
+        // to the requried state.
+        if (msg != null) {
             log.debug("sending message to traffic controller");
-            // if the queue is not empty, remove the first message
-            // from the queue, send the message, and set the state machine
-            // to the requried state.
-            try {
-                msg = requestList.take();
-            } catch (java.lang.InterruptedException ie) {
-                return; // if there was an error, exit.
-            }
-            if (msg != null) {
-                internalState = msg.getState();
-                tc.sendXNetMessage(msg.getMsg(), msg.getListener());
-            }
+            internalState = msg.getState();
+            tc.sendXNetMessage(msg.getMsg(), msg.getListener());
         } else {
             log.debug("message queue empty");
             // if the queue is empty, set the state to idle.
             internalState = IDLE;
         }
     }
-
+    
     /**
      * Queue a message.
      */
@@ -801,11 +687,7 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
         log.debug("adding message {} to message queue.  Current Internal State {}",m,internalState);
         // put the message in the queue
         RequestMessage msg = new RequestMessage(m, s, l);
-        try {
-            requestList.put(msg);
-        } catch (java.lang.InterruptedException ie) {
-            log.trace("Interrupted while queueing message {}",msg);
-        }
+        requestList.offer(msg);
         // if the state is idle, trigger the message send
         if (internalState == IDLE ) {
             sendQueuedMessage();

--- a/java/src/jmri/jmrix/lenz/XNetTurnout.java
+++ b/java/src/jmri/jmrix/lenz/XNetTurnout.java
@@ -1,8 +1,8 @@
 package jmri.jmrix.lenz;
 
-import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Queue;
 import jmri.implementation.AbstractTurnout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,7 +134,7 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
         _prefix = prefix;
         mNumber = pNumber;
 
-        requestList = new ArrayDeque<>();
+        requestList = new LinkedList<>();
 
         /* Add additiona feedback types information */
         _validFeedbackTypes |= MONITORING | EXACT | SIGNAL;
@@ -655,7 +655,7 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
 
     // A queue to hold outstanding messages
     @GuardedBy("this")
-    protected final Deque<RequestMessage> requestList;
+    protected final Queue<RequestMessage> requestList;
 
     /**
      * Send message from queue.
@@ -687,7 +687,8 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
         log.debug("adding message {} to message queue.  Current Internal State {}",m,internalState);
         // put the message in the queue
         RequestMessage msg = new RequestMessage(m, s, l);
-        requestList.offer(msg);
+        // the queue is unbounded; can't throw exceptions 
+        requestList.add(msg);
         // if the state is idle, trigger the message send
         if (internalState == IDLE ) {
             sendQueuedMessage();

--- a/java/test/jmri/jmrix/lenz/XNetReplyTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetReplyTest.java
@@ -1,5 +1,13 @@
 package jmri.jmrix.lenz;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+import jmri.Turnout;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -1387,7 +1395,288 @@ public class XNetReplyTest extends jmri.jmrix.AbstractMessageTestBase {
         XNetReply r = new XNetReply("42 FF FF 42");
         Assert.assertEquals("Monitor String","Feedback Response: 255 255",r.toMonitorString());
     }
+    
+    /**
+     * Checks that the number of feedback items are correctly returned.
+     */
+    @Test
+    public void testFeedbackItemsCount() {
+        XNetReply r = new XNetReply("42 05 48 0f");
+        assertEquals("Feedback has single item", 1, r.getFeedbackMessageItems());
+        r = new XNetReply("46 05 48 06 48 07 48 0f");
+        assertEquals("Feedback has 3 items", 3, r.getFeedbackMessageItems());
+        r = new XNetReply("E3 32 00 04 C5");
+        assertEquals(0, r.getFeedbackMessageItems());
+    }
+    
+    /**
+     * Checks that all information is consistent from the Feedback item, 
+     * and are consistent with data served from XNetReply.
+     * 
+     * @param reply the original reply
+     * @param startByte start byte where the Feedback item came from
+     * @param address the expected address
+     * @param aStatus the expected status
+     * @param tType the expected feedback type
+     * @param fItem the expected feedback address 
+     */
+    private void assertTurnoutFeedbackData(XNetReply reply, int startByte, int address, 
+            int aStatus, int tType, FeedbackItem fItem) {
+        
+        // general accessory feedback constraints
+        assertFalse("Must not be encoder", fItem.isEncoder());
+        assertNull("Encoder functions disabled", fItem.getEncoderStatus(address));
+        assertTrue("Must be accessory", fItem.isAccessory());
+        
+        // info consistent with the reply's original accessors
+        assertEquals("Motion same as reply", reply.isFeedbackMotionComplete(startByte), fItem.isMotionComplete());
+        if ((address & 0x01) == 1) {
+            assertTrue("Accepts reply's odd address", fItem.matchesAddress(reply.getTurnoutMsgAddr(startByte)));
+            assertEquals(address, reply.getTurnoutMsgAddr(startByte));
+        } else {
+            assertTrue("Accepts reply's even address", fItem.matchesAddress(reply.getTurnoutMsgAddr(startByte) + 1));
+            assertEquals(address, reply.getTurnoutMsgAddr(startByte) + 1);
+        }
+        assertEquals("Solicited same as reply", reply.isUnsolicited(), fItem.isUnsolicited());
+        
+        assertEquals("Invalid feedback type", tType, fItem.getType());
+        assertEquals("Raw accessory status", aStatus, fItem.getAccessoryStatus());
 
+        int lowAddress = (address & 0x01) > 0 ? address - 1 : address - 2;
+        int pairAddress = (address & 0x01) > 0 ? address + 1 : address - 1;
+        int highAddress = (address & 0x01) > 0 ? address + 2 : address + 1;
+        
+        assertTrue("Must accept own address", fItem.matchesAddress(address));
+        assertFalse("Must not accept other pair's address", fItem.matchesAddress(pairAddress));
+        assertFalse("Must not accept other addresses", fItem.matchesAddress(lowAddress));
+        assertFalse("Must not accept other addresses", fItem.matchesAddress(highAddress));
+
+        int tStatus;
+        switch (aStatus) {
+            case 0x00: tStatus = -1; break; // not operated; shouldn't be UNKNOWN ?
+            case 0x01: tStatus = Turnout.CLOSED; break;
+            case 0x02: tStatus = Turnout.THROWN; break;
+            case 0x03: tStatus = -1; break; // invalid; shouldn't be INCONSISTENT ?
+            default:
+                throw new IllegalArgumentException();
+        }
+        assertEquals("Turnout status", tStatus, fItem.getTurnoutStatus());
+        
+        // check the paired item:
+        FeedbackItem paired = fItem.pairedAccessoryItem();
+        assertNotNull("Accessory fedbacks are always in pairs", paired);
+        assertFalse("Must not be encoder", paired.isEncoder());
+        assertTrue("Must be accessory", paired.isAccessory());
+        assertEquals("Invalid feedback type", tType, paired.getType());
+        assertEquals("Solicited same as reply", reply.isUnsolicited(), paired.isUnsolicited());
+        assertFalse("Must not accept pair's address", paired.matchesAddress(address));
+    }
+    
+    /**
+     * Checks that information can be read from single-item feedback and
+     * the reply are consistent.
+     */
+    @Test
+    public void testSingleFeedbackTurnoutItem() {
+        // 5 * 4, lower nibble = 21 (N/A) +22 (T)
+        // movement NOT complete; turnout WITH feedback.
+        XNetReply r = new XNetReply("42 05 28 0f");
+        Optional<FeedbackItem> selected = r.selectTurnoutFeedback(20);
+        assertFalse("Incorrect turnout number", selected.isPresent());
+        selected = r.selectTurnoutFeedback(23);
+        assertFalse("Incorrect turnout number", selected.isPresent());
+        
+        selected = r.selectTurnoutFeedback(21);
+        assertTrue(selected.isPresent());
+        
+        FeedbackItem oddItem = selected.get();
+
+        assertTrue("Motion completed", oddItem.isMotionComplete());
+        assertTrue("Initially unsolicited", oddItem.isUnsolicited());
+        assertTurnoutFeedbackData(r, 1, 21, 0, 1, oddItem);
+        
+        selected = r.selectTurnoutFeedback(22);
+        assertTrue(selected.isPresent());
+        
+        FeedbackItem evenItem = selected.get();
+        assertTurnoutFeedbackData(r, 1, 22, 2, 1, evenItem);
+        
+        // make solicited:
+        oddItem.resetUnsolicited();
+        assertFalse(r.isUnsolicited());
+        
+        // 5 * 4, upper nibble = 23 (C) + 24 (T)
+        // movement IS complete; turnout WITHOUT feedback.
+        r = new XNetReply("42 05 95 0f");
+        selected = r.selectTurnoutFeedback(23);
+        assertTrue(selected.isPresent());
+        
+        oddItem = selected.get();
+        assertFalse("Motion incomplete", oddItem.isMotionComplete());
+        assertTurnoutFeedbackData(r, 1, 23, 1, 0, oddItem);
+        
+        selected = r.selectTurnoutFeedback(24);
+        assertTrue(selected.isPresent());
+        evenItem = selected.get();
+        assertTurnoutFeedbackData(r, 1, 24, 1, 0, evenItem);
+    }
+    
+    /**
+     * Checks that feedback module item gives invalid / erroneous / null
+     * information when used as accessory.
+     */
+    @Test
+    public void testOtherRepliesAsAccessoryFeedback() {
+        XNetReply r = new XNetReply("42 05 58 0f");
+        // test directly the item
+        FeedbackItem item = new FeedbackItem(r, 45, 0x58);
+        assertEquals(45, item.getAddress());
+        for (int a = 45; a < 45 + 4; a++) {
+            assertTrue(item.matchesAddress(a));
+            // last bit is set, all others are false.
+            assertEquals("Bit state for sensor " + a, a == 48, item.getEncoderStatus(a));
+        }
+        // does not match accessory for 0x05, 0x58
+        assertFalse(item.matchesAddress(21));
+        assertEquals(3, item.getAccessoryStatus());
+        assertNull(item.pairedAccessoryItem());
+
+        // check that no turnout feedback can be selected
+        for (int i = 1 ; i < 1024; i++) {
+            assertFalse(r.selectTurnoutFeedback(i).isPresent());
+        }
+        
+        // no accessory feedback present
+        r = new XNetReply("E3 40 C1 04 61");
+        for (int i = 1 ; i < 1024; i++) {
+            assertFalse(r.selectTurnoutFeedback(i).isPresent());
+        }
+    }
+    
+    /**
+     * Checks that encoder feedback will return null for turnout
+     * feedbacks.
+     */
+    @Test
+    public void testOtherRepliesAsEncoder() {
+        XNetReply r = new XNetReply("42 05 28 0f");
+        for (int i = 1 ; i < 1024; i++) {
+            assertNull(r.selectModuleFeedback(i));
+        }
+        r = new XNetReply("E3 40 C1 04 61");
+        for (int i = 1 ; i < 1024; i++) {
+            assertNull(r.selectModuleFeedback(i));
+        }
+
+    }
+
+    
+    /**
+     * Checks that select will filter out accessories with an incorrect state.
+     */
+    @Test
+    public void testInvalidAccessoryStateFiltered() {
+        XNetReply r = new XNetReply("42 05 2B 0f");
+        Optional<FeedbackItem> opt = r.selectTurnoutFeedback(21);
+        assertFalse(opt.isPresent());
+        assertEquals(-1, r.getTurnoutStatus(1));
+        
+        opt = r.selectTurnoutFeedback(22);
+        assertTrue(opt.isPresent());
+        assertEquals(Turnout.THROWN, opt.get().getTurnoutStatus());
+        assertEquals(r.getTurnoutStatus(0), opt.get().getTurnoutStatus());
+    }
+    
+    @Test
+    public void testSingleEncoderModuleFeedback() {
+        // feedback 5 * 8  + 4 (upper nibble) (+1) = 45
+        XNetReply r = new XNetReply("42 05 58 0f");
+        
+        assertNull(r.selectModuleFeedback(44));
+        
+        for (int i = 45; i < 45 + 4; i++) {
+            Boolean b = r.selectModuleFeedback(i);
+            assertNotNull(b);
+            // the highest bit in the nibble is set
+            assertEquals("sensor id " + i, i == 48, b);
+        }
+        
+        assertNull(r.selectModuleFeedback(49));
+        
+        r = new XNetReply("42 04 41 0f");
+
+        assertNull(r.selectModuleFeedback(32));
+        for (int i = 33; i < 33 + 4; i++) {
+            Boolean b = r.selectModuleFeedback(i);
+            assertNotNull(b);
+            // the lowest bit in the nibble is set
+            assertEquals("sensor id " + i, i == 33, b);
+        }
+        assertNull(r.selectModuleFeedback(37));
+    }
+    
+    @Test
+    public void testMultipleFeedbackTurnoutItem() {
+        // 1st pair: 21 (T) + 22 (C), with feedback
+        // 2nd pair: encoder feedback, NOT 25+26!
+        // 3rd pair: 31 (C) + 32 (N), without feedback, motion incomplete
+        XNetReply r = new XNetReply("46 05 29 06 48 07 91 0f");
+        
+        Optional<FeedbackItem> selected;
+        FeedbackItem odd;
+        FeedbackItem even;
+        selected = r.selectTurnoutFeedback(21);
+        assertTrue(selected.isPresent());
+        odd = selected.get();
+        selected = r.selectTurnoutFeedback(22);
+        assertTrue(selected.isPresent());
+        even = selected.get();
+        assertTrue(odd.isMotionComplete());
+        assertTurnoutFeedbackData(r, 1, 21, 1, 1, odd);
+        assertTurnoutFeedbackData(r, 1, 22, 2, 1, even);
+
+        // check that 
+        selected = r.selectTurnoutFeedback(25);
+        assertFalse(selected.isPresent());
+        selected = r.selectTurnoutFeedback(26);
+        assertFalse(selected.isPresent());
+
+        selected = r.selectTurnoutFeedback(31);
+        assertTrue(selected.isPresent());
+        odd = selected.get();
+        selected = r.selectTurnoutFeedback(32);
+        assertTrue(selected.isPresent());
+        even = selected.get();
+        
+        assertFalse(odd.isMotionComplete());
+        assertTurnoutFeedbackData(r, 5, 31, 1, 0, odd);
+        assertTurnoutFeedbackData(r, 5, 32, 0, 0, even);
+    }
+    
+    @Test
+    public void testMultipleEncoderModuleFeedback() {
+        // feedback 6 * 8  (lower nibble) (+1) = 49
+        XNetReply r = new XNetReply("46 05 29 06 48 07 91 0f");
+        
+        // the 05-29 is a turnout feedback: must not be reported
+        // as encoder 05 * 8
+        assertNull(r.selectModuleFeedback(41));
+        assertNull(r.selectModuleFeedback(44));
+        assertNull(r.selectModuleFeedback(48));
+        
+        for (int i = 49; i < 49 + 4; i++) {
+            Boolean b = r.selectModuleFeedback(i);
+            assertNotNull(b);
+            // the highest bit in the nibble is set
+            assertEquals("sensor id " + i, i == (49 + 3), b);
+        }
+        
+        // 07-91 is again a turnout, must not be mistaken for upper nibble of
+        // encoder 7
+        assertNull(r.selectModuleFeedback(7 * 8 + 4 + 1));
+    }
+    
+    // The minimal setup for log4J
     @Before
     @Override
     public void setUp() {


### PR DESCRIPTION
During work on NanoX support, when I went through `XNetTurnout` code, it seemed that there are identical branches duplicated. Also digging bits by their value, or odd/even numbers seems inappropriate for "layout object" level: could be better encapsulated in XpressNet protocol classes.
And indeed, `XNetSensor` and `XNetFeedbackMessageCache` also contains similar code replicas.

I played a "what-if" game so I can reduce the logic code before major refactoring in NanoX specific code. I've decided to contribute that back. 

The core idea is to abstract a `FeedbackItem` that describes a single turnout feedback, or a feedback module's nibble. `XNetReply` then can search for `FeedbackItem`s. That way, `XNetTurnout` or `XNetSensor` can:
- determine if there is a relevant feedback
- not worry about odd/even numbers

The code is somewhat cleaner afterwards. **No semantic changes done**

*Other changes*
* Feedback message cache
   * replaced unnecessary double-indexing by linearizing address+nibble.
   * removed `catch (NullPointerException)` that potential masks code erros
   * fixed bug: cache only worked with 1st item in a multi-item feedback broadcast
* XNetReply
  * reduced complex if-else-if-else with complex bitwise operations
* XNetTurnout
  * removed usage of `j.u.concurrent` classes: they are meant for high-contention environments, and synchronization here is external (in Turnout object) anyway
  * removed redundant nested `synchronized()`
  * simplified queue operations, removed unnecessary interrupt handling
