### PR TITLE
Add missing Javadoc items

### DIFF
--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -275,6 +275,7 @@ public abstract class AbstractNamedBean implements NamedBean {
 
     /**
      * Overload this in a sub-class to add extra info to the results of toString()
+     * @return a suffix to add at the end of #toString() result
      */
     protected String toStringSuffix() {
         return "";

--- a/java/src/jmri/implementation/AbstractStringIO.java
+++ b/java/src/jmri/implementation/AbstractStringIO.java
@@ -50,6 +50,7 @@ public abstract class AbstractStringIO extends AbstractNamedBean implements Stri
     /**
      * Set the string of this StringIO.
      * Called from the implementation class when the layout updates this StringIO.
+     * @param newValue new value to set
      */
     protected void setString(@Nonnull String newValue) {
         Object _old = this._knownString;

--- a/java/src/jmri/jmrit/beantable/signalmast/AddSignalMastPanel.java
+++ b/java/src/jmri/jmrit/beantable/signalmast/AddSignalMastPanel.java
@@ -186,6 +186,7 @@ public class AddSignalMastPanel extends JPanel {
 
     /**
      * Select a particular signal implementation to display.
+     * @param view The signal implementation pane name to display
      */
     void selection(String view) {
         log.trace(" selection({}) start", view);
@@ -427,6 +428,7 @@ public class AddSignalMastPanel extends JPanel {
      * Check of user name done when creating new SignalMast.
      * In case of error, it looks a message and (if not headless) shows a dialog.
      *
+     * @param nam User name to be checked
      * @return true if OK to proceed
      */
     boolean checkUserName(String nam) {

--- a/java/src/jmri/jmrit/beantable/signalmast/DccSignalMastAddPane.java
+++ b/java/src/jmri/jmrit/beantable/signalmast/DccSignalMastAddPane.java
@@ -216,6 +216,7 @@ public class DccSignalMastAddPane extends SignalMastAddPane {
     /**
      * Get the first part of the system name
      * for the specific mast type.
+     * @return For this specific class, "F$dsm:"
      */
     protected @Nonnull String getNamePrefix() {
         return "F$dsm:";
@@ -223,6 +224,8 @@ public class DccSignalMastAddPane extends SignalMastAddPane {
 
     /** 
      * Create a mast of the specific subtype.
+     * @param name A valid subtype name
+     * @return A SignalMast of that subtype
      */
     protected DccSignalMast constructMast(@Nonnull String name) {
         return new DccSignalMast(name);
@@ -352,6 +355,7 @@ public class DccSignalMastAddPane extends SignalMastAddPane {
 
     /**
      * Copy aspects by name from another DccSignalMast.
+     * @param strMast User or system name of mast to copy from
      */
     void copyFromAnotherDCCMastAspect(@Nonnull String strMast) {
         DccSignalMast mast = (DccSignalMast) InstanceManager.getDefault(jmri.SignalMastManager.class).getNamedBean(strMast);

--- a/java/src/jmri/jmrit/beantable/signalmast/MatrixSignalMastAddPane.java
+++ b/java/src/jmri/jmrit/beantable/signalmast/MatrixSignalMastAddPane.java
@@ -507,6 +507,9 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
     
     /**
      * Index is 1-based here:  1..MAXMATRIXBITS
+     * @param turnoutPanel The panel to convert to an output panel
+     * @param index The 1..MAXMATRIXBITS index of the one to be set visible
+     * @return An output panel containing the selected turnout panel
      */
     JPanel makeOutputPanel(JPanel turnoutPanel, int index) {
         JPanel outputpanel = new JPanel();

--- a/java/src/jmri/jmrit/display/layoutEditor/HitPointType.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/HitPointType.java
@@ -294,6 +294,7 @@ public enum HitPointType {
      * Ideally, this would be replaced by turntable code that works
      * directly with the enum values as a step toward using objects
      * to implement hit points.
+     * @return (Temporary) 0-63 index of the enum element
      */
     protected int turntableTrackIndex() {
         int result = this.ordinal() - HitPointType.TURNTABLE_RAY_0.ordinal();
@@ -314,6 +315,8 @@ public enum HitPointType {
      * Ideally, this would be replaced by turntable code that works
      * directly with the enum values as a step toward using objects
      * to implement hit points.
+     * @param i (Temporary) 0-63 index of the enum element
+     * @return Requested enum element
      */
     protected static HitPointType turntableTrackIndexedValue(int i) {
         if (i < 0 || i > 63) {
@@ -326,6 +329,7 @@ public enum HitPointType {
      * Return an array of the valid TURNTABLE_RAY enum values.
      * Meant for interations over the set of rays.  Order is
      * from 0 to 63.
+     * @return (Temporary) Array containing TURNTABLE_RAY_0 through TURNTABLE_RAY_63
      */
     protected static HitPointType[] turntableValues() {
         return new HitPointType[]{TURNTABLE_RAY_0, TURNTABLE_RAY_1, TURNTABLE_RAY_2, TURNTABLE_RAY_3, TURNTABLE_RAY_4, TURNTABLE_RAY_5, TURNTABLE_RAY_6, TURNTABLE_RAY_7, TURNTABLE_RAY_8, TURNTABLE_RAY_9, TURNTABLE_RAY_10, TURNTABLE_RAY_11, TURNTABLE_RAY_12, TURNTABLE_RAY_13, TURNTABLE_RAY_14, TURNTABLE_RAY_15, TURNTABLE_RAY_16, TURNTABLE_RAY_17, TURNTABLE_RAY_18, TURNTABLE_RAY_19, TURNTABLE_RAY_20, TURNTABLE_RAY_21, TURNTABLE_RAY_22, TURNTABLE_RAY_23, TURNTABLE_RAY_24, TURNTABLE_RAY_25, TURNTABLE_RAY_26, TURNTABLE_RAY_27, TURNTABLE_RAY_28, TURNTABLE_RAY_29, TURNTABLE_RAY_30, TURNTABLE_RAY_31, TURNTABLE_RAY_32, TURNTABLE_RAY_33, TURNTABLE_RAY_34, TURNTABLE_RAY_35, TURNTABLE_RAY_36, TURNTABLE_RAY_37, TURNTABLE_RAY_38, TURNTABLE_RAY_39, TURNTABLE_RAY_40, TURNTABLE_RAY_41, TURNTABLE_RAY_42, TURNTABLE_RAY_43, TURNTABLE_RAY_44, TURNTABLE_RAY_45, TURNTABLE_RAY_46, TURNTABLE_RAY_47, TURNTABLE_RAY_48, TURNTABLE_RAY_49, TURNTABLE_RAY_50, TURNTABLE_RAY_51, TURNTABLE_RAY_52, TURNTABLE_RAY_53, TURNTABLE_RAY_54, TURNTABLE_RAY_55, TURNTABLE_RAY_56, TURNTABLE_RAY_57, TURNTABLE_RAY_58, TURNTABLE_RAY_59, TURNTABLE_RAY_60, TURNTABLE_RAY_61, TURNTABLE_RAY_62, TURNTABLE_RAY_63};
@@ -342,6 +346,7 @@ public enum HitPointType {
      * Ideally, this would be replaced by shape code that works
      * directly with the enum values as a step toward using objects
      * to implement hit points.
+     * @return (Temporary) 0-9 index of the enum element
      */
     protected int shapePointIndex() {
         int result = this.ordinal() - HitPointType.SHAPE_POINT_0.ordinal();
@@ -362,6 +367,8 @@ public enum HitPointType {
      * Ideally, this would be replaced by shape code that works
      * directly with the enum values as a step toward using objects
      * to implement hit points.
+     * @param i (Temporary) 0-9 index of the enum element
+     * @return Requested enum element
      */
     protected static HitPointType shapePointIndexedValue(int i) {
         if (i < 0 || i > 9) {
@@ -374,6 +381,7 @@ public enum HitPointType {
      * Return an array of the valid SHAPE_POINT enum values.
      * Meant for interations over the set of points.  Order is
      * from 0 to 9.
+     * @return (Temporary) Array containing SHAPE_POINT_0 through SHAPE_POINT_9
      */
     protected static HitPointType[] shapePointValues() {
         return new HitPointType[]{SHAPE_POINT_0, SHAPE_POINT_1, SHAPE_POINT_2, SHAPE_POINT_3, SHAPE_POINT_4, SHAPE_POINT_5, SHAPE_POINT_6, SHAPE_POINT_7, SHAPE_POINT_8, SHAPE_POINT_9};
@@ -390,12 +398,13 @@ public enum HitPointType {
     // *****************************************************************
     /**
      * Find the 0-8 index with respect to BEZIER_CONTROL_POINT_0
-     * of a given enum entry.  Throws {@link IllegalArgumentException} if
-     * the given enum value isn't one of the BEZIER_CONTROL_POINT_n entries.
+     * of this enum entry. Throws {@link IllegalArgumentException} if
+     * the enum value isn't one of the BEZIER_CONTROL_POINT_n entries.
      * <p>
      * Ideally, this would be replaced by bezier code that works
      * directly with the enum values as a step toward using objects
      * to implement hit points.
+     * @return (Temporary) 0-8 index of this enum
      */
     protected int bezierPointIndex() {
         int result = this.ordinal() - HitPointType.BEZIER_CONTROL_POINT_0.ordinal();
@@ -409,13 +418,15 @@ public enum HitPointType {
     }
 
     /**
-     * Return a specific SHAPE_POINT from its 0-8 index.
+     * Return a specific BEZIER_CONTROL_POINT from its 0-8 index.
      * Throws {@link IllegalArgumentException} if
      * the given index value isn't valid for the SHAPE_POINT entries.
      * <p>
      * Ideally, this would be replaced by shape code that works
      * directly with the enum values as a step toward using objects
      * to implement hit points.
+     * @param i (Temporary) 0-8 index of the enum element
+     * @return Requested enum element
      */
     protected static HitPointType bezierPointIndexedValue(int i) {
         if (i < 0 || i > 8) {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -4528,6 +4528,8 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
     /**
      * When a route is created, check to see if the through path that this route
      * relates to is active.
+     * @param r The route to check
+     * @return true if that route is active
      */
     boolean checkIsRouteOnValidThroughPath(Routes r) {
         for (ThroughPaths t : throughPaths) {
@@ -4608,6 +4610,8 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
 
     /**
      * Set the valid flag for routes that are on a valid through path.
+     * @param nxtHopActive the start of the route
+     * @param state the state to set into the valid flag
      */
     void setRoutesValid(Block nxtHopActive, boolean state) {
         List<Routes> rtr = getRouteByNeighbour(nxtHopActive);

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -596,7 +596,7 @@ SignalMastsError12 = Error - No signal masts entered.\nPlease enter signal masts
 SignalMastsError13 = Error - Cannot assign signal mast "{0}" to this block boundary\nbecause it is already on the panel at a different place.
 SignalMastsError14 = Error - Can not assign the same signal mast in both directions
 
-DuplicatePanel = A layout editor panel with the same name\n"{0}" has already been opened.\nAre you sure that you want to open another copy?
+DuplicatePanel = A layout editor panel with the same name\n"{0}" already exists.\nLoading this file will create another by that name,\npossibly a duplicate. Do you want to continue anyway?
 DuplicatePanelTitle = Duplicate Panel name
 
 RightHandSide = Right Hand Side

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle_ca.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle_ca.properties
@@ -471,7 +471,7 @@ SignalMastsError12 = Error - No signal masts entered.\nPlease enter signal masts
 SignalMastsError13 = Error - Cannot assign signal mast "{0}" to this block boundary\nbecause it is already on the panel at a different place.
 SignalMastsError14 = Error - Can not assign the same signal mast in both directions
 
-DuplicatePanel = A layout editor panel with the same name\n"{0}" has already been opened.\nAre you sure that you want to open another copy?
+DuplicatePanel = A layout editor panel with the same name\n"{0}" already exists.\nLoading this file will create another by that name, possibly a duplicate. Do you want to continue anyway?
 DuplicatePanelTitle = Duplicate Panel name
 
 RightHandSide = Right Hand Side

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle_da.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle_da.properties
@@ -489,7 +489,7 @@ SignalMastsError12 = Fejl - No signal masts entered.\nPlease enter signal masts 
 SignalMastsError13 = Fejl - Cannot assign signal mast "{0}" to this block boundary\nbecause it is already on the panel at a different place.
 SignalMastsError14 = Fejl - Can not assign the same signal mast in both directions
 
-DuplicatePanel = A layout editor panel with the same name\n"{0}" has already been opened.\nAre you sure that you want to open another copy?
+DuplicatePanel = A layout editor panel with the same name\n"{0}" already exists.\nLoading this file will create another by that name, possibly a duplicate. Do you want to continue anyway?
 DuplicatePanelTitle = Dupliker Panel navn
 
 RightHandSide = H\u00f8jre Side

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
@@ -8812,10 +8812,8 @@ final public class LayoutEditorTools {
         return new Point(offsetx, offsety);
     }
 
-    /**
-     * come back to this as its a bit tight to the rail on SM110 need re
-     * checking
-     */
+     // Come back to this as its a bit tight to the rail on SM110 need re
+     // checking
     Point northEastToSouthWest(Point2D p, PositionableIcon l, int oldWidth, int oldHeight, double angleDEG, boolean right, double fromPoint) {
         angleDEG = angleDEG - 180;
         if (angleDEG < 45) {
@@ -11033,6 +11031,7 @@ final public class LayoutEditorTools {
      * LayoutTurnout and LayoutSlip classes.
      *
      * @since 4.11.2
+     * @param <T>        The specific type, a subtype of LayoutTurnout
      * @param trackItem  The turnout or slip that is being modified.
      * @param newSensor  The sensor that is being added.
      * @param currSensor The sensor that might already be there, otherwise null.

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorViewContext.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorViewContext.java
@@ -87,8 +87,11 @@ final public class LayoutEditorViewContext {
         gridSize1st = newSize;
         return gridSize1st;
     }
+
     /**
-     * Default/initial value set to 10
+     * Get the width drawing the grid; 10 is the 
+     * default/initial value.
+     * @return current value
      */
     final public int getGridSize() {
         return gridSize1st;
@@ -99,8 +102,11 @@ final public class LayoutEditorViewContext {
         gridSize2nd = newSize;
         return gridSize2nd;
     }
+
     /**
-     * Default/initial value set to 10
+     * Get the width for 2nd drawing of the grid; 10 is the 
+     * default/initial value.
+     * @return current value
      */
     final public int getGridSize2nd() {
         return gridSize2nd;
@@ -112,21 +118,32 @@ final public class LayoutEditorViewContext {
     final public void setMainlineTrackWidth(float width) {
         mainlineTrackWidth = (int)width;
     }
+
     /**
-     * Default/initial value set to 4.0F
+     * Get the width for drawing mainline track; 4 is the 
+     * default/initial value.
+     * @return current value
      */
     final public int getMainlineTrackWidth() {
         return (int) mainlineTrackWidth;
     }
     private float mainlineTrackWidth = 4.0F; 
 
-    // also found in LayoutTrackDrawingOptions? 
-    // why is this a float?
+    /**
+     * Set the width for sideline track; note 
+     * that the stored and retrievable value is an integer.
+     * @param width Value to store; will be cast to (int)
+     */
+    // also found in LayoutTrackDrawingOptions? (temporary?)
+    // why is this a float? (temporary?)
     final public void setSidelineTrackWidth(float width) {
         sidelineTrackWidth = (int)width;
     }
+
     /**
-     * Default/initial value set to 2.0F
+     * Get the width for drawing sideline track; 2 is the 
+     * default/initial value.
+     * @return current value
      */
     final public int getSidelineTrackWidth() {
         return (int) sidelineTrackWidth;
@@ -134,7 +151,9 @@ final public class LayoutEditorViewContext {
     private float sidelineTrackWidth = 2.0F;
 
     /**
-     * Default/initial value set to 1.0
+     * Get the X-axis scaling value; 1.0 is the 
+     * default/initial value.
+     * @return current value
      */
     final public double getXScale() {
         return xScale;
@@ -145,7 +164,9 @@ final public class LayoutEditorViewContext {
     private double xScale = 1.0;
 
     /**
-     * Default/initial value set to 1.0
+     * Get the Y-axis scaling value; 1.0 is the 
+     * default/initial value.
+     * @return current value
      */
     final public double getYScale() {
         return yScale;

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -1474,6 +1474,7 @@ public class PositionablePoint extends LayoutTrack {
 
     /**
      * "active" means that the object is still displayed, and should be stored.
+     * @return true if active
      */
     protected boolean isActive() {
         return active;

--- a/java/src/jmri/jmrit/roster/DeleteRosterItemAction.java
+++ b/java/src/jmri/jmrit/roster/DeleteRosterItemAction.java
@@ -142,6 +142,9 @@ public class DeleteRosterItemAction extends JmriAbstractAction {
      * Can provide some mechanism to prompt for user for one last chance to
      * change his/her mind.
      *
+     * @param entry Roster entry being operated on
+     * @param filename Just name of file
+     * @param fullFileName including path
      * @return true if user says to continue
      */
     boolean userOK(String entry, String filename, String fullFileName) {

--- a/java/src/jmri/jmrit/roster/FullBackupImportAction.java
+++ b/java/src/jmri/jmrit/roster/FullBackupImportAction.java
@@ -154,6 +154,8 @@ public class FullBackupImportAction extends ImportRosterItemAction {
 
     /**
      * @return true if OK to continue to next entry
+     * @param zipper Stream to receive output
+     * @throws IOException from underlying operations
      */
 
     protected boolean processRosterFile(ZipInputStream zipper) throws IOException {

--- a/java/src/jmri/jmrit/symbolicprog/AbstractQualifier.java
+++ b/java/src/jmri/jmrit/symbolicprog/AbstractQualifier.java
@@ -30,6 +30,7 @@ public abstract class AbstractQualifier implements Qualifier, java.beans.Propert
      * Process property change from the qualifier Variable (one being watched).
      * <p>
      * Follows changes "Value" property, which it assumes is an Integer.
+     * @param e The event that triggered the query
      */
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
@@ -41,6 +42,7 @@ public abstract class AbstractQualifier implements Qualifier, java.beans.Propert
     /**
      * Process Value property change from the qualifier Variable (one being
      * watched).
+     * @param e The event that triggered the query
      */
     void processValueChangeEvent(java.beans.PropertyChangeEvent e) {
         // watched value change, check if this changes state of qualified (output) object
@@ -55,6 +57,8 @@ public abstract class AbstractQualifier implements Qualifier, java.beans.Propert
     /**
      * Calculate whether this PropertyChangeEvent means that the qualified
      * Object should be set Available or not.
+     * @param e The event that triggered the query
+     * @return true if should be set available
      */
     protected boolean availableStateFromEvent(java.beans.PropertyChangeEvent e) {
         return availableStateFromValue(e.getNewValue());
@@ -62,12 +66,14 @@ public abstract class AbstractQualifier implements Qualifier, java.beans.Propert
 
     /**
      * Retrieve the current "available" state from the qualified Object.
+     * @return true if available
      */
     abstract protected boolean currentAvailableState();
 
     /**
-     * Calculate whether the current value of qualifier Variable means that the
-     * qualified object should be set Available or not.
+     * Does the current value of qualifier Variable means that the
+     * qualified object should be set Available or not?
+     * @return true if should be set available
      */
     @Override
     abstract public boolean currentDesiredState();
@@ -77,6 +83,7 @@ public abstract class AbstractQualifier implements Qualifier, java.beans.Propert
      * that the qualified Object should be set Available or not.
      *
      * @param value base for the calculation
+     * @return true if should be set available
      */
     abstract protected boolean availableStateFromValue(Object value);
 
@@ -85,6 +92,7 @@ public abstract class AbstractQualifier implements Qualifier, java.beans.Propert
      * <p>
      * Subclasses implement this to control a specific type of qualified Object,
      * like a Variable or Pane.
+     * @param enable true if should be enabled
      */
     @Override
     abstract public void setWatchedAvailable(boolean enable);

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/ProgCheckAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/ProgCheckAction.java
@@ -235,6 +235,10 @@ public class ProgCheckAction extends AbstractAction {
 
     /**
      * Ask SAX to read and verify a file
+     * @param file XML-formatted input file
+     * @return root element if successful
+     * @throws org.jdom2.JDOMException if file can't be parsed
+     * @throws java.io.IOException  if problems reading file
      */
     static Element readFile(File file) throws org.jdom2.JDOMException, java.io.IOException {
         XmlFile xf = new XmlFile() {

--- a/java/src/jmri/jmrit/ussctc/CodeLine.java
+++ b/java/src/jmri/jmrit/ussctc/CodeLine.java
@@ -91,6 +91,7 @@ public class CodeLine {
     
     /**
      * Request processing of an indication from the field
+     * @param station Station being addressed.
      */
     synchronized void requestSendCode(Station station) {
         log.debug("requestSendCode queued from {}", station.toString());
@@ -130,7 +131,8 @@ public class CodeLine {
     }
     
     /**
-     * Request processing of an indication from the field
+     * Request processing of an indication from the field.
+     * @param station Station being addressed.
      */
     synchronized void requestIndicationStart(Station station) {
         log.debug("requestIndicationStart queued from {}", station.toString());

--- a/java/src/jmri/jmrit/ussctc/Station.java
+++ b/java/src/jmri/jmrit/ussctc/Station.java
@@ -49,11 +49,13 @@ public class Station {
 
     /**
      * Provide access to CodeLine to which this Station is attached.
+     * @return Codeline reference for this Station
      */
     CodeLine getCodeLine() { return codeline; }
     
     /**
      * Provide access this Station's name
+     * @return Human-readable name
      */
     String getName() { return name; }
     

--- a/java/src/jmri/jmrit/ussctc/TurnoutSection.java
+++ b/java/src/jmri/jmrit/ussctc/TurnoutSection.java
@@ -273,6 +273,7 @@ public class TurnoutSection implements Section<CodeGroupTwoBits, CodeGroupTwoBit
 
         /** 
          * Initially, align with what's in the field
+         * @param to Turnout in field to align to
          */
         void initializeState(Turnout to) {
             if (to.getCommandedState() == Turnout.CLOSED) {

--- a/java/src/jmri/jmrix/grapevine/SerialMessage.java
+++ b/java/src/jmri/jmrix/grapevine/SerialMessage.java
@@ -173,6 +173,11 @@ public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
      * common. That forces the passing of arguments as numbers. Short messages
      * are marked by having missing bytes put to -1 in the arguments.
      * See the Grapevine <a href="package-summary.html">Binary Message Format Summary</a>
+     * @param b1 1st message byte
+     * @param b2 2nd message byte
+     * @param b3 3rd message byte
+     * @param b4 4th message byte
+     * @return Human-readable form
      */
     static String staticFormat(int b1, int b2, int b3, int b4) {
         String result;

--- a/java/src/jmri/jmrix/pricom/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/pricom/downloader/LoaderPane.java
@@ -104,6 +104,7 @@ public class LoaderPane extends javax.swing.JPanel {
 
     /**
      * Open button has been pushed, create the actual display connection
+     * @param e Event from pressed button
      */
     void openPortButtonActionPerformed(java.awt.event.ActionEvent e) {
         log.info("Open button pushed");
@@ -241,6 +242,8 @@ public class LoaderPane extends javax.swing.JPanel {
 
         /**
          * Send the next message of the download.
+         * @param buffer holds message to be sent
+         * @param length length of message within buffer
          */
         void nextMessage(byte[] buffer, int length) {
 
@@ -603,6 +606,7 @@ public class LoaderPane extends javax.swing.JPanel {
      * <p>
      * The last two bytes of the buffer hold the checksum, and are not included
      * in the checksum.
+     * @param buffer Buffer holding the message to be get a CRC
      */
     void CRC_block(byte[] buffer) {
         long crc = 0;
@@ -620,6 +624,8 @@ public class LoaderPane extends javax.swing.JPanel {
 
     /**
      * Check to see if message starts transmission
+     * @param buffer Buffer holding the message to be checked
+     * @return True if buffer is a upload-ready message
      */
     boolean isUploadReady(byte[] buffer) {
         if (buffer[0] != 31) {
@@ -642,6 +648,8 @@ public class LoaderPane extends javax.swing.JPanel {
 
     /**
      * Check to see if this is a request for the next block
+     * @param buffer Buffer holding the message to be checked
+     * @return True if buffer is a sent-next message
      */
     boolean isSendNext(byte[] buffer) {
         if (buffer[0] != 31) {
@@ -665,6 +673,7 @@ public class LoaderPane extends javax.swing.JPanel {
 
     /**
      * Get output data length from 1st message
+     * @return buffer Message from which length is to be extracted
      */
     int getDataSize(byte[] buffer) {
         if (buffer[4] == 44) {
@@ -679,6 +688,7 @@ public class LoaderPane extends javax.swing.JPanel {
 
     /**
      * Return a properly formatted boot message, complete with CRC
+     * @return buffer Contains boot message that's been created
      */
     byte[] bootMessage() {
         byte[] buffer = new byte[]{99, 0, 0, 0, 0};

--- a/java/src/jmri/jmrix/rps/Engine.java
+++ b/java/src/jmri/jmrix/rps/Engine.java
@@ -412,6 +412,7 @@ public class Engine implements ReadingListener {
     /**
      * The real core of the polling, this selects the next one to poll. -1 means
      * none selected, try again later.
+     * @return index to poll next
      */
     int selectNextPoll() {
         int startindex = pollIndex;
@@ -504,6 +505,8 @@ public class Engine implements ReadingListener {
      * Waits specified time, and then checks to see if response has been
      * returned. If not, it waits again (twice) by 1/2 the interval, then
      * finally polls anyway.
+     * @param pollingInterval in milliseconds
+     * @throws InterruptedException in theory, but not in practice.
      */
     void waitBeforeNextPoll(int pollingInterval) throws InterruptedException {
         synchronized (this) {

--- a/java/src/jmri/jmrix/rps/RpsReporter.java
+++ b/java/src/jmri/jmrix/rps/RpsReporter.java
@@ -78,7 +78,8 @@ public class RpsReporter extends AbstractReporter implements MeasurementListener
 
     /**
      * Notify parameter listeners that a device has left the region covered by
-     * this sensor.
+     * this reporter.
+     * @param id Number of region being left
      */
     void notifyLeaving(Integer id) {
         firePropertyChange("Leaving", null, id);
@@ -87,7 +88,8 @@ public class RpsReporter extends AbstractReporter implements MeasurementListener
 
     /**
      * Notify parameter listeners that a device has entered the region covered
-     * by this sensor.
+     * by this reporter.
+     * @param id Number of region being entered
      */
     void notifyArriving(Integer id) {
         firePropertyChange("Arriving", null, id);

--- a/java/src/jmri/jmrix/rps/RpsSensor.java
+++ b/java/src/jmri/jmrix/rps/RpsSensor.java
@@ -101,6 +101,7 @@ public class RpsSensor extends AbstractSensor
     /**
      * Notify parameter listeners that a device has left the region covered by
      * this sensor
+     * @param id Number of region being left
      */
     void notifyLeaving(Integer id) {
         firePropertyChange("Leaving", null, id);
@@ -109,6 +110,7 @@ public class RpsSensor extends AbstractSensor
     /**
      * Notify parameter listeners that a device has entered the region covered
      * by this sensor
+     * @param id Number of region being entered
      */
     void notifyArriving(Integer id) {
         firePropertyChange("Arriving", null, id);

--- a/java/src/jmri/jmrix/rps/reversealign/AlignmentPanel.java
+++ b/java/src/jmri/jmrix/rps/reversealign/AlignmentPanel.java
@@ -215,6 +215,10 @@ public class AlignmentPanel extends javax.swing.JPanel
 
     /**
      * Service routine for finding a Point3d from input fields
+     * @param x X coordinate of resulting point
+     * @param y Y coordinate of resulting point
+     * @param z Z coordinate of resulting point
+     * @return point from coordinates
      */
     Point3d getPoint(JTextField x, JTextField y, JTextField z) {
         float xval = Float.valueOf(x.getText()).floatValue();
@@ -589,6 +593,7 @@ public class AlignmentPanel extends javax.swing.JPanel
 
         /**
          * Service routine for finding a Point3d from input fields
+         * @return Point from input coordinate values
          */
         Point3d getPoint() {
             float xval = Float.valueOf(xl.getText()).floatValue();
@@ -599,6 +604,7 @@ public class AlignmentPanel extends javax.swing.JPanel
 
         /**
          * Service routine for setting the receiver input fields from a Point3d
+         * @param p Specific input point
          */
         void setPoint(Point3d p) {
             xl.setText("" + p.x);

--- a/java/src/jmri/jmrix/rps/serial/SerialAdapter.java
+++ b/java/src/jmri/jmrix/rps/serial/SerialAdapter.java
@@ -131,6 +131,7 @@ public class SerialAdapter extends jmri.jmrix.AbstractSerialPortController {
     /**
      * Send output bytes, e.g. characters controlling operation, with small
      * delays between the characters. This is used to reduce overrrun problems.
+     * @param bytes Array of characters to be sent one at a time
      */
     synchronized void sendBytes(byte[] bytes) {
         try {
@@ -353,6 +354,7 @@ public class SerialAdapter extends jmri.jmrix.AbstractSerialPortController {
     /**
      * Handle the message which lists the receiver numbers. Just makes an array
      * of those, which is not actually used.
+     * @param s Input line
      */
     void setReceivers(String s) {
         try {
@@ -386,6 +388,9 @@ public class SerialAdapter extends jmri.jmrix.AbstractSerialPortController {
 
     /**
      * Convert input line to Reading object.
+     * @param s The line of input
+     * @return A Reading object with content parsed from the input line
+     * @throws IOException from underlying I/O
      */
     Reading makeReading(String s) throws IOException {
         if (first) {

--- a/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingPanel.java
+++ b/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingPanel.java
@@ -207,6 +207,7 @@ public class RpsTrackingPanel extends javax.swing.JPanel
 
     /**
      * Pick a color for the next set of measurement lines to draw
+     * @return Color for next line chosen via algorithm
      */
     Color nextColor() {
         int red = Math.min(255, ((measurementColor >> 2) & 0x1) * 255 / 1);

--- a/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
@@ -426,6 +426,7 @@ public abstract class AbstractNamedBeanManagerConfigXML extends jmri.configurexm
      * @param list list of Elements read from xml
      * @param perNode Top-level XML element containing the private, single-node elements of the description.
      *                always null in current application, included to use for Element panel in jmri.jmrit.display
+     * @return true if the load was successful
      */
     boolean loadInAdapter(List<Element> list, Element perNode) {
         boolean result = true;

--- a/java/src/jmri/util/ValidatingInputPane.java
+++ b/java/src/jmri/util/ValidatingInputPane.java
@@ -188,6 +188,7 @@ final class ValidatingInputPane<T> extends javax.swing.JPanel  {
     
     /**
      * Should be called from tests only
+     * @param text String to check for validation
      */
     void validateText(String text) {
         String msg;


### PR DESCRIPTION
Add missing `@param`, `@return` and `@throws` items to resolve some Javadoc warnings