### PR TITLE
Fix clock button text on startups with clock paused

### DIFF
--- a/java/src/jmri/jmrit/analogclock/AnalogClockFrame.java
+++ b/java/src/jmri/jmrit/analogclock/AnalogClockFrame.java
@@ -54,9 +54,7 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
         // Without it, the button does not center properly
         buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
         buttonPanel.add(b = new JButton(Bundle.getMessage("ButtonPauseClock")));
-        if (!clock.getRun()) {
-            b.setText(Bundle.getMessage("ButtonRunClock"));
-        }
+        updateButtonText();
         b.addActionListener(new ButtonListener());
         b.setOpaque(true);
         b.setVisible(true);
@@ -68,11 +66,8 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
         update();  // set proper time
 
         // request callback to update time
-        clock.addMinuteChangeListener(new java.beans.PropertyChangeListener() {
-            @Override
-            public void propertyChange(java.beans.PropertyChangeEvent e) {
-                update();
-            }
+        clock.addMinuteChangeListener((java.beans.PropertyChangeEvent e) -> {
+            update();
         });
 
     }
@@ -296,37 +291,29 @@ public class AnalogClockFrame extends JmriJFrame implements java.beans.PropertyC
         repaint();
     }
 
-    @Override
-    public void dispose() {
-        super.dispose();
-    }
-
     /**
-     * Handle a change to clock properties
+     * Handle a change to clock properties.
+     * @param e unused.
      */
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
-        boolean now = clock.getRun();
-        if (now) {
-            b.setText(Bundle.getMessage("ButtonPauseClock"));
-        } else {
-            b.setText(Bundle.getMessage("ButtonRunClock"));
-        }
+        updateButtonText();
+    }
+    
+    /**
+     * Update clock button text.
+     */
+    private void updateButtonText(){
+        b.setText( Bundle.getMessage( clock.getRun() ? "ButtonPauseClock" : "ButtonRunClock") );
     }
 
     JButton b;
 
     private class ButtonListener implements ActionListener {
-
         @Override
         public void actionPerformed(ActionEvent a) {
-            boolean next = !clock.getRun();
-            clock.setRun(next);
-            if (next) {
-                b.setText(Bundle.getMessage("ButtonPauseClock"));
-            } else {
-                b.setText(Bundle.getMessage("ButtonRunClock"));
-            }
+            clock.setRun(!clock.getRun());
+            updateButtonText();
         }
     }
 

--- a/java/src/jmri/jmrit/lcdclock/LcdClockFrame.java
+++ b/java/src/jmri/jmrit/lcdclock/LcdClockFrame.java
@@ -99,15 +99,13 @@ public class LcdClockFrame extends JmriJFrame implements java.beans.PropertyChan
         b.addActionListener(new ButtonListener());
         // since Run/Stop button looks crummy, user may turn it on in clock prefs
         b.setVisible(clock.getShowStopButton()); // pick up clock prefs choice
+        updateButtonText();
         update();
         pack();
 
         // request callback to update time
-        clock.addMinuteChangeListener(new java.beans.PropertyChangeListener() {
-            @Override
-            public void propertyChange(java.beans.PropertyChangeEvent e) {
-                update();
-            }
+        clock.addMinuteChangeListener((java.beans.PropertyChangeEvent e) -> {
+            update();
         });
 
         // Add component listener to handle frame resizing event
@@ -145,7 +143,6 @@ public class LcdClockFrame extends JmriJFrame implements java.beans.PropertyChan
         colonIcon.setImage(scaledImage);
         // update the images on screen
         this.getContentPane().revalidate();
-        return;
     }
 
     @SuppressWarnings("deprecation")
@@ -160,37 +157,29 @@ public class LcdClockFrame extends JmriJFrame implements java.beans.PropertyChan
         m2.setIcon(tubes[minutes - (minutes / 10) * 10]);
     }
 
-    @Override
-    public void dispose() {
-        super.dispose();
-    }
-
     /**
-     * Handle a change to clock properties
+     * Handle a change to clock properties.
+     * @param e unused.
      */
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
-        boolean now = clock.getRun();
-        if (now) {
-            b.setText(Bundle.getMessage("ButtonPauseClock"));
-        } else {
-            b.setText(Bundle.getMessage("ButtonRunClock"));
-        }
+        updateButtonText();
+    }
+    
+    /**
+     * Update clock button text.
+     */
+    private void updateButtonText(){
+        b.setText( Bundle.getMessage( clock.getRun() ? "ButtonPauseClock" : "ButtonRunClock") );
     }
 
     JButton b;
 
     private class ButtonListener implements ActionListener {
-
         @Override
         public void actionPerformed(ActionEvent a) {
-            boolean next = !clock.getRun();
-            clock.setRun(next);
-            if (next) {
-                b.setText(Bundle.getMessage("ButtonPauseClock"));
-            } else {
-                b.setText(Bundle.getMessage("ButtonRunClock"));
-            }
+            clock.setRun(!clock.getRun());
+            updateButtonText();
         }
     }
 }

--- a/java/src/jmri/jmrit/nixieclock/NixieClockFrame.java
+++ b/java/src/jmri/jmrit/nixieclock/NixieClockFrame.java
@@ -97,16 +97,13 @@ public class NixieClockFrame extends JmriJFrame implements java.beans.PropertyCh
         b.addActionListener(new ButtonListener());
         // since Run/Stop button looks crummy, user may turn it on in clock prefs
         b.setVisible(clock.getShowStopButton()); // pick up clock prefs choice
-
+        updateButtonText();
         update();
         pack();
 
         // request callback to update time
-        clock.addMinuteChangeListener(new java.beans.PropertyChangeListener() {
-            @Override
-            public void propertyChange(java.beans.PropertyChangeEvent e) {
-                update();
-            }
+        clock.addMinuteChangeListener((java.beans.PropertyChangeEvent e) -> {
+            update();
         });
 
         // Add component listener to handle frame resizing event
@@ -144,7 +141,6 @@ public class NixieClockFrame extends JmriJFrame implements java.beans.PropertyCh
         colonIcon.setImage(scaledImage);
         // update the images on screen
         this.getContentPane().revalidate();
-        return;
     }
 
     @SuppressWarnings("deprecation")
@@ -159,37 +155,30 @@ public class NixieClockFrame extends JmriJFrame implements java.beans.PropertyCh
         m2.setIcon(tubes[minutes - (minutes / 10) * 10]);
     }
 
-    @Override
-    public void dispose() {
-        super.dispose();
-    }
-
-    /**
-     * Handle a change to clock properties
+        /**
+     * Handle a change to clock properties.
+     * @param e unused.
      */
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
-        boolean now = clock.getRun();
-        if (now) {
-            b.setText(Bundle.getMessage("ButtonPauseClock"));
-        } else {
-            b.setText(Bundle.getMessage("ButtonRunClock"));
-        }
+        updateButtonText();
+    }
+    
+    /**
+     * Update clock button text.
+     */
+    private void updateButtonText(){
+        b.setText( Bundle.getMessage( clock.getRun() ? "ButtonPauseClock" : "ButtonRunClock") );
     }
 
     JButton b;
 
     private class ButtonListener implements ActionListener {
-
         @Override
         public void actionPerformed(ActionEvent a) {
-            boolean next = !clock.getRun();
-            clock.setRun(next);
-            if (next) {
-                b.setText(Bundle.getMessage("ButtonPauseClock"));
-            } else {
-                b.setText(Bundle.getMessage("ButtonRunClock"));
-            }
+            clock.setRun(!clock.getRun());
+            updateButtonText();
         }
     }
+    
 }

--- a/java/src/jmri/jmrit/pragotronclock/PragotronClockFrame.java
+++ b/java/src/jmri/jmrit/pragotronclock/PragotronClockFrame.java
@@ -111,16 +111,13 @@ public class PragotronClockFrame extends JmriJFrame implements java.beans.Proper
         b.addActionListener(new ButtonListener());
         // since Run/Stop button looks crummy, user may turn it on in clock prefs
         b.setVisible(clock.getShowStopButton()); // pick up clock prefs choice
-
+        updateButtonText();
         update();
         pack();
 
         // request callback to update time
-        clock.addMinuteChangeListener(new java.beans.PropertyChangeListener() {
-            @Override
-            public void propertyChange(java.beans.PropertyChangeEvent e) {
-                update();
-            }
+        clock.addMinuteChangeListener((java.beans.PropertyChangeEvent e) -> {
+            update();
         });
 
         // Add component listener to handle frame resizing event
@@ -173,16 +170,8 @@ public class PragotronClockFrame extends JmriJFrame implements java.beans.Proper
         Image scaledImage = baseColon.getImage().getScaledInstance(iconWidthDot , iconHeightDot, Image.SCALE_SMOOTH);
         colonIcon.setImage(scaledImage);
 
-//      Ugly hack to force frame to redo the layout.
-//      Without this the image is scaled but the label size and position doesn't change.
-//      doLayout() doesn't work either
-        this.setVisible(false);
-        this.remove(b);
-        if (clock.getShowStopButton()) {
-            this.getContentPane().add(b); // pick up clock prefs choice
-        }
-        this.setVisible(true);
-        return;
+        // update the images on screen
+        this.getContentPane().revalidate();
     }
 
     @SuppressWarnings("deprecation")
@@ -196,37 +185,30 @@ public class PragotronClockFrame extends JmriJFrame implements java.beans.Proper
         m2.setIcon(foldingSheets10[minutes - (minutes / 10) * 10]);
     }
 
-    @Override
-    public void dispose() {
-        super.dispose();
-    }
-
     /**
-     * Handle a change to clock properties
+     * Handle a change to clock properties.
+     * @param e unused.
      */
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
-        boolean now = clock.getRun();
-        if (now) {
-            b.setText(Bundle.getMessage("ButtonPauseClock"));
-        } else {
-            b.setText(Bundle.getMessage("ButtonRunClock"));
-        }
+        updateButtonText();
+    }
+    
+    /**
+     * Update clock button text.
+     */
+    private void updateButtonText(){
+        b.setText( Bundle.getMessage( clock.getRun() ? "ButtonPauseClock" : "ButtonRunClock") );
     }
 
     JButton b;
 
     private class ButtonListener implements ActionListener {
-
         @Override
         public void actionPerformed(ActionEvent a) {
-            boolean next = !clock.getRun();
-            clock.setRun(next);
-            if (next) {
-                b.setText(Bundle.getMessage("ButtonPauseClock"));
-            } else {
-                b.setText(Bundle.getMessage("ButtonRunClock"));
-            }
+            clock.setRun(!clock.getRun());
+            updateButtonText();
         }
     }
+    
 }


### PR DESCRIPTION
Start / stop buttons on LCD Clock, Nixie Clock, Pragotron Clock display correct text if started with fc paused.
Stop multi-windows on frame resize Pragotron clock as per fix identified in #8379