### PR TITLE
fix: Get Logix system prefix on demand

### DIFF
--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -37,6 +37,7 @@ import jmri.ConditionalAction;
 import jmri.ConditionalVariable;
 import jmri.InstanceManager;
 import jmri.Logix;
+import jmri.LogixManager;
 import jmri.Route;
 import jmri.RouteManager;
 import jmri.Sensor;
@@ -1359,6 +1360,15 @@ public class RouteTableAction extends AbstractTableAction<Route> {
     }
 
 /////////////////////// Export to Logix ////////////////////////////
+    
+    private String getLogixSystemPrefix() {
+        return InstanceManager.getDefault(LogixManager.class).getSystemPrefix() + ":RTX:";
+    }
+
+    private String getConditionalSystemPrefix() {
+        return getLogixSystemPrefix() + "C";
+    }
+
     /**
      * Respond to the Export button - export to Logix.
      *
@@ -1371,7 +1381,7 @@ public class RouteTableAction extends AbstractTableAction<Route> {
             sName = fixedSystemName.getText();
         }
         String uName = _userName.getText();
-        String logixSystemName = LOGIX_SYS_NAME + sName;
+        String logixSystemName = getLogixSystemPrefix() + sName;
         Logix logix = InstanceManager.getDefault(jmri.LogixManager.class).getBySystemName(logixSystemName);
         if (logix == null) {
             logix = InstanceManager.getDefault(jmri.LogixManager.class).createNewLogix(logixSystemName, uName);
@@ -1442,13 +1452,13 @@ public class RouteTableAction extends AbstractTableAction<Route> {
         for (int i = 0; i < ch.length; i++) {
             hash += ch[i];
         }
-        String cSystemName = CONDITIONAL_SYS_PREFIX + "T" + hash;
+        String cSystemName = getConditionalSystemPrefix() + "T" + hash;
         removeConditionals(cSystemName, logix);
-        cSystemName = CONDITIONAL_SYS_PREFIX + "F" + hash;
+        cSystemName = getConditionalSystemPrefix() + "F" + hash;
         removeConditionals(cSystemName, logix);
-        cSystemName = CONDITIONAL_SYS_PREFIX + "A" + hash;
+        cSystemName = getConditionalSystemPrefix() + "A" + hash;
         removeConditionals(cSystemName, logix);
-        cSystemName = CONDITIONAL_SYS_PREFIX + "L" + hash;
+        cSystemName = getConditionalSystemPrefix() + "L" + hash;
         removeConditionals(cSystemName, logix);
 
         int n = 0;
@@ -2089,15 +2099,7 @@ public class RouteTableAction extends AbstractTableAction<Route> {
 
     private boolean showAll = true;   // false indicates show only included Turnouts
 
-    public final static String LOGIX_SYS_NAME;
-    public final static String CONDITIONAL_SYS_PREFIX;
     private static int ROW_HEIGHT;
-
-    static {
-        String logixPrefix = InstanceManager.getDefault(jmri.LogixManager.class).getSystemNamePrefix();
-        LOGIX_SYS_NAME = logixPrefix + ":RTX:";
-        CONDITIONAL_SYS_PREFIX = LOGIX_SYS_NAME + "C";
-    }
 
     private static String[] COLUMN_NAMES = {Bundle.getMessage("ColumnSystemName"),
         Bundle.getMessage("ColumnUserName"),


### PR DESCRIPTION
Don't force non-users of Logix to load the entire Logix subsystem just to preemptively get its system connection prefix.