### PR TITLE
Enumio should use name() instead of toString()

### DIFF
--- a/java/src/jmri/configurexml/AbstractXmlAdapter.java
+++ b/java/src/jmri/configurexml/AbstractXmlAdapter.java
@@ -322,7 +322,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         public T inputFromString(@Nonnull String s) {
                 T retval = mapToEnum.get(s);
                 if (retval == null) {
-                    log.error("from String {} get {} for {}", s, retval, clazz);
+                    log.error("from String {} get null for {}", s, clazz);
                 } else {
                     log.trace("from String {} get {} for {}", s, retval, clazz);
                 }

--- a/java/src/jmri/configurexml/AbstractXmlAdapter.java
+++ b/java/src/jmri/configurexml/AbstractXmlAdapter.java
@@ -1,5 +1,6 @@
 package jmri.configurexml;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
@@ -102,7 +103,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
      * @return boolean value of attribute, else default if not present or error.
      */
     final public boolean getAttributeBooleanValue(@Nonnull Element element, @Nonnull String name, boolean def) {
-        Attribute a = null;
+        Attribute a;
         String val = null;
         try {
             a = element.getAttribute(name);
@@ -135,7 +136,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
      * @return integer value of attribute, else default if not present or error.
      */
     final public int getAttributeIntegerValue(@Nonnull Element element, @Nonnull String name, int def) {
-        Attribute a = null;
+        Attribute a;
         String val = null;
         try {
             a = element.getAttribute(name);
@@ -166,7 +167,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
      * @return double value of attribute, else default if not present or error.
      */
     final public double getAttributeDoubleValue(@Nonnull Element element, @Nonnull String name, double def) {
-        Attribute a = null;
+        Attribute a;
         String val = null;
         try {
             a = element.getAttribute(name);
@@ -198,7 +199,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
      * @return float value of attribute, else default if not present or error.
      */
     final public float getAttributeFloatValue(@Nonnull Element element, @Nonnull String name, float def) {
-        Attribute a = null;
+        Attribute a;
         String val = null;
         try {
             a = element.getAttribute(name);
@@ -237,7 +238,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
          * @return enum value.
          */
         @Nonnull
-        abstract public T inputFromString(@Nonnull String s);
+        abstract public T inputFromString(@CheckForNull String s);
 
         /**
          * Convert a JDOM Attribute from an XML file to an enum value
@@ -276,9 +277,19 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         /** {@inheritDoc} */
         @Override
         @Nonnull
-        public T inputFromString(@Nonnull String s) {
-            int content = Integer.parseInt(s);
-            return clazz.getEnumConstants()[content];
+        public T inputFromString(@CheckForNull String s) {
+            if (s == null) {
+                log.error("from String null get {} for {}", clazz.getEnumConstants()[0].name(), clazz);
+                return clazz.getEnumConstants()[0];
+            }
+            
+            try {
+                int content = Integer.parseInt(s);
+                return clazz.getEnumConstants()[content];
+            } catch (RuntimeException e) {
+                log.error("from String {} get {} for {}", s, clazz.getEnumConstants()[0].name(), clazz, e);
+                return clazz.getEnumConstants()[0];
+            }
         }
 
     }
@@ -311,22 +322,28 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Override
         @Nonnull
         public String outputFromEnum(@Nonnull T e) {
-                String retval = e.name();
-                log.trace("from {} make String {} for {}", e, retval, clazz);
-                return retval;
+            String retval = e.name();
+            log.trace("from {} make String {} for {}", e, retval, clazz);
+            return retval;
         }
         
         /** {@inheritDoc} */
         @Override
         @Nonnull
-        public T inputFromString(@Nonnull String s) {
-                T retval = mapToEnum.get(s);
-                if (retval == null) {
-                    log.error("from String {} get null for {}", s, clazz);
-                } else {
-                    log.trace("from String {} get {} for {}", s, retval, clazz);
-                }
+        public T inputFromString(@CheckForNull String s) {
+            if (s == null) {
+                log.error("from String null get {} for {}", clazz.getEnumConstants()[0].name(), clazz);
+                return clazz.getEnumConstants()[0];
+            }
+            
+            T retval = mapToEnum.get(s);
+            if (retval == null) {
+                log.error("from String {} get {} for {}", s, clazz.getEnumConstants()[0].name(), clazz);
+                return clazz.getEnumConstants()[0];
+            } else {
+                log.trace("from String {} get {} for {}", s, retval, clazz);
                 return retval;
+            }
         }
     }
 
@@ -415,10 +432,25 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         /** {@inheritDoc} */
         @Override
         @Nonnull
-        public T inputFromString(@Nonnull String s) {
-            T retval = mapToEnum.get(s);
-            log.trace("from String {} get {} for {}", s, retval, clazz);
-            return retval;
+        public T inputFromString(@CheckForNull String s) {
+            if (s == null) {
+                log.error("from String null get {} for {}", clazz.getEnumConstants()[0].name(), clazz);
+                return clazz.getEnumConstants()[0];
+            }
+            
+            try {
+                T retval = mapToEnum.get(s);
+                if (retval == null) {
+                    log.error("from String {} get {} for {}", s, clazz.getEnumConstants()[0].name(), clazz);
+                    return clazz.getEnumConstants()[0];
+                } else {
+                    log.trace("from String {} get {} for {}", s, retval, clazz);
+                    return retval;
+                }
+            } catch (RuntimeException e) {
+                log.error("from String {} get {} for {}", s, clazz.getEnumConstants()[0].name(), clazz, e);
+                return clazz.getEnumConstants()[0];
+            }
         }
     }
 

--- a/java/src/jmri/configurexml/AbstractXmlAdapter.java
+++ b/java/src/jmri/configurexml/AbstractXmlAdapter.java
@@ -297,7 +297,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         public EnumIoNames(@Nonnull Class<T> clazz) {
             this.clazz = clazz;
             
-            mapToEnum = new HashMap<String, T>();
+            mapToEnum = new HashMap<>();
             for (T t : clazz.getEnumConstants() ) {
                 mapToEnum.put(t.name(), t);
             }
@@ -312,7 +312,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Nonnull
         public String outputFromEnum(@Nonnull T e) {
                 String retval = e.name();
-                log.trace("from {} make String {}} for {}", e, retval, clazz);
+                log.trace("from {} make String {} for {}", e, retval, clazz);
                 return retval;
         }
         
@@ -321,7 +321,11 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Nonnull
         public T inputFromString(@Nonnull String s) {
                 T retval = mapToEnum.get(s);
-                log.trace("from String {} get {}} for {}", s, retval, clazz);
+                if (retval == null) {
+                    log.error("from String {} get {} for {}", s, retval, clazz);
+                } else {
+                    log.trace("from String {} get {} for {}", s, retval, clazz);
+                }
                 return retval;
         }
     }
@@ -389,7 +393,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
             
             this.mapToEnum = mapToEnum;
             
-            this.mapFromEnum = new HashMap<T, String>();
+            this.mapFromEnum = new HashMap<>();
             for (T t : clazz.getEnumConstants() ) {
                 this.mapFromEnum.put(t, t.name());
             }
@@ -404,7 +408,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Nonnull
         public String outputFromEnum(@Nonnull T e) {
             String retval = mapFromEnum.get(e);
-            log.trace("from {} make String {}} for {}", e, retval, clazz);
+            log.trace("from {} make String {} for {}", e, retval, clazz);
             return retval;
         }
         
@@ -413,7 +417,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Nonnull
         public T inputFromString(@Nonnull String s) {
             T retval = mapToEnum.get(s);
-            log.trace("from String {} get {}} for {}", s, retval, clazz);
+            log.trace("from String {} get {} for {}", s, retval, clazz);
             return retval;
         }
     }

--- a/java/src/jmri/configurexml/AbstractXmlAdapter.java
+++ b/java/src/jmri/configurexml/AbstractXmlAdapter.java
@@ -299,7 +299,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
             
             mapToEnum = new HashMap<String, T>();
             for (T t : clazz.getEnumConstants() ) {
-                mapToEnum.put(t.toString(), t);
+                mapToEnum.put(t.name(), t);
             }
             
         }
@@ -311,7 +311,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Override
         @Nonnull
         public String outputFromEnum(@Nonnull T e) {
-                String retval = e.toString();
+                String retval = e.name();
                 log.trace("from {} make String {}} for {}", e, retval, clazz);
                 return retval;
         }
@@ -391,7 +391,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
             
             this.mapFromEnum = new HashMap<T, String>();
             for (T t : clazz.getEnumConstants() ) {
-                this.mapFromEnum.put(t, t.toString());
+                this.mapFromEnum.put(t, t.name());
             }
         }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutShapeXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutShapeXml.java
@@ -91,12 +91,8 @@ public class LayoutShapeXml extends AbstractXmlAdapter {
 
         String name = element.getAttribute("ident").getValue();
 
-        LayoutShape.LayoutShapeType type = LayoutShape.LayoutShapeType.Open;
-        try {
-            type = sTypeEnumMap.inputFromAttribute(element.getAttribute("type"));
-        } catch (java.lang.NullPointerException e) {
-            log.error("Layout Shape type attribute not found.");
-        }
+        LayoutShape.LayoutShapeType type =
+                sTypeEnumMap.inputFromAttribute(element.getAttribute("type"));
 
         // create the new LayoutShape
         LayoutShape s = new LayoutShape(name, type, p);
@@ -151,12 +147,9 @@ public class LayoutShapeXml extends AbstractXmlAdapter {
                     for (int i = 0; i < elementList.size(); i++) {
                         Element relem = elementList.get(i);
 
-                        LayoutShape.LayoutShapePointType pointType = LayoutShape.LayoutShapePointType.Straight;
-                        try {
-                            pointType = pTypeEnumMap.inputFromAttribute(relem.getAttribute("type"));
-                        } catch (java.lang.NullPointerException e) {
-                            log.error("Layout Shape Point #{} type attribute not found.", i, e);
-                        }
+                        LayoutShape.LayoutShapePointType pointType =
+                                pTypeEnumMap.inputFromAttribute(relem.getAttribute("type"));
+                        
                         double x = 0.0;
                         double y = 0.0;
                         try {

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutSlipXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutSlipXml.java
@@ -201,7 +201,8 @@ public class LayoutSlipXml extends AbstractXmlAdapter {
             log.error("failed to convert layoutslip center  attribute");
         }
 
-        LayoutSlip.TurnoutType type = tTypeEnumMap.inputFromAttribute(element.getAttribute("slipType"));
+        LayoutSlip.TurnoutType type =
+                tTypeEnumMap.inputFromAttribute(element.getAttribute("slipType"));
 
         // create the new LayoutSlip
         LayoutSlip l; 

--- a/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
+++ b/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
@@ -123,6 +123,12 @@ public class AbstractXmlAdapterTest{
         Assert.assertEquals(testEnum.Foo, map.inputFromString("0"));
         Assert.assertEquals("2", map.outputFromEnum(testEnum.Biff));
         Assert.assertEquals(testEnum.Biff, map.inputFromString("2"));
+        
+        Assert.assertEquals(testEnum.Foo, map.inputFromString("FooBar"));
+        JUnitAppender.assertErrorMessage("from String FooBar get Foo for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
+        
+        Assert.assertEquals(testEnum.Foo, map.inputFromString(null));
+        JUnitAppender.assertErrorMessage("from String null get Foo for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
     }
 
     @Test
@@ -132,8 +138,11 @@ public class AbstractXmlAdapterTest{
         Assert.assertEquals("Foo", map.outputFromEnum(testEnum.Foo));
         Assert.assertEquals(testEnum.Biff, map.inputFromString("Biff"));
         
-        Assert.assertEquals(null, map.inputFromString("FooBar"));
-        JUnitAppender.assertErrorMessage("from String FooBar get null for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
+        Assert.assertEquals(testEnum.Foo, map.inputFromString("FooBar"));
+        JUnitAppender.assertErrorMessage("from String FooBar get Foo for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
+        
+        Assert.assertEquals(testEnum.Foo, map.inputFromString(null));
+        JUnitAppender.assertErrorMessage("from String null get Foo for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
     }
 
     @Test
@@ -157,6 +166,12 @@ public class AbstractXmlAdapterTest{
         Assert.assertEquals("Foo", map.outputFromEnum(testEnum.Foo));
         Assert.assertEquals(testEnum.Foo, map.inputFromString("foo"));
         Assert.assertEquals(testEnum.Foo, map.inputFromString("4"));
+
+        Assert.assertEquals(testEnum.Foo, map.inputFromString("FooBar"));
+        JUnitAppender.assertErrorMessage("from String FooBar get Foo for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
+
+        Assert.assertEquals(testEnum.Foo, map.inputFromString(null));
+        JUnitAppender.assertErrorMessage("from String null get Foo for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
     }
 
     @Test
@@ -185,6 +200,12 @@ public class AbstractXmlAdapterTest{
         Assert.assertEquals("FOO", map.outputFromEnum(testEnum.Foo));
         Assert.assertEquals(testEnum.Foo, map.inputFromString("foo"));
         Assert.assertEquals(testEnum.Foo, map.inputFromString("4"));
+
+        Assert.assertEquals(testEnum.Foo, map.inputFromString("FooBar"));
+        JUnitAppender.assertErrorMessage("from String FooBar get Foo for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
+
+        Assert.assertEquals(testEnum.Foo, map.inputFromString(null));
+        JUnitAppender.assertErrorMessage("from String null get Foo for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
     }
 
 

--- a/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
+++ b/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
@@ -131,6 +131,9 @@ public class AbstractXmlAdapterTest{
         
         Assert.assertEquals("Foo", map.outputFromEnum(testEnum.Foo));
         Assert.assertEquals(testEnum.Biff, map.inputFromString("Biff"));
+        
+        Assert.assertEquals(null, map.inputFromString("FooBar"));
+        JUnitAppender.assertErrorMessage("from String FooBar get null for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
     }
 
     @Test

--- a/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
+++ b/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
@@ -101,7 +101,19 @@ public class AbstractXmlAdapterTest{
         Assert.assertEquals(21., adapter.getAttributeFloatValue(testEl, "t21", 12.f), 0.001);
     }
         
-    enum testEnum {Foo, Bar, Biff}
+    enum testEnum {
+        Foo,
+        Bar,
+        Biff;
+        
+        // The purpose of this method is to ensure that the EnumIO method
+        // doesn't use the method toString() since it could return a different
+        // value than the name of the enum, for example a localized name.
+        @Override
+        public String toString() {
+            return "A string";
+        }
+    }
     
     @Test
     public void testEnumIoOrdinals() {


### PR DESCRIPTION
In some enum classes, toString() is used for other things than returning the name of the enum, for example to return a localized name. So name() should be used instead of toString() when reading/writing xml files.

This PR fixes that and adds a check for it by adding the method toString() to the test enum clas.

@bobjacobsen 
If `AbstractXmlAdapter.EnumIoNames.inputFromString()` gets a string that's not a valid enum, it returns a `null`. Shouldn't this be an error? If I have the enum FooBar with the values Foo and Bar, and I `call inputFromString("ooF")`, I get a `null` as result and a log message with level `trace`.

I think that if the element exists in the xml file but the string is wrong, it should be an error which results in a IllegalArgumentException or at least an error message to the log. If an unknown string is in the xml file, it's probably a program error or a xml error, like in my case there I have toString() overridden.