### PR TITLE
fix: Bean fires events on generating thread by default

### DIFF
--- a/java/src/jmri/beans/Bean.java
+++ b/java/src/jmri/beans/Bean.java
@@ -24,16 +24,16 @@ public abstract class Bean extends UnboundBean implements PropertyChangeFirer, P
     protected final SwingPropertyChangeSupport propertyChangeSupport;
 
     /**
-     * Create a bean that notifies property change listeners on the event
-     * dispatch thread (EDT).
+     * Create a bean that notifies property change listeners on the thread the
+     * event was generated on.
      */
     protected Bean() {
-        this(true);
+        this(false);
     }
 
     /**
      * Create a bean.
-     * 
+     *
      * @param notifyOnEDT true to notify property change listeners on the EDT;
      *                    false to notify listeners on the thread the event was
      *                    generated on (which may or may not be the EDT)
@@ -145,7 +145,7 @@ public abstract class Bean extends UnboundBean implements PropertyChangeFirer, P
     public void removePropertyChangeListener(String propertyName, PropertyChangeListener listener) {
         propertyChangeSupport.removePropertyChangeListener(propertyName, listener);
     }
-    
+
     /**
      * Is this Bean assuring that all property change listeners will be notified
      * on the EDT?

--- a/java/test/jmri/beans/BeanTest.java
+++ b/java/test/jmri/beans/BeanTest.java
@@ -20,7 +20,7 @@ public class BeanTest {
     private boolean changed;
     private Bean bean;
     private PropertyChangeListener listener;
-    private static String PROPERTY = "property";
+    private final static String PROPERTY = "property";
 
     @Test
     public void testAddPropertyChangeListener_PropertyChangeListener() {
@@ -70,7 +70,7 @@ public class BeanTest {
         bean.fireIndexedPropertyChange(PROPERTY, 0, false, true);
         JUnitUtil.waitFor(() -> {
             return changed == true;
-        }, "Change did not fire on GUI thread in time");
+        }, "Change did not fire in time");
         assertThat(changed).isTrue();
     }
 
@@ -81,7 +81,7 @@ public class BeanTest {
         bean.fireIndexedPropertyChange(PROPERTY, 0, 0, 1);
         JUnitUtil.waitFor(() -> {
             return changed == true;
-        }, "Change did not fire on GUI thread in time");
+        }, "Change did not fire in time");
         assertThat(changed).isTrue();
     }
 
@@ -92,7 +92,7 @@ public class BeanTest {
         bean.fireIndexedPropertyChange(PROPERTY, 0, null, null);
         JUnitUtil.waitFor(() -> {
             return changed == true;
-        }, "Change did not fire on GUI thread in time");
+        }, "Change did not fire in time");
         assertThat(changed).isTrue();
     }
 
@@ -104,7 +104,7 @@ public class BeanTest {
         bean.firePropertyChange(event);
         JUnitUtil.waitFor(() -> {
             return changed == true;
-        }, "Change did not fire on GUI thread in time");
+        }, "Change did not fire in time");
         assertThat(changed).isTrue();
     }
 
@@ -115,7 +115,7 @@ public class BeanTest {
         bean.firePropertyChange(PROPERTY, false, true);
         JUnitUtil.waitFor(() -> {
             return changed == true;
-        }, "Change did not fire on GUI thread in time");
+        }, "Change did not fire in time");
         assertThat(changed).isTrue();
     }
 
@@ -126,7 +126,7 @@ public class BeanTest {
         bean.firePropertyChange(PROPERTY, 0, 1);
         JUnitUtil.waitFor(() -> {
             return changed == true;
-        }, "Change did not fire on GUI thread in time");
+        }, "Change did not fire in time");
         assertThat(changed).isTrue();
     }
 
@@ -137,7 +137,7 @@ public class BeanTest {
         bean.firePropertyChange(PROPERTY, null, null);
         JUnitUtil.waitFor(() -> {
             return changed == true;
-        }, "Change did not fire on GUI thread in time");
+        }, "Change did not fire in time");
         assertThat(changed).isTrue();
     }
 
@@ -147,7 +147,7 @@ public class BeanTest {
      */
     @Test
     public void testIsNotifyOnEDT() {
-        assertThat(new Bean() {}.isNotifyOnEDT()).isTrue();
+        assertThat(new Bean() {}.isNotifyOnEDT()).isFalse();
         assertThat(new Bean(true) {}.isNotifyOnEDT()).isTrue();
         assertThat(new Bean(false) {}.isNotifyOnEDT()).isFalse();
     }


### PR DESCRIPTION
This seems to be generally more reliable than firing events on the EDT by default. If individual listeners turn out to be having issues with this, we can make just the class generating the event for this listeners fire events on the EDT using the `Bean(boolean)` constructor, or the class having problems can use a listener that calls itself on the EDT.