### PR TITLE
Test improvements

### DIFF
--- a/.spotbugs-check.xml
+++ b/.spotbugs-check.xml
@@ -18,7 +18,6 @@
         <Confidence value="2" /> <!-- 3 is low priority, 2 is medium priority, 1 is high priority -->
         <Or>
            <Bug pattern="IS2_INCONSISTENT_SYNC" />
-           <Bug pattern="SLF4J_SIGN_ONLY_FORMAT" />
         </Or>
      </Match>
 
@@ -47,6 +46,11 @@
      <Match>
        <!-- Minor clarity issue -->
        <Bug pattern="RI_REDUNDANT_INTERFACES" />
+     </Match>
+
+     <Match>
+        <!-- Minimal messages can be very useful at DEBUG or TRACE level -->
+        <Bug pattern="SLF4J_SIGN_ONLY_FORMAT" />
      </Match>
 
      <Match>

--- a/.spotbugs.xml
+++ b/.spotbugs.xml
@@ -16,6 +16,11 @@
      </Match>
 
      <Match>
+        <!-- Minimal messages can be very useful at DEBUG or TRACE level -->
+        <Bug pattern="SLF4J_SIGN_ONLY_FORMAT" />
+     </Match>
+     
+     <Match>
        <!-- Design issue -->
        <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
      </Match>

--- a/build.xml
+++ b/build.xml
@@ -2183,7 +2183,7 @@
                   jvmargs="-Xmx1536m"
                   timeout="12000000"
                   excludeFilter=".spotbugs-check.xml"
-
+                  failOnError="true"
                   effort="max"
                   reportLevel="low"
                   >
@@ -2200,7 +2200,6 @@
                   jvmargs="-Xmx1536m"
                   timeout="12000000"
                   excludeFilter=".spotbugs.xml"
-
                   effort="max"
                   reportLevel="low"
                   >
@@ -2217,7 +2216,7 @@
                   jvmargs="-Xmx1536m"
                   timeout="12000000"
                   excludeFilter=".spotbugs-check.xml"
-
+                  failOnError="true"
                   effort="max"
                   reportLevel="low"
                   >

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitPathsTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitPathsTest.java
@@ -27,6 +27,14 @@ public class EditCircuitPathsTest {
     public void testCTor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ControlPanelEditor frame = new ControlPanelEditor("EditCircuitPathsTest");
+    }
+
+    @Test
+    public void testBasicOps() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        
+        ControlPanelEditor frame = new ControlPanelEditor("EditCircuitPathsTest");
         frame.makeCircuitMenu(true);
         CircuitBuilder cb = frame.getCircuitBuilder();
         Assert.assertNotNull("exists", cb);

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitPathsTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitPathsTest.java
@@ -26,7 +26,7 @@ public class EditCircuitPathsTest {
     @Test
     public void testCTor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        ControlPanelEditor frame = new ControlPanelEditor("EditCircuitPathsTest");
+        new ControlPanelEditor("EditCircuitPathsTest");
     }
 
     @Test


### PR DESCRIPTION
 - Run EditCircuitPathsTest separately to see if that reduces timeouts
 - Ant task needs fail specified explicitly 
 - We sometimes log without explanatory text, esp at TRACE and DEBUG level , and that's OK
