### PR TITLE
Remove max of 28 for soundlabel and functionlabel numbers.

### DIFF
--- a/xml/schema/locomotive-config.xsd
+++ b/xml/schema/locomotive-config.xsd
@@ -191,7 +191,6 @@
                   <xs:simpleType>
                     <xs:restriction base="xs:integer">
                       <xs:minInclusive value="0"/>
-                      <xs:maxInclusive value="28"/>
                     </xs:restriction>
                   </xs:simpleType>
                 </xs:attribute>
@@ -215,7 +214,6 @@
                   <xs:simpleType>
                     <xs:restriction base="xs:integer">
                       <xs:minInclusive value="0"/>
-                      <xs:maxInclusive value="28"/>
                     </xs:restriction>
                   </xs:simpleType>
                 </xs:attribute>


### PR DESCRIPTION
A [jmriusers conversation ](https://groups.io/g/jmriusers/topic/74134214) noted that validation of `roster.xml ` threw a schema validation error if any ESU Generation 5 decoders were in the roster.

In 2019 I changed functionLabels and soundlabels from fixed-length arrays to HashMaps to allow for known planned expansions. But I forgot to update "locomotive-config.xsd" to reflect the changes.