### PR TITLE
Add key navigation to Throttle window

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -471,7 +471,18 @@
     <h3>Throttle</h3>
         <a id="throttle" name="throttle"></a>
         <ul>
-            <li></li>
+            <li>Added key shortcuts to the throttle window. Hold the shift
+                down, press and release key
+            <ul>
+                <li>A to switch to the "Address" section
+                <li>F to switch to the "Functions" section
+                <li>C to switch to the "Control" section which sets speed
+            </ul>
+                This is in addition to left arrow and right arrow, which 
+                move from one throttle to the next if you have more than one open.
+                Please note that this act when the key is released.
+            </li>
+            
         </ul>
 
     <h3>Timetable</h3>

--- a/java/src/jmri/jmrit/throttle/ThrottleFrameManager.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleFrameManager.java
@@ -19,8 +19,12 @@ import org.slf4j.LoggerFactory;
  */
 public class ThrottleFrameManager implements InstanceManagerAutoDefault {
 
-    private final static int NEXT_THROTTLE_KEY = KeyEvent.VK_RIGHT;
-    private final static int PREV_THROTTLE_KEY = KeyEvent.VK_LEFT;
+    private final static int NEXT_THROTTLE_KEY  = KeyEvent.VK_RIGHT;
+    private final static int PREV_THROTTLE_KEY  = KeyEvent.VK_LEFT;
+
+    private final static int MOVE_TO_FUNCTIONS  = KeyEvent.VK_F;
+    private final static int MOVE_TO_CONTROL    = KeyEvent.VK_C;
+    private final static int MOVE_TO_ADDRESS    = KeyEvent.VK_A;
 
     private int activeFrame;
     private final ThrottleCyclingKeyListener throttleCycler;
@@ -133,6 +137,35 @@ public class ThrottleFrameManager implements InstanceManagerAutoDefault {
         tf.toFront();
     }
 
+
+    private void requestFocusAddress() {
+        throttleWindows.get(activeFrame).getCurrentThrottleFrame().getAddressPanel().requestFocus();
+        throttleWindows.get(activeFrame).getCurrentThrottleFrame().getAddressPanel().toFront();
+        try {
+            throttleWindows.get(activeFrame).getCurrentThrottleFrame().getAddressPanel().setSelected(true);
+        } catch (java.beans.PropertyVetoException ex) {
+            log.debug("address move vetoed");
+        }
+    }
+    private void requestFocusControls() {
+        throttleWindows.get(activeFrame).getCurrentThrottleFrame().getControlPanel().requestFocus();
+        throttleWindows.get(activeFrame).getCurrentThrottleFrame().getControlPanel().toFront();
+        try {
+            throttleWindows.get(activeFrame).getCurrentThrottleFrame().getControlPanel().setSelected(true);
+        } catch (java.beans.PropertyVetoException ex) {
+            log.debug("control move vetoed");
+        }
+    }
+    private void requestFocusFunctions() {
+        throttleWindows.get(activeFrame).getCurrentThrottleFrame().getFunctionPanel().requestFocus();
+        throttleWindows.get(activeFrame).getCurrentThrottleFrame().getFunctionPanel().toFront();
+        try {
+            throttleWindows.get(activeFrame).getCurrentThrottleFrame().getFunctionPanel().setSelected(true);
+        } catch (java.beans.PropertyVetoException ex) {
+            log.debug("function move vetoed");
+        }
+    }
+
     public ThrottleWindow getCurrentThrottleFrame() {
         if (throttleWindows == null) {
             return null;
@@ -161,10 +194,17 @@ public class ThrottleFrameManager implements InstanceManagerAutoDefault {
          */
         @Override
         public void keyReleased(KeyEvent e) {
+            log.trace("TFM {}", e);
             if (e.isShiftDown() && e.getKeyCode() == NEXT_THROTTLE_KEY) {
                 requestFocusForNextFrame();
             } else if (e.isShiftDown() && e.getKeyCode() == PREV_THROTTLE_KEY) {
                 requestFocusForPreviousFrame();
+            } else if (e.isShiftDown() && e.getKeyCode() == MOVE_TO_FUNCTIONS) {
+                requestFocusFunctions();
+            } else if (e.isShiftDown() && e.getKeyCode() == MOVE_TO_CONTROL) {
+                requestFocusControls();
+            } else if (e.isShiftDown() && e.getKeyCode() == MOVE_TO_ADDRESS) {
+                requestFocusAddress();
             }
         }
     }

--- a/java/src/jmri/jmrit/throttle/ThrottleWindow.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleWindow.java
@@ -72,10 +72,6 @@ public class ThrottleWindow extends JmriJFrame {
     private static int NEXT_THROTTLE_KEY = KeyEvent.VK_RIGHT;
     private static int PREV_THROTTLE_KEY = KeyEvent.VK_LEFT;
 
-    private final static int MOVE_TO_FUNCTIONS  = KeyEvent.VK_F;
-    private final static int MOVE_TO_CONTROL    = KeyEvent.VK_C;
-    private final static int MOVE_TO_ADDRESS    = KeyEvent.VK_A;
-
     private HashMap<String, ThrottleFrame> throttleFrames = new HashMap<String, ThrottleFrame>(5);
     private int cardCounterID = 0; // to generate unique names for each card
     private int cardCounterNB = 1; // real counter

--- a/java/src/jmri/jmrit/throttle/ThrottleWindow.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleWindow.java
@@ -72,6 +72,10 @@ public class ThrottleWindow extends JmriJFrame {
     private static int NEXT_THROTTLE_KEY = KeyEvent.VK_RIGHT;
     private static int PREV_THROTTLE_KEY = KeyEvent.VK_LEFT;
 
+    private final static int MOVE_TO_FUNCTIONS  = KeyEvent.VK_F;
+    private final static int MOVE_TO_CONTROL    = KeyEvent.VK_C;
+    private final static int MOVE_TO_ADDRESS    = KeyEvent.VK_A;
+
     private HashMap<String, ThrottleFrame> throttleFrames = new HashMap<String, ThrottleFrame>(5);
     private int cardCounterID = 0; // to generate unique names for each card
     private int cardCounterNB = 1; // real counter
@@ -819,6 +823,7 @@ public class ThrottleWindow extends JmriJFrame {
          */
         @Override
         public void keyReleased(KeyEvent e) {
+            log.trace("TW {}", e);
             if (e.isAltDown() && e.getKeyCode() == NEXT_THROTTLE_KEY) {
                 log.debug("next");
                 nextThrottleFrame();


### PR DESCRIPTION
On a throttle window, 
- shift-A will move the focus to the address section
- shift-F will move to the function section
- shift-C will move to the control (speed) section

Note that, for consistency with the already present codes, these act on key-up, not the key-down that one might a-priori expect.

Includes comment in release note.