### PR TITLE
Use available LE based singleton instances

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/ConnectivityUtil.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/ConnectivityUtil.java
@@ -57,7 +57,7 @@ public class ConnectivityUtil {
     // constructor method
     public ConnectivityUtil(LayoutEditor thePanel) {
         layoutEditor = thePanel;
-        auxTools = new LayoutEditorAuxTools(layoutEditor);
+        auxTools = layoutEditor.getLEAuxTools();
         layoutBlockManager = InstanceManager.getDefault(LayoutBlockManager.class);
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -1514,7 +1514,7 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
 
             if ((editor != null) && (connection == null)) {
                 // We should be able to determine block metric now as the tracksegment should be valid
-                connection = new ConnectivityUtil(editor);
+                connection = editor.getConnectivityUtil();
             }
 
             // Need to inform our neighbours of our new addition
@@ -2273,7 +2273,7 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
                                 }
                                 layoutBlock.removeRouteFromNeighbour(this, newUpdate);
                                 getAdjacency(nextblk).removeRouteAdvertisedToNeighbour(routesToRemove.get(j));
-                                
+
                             } else {
                                 if (enableDeleteRouteLogging) {
                                     log.info("{} a valid path through exists {} so we will not remove route.", msgPrefix, nextblk.getDisplayName());
@@ -2434,7 +2434,7 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
             log.info("Block {}, src: {}, dst: {}",
                     block.getDisplayName(), srcBlock.getDisplayName(), dstBlock.getDisplayName());
         }
-        connection = new ConnectivityUtil(panel);
+        connection = panel.getConnectivityUtil();
         List<LayoutTrackExpectedState<LayoutTurnout>> stod;
 
         try {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutConnectivity.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutConnectivity.java
@@ -86,7 +86,7 @@ public class LayoutConnectivity {
     // this should only be used for debugging...
     @Override
     public String toString() {
-        String result = "between " + block1 + " and " + block2 + " in direction " + Path.decodeDirection(direction);
+        String result = "between " + block1.getDisplayName() + " and " + block2.getDisplayName() + " in direction " + Path.decodeDirection(direction);
         if (track1 != null) {
             result = result + ", track: " + track1.getId();
         }


### PR DESCRIPTION
LE has a number of related classes which are defined as singletons and accessed through the LE panel instance.  Instead of using the singleton, a new related instance is created which results in hundreds of parallel instances doing the same thing.  On a large layout, the change reduces the initial startup JMRI memory size by 20%.