### PR TITLE
Improve EnumIO

### DIFF
--- a/java/src/jmri/configurexml/AbstractXmlAdapter.java
+++ b/java/src/jmri/configurexml/AbstractXmlAdapter.java
@@ -322,7 +322,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         public T inputFromString(@Nonnull String s) {
                 T retval = mapToEnum.get(s);
                 if (retval == null) {
-                    log.error("from String {} get {} for {}", s, retval, clazz);
+                    log.error("from String {} get null for {}", s, clazz);
                 } else {
                     log.trace("from String {} get {} for {}", s, retval, clazz);
                 }

--- a/java/src/jmri/configurexml/AbstractXmlAdapter.java
+++ b/java/src/jmri/configurexml/AbstractXmlAdapter.java
@@ -263,7 +263,6 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
          * @param s storage string
          * @return enum value.
          */
-        @Nonnull
         abstract protected T internalInputFromString(@Nonnull String s);
         
         /**

--- a/java/src/jmri/configurexml/AbstractXmlAdapter.java
+++ b/java/src/jmri/configurexml/AbstractXmlAdapter.java
@@ -253,7 +253,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
             try {
                 return internalInputFromString(s);
             } catch (RuntimeException e) {
-                log.error("from String null get null for {}", clazz);
+                log.error("from String null get null for {}", clazz, e);
                 return null;
             }
         }

--- a/java/src/jmri/configurexml/AbstractXmlAdapter.java
+++ b/java/src/jmri/configurexml/AbstractXmlAdapter.java
@@ -297,7 +297,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         public EnumIoNames(@Nonnull Class<T> clazz) {
             this.clazz = clazz;
             
-            mapToEnum = new HashMap<String, T>();
+            mapToEnum = new HashMap<>();
             for (T t : clazz.getEnumConstants() ) {
                 mapToEnum.put(t.name(), t);
             }
@@ -312,7 +312,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Nonnull
         public String outputFromEnum(@Nonnull T e) {
                 String retval = e.name();
-                log.trace("from {} make String {}} for {}", e, retval, clazz);
+                log.trace("from {} make String {} for {}", e, retval, clazz);
                 return retval;
         }
         
@@ -321,7 +321,11 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Nonnull
         public T inputFromString(@Nonnull String s) {
                 T retval = mapToEnum.get(s);
-                log.trace("from String {} get {}} for {}", s, retval, clazz);
+                if (retval == null) {
+                    log.error("from String {} get {} for {}", s, retval, clazz);
+                } else {
+                    log.trace("from String {} get {} for {}", s, retval, clazz);
+                }
                 return retval;
         }
     }
@@ -389,7 +393,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
             
             this.mapToEnum = mapToEnum;
             
-            this.mapFromEnum = new HashMap<T, String>();
+            this.mapFromEnum = new HashMap<>();
             for (T t : clazz.getEnumConstants() ) {
                 this.mapFromEnum.put(t, t.name());
             }
@@ -404,7 +408,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Nonnull
         public String outputFromEnum(@Nonnull T e) {
             String retval = mapFromEnum.get(e);
-            log.trace("from {} make String {}} for {}", e, retval, clazz);
+            log.trace("from {} make String {} for {}", e, retval, clazz);
             return retval;
         }
         
@@ -413,7 +417,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Nonnull
         public T inputFromString(@Nonnull String s) {
             T retval = mapToEnum.get(s);
-            log.trace("from String {} get {}} for {}", s, retval, clazz);
+            log.trace("from String {} get {} for {}", s, retval, clazz);
             return retval;
         }
     }

--- a/java/src/jmri/configurexml/AbstractXmlAdapter.java
+++ b/java/src/jmri/configurexml/AbstractXmlAdapter.java
@@ -299,7 +299,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
             
             mapToEnum = new HashMap<String, T>();
             for (T t : clazz.getEnumConstants() ) {
-                mapToEnum.put(t.toString(), t);
+                mapToEnum.put(t.name(), t);
             }
             
         }
@@ -311,7 +311,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
         @Override
         @Nonnull
         public String outputFromEnum(@Nonnull T e) {
-                String retval = e.toString();
+                String retval = e.name();
                 log.trace("from {} make String {}} for {}", e, retval, clazz);
                 return retval;
         }
@@ -391,7 +391,7 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
             
             this.mapFromEnum = new HashMap<T, String>();
             for (T t : clazz.getEnumConstants() ) {
-                this.mapFromEnum.put(t, t.toString());
+                this.mapFromEnum.put(t, t.name());
             }
         }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutShapeXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutShapeXml.java
@@ -11,8 +11,6 @@ import jmri.util.ColorUtil;
 import org.jdom2.Attribute;
 import org.jdom2.DataConversionException;
 import org.jdom2.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This module handles configuration for LayoutShape objects for a LayoutEditor.
@@ -91,10 +89,9 @@ public class LayoutShapeXml extends AbstractXmlAdapter {
 
         String name = element.getAttribute("ident").getValue();
 
-        LayoutShape.LayoutShapeType type = LayoutShape.LayoutShapeType.Open;
-        try {
-            type = sTypeEnumMap.inputFromAttribute(element.getAttribute("type"));
-        } catch (java.lang.NullPointerException e) {
+        LayoutShape.LayoutShapeType type = sTypeEnumMap.inputFromAttribute(element.getAttribute("type"));
+        if (type == null) {
+            type = LayoutShape.LayoutShapeType.Open;
             log.error("Layout Shape type attribute not found.");
         }
 
@@ -151,11 +148,10 @@ public class LayoutShapeXml extends AbstractXmlAdapter {
                     for (int i = 0; i < elementList.size(); i++) {
                         Element relem = elementList.get(i);
 
-                        LayoutShape.LayoutShapePointType pointType = LayoutShape.LayoutShapePointType.Straight;
-                        try {
-                            pointType = pTypeEnumMap.inputFromAttribute(relem.getAttribute("type"));
-                        } catch (java.lang.NullPointerException e) {
-                            log.error("Layout Shape Point #{} type attribute not found.", i, e);
+                        LayoutShape.LayoutShapePointType pointType = pTypeEnumMap.inputFromAttribute(relem.getAttribute("type"));
+                        if (pointType == null) {
+                            pointType = LayoutShape.LayoutShapePointType.Straight;
+                            log.error("Layout Shape Point #{} type attribute not found.", i);
                         }
                         double x = 0.0;
                         double y = 0.0;

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutTurnoutXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutTurnoutXml.java
@@ -188,12 +188,17 @@ public class LayoutTurnoutXml extends AbstractXmlAdapter {
         String name = element.getAttribute("ident").getValue();
         double x = 0.0;
         double y = 0.0;
-        LayoutTurnout.TurnoutType type = LayoutTurnout.TurnoutType.NONE;
+        
         try {
             x = element.getAttribute("xcen").getFloatValue();
             y = element.getAttribute("ycen").getFloatValue();
-            type = tTypeEnumMap.inputFromAttribute(element.getAttribute("type"));
         } catch (org.jdom2.DataConversionException e) {
+            log.error("failed to convert layoutturnout attribute");
+        }
+
+        LayoutTurnout.TurnoutType type = tTypeEnumMap.inputFromAttribute(element.getAttribute("type"));
+        if (type == null) {
+            type = LayoutTurnout.TurnoutType.NONE;
             log.error("failed to convert layoutturnout attribute");
         }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/PositionablePointXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/PositionablePointXml.java
@@ -97,14 +97,18 @@ public class PositionablePointXml extends AbstractXmlAdapter {
 
         // get attributes
         String name = element.getAttribute("ident").getValue();
-        PositionablePoint.PointType type = PositionablePoint.PointType.ANCHOR;
         double x = 0.0;
         double y = 0.0;
         try {
             x = element.getAttribute("x").getFloatValue();
             y = element.getAttribute("y").getFloatValue();
-            type = pTypeEnumMap.inputFromAttribute(element.getAttribute("type"));
         } catch (org.jdom2.DataConversionException e) {
+            log.error("failed to convert positionablepoint attribute");
+        }
+        
+        PositionablePoint.PointType type = pTypeEnumMap.inputFromAttribute(element.getAttribute("type"));
+        if (type == null) {
+            type = PositionablePoint.PointType.ANCHOR;
             log.error("failed to convert positionablepoint attribute");
         }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentXml.java
@@ -245,12 +245,11 @@ public class TrackSegmentXml extends AbstractXmlAdapter {
             attribute = element.getAttribute("type1");
             type1 = HitPointType.valueOf(attribute.getValue());
         } catch (IllegalArgumentException | NullPointerException e) {
-            try {
-                if (attribute == null) {
-                    throw new NullPointerException();
-                }
-                type1 = htpMap.inputFromAttribute(attribute);
-            } catch (NullPointerException e1) {
+            HitPointType t = null;
+            if (attribute != null) t = htpMap.inputFromAttribute(attribute);
+            if (t != null) {
+                type1 = t;
+            } else {
                 log.error("failed to convert tracksegment type1 attribute");
             }
         }
@@ -260,12 +259,11 @@ public class TrackSegmentXml extends AbstractXmlAdapter {
             attribute = element.getAttribute("type2");
             type2 = HitPointType.valueOf(attribute.getValue());
         } catch (IllegalArgumentException | NullPointerException e) {
-            try {
-                if (attribute == null) {
-                    throw new NullPointerException();
-                }
-                type2 = htpMap.inputFromAttribute(attribute);
-            } catch (NullPointerException e1) {
+            HitPointType t = null;
+            if (attribute != null) t = htpMap.inputFromAttribute(attribute);
+            if (t != null) {
+                type2 = t;
+            } else {
                 log.error("failed to convert tracksegment type2 attribute");
             }
         }

--- a/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
+++ b/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
@@ -2,11 +2,17 @@ package jmri.configurexml;
 
 import java.util.HashMap;
 
+import javax.annotation.Nonnull;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.jdom2.*;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * JUnit tests for the AbstractXmlAdapter class itself
@@ -123,6 +129,8 @@ public class AbstractXmlAdapterTest{
         Assert.assertEquals(testEnum.Foo, map.inputFromString("0"));
         Assert.assertEquals("2", map.outputFromEnum(testEnum.Biff));
         Assert.assertEquals(testEnum.Biff, map.inputFromString("2"));
+        
+        Assert.assertNull(map.inputFromString(null));
     }
 
     @Test
@@ -134,6 +142,8 @@ public class AbstractXmlAdapterTest{
         
         Assert.assertEquals(null, map.inputFromString("FooBar"));
         JUnitAppender.assertErrorMessage("from String FooBar get null for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
+        
+        Assert.assertNull(map.inputFromString(null));
     }
 
     @Test
@@ -157,6 +167,8 @@ public class AbstractXmlAdapterTest{
         Assert.assertEquals("Foo", map.outputFromEnum(testEnum.Foo));
         Assert.assertEquals(testEnum.Foo, map.inputFromString("foo"));
         Assert.assertEquals(testEnum.Foo, map.inputFromString("4"));
+        
+        Assert.assertNull(map.inputFromString(null));
     }
 
     @Test
@@ -185,15 +197,46 @@ public class AbstractXmlAdapterTest{
         Assert.assertEquals("FOO", map.outputFromEnum(testEnum.Foo));
         Assert.assertEquals(testEnum.Foo, map.inputFromString("foo"));
         Assert.assertEquals(testEnum.Foo, map.inputFromString("4"));
+        
+        Assert.assertNull(map.inputFromString(null));
     }
+    
+    @Test
+    public void testEnumException() {
+        AbstractXmlAdapter.EnumIO<testEnum> map = new AbstractXmlAdapter.EnumIoOrdinals<>(testEnum.class);
+        
+        Assert.assertNull(map.inputFromString("Test"));
+        JUnitAppender.assertErrorMessage("from String null get null for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
+    }
+    
+    public static class EnumIoException <T extends Enum<T>> extends AbstractXmlAdapter.EnumIO<T> {
+    
+        public EnumIoException(@Nonnull Class<T> clazz) {
+            super(clazz);
+        }
+        
+        /** {@inheritDoc} */
+        @Override
+        @Nonnull
+        public String outputFromEnum(@Nonnull T e) {
+            return e.name();
+        }
+        
+        /** {@inheritDoc} */
+        @Override
+        public T internalInputFromString(String s) {
+            // throw an exception that is not expected
+            throw new IllegalMonitorStateException();
+        }
 
-
-    @Before
+    }
+    
+    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
+++ b/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
@@ -11,8 +11,6 @@ import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * JUnit tests for the AbstractXmlAdapter class itself

--- a/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
+++ b/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
@@ -131,6 +131,9 @@ public class AbstractXmlAdapterTest{
         
         Assert.assertEquals("Foo", map.outputFromEnum(testEnum.Foo));
         Assert.assertEquals(testEnum.Biff, map.inputFromString("Biff"));
+        
+        Assert.assertEquals(null, map.inputFromString("FooBar"));
+        JUnitAppender.assertErrorMessage("from String FooBar get null for class jmri.configurexml.AbstractXmlAdapterTest$testEnum");
     }
 
     @Test

--- a/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
+++ b/java/test/jmri/configurexml/AbstractXmlAdapterTest.java
@@ -101,7 +101,19 @@ public class AbstractXmlAdapterTest{
         Assert.assertEquals(21., adapter.getAttributeFloatValue(testEl, "t21", 12.f), 0.001);
     }
         
-    enum testEnum {Foo, Bar, Biff}
+    enum testEnum {
+        Foo,
+        Bar,
+        Biff;
+        
+        // The purpose of this method is to ensure that the EnumIO method
+        // doesn't use the method toString() since it could return a different
+        // value than the name of the enum, for example a localized name.
+        @Override
+        public String toString() {
+            return "A string";
+        }
+    }
     
     @Test
     public void testEnumIoOrdinals() {


### PR DESCRIPTION
This is an extension of #8549, Enumio should use name() instead of toString(). I think this PR is better than #8549 but maybe this PR has gone too far.

@bobjacobsen wrote in #8549:
> As to error handing: the XML Schema is supposed to be the first line of defense of that. I'm not sure a `Throwable` is the right solution, because it'll really mess up the read process since it's not likely to be caught low down. EnumIO should probably do an error report before it does anything else though.

This PR ensures that EnumIO does not throw any exception. If the enum cannot be found or if an exception is thrown, it's logged as an error and `null` is returned.

I thought about not catching the exception, but still allow null to be returned. But it results in confusing Javadoc: Sometimes null is returned and sometimes an exception is thrown, and the super class EnumIO cannot know which will happen. So I think it's better that either null is always returned or an exception is always thrown, if the enum cannot be found.