### PR TITLE
chore: Run GitHub Actions on all branches

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,11 +3,11 @@
 
 name: Static Analysis
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [ push, pull_request ]
+#  push:
+#    branches: [ master ]
+#  pull_request:
+#    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -3,11 +3,11 @@
 
 name: Windows CI Tests
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [ push, pull_request ]
+#  push:
+#    branches: [ master ]
+#  pull_request:
+#    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
As originally written, the GitHub Actions ran only pushes and pull requests on the `master` branch  of JMRI or a user's fork. This change makes those Actions run against any push or pull request.