### PR TITLE
remove jmri package references to apps and appsBase handleQuit and handleRestart.

### DIFF
--- a/java/src/jmri/implementation/JmriConfigurationManager.java
+++ b/java/src/jmri/implementation/JmriConfigurationManager.java
@@ -30,7 +30,6 @@ import javax.swing.event.ListSelectionEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import apps.AppsBase;
 import apps.gui3.tabbedpreferences.EditConnectionPreferencesDialog;
 import apps.gui3.tabbedpreferences.TabbedPreferencesAction;
 import jmri.Application;
@@ -340,7 +339,7 @@ public class JmriConfigurationManager implements ConfigureManager {
 
         if (Bundle.getMessage("ErrorDialogButtonQuitProgram", Application.getApplicationName()).equals(selectedValue)) {
             // Exit program
-            AppsBase.handleQuit();
+            handleQuit();
 
         } else if (Bundle.getMessage("ErrorDialogButtonContinue").equals(selectedValue)) {
             // Do nothing. Let the program continue
@@ -348,15 +347,27 @@ public class JmriConfigurationManager implements ConfigureManager {
         } else if (Bundle.getMessage("ErrorDialogButtonEditConnections").equals(selectedValue)) {
            if (EditConnectionPreferencesDialog.showDialog()) {
                 // Restart program
-                AppsBase.handleRestart();
+               try {
+                   InstanceManager.getDefault(jmri.ShutDownManager.class).restart();
+               } catch (Exception er) {
+                   log.error("Continuing after error in handleRestart", er);
+               }
             } else {
                 // Quit program
-                AppsBase.handleQuit();
+                handleQuit();
             }
 
         } else {
             // Exit program
-            AppsBase.handleQuit();
+            handleQuit();
+        }
+    }
+
+    private void handleQuit(){
+        try {
+            InstanceManager.getDefault(jmri.ShutDownManager.class).shutdown();
+        } catch (Exception e) {
+            log.error("Continuing after error in handleQuit", e);
         }
     }
 

--- a/java/src/jmri/jmrit/operations/setup/ResetAction.java
+++ b/java/src/jmri/jmrit/operations/setup/ResetAction.java
@@ -6,12 +6,13 @@ import java.io.IOException;
 import javax.swing.AbstractAction;
 import javax.swing.JOptionPane;
 
-import apps.Apps;
 import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsManager;
 import jmri.jmrit.operations.OperationsXml;
 import jmri.util.swing.ExceptionDisplayFrame;
 import jmri.util.swing.UnexpectedExceptionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Swing action to load the operation demo files.
@@ -58,7 +59,12 @@ public class ResetAction extends AbstractAction {
             JOptionPane.showMessageDialog(null, Bundle.getMessage("YouMustRestartAfterReset"),
                     Bundle.getMessage("ResetSuccessful"), JOptionPane.INFORMATION_MESSAGE);
 
-            Apps.handleRestart();
+            try {
+                InstanceManager.getDefault(jmri.ShutDownManager.class).restart();
+            } catch (Exception er) {
+                log.error("Continuing after error in handleRestart", er);
+            }
+
 
         } catch (IOException ex) {
             UnexpectedExceptionContext context = new UnexpectedExceptionContext(ex,
@@ -67,7 +73,7 @@ public class ResetAction extends AbstractAction {
         }
     }
 
-//    private final static Logger log = LoggerFactory.getLogger(ResetAction.class);
+    private final static Logger log = LoggerFactory.getLogger(ResetAction.class);
 }
 
 

--- a/java/src/jmri/jmrit/operations/setup/RestoreDialog.java
+++ b/java/src/jmri/jmrit/operations/setup/RestoreDialog.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.setup;
 
-import apps.Apps;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -228,7 +227,11 @@ public class RestoreDialog extends JDialog {
                     Bundle.getMessage("RestoreSuccessful"), JOptionPane.INFORMATION_MESSAGE);
             dispose();
 
-            Apps.handleRestart();
+            try {
+                InstanceManager.getDefault(jmri.ShutDownManager.class).restart();
+            } catch (Exception er) {
+                log.error("Continuing after error in handleRestart", er);
+            }
         } // These may need to be enhanced to show the backup store being used,
           // auto or default.
         catch (IOException ex) {

--- a/java/src/jmri/jmrit/operations/setup/RestoreFilesAction.java
+++ b/java/src/jmri/jmrit/operations/setup/RestoreFilesAction.java
@@ -8,12 +8,13 @@ import javax.swing.AbstractAction;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 
-import apps.Apps;
 import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsManager;
 import jmri.jmrit.operations.OperationsXml;
 import jmri.util.swing.ExceptionContext;
 import jmri.util.swing.ExceptionDisplayFrame;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Swing action to backup operation files to a directory selected by the user.
@@ -87,7 +88,11 @@ public class RestoreFilesAction extends AbstractAction {
             // otherwise it is normal to not have the task running
             InstanceManager.getDefault(OperationsManager.class).setShutDownTask(null);
 
-            Apps.handleRestart();
+            try {
+                InstanceManager.getDefault(jmri.ShutDownManager.class).restart();
+            } catch (Exception er) {
+                log.error("Continuing after error in handleRestart", er);
+            }
 
         } catch (IOException ex) {
             ExceptionContext context = new ExceptionContext(ex,
@@ -119,6 +124,7 @@ public class RestoreFilesAction extends AbstractAction {
         }
     }
 
+    private static final Logger log = LoggerFactory.getLogger(RestoreFilesAction.class);
 }
 
 

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.roster.swing;
 
-import apps.AppsBase;
 import apps.gui3.Apps3;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -736,10 +735,10 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
                     prefsMgr.setSimplePreferenceState(rememberWindowClose, true);
                 }
                 if (result == JOptionPane.YES_OPTION) {
-                    AppsBase.handleQuit();
+                    handleQuit();
                 }
             } else {
-                AppsBase.handleQuit();
+                handleQuit();
             }
         } else if (frameInstances.size() > 1) {
             final String rememberWindowClose = this.getClass().getName() + ".closeMultipleDP3prompt";
@@ -759,12 +758,20 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
                     prefsMgr.setSimplePreferenceState(rememberWindowClose, true);
                 }
                 if (result == JOptionPane.YES_OPTION) {
-                    AppsBase.handleQuit();
+                    handleQuit();
                 }
             } else {
-                AppsBase.handleQuit();
+                handleQuit();
             }
             //closeWindow(null);
+        }
+    }
+
+    private void handleQuit(){
+        try {
+            InstanceManager.getDefault(jmri.ShutDownManager.class).shutdown();
+        } catch (Exception e) {
+            log.error("Continuing after error in handleQuit", e);
         }
     }
 


### PR DESCRIPTION
This is work towards restoring our architectural separation between the apps and jmri packages.