### PR TITLE
Javadoc lint

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1915,7 +1915,7 @@
             </packageset>
             <arg value="-Xdoclint:all"/><!-- remove -missing to get warnings about missing javadoc tags -->
             <arg value="-Xmaxwarns"/>
-            <arg value="1650"/><!-- change from default 100 warnings; keep synced with pom.xml, other javadoc targets -->
+            <arg value="1300"/><!-- change from default 100 warnings; keep synced with pom.xml, other javadoc targets -->
             <arg value="-quiet"/>
             <arg value="-splitindex"/>
             <arg value="-J-Dhttp.agent=javadoc"/>

--- a/java/src/jmri/jmrix/AbstractMRReply.java
+++ b/java/src/jmri/jmrix/AbstractMRReply.java
@@ -62,15 +62,28 @@ abstract public class AbstractMRReply extends AbstractMessage {
         _nDataChars = Math.max(_nDataChars, n + 1);
     }
 
+    /**
+     * Set the OpCode.
+     * Sets Element 0 to character value of integer.
+     * @param i Opcode value.
+     */
     public void setOpCode(int i) {
         _dataChars[0] = (char) i;
     }
 
+    /**
+     * Get the OpCode.
+     * @return value of Element 0.
+     */
     public int getOpCode() {
         return _dataChars[0];
     }
 
-    // accessors to the bulk data
+    /**
+     * Flush the message.
+     * Sets number of data characters to 0.
+     * Does not reset array length or data.
+     */
     public void flush() {
         _nDataChars = 0;
     }
@@ -78,18 +91,33 @@ abstract public class AbstractMRReply extends AbstractMessage {
     // mode accessors
     private boolean _isBinary;
 
+    /**
+     * Get if the Reply has Binary form flag set.
+     * @return true if binary, else false.
+     */
     public boolean isBinary() {
         return _isBinary;
     }
 
+    /**
+     * Set flag for if the Reply is Binary form.
+     * @param b true if binary, else false.
+     */
     public void setBinary(boolean b) {
         _isBinary = b;
     }
 
+    /**
+     * Set flag for Unsolicited to true.
+     */
     public final void setUnsolicited() {
         unsolicited = true;
     }
 
+    /**
+     * Get flag for Unsolicited.
+     * @return true if Unsolicited, else false.
+     */
     public boolean isUnsolicited() {
         return unsolicited;
     }

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -1153,7 +1153,7 @@ public abstract class AbstractMRTrafficController {
         }
     }
 
-    /*
+    /**
      * Log an error message for a message received in an unexpected state.
      */
     protected void unexpectedReplyStateError(int State, String msgString) {
@@ -1163,7 +1163,7 @@ public abstract class AbstractMRTrafficController {
        log.error("reply complete in unexpected state: {} was {} in class {}", State, msgString, name);
     }
 
-    /*
+    /**
      * for testing purposes, let us be able to find out
      * what the last sender was
      */

--- a/java/src/jmri/jmrix/AbstractMessage.java
+++ b/java/src/jmri/jmrix/AbstractMessage.java
@@ -46,6 +46,9 @@ public abstract class AbstractMessage implements Message {
         System.arraycopy(m._dataChars, 0, _dataChars, 0, _nDataChars);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getElement(int n) {
         return _dataChars[n];
@@ -53,11 +56,17 @@ public abstract class AbstractMessage implements Message {
 
     // accessors to the bulk data
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getNumDataElements() {
         return _nDataChars;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setElement(int n, int v) {
         _dataChars[n] = v;
@@ -93,7 +102,8 @@ public abstract class AbstractMessage implements Message {
     }
 
     /**
-     * Hash code from base data
+     * Hash code from base data.
+     * @return hashcode from sum of elements.
      */
     @Override
     public int hashCode() {

--- a/java/src/jmri/jmrix/Message.java
+++ b/java/src/jmri/jmrix/Message.java
@@ -7,12 +7,29 @@ package jmri.jmrix;
  */
 public interface Message {
 
+    /**
+     * Get a particular element in a Message.
+     * @param n Element Index.
+     * @return single element of message.
+     */
     int getElement(int n);
 
+    /**
+     * Get the number of data elements in a Message.
+     * @return number elements.
+     */
     int getNumDataElements();
 
+    /**
+     * Set a single Data Element at a particular index.
+     * @param n index of element.
+     * @param v value of element.
+     */
     void setElement(int n, int v);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     String toString();
 

--- a/java/src/jmri/jmrix/can/CanMessage.java
+++ b/java/src/jmri/jmrix/can/CanMessage.java
@@ -145,7 +145,7 @@ public class CanMessage extends AbstractMRMessage implements CanMutableFrame {
 
     /**
      * {@inheritDoc}
-     * This format matches @CanReply
+     * This format matches {@link CanReply}
      */
     @Override
     public String toMonitorString() {

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/GcPortController.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/GcPortController.java
@@ -5,31 +5,49 @@ import java.io.DataOutputStream;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 
 /**
- * Abstract base for classes representing a GridConnect communications port
+ * Abstract base for classes representing a GridConnect communications port.
  *
+ * Implementations will provide InputStream and OutputStream
+ * objects to CabrsTrafficController classes, who in turn will deal in messages.
+ * 
  * @author Bob Jacobsen Copyright (C) 2001
  * @author Andrew Crosland 2008
  */
 public abstract class GcPortController extends jmri.jmrix.AbstractSerialPortController {
-    // base class. Implementations will provide InputStream and OutputStream
-    // objects to CabrsTrafficController classes, who in turn will deal in messages.
 
+    /**
+     * Create a new GC PortController.
+     * @param connectionMemo CAN System Connection.
+     */
     protected GcPortController(CanSystemConnectionMemo connectionMemo) {
         super(connectionMemo);
     }
 
-    // returns the InputStream from the port
+    /**
+     * Get the InputStream to the port.
+     * {@inheritDoc}
+     */
     @Override
     public abstract DataInputStream getInputStream();
 
-    // returns the outputStream to the port
+    /**
+     * Get the outputStream to the port.
+     * {@inheritDoc}
+     */
     @Override
     public abstract DataOutputStream getOutputStream();
 
-    // check that this object is ready to operate
+    /**
+     * Check that this object is ready to operate.
+     * {@inheritDoc}
+     */
     @Override
     public abstract boolean status();
 
+    /**
+     * Get the CAN System Connection.
+     * {@inheritDoc}
+     */
     @Override
     public CanSystemConnectionMemo getSystemConnectionMemo() {
         return (CanSystemConnectionMemo) super.getSystemConnectionMemo();

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/GcSerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/GcSerialDriverAdapter.java
@@ -27,6 +27,9 @@ public class GcSerialDriverAdapter extends GcPortController {
 
     protected SerialPort activeSerialPort = null;
 
+    /**
+     * Creates a new CAN GridConnect Network Driver Adapter.
+     */
     public GcSerialDriverAdapter() {
         super(new jmri.jmrix.can.CanSystemConnectionMemo());
         option1Name = "Protocol"; // NOI18N
@@ -35,7 +38,12 @@ public class GcSerialDriverAdapter extends GcPortController {
         this.manufacturerName = jmri.jmrix.merg.MergConnectionTypeList.MERG;
     }
 
-    // Allow for default systemPrefix other than "M"
+    /**
+     * Creates a new CAN GridConnect Network Driver Adapter.
+     * <p>
+     * Allows for default systemPrefix other than "M".
+     * @param prefix System Prefix.
+     */
     public GcSerialDriverAdapter(String prefix) {
         super(new jmri.jmrix.can.CanSystemConnectionMemo(prefix));
         option1Name = "Protocol"; // NOI18N
@@ -44,6 +52,9 @@ public class GcSerialDriverAdapter extends GcPortController {
         this.manufacturerName = jmri.jmrix.merg.MergConnectionTypeList.MERG;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String openPort(String portName, String appName) {
         // open the port, check ability to set moderators
@@ -100,8 +111,9 @@ public class GcSerialDriverAdapter extends GcPortController {
     }
 
     /**
-     * set up all of the other objects to operate with a CAN RS adapter
-     * connected to this port
+     * Set up all of the other objects to operate with a CAN RS adapter
+     * connected to this port.
+     * {@inheritDoc}
      */
     @Override
     public void configure() {
@@ -121,20 +133,31 @@ public class GcSerialDriverAdapter extends GcPortController {
         this.getSystemConnectionMemo().configureManagers();
     }
 
+    /**
+     * Make a new GC Traffic Controller.
+     * @return new GridConnect Traffic Controller.
+     */
     protected GcTrafficController makeGcTrafficController() {
         return new GcTrafficController();
     }
 
     /**
-     * Helper class wrapping the input serial port's InputStream. It starts a
-     * helper thread at high priority that reads the input serial port as fast
-     * as it can, buffering all incoming data in memory in a queue. The queue in
-     * unbounded and readers will get the data from the queue.
+     * Helper class wrapping the input serial port's InputStream.
+     * <p>
+     * It starts a helper thread at high priority that reads the input serial 
+     * port as fast as it can, buffering all incoming data in memory in a queue.
+     * <p>
+     * The queue is unbounded and readers will get the data from the queue.
      * <p>
      * This class is thread-safe.
      */
     private static class AsyncBufferInputStream extends FilterInputStream {
 
+        /**
+         * Create new AsyncBufferInputStream.
+         * @param inputStream Input Stream.
+         * @param portName Port Name.
+         */
         AsyncBufferInputStream(InputStream inputStream, String portName) {
             super(inputStream);
             this.portName = portName;
@@ -223,16 +246,25 @@ public class GcSerialDriverAdapter extends GcPortController {
             IOException e = null;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public int read() throws IOException {
             throw new UnsupportedOperationException();
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public int read(byte[] bytes) throws IOException {
             throw new UnsupportedOperationException();
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public synchronized int read(byte[] bytes, int skip, int len) throws IOException {
             if (skip != 0) {
@@ -275,7 +307,10 @@ public class GcSerialDriverAdapter extends GcPortController {
         int errorCount = 0;
     }
 
-    // base class methods for the PortController interface
+    /**
+     * Base class methods for the PortController interface.
+     * {@inheritDoc}
+     */
     @Override
     public DataInputStream getInputStream() {
         if (!opened) {
@@ -290,6 +325,9 @@ public class GcSerialDriverAdapter extends GcPortController {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public DataOutputStream getOutputStream() {
         if (!opened) {
@@ -303,6 +341,9 @@ public class GcSerialDriverAdapter extends GcPortController {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean status() {
         return opened;
@@ -331,6 +372,9 @@ public class GcSerialDriverAdapter extends GcPortController {
         return new int[]{57600, 115200, 230400, 250000, 333333, 460800};
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int defaultBaudIndex() {
         return 0;

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/GcTrafficController.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/GcTrafficController.java
@@ -15,7 +15,9 @@ import org.slf4j.LoggerFactory;
  * Traffic controller for the GridConnect protocol.
  * <p>
  * GridConnect uses messages transmitted as an ASCII string of up to 24
- * characters of the form: :ShhhhNd0d1d2d3d4d5d6d7; The S indicates a standard
+ * characters of the form: :ShhhhNd0d1d2d3d4d5d6d7; 
+ * <p>
+ * The S indicates a standard
  * CAN frame hhhh is the two byte header (11 useful bits) N or R indicates a
  * normal or remote frame d0 - d7 are the (up to) 8 data bytes
  *
@@ -23,6 +25,9 @@ import org.slf4j.LoggerFactory;
  */
 public class GcTrafficController extends TrafficController {
 
+    /**
+     * Create new GridConnect Traffic Controller.
+     */
     public GcTrafficController() {
         super();
         this.setSynchronizeRx(false);
@@ -30,6 +35,7 @@ public class GcTrafficController extends TrafficController {
 
     /**
      * Forward a CanMessage to all registered CanInterface listeners.
+     * {@inheritDoc}
      */
     @Override
     protected void forwardMessage(AbstractMRListener client, AbstractMRMessage m) {
@@ -38,6 +44,7 @@ public class GcTrafficController extends TrafficController {
 
     /**
      * Forward a CanReply to all registered CanInterface listeners.
+     * {@inheritDoc}
      */
     @Override
     protected void forwardReply(AbstractMRListener client, AbstractMRReply r) {
@@ -48,21 +55,34 @@ public class GcTrafficController extends TrafficController {
     public static final int NORMAL = 0;
     public static final int BOOTMODE = 1;
 
+    /**
+     * Get the GridConnect State.
+     * @return NORMAL or BOOTMODE
+     */
     public int getgcState() {
         return gcState;
     }
 
-    public void setgcState(int s) {
-        gcState = s;
-        log.debug("Setting gcState {}", s);
+    /**
+     * Set the GridConnect State.
+     * @param state NORMAL or BOOTMODE
+     */
+    public void setgcState(int state) {
+        gcState = state;
+        log.debug("Setting gcState {}", state);
     }
 
+    /**
+     * Get if GcTC is in Boot Mode.
+     * @return true if in Boot Mode, else False.
+     */
     public boolean isBootMode() {
         return gcState == BOOTMODE;
     }
 
     /**
      * Forward a preformatted message to the actual interface.
+     * {@inheritDoc}
      */
     @Override
     public void sendCanMessage(CanMessage m, CanListener reply) {
@@ -72,6 +92,7 @@ public class GcTrafficController extends TrafficController {
 
     /**
      * Forward a preformatted reply to the actual interface.
+     * {@inheritDoc}
      */
     @Override
     public void sendCanReply(CanReply r, CanListener reply) {
@@ -80,19 +101,16 @@ public class GcTrafficController extends TrafficController {
     }
 
     /**
-     * Add trailer to the outgoing byte stream.
-     *
-     * @param msg    The output byte stream
-     * @param offset the first byte not yet used
+     * Does nothing.
+     * {@inheritDoc}
      */
     @Override
     protected void addTrailerToOutput(byte[] msg, int offset, AbstractMRMessage m) {
-        return;
     }
 
     /**
-     * Determine how much many bytes the entire message will take, including
-     * space for header and trailer
+     * Determine how much many bytes the entire message will take, 
+     * including space for header and trailer.
      *
      * @param m The message to be sent
      * @return Number of bytes
@@ -102,7 +120,10 @@ public class GcTrafficController extends TrafficController {
         return m.getNumDataElements();
     }
 
-    // New message for hardware protocol
+    /**
+     * Get new message for hardware protocol.
+     * @return New GridConnect Message.
+     */
     @Override
     protected AbstractMRMessage newMessage() {
         log.debug("New GridConnectMessage created");
@@ -111,7 +132,8 @@ public class GcTrafficController extends TrafficController {
     }
 
     /**
-     * Make a CanReply from a GridConnect reply
+     * Make a CanReply from a GridConnect reply.
+     * {@inheritDoc}
      */
     @Override
     public CanReply decodeFromHardware(AbstractMRReply m) {
@@ -127,7 +149,8 @@ public class GcTrafficController extends TrafficController {
     }
 
     /**
-     * Encode a CanMessage for the hardware
+     * Encode a CanMessage for the hardware.
+     * {@inheritDoc}
      */
     @Override
     public AbstractMRMessage encodeForHardware(CanMessage m) {
@@ -137,7 +160,10 @@ public class GcTrafficController extends TrafficController {
         return ret;
     }
 
-    // New reply from hardware
+    /**
+     * New reply from hardware.
+     * {@inheritDoc}
+     */
     @Override
     protected AbstractMRReply newReply() {
         log.debug("New GridConnectReply created");
@@ -158,8 +184,12 @@ public class GcTrafficController extends TrafficController {
         return false;
     }
 
+    /**
+     * Detect if the reply buffer ends with ";".
+     * @param r Reply
+     * @return true if contais end, else false.
+     */
     boolean endNormalReply(AbstractMRReply r) {
-        // Detect if the reply buffer ends with ";"
         int num = r.getNumDataElements() - 1;
         //log.debug("endNormalReply checking "+(num+1)+" of "+(r.getNumDataElements()));
         if (r.getElement(num) == ';') {

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/GridConnectMessage.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/GridConnectMessage.java
@@ -9,7 +9,9 @@ import org.slf4j.LoggerFactory;
  * Class for GridConnect messages for a CAN hardware adapter.
  * <p>
  * The GridConnect protocol encodes messages as an ASCII string of up to 24
- * characters of the form: :ShhhhNd0d1d2d3d4d5d6d7; The S indicates a standard
+ * characters of the form: :ShhhhNd0d1d2d3d4d5d6d7;
+ * <p>
+ * The S indicates a standard
  * CAN frame :XhhhhhhhhNd0d1d2d3d4d5d6d7; The X indicates an extended CAN frame
  * hhhh is the two byte header N or R indicates a normal or remote frame, in
  * position 6 or 10 d0 - d7 are the (up to) 8 data bytes
@@ -19,13 +21,19 @@ import org.slf4j.LoggerFactory;
  */
 public class GridConnectMessage extends AbstractMRMessage {
 
-    // Creates a new instance of GridConnectMessage
+    /**
+     * Create a new instance of GridConnectMessage.
+     */
     public GridConnectMessage() {
         _nDataChars = 28;
         _dataChars = new int[_nDataChars];
         setElement(0, ':');
     }
 
+    /**
+     * Create a new GridConnectMessage from CanMessage.
+     * @param m CanMessage outgoing from JMRI.
+     */
     public GridConnectMessage(CanMessage m) {
         this();
 
@@ -46,38 +54,54 @@ public class GridConnectMessage extends AbstractMRMessage {
         int offset = isExtended() ? 11 : 6;
         setElement(offset + m.getNumDataElements() * 2, ';');
         setNumDataElements(offset + 1 + m.getNumDataElements() * 2);
-        if (log.isDebugEnabled()) {
-            log.debug("encoded as {}", this.toString());
-        }
+        log.debug("encoded as {}", this.toString());
     }
 
-    // accessors to the bulk data
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getNumDataElements() {
         return _nDataChars;
     }
 
+    /**
+     * Set Number of Data Elements.
+     * @param n number Elements.  Max 28.
+     */
     public void setNumDataElements(int n) {
         _nDataChars = (n <= 28) ? n : 28;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getElement(int n) {
         return _dataChars[n];
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setElement(int n, int v) {
         _dataChars[n] = v;
     }
 
+    /**
+     * Set data from array.
+     * @param d array, max length 24.
+     */
     public void setData(int[] d) {
         int len = (d.length <= 24) ? d.length : 24;
-        for (int i = 0; i < len; i++) {
-            _dataChars[i] = d[i];
-        }
+        System.arraycopy(d, 0, _dataChars, 0, len);
     }
 
+    /**
+     * Set the GC Message as Extended.
+     * @param extended true for extended, else false
+     */
     public void setExtended(boolean extended) {
         // Standard or extended frame
         if (extended) {
@@ -87,14 +111,18 @@ public class GridConnectMessage extends AbstractMRMessage {
         }
     }
 
+    /**
+     * Get if the GC Message is Extended.
+     * @return true for extended, else false
+     */
     public boolean isExtended() {
         return getElement(1) == 'X';
     }
 
     /**
-     * Set the header
+     * Set the header.
      *
-     * @param header A valid CAN header value
+     * @param header A valid CAN header value.
      */
     public void setHeader(int header) {
         if (isExtended()) {
@@ -113,19 +141,23 @@ public class GridConnectMessage extends AbstractMRMessage {
         }
     }
 
+    /**
+     * Set CAN Frame as RtR.
+     * @param rtr true to set rtr, else false.
+     */
     public void setRtr(boolean rtr) {
         int offset = isExtended() ? 10 : 5;
         setElement(offset, rtr ? 'R' : 'N');
     }
 
     /**
-     * Set a byte as two ASCII hex digits
+     * Set a byte as two ASCII hex digits.
      * <p>
      * Data bytes are encoded as two ASCII hex digits starting at byte 7 of the
      * message.
      *
-     * @param val the value to set
-     * @param n   the index of the byte to be set
+     * @param val the value to set.
+     * @param n   the index of the byte to be set.
      */
     public void setByte(int val, int n) {
         if ((n >= 0) && (n <= 7)) {
@@ -135,7 +167,11 @@ public class GridConnectMessage extends AbstractMRMessage {
         }
     }
 
-    // Set a hex digit at offset n in _dataChars
+    /**
+     * Set a hex digit at offset n in _dataChars.
+     * @param val min 0, max value 15.
+     * @param n _dataChars Array Index.
+     */
     protected void setHexDigit(int val, int n) {
         if ((val >= 0) && (val <= 15)) {
             if (val < 10) {

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/GridConnectReply.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/GridConnectReply.java
@@ -9,7 +9,9 @@ import org.slf4j.LoggerFactory;
  * Class for replies in a GridConnect based message/reply protocol.
  * <p>
  * The GridConnect protocol encodes messages as an ASCII string of up to 24
- * characters of the form: :ShhhhNd0d1d2d3d4d5d6d7; hhhh is the two byte (11
+ * characters of the form: :ShhhhNd0d1d2d3d4d5d6d7;
+ * <p>
+ * hhhh is the two byte (11
  * useful bits) header The S indicates a standard CAN frame
  * :XhhhhhhhhNd0d1d2d3d4d5d6d7; The X indicates an extended CAN frame N or R
  * indicates a normal or remote frame, in position 6 or 10 d0 - d7 are the (up
@@ -23,12 +25,18 @@ public class GridConnectReply extends AbstractMRReply {
 
     static final int MAXLEN = 27;
 
-    // Creates a new instance of GridConnectReply
+    /**
+     * Creates a new instance of GridConnectReply.
+     */
     public GridConnectReply() {
         _nDataChars = 0;
         _dataChars = new int[MAXLEN];
     }
 
+    /**
+     * Creates a new GridConnectReply from String.
+     * @param s String to use as basis for the GCReply.
+     */
     public GridConnectReply(String s) {
         _nDataChars = s.length();
         for (int i = 0; i < s.length(); i++) {
@@ -36,6 +44,10 @@ public class GridConnectReply extends AbstractMRReply {
         }
     }
 
+    /**
+     * Create a CanReply from a GridConnectReply.
+     * @return new CanReply Outgoing message.
+     */
     public CanReply createReply() {
         CanReply ret = new CanReply();
 
@@ -70,13 +82,17 @@ public class GridConnectReply extends AbstractMRReply {
         return ret;
     }
 
+    /**
+     * Check if this GCReply contains an Extended or Standard flag.
+     * @return true if contains a flag, else false.
+     */
     protected boolean basicFormatCheck() {
-        if ((getElement(1) != 'X') && (getElement(1) != 'S')) {
-            return false;
-        }
-        return true;
+        return !((getElement(1) != 'X') && (getElement(1) != 'S'));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected int skipPrefix(int index) {
         while (_dataChars[index] == ':') {
@@ -85,21 +101,34 @@ public class GridConnectReply extends AbstractMRReply {
         return index;
     }
 
-    // accessors to the bulk data
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getNumDataElements() {
         return _nDataChars;
     }
 
+    /**
+     * Set Number of Data Elements.
+     * Max. length set by the MAXLEN constant.
+     * @param n Number Elements.
+     */
     public void setNumDataElements(int n) {
         _nDataChars = (n <= MAXLEN) ? n : MAXLEN;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getElement(int n) {
         return _dataChars[n];
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setElement(int n, int v) {
         if (n < MAXLEN) {
@@ -108,20 +137,34 @@ public class GridConnectReply extends AbstractMRReply {
         }
     }
 
+    /**
+     * Get if the GridConnectReply is Extended.
+     * @return true if extended, else false.
+     */
     public boolean isExtended() {
         return (getElement(1) == 'X');
     }
 
+    /**
+     * Get if the GridConnectReply is RtR.
+     * @return true if RtR, else false.
+     */
     public boolean isRtr() {
         return (getElement(_RTRoffset) == 'R');
     }
 
-    // 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int maxSize() {
         return MAXLEN;
     }
 
+    /**
+     * Set the GridConnectReply data by Array.
+     * @param d data array.
+     */
     public void setData(int[] d) {
         int len = (d.length <= MAXLEN) ? d.length : MAXLEN;
         for (int i = 0; i < len; i++) {
@@ -133,8 +176,9 @@ public class GridConnectReply extends AbstractMRReply {
     int _RTRoffset = -1;
 
     /**
-     * Get the CAN header by using chars from 2 to up to 9 Right justify
-     * standard headers that had 4 digits
+     * Get the CAN header by using chars from 2 to up to 9.
+     * <p>
+     * Right justify standard headers that had 4 digits.
      *
      * @return the CAN header as an int
      */
@@ -154,9 +198,8 @@ public class GridConnectReply extends AbstractMRReply {
     }
 
     /**
-     * Get the number of data bytes
-     *
-     * @return int the number of bytes
+     * Get the number of data bytes.
+     * @return number of bytes in reply.
      */
     public int getNumBytes() {
         // subtract framing and ID bytes, etc and each byte is two ASCII hex digits
@@ -164,7 +207,7 @@ public class GridConnectReply extends AbstractMRReply {
     }
 
     /**
-     * Get a hex data byte from the message
+     * Get a hex data byte from the message.
      * <p>
      * Data bytes are encoded as two ASCII hex digits starting at byte 7 of the
      * message.

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/canrs/MergReply.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/canrs/MergReply.java
@@ -6,11 +6,15 @@ import jmri.jmrix.can.adapters.gridconnect.GridConnectReply;
  * Class for replies in a MERG GridConnect based message/reply protocol.
  * <p>
  * The GridConnect protocol encodes messages as an ASCII string of up to 24
- * characters of the form: :ShhhhNd0d1d2d3d4d5d6d7; hhhh is the two byte (11
+ * characters of the form: :ShhhhNd0d1d2d3d4d5d6d7;
+ * <p>
+ * hhhh is the two byte (11
  * useful bits) header The S indicates a standard CAN frame
  * :XhhhhhhhhNd0d1d2d3d4d5d6d7; The X indicates an extended CAN frame Strict
+ * <p>
  * Gridconnect protocol allows a variable number of header characters, e.g., a
  * header value of 0x123 could be encoded as S123, X123, S0123 or X00000123.
+ * <p>
  * MERG hardware uses a fixed 4 or 8 byte header when sending
  * GridConnectMessages to the computer. The 11 bit standard header is left
  * justified in these 4 bytes. The 29 bit standard header is sent as
@@ -24,16 +28,23 @@ import jmri.jmrix.can.adapters.gridconnect.GridConnectReply;
  */
 public class MergReply extends GridConnectReply {
 
+    /**
+     * Create new MergReply.
+     */
     public MergReply() {
         super();
     }
 
+    /**
+     * Create new MergReply from String.
+     * @param s Frame data to create MergReply from.
+     */
     public MergReply(String s) {
         super(s);
     }
 
     /**
-     * Get the CAN header from MERG format in digits 2 to 9
+     * Get the CAN header from MERG format in digits 2 to 9.
      *
      * @return the CAN header as an int
      */

--- a/java/src/jmri/jmrix/can/cbus/swing/CbusCommonSwing.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/CbusCommonSwing.java
@@ -23,6 +23,13 @@ public class CbusCommonSwing {
     public static final Color WHITE_GREEN = new Color(0xf5,0xf5,0xf5);
     public static final Color GOLD = new Color(255,204,51);
     
+    /**
+     * Set cell background with alternating rows.
+     * @param isSelected true if selected.
+     * @param f cell component.
+     * @param table cell table.
+     * @param row cell row.
+     */
     public static void setCellBackground( boolean isSelected, JComponent f, JTable table, int row){
         f.setBackground(isSelected ? table.getSelectionBackground() : 
             (( row % 2 == 0 ) ? table.getBackground() : WHITE_GREEN ) );

--- a/java/src/jmri/jmrix/maple/MapleSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/maple/MapleSystemConnectionMemo.java
@@ -52,6 +52,7 @@ public class MapleSystemConnectionMemo extends SystemConnectionMemo {
 
     /**
      * Get the traffic controller instance associated with this connection memo.
+     * @return traffic controller, new instance if null.
      */
     public SerialTrafficController getTrafficController(){
         if (tc == null) {
@@ -89,6 +90,7 @@ public class MapleSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the SensorManager for this particular connection.
      * <p>
      * NOTE: SensorManager defaults to NULL
+     * @return sensor manager.
      */
     public SensorManager getSensorManager() {
         return sensorManager;
@@ -105,6 +107,7 @@ public class MapleSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the TurnoutManager for this particular connection.
      * <p>
      * NOTE: TurnoutManager defaults to NULL
+     * @return turnout manager.
      */
     public TurnoutManager getTurnoutManager() {
         return turnoutManager;
@@ -121,6 +124,7 @@ public class MapleSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the LightManager for this particular connection.
      * <p>
      * NOTE: LightManager defaults to NULL
+     * @return light manager.
      */
     public LightManager getLightManager() {
         return lightManager;

--- a/java/src/jmri/jmrix/maple/OutputBits.java
+++ b/java/src/jmri/jmrix/maple/OutputBits.java
@@ -58,6 +58,8 @@ public class OutputBits {
      * <p>
      * Note: state = 'true' for 0, 'false' for 1.
      * Bits are numbered from 1 (not 0)
+     * @param bitNumber bit index number starting from 1.
+     * @param state true for 0, false for 1.
      */
     public void setOutputBit(int bitNumber, boolean state) {
         // validate that this bitNumber is defined
@@ -81,6 +83,7 @@ public class OutputBits {
      * <p>
      * Bits are numbered from 1 (not 0).
      *
+     * @param bitNumber bit number to check, index starts at 1.
      * @return 'true' for 0, 'false' for 1
      */
     public boolean getOutputBit(int bitNumber) {
@@ -103,6 +106,9 @@ public class OutputBits {
 
     /**
      * Create a Transmit packet (SerialMessage).
+     * @param startBitNum start bit number.
+     * @param endBitNum end bit number.
+     * @return serial message.
      */
     public SerialMessage createOutPacket(int startBitNum, int endBitNum) {
         int nBits = endBitNum - startBitNum + 1;

--- a/java/src/jmri/jmrix/maple/SerialAddress.java
+++ b/java/src/jmri/jmrix/maple/SerialAddress.java
@@ -31,8 +31,11 @@ public class SerialAddress {
 
     /**
      * Public static method to parse a Maple system name and return the bit number.
+     * <p>
      * Notes: Bits are numbered from 1.
      *
+     * @param systemName system name.
+     * @param prefix system prefix.
      * @return the bit number, return 0 if an error is found
      */
     public static int getBitFromSystemName(String systemName, String prefix) {
@@ -81,6 +84,9 @@ public class SerialAddress {
     /**
      * Public static method to validate system name format.
      *
+     * @param systemName system name to validate.
+     * @param type bean type, ie S for Sensor, T for Turnout.
+     * @param prefix system prefix.
      * @return 'true' if system name has a valid format,
      * else returns 'false'
      */
@@ -108,6 +114,9 @@ public class SerialAddress {
     /**
      * Public static method to validate system name for configuration.
      *
+     * @param systemName system name to validate.
+     * @param type bean type, ie S for Sensor, T for Turnout.
+     * @param memo system connection.
      * @return 'true' if system name has a valid meaning in current configuration,
      * else returns 'false'
      */
@@ -147,6 +156,8 @@ public class SerialAddress {
      * to a bit, by removing extra zeros inserted by the user.
      * It's not applied to sensors (whick might be addressed using the KS3:5 format.
      *
+     * @param systemName systemname to normalize.
+     * @param prefix system prefix.
      * @return if the supplied system name does not have a valid format, an empty string
      * is returned. If the address in the system name is not within the legal
      * maximum range for the type of item (L, T, or S), an empty string is
@@ -185,6 +196,9 @@ public class SerialAddress {
      * This routine returns a system name in the KLxxxx, KTxxxx, or KSxxxx
      * format. The returned name is normalized.
      *
+     * @param type bean type, ie S Sensor, T Turnout.
+     * @param bitNum bit number.
+     * @param prefix system prefix.
      * @return "" (null string) if the supplied type character is not valid,
      * or the bit number is out of the 1 - 9000 range, and an error message is
      * logged.
@@ -215,6 +229,8 @@ public class SerialAddress {
     /**
      * Public static method to test if an output bit is free for assignment.
      *
+     * @param bitNum bit number.
+     * @param prefix system prefix.
      * @return "" (null string) if the specified output bit is free for
      * assignment, else returns the system name of the conflicting assignment.
      * Test is not performed if the node address or bit number are valid.
@@ -263,7 +279,9 @@ public class SerialAddress {
     /**
      * Public static method to test if an input bit is free for assignment.
      *
-     * @return "" (null string) if the specified input bit is free for
+     * @param bitNum bit number.
+     * @param prefix system prefix.
+     * @return "" (empty string) if the specified input bit is free for
      * assignment, else returns the system name of the conflicting assignment.
      * Test is not performed if the node address is illegal or bit number is
      * valid.
@@ -294,7 +312,9 @@ public class SerialAddress {
     /**
      * Public static method to get the user name for a valid system name.
      *
-     * @return "" (null string) if the system name is not valid or does not exist
+     * @param systemName system name.
+     * @param prefix system prefix.
+     * @return "" (empty string) if the system name is not valid or does not exist
      */
     public static String getUserNameFromSystemName(String systemName, String prefix) {
         if (prefix.length() < 1) {

--- a/java/src/jmri/jmrix/maple/SerialLight.java
+++ b/java/src/jmri/jmrix/maple/SerialLight.java
@@ -21,6 +21,7 @@ public class SerialLight extends AbstractLight {
      * 'systemName' has already been validated in SerialLightManager
      *
      * @param systemName the system name for this Light
+     * @param memo system connection.
      */
     public SerialLight(String systemName, MapleSystemConnectionMemo memo) {
         super(systemName);
@@ -36,6 +37,7 @@ public class SerialLight extends AbstractLight {
      *
      * @param systemName the system name for this Light
      * @param userName   the user name for this Light
+     * @param memo system connection.
      */
     public SerialLight(String systemName, String userName, MapleSystemConnectionMemo memo) {
         super(systemName, userName);

--- a/java/src/jmri/jmrix/maple/SerialLightManager.java
+++ b/java/src/jmri/jmrix/maple/SerialLightManager.java
@@ -73,6 +73,8 @@ public class SerialLightManager extends AbstractLightManager {
 
     /**
      * Public method to notify user of Light creation error.
+     * @param conflict human readable name of conflicting light.
+     * @param bitNum bit number of conflicting light.
      */
     public void notifyLightCreationError(String conflict, int bitNum) {
         javax.swing.JOptionPane.showMessageDialog(null, "The output bit, " + bitNum

--- a/java/src/jmri/jmrix/maple/SerialMessage.java
+++ b/java/src/jmri/jmrix/maple/SerialMessage.java
@@ -32,6 +32,7 @@ public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * This ctor interprets the String as the exact sequence to send,
      * byte-for-byte.
+     * @param m message string.
      */
     public SerialMessage(String m) {
         super(m);

--- a/java/src/jmri/jmrix/maple/SerialNode.java
+++ b/java/src/jmri/jmrix/maple/SerialNode.java
@@ -36,8 +36,9 @@ public class SerialNode extends AbstractNode {
     // operational instance variables (should not be preserved between runs)
 
     /**
-     * Assumes a node address of 1, and a node type of 0. If this constructor is
-     * used, actual node address must be set using setNodeAddress.
+     * Assumes a node address of 1, and a node type of 0.
+     * If this constructor is used, actual node address must be set using setNodeAddress.
+     * @param tc serial traffic controller.
      */
     public SerialNode(SerialTrafficController tc) {
         this(1, 0, tc);
@@ -48,6 +49,7 @@ public class SerialNode extends AbstractNode {
      *
      * @param address Address of node on serial bus (0-99)
      * @param type 0 (ignored)
+     * @param tc system traffic controller.
      */
     public SerialNode(int address, int type, SerialTrafficController tc) {
         // set address 
@@ -79,7 +81,8 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Get this node's address
+     * Get this node's address.
+     * @return node address.
      */
     public int getAddress() {
         return _address;

--- a/java/src/jmri/jmrix/maple/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/maple/SerialSensorManager.java
@@ -124,7 +124,8 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     }
 
     /**
-     * Dummy routine
+     * Dummy routine.
+     * @param r unused.
      */
     @Override
     public void message(SerialMessage r) {
@@ -133,6 +134,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
 
     /**
      * Process a reply to a poll of Sensors of one panel node.
+     * {@inheritDoc}
      */
     @Override
     public void reply(SerialReply r) {
@@ -140,7 +142,8 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     }
 
     /**
-     * Method to register any orphan Sensors when a new Serial Node is created
+     * Method to register any orphan Sensors when a new Serial Node is created.
+     * @param node node to register.
      */
     @SuppressWarnings("deprecation") // needs careful unwinding for Set operations
     public void registerSensorsForNode(SerialNode node) {

--- a/java/src/jmri/jmrix/maple/SerialTrafficController.java
+++ b/java/src/jmri/jmrix/maple/SerialTrafficController.java
@@ -75,6 +75,7 @@ public class SerialTrafficController extends AbstractMRNodeTrafficController imp
 
     /**
      * Public method to set up for initialization of a Serial node.
+     * @param node unused.
      */
     public void initializeSerialNode(SerialNode node) {
         // dummy routine - Maple System devices do not require initialization

--- a/java/src/jmri/jmrix/maple/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/maple/SerialTurnoutManager.java
@@ -79,6 +79,8 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
 
     /**
      * Public method to notify user of Turnout creation error.
+     * @param conflict string of the turnout which is in conflict.
+     * @param bitNum the bit number in conflict.
      */
     public void notifyTurnoutCreationError(String conflict, int bitNum) {
         javax.swing.JOptionPane.showMessageDialog(null, "ERROR - The output bit, "
@@ -189,10 +191,6 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
 //       javax.swing.JOptionPane.INFORMATION_MESSAGE,null);
 // }
 
-    @Deprecated
-    static public SerialTurnoutManager instance() {
-        return null;
-    }
 
     private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManager.class);
 

--- a/java/src/jmri/jmrix/maple/assignment/ListFrame.java
+++ b/java/src/jmri/jmrix/maple/assignment/ListFrame.java
@@ -243,6 +243,7 @@ public class ListFrame extends jmri.util.JmriJFrame {
 
     /**
      * Handle selection of a Node for info display.
+     * @param nodeID node ID string.
      */
     public void displayNodeInfo(String nodeID) {
         if (!nodeID.equals(selNodeID)) {
@@ -281,6 +282,7 @@ public class ListFrame extends jmri.util.JmriJFrame {
 
     /**
      * Handle print button in List Frame.
+     * @param e unused.
      */
     public void printButtonActionPerformed(java.awt.event.ActionEvent e) {
         int[] colWidth = new int[4];
@@ -425,13 +427,17 @@ public class ListFrame extends jmri.util.JmriJFrame {
         public static final int USERNAME_COLUMN = 3;
 
         /**
-         * Print or print preview the assignment table. Printed in
-         * proportionately sized columns across the page with headings and
-         * vertical lines between each column. Data is word wrapped within a
-         * column. Can only handle 4 columns of data as strings.
+         * Print or print preview the assignment table.
+         * <p>
+         * Printed in proportionately sized columns across the page with 
+         * headings and vertical lines between each column.
+         * Data is word wrapped within a column.
+         * Can only handle 4 columns of data as strings.
          * <p>
          * Adapted from routines in BeanTableDataModel.java by
          * Bob Jacobsen and Dennis Miller
+         * @param w the HardcopyWriter instance.
+         * @param colWidth column width array.
          */
         public void printTable(HardcopyWriter w, int colWidth[]) {
             // determine the column sizes - proportionately sized, with space between for lines

--- a/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigFrame.java
+++ b/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigFrame.java
@@ -74,7 +74,8 @@ public class NodeConfigFrame extends jmri.util.JmriJFrame {
     private MapleSystemConnectionMemo _memo = null;
 
     /**
-     * Constructor method
+     * Constructor method.
+     * @param memo system connection.
      */
     public NodeConfigFrame(MapleSystemConnectionMemo memo) {
         super();

--- a/java/src/jmri/jmrix/maple/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/maple/serialdriver/ConnectionConfig.java
@@ -16,6 +16,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/maple/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/maple/serialdriver/SerialDriverAdapter.java
@@ -102,6 +102,7 @@ public class SerialDriverAdapter extends SerialPortController {
 
     /**
      * Can the port accept additional characters? Yes, always
+     * @return always true.
      */
     public boolean okToSend() {
         return true;

--- a/java/src/jmri/jmrix/maple/simulator/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/maple/simulator/ConnectionConfig.java
@@ -24,6 +24,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConf
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/marklin/MarklinSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/marklin/MarklinSystemConnectionMemo.java
@@ -41,6 +41,7 @@ public class MarklinSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
 
     /**
      * Provides access to the TrafficController for this particular connection.
+     * @return the traffic controller.
      */
     public MarklinTrafficController getTrafficController() {
         return et;

--- a/java/src/jmri/jmrix/marklin/MarklinThrottle.java
+++ b/java/src/jmri/jmrix/marklin/MarklinThrottle.java
@@ -18,6 +18,8 @@ public class MarklinThrottle extends AbstractThrottle implements MarklinListener
 
     /**
      * Constructor.
+     * @param memo system connection.
+     * @param address loco address.
      */
     public MarklinThrottle(MarklinSystemConnectionMemo memo, LocoAddress address) {
         super(memo);

--- a/java/src/jmri/jmrix/marklin/MarklinThrottleManager.java
+++ b/java/src/jmri/jmrix/marklin/MarklinThrottleManager.java
@@ -18,6 +18,7 @@ public class MarklinThrottleManager extends AbstractThrottleManager implements M
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public MarklinThrottleManager(MarklinSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/marklin/MarklinTrafficController.java
+++ b/java/src/jmri/jmrix/marklin/MarklinTrafficController.java
@@ -162,6 +162,8 @@ public class MarklinTrafficController extends AbstractMRTrafficController implem
      * As we have to poll the tams system to get updates we put request into a
      * queue and allow the abstrct traffic controller to handle them when it
      * is free.
+     * @param mm marklin message to add.
+     * @param ml marklin listener.
      */
     public void addPollMessage(MarklinMessage mm, MarklinListener ml) {
         mm.setTimeout(500);
@@ -177,6 +179,8 @@ public class MarklinTrafficController extends AbstractMRTrafficController implem
 
     /**
      * Removes a message that is used for polling from the queue.
+     * @param mm marklin message to remove.
+     * @param ml marklin listener.
      */
     public void removePollMessage(MarklinMessage mm, MarklinListener ml) {
         for (PollMessage pm : pollQueue) {

--- a/java/src/jmri/jmrix/marklin/MarklinTurnout.java
+++ b/java/src/jmri/jmrix/marklin/MarklinTurnout.java
@@ -27,6 +27,8 @@ public class MarklinTurnout extends AbstractTurnout
      * identification in the system name.
      *
      * @param number address of the turnout
+     * @param prefix system prefix.
+     * @param etc connection traffic controller.
      */
     public MarklinTurnout(int number, String prefix, MarklinTrafficController etc) {
         super(prefix + "T" + number);

--- a/java/src/jmri/jmrix/marklin/networkdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/marklin/networkdriver/ConnectionConfig.java
@@ -13,6 +13,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/marklin/swing/MarklinNamedPaneAction.java
+++ b/java/src/jmri/jmrix/marklin/swing/MarklinNamedPaneAction.java
@@ -16,6 +16,10 @@ public class MarklinNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction 
 
     /**
      * Enhanced constructor for placing the pane in various GUIs
+     * @param s pane name.
+     * @param wi the window interface.
+     * @param paneClass pane class.
+     * @param memo system connection.
      */
     public MarklinNamedPaneAction(String s, WindowInterface wi, String paneClass, MarklinSystemConnectionMemo memo) {
         super(s, wi, paneClass);

--- a/java/src/jmri/jmrix/marklin/swing/MarklinPanelInterface.java
+++ b/java/src/jmri/jmrix/marklin/swing/MarklinPanelInterface.java
@@ -16,6 +16,7 @@ public interface MarklinPanelInterface {
      * <p>
      * This needs to be connected to the initContext() method in implementing
      * classes.
+     * @param memo system connection.
      */
     public void initComponents(MarklinSystemConnectionMemo memo);
 

--- a/java/src/jmri/jmrix/mqtt/MqttContentParser.java
+++ b/java/src/jmri/jmrix/mqtt/MqttContentParser.java
@@ -14,6 +14,7 @@ public interface MqttContentParser<T extends NamedBean> {
      * Load a bean's state from a received MQTT payload.
      * @param bean The particular item receiving the payload
      * @param payload The entire string received via MQTT
+     * @param topic MQTT topic.
      * @throws IllegalArgumentException if the payload is unparsable.
      */
     public void beanFromPayload(@Nonnull T bean, @Nonnull String payload, @Nonnull String topic);

--- a/java/src/jmri/jmrix/oaktree/OakTreeSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/oaktree/OakTreeSystemConnectionMemo.java
@@ -51,6 +51,7 @@ public class OakTreeSystemConnectionMemo extends SystemConnectionMemo {
 
     /**
      * Get the traffic controller instance associated with this connection memo.
+     * @return traffic controller, new instance created if null.
      */
     public SerialTrafficController getTrafficController() {
         if (tc == null) {
@@ -86,6 +87,7 @@ public class OakTreeSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the SensorManager for this particular connection.
      * <p>
      * NOTE: SensorManager defaults to NULL
+     * @return sensor manager.
      */
     public SensorManager getSensorManager() {
         return sensorManager;
@@ -103,6 +105,7 @@ public class OakTreeSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the TurnoutManager for this particular connection.
      * <p>
      * NOTE: TurnoutManager defaults to NULL
+     * @return turnout manager.
      */
     public TurnoutManager getTurnoutManager() {
         return turnoutManager;
@@ -119,6 +122,7 @@ public class OakTreeSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the LightManager for this particular connection.
      * <p>
      * NOTE: LightManager defaults to NULL
+     * @return light manager.
      */
     public LightManager getLightManager() {
         return lightManager;

--- a/java/src/jmri/jmrix/oaktree/SerialAddress.java
+++ b/java/src/jmri/jmrix/oaktree/SerialAddress.java
@@ -49,6 +49,8 @@ public class SerialAddress {
     /**
      * Static method to parse a system name and return the Serial Node.
      *
+     * @param systemName system name.
+     * @param tc traffic controller.
      * @return 'NULL' if illegal systemName format or if the node is not found
      */
     public static SerialNode getNodeFromSystemName(String systemName, SerialTrafficController tc) {
@@ -110,6 +112,8 @@ public class SerialAddress {
      * Static method to parse a system name and return the bit number.
      * Note: Bits are numbered from 1.
      *
+     * @param systemName system name.
+     * @param prefix system prefix.
      * @return 0 if an error is found
      */
     public static int getBitFromSystemName(String systemName, String prefix) {
@@ -237,7 +241,9 @@ public class SerialAddress {
     /**
      * Static method to validate system name format.
      *
+     * @param systemName system name.
      * @param type Letter indicating device type expected
+     * @param prefix system prefix.
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     public static NameValidity validSystemNameFormat(@Nonnull String systemName, char type, String prefix) {
@@ -310,6 +316,9 @@ public class SerialAddress {
     /**
      * Static method to validate system name for configuration.
      *
+     * @param systemName system name.
+     * @param type bean type, e.g. S for Sensor, T for Turnout.
+     * @param memo system connection.
      * @return 'true' if system name has a valid meaning in current configuration, else
      * return 'false'
      */
@@ -350,6 +359,8 @@ public class SerialAddress {
      * Static method to convert one format system name for the alternate
      * format.
      *
+     * @param systemName system name.
+     * @param prefix system prefix.
      * @return an empty string if the supplied system name does not have a valid
      * format, or if there is no representation in the alternate naming scheme
      */
@@ -397,6 +408,8 @@ public class SerialAddress {
      * This routine is used to ensure that each system name is uniquely linked
      * to one bit, by removing extra zeros inserted by the user.
      *
+     * @param systemName system name.
+     * @param prefix system prefix.
      * @return an empty string if the supplied system name does not have a valid format.
      * Otherwise a normalized name is returned in the same format as the input name.
      */

--- a/java/src/jmri/jmrix/oaktree/SerialLight.java
+++ b/java/src/jmri/jmrix/oaktree/SerialLight.java
@@ -20,6 +20,8 @@ public class SerialLight extends AbstractLight {
      * Create a Light object, with only system name.
      * <p>
      * 'systemName' was previously validated in SerialLightManager
+     * @param systemName light system name.
+     * @param memo system connection.
      */
     public SerialLight(String systemName, OakTreeSystemConnectionMemo memo) {
         super(systemName);
@@ -32,6 +34,9 @@ public class SerialLight extends AbstractLight {
      * Create a Light object, with both system and user names.
      * <p>
      * 'systemName' was previously validated in SerialLightManager
+     * @param systemName light system name.
+     * @param userName light username.
+     * @param memo system connection.
      */
     public SerialLight(String systemName, String userName, OakTreeSystemConnectionMemo memo) {
         super(systemName, userName);

--- a/java/src/jmri/jmrix/oaktree/SerialMessage.java
+++ b/java/src/jmri/jmrix/oaktree/SerialMessage.java
@@ -35,6 +35,8 @@ public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Interpret the String as the exact sequence to send,
      * byte-for-byte.
+     * @param m message string.
+     * @param l response length.
      */
     public SerialMessage(String m, int l) {
         super(m);
@@ -46,6 +48,7 @@ public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
      * Interpret the byte array as a sequence of characters to send.
      *
      * @param a Array of bytes to send
+     * @param l response length.
      */
     public SerialMessage(byte[] a, int l) {
         super(String.valueOf(a));

--- a/java/src/jmri/jmrix/oaktree/SerialNode.java
+++ b/java/src/jmri/jmrix/oaktree/SerialNode.java
@@ -70,9 +70,11 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Create a new SerialNode without a name supplied.
-     * Assumes a node address of 0, and a node type of 0 (IO24). If this
-     * constructor is used, actual node address must be set using
+     * <p>
+     * Assumes a node address of 0, and a node type of 0 (IO24).
+     * If this constructor is used, actual node address must be set using 
      * setNodeAddress, and actual node type using 'setNodeType'
+     * @param memo system connection.
      */
     public SerialNode(OakTreeSystemConnectionMemo memo) {
         this(0, IO24, memo);
@@ -80,8 +82,10 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Create a new SerialNode and initialize default instance variables
-     * address - Address of node on serial bus (0-255) type - a type constant
-     * from the class
+     * 
+     * @param address Address of node on serial bus (0-255).
+     * @param type type constant from the class.
+     * @param memo system connection.
      */
     public SerialNode(int address, int type, OakTreeSystemConnectionMemo memo) {
         _memo = memo;
@@ -163,7 +167,10 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Get Node type. Current types are: IO24, I048, O48.
+     * Get Node type.
+     * <p>
+     * Current types are: IO24, I048, O48.
+     * @return node type.
      */
     public int getNodeType() {
         return (nodeType);
@@ -171,6 +178,7 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Set Node type.
+     * @param type node type e.g. IO48 , IO24
      */
     @SuppressWarnings("fallthrough")
     @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH")

--- a/java/src/jmri/jmrix/oaktree/SerialReply.java
+++ b/java/src/jmri/jmrix/oaktree/SerialReply.java
@@ -26,7 +26,8 @@ public class SerialReply extends jmri.jmrix.AbstractMRReply {
     }
 
     /**
-     * Is reply to poll message
+     * Is reply to poll message.
+     * @return element 0.
      */
     public int getAddr() {
         return getElement(0);

--- a/java/src/jmri/jmrix/oaktree/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/oaktree/SerialSensorManager.java
@@ -142,6 +142,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
 
     /**
      * Method to register any orphan Sensors when a new Serial Node is created.
+     * @param node node to register.
      */
     @SuppressWarnings("deprecation") // needs careful unwinding for Set operations
     public void registerSensorsForNode(SerialNode node) {

--- a/java/src/jmri/jmrix/oaktree/SerialTrafficController.java
+++ b/java/src/jmri/jmrix/oaktree/SerialTrafficController.java
@@ -57,7 +57,8 @@ public class SerialTrafficController extends AbstractMRNodeTrafficController imp
     }
 
     /**
-     * Set up for initialization of a Serial node
+     * Set up for initialization of a Serial node.
+     * @param node node to initialize.
      */
     public void initializeSerialNode(SerialNode node) {
         synchronized (this) {

--- a/java/src/jmri/jmrix/oaktree/SerialTurnout.java
+++ b/java/src/jmri/jmrix/oaktree/SerialTurnout.java
@@ -23,6 +23,9 @@ public class SerialTurnout extends AbstractTurnout {
      * Create a Turnout object, with both system and user names.
      * <p>
      * 'systemName' was previously validated in SerialTurnoutManager
+     * @param systemName turnout system name.
+     * @param userName turnout user name.
+     * @param memo system connection.
      */
     public SerialTurnout(String systemName, String userName, OakTreeSystemConnectionMemo memo) {
         super(systemName, userName);

--- a/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigFrame.java
+++ b/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigFrame.java
@@ -58,7 +58,8 @@ public class NodeConfigFrame extends jmri.util.JmriJFrame {
     private OakTreeSystemConnectionMemo _memo = null;
 
     /**
-     * Constructor method
+     * Constructor method.
+     * @param memo system connection.
      */
     public NodeConfigFrame(OakTreeSystemConnectionMemo memo) {
         super();

--- a/java/src/jmri/jmrix/oaktree/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/oaktree/serialdriver/ConnectionConfig.java
@@ -15,6 +15,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/oaktree/simulator/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/oaktree/simulator/ConnectionConfig.java
@@ -24,6 +24,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConf
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/openlcb/OlcbAddress.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbAddress.java
@@ -50,8 +50,9 @@ public class OlcbAddress {
     static final int NODEFACTOR = 100000;
 
     /** 
-     * Construct from OlcbEvent
+     * Construct from OlcbEvent.
      *
+     * @param e the event ID.
      */
     public OlcbAddress(EventID e) {
         byte[] contents = e.getContents();
@@ -161,9 +162,12 @@ public class OlcbAddress {
 
     /**
      * Confirm that the address string (provided earlier) is fully
-     * valid.  This is an expensive call. It's complete-compliance done
+     * valid.
+     * <p>
+     * This is an expensive call. It's complete-compliance done
      * using a regular expression. It can reject some 
      * forms that the code will normally handle OK.
+     * @return true if valid, else false.
      */
     public boolean check() {
         return getMatcher().reset(aString).matches();
@@ -260,7 +264,8 @@ public class OlcbAddress {
     }
 
     /**
-     * Provide as dotted pairs
+     * Provide as dotted pairs.
+     * @return dotted pair form off string.
      */
     public String toDottedString() {
         String retval = "";

--- a/java/src/jmri/jmrix/openlcb/OlcbSignalMast.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSignalMast.java
@@ -176,8 +176,9 @@ public class OlcbSignalMast extends AbstractSignalMast {
     }
 
     /**
-     * Handle incoming messages
+     * Handle incoming messages.
      * 
+     * @param msg the message to handle.
      */
     public void handleMessage(Message msg) {
         // gather before state
@@ -237,6 +238,7 @@ public class OlcbSignalMast extends AbstractSignalMast {
 
     /**
      * Provide the last used sequence number of all OlcbSignalMasts in use.
+     * @return last used OlcbSignalMasts sequence number
      */
     public static int getLastRef() {
         return lastRef;

--- a/java/src/jmri/jmrix/openlcb/OlcbSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSystemConnectionMemo.java
@@ -189,9 +189,12 @@ public class OlcbSystemConnectionMemo extends jmri.jmrix.can.CanSystemConnection
 
     /**
      * See {@link jmri.NamedBean#compareSystemNameSuffix} for background.
-     * 
-     * This is a common implementation for OpenLCB Sensors and Turnouts
+     * This is a common implementation for OpenLCB Sensors and Turnouts 
      * of the comparison method.
+     *
+     * @param suffix1 1st suffix to compare.
+     * @param suffix2 2nd suffix to compare.
+     * @return true if suffixes match, else false.
      */
     @CheckReturnValue
     public static int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2) {

--- a/java/src/jmri/jmrix/pricom/downloader/PdiFile.java
+++ b/java/src/jmri/jmrix/pricom/downloader/PdiFile.java
@@ -86,7 +86,8 @@ public class PdiFile {
     }
 
     /**
-     * Return the comment embedded at the front of the file
+     * Return the comment embedded at the front of the file.
+     * @return file comment.
      */
     public String getComment() {
         return comment;

--- a/java/src/jmri/jmrix/pricom/pockettester/MonitorFrame.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/MonitorFrame.java
@@ -44,7 +44,9 @@ public class MonitorFrame extends jmri.jmrix.AbstractMonFrame implements DataLis
 
     /**
      * Start filtering input to include only lines that start with a specific
-     * string. A null input passes all.
+     * string.
+     * A null input passes all.
+     * @param s string to filter, can be null.
      */
     public void setFilter(String s) {
         filter = s;

--- a/java/src/jmri/jmrix/pricom/pockettester/PacketDataModel.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/PacketDataModel.java
@@ -139,10 +139,11 @@ public class PacketDataModel extends javax.swing.table.AbstractTableModel {
     }
 
     /**
-     * Configure a table to have our standard rows and columns. This is
-     * optional, in that other table formats can use this table model. But we
-     * put it here to help keep it consistent.
+     * Configure a table to have our standard rows and columns.
+     * This is optional, in that other table formats can use this table model.
+     * But we put it here to help keep it consistent.
      *
+     * @param slotTable the table to configure.
      */
     public void configureTable(JTable slotTable) {
         // allow reordering of the columns

--- a/java/src/jmri/jmrix/qsi/QsiSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/qsi/QsiSystemConnectionMemo.java
@@ -42,6 +42,7 @@ public class QsiSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     /**
      * Provides access to the TrafficController for this particular connection.
+     * @return the QSI traffic controller.
      */
     public QsiTrafficController getQsiTrafficController() {
         return st;
@@ -53,7 +54,8 @@ public class QsiSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
     private QsiTrafficController st;
 
     /**
-     * Provide a menu with all items attached to this system connection
+     * Provide a menu with all items attached to this system connection.
+     * @return new QSIMenu.
      */
     public javax.swing.JMenu getMenu() {
         return new QSIMenu("QSI",this);

--- a/java/src/jmri/jmrix/qsi/QsiTrafficController.java
+++ b/java/src/jmri/jmrix/qsi/QsiTrafficController.java
@@ -214,6 +214,7 @@ public class QsiTrafficController implements QsiInterface, Runnable {
 
     /**
      * Make connection to existing PortController object.
+     * @param p the QSI port controller.
      */
     public void connectPort(QsiPortController p) {
         istream = p.getInputStream();
@@ -225,8 +226,9 @@ public class QsiTrafficController implements QsiInterface, Runnable {
     }
 
     /**
-     * Break connection to existing QsiPortController object. Once broken,
-     * attempts to send via "message" member will fail.
+     * Break connection to existing QsiPortController object.
+     * Once broken, attempts to send via "message" member will fail.
+     * @param p the QSI port controller.
      */
     public void disconnectPort(QsiPortController p) {
         istream = null;

--- a/java/src/jmri/jmrix/qsi/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/qsi/serialdriver/ConnectionConfig.java
@@ -13,6 +13,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/rfid/RfidStreamConnectionConfig.java
+++ b/java/src/jmri/jmrix/rfid/RfidStreamConnectionConfig.java
@@ -21,6 +21,7 @@ public class RfidStreamConnectionConfig extends jmri.jmrix.AbstractStreamConnect
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p stream port controller.
      */
     public RfidStreamConnectionConfig(jmri.jmrix.AbstractStreamPortController p) {
         super(p);

--- a/java/src/jmri/jmrix/rfid/RfidTrafficController.java
+++ b/java/src/jmri/jmrix/rfid/RfidTrafficController.java
@@ -57,6 +57,8 @@ abstract public class RfidTrafficController extends AbstractMRTrafficController 
      * <p>
      * This is a default, null implementation, which must be overridden in an
      * adapter-specific subclass.
+     * @param length message length.
+     * @return the RfidMessage.
      */
     public RfidMessage getRfidMessage(int length) {
         return null;

--- a/java/src/jmri/jmrix/rfid/networkdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/rfid/networkdriver/ConnectionConfig.java
@@ -19,6 +19,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/rfid/swing/RfidNamedPaneAction.java
+++ b/java/src/jmri/jmrix/rfid/swing/RfidNamedPaneAction.java
@@ -17,7 +17,11 @@ import org.slf4j.LoggerFactory;
 public class RfidNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction {
 
     /**
-     * Enhanced constructor for placing the pane in various GUIs
+     * Enhanced constructor for placing the pane in various GUIs.
+     * @param s action name.
+     * @param wi the window interface.
+     * @param paneClass the pane class.
+     * @param memo system connection.
      */
     public RfidNamedPaneAction(String s, WindowInterface wi, String paneClass, RfidSystemConnectionMemo memo) {
         super(s, wi, paneClass);

--- a/java/src/jmri/jmrix/roco/RocoXNetThrottle.java
+++ b/java/src/jmri/jmrix/roco/RocoXNetThrottle.java
@@ -16,14 +16,19 @@ import org.slf4j.LoggerFactory;
 public class RocoXNetThrottle extends jmri.jmrix.lenz.XNetThrottle {
 
     /**
-     * Constructor
+     * Constructor.
+     * @param memo system connection.
+     * @param controller traffic controller.
      */
     public RocoXNetThrottle(XNetSystemConnectionMemo memo, XNetTrafficController controller) {
         super(memo,controller);
     }
 
     /**
-     * Constructor
+     * Constructor.
+     * @param memo system connection.
+     * @param address loco address.
+     * @param controller traffic controller.
      */
     public RocoXNetThrottle(XNetSystemConnectionMemo memo, LocoAddress address, XNetTrafficController controller) {
         super(memo,address,controller);

--- a/java/src/jmri/jmrix/roco/RocoXNetThrottleManager.java
+++ b/java/src/jmri/jmrix/roco/RocoXNetThrottleManager.java
@@ -15,6 +15,7 @@ public class RocoXNetThrottleManager extends jmri.jmrix.lenz.XNetThrottleManager
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public RocoXNetThrottleManager(XNetSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/roco/z21/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/roco/z21/ConnectionConfig.java
@@ -16,6 +16,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/roco/z21/Z21CanBusAddress.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21CanBusAddress.java
@@ -31,6 +31,8 @@ public class Z21CanBusAddress {
      * Public static method to parse a Z21CanBus system name.
      * Note: Bits are numbered from 0.
      *
+     * @param systemName system name.
+     * @param prefix system prefix.
      * @return the hardware address number, return -1 if an error is found
      */
     public static int getBitFromSystemName(String systemName, String prefix) {
@@ -143,6 +145,9 @@ public class Z21CanBusAddress {
      * Public static method to validate system name format.
      * Logging of handled cases no higher than WARN.
      *
+     * @param systemName system name.
+     * @param type bean type, S for Sensor, T for Turnout.
+     * @param prefix system prefix.
      * @return VALID if system name has a valid format, else return INVALID
      */
     public static NameValidity validSystemNameFormat(@Nonnull String systemName, char type, String prefix) {
@@ -162,6 +167,8 @@ public class Z21CanBusAddress {
     /**
      * Public static method to check the user name for a valid system name.
      *
+     * @param systemName system name.
+     * @param prefix system prefix.
      * @return "" (null string) if the system name is not valid or does not exist
      */
     public static String getUserNameFromSystemName(String systemName, String prefix) {

--- a/java/src/jmri/jmrix/roco/z21/Z21LocoNetTunnel.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21LocoNetTunnel.java
@@ -35,6 +35,7 @@ public class Z21LocoNetTunnel implements Z21Listener, LocoNetListener , Runnable
 
     /**
      * Build a new LocoNet tunnel.
+     * @param memo system connection.
      */
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value="SC_START_IN_CTOR", justification="done at end, waits for data")
     public Z21LocoNetTunnel(Z21SystemConnectionMemo memo) {

--- a/java/src/jmri/jmrix/roco/z21/Z21Message.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21Message.java
@@ -57,6 +57,7 @@ public class Z21Message extends AbstractMRMessage {
      * This ctor interprets the String as the exact sequence to send,
      * byte-for-byte.
      *
+     * @param m message string.
      */
     public Z21Message(String m) {
         super(m);
@@ -80,6 +81,7 @@ public class Z21Message extends AbstractMRMessage {
      * This ctor interprets the byte array as a sequence of characters to send.
      *
      * @param a Array of bytes to send
+     * @param l unused.
      */
     public Z21Message(byte[] a, int l) {
         super(String.valueOf(a));

--- a/java/src/jmri/jmrix/roco/z21/Z21RMBusAddress.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21RMBusAddress.java
@@ -33,9 +33,10 @@ public class Z21RMBusAddress {
     static final int MAXSENSORADDRESS = 160; // 20 RM bus modules with 8 contacts each.
 
     /**
-     * Public static method to parse a Z21RMBus system name.
-     * Note: Bits are numbered from 1.
+     * Public static method to parse a Z21RMBus system name.Note: Bits are numbered from 1.
      *
+     * @param systemName system name.
+     * @param prefix system prefix.
      * @return the hardware address number, return -1 if an error is found
      */
     public static int getBitFromSystemName(String systemName, String prefix) {
@@ -84,6 +85,9 @@ public class Z21RMBusAddress {
      * Public static method to validate system name format.
      * Logging of handled cases no higher than WARN.
      *
+     * @param systemName system name.
+     * @param type bean type, S for Sensor, T for Turnout.
+     * @param prefix system prefix.
      * @return VALID if system name has a valid format, else return INVALID
      */
     public static NameValidity validSystemNameFormat(@Nonnull String systemName, char type, String prefix) {
@@ -104,6 +108,8 @@ public class Z21RMBusAddress {
     /**
      * Public static method to check the user name for a valid system name.
      *
+     * @param systemName system name.
+     * @param prefix system prefix.
      * @return "" (null string) if the system name is not valid or does not exist
      */
     public static String getUserNameFromSystemName(String systemName, String prefix) {

--- a/java/src/jmri/jmrix/roco/z21/Z21Reply.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21Reply.java
@@ -30,7 +30,8 @@ public class Z21Reply extends AbstractMRReply {
     /**
      * This ctor interprets the byte array as a sequence of characters to send.
      *
-     * @param a Array of bytes to send
+     * @param a Array of bytes to send.
+     * @param l length of reply.
      */
     public Z21Reply(byte[] a, int l) {
         super();

--- a/java/src/jmri/jmrix/roco/z21/Z21SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21SystemConnectionMemo.java
@@ -53,6 +53,7 @@ public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     /**
      * Traffic Controller for this instance.
+     * @param newtc Z21 traffic controller.
      */
     public void setTrafficController(Z21TrafficController newtc) {
         _tc = newtc;
@@ -65,6 +66,7 @@ public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     /**
      * Reporter Manager for this instance.
+     * @param rm reporter manager.
      */
     public void setReporterManager(Z21ReporterManager rm){
         _rm = rm;
@@ -81,6 +83,7 @@ public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     /**
      * SensorManager for this instance.
+     * @param sm sensor manager.
      */
     public void setSensorManager(Z21SensorManager sm){
         _sm = sm;
@@ -229,6 +232,7 @@ public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
      * Provide access to the Command Station for this particular connection.
      * <p>
      * NOTE: Command Station defaults to NULL
+     * @return command station, may be null.
      */
     public CommandStation getCommandStation() {
         return commandStation;
@@ -245,6 +249,7 @@ public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
      * connection.
      * <p>
      * NOTE: Command Station defaults to NULL
+     * @return Roco Z21 Command Station, may be null.
      */
     public RocoZ21CommandStation getRocoZ21CommandStation() {
         return z21CommandStation;
@@ -261,6 +266,7 @@ public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
      * connection.
      * <p>
      * NOTE: MultiMeter defaults to NULL
+     * @return MultiMeter, creates new if null.
      */
     public jmri.MultiMeter getMultiMeter() {
         if(meter == null){
@@ -276,6 +282,7 @@ public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
      * Provide access to the Z21HeartBeat instance for this connection.
      * <p>
      * NOTE: HeartBeat defaults to NULL
+     * @return the HeartBeat, creates new if null.
      */
     public Z21HeartBeat getHeartBeat() {
         if(heartBeat == null){

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetConnectionConfig.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetConnectionConfig.java
@@ -19,6 +19,7 @@ public class Z21XNetConnectionConfig extends jmri.jmrix.AbstractStreamConnection
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p stream port controller.
      */
     public Z21XNetConnectionConfig(jmri.jmrix.AbstractStreamPortController p) {
         super(p);

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetMessage.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetMessage.java
@@ -17,14 +17,16 @@ import jmri.jmrix.lenz.XNetMessage;
 public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage {
 
     /**
-     * Constructor, just pass on to the supperclass.
+     * Constructor, just pass on to the superclass.
+     * @param len message length.
      */
     public Z21XNetMessage(int len) {
         super(len);
     }
 
     /**
-     * Constructor from a Z21Message
+     * Constructor from a Z21Message.
+     * @param m the Z21Message.
      */
     public Z21XNetMessage(Z21Message m) {
         super(m.getLength()-4);
@@ -44,6 +46,7 @@ public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage {
 
     /**
      * Create an Z21XNetMessage from an Z21XNetReply.
+     * @param message the existing Z21XNetReply.
      */
     public Z21XNetMessage(Z21XNetReply message) {
         super(message);
@@ -51,6 +54,7 @@ public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage {
 
     /**
      * Create an XNetMessage from a String containing bytes.
+     * @param s byte string.
      */
     public Z21XNetMessage(String s) {
         super(s);
@@ -76,7 +80,9 @@ public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage {
     }
 
     /**
-     * Create messages of a particular form
+     * Create messages of a particular form.
+     * @param cv CV index
+     * @return message to send.
      */
     public static Z21XNetMessage getZ21ReadDirectCVMsg(int cv) {
         Z21XNetMessage m = new Z21XNetMessage(5);
@@ -107,6 +113,7 @@ public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage {
      * Given a locomotive address, request its status.
      *
      * @param address is the locomotive address
+     * @return message to send.
      */
     public static Z21XNetMessage getZ21LocomotiveInfoRequestMsg(int address) {
         Z21XNetMessage msg = new Z21XNetMessage(5);
@@ -125,6 +132,7 @@ public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage {
      * @param address is the locomotive address
      * @param functionno is the function to change
      * @param state is boolean representing whether the function is to be on or off
+     * @return message to send.
      */
     public static Z21XNetMessage getZ21LocomotiveFunctionOperationMsg(int address, int functionno, boolean state) {
         Z21XNetMessage msg = new Z21XNetMessage(6);
@@ -156,6 +164,7 @@ public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage {
      * @param speed a normalized speed value (a floating point number between 0
      *              and 1).  A negative value indicates emergency stop.
      * @param isForward true for forward, false for reverse.
+     * @return message to send.
      */
     public static XNetMessage getZ21LanXSetLocoDriveMsg(int address, SpeedStepMode speedMode, float speed, boolean isForward) {
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(address,
@@ -169,6 +178,7 @@ public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage {
      * Given a turnout address, generate a message to request the state.
      *
      * @param address the turnout address
+     * @return message to send.
      */
     public static Z21XNetMessage getZ21TurnoutInfoRequestMessage(int address ) {
         // refer to section 5.1 of the z21 lan protocol manual.
@@ -193,6 +203,7 @@ public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage {
      * to active.
      * @param queue boolean value representing whehter or not the message is 
      * added to the queue.
+     * @return message to send.
      */
     public static Z21XNetMessage getZ21SetTurnoutRequestMessage(int address, boolean thrown, boolean active, boolean queue) {
         // refer to section 5.2 of the z21 lan protocol manual.

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetReply.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetReply.java
@@ -23,6 +23,7 @@ public class Z21XNetReply extends XNetReply {
 
     /**
      * Create a reply from an XNetMessage.
+     * @param message message to create reply from.
      */
     public Z21XNetReply(Z21XNetMessage message) {
         super(message);
@@ -30,6 +31,7 @@ public class Z21XNetReply extends XNetReply {
 
     /**
      * Create a reply from a string of hex characters.
+     * @param message hex character string.
      */
     public Z21XNetReply(String message) {
         super(message);

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetThrottle.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetThrottle.java
@@ -17,14 +17,19 @@ import org.slf4j.LoggerFactory;
 public class Z21XNetThrottle extends jmri.jmrix.roco.RocoXNetThrottle {
 
     /**
-     * Constructor
+     * Constructor.
+     * @param memo system connection.
+     * @param controller traffic controller.
      */
     public Z21XNetThrottle(XNetSystemConnectionMemo memo, XNetTrafficController controller) {
         super(memo,controller);
     }
 
     /**
-     * Constructor
+     * Constructor.
+     * @param memo system connection.
+     * @param address loco address.
+     * @param controller traffic controller.
      */
     public Z21XNetThrottle(XNetSystemConnectionMemo memo, LocoAddress address, XNetTrafficController controller) {
         super(memo,address,controller);

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetThrottleManager.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetThrottleManager.java
@@ -15,6 +15,7 @@ public class Z21XNetThrottleManager extends jmri.jmrix.roco.RocoXNetThrottleMana
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public Z21XNetThrottleManager(XNetSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/roco/z21/Z21XPressNetTunnel.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XPressNetTunnel.java
@@ -33,6 +33,7 @@ public class Z21XPressNetTunnel implements Z21Listener, XNetListener, Runnable {
 
     /**
      * Build a new XpressNet tunnel.
+     * @param memo system connection.
      */
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value="SC_START_IN_CTOR", justification="done at end, waits for data")
     public Z21XPressNetTunnel(Z21SystemConnectionMemo memo) {

--- a/java/src/jmri/jmrix/roco/z21/simulator/Z21SimulatorConnectionConfig.java
+++ b/java/src/jmri/jmrix/roco/z21/simulator/Z21SimulatorConnectionConfig.java
@@ -19,6 +19,7 @@ public class Z21SimulatorConnectionConfig extends jmri.jmrix.roco.z21.Connection
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p network port adapter.
      */
     public Z21SimulatorConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/rps/Algorithms.java
+++ b/java/src/jmri/jmrix/rps/Algorithms.java
@@ -26,7 +26,12 @@ public class Algorithms implements Constants {
     }
 
     /**
-     * Create proper Calculator instance
+     * Create proper Calculator instance.
+     * @param points the points array.
+     * @param vs algorithm getVSound.
+     * @param offset algorithm offset.
+     * @param name algorithm name.
+     * @return the calculator.
      */
     public static Calculator newCalculator(Point3d[] points, double vs, int offset, String name) {
         if (name.equals(names[0])) {

--- a/java/src/jmri/jmrix/rps/Distributor.java
+++ b/java/src/jmri/jmrix/rps/Distributor.java
@@ -13,6 +13,7 @@ public class Distributor {
 
     /**
      * Request being informed when a new Reading is available.
+     * @param l the reading listener to add.
      */
     public void addReadingListener(ReadingListener l) {
         // add only if not already registered
@@ -23,6 +24,7 @@ public class Distributor {
 
     /**
      * Request to no longer be informed when new Readings arrive.
+     * @param l the reading listener to remove.
      */
     public void removeReadingListener(ReadingListener l) {
         if (readingListeners.contains(l)) {
@@ -32,6 +34,7 @@ public class Distributor {
 
     /**
      * Invoked when a new Reading is created.
+     * @param s the reading.
      */
     @SuppressWarnings("unchecked")
     public void submitReading(Reading s) {
@@ -51,6 +54,7 @@ public class Distributor {
 
     /**
      * Request being informed when a new Measurement is available.
+     * @param l the listener to add.
      */
     public void addMeasurementListener(MeasurementListener l) {
         // add only if not already registered
@@ -61,6 +65,7 @@ public class Distributor {
 
     /**
      * Request to no longer be informed when new Measurements arrive.
+     * @param l the listener to remove.
      */
     public void removeMeasurementListener(MeasurementListener l) {
         if (measurementListeners.contains(l)) {
@@ -70,6 +75,7 @@ public class Distributor {
 
     /**
      * Invoked when a new Measurement is created.
+     * @param s the measurement.
      */
     @SuppressWarnings("unchecked")
     public void submitMeasurement(Measurement s) {

--- a/java/src/jmri/jmrix/rps/Engine.java
+++ b/java/src/jmri/jmrix/rps/Engine.java
@@ -71,8 +71,10 @@ public class Engine implements ReadingListener {
     Receiver[] receivers;
 
     /**
-     * Set the maximum receiver number expected. If the highest value in the
-     * hardware is 5, that's what's needed here.
+     * Set the maximum receiver number expected.
+     * <p>
+     * If the highest value in the hardware is 5, that's what's needed here.
+     * @param n max receivers.
      */
     public void setMaxReceiverNumber(int n) {
         log.debug("setReceiverCount to {}", n);
@@ -102,7 +104,9 @@ public class Engine implements ReadingListener {
     }
 
     /**
-     * Get a particular receiver by address (starting at 1).
+     * Set a particular receiver by address (starting at 1).
+     * @param address the receiver address.
+     * @param receiver the receiver.
      */
     public void setReceiver(int address, Receiver receiver) {
         if (receivers == null) {

--- a/java/src/jmri/jmrix/rps/Measurement.java
+++ b/java/src/jmri/jmrix/rps/Measurement.java
@@ -4,7 +4,7 @@ import javax.vecmath.Point3d;
 import javax.vecmath.Vector3d;
 
 /**
- * Encodes a single measurement point for RPS
+ * Encodes a single measurement point for RPS.
  * <p>
  * Immutable
  *
@@ -31,13 +31,15 @@ public class Measurement {
      * <p>
      * By definition, Reading objects are immutable
      *
+     * @return the reading.
      */
     public Reading getReading() {
         return r;
     }
 
     /**
-     * Return the ID int of the transmitter this measurement describes
+     * Return the ID int of the transmitter this measurement describes.
+     * @return transmitter ID.
      */
     public String getId() {
         if (r == null) {
@@ -76,7 +78,8 @@ public class Measurement {
     }
 
     /**
-     * Error code, defined specifically by generator
+     * Error code, defined specifically by generator.
+     * @return error code.
      */
     public int getCode() {
         return code;
@@ -84,6 +87,7 @@ public class Measurement {
 
     /**
      * Should this be considered a valid measurement?
+     * @return if getCode greater 0.
      */
     public boolean isOkPoint() {
         if (getCode() > 0) {
@@ -93,7 +97,8 @@ public class Measurement {
     }
 
     /**
-     * Get the error code as a human-readable string
+     * Get the error code as a human-readable string.
+     * @return readable error code.
      */
     public String textCode() {
         return "" + getCode();
@@ -108,7 +113,8 @@ public class Measurement {
     }
 
     /**
-     * Get name of the source
+     * Get name of the source.
+     * @return source name.
      */
     public String getSource() {
         return source;

--- a/java/src/jmri/jmrix/rps/Model.java
+++ b/java/src/jmri/jmrix/rps/Model.java
@@ -28,14 +28,16 @@ public class Model {
     ArrayList<Region> regions = new ArrayList<Region>();
 
     /**
-     * Include a region in the model
+     * Include a region in the model.
+     * @param r region to add.
      */
     public void addRegion(Region r) {
         regions.add(r);
     }
 
     /**
-     * Include a region in the model
+     * Include a region in the model.
+     * @param r region to remove.
      */
     public void removeRegion(Region r) {
         regions.remove(r);
@@ -45,6 +47,7 @@ public class Model {
      * Get the list of active regions.
      * <p>
      * This list should be immutable, hence copied, but for now it's not.
+     * @return list of regions.
      */
     public List<Region> getRegions() {
         return regions;

--- a/java/src/jmri/jmrix/rps/PollingFile.java
+++ b/java/src/jmri/jmrix/rps/PollingFile.java
@@ -68,7 +68,10 @@ public class PollingFile extends XmlFile {
     }
 
     /**
-     * Read in the file, and make available for examination
+     * Read in the file, and make available for examination.
+     * @param f the file to load.
+     * @throws org.jdom2.JDOMException other errors.
+     * @throws java.io.IOException error accessing file.
      */
     public void loadFile(File f)
             throws org.jdom2.JDOMException, java.io.IOException {
@@ -119,7 +122,8 @@ public class PollingFile extends XmlFile {
     }
 
     /**
-     * Get the transmitters from the file
+     * Get the transmitters from the file.
+     * @param engine a single engine.
      */
     public void getTransmitters(Engine engine) {
         List<Element> l = root.getChildren("transmitter");

--- a/java/src/jmri/jmrix/rps/PositionFile.java
+++ b/java/src/jmri/jmrix/rps/PositionFile.java
@@ -147,7 +147,10 @@ public class PositionFile extends XmlFile {
     }
 
     /**
-     * Read in the file, and make available for examination
+     * Read in the file, and make available for examination.
+     * @param f file to load.
+     * @throws org.jdom2.JDOMException other errors
+     * @throws java.io.IOException error accessing file
      */
     public void loadFile(File f)
             throws org.jdom2.JDOMException, java.io.IOException {
@@ -172,6 +175,7 @@ public class PositionFile extends XmlFile {
 
     /**
      * FInd the highest numbered receiver in the file
+     * @return highest numbered receiver.
      */
     public int maxReceiver() {
         List<Element> kids = root.getChildren("receiver");
@@ -195,6 +199,7 @@ public class PositionFile extends XmlFile {
     /**
      * Get the nth receiver position in the file.
      *
+     * @param n receiver index.
      * @return null if not present
      */
     public Point3d getReceiverPosition(int n) {
@@ -221,6 +226,7 @@ public class PositionFile extends XmlFile {
     /**
      * Get the nth receiver active state in the file.
      *
+     * @param n receiver index.
      * @return true if not present
      */
     public boolean getReceiverActive(int n) {
@@ -255,6 +261,7 @@ public class PositionFile extends XmlFile {
     /**
      * Get the nth receiver min time.
      *
+     * @param n receiver index.
      * @return 0 if not present
      */
     public int getReceiverMin(int n) {
@@ -290,6 +297,7 @@ public class PositionFile extends XmlFile {
     /**
      * Get the nth receiver max time.
      *
+     * @param n receiver index.
      * @return 0 if not present
      */
     public int getReceiverMax(int n) {
@@ -325,6 +333,7 @@ public class PositionFile extends XmlFile {
     /**
      * Get the nth calibration position in the file.
      *
+     * @param n calibration index.
      * @return null if not present
      */
     public Point3d getCalibrationPosition(int n) {
@@ -339,6 +348,7 @@ public class PositionFile extends XmlFile {
     /**
      * Get the nth calibration reading in the file.
      *
+     * @param n reading index.
      * @return null if not present
      */
     public Reading getCalibrationReading(int n) {

--- a/java/src/jmri/jmrix/rps/Reading.java
+++ b/java/src/jmri/jmrix/rps/Reading.java
@@ -52,6 +52,7 @@ public class Reading {
 
     /**
      * Return the time at which this Reading was requested.
+     * @return read request time.
      */
     public int getTime() {
         return time;
@@ -59,6 +60,7 @@ public class Reading {
 
     /**
      * Return the ID int of the transmitter this reading describes.
+     * @return ID of the transmitter.
      */
     public String getId() {
         return id;
@@ -66,6 +68,7 @@ public class Reading {
 
     /**
      * NValues is really the highest receiver number possible.
+     * @return highest receiver number possible.
      */
     public int getNValues() {
         return values.length - 1;
@@ -73,6 +76,8 @@ public class Reading {
 
     /**
      * Convenience method to get a specific one of the values.
+     * @param i value index.
+     * @return value.
      */
     public double getValue(int i) {
         return values[i];

--- a/java/src/jmri/jmrix/rps/Region.java
+++ b/java/src/jmri/jmrix/rps/Region.java
@@ -41,7 +41,8 @@ public class Region {
     GeneralPath path;
 
     /**
-     * Ctor from a string like "(0,0,0);(1,0,0);(1,1,0);(0,1,0)"
+     * Ctor from a string like "(0,0,0);(1,0,0);(1,1,0);(0,1,0)" .
+     * @param s construction string.
      */
     public Region(String s) {
         String[] pStrings = s.split(";");
@@ -70,6 +71,7 @@ public class Region {
      * underlying object immutable, but by returning a Shape type hopefully we
      * achieve the same result with a little better performance. Please don't
      * assume you can cast and modify this.
+     * @return the path.
      */
     public Shape getPath() {
         return path;

--- a/java/src/jmri/jmrix/rps/RpsReporter.java
+++ b/java/src/jmri/jmrix/rps/RpsReporter.java
@@ -115,8 +115,10 @@ public class RpsReporter extends AbstractReporter implements MeasurementListener
 
     /**
      * Parses out a (possibly old) RpsReporter-generated report string to
-     * extract the address from the front. Assumes the RpsReporter format is
-     * "NNNN".
+     * extract the address from the front.
+     * Assumes the RpsReporter format is "NNNN".
+     * @param rep loco string.
+     * @return loco address, may be null.
      */
     public LocoAddress getLocoAddress(String rep) {
         // The report is a string, that is the ID of the locomotive (I think)
@@ -140,6 +142,8 @@ public class RpsReporter extends AbstractReporter implements MeasurementListener
      * Get the direction (ENTER/EXIT) of the report.
      * <p>
      * Because of the way Ecos Reporters work (or appear to), all reports are ENTER type.
+     * @param rep reporter ID in string form.
+     * @return direction is always a location entrance
      */
     public PhysicalLocationReporter.Direction getDirection(String rep) {
         // The RPS reporter only sends a report on entry.
@@ -147,22 +151,27 @@ public class RpsReporter extends AbstractReporter implements MeasurementListener
     }
 
     /**
-     * Get the PhysicalLocation of the Reporter
-     *
-     * Reports its own location, for now. Not sure if that's the right thing or
-     * not. Would be nice if it reported the exact measured location of the
+     * Get the PhysicalLocation of the Reporter.
+     * <p>
+     * Reports its own location, for now.
+     * Not sure if that's the right thing or not. 
+     * Would be nice if it reported the exact measured location of the
      * transmitter, but right now that doesn't appear to be being stored
      * anywhere retrievable. NOT DONE YET
+     * @return PhysicalLocation.getBeanPhysicalLocation
      */
     public PhysicalLocation getPhysicalLocation() {
         return (PhysicalLocation.getBeanPhysicalLocation(this));
     }
 
     /**
-     * Get the PhysicalLocation of the Transmitter for a given ID
-     *
+     * Get the PhysicalLocation of the Transmitter for a given ID.
+     * <p>
      * Given an ID (in String form), looks up the Transmitter and gets its
      * current PhysicalLocation (translated from the RPS Measurement).
+     *
+     * @param s transmitter ID.
+     * @return physical location.
      */
     public PhysicalLocation getPhysicalLocation(String s) {
         if (s.length() > 0) {

--- a/java/src/jmri/jmrix/rps/RpsSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/rps/RpsSystemConnectionMemo.java
@@ -159,6 +159,8 @@ public class RpsSystemConnectionMemo extends SystemConnectionMemo {
     /**
      * Validate RPS system name format.
      *
+     * @param systemName system name.
+     * @param type e.g. S for Sensor, T for Turnout.
      * @return VALID if system name has a valid format, else return INVALID
      */
     public NameValidity validSystemNameFormat(@Nonnull String systemName, char type) {

--- a/java/src/jmri/jmrix/rps/aligntable/AlignTableFrame.java
+++ b/java/src/jmri/jmrix/rps/aligntable/AlignTableFrame.java
@@ -23,6 +23,7 @@ public class AlignTableFrame extends jmri.util.JmriJFrame {
 
     /**
      * Constructor method
+     * @param _memo system connection.
      */
     public AlignTableFrame(RpsSystemConnectionMemo _memo) {
         super();

--- a/java/src/jmri/jmrix/rps/aligntable/AlignTablePane.java
+++ b/java/src/jmri/jmrix/rps/aligntable/AlignTablePane.java
@@ -38,7 +38,8 @@ public class AlignTablePane extends javax.swing.JPanel {
     static ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.rps.aligntable.AlignTableBundle");
 
     /**
-     * Constructor method
+     * Constructor method.
+     * @param flag the ModifiedFlag tag.
      */
     public AlignTablePane(jmri.ModifiedFlag flag) {
         super();

--- a/java/src/jmri/jmrix/rps/serial/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/rps/serial/ConnectionConfig.java
@@ -12,6 +12,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/rps/swing/polling/PollTablePane.java
+++ b/java/src/jmri/jmrix/rps/swing/polling/PollTablePane.java
@@ -40,6 +40,7 @@ public class PollTablePane extends javax.swing.JPanel {
 
     /**
      * Constructor method
+     * @param flag the ModifiedFlag tag.
      */
     public PollTablePane(jmri.ModifiedFlag flag) {
         super();

--- a/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingPanel.java
+++ b/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingPanel.java
@@ -91,8 +91,10 @@ public class RpsTrackingPanel extends javax.swing.JPanel
     }
 
     /**
-     * Sets the coordinates of the lower left corner of the screen/paper. Note
-     * this is different from the usual Swing coordinate system!
+     * Sets the coordinates of the lower left corner of the screen/paper.
+     * Note this is different from the usual Swing coordinate system!
+     * @param x distance from left.
+     * @param y distance from bottom.
      */
     public void setOrigin(double x, double y) {
         xorigin = x;
@@ -116,8 +118,10 @@ public class RpsTrackingPanel extends javax.swing.JPanel
     boolean showRegions = false;
 
     /**
-     * Sets the coordinates of the upper-right corner of the screen/paper. Note
-     * this is different from the usual Swing coordinate system!
+     * Sets the coordinates of the upper-right corner of the screen/paper.
+     * Note this is different from the usual Swing coordinate system!
+     * @param x distance from right.
+     * @param y distance from top.
      */
     public void setCoordMax(double x, double y) {
         xmax = x;

--- a/java/src/jmri/jmrix/secsi/SecsiSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/secsi/SecsiSystemConnectionMemo.java
@@ -50,6 +50,7 @@ public class SecsiSystemConnectionMemo extends SystemConnectionMemo {
 
     /**
      * Get the traffic controller instance associated with this connection memo.
+     * @return traffic controller, new TC provided if null.
      */
     public SerialTrafficController getTrafficController() {
         if (tc == null) {
@@ -84,6 +85,7 @@ public class SecsiSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the SensorManager for this particular connection.
      * <p>
      * NOTE: SensorManager defaults to NULL
+     * @return sensor manager.
      */
     public SensorManager getSensorManager() {
         return sensorManager;
@@ -101,6 +103,7 @@ public class SecsiSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the TurnoutManager for this particular connection.
      * <p>
      * NOTE: TurnoutManager defaults to NULL
+     * @return turnout manager.
      */
     public TurnoutManager getTurnoutManager() {
         return turnoutManager;
@@ -117,6 +120,7 @@ public class SecsiSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the LightManager for this particular connection.
      * <p>
      * NOTE: LightManager defaults to NULL
+     * @return light manager.
      */
     public LightManager getLightManager() {
         return lightManager;

--- a/java/src/jmri/jmrix/secsi/SerialAddress.java
+++ b/java/src/jmri/jmrix/secsi/SerialAddress.java
@@ -48,6 +48,8 @@ public class SerialAddress {
     /**
      * Parse a system name and return the Serial Node.
      *
+     * @param systemName system name.
+     * @param tc system connection traffic controller.
      * @return 'NULL' if illegal systemName format or if the node is not
      * found
      */
@@ -99,6 +101,8 @@ public class SerialAddress {
      * <p>
      * Note: Bits are numbered from 1.
      *
+     * @param systemName system name.
+     * @param prefix system prefix.
      * @return the bit number, 0 if an error occurred
      */
     public static int getBitFromSystemName(String systemName, String prefix) {
@@ -221,9 +225,12 @@ public class SerialAddress {
 
     /**
      * Public static method to validate system name format.
+     * <p>
      * Logging of handled cases no higher than WARN.
      *
+     * @param systemName system name.
      * @param type Letter indicating device type expected
+     * @param prefix system prefix.
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     public static NameValidity validSystemNameFormat(@Nonnull String systemName, char type, String prefix) {
@@ -299,6 +306,9 @@ public class SerialAddress {
     /**
      * Public static method to validate system name for configuration.
      *
+     * @param systemName system name.
+     * @param type bean type, e.g. S for Sensor, T for Turnout.
+     * @param tc system traffic controller.
      * @return 'true' if system name has a valid meaning in current configuration, else
      * returns 'false'
      */
@@ -340,6 +350,8 @@ public class SerialAddress {
      * Public static method to convert one format system name for the alternate
      * format.
      *
+     * @param systemName system name.
+     * @param prefix system prefix.
      * @return an empty string if the supplied system name does not have a valid
      * format, or if there is no representation in the alternate naming scheme
      */
@@ -387,6 +399,8 @@ public class SerialAddress {
      * This routine is used to ensure that each system name is uniquely linked
      * to one bit, by removing extra zeros inserted by the user.
      *
+     * @param systemName system name.
+     * @param prefix system prefix.
      * @return an empty string if the supplied system name does not have a valid
      * format. Otherwise a normalized name is returned in the same format
      * as the input name.

--- a/java/src/jmri/jmrix/secsi/SerialLight.java
+++ b/java/src/jmri/jmrix/secsi/SerialLight.java
@@ -18,6 +18,8 @@ public class SerialLight extends AbstractLight {
      * Create a Light object, with only system name.
      * <p>
      * 'systemName' was previously validated in SerialLightManager
+     * @param systemName light system name.
+     * @param _memo system connection.
      */
     public SerialLight(String systemName, SecsiSystemConnectionMemo _memo) {
         super(systemName);
@@ -30,6 +32,9 @@ public class SerialLight extends AbstractLight {
      * Create a Light object, with both system and user names.
      * <p>
      * 'systemName' was previously validated in SerialLightManager
+     * @param systemName light system name.
+     * @param userName light user name.
+     * @param _memo system connection.
      */
     public SerialLight(String systemName, String userName, SecsiSystemConnectionMemo _memo) {
         super(systemName, userName);

--- a/java/src/jmri/jmrix/secsi/SerialMessage.java
+++ b/java/src/jmri/jmrix/secsi/SerialMessage.java
@@ -32,6 +32,8 @@ public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * This ctor interprets the String as the exact sequence to send,
      * byte-for-byte.
+     * @param m message string.
+     * @param l response length.
      */
     public SerialMessage(String m, int l) {
         super(m);
@@ -43,6 +45,7 @@ public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
      * This ctor interprets the byte array as a sequence of characters to send.
      *
      * @param a Array of bytes to send
+     * @param l response length
      */
     public SerialMessage(byte[] a, int l) {
         super(String.valueOf(a));

--- a/java/src/jmri/jmrix/secsi/SerialNode.java
+++ b/java/src/jmri/jmrix/secsi/SerialNode.java
@@ -72,6 +72,7 @@ public class SerialNode extends AbstractNode {
      * Assumes a node address of 0, and a node type of 0 (IO24) If this
      * constructor is used, actual node address must be set using
      * setNodeAddress, and actual node type using 'setNodeType'
+     * @param _tc system connection traffic controller.
      */
     public SerialNode(SerialTrafficController _tc) {
         this(0, DAUGHTER, _tc);
@@ -145,6 +146,7 @@ public class SerialNode extends AbstractNode {
     /**
      * Public method to return node type.
      * Current types are: DAUGHTER, CABDRIVER
+     * @return node type.
      */
     public int getNodeType() {
         return (nodeType);
@@ -152,6 +154,7 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Set node type.
+     * @param type node type, e.g. DAUGHTER or CABDRIVER
      */
     public void setNodeType(int type) {
         nodeType = type;

--- a/java/src/jmri/jmrix/secsi/SerialReply.java
+++ b/java/src/jmri/jmrix/secsi/SerialReply.java
@@ -26,6 +26,7 @@ public class SerialReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Is reply to poll message.
+     * @return element 0 of reply.
      * @see SerialSensorManager#reply(SerialReply)
      */
     public int getAddr() {

--- a/java/src/jmri/jmrix/secsi/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/secsi/SerialSensorManager.java
@@ -146,6 +146,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
 
     /**
      * Register any orphan Sensors when a new Serial Node is created.
+     * @param node node to register.
      */
     @SuppressWarnings("deprecation") // needs careful unwinding for Set operations
     public void registerSensorsForNode(SerialNode node) {

--- a/java/src/jmri/jmrix/secsi/SerialTrafficController.java
+++ b/java/src/jmri/jmrix/secsi/SerialTrafficController.java
@@ -57,6 +57,7 @@ public class SerialTrafficController extends AbstractMRNodeTrafficController imp
 
     /**
      * Set up for initialization of a Serial node.
+     * @param node node to initialize.
      */
     public void initializeSerialNode(SerialNode node) {
         synchronized (this) {

--- a/java/src/jmri/jmrix/secsi/SerialTurnout.java
+++ b/java/src/jmri/jmrix/secsi/SerialTurnout.java
@@ -23,6 +23,9 @@ public class SerialTurnout extends AbstractTurnout {
      * Create a Turnout object, with both system and user names.
      * <p>
      * 'systemName' was previously validated in SerialTurnoutManager.
+     * @param systemName turnout system name.
+     * @param userName turnout user name.
+     * @param _memo system connection.
      */
     public SerialTurnout(String systemName, String userName, SecsiSystemConnectionMemo _memo) {
         super(systemName, userName);

--- a/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigFrame.java
+++ b/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigFrame.java
@@ -57,6 +57,7 @@ public class NodeConfigFrame extends jmri.util.JmriJFrame {
 
     /**
      * Constructor method
+     * @param _memo system connection.
      */
     public NodeConfigFrame(SecsiSystemConnectionMemo _memo) {
         super();

--- a/java/src/jmri/jmrix/secsi/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/secsi/serialdriver/ConnectionConfig.java
@@ -15,6 +15,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/secsi/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/secsi/serialdriver/SerialDriverAdapter.java
@@ -194,7 +194,8 @@ public class SerialDriverAdapter extends SerialPortController {
 
     /**
      * Get an array of valid values for "option 2"; used to display valid
-     * options. May not be null, but may have zero entries
+     * options.May not be null, but may have zero entries
+     * @return zero entries.
      */
     public String[] validOption2() {
         return new String[]{""};

--- a/java/src/jmri/jmrix/secsi/simulator/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/secsi/simulator/ConnectionConfig.java
@@ -24,6 +24,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConf
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/serialsensor/SerialSensorAdapter.java
+++ b/java/src/jmri/jmrix/serialsensor/SerialSensorAdapter.java
@@ -212,6 +212,8 @@ public class SerialSensorAdapter extends AbstractSerialPortController {
 
     /**
      * Do a sensor change on the event queue.
+     * @param sensor sensor 
+     * @param value true if sensor changes on, else false.
      */
     public void notify(String sensor, boolean value) {
     }

--- a/java/src/jmri/jmrix/sprog/SprogCSStreamConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/SprogCSStreamConnectionConfig.java
@@ -16,6 +16,7 @@ public class SprogCSStreamConnectionConfig extends jmri.jmrix.AbstractStreamConn
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Stream port controller.
      */
     public SprogCSStreamConnectionConfig(jmri.jmrix.AbstractStreamPortController p) {
         super(p);

--- a/java/src/jmri/jmrix/sprog/SprogCSThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogCSThrottle.java
@@ -20,6 +20,8 @@ public class SprogCSThrottle extends AbstractThrottle {
 
     /**
      * Constructor.
+     * @param memo system connection.
+     * @param address Loco Address.
      */
     public SprogCSThrottle(SprogSystemConnectionMemo memo, LocoAddress address) {
         super(memo);

--- a/java/src/jmri/jmrix/sprog/SprogCSThrottleManager.java
+++ b/java/src/jmri/jmrix/sprog/SprogCSThrottleManager.java
@@ -19,6 +19,7 @@ public class SprogCSThrottleManager extends AbstractThrottleManager {
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public SprogCSThrottleManager(SprogSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/sprog/SprogCommandStation.java
+++ b/java/src/jmri/jmrix/sprog/SprogCommandStation.java
@@ -297,13 +297,19 @@ public class SprogCommandStation implements CommandStation, SprogListener, Runna
     }
 
     /**
-     * Handle speed changes from throttle. As well as updating an existing slot,
+     * Handle speed changes from throttle.
+     * <p>
+     * As well as updating an existing slot,
      * or creating a new on where necessary, the speed command is added to the
-     * queue of packets to be sent immediately. This ensures minimum latency
+     * queue of packets to be sent immediately.This ensures minimum latency
      * between the user adjusting the throttle and a loco responding, rather
      * than possibly waiting for a complete traversal of all slots before the
      * new speed is actually sent to the hardware.
      *
+     * @param mode speed step mode.
+     * @param address loco address.
+     * @param spd speed to send.
+     * @param isForward true if forward, else false.
      */
     public void setSpeed(jmri.SpeedStepMode mode, DccLocoAddress address, int spd, boolean isForward) {
         SprogSlot s = this.findAddressSpeedPacket(address);

--- a/java/src/jmri/jmrix/sprog/SprogPowerManager.java
+++ b/java/src/jmri/jmrix/sprog/SprogPowerManager.java
@@ -58,6 +58,7 @@ public class SprogPowerManager extends jmri.managers.AbstractPowerManager
     /**
      * Update power state after service mode programming operation
      * without sending a message to the SPROG.
+     * @param v new power state.
      */
     public void notePowerState(int v) {
         power = v;

--- a/java/src/jmri/jmrix/sprog/SprogThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogThrottle.java
@@ -21,6 +21,8 @@ public class SprogThrottle extends AbstractThrottle {
 
     /**
      * Constructor.
+     * @param memo system connection.
+     * @param address Loco address.
      */
     public SprogThrottle(SprogSystemConnectionMemo memo, DccLocoAddress address) {
         super(memo);

--- a/java/src/jmri/jmrix/sprog/SprogThrottleManager.java
+++ b/java/src/jmri/jmrix/sprog/SprogThrottleManager.java
@@ -19,17 +19,10 @@ public class SprogThrottleManager extends AbstractThrottleManager {
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public SprogThrottleManager(SprogSystemConnectionMemo memo) {
         super(memo);
-    }
-
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    static public SprogThrottleManager instance() {
-        return null;
     }
 
     boolean throttleInUse = false;

--- a/java/src/jmri/jmrix/sprog/SprogTurnout.java
+++ b/java/src/jmri/jmrix/sprog/SprogTurnout.java
@@ -25,6 +25,8 @@ public class SprogTurnout extends AbstractTurnout {
      * <p>
      * Sprog turnouts use the NMRA number (0-511) as their numerical
      * identification.
+     * @param number NMRA number.
+     * @param memo system connection.
      */
     public SprogTurnout(int number, SprogSystemConnectionMemo memo) {
         super(memo.getSystemPrefix() + "T" + number);

--- a/java/src/jmri/jmrix/sprog/pi/pisprognano/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/pi/pisprognano/ConnectionConfig.java
@@ -13,6 +13,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/sprog/pi/pisprognano/PiSprogNanoSerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/sprog/pi/pisprognano/PiSprogNanoSerialDriverAdapter.java
@@ -43,13 +43,6 @@ public class PiSprogNanoSerialDriverAdapter
         return new int[]{115200};
     }
 
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated  // will be removed when class converted to multi-system
-    static public PiSprogNanoSerialDriverAdapter instance() {
-        return null;
-    }
     // private final static Logger log = LoggerFactory.getLogger(PiSprogNanoSerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/sprog/pi/pisprogone/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/pi/pisprogone/ConnectionConfig.java
@@ -13,6 +13,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/sprog/pi/pisprogone/PiSprogOneSerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/sprog/pi/pisprogone/PiSprogOneSerialDriverAdapter.java
@@ -37,14 +37,7 @@ public class PiSprogOneSerialDriverAdapter
     public int[] validBaudNumbers() {
         return new int[]{115200};
     }
-
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated  // will be removed when class converted to multi-system
-    static public PiSprogOneSerialDriverAdapter instance() {
-        return null;
-    }
+    
     // private final static Logger log = LoggerFactory.getLogger(PiSprogOneSerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/sprog/pi/pisprogonecs/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/pi/pisprogonecs/ConnectionConfig.java
@@ -13,6 +13,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/sprog/pi/pisprogonecs/PiSprogOneCSSerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/sprog/pi/pisprogonecs/PiSprogOneCSSerialDriverAdapter.java
@@ -40,14 +40,7 @@ public class PiSprogOneCSSerialDriverAdapter
     public int[] validBaudNumbers() {
         return new int[]{115200};
     }
-
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated  // will be removed when class converted to multi-system
-    static public PiSprogOneCSSerialDriverAdapter instance() {
-        return null;
-    }
+    
     // private final static Logger log = LoggerFactory.getLogger(PiSprogOneCSSerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/sprog/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/serialdriver/ConnectionConfig.java
@@ -13,6 +13,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/sprog/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/sprog/serialdriver/SerialDriverAdapter.java
@@ -205,14 +205,6 @@ public class SerialDriverAdapter extends SprogPortController {
     InputStream serialStream = null;
 
     /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    static public SerialDriverAdapter instance() {
-        return null;
-    }
-
-    /**
      * Set up all of the other objects to operate with an Sprog command station
      * connected to this port.
      */

--- a/java/src/jmri/jmrix/sprog/simulator/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/simulator/ConnectionConfig.java
@@ -19,6 +19,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConf
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/sprog/sprog/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/sprog/ConnectionConfig.java
@@ -14,6 +14,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/sprog/sprogCS/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/sprogCS/ConnectionConfig.java
@@ -13,6 +13,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p Serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/sprog/sprogCS/SprogCSSerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/sprog/sprogCS/SprogCSSerialDriverAdapter.java
@@ -25,14 +25,6 @@ public class SprogCSSerialDriverAdapter
         this.getSystemConnectionMemo().setUserName(Bundle.getMessage("SprogCSTitle"));
     }
 
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated  // will be removed when class is converted
-    static public SprogCSSerialDriverAdapter instance() {
-        return null;
-    }
-
     // private final static Logger log = LoggerFactory.getLogger(SprogCSSerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/sprog/sprognano/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/sprognano/ConnectionConfig.java
@@ -13,6 +13,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/sprog/sprognano/SprogNanoSerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/sprog/sprognano/SprogNanoSerialDriverAdapter.java
@@ -24,14 +24,7 @@ public class SprogNanoSerialDriverAdapter
         //Set the username to match name; once refactored to handle multiple connections or user setable names/prefixes then this can be removed
         this.getSystemConnectionMemo().setUserName(Bundle.getMessage("SprogNanoCSTitle"));
     }
-
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated  // will be removed when superclass method is removed due to @Override
-    static public SprogNanoSerialDriverAdapter instance() {
-        return null;
-    }
+    
     // private final static Logger log = LoggerFactory.getLogger(SprogNanoSerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/sprog/sprogslotmon/SprogSlotMonDataModel.java
+++ b/java/src/jmri/jmrix/sprog/sprogslotmon/SprogSlotMonDataModel.java
@@ -260,10 +260,11 @@ public class SprogSlotMonDataModel extends javax.swing.table.AbstractTableModel 
     }
 
     /**
-     * Configure a table to have our standard rows and columns. This is
-     * optional, in that other table formats can use this table model. But we
-     * put it here to help keep it consistent.
+     * Configure a table to have our standard rows and columns.
+     * This is optional, in that other table formats can use this table model. 
+     * But we put it here to help keep it consistent.
      *
+     * @param slotTable the slot table to configure.
      */
     public void configureTable(JTable slotTable) {
         // allow reordering of the columns

--- a/java/src/jmri/jmrix/sprog/sprogslotmon/SprogSlotMonFrame.java
+++ b/java/src/jmri/jmrix/sprog/sprogslotmon/SprogSlotMonFrame.java
@@ -149,17 +149,6 @@ public class SprogSlotMonFrame extends jmri.util.JmriJFrame implements SprogList
         addHelpMenu("package.jmri.jmrix.sprog.sprogslotmon.SprogSlotMonFrame", true);  // NOI18N
     }
 
-    /**
-     * Find the existing SprogSlotMonFrame object.
-     *
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI
-     * multi-system support structure
-     */
-    @Deprecated
-    static public final SprogSlotMonFrame instance() {
-        return null;
-    }
-
     public void update() {
         slotModel.fireTableDataChanged();
     }

--- a/java/src/jmri/jmrix/sprog/update/SprogVersion.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogVersion.java
@@ -149,7 +149,8 @@ public class SprogVersion {
     }
 
     /**
-     *
+     * Custom toString with Version Number.
+     * @param s sprog version.
      * @return String representation of SPROG version
      */
     public String toString(SprogVersion s) {

--- a/java/src/jmri/jmrix/srcp/SRCPBusConnectionMemo.java
+++ b/java/src/jmri/jmrix/srcp/SRCPBusConnectionMemo.java
@@ -49,6 +49,7 @@ public class SRCPBusConnectionMemo extends jmri.jmrix.SystemConnectionMemo imple
 
     /**
      * Provides access to the TrafficController for this particular connection.
+     * @return SRCP Traffic Controller.
      */
     public SRCPTrafficController getTrafficController() {
         return et;
@@ -89,8 +90,10 @@ public class SRCPBusConnectionMemo extends jmri.jmrix.SystemConnectionMemo imple
     }
 
     /**
-     * Provides access to the Programmer for this particular connection. NOTE:
-     * Programmer defaults to null
+     * Provides access to the Programmer for this particular connection.
+     * <p>
+     * NOTE: Programmer defaults to null
+     * @return programmer manager.
      */
     public SRCPProgrammerManager getProgrammerManager() {
         return programmerManager;

--- a/java/src/jmri/jmrix/srcp/SRCPSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/srcp/SRCPSystemConnectionMemo.java
@@ -41,6 +41,7 @@ public class SRCPSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     /**
      * Provides access to the TrafficController for this particular connection.
+     * @return SRCP traffic controller.
      */
     public SRCPTrafficController getTrafficController() {
         return et;

--- a/java/src/jmri/jmrix/srcp/SRCPThrottleManager.java
+++ b/java/src/jmri/jmrix/srcp/SRCPThrottleManager.java
@@ -22,6 +22,7 @@ public class SRCPThrottleManager extends AbstractThrottleManager {
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public SRCPThrottleManager(SRCPBusConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/tams/TamsSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/tams/TamsSystemConnectionMemo.java
@@ -43,6 +43,7 @@ public class TamsSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     /**
      * Provides access to the TrafficController for this particular connection.
+     * @return Tams Traffic Controller.
      */
     public TamsTrafficController getTrafficController() {
         return et;
@@ -87,8 +88,9 @@ public class TamsSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
     }
 
     /**
-     * Provides access to the Programmer for this particular connection. NOTE:
-     * Programmer defaults to null
+     * Provides access to the Programmer for this particular connection.
+     * NOTE: Programmer defaults to null
+     * @return programmer manager.
      */
     public TamsProgrammerManager getProgrammerManager() {
         if (programmerManager == null) {

--- a/java/src/jmri/jmrix/tams/TamsThrottleManager.java
+++ b/java/src/jmri/jmrix/tams/TamsThrottleManager.java
@@ -22,6 +22,7 @@ public class TamsThrottleManager extends AbstractThrottleManager implements Tams
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public TamsThrottleManager(TamsSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/tams/TamsTurnout.java
+++ b/java/src/jmri/jmrix/tams/TamsTurnout.java
@@ -27,6 +27,8 @@ public class TamsTurnout extends AbstractTurnout
      * identification in the system name.
      *
      * @param number DCC address of the turnout
+     * @param prefix system prefic
+     * @param etc Tams system connection traffic controller
      */
     public TamsTurnout(int number, String prefix, TamsTrafficController etc) {
         super(prefix + "T" + number);

--- a/java/src/jmri/jmrix/tams/swing/TamsNamedPaneAction.java
+++ b/java/src/jmri/jmrix/tams/swing/TamsNamedPaneAction.java
@@ -15,13 +15,25 @@ import jmri.util.swing.WindowInterface;
 public class TamsNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction {
 
     /**
-     * Enhanced constructor for placing the pane in various GUIs
+     * Enhanced constructor for placing the pane in various GUIs.
+     * @param s action name.
+     * @param wi window interface in use.
+     * @param paneClass pane class.
+     * @param memo system connection.
      */
     public TamsNamedPaneAction(String s, WindowInterface wi, String paneClass, TamsSystemConnectionMemo memo) {
         super(s, wi, paneClass);
         this.memo = memo;
     }
 
+    /**
+     * Enhanced constructor for placing the pane in various GUIs.
+     * @param s action name.
+     * @param i icon to use
+     * @param wi window interface in use.
+     * @param paneClass pane class.
+     * @param memo system connection.
+     */
     public TamsNamedPaneAction(String s, Icon i, WindowInterface wi, String paneClass, TamsSystemConnectionMemo memo) {
         super(s, i, wi, paneClass);
         this.memo = memo;

--- a/java/src/jmri/jmrix/tams/swing/TamsPanelInterface.java
+++ b/java/src/jmri/jmrix/tams/swing/TamsPanelInterface.java
@@ -13,10 +13,11 @@ import jmri.jmrix.tams.TamsSystemConnectionMemo;
 public interface TamsPanelInterface {
 
     /**
-     * 2nd stage of initialization, invoked after the constuctor is complete.
+     * 2nd stage of initialization, invoked after the constructor is complete.
      * <p>
      * This needs to be connected to the initContext() method in implementing
      * classes.
+     * @param memo system Connection.
      */
     public void initComponents(TamsSystemConnectionMemo memo);
 

--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -51,10 +51,15 @@ public class Log4JUtil {
 
     /**
      * Emit a particular WARNING-level message just once.
+     * <p>
+     * Goal is to be lightweight and fast;
+     * this will only be used in a few places,
+     * and only those should appear in data structure.
+     * @param logger The Logger to warn.
+     * @param msg Message.
+     * @param args Message Arguments.
      * @return true if the log was emitted this time
      */
-    // Goal is to be lightweight and fast; this will only be used in a few places,
-    // and only those should appear in data structure.
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "SLF4J_UNKNOWN_ARRAY",justification="Passing varargs array through")
     static public boolean warnOnce(@Nonnull Logger logger, @Nonnull String msg, Object... args) {
         Set<String> loggerSet = warnedOnce.get(logger);
@@ -91,11 +96,14 @@ public class Log4JUtil {
     
     /**
      * Warn that a deprecated method has been invoked.
-     * Can also be used to warn of some deprecated condition, i.e.
-     * obsolete-format input data.
      * <p>
-     * Thie logging is turned off by default during testing to
+     * Can also be used to warn of some deprecated condition,
+     * i.e. obsolete-format input data.
+     * <p>
+     * The logging is turned off by default during testing to
      * simplify updating tests when warnings are added.
+     * @param logger The Logger to warn.
+     * @param methodName method name.
      */
      static public void deprecationWarning(@Nonnull Logger logger, @Nonnull String methodName) {
         if (logDeprecations) {
@@ -111,6 +119,7 @@ public class Log4JUtil {
      * Should only be used by test code. We denote this
      * by marking it deprecated, but we don't intend to remove it.
      * (Might have to if we start removing deprecated references from test code)
+     * @param log true to log deprecations, else false.
      * @deprecated - do not remove
      */
     @Deprecated // do not remove
@@ -122,6 +131,7 @@ public class Log4JUtil {
      * Should only be used by test code. We denote this
      * by marking it deprecated, but we don't intend to remove it.
      * (Might have to if we start removing deprecated references from test code)
+     * @return true if deprecation warnings are logged.
      * @deprecated - do not remove
      */
     @Deprecated // do not remove
@@ -267,6 +277,7 @@ public class Log4JUtil {
      * <p>
      * If you then pass it to 
      * Log4J for logging, it'll take up less space.
+     * @param <T> Throwable generic
      * @param t The Throwable to truncate and return
      * @return The original object with truncated stack trace
      */
@@ -288,6 +299,7 @@ public class Log4JUtil {
      * <p>
      * If you then pass it to 
      * Log4J for logging, it'll take up less space.
+     * @param <T> Throwable generic
      * @param t The Throwable to truncate and return
      * @param len The number of stack trace entries to keep.
      * @return The original object with truncated stack trace

--- a/java/src/jmri/util/QuickPromptUtil.java
+++ b/java/src/jmri/util/QuickPromptUtil.java
@@ -22,8 +22,9 @@ import javax.swing.SwingConstants;
 public class QuickPromptUtil {
 
     /**
-     * Utility function to prompt for new string value
+     * Utility function to prompt for new string value.
      *
+     * @param parentComponent the parent component
      * @param message  the prompt message
      * @param title    the dialog title
      * @param oldValue the original string value
@@ -41,8 +42,9 @@ public class QuickPromptUtil {
     }
 
     /**
-     * Utility function to prompt for new integer value
+     * Utility function to prompt for new integer value.
      *
+     * @param parentComponent the parent component
      * @param message  the prompt message
      * @param title    the dialog title
      * @param oldValue the original integer value
@@ -155,8 +157,9 @@ public class QuickPromptUtil {
     }
 
     /**
-     * Utility function to prompt for new float value
+     * Utility function to prompt for new float value.
      *
+     * @param parentComponent the parent component.
      * @param message  the prompt message
      * @param title    the dialog title
      * @param oldValue the original float value
@@ -176,8 +179,9 @@ public class QuickPromptUtil {
     }
 
     /**
-     * Utility function to prompt for new double value
+     * Utility function to prompt for new double value.
      *
+     * @param parentComponent the parent component
      * @param message  the prompt message
      * @param title    the dialog title
      * @param oldValue the original double value

--- a/java/src/jmri/util/ThreadingUtil.java
+++ b/java/src/jmri/util/ThreadingUtil.java
@@ -126,7 +126,7 @@ public class ThreadingUtil {
     }
 
     /**
-     * Run some GUI-specific code before returning a value
+     * Run some GUI-specific code before returning a value.
      * <p>
      * Typical uses:
      * <p>
@@ -139,6 +139,7 @@ public class ThreadingUtil {
      * If an InterruptedException is encountered, it'll be deferred to the next
      * blocking call via Thread.currentThread().interrupt()
      * 
+     * @param <E> generic
      * @param ta What to run, usually as a lambda expression
      * @return the value returned by ta
      */
@@ -226,13 +227,18 @@ public class ThreadingUtil {
 
     /**
      * Create a new thread in the JMRI group
+     * @param runner Runnable.
+     * @return new Thread.
      */
     static public Thread newThread(Runnable runner) {
         return new Thread(getJmriThreadGroup(), runner);
     }
     
     /**
-     * Create a new thread in the JMRI group
+     * Create a new thread in the JMRI group.
+     * @param runner Thread runnable.
+     * @param name Thread name.
+     * @return New Thread.
      */
     static public Thread newThread(Runnable runner, String name) {
         return new Thread(getJmriThreadGroup(), runner, name);
@@ -240,8 +246,9 @@ public class ThreadingUtil {
     
     /**
      * Get the JMRI default thread group.
-     * This should be passed to as the first argument to the {@link Thread} constructor
-     * so we can track JMRI-created threads.
+     * This should be passed to as the first argument to the {@link Thread} 
+     * constructor so we can track JMRI-created threads.
+     * @return JMRI default thread group.
      */
     static public ThreadGroup getJmriThreadGroup() {
         // we access this dynamically instead of keeping it in a static

--- a/java/src/jmri/util/UnzipFileClass.java
+++ b/java/src/jmri/util/UnzipFileClass.java
@@ -17,12 +17,13 @@ import java.util.zip.ZipInputStream;
 public class UnzipFileClass {
 
     /**
-     * Unzip contents into a directory
+     * Unzip contents into a directory.
      *
      * @param destinationFolder Destination for contents, created if need be;
-     *                          relative or absolute, but must be pre-expanded
+     *                          relative or absolute, but must be pre-expanded.
      * @param zipFile           .zip file name; relative or absolute, but must
-     *                          be pre-expanded
+     *                          be pre-expanded.
+     * @throws                  java.io.FileNotFoundException if File Not Found.
      */
     public static void unzipFunction(String destinationFolder, String zipFile) throws java.io.FileNotFoundException {
         File directory = new File(destinationFolder);
@@ -32,7 +33,7 @@ public class UnzipFileClass {
     }
 
     /**
-     * Unzip contents into a directory
+     * Unzip contents into a directory.
      *
      * @param directory Destination for contents, created if need be
      * @param input     in .zip format

--- a/pom.xml
+++ b/pom.xml
@@ -677,7 +677,7 @@
                     <sourcepath>${basedir}/java/src:${project.build.directory}/generated-sources/javacc:${project.build.directory}/generated-sources/jjtree</sourcepath>
                     <show>package</show>
                     <!-- change from default 100 warnings; keep number synced with ant javadoc-lint target -->
-                    <additionalJOption>-breakiterator -Xmaxwarns 1650</additionalJOption>
+                    <additionalJOption>-breakiterator -Xmaxwarns 1300</additionalJOption>
                     <!-- remove ",-missing" to get warnings about missing Javadoc tags -->
                     <doclint>all,-missing</doclint>
                     <author>true</author><!-- default -->


### PR DESCRIPTION
Javadoc update.

Primarily jmrix, tams, srcp, sprog, secsi, serial, rps, roco, rfid, qsi, pricom, olcb, oaktree, mqtt, marklin, maple.
Extra javadoc for some CAN classes.

Reduces javadoc-lint actual from 1550 to 1200
Sets max from 1650 to 1300

Removes small number of deprecated 4.4 instance methods.