### PR TITLE
WIP add interface for jmri.StartupActionModelUtil.  

### DIFF
--- a/java/src/apps/startup/StartupActionModelUtil.java
+++ b/java/src/apps/startup/StartupActionModelUtil.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Randall Wood (c) 2016
  */
-public class StartupActionModelUtil extends Bean {
+public class StartupActionModelUtil extends Bean implements jmri.StartupActionModelUtil {
 
     private HashMap<Class<?>, ActionAttributes> actions = null;
     private HashMap<String, Class<?>> overrides = null;
@@ -41,6 +41,7 @@ public class StartupActionModelUtil extends Bean {
         });
     }
 
+    @Override
     @CheckForNull
     public String getActionName(@Nonnull Class<?> clazz) {
         this.prepareActionsHashMap();
@@ -48,6 +49,7 @@ public class StartupActionModelUtil extends Bean {
         return attrs != null ? attrs.name : null;
     }
 
+    @Override
     @CheckForNull
     public String getActionName(@Nonnull String className) {
         if (!className.isEmpty()) {
@@ -60,6 +62,7 @@ public class StartupActionModelUtil extends Bean {
         return null;
     }
 
+    @Override
     public boolean isSystemConnectionAction(@Nonnull Class<?> clazz) {
         this.prepareActionsHashMap();
         if (this.actions.containsKey(clazz)) {
@@ -68,6 +71,7 @@ public class StartupActionModelUtil extends Bean {
         return false;
     }
 
+    @Override
     public boolean isSystemConnectionAction(@Nonnull String className) {
         if (!className.isEmpty()) {
             try {
@@ -79,6 +83,7 @@ public class StartupActionModelUtil extends Bean {
         return false;
     }
 
+    @Override
     @CheckForNull
     public String getClassName(@CheckForNull String name) {
         if (name != null && !name.isEmpty()) {
@@ -92,6 +97,7 @@ public class StartupActionModelUtil extends Bean {
         return null;
     }
 
+    @Override
     @CheckForNull
     public String[] getNames() {
         this.prepareActionsHashMap();
@@ -105,12 +111,14 @@ public class StartupActionModelUtil extends Bean {
         return this.actionNames.toArray(new String[this.actionNames.size()]);
     }
 
+    @Override
     @Nonnull
     public Class<?>[] getClasses() {
         this.prepareActionsHashMap();
         return actions.keySet().toArray(new Class<?>[actions.size()]);
     }
 
+    @Override
     public void addAction(@Nonnull String strClass, @Nonnull String name) throws ClassNotFoundException {
         this.prepareActionsHashMap();
         this.actionNames = null;
@@ -126,6 +134,7 @@ public class StartupActionModelUtil extends Bean {
         this.firePropertyChange("length", null, null);
     }
 
+    @Override
     public void removeAction(@Nonnull String strClass) throws ClassNotFoundException {
         this.prepareActionsHashMap();
         this.actionNames = null;
@@ -168,6 +177,7 @@ public class StartupActionModelUtil extends Bean {
         }
     }
 
+    @Override
     @CheckForNull
     public String getOverride(@CheckForNull String name) {
         this.prepareActionsHashMap();

--- a/java/src/jmri/StartupActionModelUtil.java
+++ b/java/src/jmri/StartupActionModelUtil.java
@@ -1,0 +1,33 @@
+package jmri;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+public interface StartupActionModelUtil {
+    @CheckForNull
+    String getActionName(@Nonnull Class<?> clazz);
+
+    @CheckForNull
+    String getActionName(@Nonnull String className);
+
+    boolean isSystemConnectionAction(@Nonnull Class<?> clazz);
+
+    boolean isSystemConnectionAction(@Nonnull String className);
+
+    @CheckForNull
+    String getClassName(@CheckForNull String name);
+
+    @CheckForNull
+    String[] getNames();
+
+    @Nonnull
+    Class<?>[] getClasses();
+
+    void addAction(@Nonnull String strClass, @Nonnull String name) throws ClassNotFoundException;
+
+    void removeAction(@Nonnull String strClass) throws ClassNotFoundException;
+
+    @CheckForNull
+    String getOverride(@CheckForNull String name);
+
+}

--- a/java/src/jmri/jmrix/AbstractSerialConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractSerialConnectionConfig.java
@@ -1,6 +1,5 @@
 package jmri.jmrix;
 
-import apps.startup.StartupActionModelUtil;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.GridBagConstraints;
@@ -23,6 +22,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.ListCellRenderer;
 import jmri.InstanceManager;
+import jmri.StartupActionModelUtil;
 import jmri.util.PortNameMapper;
 import jmri.util.PortNameMapper.SerialPortFriendlyName;
 import org.slf4j.Logger;

--- a/java/src/jmri/jmrix/SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/SystemConnectionMemo.java
@@ -1,7 +1,5 @@
 package jmri.jmrix;
 
-import apps.startup.StartupActionModelUtil;
-
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.ResourceBundle;
@@ -10,6 +8,7 @@ import javax.annotation.OverridingMethodsMustInvokeSuper;
 import jmri.ConsistManager;
 import jmri.InstanceManager;
 import jmri.NamedBean;
+import jmri.StartupActionModelUtil;
 import jmri.beans.Bean;
 import jmri.implementation.DccConsistManager;
 import jmri.implementation.NmraConsistManager;
@@ -259,10 +258,10 @@ public abstract class SystemConnectionMemo extends Bean {
     }
 
     private void changeActionList(boolean add) {
-        StartupActionModelUtil util = StartupActionModelUtil.getDefault();
+        StartupActionModelUtil util = InstanceManager.getNullableDefault(StartupActionModelUtil.class);
         ResourceBundle rb = getActionModelResourceBundle();
-        if (rb == null) {
-            // don't bother trying if there is no ActionModelResourceBundle
+        if (rb == null || util == null) {
+            // don't bother trying if there is no ActionModelResourceBundle or StartupActionModelUtil
             return;
         }
         log.debug("Removing actions from bundle {}", rb.getBaseBundleName());


### PR DESCRIPTION
Use this interface to remove reference to apps package in jmri package.

This was prompted by #8536 and the discovery that the 'apps.startup.StartupActionModelUtil.getDefault()' was being triggered directly by jmri.jmirx.SystemConnectionMemo.  This should have used the InstanceManager instead.

This lets us leave the implementation of StartupActionModelUtil in apps, while referencing the interface in the jmri package.
