### PR TITLE
Gentler JUnitUtil.deregisterBlockManagerShutdownTask

### DIFF
--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -423,6 +423,20 @@ public final class InstanceManager {
     }
 
     /**
+     * Check if a particular type has been initialized without
+     * triggering an automatic initialization.
+     *
+     * @param <T>  The type of the class
+     * @param type The class type
+     * @return true if an item is available as a default for the given type;
+     *         false otherwise
+     */
+    public static <T> boolean isInitialized(@Nonnull Class<T> type) {
+        return getDefault().managerLists.get(type) != null;
+    }
+
+
+    /**
      * Dump generic content of InstanceManager by type.
      *
      * @return A formatted multiline list of managed objects

--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -411,6 +411,10 @@ public final class InstanceManager {
 
     /**
      * Check if a default has been set for the given type.
+     * <p>
+     * As a side-effect, then (a) ensures that the list for the given 
+     * type exists, though it may be empty, and (b) if it had to create
+     * the list, a PropertyChangeEvent is fired to denote that.
      *
      * @param <T>  The type of the class
      * @param type The class type
@@ -424,7 +428,9 @@ public final class InstanceManager {
 
     /**
      * Check if a particular type has been initialized without
-     * triggering an automatic initialization.
+     * triggering an automatic initialization. The existence or
+     * non-existence of the corresponding list is not changed, and 
+     * no PropertyChangeEvent is fired.
      *
      * @param <T>  The type of the class
      * @param type The class type

--- a/java/test/jmri/InstanceManagerTest.java
+++ b/java/test/jmri/InstanceManagerTest.java
@@ -65,6 +65,21 @@ public class InstanceManagerTest {
         Assert.assertTrue("2nd addressed programmer manager is default", InstanceManager.getDefault(AddressedProgrammerManager.class) == m2);
     }
 
+    @Test
+    public void testIsInitialized() {
+        // counts on the following test class to be loaded
+        Assert.assertFalse(InstanceManager.isInitialized(jmri.InstanceManagerTest.InstanceManagerInitCheck.class));
+        Assert.assertFalse(InstanceManager.isInitialized(jmri.InstanceManagerTest.InstanceManagerInitCheck.class));
+        
+        Assert.assertNotNull(InstanceManager.getDefault(jmri.InstanceManagerTest.InstanceManagerInitCheck.class));
+        
+        Assert.assertTrue(InstanceManager.isInitialized(jmri.InstanceManagerTest.InstanceManagerInitCheck.class));
+    }
+    
+    static public class InstanceManagerInitCheck implements jmri.InstanceManagerAutoDefault {
+        public InstanceManagerInitCheck() {}
+    }
+    
     // the following test was moved from jmri.jmrit.symbolicprog.PackageTet when
     // it was converted to JUnit4 format.  It seemed out of place there.
     // check configuring the programmer

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -742,6 +742,9 @@ public class JUnitUtil {
     }
 
     public static void deregisterBlockManagerShutdownTask() {
+        if (! InstanceManager.isInitialized(ShutDownManager.class)) return;
+        if (! InstanceManager.isInitialized(BlockManager.class)) return;
+        
         InstanceManager
                 .getDefault(ShutDownManager.class)
                 .deregister(InstanceManager.getDefault(BlockManager.class).shutDownTask);


### PR DESCRIPTION
- Add `isInitialized` to `InstanceManager` to check if a type is available without forcing a load of it

- Use that in `JUnitUtil.deregisterBlockManagerShutdownTask` to not create managers if they don't exist