### PR TITLE
Increase EcosThrottle functions to 32, Function range tests

### DIFF
--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -37,15 +37,17 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      * Array of Function values.
      * <p>
      * Contains current Boolean value for functions 0-28.
+     * This array should not be accessed directly by Throttles,
+     * use setFunction / getFunction.
      */
-    private final boolean[] FUNCTION_BOOLEAN_ARRAY;
+    protected boolean[] FUNCTION_BOOLEAN_ARRAY;
 
     /**
      * Array of Momentary Function values.
      * <p>
      * Contains current Boolean value for Momentary functions 0-28.
      */
-    private final boolean[] FUNCTION_MOMENTARY_BOOLEAN_ARRAY;
+    protected boolean[] FUNCTION_MOMENTARY_BOOLEAN_ARRAY;
     
     /**
      * Is this object still usable? Set false after dispose, this variable is
@@ -157,6 +159,10 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      */
     @Override
     public boolean getFunction(int fN) {
+        if (fN<0 || fN > FUNCTION_BOOLEAN_ARRAY.length-1){
+            log.warn("Unhandled get function: {}",fN);
+            return false;
+        }
         return FUNCTION_BOOLEAN_ARRAY[fN];
     }
 
@@ -165,6 +171,10 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      */
     @Override
     public boolean getFunctionMomentary(int fN) {
+        if (fN<0 || fN > FUNCTION_MOMENTARY_BOOLEAN_ARRAY.length-1){
+            log.warn("Unhandled get momentary function: {}",fN);
+            return false;
+        }
         return FUNCTION_MOMENTARY_BOOLEAN_ARRAY[fN];
     
     }
@@ -366,14 +376,14 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      */
     @Override
     public void setFunction(int functionNum, boolean newState) {
-        if (functionNum < 0 || functionNum > 28) {
-            log.warn("Unhandled function number: {}", functionNum);
+        if (functionNum < 0 || functionNum > FUNCTION_BOOLEAN_ARRAY.length-1) {
+            log.warn("Unhandled set function number: {} {}", functionNum, this.getClass().getName());
             return;
         }
         boolean old = FUNCTION_BOOLEAN_ARRAY[functionNum];
         FUNCTION_BOOLEAN_ARRAY[functionNum] = newState;
         sendFunctionGroup(functionNum,false);
-        firePropertyChange(FUNCTION_STRING_ARRAY[functionNum], old, newState);
+        firePropertyChange("F"+functionNum, old, newState);
     }
 
     /**
@@ -384,13 +394,13 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      * @param state On - True, Off - False
      */
     public void updateFunction(int fn, boolean state) {
-        if (fn < 0 || fn > 28) {
-            log.warn("Unhandled function number: {}", fn);
+        if (fn < 0 || fn > FUNCTION_BOOLEAN_ARRAY.length-1) {
+            log.warn("Unhandled update function number: {} {}", fn, this.getClass().getName());
             return;
         }
         boolean old = FUNCTION_BOOLEAN_ARRAY[fn];
         FUNCTION_BOOLEAN_ARRAY[fn] = state;
-        firePropertyChange(FUNCTION_STRING_ARRAY[fn], old, state);
+        firePropertyChange("F"+fn, old, state);
     }
     
     /**
@@ -402,8 +412,8 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      * @param state On - True, Off - False
      */
     protected void updateFunctionMomentary(int fn, boolean state) {
-        if (fn < 0 || fn > 28) {
-            log.warn("Unhandled Momentary function number: {}", fn);
+        if (fn < 0 || fn > FUNCTION_MOMENTARY_BOOLEAN_ARRAY.length-1) {
+            log.warn("Unhandled update momentary function number: {}", fn);
             return;
         }
         boolean old = FUNCTION_MOMENTARY_BOOLEAN_ARRAY[fn];
@@ -512,14 +522,14 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      */
     @Override
     public void setFunctionMomentary(int momFuncNum, boolean state){
-        if (momFuncNum < 0 || momFuncNum > 28) {
-            log.warn("Unhandled Momentary function number: {}", momFuncNum);
+        if (momFuncNum < 0 || momFuncNum > FUNCTION_MOMENTARY_BOOLEAN_ARRAY.length-1) {
+            log.warn("Unhandled set momentary function number: {}", momFuncNum);
             return;
         }
         boolean old = FUNCTION_MOMENTARY_BOOLEAN_ARRAY[momFuncNum];
         FUNCTION_MOMENTARY_BOOLEAN_ARRAY[momFuncNum] = state;
         sendFunctionGroup(momFuncNum,true);
-        firePropertyChange(FUNCTION_MOMENTARY_STRING_ARRAY[momFuncNum], old, state);
+        firePropertyChange("F" + momFuncNum + "Momentary", old, state);
     }
 
     /**

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
@@ -46,7 +46,8 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
         //The script will go through and read the values from the Ecos
 
         this.speedSetting = 0;
-        // Functions 0-28 default to false
+        // Functions 0-31 default to false
+        FUNCTION_BOOLEAN_ARRAY = new boolean[32];
 
         this.address = address;
         this.isForward = true;

--- a/java/src/jmri/jmrix/tmcc/SerialThrottle.java
+++ b/java/src/jmri/jmrix/tmcc/SerialThrottle.java
@@ -52,7 +52,7 @@ public class SerialThrottle extends AbstractThrottle {
     @Override
     public void setFunction(int func, boolean value) {
         updateFunction(func, value);
-        if (func<22) {
+        if (func>=0 && func<22) {
             sendToLayout(SERIAL_FUNCTION_CODES[func] + address.getNumber() * 128);
         }
         else {

--- a/java/src/jmri/jmrix/xpa/XpaThrottle.java
+++ b/java/src/jmri/jmrix/xpa/XpaThrottle.java
@@ -95,7 +95,7 @@ public class XpaThrottle extends AbstractThrottle {
      */
     @Override
     public void setFunction(int func, boolean value){
-        if ( func<13 && getFunction(func)!=value){
+        if ( func>=0 && func<13 && getFunction(func)!=value){
             updateFunction(func,value);    
             tc.sendXpaMessage(XpaMessage.getFunctionMsg(address, 0), null);
         }

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -776,6 +776,70 @@ public class AbstractThrottleTest {
         Assert.assertEquals(expResult, result, 0.0);
     }
 
+    @Test
+    public void testOutOfRangeUpdateFunction(){
+        
+        instance.updateFunction(-1, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update function number: -1");
+        
+        instance.updateFunction(29, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update function number: 29");
+        
+    }
+    
+    @Test
+    public void testOutOfRangeSetFunction(){
+        
+        instance.setFunction(-1, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled set function number: -1");
+        
+        instance.setFunction(29, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled set function number: 29");
+        
+    }
+    
+    @Test
+    public void testOutOfRangeGetFunction(){
+        instance.getFunction(-1);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled get function: -1");
+        
+        instance.getFunction(29);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled get function: 29");
+    }
+    
+    @Test
+    public void testOutOfRangeUpdateFunctionMomentary(){
+        
+        instance.updateFunctionMomentary(-1, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update momentary function number: -1");
+        
+        instance.updateFunctionMomentary(29, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update momentary function number: 29");
+        
+    }
+    
+    @Test
+    public void testOutOfRangeSetFunctionMomentary(){
+        
+        instance.setFunctionMomentary(-1, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled set momentary function number: -1");
+        
+        instance.setFunctionMomentary(29, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled set momentary function number: 29");
+        
+    }
+    
+    @Test
+    public void testOutOfRangeGetFunctionMomentary(){
+        instance.getFunctionMomentary(-1);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled get momentary function: -1");
+        
+        instance.getFunctionMomentary(29);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled get momentary function: 29");
+    }
+    
+    
+    
     /**
      * Test of setF0 method, of class AbstractThrottle.
      */

--- a/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
@@ -180,7 +180,7 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
             JUnitUtil.waitFor(()->{ return(tm.getThrottleInfo(addr,_f).equals(false)); }, "Function loop off " + i);          
         }
         
-        JUnitAppender.assertWarnMessage("Unhandled function number: 255");
+        JUnitAppender.assertWarnMessageStartingWith("Unhandled update function number: 255");
     }
     
     @Test

--- a/java/test/jmri/jmrix/ecos/EcosDccThrottleTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosDccThrottleTest.java
@@ -374,7 +374,108 @@ public class EcosDccThrottleTest extends AbstractThrottleTest {
         boolean f28 = false;
         instance.setF28(f28);
     }
+    
+    @Test
+    public void testSetGetF29(){
+        instance.setFunction(29, true);
+        Assert.assertTrue(instance.getFunction(29));
+        instance.setFunction(29, false);
+        Assert.assertFalse(instance.getFunction(29));
+    }
+    
+    @Test
+    public void testSetGetF30(){
+        instance.setFunction(30, true);
+        Assert.assertTrue(instance.getFunction(30));
+        instance.setFunction(30, false);
+        Assert.assertFalse(instance.getFunction(30));
+    }
+    
+    @Test
+    public void testSetGetF31(){
+        instance.setFunction(31, true);
+        Assert.assertTrue(instance.getFunction(31));
+        instance.setFunction(31, false);
+        Assert.assertFalse(instance.getFunction(31));
+    }
+    
+    @Test
+    public void testUpdateFunction0(){
+        instance.updateFunction(0, true);
+        Assert.assertTrue(instance.getFunction(0));
+        instance.updateFunction(0, false);
+        Assert.assertFalse(instance.getFunction(0));
+    }
+    
+    @Test
+    public void testUpdateFunction1(){
+        instance.updateFunction(1, true);
+        Assert.assertTrue(instance.getFunction(1));
+        instance.updateFunction(1, false);
+        Assert.assertFalse(instance.getFunction(1));
+    }
+    
+    @Test
+    public void testUpdateFunction29(){
+        instance.updateFunction(29, true);
+        Assert.assertTrue(instance.getFunction(29));
+        instance.updateFunction(29, false);
+        Assert.assertFalse(instance.getFunction(29));
+    }
+    
+    @Test
+    public void testUpdateFunction30(){
+        instance.updateFunction(30, true);
+        Assert.assertTrue(instance.getFunction(30));
+        instance.updateFunction(30, false);
+        Assert.assertFalse(instance.getFunction(30));
+    }
+    
+    @Test
+    public void testUpdateFunction31(){
+        instance.updateFunction(31, true);
+        Assert.assertTrue(instance.getFunction(31));
+        instance.updateFunction(31, false);
+        Assert.assertFalse(instance.getFunction(31));
+    }
 
+    @Test
+    @Override
+    public void testOutOfRangeUpdateFunction(){
+        
+        instance.updateFunction(-1, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update function number: -1");
+        
+        instance.updateFunction(32, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update function number: 32");
+        
+    }
+    
+    @Test
+    @Override
+    public void testOutOfRangeSetFunction(){
+        
+        instance.setFunction(-1, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update function number: -1");
+        
+        instance.setFunction(32, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update function number: 32");
+        
+    }
+    
+    @Test
+    @Override
+    public void testOutOfRangeGetFunction(){
+        
+        instance.getFunction(-1);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled get function: -1");
+        
+        instance.getFunction(32);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled get function: 32");
+        
+    }
+    
+    
     /**
      * Test of sendFunctionGroup1 method, of class AbstractThrottle.
      */

--- a/java/test/jmri/jmrix/openlcb/OlcbThrottleTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbThrottleTest.java
@@ -28,6 +28,16 @@ public class OlcbThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         boolean result = instance.getIsForward();
         Assert.assertEquals(expResult, result);
     }
+    
+    @Test
+    @Override
+    public void testOutOfRangeSetFunction(){
+        instance.setFunction(-1, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update function number: -1");
+        
+        instance.setFunction(29, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update function number: 29");
+    }
 
     /**
      * Test of setF0 method, of class AbstractThrottle.

--- a/java/test/jmri/jmrix/tmcc/SerialThrottleTest.java
+++ b/java/test/jmri/jmrix/tmcc/SerialThrottleTest.java
@@ -270,6 +270,17 @@ public class SerialThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         boolean f21 = false;
         instance.setF21(f21);
     }
+    
+    @Test
+    @Override
+    public void testOutOfRangeSetFunction(){
+        instance.setFunction(-1, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update function number: -1");
+        
+        instance.setFunction(29, true);
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled update function number: 29");
+        jmri.util.JUnitAppender.assertWarnMessageStartingWith("Unhandled set function number: 29");
+    }
 
     @Before
     @Override


### PR DESCRIPTION
Increase EcosThrottle functions handled to 32.
https://groups.io/g/jmriusers/message/173132
Updates AbstracctThrottle to warn if function out of range
Tests for out of range functions.