### PR TITLE
Javadoc lint jmrix

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1915,7 +1915,7 @@
             </packageset>
             <arg value="-Xdoclint:all"/><!-- remove -missing to get warnings about missing javadoc tags -->
             <arg value="-Xmaxwarns"/>
-            <arg value="1300"/><!-- change from default 100 warnings; keep synced with pom.xml, other javadoc targets -->
+            <arg value="700"/><!-- change from default 100 warnings; keep synced with pom.xml, other javadoc targets -->
             <arg value="-quiet"/>
             <arg value="-splitindex"/>
             <arg value="-J-Dhttp.agent=javadoc"/>

--- a/java/src/jmri/jmrix/AbstractMRMessage.java
+++ b/java/src/jmri/jmrix/AbstractMRMessage.java
@@ -90,14 +90,18 @@ abstract public class AbstractMRMessage extends AbstractMessage {
     private int mNeededMode;
 
     /**
-     * final so that it can be called in constructors
+     * Set a needed mode.
+     * Final so that it can be called in constructors.
+     * @param pMode required mode value.
      */
     final public void setNeededMode(int pMode) {
         mNeededMode = pMode;
     }
 
     /**
-     * final so that it can be called in constructors
+     * Get needed mode.
+     * Final so that it can be called in constructors.
+     * @return mNeededMode required mode value.
      */
     final public int getNeededMode() {
         return mNeededMode;
@@ -111,6 +115,7 @@ abstract public class AbstractMRMessage extends AbstractMessage {
      * <p>
      * If this returns false, the transmit queue will immediately go on to
      * transmit the next message (if any).
+     * @return true by default in Abstract MR message.
      */
     public boolean replyExpected() {
         return true;
@@ -120,14 +125,18 @@ abstract public class AbstractMRMessage extends AbstractMessage {
     private boolean _isBinary;
 
     /**
-     * final so that it can be called in constructors
+     * Get if is binary.
+     * Final so that it can be called in constructors.
+     * @return true if binary, else false.
      */
     final public boolean isBinary() {
         return _isBinary;
     }
 
     /**
-     * final so that it can be called in constructors
+     * Set if Binary.
+     * final so that it can be called in constructors.
+     * @param b true if binary, else false.
      */
     final public void setBinary(boolean b) {
         _isBinary = b;
@@ -148,14 +157,18 @@ abstract public class AbstractMRMessage extends AbstractMessage {
     private int mTimeout;  // in milliseconds
 
     /**
-     * final so that it can be called in constructors
+     * Set Timeout.
+     * Final so that it can be called in constructors.
+     * @param t timeout value.
      */
     final public void setTimeout(int t) {
         mTimeout = t;
     }
 
     /**
-     * final so that it can be called in constructors
+     * Get Timeout.
+     * Final so that it can be called in constructors.
+     * @return timeout value.
      */
     final public int getTimeout() {
         return mTimeout;
@@ -166,14 +179,18 @@ abstract public class AbstractMRMessage extends AbstractMessage {
     private int mRetries = 0; // number of retries, default = 0;
 
     /**
-     * final so that it can be called in constructors
+     * Set number of retries.
+     * Final so that it can be called in constructors
+     * @param i number of retries, actual value to set, not an increment.
      */
     final public void setRetries(int i) {
         mRetries = i;
     }
 
     /**
+     * Get number of retries.
      * final so that it can be called in constructors
+     * @return number of retries count.
      */
     final public int getRetries() {
         return mRetries;
@@ -198,6 +215,8 @@ abstract public class AbstractMRMessage extends AbstractMessage {
     /**
      * Put an int value into the message as 
      * two ASCII upper-case hex characters.
+     * @param val value to convert.
+     * @param offset offset in message.
      */
     public void addIntAsTwoHex(int val, int offset) {
         String s = ("" + Integer.toHexString(val)).toUpperCase();
@@ -214,6 +233,8 @@ abstract public class AbstractMRMessage extends AbstractMessage {
     /**
      * Put an int value into the message as 
      * three ASCII upper-case hex characters.
+     * @param val value to convert.
+     * @param offset offset in message.
      */
     public void addIntAsThreeHex(int val, int offset) {
         String s = ("" + Integer.toHexString(val)).toUpperCase();
@@ -234,6 +255,8 @@ abstract public class AbstractMRMessage extends AbstractMessage {
     /**
      * Put an int value into the message as 
      * four ASCII upper-case hex characters.
+     * @param val value to convert.
+     * @param offset offset in message.
      */
     public void addIntAsFourHex(int val, int offset) {
         String s = ("" + Integer.toHexString(val)).toUpperCase();

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -176,7 +176,10 @@ public abstract class AbstractMRTrafficController {
 
     /**
      * Implement this to forward a specific message type to a protocol-specific
-     * listener interface. This puts the casting into the concrete class.
+     * listener interface.
+     * This puts the casting into the concrete class.
+     * @param client abstract listener.
+     * @param m message to forward.
      */
     protected abstract void forwardMessage(AbstractMRListener client, AbstractMRMessage m);
 
@@ -1034,6 +1037,7 @@ public abstract class AbstractMRTrafficController {
      * <p>
      * (This is public for testing purposes) Runs in the "Receive" thread.
      *
+     * @throws java.io.IOException on error.
      */
     public void handleOneIncomingReply() throws IOException {
         // we sit in this until the message is complete, relying on
@@ -1155,6 +1159,8 @@ public abstract class AbstractMRTrafficController {
 
     /**
      * Log an error message for a message received in an unexpected state.
+     * @param State message state.
+     * @param msgString message string.
      */
     protected void unexpectedReplyStateError(int State, String msgString) {
        String[] packages = this.getClass().getName().split("\\.");
@@ -1165,7 +1171,8 @@ public abstract class AbstractMRTrafficController {
 
     /**
      * for testing purposes, let us be able to find out
-     * what the last sender was
+     * what the last sender was.
+     * @return last sender, mLastSender.
      */
     public AbstractMRListener getLastSender() {
         return mLastSender;

--- a/java/src/jmri/jmrix/AbstractMonFrame.java
+++ b/java/src/jmri/jmrix/AbstractMonFrame.java
@@ -382,8 +382,10 @@ public abstract class AbstractMonFrame extends JmriJFrame {
     }
 
     /** 
-     * Get access to the main text area. This is intended
-     * for use in e.g. scripting to extend the behavior of the window.
+     * Get access to the main text area.
+     * This is intended for use in e.g. scripting 
+     * to extend the behaviour of the window.
+     * @return the text area.
      */
     public final synchronized JTextArea getTextArea() {
         return monTextPane;

--- a/java/src/jmri/jmrix/AbstractNode.java
+++ b/java/src/jmri/jmrix/AbstractNode.java
@@ -49,6 +49,7 @@ public abstract class AbstractNode {
     /**
      * Check for valid address with respect to range, etc.
      *
+     * @param address node number to check.
      * @return true if valid
      */
     abstract protected boolean checkNodeAddress(int address);
@@ -63,6 +64,7 @@ public abstract class AbstractNode {
 
     /**
      * Create a Transmit packet (AbstractMRMessage) to send current state.
+     * @return packet to send current node state.
      */
     abstract public AbstractMRMessage createOutPacket();
 
@@ -90,7 +92,8 @@ public abstract class AbstractNode {
     abstract public void resetTimeout(AbstractMRMessage m);
 
     /**
-     * Return state of needSend flag.
+     * Get Must Send state.
+     * @return state of needSend flag.
      */
     public boolean mustSend() {
         return needSend;

--- a/java/src/jmri/jmrix/ActiveSystemsMenu.java
+++ b/java/src/jmri/jmrix/ActiveSystemsMenu.java
@@ -30,6 +30,7 @@ public class ActiveSystemsMenu extends JMenu {
 
     /**
      * Add menus for active systems to the menu bar.
+     * @param m the menu bar to add the system menu to.
      */
     static public void addItems(JMenuBar m) {
 
@@ -51,6 +52,7 @@ public class ActiveSystemsMenu extends JMenu {
 
     /**
      * Add active systems as submenus inside a single menu entry.
+     * @param m menu to add the sub menus to.
      */
     static public void addItems(JMenu m) {
 

--- a/java/src/jmri/jmrix/NetMessage.java
+++ b/java/src/jmri/jmrix/NetMessage.java
@@ -42,7 +42,8 @@ public abstract class NetMessage implements Serializable {
     }
 
     /**
-     * Get a String representation of the op code in hex
+     * Get a String representation of the op code in hex.
+     * @return string of Opcode, 0x format.
      */
     public String getOpCodeHex() {
         return "0x" + Integer.toHexString(getOpCode());
@@ -50,6 +51,7 @@ public abstract class NetMessage implements Serializable {
 
     /**
      * Get length, including op code and error-detection byte
+     * @return total number of data elements.
      */
     public int getNumDataElements() {
         return mNDataBytes;
@@ -84,6 +86,7 @@ public abstract class NetMessage implements Serializable {
 
     /**
      * check whether the message has a valid parity
+     * @return true if parity valid, else false.
      */
     public abstract boolean checkParity();
 

--- a/java/src/jmri/jmrix/NetworkPortAdapter.java
+++ b/java/src/jmri/jmrix/NetworkPortAdapter.java
@@ -12,6 +12,9 @@ public interface NetworkPortAdapter extends PortAdapter {
 
     /**
      * Connects to the end device using a hostname/ip address and port
+     * @param host hostname / ip address.
+     * @param port network port.
+     * @throws java.io.IOException on connection error.
      */
     public void connect(String host, int port) throws java.io.IOException;
 
@@ -24,14 +27,15 @@ public interface NetworkPortAdapter extends PortAdapter {
     /**
      * Query the status of this connection.
      *
-     * @return true if all is OK, at least as far as known
+     * @return true if all is OK, at least as far as known.
      */
     @Override
     public boolean status();
 
     /**
-     * Remember the associated port name
+     * Remember the associated port name.
      *
+     * @param s port name.
      */
     public void setPort(String s);
 

--- a/java/src/jmri/jmrix/SerialPortAdapter.java
+++ b/java/src/jmri/jmrix/SerialPortAdapter.java
@@ -14,6 +14,7 @@ public interface SerialPortAdapter extends PortAdapter {
 
     /**
      * Provide a vector of valid port names, each a String.
+     * @return port names.
      */
     public Vector<String> getPortNames();
 
@@ -23,6 +24,7 @@ public interface SerialPortAdapter extends PortAdapter {
      * @param portName name tu use for this port
      * @param appName provided to the underlying OS during startup so
      *                that it can show on status displays, etc.
+     * @return null indicates OK return, else error message.
      */
     public String openPort(String portName, String appName);
 
@@ -137,6 +139,12 @@ public interface SerialPortAdapter extends PortAdapter {
     /**
      * Error handling for busy port at open.
      *
+     * @param p        the exception being handled, if additional information
+     *                 from it is desired.
+     * @param portName name of the port being accessed.
+     * @param log      where to log a status message.
+     * @return Localized message, in case separate presentation to user is
+     *         desired.
      * @see jmri.jmrix.AbstractSerialPortController
      */
     public String handlePortBusy(PortInUseException p, String portName, Logger log);

--- a/java/src/jmri/jmrix/acela/AcelaAddress.java
+++ b/java/src/jmri/jmrix/acela/AcelaAddress.java
@@ -31,8 +31,14 @@ public class AcelaAddress {
 
     /**
      * Public static method to parse an Acela system name and return the Acela
-     * Node Address Note: Returns '-1' if illegal systemName format or if the
-     * node is not found. Nodes are numbered from 0 - {@value AcelaNode#MAXNODE}.
+     * Node Address.
+     * <p>
+     * Note: Returns '-1' if illegal systemName format or if the
+     * node is not found.
+     * Nodes are numbered from 0 - {@value AcelaNode#MAXNODE}.
+     * @param systemName system name.
+     * @param memo system connection.
+     * @return node address number.
      */
     public static int getNodeAddressFromSystemName(String systemName, AcelaSystemConnectionMemo memo) {
         // validate the system Name leader characters
@@ -60,6 +66,8 @@ public class AcelaAddress {
     /**
      * Public static method to parse an Acela system name.
      *
+     * @param systemName system name to parse.
+     * @param memo system connection.
      * @return the Acela Node number, return 'null' if illegal systemName format or if the node is
      * not found
      */
@@ -83,6 +91,8 @@ public class AcelaAddress {
      * Public static method to parse an Acela system name and return the bit number.
      * Note: Bits are numbered from 1.
      *
+     * @param systemName system name.
+     * @param prefix bean type, S, T, L or H.
      * @return the bit number, return -1 if an error is found (0 is a valid bit?)
      */
     public static int getBitFromSystemName(String systemName, String prefix) {
@@ -113,6 +123,9 @@ public class AcelaAddress {
      * Public static method to validate system name format.
      * Logging of handled cases no higher than WARN.
      *
+     * @param systemName system name to validate.
+     * @param type bean type, S, T or L.
+     * @param prefix system prefix.
      * @return 'true' if system name has a valid format, else return 'false'
      */
     public static NameValidity validSystemNameFormat(@Nonnull String systemName, char type, String prefix) {
@@ -141,6 +154,9 @@ public class AcelaAddress {
     /**
      * Public static method to validate Acela system name for configuration.
      *
+     * @param systemName system name to validate.
+     * @param type bean type, S, T or L.
+     * @param memo system connection.
      * @return 'true' if system name has a valid meaning in current
      * configuration, else return 'false'
      */
@@ -188,6 +204,8 @@ public class AcelaAddress {
      * Public static method to convert one format Acela system name for the
      * alternate format.
      *
+     * @param systemName system name to convert.
+     * @param prefix system prefix.
      * @return name (string) in alternate format, or empty string if the supplied
      * system name does not have a valid format, or if there is no representation
      * in the alternate naming scheme.
@@ -209,6 +227,8 @@ public class AcelaAddress {
      * This routine is used to ensure that each system name is uniquely linked
      * to one Acela bit, by removing extra zeros inserted by the user.
      *
+     * @param systemName system name to normalize.
+     * @param prefix system prefix.
      * @return a normalized name is returned in the same format as the input name,
      * or an empty string if the supplied system name does not have a valid format.
      */
@@ -232,8 +252,12 @@ public class AcelaAddress {
 
     /**
      * Public static method to construct an Acela system name from type
-     * character, node address, and bit number
+     * character, node address, and bit number.
      *
+     * @param type bean type letter, S, T or L.
+     * @param nAddress node address.
+     * @param bitNum bit number.
+     * @param memo system connection.
      * @return a system name in the ALxxxx, ATxxxx, or ASxxxx
      * format. The returned name is normalized.
      * Return the null string "" if the supplied character is not valid,
@@ -273,6 +297,8 @@ public class AcelaAddress {
     /**
      * Public static method to check the user name for a valid system name.
      *
+     * @param systemName system name to check.
+     * @param prefix bean prefix, S, T or L.
      * @return "" (null string) if the system name is not valid or does not exist
      */
     public static String getUserNameFromSystemName(String systemName, String prefix) {

--- a/java/src/jmri/jmrix/acela/AcelaMessage.java
+++ b/java/src/jmri/jmrix/acela/AcelaMessage.java
@@ -32,6 +32,7 @@ public class AcelaMessage extends jmri.jmrix.AbstractMRMessage {
      * This ctor interprets the String as the exact sequence to send,
      * byte-for-byte.
      *
+     * @param m string form of message.
      */
     public AcelaMessage(String m) {
         super(m);

--- a/java/src/jmri/jmrix/acela/AcelaNode.java
+++ b/java/src/jmri/jmrix/acela/AcelaNode.java
@@ -235,6 +235,7 @@ public class AcelaNode extends AbstractNode {
     /**
      * Set starting output address for range.
      * Used to help linear address search.
+     * @param startingAddress starting output address for range.
      */
     public void setStartingOutputAddress(int startingAddress) {
         startingOutputAddress = startingAddress;
@@ -243,6 +244,7 @@ public class AcelaNode extends AbstractNode {
     /**
      * Get starting output address for range.
      * Used to help linear address search.
+     * @return starting output address.
      */
     public int getStartingOutputAddress() {
         return startingOutputAddress;
@@ -251,6 +253,7 @@ public class AcelaNode extends AbstractNode {
     /**
      * Set ending output address for range.
      * Used to help linear address search.
+     * @param endingAddress end output address for range.
      */
     public void setEndingOutputAddress(int endingAddress) {
         endingOutputAddress = endingAddress;
@@ -259,6 +262,7 @@ public class AcelaNode extends AbstractNode {
     /**
      * Get ending output address for range.
      * Used to help linear address search.
+     * @return end output address for range.
      */
     public int getEndingOutputAddress() {
         return endingOutputAddress;
@@ -267,6 +271,7 @@ public class AcelaNode extends AbstractNode {
     /**
      * Set starting sensor address for range.
      * Used to help linear address search.
+     * @param startingAddress start sensor address for range.
      */
     public void setStartingSensorAddress(int startingAddress) {
         startingSensorAddress = startingAddress;
@@ -275,6 +280,7 @@ public class AcelaNode extends AbstractNode {
     /**
      * Get starting sensor addresses for range.
      * Used to help linear address search.
+     * @return starting sensor address for range.
      */
     public int getStartingSensorAddress() {
         return startingSensorAddress;
@@ -283,6 +289,7 @@ public class AcelaNode extends AbstractNode {
     /**
      * Set ending sensor addresses for range.
      * Used to help linear address search.
+     * @param endingAddress end sensor address.
      */
     public void setEndingSensorAddress(int endingAddress) {
         endingSensorAddress = endingAddress;
@@ -291,6 +298,7 @@ public class AcelaNode extends AbstractNode {
     /**
      * Get ending sensor addresses for range.
      * Used to help linear address search.
+     * @return end of range sensor address.
      */
     public int getEndingSensorAddress() {
         return endingSensorAddress;
@@ -359,6 +367,8 @@ public class AcelaNode extends AbstractNode {
 
     /**
      * Get Output configuration values.
+     * @param circuitnum wired output index number.
+     * @return  configuration value.
      */
     public int getOutputWired(int circuitnum) {
         return outputWired[circuitnum];
@@ -371,6 +381,8 @@ public class AcelaNode extends AbstractNode {
 
     /**
      * Set Output configuration values.
+     * @param circuitnum output index number.
+     * @param type output type.
      */
     public void setOutputWired(int circuitnum, int type) {
         outputWired[circuitnum] = type;
@@ -459,6 +471,8 @@ public class AcelaNode extends AbstractNode {
 
     /**
      * Public method to set and return Sensor configuration values.
+     * @param circuitnum sensor type array index number.
+     * @return sensor index value.
      */
     public int getSensorType(int circuitnum) {
         return sensorType[circuitnum];
@@ -506,6 +520,7 @@ public class AcelaNode extends AbstractNode {
 
     /**
      * Public method to return node type.
+     * @return node type number.
      */
     public int getNodeType() {
         return (nodeType);
@@ -517,6 +532,7 @@ public class AcelaNode extends AbstractNode {
 
     /**
      * Public method to set node type.
+     * @param stringtype string form of node type.
      */
     public void setNodeTypeString(String stringtype) {
         int type = moduleTypes.lastIndexOf(stringtype) / 2;
@@ -567,6 +583,7 @@ public class AcelaNode extends AbstractNode {
 
     /**
      * Public method to return number of bits per card.
+     * @return number of output bits per card.
      */
     public int getNumOutputBitsPerCard() {
         return (outputbitsPerCard);
@@ -594,7 +611,8 @@ public class AcelaNode extends AbstractNode {
     }
 
     /**
-     * Get the transmission delay on thsi node.
+     * Get the transmission delay on this node.
+     * @return delay in 10s of microseconds.
      */
     public int getTransmissionDelay() {
         return (transmissionDelay);

--- a/java/src/jmri/jmrix/acela/AcelaSensorManager.java
+++ b/java/src/jmri/jmrix/acela/AcelaSensorManager.java
@@ -224,6 +224,7 @@ public class AcelaSensorManager extends jmri.managers.AbstractSensorManager
 
     /**
      * Register any orphan Sensors when a new Acela Node is created.
+     * @param node which node to search for sensors.
      */
     @SuppressWarnings("deprecation") // needs careful unwinding for Set operations
     public void registerSensorsForNode(AcelaNode node) {

--- a/java/src/jmri/jmrix/acela/AcelaSignalHead.java
+++ b/java/src/jmri/jmrix/acela/AcelaSignalHead.java
@@ -17,7 +17,8 @@ public class AcelaSignalHead extends DefaultSignalHead {
     /**
      * Create a SignalHead object, with only a system name.
      * <p>
-     * 'systemName' should have been previously validated
+     * @param systemName should have been previously validated.
+     * @param memo system connection.
      */
     public AcelaSignalHead(String systemName, AcelaSystemConnectionMemo memo) {
         super(systemName);
@@ -42,7 +43,9 @@ public class AcelaSignalHead extends DefaultSignalHead {
     /**
      * Create a SignalHead object, with both system and user names.
      * <p>
-     * 'systemName' should have been previously validated
+     * @param systemName should have been previously validated.
+     * @param userName user name.
+     * @param memo system connection.
      */
     public AcelaSignalHead(String systemName, String userName, AcelaSystemConnectionMemo memo) {
         super(systemName, userName);

--- a/java/src/jmri/jmrix/acela/AcelaSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/acela/AcelaSystemConnectionMemo.java
@@ -55,6 +55,7 @@ public class AcelaSystemConnectionMemo extends SystemConnectionMemo {
 
     /**
      * Provides access to the TrafficController for this particular connection.
+     * @return traffic controller, provided if null.
      */
     public AcelaTrafficController getTrafficController() {
         if (tc == null) {

--- a/java/src/jmri/jmrix/acela/AcelaTrafficController.java
+++ b/java/src/jmri/jmrix/acela/AcelaTrafficController.java
@@ -93,6 +93,7 @@ public class AcelaTrafficController extends AbstractMRNodeTrafficController impl
 
     /**
      * Get minimum address of an Acela node as set on this TrafficController.
+     * @return minimum node address.
      */
     public int getMinimumNodeAddress() {
         return minNode;
@@ -100,6 +101,7 @@ public class AcelaTrafficController extends AbstractMRNodeTrafficController impl
 
     /**
      * Get maximum number of Acela nodes as set on this TrafficController.
+     * @return max number of nodes.
      */
     public int getMaximumNumberOfNodes() {
         return maxNode;
@@ -154,6 +156,7 @@ public class AcelaTrafficController extends AbstractMRNodeTrafficController impl
 
     /**
      * Public method to register an Acela node.
+     * @param node which node to register.
      */
     public void registerAcelaNode(AcelaNode node) {
         synchronized (this) {
@@ -190,6 +193,7 @@ public class AcelaTrafficController extends AbstractMRNodeTrafficController impl
 
     /**
      * Public method to set up for initialization of an Acela node.
+     * @param node which node to initialize.
      */
     public void initializeAcelaNode(AcelaNode node) {
         synchronized (this) {
@@ -203,6 +207,8 @@ public class AcelaTrafficController extends AbstractMRNodeTrafficController impl
      * <p>
      * Note: nodeAddress is numbered from 0
      *
+     * @param bitAddress address to query.
+     * @param isSensor true to use start sensor address, false to use start output address.
      * @return '-1' if an AcelaNode with the specified address was not found
      */
     public int lookupAcelaNodeAddress(int bitAddress, boolean isSensor) {
@@ -237,6 +243,7 @@ public class AcelaTrafficController extends AbstractMRNodeTrafficController impl
 
     /**
      * Forward an AcelaMessage to all registered AcelaInterface listeners.
+     * {@inheritDoc}
      */
     @Override
     protected void forwardMessage(AbstractMRListener client, AbstractMRMessage m) {
@@ -245,6 +252,7 @@ public class AcelaTrafficController extends AbstractMRNodeTrafficController impl
 
     /**
      * Forward an AcelaReply to all registered AcelaInterface listeners.
+     * {@inheritDoc}
      */
     @Override
     protected void forwardReply(AbstractMRListener client, AbstractMRReply m) {
@@ -397,6 +405,7 @@ public class AcelaTrafficController extends AbstractMRNodeTrafficController impl
 
     /**
      * Forward a pre-formatted message to the actual interface.
+     * {@inheritDoc}
      */
     @Override
     public void sendAcelaMessage(AcelaMessage m, AcelaListener reply) {
@@ -463,6 +472,7 @@ public class AcelaTrafficController extends AbstractMRNodeTrafficController impl
 
     /**
      * For each sensor node call markChanges.
+     * @param r reply to use in sensor update.
      */
     public void updateSensorsFromPoll(AcelaReply r) {
         for (int i = 0; i < getNumNodes(); i++) {

--- a/java/src/jmri/jmrix/acela/AcelaTurnoutManager.java
+++ b/java/src/jmri/jmrix/acela/AcelaTurnoutManager.java
@@ -38,6 +38,8 @@ public class AcelaTurnoutManager extends AbstractTurnoutManager {
      * Assumes calling method has checked that a Turnout with this
      * system name does not already exist.
      *
+     * @param systemName turnout system name.
+     * @param userName turnout user name.
      * @return null if the system name is not in a valid format
      */
     @Override
@@ -94,6 +96,7 @@ public class AcelaTurnoutManager extends AbstractTurnoutManager {
     /**
      * Public method to validate system name for configuration.
      *
+     * @param systemName system name to validate.
      * @return 'true' if system name has a valid meaning in the current
      * configuration, else return 'false'
      */
@@ -102,9 +105,10 @@ public class AcelaTurnoutManager extends AbstractTurnoutManager {
     }
 
     /**
-     * Public method to convert system name to its alternate format
+     * Public method to convert system name to its alternate format.
      * <p>
-     * Returns a normalized system name if system name is valid and has a valid
+     * @param systemName system name to convert.
+     * @return a normalized system name if system name is valid and has a valid
      * alternate representation, else return "".
      */
     public String convertSystemNameToAlternate(String systemName) {

--- a/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigFrame.java
+++ b/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigFrame.java
@@ -158,7 +158,8 @@ public class NodeConfigFrame extends jmri.util.JmriJFrame {
     protected javax.swing.JTextField receiveDelayField = new javax.swing.JTextField(3);
 
     /**
-     * Constructor method
+     * Constructor method.
+     * @param memo system connection.
      */
     public NodeConfigFrame(AcelaSystemConnectionMemo memo) {
         super();

--- a/java/src/jmri/jmrix/acela/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/acela/serialdriver/SerialDriverAdapter.java
@@ -153,22 +153,6 @@ public class SerialDriverAdapter extends AcelaPortController {
     private boolean opened = false;
     InputStream serialStream = null;
 
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    static public SerialDriverAdapter instance() {
-        if (mInstance == null) {
-            mInstance = new SerialDriverAdapter();
-        }
-        return mInstance;
-    }
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    static SerialDriverAdapter mInstance = null;
-
     private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/anyma/AnymaDMX_SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/anyma/AnymaDMX_SystemConnectionMemo.java
@@ -32,7 +32,9 @@ public class AnymaDMX_SystemConnectionMemo extends SystemConnectionMemo {
     }
 
     /**
-     * constructor
+     * constructor.
+     * @param prefix system prefix.
+     * @param userName system username.
      */
     public AnymaDMX_SystemConnectionMemo(@Nonnull String prefix, @Nonnull String userName) {
         super(prefix, userName);
@@ -94,7 +96,7 @@ public class AnymaDMX_SystemConnectionMemo extends SystemConnectionMemo {
      * <li>Channels are numbered from 1 to 512.</li>
      * <li>Does not check whether that node is defined on current system.</li>
      * </ul>
-     *
+     * @param systemName system name.
      * @return 0 if an error is found.
      */
     public int getChannelFromSystemName(String systemName) {
@@ -132,6 +134,7 @@ public class AnymaDMX_SystemConnectionMemo extends SystemConnectionMemo {
      * Public static method to check and skip the System Prefix string on a
      * system name.
      *
+     * @param systemName system name string.
      * @return offset of the 1st character past the prefix, or -1 if not valid
      *         for this connection
      */
@@ -148,6 +151,7 @@ public class AnymaDMX_SystemConnectionMemo extends SystemConnectionMemo {
      * Public static method to convert one format anyma dmx system name to the
      * alternate format.
      *
+     * @param systemName system name string.
      * @return "" (empty string) if the supplied system name does not have a
      *         valid format, or if there is no representation in the alternate
      *         naming scheme
@@ -171,9 +175,11 @@ public class AnymaDMX_SystemConnectionMemo extends SystemConnectionMemo {
     }
 
     /**
-     * Public static method to validate system name format. Does not check
-     * whether that node is defined on current system.
+     * Public static method to validate system name format.
+     * Does not check whether that node is defined on current system.
      *
+     * @param systemName proposed system name.
+     * @param type bean type, only L supported.
      * @return enum indicating current validity, which might be just as a prefix
      */
     public NameValidity validSystemNameFormat(@Nonnull String systemName, char type) {
@@ -208,6 +214,8 @@ public class AnymaDMX_SystemConnectionMemo extends SystemConnectionMemo {
      * Public static method to validate anyma dmx system name for configuration.
      * Does validate node number and system prefix.
      *
+     * @param systemName anya dmx systemName.
+     * @param type bean type, only L supported.
      * @return 'true' if system name has a valid meaning in current
      *         configuration, else returns 'false'.
      */
@@ -236,6 +244,7 @@ public class AnymaDMX_SystemConnectionMemo extends SystemConnectionMemo {
      * Nodes are numbered from 0 - 127. Does not check whether that node is
      * defined on current system.
      *
+     * @param systemName system name.
      * @return '-1' if invalid systemName format or if the node is not found.
      */
     public int getNodeAddressFromSystemName(String systemName) {

--- a/java/src/jmri/jmrix/bachrus/SpeedoSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoSystemConnectionMemo.java
@@ -38,6 +38,7 @@ public class SpeedoSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo 
 
     /**
      * Provide access to the TrafficController for this particular connection.
+     * @return traffic controller.
      */
     public SpeedoTrafficController getTrafficController() {
         return tc;

--- a/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
@@ -96,6 +96,7 @@ public class SpeedoTrafficController implements SpeedoInterface, SerialPortEvent
 
     /**
      * Make connection to existing PortController object.
+     * @param p speedo port controller.
      */
     public void connectPort(SpeedoPortController p) {
         istream = p.getInputStream();
@@ -107,8 +108,9 @@ public class SpeedoTrafficController implements SpeedoInterface, SerialPortEvent
     }
 
     /**
-     * Break connection to existing SpeedoPortController object. Once broken,
-     * attempts to send via "message" member will fail.
+     * Break connection to existing SpeedoPortController object.
+     * Once broken, attempts to send via "message" member will fail.
+     * @param p speedo port controller.
      */
     public void disconnectPort(SpeedoPortController p) {
         istream = null;

--- a/java/src/jmri/jmrix/bachrus/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/bachrus/serialdriver/SerialDriverAdapter.java
@@ -37,7 +37,6 @@ public class SerialDriverAdapter extends SpeedoPortController {
     public SerialDriverAdapter() {
         super(new SpeedoSystemConnectionMemo());
         setManufacturer(SpeedoConnectionTypeList.BACHRUS);
-        mInstance = this;
         this.getSystemConnectionMemo().setSpeedoTrafficController(new SpeedoTrafficController(this.getSystemConnectionMemo()));
     }
 
@@ -181,19 +180,6 @@ public class SerialDriverAdapter extends SpeedoPortController {
 
     private boolean opened = false;
     InputStream serialStream = null;
-
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    public synchronized SerialDriverAdapter instance() {
-        if (mInstance == null) {
-            mInstance = new SerialDriverAdapter();
-            mInstance.setManufacturer(SpeedoConnectionTypeList.BACHRUS);
-        }
-        return mInstance;
-    }
-    private SerialDriverAdapter mInstance = null;
 
     private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
 

--- a/java/src/jmri/jmrix/can/ConfigurationManager.java
+++ b/java/src/jmri/jmrix/can/ConfigurationManager.java
@@ -68,7 +68,9 @@ abstract public class ConfigurationManager {
     abstract public void configureManagers();
 
     /**
-     * Tells which managers this class provides.
+     * Get which managers this class provides.
+     * @param type class to query.
+     * @return true if provided, else false.
      */
     abstract public boolean provides(Class<?> type);
 

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/GcSerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/GcSerialDriverAdapter.java
@@ -381,7 +381,8 @@ public class GcSerialDriverAdapter extends GcPortController {
     }
 
     /**
-     * Migration method
+     * Migration method.
+     * @return array of valid baud numbers.
      * @deprecated since 4.16
      */
     @Deprecated

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/net/NetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/net/NetworkDriverAdapter.java
@@ -26,10 +26,6 @@ public class NetworkDriverAdapter extends jmri.jmrix.AbstractNetworkPortControll
         options.put(option2Name, new Option(Bundle.getMessage("ConnectionProtocol"), jmri.jmrix.can.ConfigurationManager.getSystemOptions(), false));
         setManufacturer(jmri.jmrix.openlcb.OlcbConnectionTypeList.OPENLCB);
         allowConnectionRecovery = true;
-        
-        maxreconnectinterval = 30000; // 30s
-        retryAttempts = Integer.MAX_VALUE;
-        
     }
 
     /**

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/net/NetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/net/NetworkDriverAdapter.java
@@ -26,6 +26,10 @@ public class NetworkDriverAdapter extends jmri.jmrix.AbstractNetworkPortControll
         options.put(option2Name, new Option(Bundle.getMessage("ConnectionProtocol"), jmri.jmrix.can.ConfigurationManager.getSystemOptions(), false));
         setManufacturer(jmri.jmrix.openlcb.OlcbConnectionTypeList.OPENLCB);
         allowConnectionRecovery = true;
+        
+        maxreconnectinterval = 30000; // 30s
+        retryAttempts = Integer.MAX_VALUE;
+        
     }
 
     /**

--- a/java/src/jmri/jmrix/can/adapters/lawicell/Message.java
+++ b/java/src/jmri/jmrix/can/adapters/lawicell/Message.java
@@ -96,10 +96,11 @@ public class Message extends AbstractMRMessage {
     }
 
     /**
-     * Set the CAN header as ASCII hex digits. Handles extended/standard
-     * internally
+     * Set the CAN header as ASCII hex digits.
+     * Handles extended/standard internally.
      *
      * @param header A valid CAN header value
+     * @param index start index.
      * @return index to next bytes, after this
      */
     public int setHeader(int header, int index) {

--- a/java/src/jmri/jmrix/can/adapters/lawicell/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/lawicell/SerialDriverAdapter.java
@@ -155,7 +155,8 @@ public class SerialDriverAdapter extends PortController {
     }
 
     /**
-     * Migration method
+     * Migration method.
+     * @return valid baud values.
      * @deprecated since 4.16
      */
     @Deprecated

--- a/java/src/jmri/jmrix/can/cbus/swing/CbusEventHighlightFrame.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/CbusEventHighlightFrame.java
@@ -102,6 +102,13 @@ public class CbusEventHighlightFrame extends JmriJFrame {
 
     /**
      * Enable Highlighter.
+     * @param index highlighter index.
+     * @param nn node number.
+     * @param nnEn node number enabled.
+     * @param ev event number.
+     * @param evEn event number enabled.
+     * @param ty event type.
+     * @param dr event direction.
      */
     public void enable(int index, int nn, boolean nnEn, int ev, boolean evEn, int ty, int dr) {
         

--- a/java/src/jmri/jmrix/can/cbus/swing/bootloader/HexFile.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/bootloader/HexFile.java
@@ -105,11 +105,12 @@ public class HexFile {
 
     
     /**
-     * Read a hex file
-     * 
+     * Read a hex file.
+     * <p>
      * Read into the array of individual records.
      * Add the actual programming data to the data arrays.
      * Track the highest used addresses
+     * @throws java.io.IOException on read error.
      */
     public void read() throws IOException {
         HexRecord r;

--- a/java/src/jmri/jmrix/can/swing/CanPanelInterface.java
+++ b/java/src/jmri/jmrix/can/swing/CanPanelInterface.java
@@ -16,6 +16,7 @@ public interface CanPanelInterface {
      * <p>
      * This needs to be connected to the initContext() method in implementing
      * classes.
+     * @param memo system connection.
      */
     public void initComponents(CanSystemConnectionMemo memo);
 

--- a/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
@@ -680,6 +680,9 @@ public class CMRISystemConnectionMemo extends SystemConnectionMemo {
      * 
      * This is a common implementation for C/MRI Lights, Sensors and Turnouts
      * of the comparison method.
+     * @param suffix1 suffix to compare.
+     * @param suffix2 suffix to compare.
+     * @return CMRI comparison of suffixes.
      */
     @CheckReturnValue
     public static int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2) {

--- a/java/src/jmri/jmrix/cmri/serial/SerialLight.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialLight.java
@@ -25,6 +25,8 @@ public class SerialLight extends AbstractLight {
      * Create a Light object, with only system name.
      * <p>
      * 'systemName' was previously validated in SerialLightManager
+     * @param systemName light system name.
+     * @param memo system connection.
      */
     public SerialLight(String systemName,CMRISystemConnectionMemo memo) {
         super(systemName);
@@ -37,6 +39,9 @@ public class SerialLight extends AbstractLight {
      * Create a Light object, with both system and user names.
      * <p>
      * 'systemName' was previously validated in SerialLightManager
+     * @param systemName light system name.
+     * @param userName light username.
+     * @param memo system connection.
      */
     public SerialLight(String systemName, String userName,CMRISystemConnectionMemo memo) {
         super(systemName, userName);

--- a/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
@@ -77,6 +77,8 @@ public class SerialLightManager extends AbstractLightManager {
 
     /**
      * Public method to notify user of Light creation error.
+     * @param conflict human readable light name of light in conflict.
+     * @param bitNum bit number of light in conflict.
      */
     public void notifyLightCreationError(String conflict, int bitNum) {
         javax.swing.JOptionPane.showMessageDialog(null, Bundle.getMessage("ErrorAssignDialog", bitNum, conflict) + "\n" +

--- a/java/src/jmri/jmrix/cmri/serial/SerialMessage.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialMessage.java
@@ -31,6 +31,7 @@ public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
      * This ctor interprets the String as the exact sequence to send,
      * byte-for-byte.
      *
+     * @param m message string.
      */
     public SerialMessage(String m) {
         super(m);

--- a/java/src/jmri/jmrix/cmri/serial/SerialNode.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialNode.java
@@ -127,18 +127,21 @@ public class SerialNode extends AbstractNode {
     protected boolean[] monitorPacketBits = new boolean[SerialFilterFrame.numMonPkts];
 
     /**
-     * Assumes a node address of 0, and a node type of SMINI If this constructor
+     * Assumes a node address of 0, and a node type of SMINI.
+     * If this constructor
      * is used, actual node address must be set using setNodeAddress, and actual
      * node type using 'setNodeType'
+     * @param tc system connection traffic controller.
      */
     public SerialNode(SerialTrafficController tc) {
         this(0, SMINI,tc);
     }
 
     /**
-     * Creates a new SerialNode and initialize default instance variables
-     * address - Address of node on CMRI serial bus (0-127) type - SMINI,
-     * USIC_SUSIC,
+     * Creates a new SerialNode and initialize default instance variables.
+     * @param address Address of node on CMRI serial bus (0-127).
+     * @param type Node type, e.g. SMINI or USIC_SUSIC.
+     * @param tc system connection traffic controller.
      */
     public SerialNode(int address, int type, SerialTrafficController tc) {
         // set address and type and check validity
@@ -205,8 +208,9 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Set a single output bit. Note: state = 'true' for 0, 'false' for 1 bits
-     * are numbered from 1 (not 0)
+     * Set a single output bit.
+     * @param bitNumber bit number, bits are numbered from 1 (not 0).
+     * @param state true for 0, false for 1.
      */
     public void setOutputBit(int bitNumber, boolean state) {
         // locate in the outputArray
@@ -233,8 +237,9 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Get the current state of a single output bit. Note: returns 'true' for 0,
-     * 'false' for 1 bits are numbered from 1 (not 0)
+     * Get the current state of a single output bit.
+     * @param bitNumber bit number, bits are numbered from 1 (not 0).
+     * @return true for 0, false for 1. 
      */
     public boolean getOutputBit(int bitNumber) {
         // locate in the outputArray
@@ -267,8 +272,9 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Set state of Sensor polling. Used to disable polling for test purposes
-     * only.
+     * Set state of Sensor polling.
+     * Used to disable polling for test purposes only.
+     * @param flag true to set active flag, else false.
      */
     public void setSensorsActive(boolean flag) {
         hasActiveSensors = flag;
@@ -276,6 +282,7 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Get number of input cards.
+     * @return number of input cards.
      */
     public int numInputCards() {
         int result = 0;
@@ -319,6 +326,7 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Get number of output cards.
+     * @return number of output cards.
      */
     public int numOutputCards() {
         int result = 0;
@@ -363,15 +371,19 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Get node type Current types are: SMINI, USIC_SUSIC,
+     * @return node type, e.g. USIC_SUSIC.
      */
     public int getNodeType() {
         return (nodeType);
     }
 
     /**
-     * Set node type Current types are: SMINI, USIC_SUSIC, For SMINI, also sets
-     * cardTypeLocation[] and bitsPerCard For USIC_SUSIC, also clears
-     * cardTypeLocation
+     * Set node type.
+     * <p>
+     * Current types are: SMINI, USIC_SUSIC
+     * For SMINI, also sets cardTypeLocation[] and bitsPerCard.
+     * For USIC_SUSIC, also clears cardTypeLocation.
+     * @param type node type, e.g. USIC_SUSIC.
      */
     public void setNodeType(int type) {
 
@@ -461,6 +473,7 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Get number of bits per card.
+     * @return number of bits per card.
      */
     public int getNumBitsPerCard() {
         return (bitsPerCard);
@@ -468,6 +481,7 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Set number of bits per card.
+     * @param bits number of bits.
      */
     public void setNumBitsPerCard(int bits) {
         if ((bits == 24) || (bits == 32) || (bits == 16) || (bits == 8)) {
@@ -478,15 +492,19 @@ public class SerialNode extends AbstractNode {
         }
     }
 
-     /**  
-     * return CMRInet options.  
+    /**  
+     * Get CMRInet options.
+     * @param optionbit option index.
+     * @return option value.
      */
     public int getCMRInetOpts(int optionbit) { return (cmrinetOptions[optionbit]); }
     public void setCMRInetOpts(int optionbit,int val) { cmrinetOptions[optionbit] = (byte)val; }
     public boolean isCMRInetBit(int optionbit) { return (cmrinetOptions[optionbit] == 1); }
-
-    /** 
-     * return cpNode Initialization options.  
+    
+    /**
+     * Get cpNode options.
+     * @param optionbit option index.
+     * @return option value.
      */
     public int getcpnodeOpts(int optionbit) { return (cpnodeOptions[optionbit]); }
     public void setcpnodeOpts(int optionbit,int val) { cpnodeOptions[optionbit] = (byte)val; }
@@ -494,12 +512,12 @@ public class SerialNode extends AbstractNode {
 
     /**
      * get and set specific option bits.
-     * 
+     * Network Option Bits
      */
     
-   /**
-     * Network Option Bits
-     * 
+    /**
+     * Get if Autopoll bit set.
+     * @return true if set, else false.
      */
     public boolean getOptNet_AUTOPOLL() { return (cmrinetOptions[optbitNet_AUTOPOLL] == 1); }
     public boolean getOptNet_USECMRIX() { return (cmrinetOptions[optbitNet_USECMRIX] == 1); }
@@ -517,8 +535,12 @@ public class SerialNode extends AbstractNode {
     public int getOptNet_byte1() {return cmrinetOptions[1];}
 
     /**
-     * Node Option Bits  
-     * 
+     * Node Option Bits.
+     */
+    
+    /**
+     * Get Node Option SENDEOT.
+     * @return true if SENDEOT, else false.
      */
     public boolean getOptNode_SENDEOT()  { return (cpnodeOptions[optbitNode_SENDEOT] == 1); }
     public boolean getOptNode_USECMRIX() { return (cpnodeOptions[optbitNode_USECMRIX] == 1); }
@@ -536,31 +558,35 @@ public class SerialNode extends AbstractNode {
     public int getOptNode_byte1() {return cpnodeOptions[1];}
     
     /**
-     * node description 
-     * 
+     * Get node description.
+     * @return node description.
      */
     public String getcmriNodeDesc() { return cmriNodeDesc; }
+    
     public void setcmriNodeDesc(String nodeDesc) { cmriNodeDesc = nodeDesc; }
     
     /**
-     * cpNode poll list position
-     * 
+     * Get cpNode poll list position.
+     * @return poll list position.
      */
     public int getPollListPosition() { return pollListPosition; }
+    
     public void setPollListPosition(int pos)  { pollListPosition = pos; }
 
     /**
-     * cpNode polling status
-     * 
+     * Get cpNode polling status.
+     * @return true if polling status flag set, else false.
      */
     public int getPollStatus() { return pollStatus; }
+    
     public void setPollStatus(int status) { pollStatus = status; }
 
     /**
-     * checking cpNode polling enabled state
-     * 
+     * Check cpNode polling enabled state.
+     * @return true if polling is enabled.
      */
     public boolean getPollingEnabled() { return (cmrinetOptions[optbitNet_AUTOPOLL] == 1); }
+    
     public void setPollingEnabled(boolean isEnabled)
     {  
       if(isEnabled)
@@ -570,27 +596,30 @@ public class SerialNode extends AbstractNode {
     }
    
    /**
-    * 
-    * Set/Get packet monitoring for the node 
+    * Get packet monitoring for the node .
+    * @return true if packet monitoring flag set true, else false.
     */
    public boolean getMonitorNodePackets()  { return monitorNodePackets; }
+   
    public void setMonitorNodePackets(boolean onoff) { monitorNodePackets = onoff; }
    
-   /**
-    * Set/Get the specific packet monitoring enable bit
-   */
-   public void setMonitorPacketBit(int pktTypeBit, boolean onoff)
-   { 
+    /**
+     * Set the specific packet monitoring enable bit.
+     * @param pktTypeBit index.
+     * @param onoff true enables, false disabled.
+     */
+    public void setMonitorPacketBit(int pktTypeBit, boolean onoff) { 
        monitorPacketBits[pktTypeBit] = onoff; 
-   }
+    }
    
    public boolean getMonitorPacketBit(int pktTypeBit)
    { 
        return monitorPacketBits[pktTypeBit]; 
    }
    
-        /**
-     * Check valid node address, must match value in dip switches (0 - 127)
+    /**
+     * Check valid node address, must match value in dip switches (0 - 127).
+     * {@inheritDoc}
      */
     @Override
     protected boolean checkNodeAddress(int address) {
@@ -599,15 +628,19 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Get transmission delay.
+     * @return delay, ms.
      */
     public int getTransmissionDelay() {
         return (transmissionDelay);
     }
 
     /**
-     * Set transmission delay. delay - delay between bytes on receive (units of
-     * 10 microsec.) Note: two bytes are used, so range is 0-65,535. If delay is
-     * out of range, it is restricted to the allowable range
+     * Set transmission delay.
+     * <p>
+     * two bytes are used, so range is 0-65,535. If delay is
+     * out of range, it is restricted to the allowable range.
+     * @param delay - delay between bytes on receive (units of
+     * 10 microsec.)
      */
     public void setTransmissionDelay(int delay) {
         if ((delay < 0) || (delay > 65535)) {
@@ -623,14 +656,17 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Get pulse width. Used with pulsed turnout control.
+     * Get pulse width.
+     * Used with pulsed turnout control.
+     * @return pulse width, ms.
      */
     public int getPulseWidth() {
         return (pulseWidth);
     }
 
     /**
-     * Set pulse width. width - width of pulse used for pulse controlled turnout
+     * Set pulse width.
+     * @param width width of pulse used for pulse controlled turnout
      * control (millisec.) Note: Pulse width must be between 100 and 10000
      * milliseconds. If width is out of range, it is restricted to the allowable
      * range
@@ -649,9 +685,12 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Set the type of one card. address - address recognized for this card by
+     * Set the type of one card. 
+     * 
+     * @param address address recognized for this card by
      * the node hardware. for USIC_SUSIC address set in card's dip switches (0 -
-     * 63) type - INPUT_CARD, OUTPUT_CARD, or NO_CARD
+     * 63) 
+     * @param type INPUT_CARD, OUTPUT_CARD, or NO_CARD
      */
     public void setCardTypeByAddress(int address, int type) {
         // validate address
@@ -677,9 +716,11 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Test for OUTPUT_CARD type. Returns true if card with 'cardNum' is an
-     * output card. Returns false if card is not an output card, or if 'cardNum'
-     * is out of range.
+     * Test for OUTPUT_CARD type. 
+     * 
+     * @param cardNum index number.
+     * @return true if card with 'cardNum' is an output card. false if card 
+     * is not an output card, or if 'cardNum' is out of range.
      */
     public boolean isOutputCard(int cardNum) {
         if (cardNum > 63) {
@@ -697,8 +738,10 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Test for INPUT_CARD type. Returns true if card with 'cardNum' is an input
-     * card. Returns false if card is not an input card, or if 'cardNum' is out
+     * Test for INPUT_CARD type.
+     * @param cardNum index number.
+     * @return true if card with 'cardNum' is an input card, 
+     *         false if card is not an input card, or if 'cardNum' is out
      * of range.
      */
     public boolean isInputCard(int cardNum) {
@@ -717,9 +760,13 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Get 'Output Card Index' Returns the index this output card would have in
-     * an array of output cards for this node. Can be used to locate this card's
+     * Get 'Output Card Index'.
+     * <p>
+     * Can be used to locate this card's
      * bytes in an output message. Array is ordered by increasing node address.
+     * @param cardNum index number.
+     * @return the index this output card would have in
+     * an array of output cards for this node. 
      */
     public int getOutputCardIndex(int cardNum) {
         if (nodeType == SMINI) {
@@ -744,9 +791,14 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Get 'Input Card Index' Returns the index this input card would have in an
-     * array of input cards for this node. Can be used to locate this card's
-     * bytes in an receive message. Array is ordered by increasing node address.
+     * Get 'Input Card Index'.
+     * <p>
+     * Can be used to locate this card's bytes in an receive message. 
+     * Array is ordered by increasing node address.
+     * @param cardNum index number.
+     * @return the index this input card would have in an
+     * array of input cards for this node. 
+     * 
      */
     public int getInputCardIndex(int cardNum) {
         if (nodeType == SMINI) {
@@ -771,9 +823,12 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Set location of SearchLightBits (SMINI only) bit - bitNumber of the low
-     * bit of an oscillating search light bit pair Notes: Bits are numbered from
-     * 0 Two bits are set by each call - bit and bit + 1. If either bit is
+     * Set location of SearchLightBits (SMINI only).
+     * @param bit - bitNumber of the low
+     * bit of an oscillating search light bit pair
+     * <p>
+     * Bits are numbered from 0.
+     * Two bits are set by each call - bit and bit + 1. If either bit is
      * already set, an error is logged and no bits are set.
      */
     public void set2LeadSearchLight(int bit) {
@@ -800,8 +855,11 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Clear location of SearchLightBits (SMINI only) bit - bitNumber of the low
-     * bit of an oscillating search light bit pair Notes: Bits are numbered from
+     * Clear location of SearchLightBits (SMINI only).
+     * @param bit - bitNumber of the low
+     * bit of an oscillating search light bit pair 
+     * <p>
+     * Notes: Bits are numbered from
      * 0 Two bits are cleared by each call - bit and bit + 1. If either bit is
      * already clear, an error is logged and no bits are set.
      */
@@ -829,9 +887,9 @@ public class SerialNode extends AbstractNode {
     }
 
     /**
-     * Query SearchLightBits by bit number (SMINI only) bit - bitNumber of the
-     * either bit of an oscillating search light bit pair Note: returns 'true'
-     * if bit is an oscillating SearchLightBit, otherwise 'false' is returned
+     * Query SearchLightBits by bit number (SMINI only).
+     * @param bit bitNumber of the either bit of an oscillating search light bit pair.
+     * @return true if bit is an oscillating SearchLightBit, otherwise false.
      */
     public boolean isSearchLightBit(int bit) {
         // check for SMINI

--- a/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
@@ -129,7 +129,8 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     }
 
     /**
-     * Method to register any orphan Sensors when a new Serial Node is created
+     * Method to register any orphan Sensors when a new Serial Node is created.
+     * @param node the node with potential orphan sensors.
      */
     @SuppressWarnings("deprecation") // needs careful unwinding for Set operations
     public void registerSensorsForNode(SerialNode node) {

--- a/java/src/jmri/jmrix/cmri/serial/SerialTurnout.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialTurnout.java
@@ -57,6 +57,9 @@ public class SerialTurnout extends AbstractTurnout {
      * Create a Turnout object, with both system and user names.
      * <p>
      * 'systemName' was previously validated in SerialTurnoutManager
+     * @param systemName system name.
+     * @param userName user name.
+     * @param memo system connection.
      */
     public SerialTurnout(@Nonnull String systemName, String userName, CMRISystemConnectionMemo memo) {
         super(systemName, userName);

--- a/java/src/jmri/jmrix/cmri/serial/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialTurnoutManager.java
@@ -86,6 +86,8 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
 
     /**
      * Public method to notify user of Turnout creation error.
+     * @param conflict human readable name of turnout with conflict.
+     * @param bitNum conflict bit number.
      */
     public void notifyTurnoutCreationError(String conflict, int bitNum) {
         JOptionPane.showMessageDialog(null, Bundle.getMessage("ErrorAssignDialog", bitNum, conflict) + "\n" +
@@ -204,6 +206,8 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
     /**
      * Public method to notify user when the second bit of a proposed two output
      * bit turnout has a conflict with another assigned bit.
+     * @param conflict human readable name of turnout with conflict.
+     * @param bitNum conflict bit number.
      */
     public void notifySecondBitConflict(String conflict, int bitNum) {
         JOptionPane.showMessageDialog(null, Bundle.getMessage("ErrorAssign2Dialog", bitNum, conflict) + "\n" +

--- a/java/src/jmri/jmrix/cmri/serial/assignment/ListFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/assignment/ListFrame.java
@@ -243,7 +243,8 @@ public class ListFrame extends jmri.util.JmriJFrame {
     }
 
     /**
-     * Method to handle selection of a Node for info display
+     * Method to handle selection of a Node for info display.
+     * @param nodeID node ID string.
      */
     public void displayNodeInfo(String nodeID) {
         if (!nodeID.equals(selNodeID)) {
@@ -315,6 +316,7 @@ public class ListFrame extends jmri.util.JmriJFrame {
 
     /**
      * Handle print button in List Frame.
+     * @param e unused.
      */
     public void printButtonActionPerformed(java.awt.event.ActionEvent e) {
         int[] colWidth = new int[AssignmentTableModel.MAX_COLS];
@@ -481,6 +483,8 @@ public class ListFrame extends jmri.util.JmriJFrame {
          * vertical lines between each column. Data is word wrapped within a
          * column. Can only handle 4 columns of data as strings. Adapted from
          * routines in BeanTableDataModel.java by Bob Jacobsen and Dennis Miller
+         * @param w hard copy writer instance.
+         * @param colWidth column width array.
          */
         public void printTable(HardcopyWriter w, int colWidth[]) {
             // determine the column sizes - proportionately sized, with space between for lines

--- a/java/src/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetMetricsFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetMetricsFrame.java
@@ -264,10 +264,13 @@ public class CMRInetMetricsFrame extends jmri.util.JmriJFrame {
     volatile PrintStream logStream = null;
 
     /**
-     *
-     * Save Metrics button handler Metric data is saved to a text file named
-     * CMRInetMetrics_YYYYMMDD_HHMMSS The file is text lines, one for each
-     * metric displayed and the count
+     * Save Metrics button handler.
+     * <p>
+     * Metric data is saved to a text file named
+     * CMRInetMetrics_YYYYMMDD_HHMMSS 
+     * The file is text lines, one for each metric displayed and the count.
+     * 
+     * @param e unused.
      */
     public void saveMetricsButtonActionPerformed(ActionEvent e) {
         String fileName = "CMRInetMetrics_";
@@ -313,8 +316,8 @@ public class CMRInetMetricsFrame extends jmri.util.JmriJFrame {
     }
 
     /**
-     * ------------------------------ Reset All Metrics button handler
-     * ------------------------------
+     * Reset All Metrics button handler.
+     * @param e unused.
      */
     public void resetAllMetricsButtonActionPerformed(ActionEvent e) {
         metricsData.clearAllDataMetrics();

--- a/java/src/jmri/jmrix/cmri/serial/cmrinetmetrics/CMRInetMetricsData.java
+++ b/java/src/jmri/jmrix/cmri/serial/cmrinetmetrics/CMRInetMetricsData.java
@@ -77,11 +77,16 @@ package jmri.jmrix.cmri.serial.cmrinetmetrics;
         }
         
         /**
-         * Methods for Metric Error data
+         * Methods for Metric Error data.
          * 
-         */        
-        // Get the error count
-        //---------------------
+         */
+        
+        /**
+         * Get the error count.
+         * 
+         * @param metricName metric index.
+         * @return error count.
+         */
         synchronized public int getMetricErrValue( int metricName ){
             return CMRInetMetricErrCount[metricName];
         }
@@ -109,10 +114,13 @@ package jmri.jmrix.cmri.serial.cmrinetmetrics;
        
         /**
          * Methods for Metric data
-         * 
-         */        
-        // Get the metric value
-        //---------------------
+         */
+        
+        /**
+         * Get the metric value.
+         * @param metricName index.
+         * @return data value.
+         */
         synchronized public int getMetricDataValue( int metricName ){
             return CMRInetMetricDataCount[metricName];
         }

--- a/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
@@ -514,8 +514,10 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
             index++;
         }
     }
+    
     /**
-     * Method to handle selection of a Node for info display
+     * Method to handle selection of a Node for info display.
+     * @param nodeID Node ID.
      */
     public void displayNodeInfo(String nodeID) {
         if (!nodeID.equals(testNodeID)) {
@@ -601,8 +603,10 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
         statusText2.setVisible(true);
 
     }
+    
     /**
      * Handle run button in Diagnostic Frame.
+     * @param e unused.
      */
     public void runButtonActionPerformed(java.awt.event.ActionEvent e) {
         // Ignore button if test is already running
@@ -778,6 +782,7 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
 
     /**
      * Handle continue button in Diagnostic Frame.
+     * @param e unused.
      */
     public void continueButtonActionPerformed(java.awt.event.ActionEvent e) {
         if (testRunning && testSuspended) {
@@ -791,6 +796,7 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
 
     /**
      * Handle Stop button in Diagnostic Frame.
+     * @param e unused.
      */
     public void stopButtonActionPerformed(java.awt.event.ActionEvent e) {
         // Ignore button push if test is not running, else change flag
@@ -1162,6 +1168,7 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
     
     /**
      * Handle poll node button in Diagnostic Frame.
+     * @param e unused.
      */
     public synchronized void pollButtonActionPerformed(java.awt.event.ActionEvent e) {
             portsPerCard = (testNode.getNumBitsPerCard()) / 8;
@@ -1222,10 +1229,11 @@ public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.
     }
     
     /**
-    * Transmit bytes to selected output card starting with out card number
-    * for number of bytes entered.
-    * If inverted checked, data is flipped.
-    */    
+     * Transmit bytes to selected output card starting with out card number
+     * for number of bytes entered.
+     * If inverted checked, data is flipped.
+     * @param e unused.
+     */    
     public synchronized void sendButtonActionPerformed(java.awt.event.ActionEvent e) {
 
        portsPerCard = (testNode.getNumBitsPerCard()) / 8;

--- a/java/src/jmri/jmrix/cmri/serial/networkdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/cmri/serial/networkdriver/ConnectionConfig.java
@@ -18,6 +18,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/cmri/serial/nodeconfigmanager/NodeConfigManagerFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/nodeconfigmanager/NodeConfigManagerFrame.java
@@ -144,7 +144,8 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
     private CMRISystemConnectionMemo _memo = null;
 
     /**
-     * Constructor method
+     * Constructor method.
+     * @param memo system connection.
      */
     public NodeConfigManagerFrame(CMRISystemConnectionMemo memo) {
         super();
@@ -317,6 +318,7 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
 
     /**
      * Get the selected node address from the node table.
+     * @return selected node ID.
      */
     public int getSelectedNodeAddr() {
         return (Integer) nodeTable.getValueAt(nodeTable.getSelectedRow(), 0);
@@ -613,7 +615,9 @@ public class NodeConfigManagerFrame extends jmri.util.JmriJFrame {
          * vertical lines between each column. Data is word wrapped within a
          * column. Can only handle 4 columns of data as strings. Adapted from
          * routines in BeanTableDataModel.java by Bob Jacobsen and Dennis Miller
-         */
+         * @param w hardcopywriter instance.
+         * @param colWidth column width array.
+        */
         public void printTable(HardcopyWriter w, int colWidth[]) {
             // determine the column sizes - proportionately sized, with space between for lines
             int[] columnSize = new int[NUM_COLUMNS];

--- a/java/src/jmri/jmrix/cmri/serial/nodeiolist/NodeIOListFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/nodeiolist/NodeIOListFrame.java
@@ -222,7 +222,8 @@ public class NodeIOListFrame extends jmri.util.JmriJFrame {
     }
 
     /**
-     * Method to handle selection of a Node for info display
+     * Method to handle selection of a Node for info display.
+     * @param nodeID node ID number.
      */
     public void displayNodeIOBits(int nodeID) {
         nodeLabel.setText("Node: " + nodeID + "     ");
@@ -290,7 +291,8 @@ public class NodeIOListFrame extends jmri.util.JmriJFrame {
     }
 
     /**
-     * Method to handle print button in List Frame
+     * Method to handle print button in List Frame.
+     * @param e unused.
      */
     public void printButtonActionPerformed(java.awt.event.ActionEvent e) {
         int[] colWidth = new int[5];
@@ -457,6 +459,8 @@ public class NodeIOListFrame extends jmri.util.JmriJFrame {
          * vertical lines between each column. Data is word wrapped within a
          * column. Can only handle 4 columns of data as strings. Adapted from
          * routines in BeanTableDataModel.java by Bob Jacobsen and Dennis Miller
+         * @param w hard copy writer instance.
+         * @param colWidth column width array.
          */
         public void printTable(HardcopyWriter w, int colWidth[]) {
             // determine the column sizes - proportionately sized, with space between for lines

--- a/java/src/jmri/jmrix/cmri/serial/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/cmri/serial/serialdriver/ConnectionConfig.java
@@ -20,6 +20,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/cmri/serial/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/cmri/serial/serialdriver/SerialDriverAdapter.java
@@ -101,6 +101,7 @@ public class SerialDriverAdapter extends SerialPortAdapter {
 
     /**
      * Can the port accept additional characters? Yes, always
+     * @return always true.
      */
     public boolean okToSend() {
         return true;
@@ -189,22 +190,6 @@ public class SerialDriverAdapter extends SerialPortAdapter {
     // private control members
     private boolean opened = false;
     InputStream serialStream = null;
-
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    static public SerialDriverAdapter instance() {
-        if (mInstance == null) {
-            mInstance = new SerialDriverAdapter();
-        }
-        return mInstance;
-    }
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    static SerialDriverAdapter mInstance = null;
 
     private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
 

--- a/java/src/jmri/jmrix/cmri/serial/serialmon/SerialMonFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/serialmon/SerialMonFrame.java
@@ -117,6 +117,7 @@ public class SerialMonFrame extends jmri.jmrix.AbstractMonFrame implements Seria
 
     /**
      * Open the node/packet filter window.
+     * @param e unused.
      */
     public void openPacketFilterPerformed(ActionEvent e) {
         // create a SerialFilterFrame

--- a/java/src/jmri/jmrix/cmri/serial/sim/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/cmri/serial/sim/ConnectionConfig.java
@@ -18,6 +18,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConf
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcReply.java
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcReply.java
@@ -72,6 +72,7 @@ public class Dcc4PcReply extends AbstractMRReply {
 
     /**
      * Is this reply indicating that a general error has occurred?
+     * @return true if error, else false.
      */
     public boolean isError() {
         return error;
@@ -109,7 +110,8 @@ public class Dcc4PcReply extends AbstractMRReply {
     }
 
     /**
-     * Returns a string representation of this Dcc4PcReply
+     * Returns a hex string representation of this Dcc4PcReply.
+     * @return hex string format of Reply using 0x format.
      */
     public String toHexString() {
 

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcSystemConnectionMemo.java
@@ -43,6 +43,7 @@ public class Dcc4PcSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo 
 
     /**
      * Provides access to the TrafficController for this particular connection.
+     * @return traffic controller.
      */
     public Dcc4PcTrafficController getDcc4PcTrafficController() {
         return tc;

--- a/java/src/jmri/jmrix/dcc4pc/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/dcc4pc/serialdriver/ConnectionConfig.java
@@ -11,6 +11,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/dcc4pc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/dcc4pc/serialdriver/SerialDriverAdapter.java
@@ -88,7 +88,8 @@ public class SerialDriverAdapter extends Dcc4PcPortController {
     }
 
     /**
-     * Option 1 controls the connection used for programming
+     * Option 1 controls the connection used for programming.
+     * @return array with options for programming.
      */
     public String[] validOption1() {
         List<SystemConnectionMemo> connList = jmri.InstanceManager.getList(SystemConnectionMemo.class);
@@ -115,6 +116,7 @@ public class SerialDriverAdapter extends Dcc4PcPortController {
     /**
      * Get a String that says what Option 2 represents May be an empty string,
      * but will not be null
+     * @return option to match detected locos to roster.
      */
     public String option2Name() {
         return "Match Detected Locos to Roster: ";
@@ -184,6 +186,7 @@ public class SerialDriverAdapter extends Dcc4PcPortController {
     InputStream serialStream = null;
 
     /**
+     * @return instance.
      * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
      */
     @Deprecated

--- a/java/src/jmri/jmrix/dcc4pc/swing/Dcc4PcNamedPaneAction.java
+++ b/java/src/jmri/jmrix/dcc4pc/swing/Dcc4PcNamedPaneAction.java
@@ -16,6 +16,10 @@ public class Dcc4PcNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction {
 
     /**
      * Enhanced constructor for placing the pane in various GUIs
+     * @param s action string name.
+     * @param wi window interface.
+     * @param paneClass pane class string.
+     * @param memo system connection.
      */
     public Dcc4PcNamedPaneAction(String s, WindowInterface wi, String paneClass, Dcc4PcSystemConnectionMemo memo) {
         super(s, wi, paneClass);

--- a/java/src/jmri/jmrix/dcc4pc/swing/Dcc4PcPanelInterface.java
+++ b/java/src/jmri/jmrix/dcc4pc/swing/Dcc4PcPanelInterface.java
@@ -12,10 +12,11 @@ import jmri.jmrix.dcc4pc.Dcc4PcSystemConnectionMemo;
 public interface Dcc4PcPanelInterface {
 
     /**
-     * 2nd stage of initialization, invoked after the constuctor is complete.
+     * 2nd stage of initialization, invoked after the constructor is complete.
      * <p>
      * This needs to be connected to the initContext() method in implementing
      * classes.
+     * @param memo system connection.
      */
     public void initComponents(Dcc4PcSystemConnectionMemo memo);
 

--- a/java/src/jmri/jmrix/dccpp/AbstractDCCppSerialConnectionConfig.java
+++ b/java/src/jmri/jmrix/dccpp/AbstractDCCppSerialConnectionConfig.java
@@ -13,6 +13,7 @@ public abstract class AbstractDCCppSerialConnectionConfig extends jmri.jmrix.Abs
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public AbstractDCCppSerialConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
@@ -56,6 +56,7 @@ public class DCCppCommandStation implements jmri.CommandStation {
     /**
      * Parses the DCC++ CS status response to pull out the base station version
      * and software version.
+     * @param l status response to query.
      */
     protected void setCommandStationInfo(DCCppReply l) {
  // V1.0 Syntax
@@ -100,6 +101,7 @@ public class DCCppCommandStation implements jmri.CommandStation {
     /**
      * Provide the version string returned during the initial check.
      * This function is not yet implemented...
+     * @return version string.
      */
     public String getVersionString() {
         return(baseStationType + ": BUILD " + codeBuildDate);
@@ -112,15 +114,18 @@ public class DCCppCommandStation implements jmri.CommandStation {
 
     /**
      * DCC++ command station does provide Ops Mode.
+     * @return always true.
      */
     public boolean isOpsModePossible() {
- return true;
+        return true;
     }
 
     // A few utility functions
     /**
      * Get the Lower byte of a locomotive address from the decimal locomotive
      * address.
+     * @param address loco address.
+     * @return loco address byte lo.
      */
     public static int getDCCAddressLow(int address) {
         /* For addresses below 128, we just return the address, otherwise,
@@ -138,6 +143,8 @@ public class DCCppCommandStation implements jmri.CommandStation {
     /**
      * Get the Upper byte of a locomotive address from the decimal locomotive
      * address.
+     * @param address loco address.
+     * @return high byte of address.
      */
     public static int getDCCAddressHigh(int address) {
         /* this isn't actually the high byte, For addresses below 128, we

--- a/java/src/jmri/jmrix/dccpp/DCCppListener.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppListener.java
@@ -41,6 +41,7 @@ public interface DCCppListener extends jmri.jmrix.AbstractMRListener {
      * Member function invoked by an DCCppInterface implementation to notify a
      * sender that an outgoing message timed out and was dropped from the
      * queue.
+     * @param msg the message that timed out.
      */
     public void notifyTimeout(DCCppMessage msg);
 

--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -93,8 +93,9 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
 
     /**
      * Create an DCCppMessage from an DCCppReply.
+     * Not used.  Really, not even possible.  Consider removing.
+     * @param message existing reply to replicate.
      */
-    // NOTE: Not used.  Really, not even possible.  Consider removing.
     public DCCppMessage(DCCppReply message) {
         super(message.getNumDataElements());
         setBinary(false);
@@ -106,15 +107,17 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
 
     /**
-     * Create a DCCppMessage from a String containing bytes. Since DCCppMessages
-     * are text, there is no Hex-to-byte conversion
+     * Create a DCCppMessage from a String containing bytes.
+     * <p>
+     * Since DCCppMessages are text, there is no Hex-to-byte conversion.
      * <p>
      * NOTE 15-Feb-17: un-Deprecating this function so that it can be used in
-     * the DCCppOverTCP server/client interface. Messages shouldn't be parsed,
-     * they are already in DCC++ format, so we need the string constructor to
-     * generate a DCCppMessage from the incoming byte stream
+     * the DCCppOverTCP server/client interface. 
+     * Messages shouldn't be parsed, they are already in DCC++ format,
+     * so we need the string constructor to generate a DCCppMessage from 
+     * the incoming byte stream.
+     * @param s message in string form.
      */
-    //@Deprecated
     public DCCppMessage(String s) {
         setBinary(false);
         setRetries(_nRetries);
@@ -1516,13 +1519,9 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * control code.  These are used in multiple places within the code,
      * so they appear here.
      */
+    
     /**
-     * Stationary Decoder Message
-     * <p>
-     * Format: {@code <a ADDRESS SUBADDRESS ACTIVATE>}
-     * <p>
-     * ADDRESS: the primary address of the decoder (0-511) SUBADDRESS: the
-     * subaddress of the decoder (0-3) ACTIVATE: 1=on (set), 0=off (clear)
+     * Stationary Decoder Message.
      * <p>
      * Note that many decoders and controllers combine the ADDRESS and
      * SUBADDRESS into a single number, N, from 1 through a max of 2044, where
@@ -1534,7 +1533,10 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * {@code ADDRESS = INT((N - 1) / 4) + 1}
      *    {@code SUBADDRESS = (N - 1) % 4}
      * <p>
-     * returns: NONE
+     * @param address the primary address of the decoder (0-511).
+     * @param subaddress the subaddress of the decoder (0-3).
+     * @param activate true on, false off.
+     * @return accessory decoder message.
      */
     public static DCCppMessage makeAccessoryDecoderMsg(int address, int subaddress, boolean activate) {
         // Sanity check inputs
@@ -1571,25 +1573,11 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
 
     /**
-     * Predefined Turnout Control Message
+     * Predefined Turnout Control Message.
      * <p>
-     * Format: {@code <T ID THROW>}
-     * <p>
-     * ID: the numeric ID (0-32767) of the turnout to control THROW: 0
-     * (unthrown) or 1 (thrown)
-     * <p>
-     * returns:{@code <H ID THROW>}
-     * <p>
-     * ADD: {@code <T ID ADDRESS SUBADDRESS>} ID: the numeric ID (0-32767) of
-     * the turnout to control ADDRESS: Decoder address (0-511) SUBADDRESS:
-     * Decoder subaddress (0-3) RETURNS: {@code <O>} on success, {@code <X>} on
-     * failure
-     * <p>
-     * DELETE: {@code <T ID>} ID: the numeric ID (0-32767) of the turnout to
-     * control RETURNS: {@code <O>} on success, {@code <X>} on failure
-     * <p>
-     * LIST: {@code <T>} RETURNS: {@code <H ID ADDRESS SUBADDRESS THROW>} for
-     * each defined turnout or {@code <X>} if no turnouts defined.
+     * @param id the numeric ID (0-32767) of the turnout to control.
+     * @param thrown true thrown, false closed.
+     * @return message to set turnout.
      */
     public static DCCppMessage makeTurnoutCommandMsg(int id, boolean thrown) {
         // Sanity check inputs
@@ -1698,17 +1686,13 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
 
     /**
-     * Create/Delete/Query Sensor
+     * Create/Delete/Query Sensor.
      * <p>
-     * ADD: {@code <S ID PIN PULLUP>} ID (0-32767) PIN: Arduino Pin # of sensor
-     * PULLUP: TRUE if use internal pullup for PIN, FALSE if don't. RETURNS:
-     * {@code <O>} on success, {@code <X>} on failure
-     * <p>
-     * DELETE: {@code <S ID>} RETURNS: {@code <O>} on success, {@code <X>} on
-     * failure
-     * <p>
-     * LIST: {@code <S>} RETURNS: {@code <Q ID PIN PULLUP>} for each defined
      * sensor, or {@code <X>} if no sensors defined.
+     * @param id pin pullup (0-32767).
+     * @param pin Arduino pin index of sensor.
+     * @param pullup true if use internal pullup for PIN, false if not.
+     * @return message to create the sensor.
      */
     public static DCCppMessage makeSensorAddMsg(int id, int pin, int pullup) {
         // Sanity check inputs
@@ -1746,11 +1730,9 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
 
     /**
-     * Query All Sensors States
+     * Query All Sensors States.
      * <p>
-     * Format: {@code <Q>}
-     * <p>
-     * returns status messages containing the status of each connected sensor.
+     * @return message to query all sensor states.
      */
     public static DCCppMessage makeQuerySensorStatesMsg() {
         return (new DCCppMessage(DCCppConstants.QUERY_SENSOR_STATES_CMD, DCCppConstants.QUERY_SENSOR_STATES_REGEX));
@@ -1778,6 +1760,9 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * returns: {@code <r CALLBACKNUM|CALLBACKSUB|CV Value)} where VALUE is a
      * number from 0-255 as read from the requested CV, or -1 if verificaiton
      * read fails
+     * @param cv CV index, 1-1024.
+     * @param val new CV value, 0-255.
+     * @return message to write Direct CV.
      */
     public static DCCppMessage makeWriteDirectCVMsg(int cv, int val) {
         return (makeWriteDirectCVMsg(cv, val, 0, DCCppConstants.PROG_WRITE_CV_BYTE));
@@ -1834,6 +1819,10 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * returns: {@code <r CALLBACKNUM|CALLBACKSUB|CV BIT VALUE)} where VALUE is
      * a number from 0-1 as read from the requested CV bit, or -1 if
      * verificaiton read fails
+     * @param cv CV index, 1-1024.
+     * @param bit bit index, 0-7
+     * @param val bit value, 0-1.
+     * @return message to write driect CV bit.
      */
     public static DCCppMessage makeBitWriteDirectCVMsg(int cv, int bit, int val) {
         return (makeBitWriteDirectCVMsg(cv, bit, val, 0, DCCppConstants.PROG_WRITE_CV_BIT));
@@ -1869,7 +1858,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
 
     /**
-     * Read Direct CV Byte from Programming Track
+     * Read Direct CV Byte from Programming Track.
      * <p>
      * Format: {@code <R CV CALLBACKNUM CALLBACKSUB>}
      * <p>
@@ -1890,6 +1879,8 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * returns: {@code <r CALLBACKNUM|CALLBACKSUB|CV VALUE>} where VALUE is a
      * number from 0-255 as read from the requested CV, or -1 if read could not
      * be verified
+     * @param cv CV index.
+     * @return message to send read direct CV.
      */
     public static DCCppMessage makeReadDirectCVMsg(int cv) {
         return (makeReadDirectCVMsg(cv, 0, DCCppConstants.PROG_READ_CV));
@@ -1923,15 +1914,16 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * <p>
      * Format: {@code <w CAB CV VALUE>}
      * <p>
-     * writes, without any verification, a Configuration Variable to the decoder
-     * of an engine on the main operations track
+     * Writes, without any verification, a Configuration Variable to the decoder
+     * of an engine on the main operations track.
      * <p>
-     * CAB: the short (1-127) or long (128-10293) address of the engine decoder
-     * CV: the number of the Configuration Variable memory location in the
-     * decoder to write to (1-1024) VALUE: the value to be written to the
-     * Configuration Variable memory location (0-255)
-     * <p>
-     * returns: NONE
+     * @param address the short (1-127) or long (128-10293) address of the 
+     *                  engine decoder.
+     * @param cv the number of the Configuration Variable memory location in the
+     *                  decoder to write to (1-1024).
+     * @param val the value to be written to the
+     *                  Configuration Variable memory location (0-255).
+     * @return message to Write CV in Ops Mode.
      */
     public static DCCppMessage makeWriteOpsModeCVMsg(int address, int cv, int val) {
         // Sanity check inputs
@@ -1957,7 +1949,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
 
     /**
-     * Write Direct CV Bit to Main Track
+     * Write Direct CV Bit to Main Track.
      * <p>
      * Format: {@code <b CAB CV BIT VALUE>}
      * <p>
@@ -1966,11 +1958,16 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * <p>
      * CAB: the short (1-127) or long (128-10293) address of the engine decoder
      * CV: the number of the Configuration Variable memory location in the
-     * decoder to write to (1-1024) BIT: the bit number of the Configurarion
-     * Variable regsiter to write (0-7) VALUE: the value of the bit to be
+     * decoder to write to (1-1024) BIT: the bit number of the Configuration
+     * Variable register to write (0-7) VALUE: the value of the bit to be
      * written (0-1)
      * <p>
      * returns: NONE
+     * @param address loco cab address.
+     * @param cv CV index, 1-1024.
+     * @param bit bit index, 0-7.
+     * @param val bit value, 0 or 1.
+     * @return message to write direct CV bit to main track.
      */
     public static DCCppMessage makeBitWriteOpsModeCVMsg(int address, int cv, int bit, int val) {
         // Sanity Check Inputs
@@ -1998,11 +1995,12 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
 
     /**
-     * Set Track Power ON or OFFf
+     * Set Track Power ON or OFF.
      * <p>
      * Format: {@code <1> (ON) or <0> (OFF)}
      * <p>
-     * Returns {@code <p1> (ON) or <p0> (OFF)}
+     * @return message to send track power on or off.
+     * @param on true on, false off.
      */
     public static DCCppMessage makeSetTrackPowerMsg(boolean on) {
         return (new DCCppMessage((on ? DCCppConstants.TRACK_POWER_ON : DCCppConstants.TRACK_POWER_OFF),
@@ -2024,7 +2022,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * <p>
      * reads current being drawn on main operations track
      * <p>
-     * returns: {@code <a CURRENT>} where CURRENT = 0-1024, based on
+     * @return {@code <a CURRENT>} where CURRENT = 0-1024, based on
      * exponentially-smoothed weighting scheme
      */
     public static DCCppMessage makeReadTrackCurrentMsg() {
@@ -2042,7 +2040,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * connectivity and update any GUI to reflect actual throttle and turn-out
      * settings
      * <p>
-     * returns: series of status messages that can be read by an interface to
+     * @return series of status messages that can be read by an interface to
      * determine status of DCC++ Base Station and important settings
      */
     public static DCCppMessage makeCSStatusMsg() {
@@ -2057,18 +2055,20 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * returns number of slots NOTE: this is not implemented in older versions
      * which then do not return anything at all
      * <p>
-     * returns: status message with to get number of slots
+     * @return status message with to get number of slots.
      */
     public static DCCppMessage makeCSMaxNumSlotsMsg() {
         return (new DCCppMessage(DCCppConstants.READ_CS_MAXNUMSLOTS, DCCppConstants.READ_CS_MAXNUMSLOTS_REGEX));
     }
 
     /**
-     * Generate an emergency stop for the specified address
-     *
-     * @param address is the locomotive address
-     *
+     * Generate an emergency stop for the specified address.
+     * <p>
      * Note: This just sends a THROTTLE command with speed = -1
+     * 
+     * @param register Register Number for the loco assigned address.
+     * @param address is the locomotive address.
+     * @return message to send e stop to the specified address.
      */
     public static DCCppMessage makeAddressedEmergencyStop(int register, int address) {
         // Sanity check inputs
@@ -2108,7 +2108,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * when speed=0 or speed=-1 only effects directionality of cab lighting for
      * a stopped train
      *
-     * returns: {@code <T REGISTER SPEED DIRECTION>}
+     * @return {@code <T REGISTER SPEED DIRECTION>}
      *
      */
     public static DCCppMessage makeSpeedAndDirectionMsg(int register, int address, float speed, boolean isForward) {
@@ -2180,6 +2180,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * @param f2      is true if f2 is on, false if f2 is off
      * @param f3      is true if f3 is on, false if f3 is off
      * @param f4      is true if f4 is on, false if f4 is off
+     * @return message to set function group 1.
      */
     public static DCCppMessage makeFunctionGroup1OpsMsg(int address,
             boolean f0,
@@ -2216,6 +2217,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * @param f2      is true if f2 is momentary
      * @param f3      is true if f3 is momentary
      * @param f4      is true if f4 is momentary
+     * @return message to set momentary function group 1.
      */
     public static DCCppMessage makeFunctionGroup1SetMomMsg(int address,
             boolean f0,
@@ -2253,6 +2255,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * @param f6      is true if f6 is on, false if f6 is off
      * @param f7      is true if f7 is on, false if f7 is off
      * @param f8      is true if f8 is on, false if f8 is off
+     * @return message to set function group 2.
      */
     public static DCCppMessage makeFunctionGroup2OpsMsg(int address,
             boolean f5,
@@ -2289,6 +2292,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * @param f6      is true if f6 is momentary
      * @param f7      is true if f7 is momentary
      * @param f8      is true if f8 is momentary
+     * @return message to set momentary function group 2.
      */
     public static DCCppMessage makeFunctionGroup2SetMomMsg(int address,
             boolean f5,
@@ -2324,6 +2328,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * @param f10     is true if f10 is on, false if f10 is off
      * @param f11     is true if f11 is on, false if f11 is off
      * @param f12     is true if f12 is on, false if f12 is off
+     * @return message to set function group 3.
      */
     public static DCCppMessage makeFunctionGroup3OpsMsg(int address,
             boolean f9,
@@ -2359,6 +2364,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * @param f10     is true if f10 is momentary
      * @param f11     is true if f11 is momentary
      * @param f12     is true if f12 is momentary
+     * @return message to set momentary function group 3.
      */
     public static DCCppMessage makeFunctionGroup3SetMomMsg(int address,
             boolean f9,
@@ -2398,6 +2404,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * @param f18     is true if f18 is on, false if f18 is off
      * @param f19     is true if f19 is on, false if f19 is off
      * @param f20     is true if f20 is on, false if f20 is off
+     * @return message to set function group 4.
      */
     public static DCCppMessage makeFunctionGroup4OpsMsg(int address,
             boolean f13,
@@ -2446,6 +2453,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * @param f18     is true if f18 is Momentary
      * @param f19     is true if f19 is Momentary
      * @param f20     is true if f20 is Momentary
+     * @return message to set momentary function group 4.
      */
     public static DCCppMessage makeFunctionGroup4SetMomMsg(int address,
             boolean f13,
@@ -2495,6 +2503,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * @param f26     is true if f26 is on, false if f26 is off
      * @param f27     is true if f27 is on, false if f27 is off
      * @param f28     is true if f28 is on, false if f28 is off
+     * @return message to set function group 5.
      */
     public static DCCppMessage makeFunctionGroup5OpsMsg(int address,
             boolean f21,
@@ -2544,6 +2553,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * @param f26     is true if f26 is momentary
      * @param f27     is true if f27 is momentary
      * @param f28     is true if f28 is momentary
+     * @return message to set momentary function group 5.
      */
     public static DCCppMessage makeFunctionGroup5SetMomMsg(int address,
             boolean f21,

--- a/java/src/jmri/jmrix/dccpp/DCCppNetworkPortController.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppNetworkPortController.java
@@ -51,6 +51,7 @@ public abstract class DCCppNetworkPortController extends jmri.jmrix.AbstractNetw
     // in pr3/PR3Adapter
     /**
      * Set config info from a name, which needs to be one of the valid ones.
+     * @param name exact name of command station type.
      */
     public void setCommandStationType(String name) {
         for (int i = 0; i < commandStationNames.length; i++) {
@@ -65,6 +66,7 @@ public abstract class DCCppNetworkPortController extends jmri.jmrix.AbstractNetw
     
     /**
      * Set config info from the command station type enum.
+     * @param value command station type.
      */
     public void setCommandStationType(int value) {
         log.debug("setCommandStationType: {}{}", Integer.toString(value));

--- a/java/src/jmri/jmrix/dccpp/DCCppPortController.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPortController.java
@@ -21,11 +21,13 @@ public interface DCCppPortController extends jmri.jmrix.PortAdapter {
     /**
      * Can the port accept additional characters? This might go false for short
      * intervals, but it might also stick off if something goes wrong.
+     * @return true if OK to send, else false.
      */
     public boolean okToSend();
 
     /**
      * We need a way to say if the output buffer is empty or not
+     * @param s true to set buffer empty, else false.
      */
     public void setOutputBufferEmpty(boolean s);
 

--- a/java/src/jmri/jmrix/dccpp/DCCppStreamConnectionConfig.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppStreamConnectionConfig.java
@@ -16,6 +16,7 @@ public class DCCppStreamConnectionConfig extends jmri.jmrix.AbstractStreamConnec
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p stream port controller.
      */
     public DCCppStreamConnectionConfig(jmri.jmrix.AbstractStreamPortController p) {
         super(p);

--- a/java/src/jmri/jmrix/dccpp/DCCppSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppSystemConnectionMemo.java
@@ -61,6 +61,7 @@ public class DCCppSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     /**
      * Provide access to the TrafficController for this particular connection.
+     * @return traffic controller, one is provided if null.
      */
     public DCCppTrafficController getDCCppTrafficController() {
         if (xt == null) {
@@ -85,8 +86,9 @@ public class DCCppSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
     }
 
     /**
-     * Provides access to the Programmer for this particular connection. NOTE:
-     * Programmer defaults to null
+     * Provides access to the Programmer for this particular connection.
+     * NOTE: Programmer defaults to null
+     * @return programmer manager.
      */
     public DCCppProgrammerManager getProgrammerManager() {
         return programmerManager;

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
@@ -32,7 +32,9 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
     protected int address;
 
     /**
-     * Constructor
+     * Constructor.
+     * @param memo system connection.
+     * @param controller system connection traffic controller.
      */
     public DCCppThrottle(DCCppSystemConnectionMemo memo, DCCppTrafficController controller) {
         super(memo);
@@ -44,7 +46,10 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
     }
 
     /**
-     * Constructor
+     * Constructor.
+     * @param memo system connection.
+     * @param address loco address.
+     * @param controller system connection traffic controller.
      */
     public DCCppThrottle(DCCppSystemConnectionMemo memo, LocoAddress address, DCCppTrafficController controller) {
         super(memo);

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
@@ -25,6 +25,7 @@ public class DCCppThrottleManager extends AbstractThrottleManager implements DCC
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public DCCppThrottleManager(DCCppSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/dccpp/dccppovertcp/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/dccpp/dccppovertcp/ConnectionConfig.java
@@ -27,6 +27,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Ctor for a connection configuration with no preexisting adapter.
      * {@link #setInstance()} will fill the adapter member.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/dccpp/network/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/dccpp/network/ConnectionConfig.java
@@ -19,6 +19,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/dccpp/network/DCCppEthernetAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/network/DCCppEthernetAdapter.java
@@ -80,18 +80,6 @@ public class DCCppEthernetAdapter extends DCCppNetworkPortController {
     }
     
     /**
-     * Local method to do specific configuration.
-     */
-    @Deprecated
-    static public DCCppEthernetAdapter instance() {
-        if (mInstance == null) {
-            mInstance = new DCCppEthernetAdapter();
-        }
-        return mInstance;
-    }
-    volatile static DCCppEthernetAdapter mInstance = null;
-    
-    /**
      * Set up the keepAliveTimer, and start it.
      */
     private void keepAliveTimer() {

--- a/java/src/jmri/jmrix/dccpp/serial/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/dccpp/serial/ConnectionConfig.java
@@ -18,6 +18,7 @@ public class ConnectionConfig extends jmri.jmrix.dccpp.AbstractDCCppSerialConnec
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/dccpp/simulator/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/dccpp/simulator/ConnectionConfig.java
@@ -19,6 +19,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConf
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/debugthrottle/DebugThrottle.java
+++ b/java/src/jmri/jmrix/debugthrottle/DebugThrottle.java
@@ -16,7 +16,9 @@ import org.slf4j.LoggerFactory;
 public class DebugThrottle extends AbstractThrottle {
 
     /**
-     * Constructor
+     * Constructor.
+     * @param address loco address.
+     * @param memo system connection.
      */
     public DebugThrottle(DccLocoAddress address, SystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/debugthrottle/DebugThrottleManager.java
+++ b/java/src/jmri/jmrix/debugthrottle/DebugThrottleManager.java
@@ -22,6 +22,7 @@ public class DebugThrottleManager extends AbstractThrottleManager {
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public DebugThrottleManager(jmri.jmrix.SystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/direct/DirectSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/direct/DirectSystemConnectionMemo.java
@@ -51,6 +51,7 @@ public class DirectSystemConnectionMemo extends SystemConnectionMemo {
 
     /**
      * Get the traffic controller instance associated with this connection memo.
+     * @return traffic controller, provided if null.
      */
     public TrafficController getTrafficController(){
         if (tc == null) {
@@ -74,6 +75,7 @@ public class DirectSystemConnectionMemo extends SystemConnectionMemo {
 
     /**
      * Get the ThrottleManager instance associated with this connection memo.
+     * @return throttle manager, provided if null.
      */
     public ThrottleManager getThrottleManager(){
         if (tm == null) {

--- a/java/src/jmri/jmrix/direct/Throttle.java
+++ b/java/src/jmri/jmrix/direct/Throttle.java
@@ -18,6 +18,8 @@ public class Throttle extends AbstractThrottle {
 
     /**
      * Constructor.
+     * @param address loco address.
+     * @param tc system connection traffic controller.
      */
     public Throttle(DccLocoAddress address, CommandStation tc) {
         super(null);

--- a/java/src/jmri/jmrix/direct/ThrottleManager.java
+++ b/java/src/jmri/jmrix/direct/ThrottleManager.java
@@ -24,6 +24,7 @@ public class ThrottleManager extends AbstractThrottleManager {
     private CommandStation tc = null;
     /**
      * Constructor for a Direct ThrottleManager.
+     * @param memo system connection.
      */
     public ThrottleManager(DirectSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/direct/TrafficController.java
+++ b/java/src/jmri/jmrix/direct/TrafficController.java
@@ -27,6 +27,7 @@ public class TrafficController implements jmri.CommandStation {
 
     /**
      * Create a new Direct TrafficController instance.
+     * @param memo system connection.
      */
     public TrafficController(DirectSystemConnectionMemo memo) {
         super();

--- a/java/src/jmri/jmrix/direct/serial/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/direct/serial/ConnectionConfig.java
@@ -13,6 +13,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/direct/serial/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/direct/serial/SerialDriverAdapter.java
@@ -189,24 +189,6 @@ public class SerialDriverAdapter extends PortController {
     InputStream serialInStream = null;
     OutputStream serialOutStream = null;
 
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI
-     * multi-system support structure
-     */
-    @Deprecated
-    static public SerialDriverAdapter instance() {
-        if (mInstance == null) {
-            mInstance = new SerialDriverAdapter();
-        }
-        return mInstance;
-    }
-    /**
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI
-     * multi-system support structure
-     */
-    @Deprecated
-    static SerialDriverAdapter mInstance = null;
-
     private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/direct/simulator/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/direct/simulator/ConnectionConfig.java
@@ -19,6 +19,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConf
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/easydcc/EasyDccSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccSystemConnectionMemo.java
@@ -68,6 +68,7 @@ public class EasyDccSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
 
     /**
      * Provide access to the TrafficController for this particular connection.
+     * @return traffic controller, provided if null.
      */
     public EasyDccTrafficController getTrafficController() {
         if (et == null) {

--- a/java/src/jmri/jmrix/easydcc/EasyDccThrottleManager.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccThrottleManager.java
@@ -22,6 +22,7 @@ public class EasyDccThrottleManager extends AbstractThrottleManager {
 
     /**
      * Constructor
+     * @param memo system connection.
      */
     public EasyDccThrottleManager(EasyDccSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/easydcc/EasyDccTurnout.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccTurnout.java
@@ -23,10 +23,13 @@ public class EasyDccTurnout extends AbstractTurnout {
     protected String _prefix = "E"; // default to "E"
 
     /**
-     * Create a turnout. EasyDCC turnouts use the NMRA number (0-511) as their
-     * numerical identification.
+     * Create a turnout.
+     * <p>
+     * EasyDCC turnouts use the NMRA number (0-511) as their numerical identification.
      *
-     * @param number the NMRA turnout number from 0 to 511
+     * @param prefix system connection prefix.
+     * @param number the NMRA turnout number from 0 to 511.
+     * @param memo system connection.
      */
     public EasyDccTurnout(String prefix, int number, EasyDccSystemConnectionMemo memo) {
         super(prefix + "T" + number);

--- a/java/src/jmri/jmrix/easydcc/networkdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/easydcc/networkdriver/ConnectionConfig.java
@@ -13,6 +13,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/easydcc/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/easydcc/serialdriver/ConnectionConfig.java
@@ -11,6 +11,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process.
      * Swing init is deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/easydcc/simulator/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/easydcc/simulator/ConnectionConfig.java
@@ -19,6 +19,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConf
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
@@ -35,6 +35,7 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
      * Create a new EcosDccThrottle.
      * @param address Throttle Address
      * @param memo System Connection
+     * @param control sets _control flag which NEEDS CLARIFICATION.
      */
     public EcosDccThrottle(DccLocoAddress address, EcosSystemConnectionMemo memo, boolean control) {
         super(memo);

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottleManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottleManager.java
@@ -20,6 +20,7 @@ public class EcosDccThrottleManager extends AbstractThrottleManager implements E
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public EcosDccThrottleManager(EcosSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/ecos/EcosLocoAddressManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosLocoAddressManager.java
@@ -286,6 +286,7 @@ public class EcosLocoAddressManager extends jmri.managers.AbstractManager<NamedB
      * Forget a NamedBean Object created outside the manager.
      * <p>
      * The non-system-specific RouteManager uses this method.
+     * @param s Ecos Loco Address to de-register.
      */
     public void deregister(EcosLocoAddress s) {
         s.removePropertyChangeListener(this);

--- a/java/src/jmri/jmrix/ecos/EcosReply.java
+++ b/java/src/jmri/jmrix/ecos/EcosReply.java
@@ -53,7 +53,8 @@ public class EcosReply extends jmri.jmrix.AbstractMRReply {
     int endAtElement = -1;
 
     /**
-     * Check for last line starts with {@code "<END "}
+     * Check for last line starts with {@code "<END "}.
+     * @return true if contains END, else false.
      */
     public boolean containsEnd() {
         for (int i = 0; i < getNumDataElements() - 6; i++) {
@@ -71,7 +72,8 @@ public class EcosReply extends jmri.jmrix.AbstractMRReply {
     }
 
     /**
-     * returns -1 if the end code has not been found.
+     * Get the Result Code.
+     * @return result code, else -1 if the end code has not been found.
      */
     public int getResultCode() {
         if (!containsEnd()) {
@@ -239,6 +241,7 @@ public class EcosReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * get the contents of the reply, excluding the header and footer
+     * @return array with reply values.
      */
     public String[] getContents() {
         String[] lines = toString().split("\n");

--- a/java/src/jmri/jmrix/ecos/EcosSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/ecos/EcosSystemConnectionMemo.java
@@ -45,6 +45,7 @@ public class EcosSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     /**
      * Provides access to the TrafficController for this particular connection.
+     * @return Ecos traffic controller.
      */
     public EcosTrafficController getTrafficController() {
         return et;

--- a/java/src/jmri/jmrix/ecos/EcosTurnout.java
+++ b/java/src/jmri/jmrix/ecos/EcosTurnout.java
@@ -30,7 +30,10 @@ public class EcosTurnout extends AbstractTurnout
      * ECoS turnouts use the NMRA number (0-2044) as their numerical
      * identification in the system name.
      *
-     * @param number DCC address of the turnout
+     * @param number DCC address of the turnout.
+     * @param prefix system prefix.
+     * @param etc system connection traffic controller.
+     * @param etm ecos turnout manager.
      */
     public EcosTurnout(int number, String prefix, EcosTrafficController etc, EcosTurnoutManager etm) {
         super(prefix + "T" + number);

--- a/java/src/jmri/jmrix/ecos/networkdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/ecos/networkdriver/ConnectionConfig.java
@@ -11,6 +11,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/ecos/swing/EcosNamedPaneAction.java
+++ b/java/src/jmri/jmrix/ecos/swing/EcosNamedPaneAction.java
@@ -16,6 +16,10 @@ public class EcosNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction {
 
     /**
      * Enhanced constructor for placing the pane in various GUIs.
+     * @param s action title string.
+     * @param wi window interface.
+     * @param paneClass pane class string.
+     * @param memo system connection.
      */
     public EcosNamedPaneAction(String s, WindowInterface wi, String paneClass, EcosSystemConnectionMemo memo) {
         super(s, wi, paneClass);

--- a/java/src/jmri/jmrix/ecos/swing/EcosPanelInterface.java
+++ b/java/src/jmri/jmrix/ecos/swing/EcosPanelInterface.java
@@ -16,6 +16,7 @@ public interface EcosPanelInterface {
      * <p>
      * This needs to be connected to the initContext() method in implementing
      * classes.
+     * @param memo system connection.
      */
     public void initComponents(EcosSystemConnectionMemo memo);
 

--- a/java/src/jmri/jmrix/ecos/swing/locodatabase/EcosLocoTableAction.java
+++ b/java/src/jmri/jmrix/ecos/swing/locodatabase/EcosLocoTableAction.java
@@ -50,6 +50,7 @@ public class EcosLocoTableAction extends AbstractTableAction<NamedBean> {
      * <p>
      * Note that the argument is the Action title, not the title of the
      * resulting frame. Perhaps this should be changed?
+     * @param s Action title string.
      */
     public EcosLocoTableAction(String s) {
         super(s);

--- a/java/src/jmri/jmrix/ecos/utilities/AddRosterEntryToEcos.java
+++ b/java/src/jmri/jmrix/ecos/utilities/AddRosterEntryToEcos.java
@@ -22,7 +22,8 @@ public class AddRosterEntryToEcos extends AbstractAction {
     private EcosLocoAddressManager objEcosLocoManager;
 
     /**
-     * @param s Name of this action, e.g. in menus
+     * @param s Name of this action, e.g. in menus.
+     * @param memo system connection.
      */
     public AddRosterEntryToEcos(String s, EcosSystemConnectionMemo memo) {
         super(s);

--- a/java/src/jmri/jmrix/ecos/utilities/EcosLocoToRoster.java
+++ b/java/src/jmri/jmrix/ecos/utilities/EcosLocoToRoster.java
@@ -596,7 +596,8 @@ public class EcosLocoToRoster implements EcosListener {
     }
 
     /**
-     *
+     * Check for Duplicate roster entry.
+     * @param id Loco ID String.
      * @return true if the value in the Ecos Description is a duplicate of some
      *         other RosterEntry in the roster
      */

--- a/java/src/jmri/jmrix/ecos/utilities/GetEcosObjectNumber.java
+++ b/java/src/jmri/jmrix/ecos/utilities/GetEcosObjectNumber.java
@@ -10,7 +10,10 @@ package jmri.jmrix.ecos.utilities;
 public class GetEcosObjectNumber {
 
     /**
-     * @param s Name of this action, e.g. in menus
+     * @param s Name of this action, e.g. in menus.
+     * @param start start string.
+     * @param finish finish string.
+     * @return object number.
      */
     static public int getEcosObjectNumber(String s, String start, String finish) {
         int intStart = 0;

--- a/java/src/jmri/jmrix/grapevine/GrapevineSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/grapevine/GrapevineSystemConnectionMemo.java
@@ -54,6 +54,7 @@ public class GrapevineSystemConnectionMemo extends SystemConnectionMemo {
 
     /**
      * Get the traffic controller instance associated with this connection memo.
+     * @return traffic controller, one is provided if null.
      */
     public SerialTrafficController getTrafficController(){
         if (tc == null) {
@@ -97,6 +98,7 @@ public class GrapevineSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the SensorManager for this particular connection.
      * <p>
      * NOTE: SensorManager defaults to NULL
+     * @return sensor manager.
      */
     public SensorManager getSensorManager() {
         log.debug(sensorManager != null ? "getSensorManager OK": "getSensorManager returned NULL");
@@ -114,6 +116,7 @@ public class GrapevineSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the TurnoutManager for this particular connection.
      * <p>
      * NOTE: TurnoutManager defaults to NULL
+     * @return turnout manager.
      */
     public TurnoutManager getTurnoutManager() {
         log.debug(turnoutManager != null ? "getTurnoutManager OK": "getTurnoutManager returned NULL");
@@ -131,6 +134,7 @@ public class GrapevineSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the LightManager for this particular connection.
      * <p>
      * NOTE: LightManager defaults to NULL
+     * @return light manager.
      */
     public LightManager getLightManager() {
         log.debug(lightManager != null ? "getLightManager OK": "getLightManager returned NULL");

--- a/java/src/jmri/jmrix/grapevine/SerialAddress.java
+++ b/java/src/jmri/jmrix/grapevine/SerialAddress.java
@@ -197,6 +197,8 @@ public class SerialAddress {
     /**
      * Public static method to parse a system name and return the Serial Node.
      *
+     * @param systemName system name.
+     * @param tc system connection traffic controller.
      * @return 'NULL' if illegal systemName format or if the node is not found
      */
     public static SerialNode getNodeFromSystemName(String systemName, SerialTrafficController tc) {
@@ -229,6 +231,8 @@ public class SerialAddress {
      * Public static method to parse a system name and return the bit number.
      * Notes: Bits are numbered from 1.
      *
+     * @param systemName system name.
+     * @param prefix unused.
      * @return 0 if an error is found
      */
     public static int getBitFromSystemName(String systemName, String prefix) {
@@ -263,6 +267,8 @@ public class SerialAddress {
      * <p>
      * Note: Nodes are numbered from 1.
      *
+     * @param systemName system name.
+     * @param prefix unused.
      * @return node number. If an error is found, returns -1
      */
     public static int getNodeAddressFromSystemName(String systemName, String prefix) {
@@ -532,8 +538,12 @@ public class SerialAddress {
     /**
      * Public static method to validate system name for configuration.
      *
-     * @return 'true' if system name has a valid meaning in current configuration, else
-     * returns 'false'
+     * @param systemName system name to validate.
+     * @param type bean type, S, T or L.
+     * @param tc system connection traffic controller.
+     * @return 'true' if system name has a valid meaning in current configuration, 
+     *                else returns 'false'.
+     * 
      */
     public static boolean validSystemNameConfig(String systemName, char type, SerialTrafficController tc) {
         String prefix = tc.getSystemConnectionMemo().getSystemPrefix();
@@ -573,9 +583,14 @@ public class SerialAddress {
 
     /**
      * Public static method to convert any format system name for the alternate
-     * format (nnBnn). If the supplied system name does not have a valid format,
-     * or if there is no representation in the alternate naming scheme, an empty
-     * string is returned.
+     * format (nnBnn).
+     * <p>
+     * If the supplied system name does not have a valid format,
+     * or if there is no representation in the alternate naming scheme,
+     * an empty string is returned.
+     * @param systemName system name to convert.
+     * @param prefix system prefix.
+     * @return alternate string.
      */
     public static String convertSystemNameToAlternate(String systemName, String prefix) {
         // ensure that input system name has a valid format
@@ -606,6 +621,9 @@ public class SerialAddress {
      * If the supplied system name does not have a valid format, an empty string
      * is returned. Otherwise a normalized name is returned in the same format
      * as the input name.
+     * @param systemName system name to normalize.
+     * @param prefix system prefix.
+     * @return normalized string.
      */
     public static String normalizeSystemName(String systemName, String prefix) {
         // ensure that input system name has a valid format

--- a/java/src/jmri/jmrix/grapevine/SerialMessage.java
+++ b/java/src/jmri/jmrix/grapevine/SerialMessage.java
@@ -81,8 +81,10 @@ public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
 
     /**
      * For Grapevine, which doesn't have a data poll, the poll operation is only
-     * used to see that the nodes are present. This is done by sending a "get
-     * software version" command.
+     * used to see that the nodes are present.
+     * This is done by sending a "get software version" command.
+     * @param addr address to poll.
+     * @return serial message to poll data.
      */
     static public SerialMessage getPoll(int addr) {
         // eventually this will have to include logic for reading 
@@ -138,6 +140,7 @@ public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
      * Set the number of characters expected back from the command station.
      * Normally four, this is used to set other lengths for special cases, like
      * a reply to a poll (software version) message.
+     * @param len reply length.
      */
     public void setReplyLen(int len) {
         replyLen = len;
@@ -149,6 +152,7 @@ public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
 
     /**
      * Format the reply as human-readable text.
+     * @return human-readable text of reply.
      */
     public String format() {
         if (getNumDataElements() == 8) {

--- a/java/src/jmri/jmrix/grapevine/SerialNode.java
+++ b/java/src/jmri/jmrix/grapevine/SerialNode.java
@@ -74,6 +74,7 @@ public class SerialNode extends AbstractNode {
      * Assumes a node address of 1, and a node type of 0 (NODE2002V6).
      * If this constructor is used, actual node address must be set using
      * 'setNodeAddress()', and actual node type using 'setNodeType()'
+     * @param tc system connection traffic controller.
      */
     public SerialNode(SerialTrafficController tc) {
         this(1, tc);
@@ -172,6 +173,7 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Get node type.
+     * @return node type, e.g. NODE2002V1 or NODE2002V6.
      */
     public int getNodeType() {
         return (nodeType);
@@ -179,6 +181,7 @@ public class SerialNode extends AbstractNode {
 
     /**
      * Set node type.
+     * @param type node type, e.g. NODE2002V1 or NODE2002V6.
      */
     @SuppressWarnings("fallthrough")
     @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH")

--- a/java/src/jmri/jmrix/grapevine/SerialReply.java
+++ b/java/src/jmri/jmrix/grapevine/SerialReply.java
@@ -42,6 +42,7 @@ public class SerialReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Is reply to poll message.
+     * @return true if reply to a poll message, else false.
      */
     public int getAddr() {
         return getElement(0) & 0x7F;
@@ -109,6 +110,7 @@ public class SerialReply extends jmri.jmrix.AbstractMRReply {
      * <p>
      * Since Grapevine doesn't distinguish between message and reply, this uses
      * the Message method.
+     * @return human readable text of reply.
      */
     @SuppressWarnings("fallthrough")
     @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH")

--- a/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
@@ -167,6 +167,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
 
     /**
      * Register any orphan Sensors when a new Serial Node is created.
+     * @param node node to register sensors for.
      */
     @SuppressWarnings("deprecation") // needs careful unwinding for Set operations
     public void registerSensorsForNode(SerialNode node) {

--- a/java/src/jmri/jmrix/grapevine/SerialTrafficController.java
+++ b/java/src/jmri/jmrix/grapevine/SerialTrafficController.java
@@ -54,6 +54,7 @@ public class SerialTrafficController extends AbstractMRNodeTrafficController imp
 
     /**
      * Get minimum address of an Grapevine node as set on this TrafficController.
+     * @return minimum node address.
      */
     public int getMinimumNodeAddress() {
         return minNode;
@@ -88,6 +89,7 @@ public class SerialTrafficController extends AbstractMRNodeTrafficController imp
 
     /**
      * Set up for initialization of a Serial node.
+     * @param node node to initialize.
      */
     public void initializeSerialNode(SerialNode node) {
         synchronized (this) {

--- a/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigFrame.java
+++ b/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigFrame.java
@@ -63,7 +63,8 @@ public class NodeConfigFrame extends jmri.util.JmriJFrame {
     protected String editStatus3 = Bundle.getMessage("NotesEdit3");
 
     /**
-     * Constructor method
+     * Constructor method.
+     * @param _memo system connection.
      */
     public NodeConfigFrame(GrapevineSystemConnectionMemo _memo) {
         super();
@@ -223,6 +224,7 @@ public class NodeConfigFrame extends jmri.util.JmriJFrame {
 
     /**
      * Set the node number.
+     * @param node node address.
      */
     public void setNodeAddress(int node) {
         nodeAddrSpinner.setValue(node);

--- a/java/src/jmri/jmrix/grapevine/nodetable/NodeTablePane.java
+++ b/java/src/jmri/jmrix/grapevine/nodetable/NodeTablePane.java
@@ -44,7 +44,8 @@ public class NodeTablePane extends javax.swing.JPanel implements jmri.jmrix.grap
     private GrapevineSystemConnectionMemo memo = null;
 
     /**
-     * Constructor method
+     * Constructor method.
+     * @param _memo system connection.
      */
     public NodeTablePane(GrapevineSystemConnectionMemo _memo) {
         super();

--- a/java/src/jmri/jmrix/grapevine/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/grapevine/serialdriver/ConnectionConfig.java
@@ -16,6 +16,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/grapevine/simulator/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/grapevine/simulator/ConnectionConfig.java
@@ -24,6 +24,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConf
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeNode.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeNode.java
@@ -87,6 +87,7 @@ public class XBeeNode extends IEEE802154Node {
 
     /**
      * Set the Traffic Controller associated with this node.
+     * @param controller system connection traffic controller.
      */
     public void setTrafficController(XBeeTrafficController controller) {
         tc = controller;
@@ -130,6 +131,7 @@ public class XBeeNode extends IEEE802154Node {
 
     /**
      * Set the isPolled attribute.
+     * @param poll true to set flag polled, else false.
      */
     public void setPoll(boolean poll) {
         isPolled = poll;
@@ -137,6 +139,7 @@ public class XBeeNode extends IEEE802154Node {
 
     /**
      * Get the isPolled attribute.
+     * @return true if isPolled flag set, else false.
      */
     public boolean getPoll() {
         return isPolled;
@@ -156,6 +159,8 @@ public class XBeeNode extends IEEE802154Node {
 
     /**
      * A reply was received, so there was not timeout; do any needed processing.
+     * Implementation does nothing.
+     * @param m message to process.
      */
     @Override
     public void resetTimeout(AbstractMRMessage m) {
@@ -164,6 +169,7 @@ public class XBeeNode extends IEEE802154Node {
 
     /**
      * Convert the 16 bit user address to an XBee16BitAddress object.
+     * @return converted address object.
      */
     public XBee16BitAddress getXBeeAddress16() {
         if(device!=null) {
@@ -175,6 +181,7 @@ public class XBeeNode extends IEEE802154Node {
 
     /**
      * Convert the 64 bit address to an XBee64BitAddress object.
+     * @return converted address object.
      */
     public XBee64BitAddress getXBeeAddress64() {
         if(device!=null) {
@@ -321,8 +328,8 @@ public class XBeeNode extends IEEE802154Node {
     }
 
     /**
-     * Get the stream object associated with this node. Create it if it does
-     * not exist.
+     * Get the stream object associated with this node.
+     * @return stream object, created if does not exist.
      */
     public XBeeIOStream getIOStream() {
         if (mStream == null) {

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientLight.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientLight.java
@@ -20,6 +20,8 @@ public class JMRIClientLight extends AbstractLight implements JMRIClientListener
 
     /**
      * JMRIClient lights use the light number on the remote host.
+     * @param number light number.
+     * @param memo system connection.
      */
     public JMRIClientLight(int number, JMRIClientSystemConnectionMemo memo) {
         super(memo.getSystemPrefix() + "l" + number);

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientReporter.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientReporter.java
@@ -22,6 +22,8 @@ public class JMRIClientReporter extends AbstractReporter implements JMRIClientLi
 
     /**
      * JMRIClient reporters use the reporter number on the remote host.
+     * @param number reporter number.
+     * @param memo system connection.
      */
     public JMRIClientReporter(int number, JMRIClientSystemConnectionMemo memo) {
         super(memo.getSystemPrefix() + "R" + number);

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientSensor.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientSensor.java
@@ -20,6 +20,8 @@ public class JMRIClientSensor extends AbstractSensor implements JMRIClientListen
 
     /**
      * JMRIClient sensors use the sensor number on the remote host.
+     * @param number sensor number.
+     * @param memo system connection.
      */
     public JMRIClientSensor(int number, JMRIClientSystemConnectionMemo memo) {
         super(memo.getSystemPrefix() + "S" + number);

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientSystemConnectionMemo.java
@@ -47,6 +47,7 @@ public class JMRIClientSystemConnectionMemo extends jmri.jmrix.SystemConnectionM
 
     /**
      * Provides access to the TrafficController for this particular connection.
+     * @return traffic controller.
      */
     public JMRIClientTrafficController getJMRIClientTrafficController() {
         return jt;

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientTurnout.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientTurnout.java
@@ -25,6 +25,8 @@ public class JMRIClientTurnout extends AbstractTurnout implements JMRIClientList
 
     /**
      * JMRIClient turnouts use the turnout number on the remote host.
+     * @param number turnout number.
+     * @param memo system connection.
      */
     public JMRIClientTurnout(int number, JMRIClientSystemConnectionMemo memo) {
         super(memo.getSystemPrefix() + "T" + number);

--- a/java/src/jmri/jmrix/jmriclient/networkdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/jmriclient/networkdriver/ConnectionConfig.java
@@ -22,6 +22,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Constructor for an object being created during load process; Swing init
      * is deferred.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/AbstractXNetSerialConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/AbstractXNetSerialConnectionConfig.java
@@ -10,6 +10,7 @@ public abstract class AbstractXNetSerialConnectionConfig extends jmri.jmrix.Abst
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public AbstractXNetSerialConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/LenzCommandStation.java
+++ b/java/src/jmri/jmrix/lenz/LenzCommandStation.java
@@ -24,6 +24,7 @@ public class LenzCommandStation implements jmri.CommandStation {
 
     /**
      * Return the CS Type.
+     * @return CS type.
      */
     public int getCommandStationType() {
         return cmdStationType;
@@ -31,6 +32,7 @@ public class LenzCommandStation implements jmri.CommandStation {
 
     /**
      * Set the CS Type.
+     * @param t CS type.
      */
     public void setCommandStationType(int t) {
         cmdStationType = t;
@@ -38,6 +40,7 @@ public class LenzCommandStation implements jmri.CommandStation {
 
     /**
      * Set the CS Type based on an XpressNet Message.
+     * @param l XNetReply containing the CS type.
      */
     public void setCommandStationType(XNetReply l) {
         if (l.getElement(0) == XNetConstants.CS_SERVICE_MODE_RESPONSE) {
@@ -50,6 +53,7 @@ public class LenzCommandStation implements jmri.CommandStation {
 
     /**
      * Get the CS Software Version.
+     * @return software version.
      */
     public float getCommandStationSoftwareVersion() {
         return cmdStationSoftwareVersion;
@@ -57,6 +61,7 @@ public class LenzCommandStation implements jmri.CommandStation {
 
     /**
      * Get the CS Software Version in BCD (for use in comparisons).
+     * @return software version.
      */
     public float getCommandStationSoftwareVersionBCD() {
         return cmdStationSoftwareVersionBCD;
@@ -64,6 +69,7 @@ public class LenzCommandStation implements jmri.CommandStation {
 
     /**
      * Set the CS Software Version.
+     * @param v software version.
      */
     public void setCommandStationSoftwareVersion(float v) {
         cmdStationSoftwareVersion = v;
@@ -71,6 +77,7 @@ public class LenzCommandStation implements jmri.CommandStation {
 
     /**
      * Set the CS Software Version based on an XpressNet Message.
+     * @param l reply containing CS version.
      */
     public void setCommandStationSoftwareVersion(XNetReply l) {
         if (l.getElement(0) == XNetConstants.CS_SERVICE_MODE_RESPONSE) {
@@ -91,15 +98,16 @@ public class LenzCommandStation implements jmri.CommandStation {
 
     /**
      * Provide the version string returned during the initial check.
+     * @return human readable version string.
      */
     public String getVersionString() {
         return Bundle.getMessage("CSVersionString", getCommandStationType(),getCommandStationSoftwareVersionBCD());
     }
 
     /**
-     * XpressNet command station does provide Ops Mode. We should make this
-     * return false based on what command station we're using but for now, we'll
-     * return true.
+     * XpressNet command station does provide Ops Mode.
+     * <p>
+     * @return true if CS type 1 or 2, else false.
      */
     public boolean isOpsModePossible() {
         if (cmdStationType == 0x01 || cmdStationType == 0x02) {
@@ -114,6 +122,8 @@ public class LenzCommandStation implements jmri.CommandStation {
     /**
      * Get the Lower byte of a locomotive address from the decimal locomotive
      * address.
+     * @param address loco address.
+     * @return low address byte including DCC offset.
      */
     public static int getDCCAddressLow(int address) {
         /* For addresses below 100, we just return the address, otherwise,
@@ -131,6 +141,8 @@ public class LenzCommandStation implements jmri.CommandStation {
     /**
      * Get the Upper byte of a locomotive address from the decimal locomotive
      * address.
+     * @param address loco address.
+     * @return upper byte after DCC offset.
      */
     public static int getDCCAddressHigh(int address) {
         /* this isn't actually the high byte, For addresses below 100, we

--- a/java/src/jmri/jmrix/lenz/XNetAddress.java
+++ b/java/src/jmri/jmrix/lenz/XNetAddress.java
@@ -37,6 +37,8 @@ public class XNetAddress {
      * Public static method to parse a Lenz XpressNet system name.
      * Note: Bits are numbered from 1.
      *
+     * @param systemName system name to parse.
+     * @param prefix system prefix.
      * @return the hardware address number, return -1 if an error is found
      */
     public static int getBitFromSystemName(String systemName, String prefix) {
@@ -78,6 +80,9 @@ public class XNetAddress {
      * Public static method to validate system name format.
      * Logging of handled cases no higher than WARN.
      *
+     * @param systemName system name.
+     * @param type bean type, S for Sensor, T for Turnout, L for Light.
+     * @param prefix system prefix.
      * @return VALID if system name has a valid format, else return INVALID
      */
     public static NameValidity validSystemNameFormat(@Nonnull String systemName, char type, String prefix) {
@@ -98,6 +103,8 @@ public class XNetAddress {
     /**
      * Public static method to check the user name for a valid system name.
      *
+     * @param systemName system name to check.
+     * @param prefix system prefix.
      * @return "" (null string) if the system name is not valid or does not exist
      */
     public static String getUserNameFromSystemName(String systemName, String prefix) {

--- a/java/src/jmri/jmrix/lenz/XNetConsist.java
+++ b/java/src/jmri/jmrix/lenz/XNetConsist.java
@@ -30,8 +30,11 @@ public class XNetConsist extends jmri.implementation.DccConsist implements XNetL
     protected XNetTrafficController tc = null; // hold the traffic controller associated with this consist.
 
     /**
-     * Initialize a consist for the specific address. Default consist type is an
-     * advanced consist.
+     * Initialize a consist for the specific address.
+     * Default consist type is an advanced consist.
+     * @param address loco address.
+     * @param controller system connection traffic controller.
+     * @param systemMemo system connection.
      */
     public XNetConsist(int address, XNetTrafficController controller, XNetSystemConnectionMemo systemMemo) {
         super(address);
@@ -44,8 +47,11 @@ public class XNetConsist extends jmri.implementation.DccConsist implements XNetL
     }
 
     /**
-     * Initialize a consist for the specific address. Default consist type is an
-     * advanced consist.
+     * Initialize a consist for the specific address.
+     * Default consist type is an advanced consist.
+     * @param address loco address.
+     * @param controller system connection traffic controller.
+     * @param systemMemo system connection.
      */
     public XNetConsist(DccLocoAddress address, XNetTrafficController controller, XNetSystemConnectionMemo systemMemo) {
         super(address);

--- a/java/src/jmri/jmrix/lenz/XNetConsistManager.java
+++ b/java/src/jmri/jmrix/lenz/XNetConsistManager.java
@@ -21,6 +21,7 @@ public class XNetConsistManager extends AbstractConsistManager {
      * Constructor - call the constructor for the superclass, and initialize the
      * consist reader thread, which retrieves consist information from the
      * command station.
+     * @param systemMemo system connection.
      */
     public XNetConsistManager(XNetSystemConnectionMemo systemMemo) {
         super();

--- a/java/src/jmri/jmrix/lenz/XNetInterface.java
+++ b/java/src/jmri/jmrix/lenz/XNetInterface.java
@@ -33,6 +33,8 @@ public interface XNetInterface {
      * in a reply, you need to register an XNetListener object to watch the
      * message stream. When sending, you specify (in 2nd parameter) who
      * you are so you're not redundantly notified of this message.
+     * @param msg the XNet message to send.
+     * @param replyTo sending listener to NOT notify.
      */
     public void sendXNetMessage(XNetMessage msg, XNetListener replyTo);
 
@@ -59,13 +61,17 @@ public interface XNetInterface {
     void addXNetListener(int mask, XNetListener l);
 
     /**
-     * Stop notification of things happening on the XNet. Note that mask and XNetListener
-     * must match a previous request exactly.
+     * Stop notification of things happening on the XNet.
+     * <p>
+     * Note that mask and XNetListener must match a previous request exactly.
+     * @param mask listening mask.
+     * @param listener listener to remove notifications for. 
      */
     void removeXNetListener(int mask, XNetListener listener);
 
     /**
-     * Check whether an implementation is operational. True indicates OK.
+     * Check whether an implementation is operational.
+     * @return true if OK, else false.
      */
     public boolean status();
 

--- a/java/src/jmri/jmrix/lenz/XNetListener.java
+++ b/java/src/jmri/jmrix/lenz/XNetListener.java
@@ -38,6 +38,7 @@ public interface XNetListener extends jmri.jmrix.AbstractMRListener {
      * Member function invoked by an XNetInterface implementation to notify a
      * sender that an outgoing message timed out and was dropped from the
      * queue.
+     * @param msg message which has timed out.
      */
     public void notifyTimeout(XNetMessage msg);
 

--- a/java/src/jmri/jmrix/lenz/XNetMessage.java
+++ b/java/src/jmri/jmrix/lenz/XNetMessage.java
@@ -72,6 +72,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Create an XNetMessage from an XNetReply.
+     * @param message existing XNetReply.
      */
     public XNetMessage(XNetReply message) {
         super(message.getNumDataElements());
@@ -85,6 +86,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Create an XNetMessage from a String containing bytes.
+     * @param s string containing data bytes.
      */
     public XNetMessage(String s) {
         setBinary(true);
@@ -124,6 +126,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Get a String representation of the op code in hex.
+     * {@inheritDoc}
      */
     @Override
     public String getOpCodeHex() {
@@ -132,6 +135,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Check whether the message has a valid parity.
+     * @return true if parity valid, else false.
      */
     public boolean checkParity() {
         int len = getNumDataElements();
@@ -159,6 +163,8 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Get an integer representation of a BCD value.
+     * @param n message element index.
+     * @return integer of BCD.
      */
     public Integer getElementBCD(int n) {
         return Integer.decode(Integer.toHexString(getElement(n)));
@@ -166,6 +172,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Get the message length.
+     * @return message length.
      */
     public int length() {
         return _nDataChars;
@@ -194,6 +201,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * we have a few that we treat as though the reply is always
      * a broadcast message, because the reply usually comes to us 
      * that way.
+     * {@inheritDoc}
      */
     @Override
     public boolean replyExpected() {
@@ -224,6 +232,8 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      *     <p>
      *     NOTE: Lenz does not say this will work for anything but 5
      *     byte packets.
+     * @param packet byte array containing packet data elements.
+     * @return message to send DCC packet.
      */
     public static XNetMessage getNMRAXNetMsg(byte[] packet) {
         XNetMessage msg = new XNetMessage(packet.length + 2);
@@ -244,6 +254,11 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Generate a message to change turnout state.
+     * @param pNumber address number.
+     * @param pClose true if set turnout closed.
+     * @param pThrow true if set turnout thrown.
+     * @param pOn accessory line true for on, false off.
+     * @return message containing turnout command.
      */
     public static XNetMessage getTurnoutCommandMsg(int pNumber, boolean pClose,
             boolean pThrow, boolean pOn) {
@@ -283,6 +298,9 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
     /**
      * Generate a message to receive the feedback information for an upper or
      * lower nibble of the feedback address in question.
+     * @param pNumber feedback address.
+     * @param pLowerNibble true for upper nibble, else false for lower.
+     * @return feedback request message.
      */
     public static XNetMessage getFeedbackRequestMsg(int pNumber,
             boolean pLowerNibble) {
@@ -523,6 +541,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      *
      * @param address1 the first address in the consist
      * @param address2 the second address in the consist.
+     * @return message to build double header.
      */
     public static XNetMessage getBuildDoubleHeaderMsg(int address1, int address2) {
         XNetMessage msg = new XNetMessage(7);
@@ -540,6 +559,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * Dissolve a Double Header.
      *
      * @param address one of the two addresses in the Double Header
+     * @return message to dissolve a double header.
      */
     public static XNetMessage getDisolveDoubleHeaderMsg(int address) {
         // All we have to do is call getBuildDoubleHeaderMsg with the 
@@ -554,6 +574,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param address the locomotive address to add.
      * @param isNormalDir tells us if the locomotive is going forward when 
      * the consist is going forward.
+     * @return message to add address to consist.
      */
     public static XNetMessage getAddLocoToConsistMsg(int consist, int address,
             boolean isNormalDir) {
@@ -576,6 +597,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      *
      * @param consist the consist address (1-99)
      * @param address the locomotive address to remove
+     * @return message to remove single address from consist.
      */
     public static XNetMessage getRemoveLocoFromConsistMsg(int consist, int address) {
         XNetMessage msg = new XNetMessage(6);
@@ -596,12 +618,13 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Given a locomotive address, search the database for the next 
-     * member. (if the Address is zero start at the begining of the 
-     * database).
+     * member.
+     * (if the Address is zero start at the beginning of the database).
      *
      * @param address is the locomotive address
      * @param searchForward indicates to search the database Forward if 
      * true, or backwards if False 
+     * @return message to request next address.
      */
     public static XNetMessage getNextAddressOnStackMsg(int address, boolean searchForward) {
         XNetMessage msg = new XNetMessage(5);
@@ -625,6 +648,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * If the Address is zero start at the beginning of the database.
      * @param searchForward indicates to search the database Forward if 
      * true, or backwards if false
+     * @return message to get next consist address.
      */
     public static XNetMessage getDBSearchMsgConsistAddress(int address, boolean searchForward) {
         XNetMessage msg = new XNetMessage(4);
@@ -649,6 +673,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * If the Address is zero start at the begining of the consist
      * @param searchForward indicates to search the database Forward if 
      * true, or backwards if False 
+     * @return  message to request next loco in consist.
      */
     public static XNetMessage getDBSearchMsgNextMULoco(int consist, int address, boolean searchForward) {
         XNetMessage msg = new XNetMessage(6);
@@ -669,6 +694,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * Given a locomotive address, delete it from the database .
      *
      * @param address the locomotive address
+     * @return message to delete loco address from stack.
      */
     public static XNetMessage getDeleteAddressOnStackMsg(int address) {
         XNetMessage msg = new XNetMessage(5);
@@ -684,6 +710,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * Given a locomotive address, request its status .
      *
      * @param address the locomotive address
+     * @return message to request loco status.
      */
     public static XNetMessage getLocomotiveInfoRequestMsg(int address) {
         XNetMessage msg = new XNetMessage(5);
@@ -699,6 +726,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * Given a locomotive address, request the function state (momentary status).
      *
      * @param address the locomotive address
+     * @return momentary function state request request.
      */
     public static XNetMessage getLocomotiveFunctionStatusMsg(int address) {
         XNetMessage msg = new XNetMessage(5);
@@ -715,6 +743,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * for functions 13-28
      *
      * @param address the locomotive address
+     * @return function state request request f13-f28.
      */
     public static XNetMessage getLocomotiveFunctionHighOnStatusMsg(int address) {
         XNetMessage msg = new XNetMessage(5);
@@ -731,6 +760,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * for high functions (functions 13-28).
      *
      * @param address the locomotive address
+     * @return momentary function state request request f13-f28.
      */
     public static XNetMessage getLocomotiveFunctionHighMomStatusMsg(int address) {
         XNetMessage msg = new XNetMessage(5);
@@ -769,6 +799,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param speed a normalized speed value (a floating point number between 0 
      *              and 1).  A negative value indicates emergency stop.
      * @param isForward true for forward, false for reverse.
+     * @return set speed and direction message.
      */
     public static XNetMessage getSpeedAndDirectionMsg(int address,
             SpeedStepMode speedStepMode,
@@ -854,6 +885,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param f2 is true if f2 is on, false if f2 is off
      * @param f3 is true if f3 is on, false if f3 is off
      * @param f4 is true if f4 is on, false if f4 is off
+     * @return set function group 1 message.
      */
     public static XNetMessage getFunctionGroup1OpsMsg(int address,
             boolean f0,
@@ -899,6 +931,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param f2 is true if f2 is momentary
      * @param f3 is true if f3 is momentary
      * @param f4 is true if f4 is momentary
+     * @return set momentary function group 1 message.
      */
     public static XNetMessage getFunctionGroup1SetMomMsg(int address,
             boolean f0,
@@ -943,6 +976,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param f6 is true if f6 is on, false if f6 is off
      * @param f7 is true if f7 is on, false if f7 is off
      * @param f8 is true if f8 is on, false if f8 is off
+     * @return set function group 2 message.
      */
     public static XNetMessage getFunctionGroup2OpsMsg(int address,
             boolean f5,
@@ -983,6 +1017,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param f6 is true if f6 is momentary
      * @param f7 is true if f7 is momentary
      * @param f8 is true if f8 is momentary
+     * @return set momentary function group 2 message.
      */
     public static XNetMessage getFunctionGroup2SetMomMsg(int address,
             boolean f5,
@@ -1023,6 +1058,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param f10 is true if f10 is on, false if f10 is off
      * @param f11 is true if f11 is on, false if f11 is off
      * @param f12 is true if f12 is on, false if f12 is off
+     * @return set function group 3 message.
      */
     public static XNetMessage getFunctionGroup3OpsMsg(int address,
             boolean f9,
@@ -1063,6 +1099,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param f10 is true if f10 is momentary
      * @param f11 is true if f11 is momentary
      * @param f12 is true if f12 is momentary
+     * @return set momentary function group 3 message.
      */
     public static XNetMessage getFunctionGroup3SetMomMsg(int address,
             boolean f9,
@@ -1107,6 +1144,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param f18 is true if f18 is on, false if f18 is off
      * @param f19 is true if f19 is on, false if f19 is off
      * @param f20 is true if f20 is on, false if f20 is off
+     * @return set function group 4 message.
      */
     public static XNetMessage getFunctionGroup4OpsMsg(int address,
             boolean f13,
@@ -1167,6 +1205,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param f18 is true if f18 is Momentary
      * @param f19 is true if f19 is Momentary
      * @param f20 is true if f20 is Momentary
+     * @return set momentary function group 4 message.
      */
     public static XNetMessage getFunctionGroup4SetMomMsg(int address,
             boolean f13,
@@ -1227,6 +1266,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param f26 is true if f26 is on, false if f26 is off
      * @param f27 is true if f27 is on, false if f27 is off
      * @param f28 is true if f28 is on, false if f28 is off
+     * @return set function group 5 message.
      */
     public static XNetMessage getFunctionGroup5OpsMsg(int address,
             boolean f21,
@@ -1287,6 +1327,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param f26 is true if f26 is momentary
      * @param f27 is true if f27 is momentary
      * @param f28 is true if f28 is momentary
+     * @return set momentary function group 5 message.
      */
     public static XNetMessage getFunctionGroup5SetMomMsg(int address,
             boolean f21,
@@ -1337,6 +1378,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Build a Resume operations Message.
+     * @return resume message.
      */
     public static XNetMessage getResumeOperationsMsg() {
         XNetMessage msg = new XNetMessage(3);
@@ -1348,6 +1390,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Build an EmergencyOff Message.
+     * @return emergency off message.
      */
     public static XNetMessage getEmergencyOffMsg() {
         XNetMessage msg = new XNetMessage(3);
@@ -1359,6 +1402,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Build an EmergencyStop Message.
+     * @return emergency stop message.
      */
     public static XNetMessage getEmergencyStopMsg() {
         XNetMessage msg = new XNetMessage(2);
@@ -1370,6 +1414,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
     /**
      * Generate the message to request the Command Station Hardware/Software
      * Version.
+     * @return message to request CS hardware and software version.
      */
     public static XNetMessage getCSVersionRequestMessage() {
         XNetMessage msg = new XNetMessage(3);
@@ -1381,6 +1426,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
 
     /**
      * Generate the message to request the Command Station Status.
+     * @return message to request CS status.
      */
     public static XNetMessage getCSStatusRequestMessage() {
         XNetMessage msg = new XNetMessage(3);
@@ -1393,6 +1439,8 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
     /**
      * Generate the message to set the Command Station to Auto or Manual restart
      * mode.
+     * @param autoMode true if auto, false for manual.
+     * @return message to set CS restart mode.
      */
     public static XNetMessage getCSAutoStartMessage(boolean autoMode) {
         XNetMessage msg = new XNetMessage(4);
@@ -1410,6 +1458,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
     /**
      * Generate the message to request the Computer Interface Hardware/Software
      * Version.
+     * @return message to request interface hardware and software version.
      */
     public static XNetMessage getLIVersionRequestMessage() {
         XNetMessage msg = new XNetMessage(2);
@@ -1423,6 +1472,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      *
      * @param address Interface address (0-31). Send invalid address to request
      *                the address (32-255).
+     * @return message to set or request interface address.
      */
     public static XNetMessage getLIAddressRequestMsg(int address) {
         XNetMessage msg = new XNetMessage(4);
@@ -1439,6 +1489,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param speed 1 is 19,200bps, 2 is 38,400bps, 3 is 57,600bps, 4 is
      *              115,200bps. Send invalid speed to request the current
      *              setting.
+     * @return message for set / request interface speed.
      */
     public static XNetMessage getLISpeedRequestMsg(int speed) {
         XNetMessage msg = new XNetMessage(4);

--- a/java/src/jmri/jmrix/lenz/XNetPortController.java
+++ b/java/src/jmri/jmrix/lenz/XNetPortController.java
@@ -15,13 +15,17 @@ public interface XNetPortController extends jmri.jmrix.PortAdapter {
     public boolean status();
 
     /**
-     * Can the port accept additional characters? This might go false for short
+     * Can the port accept additional characters?
+     * <p>
+     * This might go false for short
      * intervals, but it might also stick off if something goes wrong.
+     * @return true if OK to send, else false.
      */
     public boolean okToSend();
 
     /**
      * We need a way to say if the output buffer is empty or not.
+     * @param s true to set buffer empty, else false.
      */
     public void setOutputBufferEmpty(boolean s);
 

--- a/java/src/jmri/jmrix/lenz/XNetProgrammer.java
+++ b/java/src/jmri/jmrix/lenz/XNetProgrammer.java
@@ -520,6 +520,7 @@ public class XNetProgrammer extends AbstractProgrammer implements XNetListener {
      * operations, we want to be able to check and see if we are
      * currently programming before allowing the Traffic Controller 
      * to send a request to exit service mode.
+     * @return true if programmer busy, else false.
      */
     public synchronized boolean programmerBusy() {
         return (progState != NOTPROGRAMMING);

--- a/java/src/jmri/jmrix/lenz/XNetReply.java
+++ b/java/src/jmri/jmrix/lenz/XNetReply.java
@@ -45,6 +45,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Create a reply from an XNetMessage.
+     * @param message existing message.
      */
     public XNetReply(XNetMessage message) {
         super();
@@ -56,6 +57,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Create a reply from a string of hex characters.
+     * @param message hex string of message.
      */
     public XNetReply(String message) {
         super();
@@ -77,6 +79,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Get the opcode as a string in hex format.
+     * @return 0x hex string of OpCode.
      */
     public String getOpCodeHex() {
         return "0x" + Integer.toHexString(this.getOpCode());
@@ -84,6 +87,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Check whether the message has a valid parity.
+     * @return true if parity valid, else false.
      */
     public boolean checkParity() {
         int len = getNumDataElements();
@@ -288,6 +292,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Is this a feedback response message?
+     * @return true if a feedback response, else false.
      */
     public boolean isFeedbackMessage() {
         return (this.getElement(0) == XNetConstants.ACC_INFO_RESPONSE);
@@ -295,6 +300,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Is this a feedback broadcast message?
+     * @return true if a feedback broadcast message, else false.
      */
     public boolean isFeedbackBroadcastMessage() {
         return ((this.getElement(0) & 0xF0) == XNetConstants.BC_FEEDBACK);
@@ -360,9 +366,12 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
      */
 
     /**
-     * If this is a throttle-type message, return address. Otherwise return -1.
-     * Note we only identify the command now; the reponse to a request for
-     * status is not yet seen here.
+     * If this is a throttle-type message, return address.
+     * Otherwise return -1. 
+     * <p>
+     * Note we only identify the command now;
+     * the response to a request for status is not yet seen here.
+     * @return address if throttle-type message, else -1.
      */
     public int getThrottleMsgAddr() {
         if (this.isThrottleMessage()) {
@@ -380,6 +389,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Is this a throttle message?
+     * @return true if throttle message. else false.
      */
     public boolean isThrottleMessage() {
         int message = this.getElement(0);
@@ -397,6 +407,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
     /**
      * Does this message indicate the locomotive has been taken over by another
      * device?
+     * @return true if take over message, else false.
      */
     public boolean isThrottleTakenOverMessage() {
         return (this.getElement(0) == XNetConstants.LOCO_INFO_RESPONSE
@@ -405,6 +416,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Is this a consist message?
+     * @return true if consist message, else false.
      */
     public boolean isConsistMessage() {
         int message = this.getElement(0);
@@ -421,6 +433,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
     /**
      * In the interest of code reuse, the following function checks to see
      * if an XpressNet Message is the OK message (01 04 05).
+     * @return true if an OK message, else false.
      */
     public boolean isOkMessage() {
         return (this.getElement(0) == XNetConstants.LI_MESSAGE_RESPONSE_HEADER
@@ -430,6 +443,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
     /**
      * In the interest of code reuse, the following function checks to see
      * if an XpressNet Message is the timeslot restored message (01 07 06).
+     * @return true if a time-slot restored message.
      */
     public boolean isTimeSlotRestored() {
         return (this.getElement(0) == XNetConstants.LI_MESSAGE_RESPONSE_HEADER
@@ -438,8 +452,9 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * In the interest of code reuse, the following function checks to see
-     * if an XpressNet Message is the Command Station no longer provideing a
+     * if an XpressNet Message is the Command Station no longer providing a
      * timeslot message (01 05 04).
+     * @return true if a time-slot revoked message, else false.
      */
     public boolean isTimeSlotRevoked() {
         return (this.getElement(0) == XNetConstants.LI_MESSAGE_RESPONSE_HEADER
@@ -449,6 +464,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
     /**
      * In the interest of code reuse, the following function checks to see
      * if an XpressNet Message is the Command Station Busy message (61 81 e3).
+     * @return true if is a CS Busy message, else false.
      */
     public boolean isCSBusyMessage() {
         return (this.getElement(0) == XNetConstants.CS_INFO
@@ -460,6 +476,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
      * In the interest of code reuse, the following function checks to see
      * if an XpressNet Message is the Command Station Transfer Error
      * message (61 80 e1).
+     * @return if CS Transfer error, else false.
      */
     public boolean isCSTransferError() {
         return (this.getElement(0) == XNetConstants.CS_INFO
@@ -470,6 +487,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
      * In the interest of code reuse, the following function checks to see
      * if an XpressNet Message is the not supported Error
      * message (61 82 e3).
+     * @return true if unsupported error, else false.
      */
     public boolean isUnsupportedError() {
         return (this.getElement(0) == XNetConstants.CS_INFO
@@ -479,12 +497,14 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
     /**
      * In the interest of code reuse, the following function checks to see
      * if an XpressNet Message is a communications error message.
+     * <p>
      * The errors handled are:
      *  01 01 00  -- Error between interface and the PC
      *  01 02 03  -- Error between interface and the Command Station
      *  01 03 02  -- Unknown Communications Error
-     *      01 06 07  -- LI10x Buffer Overflow
-     *      01 0A 0B  -- LIUSB only. Request resend of data.
+     *  01 06 07  -- LI10x Buffer Overflow
+     *  01 0A 0B  -- LIUSB only. Request resend of data.
+     * @return true if comm error message, else false.
      */
     public boolean isCommErrorMessage() {
         return (this.getElement(0) == XNetConstants.LI_MESSAGE_RESPONSE_HEADER
@@ -499,10 +519,12 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
     /**
      * In the interest of code reuse, the following function checks to see
      * if an XpressNet Message is a communications error message.
+     * <p>
      * The errors handled are:
      *  01 05 04  -- Timeslot Error
      *  01 07 06  -- Timeslot Restored
      *  01 08 09  -- Data sent while there is no Timeslot
+     * @return true if time slot error, else false.
      */
     public boolean isTimeSlotErrorMessage() {
         return (this.getElement(0) == XNetConstants.LI_MESSAGE_RESPONSE_HEADER
@@ -514,6 +536,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Is this message a service mode response?
+     * @return true if a service mode response, else false.
      */
     public boolean isServiceModeResponse() {
         return (getElement(0) == XNetConstants.CS_SERVICE_MODE_RESPONSE
@@ -526,6 +549,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Is this message a register or paged mode programming response?
+     * @return true if register or paged mode programming response, else false.
      */
     public boolean isPagedModeResponse() {
         return (getElement(0) == XNetConstants.CS_SERVICE_MODE_RESPONSE
@@ -534,6 +558,7 @@ public class XNetReply extends jmri.jmrix.AbstractMRReply {
 
     /**
      * Is this message a direct CV mode programming response?
+     * @return true if direct CV mode programming response, else false.
      */
     public boolean isDirectModeResponse() {
         return (getElement(0) == XNetConstants.CS_SERVICE_MODE_RESPONSE

--- a/java/src/jmri/jmrix/lenz/XNetStreamConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/XNetStreamConnectionConfig.java
@@ -16,6 +16,7 @@ public class XNetStreamConnectionConfig extends jmri.jmrix.AbstractStreamConnect
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p stream port controller.
      */
     public XNetStreamConnectionConfig(jmri.jmrix.AbstractStreamPortController p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/XNetSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/lenz/XNetSystemConnectionMemo.java
@@ -59,6 +59,7 @@ public class XNetSystemConnectionMemo extends SystemConnectionMemo {
 
     /**
      * Provide access to the TrafficController for this particular connection.
+     * @return traffic controller.
      */
     public XNetTrafficController getXNetTrafficController() {
         return xt;
@@ -79,6 +80,7 @@ public class XNetSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the Programmer for this particular connection.
      * <p>
      * NOTE: Programmer defaults to null
+     * @return programmer manager.
      */
     public XNetProgrammerManager getProgrammerManager() {
         return programmerManager;
@@ -131,6 +133,7 @@ public class XNetSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the SensorManager for this particular connection.
      * <p>
      * NOTE: SensorManager defaults to NULL
+     * @return sensor manager.
      */
     public SensorManager getSensorManager() {
         return sensorManager;
@@ -147,6 +150,7 @@ public class XNetSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the TurnoutManager for this particular connection.
      * <p>
      * NOTE: TurnoutManager defaults to NULL
+     * @return turnout manager.
      */
     public TurnoutManager getTurnoutManager() {
         return turnoutManager;
@@ -163,6 +167,7 @@ public class XNetSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the LightManager for this particular connection.
      * <p>
      * NOTE: LightManager defaults to NULL
+     * @return light manager.
      */
     public LightManager getLightManager() {
         return lightManager;
@@ -179,6 +184,7 @@ public class XNetSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the Command Station for this particular connection.
      * <p>
      * NOTE: Command Station defaults to NULL
+     * @return command station.
      */
     public CommandStation getCommandStation() {
         return commandStation;
@@ -197,6 +203,7 @@ public class XNetSystemConnectionMemo extends SystemConnectionMemo {
      * Provide access to the Lenz Command Station for this particular connection.
      * <p>
      * NOTE: Lenz Command Station defaults to NULL
+     * @return Lenz command station.
      */
     public LenzCommandStation getLenzCommandStation() {
         return lenzCommandStation;

--- a/java/src/jmri/jmrix/lenz/XNetThrottle.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottle.java
@@ -40,6 +40,8 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
 
     /**
      * Constructor
+     * @param memo system connection.
+     * @param controller system connection traffic controller.
      */
     public XNetThrottle(XNetSystemConnectionMemo memo, XNetTrafficController controller) {
         super(memo);
@@ -49,7 +51,10 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
     }
 
     /**
-     * Constructor
+     * Constructor.
+     * @param memo system connection.
+     * @param address loco address.
+     * @param controller system connection traffic controller.
      */
     public XNetThrottle(XNetSystemConnectionMemo memo, LocoAddress address, XNetTrafficController controller) {
         super(memo);

--- a/java/src/jmri/jmrix/lenz/XNetThrottleManager.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottleManager.java
@@ -23,6 +23,7 @@ public class XNetThrottleManager extends AbstractThrottleManager implements XNet
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public XNetThrottleManager(XNetSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/lenz/XNetTrafficController.java
+++ b/java/src/jmri/jmrix/lenz/XNetTrafficController.java
@@ -324,6 +324,7 @@ public abstract class XNetTrafficController extends AbstractMRTrafficController 
     /**
      * Return an XNetFeedbackMessageCache object associated with this traffic
      * controller.
+     * @return the feedback message cache. One is provided if null.
      */
     public XNetFeedbackMessageCache getFeedbackMessageCache() {
         if (_FeedbackCache == null) {

--- a/java/src/jmri/jmrix/lenz/hornbyelite/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/ConnectionConfig.java
@@ -16,6 +16,7 @@ public class ConnectionConfig extends jmri.jmrix.lenz.AbstractXNetSerialConnecti
     /**
      * Ctor for an object being created during load process.
      * Swing init is deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottle.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottle.java
@@ -22,7 +22,9 @@ public class EliteXNetThrottle extends jmri.jmrix.lenz.XNetThrottle {
     private static final String MOMENTARY_FUNCTION_REQUEST_NOT_SUPPORTED_BY_ELITE = "Momentary function request not supported by Elite.";
 
     /**
-     * Constructor
+     * Constructor.
+     * @param memo system connection.
+     * @param tc traffic controller.
      */
     public EliteXNetThrottle(XNetSystemConnectionMemo memo, XNetTrafficController tc) {
         super(memo, tc);
@@ -30,7 +32,10 @@ public class EliteXNetThrottle extends jmri.jmrix.lenz.XNetThrottle {
     }
 
     /**
-     * Constructor by address
+     * Constructor by address.
+     * @param memo system connection.
+     * @param address loco address.
+     * @param tc system connection traffic controller.
      */
     public EliteXNetThrottle(XNetSystemConnectionMemo memo, LocoAddress address, XNetTrafficController tc) {
         super(memo, address, tc);

--- a/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottleManager.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottleManager.java
@@ -15,6 +15,7 @@ public class EliteXNetThrottleManager extends jmri.jmrix.lenz.XNetThrottleManage
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public EliteXNetThrottleManager(XNetSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/lenz/li100/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/li100/ConnectionConfig.java
@@ -15,6 +15,7 @@ public class ConnectionConfig extends jmri.jmrix.lenz.AbstractXNetSerialConnecti
     /**
      * Ctor for an object being created during load process.
      * Swing init is deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/li100f/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/li100f/ConnectionConfig.java
@@ -15,6 +15,7 @@ public class ConnectionConfig extends jmri.jmrix.lenz.AbstractXNetSerialConnecti
     /**
      * Ctor for an object being created during load process.
      * Swing init is deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/li100f/LI100fAdapter.java
+++ b/java/src/jmri/jmrix/lenz/li100f/LI100fAdapter.java
@@ -177,6 +177,7 @@ public class LI100fAdapter extends XNetSerialPortController {
 
     /**
      * option1 controls flow control option.
+     * @return human readable string, uses IFTypeLI100F .
      */
     public String option1Name() {
         return Bundle.getMessage("XconnectionUsesLabel", Bundle.getMessage("IFTypeLI100F"));

--- a/java/src/jmri/jmrix/lenz/li101/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/li101/ConnectionConfig.java
@@ -14,6 +14,7 @@ public class ConnectionConfig extends jmri.jmrix.lenz.AbstractXNetSerialConnecti
     /**
      * Ctor for an object being created during load process.
      * Swing init is deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/liusb/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/liusb/ConnectionConfig.java
@@ -16,6 +16,7 @@ public class ConnectionConfig extends jmri.jmrix.lenz.AbstractXNetSerialConnecti
     /**
      * Ctor for an object being created during load process.
      * Swing init is deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/liusbethernet/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/liusbethernet/ConnectionConfig.java
@@ -16,6 +16,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Ctor for an object being created during load process.
      * Swing init is deferred.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/liusbserver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/liusbserver/ConnectionConfig.java
@@ -16,6 +16,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Ctor for an object being created during load process.
      * Swing init is deferred.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/lzv200/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/lzv200/ConnectionConfig.java
@@ -19,6 +19,7 @@ public class ConnectionConfig extends jmri.jmrix.lenz.liusb.ConnectionConfig {
     /**
      * Ctor for an object being created during load process.
      * Swing init is deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonDataModel.java
+++ b/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonDataModel.java
@@ -138,6 +138,8 @@ public class StackMonDataModel extends javax.swing.table.AbstractTableModel {
 
     /**
      * Update the internal data structures for a specified address.
+     * @param address which address to update.
+     * @param type address type.
      */
     public void updateData(Integer address, String type) {
         if (_addressList == null) {

--- a/java/src/jmri/jmrix/lenz/xnetsimulator/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/xnetsimulator/ConnectionConfig.java
@@ -16,6 +16,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConf
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/xntcp/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/xntcp/ConnectionConfig.java
@@ -27,6 +27,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p network port adapter.
      */
     public ConnectionConfig(jmri.jmrix.NetworkPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/lenz/ztc640/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/lenz/ztc640/ConnectionConfig.java
@@ -15,6 +15,7 @@ public class ConnectionConfig extends jmri.jmrix.lenz.AbstractXNetSerialConnecti
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/loconet/Ib1Throttle.java
+++ b/java/src/jmri/jmrix/loconet/Ib1Throttle.java
@@ -11,8 +11,9 @@ import org.slf4j.LoggerFactory;
 public class Ib1Throttle extends LocoNetThrottle {
 
     /**
-     * Constructor
+     * Constructor.
      *
+     * @param memo system connection.
      * @param slot The LocoNetSlot this throttle will talk on.
      */
     public Ib1Throttle(LocoNetSystemConnectionMemo memo, LocoNetSlot slot) {

--- a/java/src/jmri/jmrix/loconet/Ib1ThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/Ib1ThrottleManager.java
@@ -13,6 +13,7 @@ public class Ib1ThrottleManager extends jmri.jmrix.loconet.LnThrottleManager {
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public Ib1ThrottleManager(LocoNetSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/loconet/Ib2Throttle.java
+++ b/java/src/jmri/jmrix/loconet/Ib2Throttle.java
@@ -11,8 +11,9 @@ import org.slf4j.LoggerFactory;
 public class Ib2Throttle extends LocoNetThrottle {
 
     /**
-     * Constructor
+     * Constructor.
      *
+     * @param memo system connection.
      * @param slot The LocoNetSlot this throttle will talk on.
      */
     public Ib2Throttle(LocoNetSystemConnectionMemo memo, LocoNetSlot slot) {

--- a/java/src/jmri/jmrix/loconet/Ib2ThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/Ib2ThrottleManager.java
@@ -13,6 +13,7 @@ public class Ib2ThrottleManager extends jmri.jmrix.loconet.LnThrottleManager {
 
     /**
      * Constructor.
+     * @param memo system connection.
      */
     public Ib2ThrottleManager(LocoNetSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/loconet/Intellibox/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/Intellibox/ConnectionConfig.java
@@ -11,6 +11,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/loconet/Intellibox/IntelliboxAdapter.java
+++ b/java/src/jmri/jmrix/loconet/Intellibox/IntelliboxAdapter.java
@@ -69,6 +69,7 @@ public class IntelliboxAdapter extends LocoBufferAdapter {
 
     /**
      * Rephrase option 1, so that it doesn't talk about LocoBuffer.
+     * @return human readable string, TypeSerial.
      */
     public String option1Name() {
         return Bundle.getMessage("XconnectionUsesLabel", Bundle.getMessage("TypeSerial"));
@@ -76,6 +77,7 @@ public class IntelliboxAdapter extends LocoBufferAdapter {
 
     /**
      * Provide just one valid command station value.
+     * @return single value array with name of COMMAND_STATION_IBX_TYPE_1 .
      */
     public String[] commandStationOptions() {
         String[] retval = {

--- a/java/src/jmri/jmrix/loconet/LnSensor.java
+++ b/java/src/jmri/jmrix/loconet/LnSensor.java
@@ -84,6 +84,7 @@ public class LnSensor extends AbstractSensor  {
      * _once_ if anything has changed state (or set the commanded state
      * directly)
      *
+     * @param l LocoNet message from manager.
      */
     public void messageFromManager(LocoNetMessage l) {
         // parse message type

--- a/java/src/jmri/jmrix/loconet/bluetooth/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/bluetooth/ConnectionConfig.java
@@ -17,6 +17,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p serial port adapter.
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/loconet/locobufferii/LocoBufferIIAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobufferii/LocoBufferIIAdapter.java
@@ -32,6 +32,7 @@ public class LocoBufferIIAdapter extends LocoBufferAdapter {
 
     /**
      * Get a String that says what Option 1 represents.
+     * @return human readable string form uses LocoBuffer-II.
      */
     public String option1Name() {
         return Bundle.getMessage("XconnectionUsesLabel", "LocoBuffer-II");

--- a/java/src/jmri/jmrix/loconet/locoio/LocoIOData.java
+++ b/java/src/jmri/jmrix/loconet/locoio/LocoIOData.java
@@ -56,6 +56,9 @@ public class LocoIOData extends PropertyChangeSupport
 
     /**
      * Create a new instance of LocoIOData.
+     * @param unitAddr unit address.
+     * @param unitSubAddr unit SubAddress.
+     * @param tc system connection traffic controller.
      */
     public LocoIOData(int unitAddr, int unitSubAddr, LnTrafficController tc) {
         timeoutcounter = 0;
@@ -102,6 +105,8 @@ public class LocoIOData extends PropertyChangeSupport
      * The subAddress is in the range of 0x01 .. 0x7E
      * <br>
      * (0x7F is reserved)
+     * @param unit unit address.
+     * @param unitSub unit subAddress.
      */
     public synchronized void setUnitAddress(int unit, int unitSub) {
         setUnitAddress(unit);
@@ -137,6 +142,10 @@ public class LocoIOData extends PropertyChangeSupport
      *
      * If possibe add/support the additional config options for HDL boards
      * </pre>
+     * @param portRefresh port refresh value, bit 0.
+     * @param altCodePBs alternated code PBs, bit 1.
+     * @param isServo servo port, bit 3.
+     * @param blinkRate blink rate, bits 4-7.
      */
     public void setUnitConfig(int portRefresh, int altCodePBs, int isServo, int blinkRate) {
         int newsv0 = ((portRefresh & 0x01)) |   // bit 0
@@ -219,6 +228,7 @@ public class LocoIOData extends PropertyChangeSupport
      *
      * @param channel integer value of the addresses in use for this row
      *                (0 = invalid)
+     * @param value channel value.
      */
     public void setAddr(int channel, int value) {
         addr[channel] = value & 0x7FF;

--- a/java/src/jmri/jmrix/loconet/locoio/LocoIOMode.java
+++ b/java/src/jmri/jmrix/loconet/locoio/LocoIOMode.java
@@ -8,6 +8,11 @@ public class LocoIOMode {
 
     /**
      * Create a new instance of LocoIOMode.
+     * @param isOutput isOutput value.
+     * @param opcode opcode.
+     * @param sv0 sv0 value.
+     * @param sv2 sv2 value.
+     * @param mode IO mode.
      */
     public LocoIOMode(int isOutput, int opcode, int sv0, int sv2, String mode) {
         this.isOutput = isOutput;

--- a/java/src/jmri/jmrix/loconet/locoio/LocoIOTableModel.java
+++ b/java/src/jmri/jmrix/loconet/locoio/LocoIOTableModel.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Basic Configurer for LocoIO hardware.
  * <p>
- * This code derves the SV values from the user-selected mode and address; this
+ * This code derives the SV values from the user-selected mode and address; this
  * is different from earlier versions where the user was expected to do the
  * derivation manually. This derivation is complicated by the fact that the
  * "mode" SV[port.0] in the LocoIO doesn't fully specify the operation being
@@ -73,6 +73,7 @@ public class LocoIOTableModel
     //private JLabel     locobuffer = null;
     /**
      * Primary constructor. Initializes all the arrays.
+     * @param ldata the data.
      */
     public LocoIOTableModel(LocoIOData ldata) {
         super();

--- a/java/src/jmri/jmrix/loconet/locormi/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/locormi/ConnectionConfig.java
@@ -20,6 +20,8 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p host name.
+     * @param m manufacturer name.
      */
     public ConnectionConfig(String p, String m) {
         super();

--- a/java/src/jmri/jmrix/loconet/locormi/LnMessageClient.java
+++ b/java/src/jmri/jmrix/loconet/locormi/LnMessageClient.java
@@ -65,6 +65,9 @@ public class LnMessageClient extends LnTrafficRouter {
     // be passed to this.notify(LocoNetMessage m)
     /**
      * Start the connection to the server. This is invoked once.
+     * @param remoteHostName remote host name.
+     * @param timeoutSec timeout, value in seconds, not ms.
+     * @throws jmri.jmrix.loconet.LocoNetException if failed to connect to server.
      */
     public void configureRemoteConnection(String remoteHostName, int timeoutSec) throws LocoNetException {
         serverName = remoteHostName;

--- a/java/src/jmri/jmrix/loconet/sdfeditor/SdfMacroEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/SdfMacroEditor.java
@@ -82,6 +82,8 @@ public abstract class SdfMacroEditor extends JPanel {
 
     /**
      * Return an editor object for a SdfMacro type.
+     * @param inst macro instance.
+     * @return editor according to macro type.
      */
     static public SdfMacroEditor attachEditor(SdfMacro inst) {
 

--- a/java/src/jmri/jmrix/loconet/soundloader/EditorTableDataModel.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/EditorTableDataModel.java
@@ -291,9 +291,10 @@ public class EditorTableDataModel extends javax.swing.table.AbstractTableModel {
     }
 
     /**
-     * Configure a table to have our standard rows and columns. This is
-     * optional, in that other table formats can use this table model. But we
-     * put it here to help keep it consistent.
+     * Configure a table to have our standard rows and columns.
+     * This is optional, in that other table formats can use this table model. 
+     * But we put it here to help keep it consistent.
+     * @param table table to configured.
      */
     public void configureTable(JTable table) {
         // allow reordering of the columns

--- a/java/src/jmri/jmrix/loconet/soundloader/LoaderEngine.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/LoaderEngine.java
@@ -32,9 +32,13 @@ public class LoaderEngine {
 
     /**
      * Send the complete sequence to download to a decoder.
+     * <p>
+     * Intended to be run in a separate thread.
      *
-     * Intended to be run in a separate thread. Uses "notify" method for status
-     * updates; overload that to redirect the messages
+     * Uses "notify" method for status updates; 
+     * overload that to redirect the messages.
+     * 
+     * @param file the spjfile to be used.
      */
     public void runDownload(SpjFile file) {
         this.spjFile = file;
@@ -133,10 +137,11 @@ public class LoaderEngine {
     }
 
     /**
-     * Nofify of status of download.
-     *
+     * Notify of status of download.
+     * <p>
      * This implementation doesn't do much, but this is provided as a separate
-     * method to allow easy overloading
+     * method to allow easy overloading.
+     * @param message string form of message.
      */
     public void notify(String message) {
         log.debug(message);
@@ -167,8 +172,10 @@ public class LoaderEngine {
     }
 
     /**
-     * Provide a simple object wait. This handles interrupts, synchonization,
-     * etc
+     * Provide a simple object wait.
+     * <p>
+     * This handles interrupts, synchronization, etc.
+     * @param millis milliseconds to wait.
      */
     public void protectedWait(int millis) {
         synchronized (this) {
@@ -207,9 +214,10 @@ public class LoaderEngine {
 
     /**
      * Get the next message for an ongoing WAV download.
-     *
-     * You loop calling nextWavTransfer() until it says it's complete by
+     * <p>
+     * You loop calling nextWavTransfer() until it says it's complete by 
      * returning null.
+     * @return message to send.
      */
     public LocoNetMessage nextTransfer() {
         if (transferStart) {

--- a/java/src/jmri/jmrix/loconet/spjfile/SpjFile.java
+++ b/java/src/jmri/jmrix/loconet/spjfile/SpjFile.java
@@ -56,6 +56,8 @@ public class SpjFile {
     /**
      * Find the map entry (character string) that corresponds to a particular
      * handle number.
+     * @param i handle index.
+     * @return string of map entry.
      */
     public String getMapEntry(int i) {
         log.debug("getMapEntry({})", i);
@@ -133,9 +135,12 @@ public class SpjFile {
     }
 
     /**
-     * Save this file. It lays the file out again, changing the record start
+     * Save this file.
+     * <p>
+     * It lays the file out again, changing the record start
      * addresses into a sequential series.
      *
+     * @param name file name.
      * @throws java.io.IOException if anything goes wrong
      */
     public void save(String name) throws java.io.IOException {
@@ -198,7 +203,8 @@ public class SpjFile {
     }
 
     /**
-     * Read the file whose name was provided earlier
+     * Read the file whose name was provided earlier.
+     * @throws java.io.IOException on file error.
      */
     public void read() throws java.io.IOException {
         if (file == null) {
@@ -286,9 +292,10 @@ public class SpjFile {
 
     /**
      * Write data from headers into separate files.
-     *
-     * Normally, we just work with the data within this file. This method allows
-     * us to extract the contents of the file for external use.
+     * <p>
+     * Normally, we just work with the data within this file.
+     * This method allows us to extract the contents of the file for external use.
+     * @throws java.io.IOException on file error.
      */
     public void writeSubFiles() throws IOException {
         // write data from WAV headers into separate files
@@ -414,8 +421,11 @@ public class SpjFile {
         }
 
         /**
+         * Get Record Length.
+         * <p>
          * This method, in addition to returning the needed record size, will
          * also pull a SdfBuffer back into the record if one exists.
+         * @return record length.
          */
         public int getRecordLength() {
             if (sdfBuffer != null) {
@@ -460,8 +470,10 @@ public class SpjFile {
         }
 
         /**
-         * Get as a SDF buffer. This buffer then becomes associated, and a later
-         * write will use the buffer's contents.
+         * Get as a SDF buffer.
+         * This buffer then becomes associated, and a later write will use 
+         * the buffer's contents.
+         * @return the byte array as SDF buffer.
          */
         public SdfBuffer getSdfBuffer() {
             sdfBuffer = new SdfBuffer(getByteArray());

--- a/java/src/jmri/jmrix/loconet/streamport/LnStreamConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/streamport/LnStreamConnectionConfig.java
@@ -16,6 +16,7 @@ public class LnStreamConnectionConfig extends jmri.jmrix.AbstractStreamConnectio
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
+     * @param p stream port controller.
      */
     public LnStreamConnectionConfig(jmri.jmrix.AbstractStreamPortController p) {
         super(p);

--- a/java/src/jmri/jmrix/loconet/streamport/LnStreamPortController.java
+++ b/java/src/jmri/jmrix/loconet/streamport/LnStreamPortController.java
@@ -72,6 +72,7 @@ public class LnStreamPortController extends jmri.jmrix.AbstractStreamPortControl
      * <p>
      * Provide a default implementation for the MS100, etc, in which this is
      * _always_ true, as we rely on the queueing in the port itself.
+     * @return always true.
      */
     public boolean okToSend() {
         return true;
@@ -84,6 +85,7 @@ public class LnStreamPortController extends jmri.jmrix.AbstractStreamPortControl
 
     /**
      * Set config info from the Command Station type enum.
+     * @param value Command Station Type, can be null while switching protocols. 
      */
     public void setCommandStationType(LnCommandStationType value) {
         if (value == null) {

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockAdapter.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockAdapter.java
@@ -103,6 +103,7 @@ public class UhlenbrockAdapter extends LocoBufferAdapter {
 
     /**
      * Provide just one valid command station value.
+     * @return array with single entry, name of COMMAND_STATION_IBX_TYPE_2 .
      */
     public String[] commandStationOptions() {
         String[] retval = {

--- a/java/src/jmri/jmrix/swing/ComponentFactory.java
+++ b/java/src/jmri/jmrix/swing/ComponentFactory.java
@@ -14,7 +14,8 @@ import javax.swing.JMenu;
 abstract public class ComponentFactory {
 
     /**
-     * Provide a menu with all items attached to this system connection
+     * Provide a menu with all items attached to this system connection.
+     * @return menu with all items attached to this system connection.
      */
     abstract public JMenu getMenu();
 

--- a/pom.xml
+++ b/pom.xml
@@ -677,7 +677,7 @@
                     <sourcepath>${basedir}/java/src:${project.build.directory}/generated-sources/javacc:${project.build.directory}/generated-sources/jjtree</sourcepath>
                     <show>package</show>
                     <!-- change from default 100 warnings; keep number synced with ant javadoc-lint target -->
-                    <additionalJOption>-breakiterator -Xmaxwarns 1300</additionalJOption>
+                    <additionalJOption>-breakiterator -Xmaxwarns 700</additionalJOption>
                     <!-- remove ",-missing" to get warnings about missing Javadoc tags -->
                     <doclint>all,-missing</doclint>
                     <author>true</author><!-- default -->


### PR DESCRIPTION
loconet, lenz, jmriclient, xbee, grapevine, ecos, easydcc, direct, debug, dccpp, dcc4pc, cmri, can, bachrus, anyma dmx, acela, jmrix

Reduces errors in javadoc-lint from 1200 to 600.
Reduces max warns from 1300 to 700.