### PR TITLE
test: free up a Travis CI slot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ cache:
 
 os:
   - linux
-#  - osx # temporarilly disabled -- its more complex than originally anticipated to do conditional matrixes based on PR/push differentiation
 
 dist: bionic
 
@@ -72,9 +71,6 @@ jobs:
   - name: Headless Tests
     os: linux
     env: HEADLESS=true STATIC=false
-  - name: Static Analysis
-    os: linux
-    env: HEADLESS=true STATIC=true
   - name: Intermittently Failing GUI Tests
     os: linux
     env: HEADLESS=false SKIPINTERMITTENT=false STATIC=true


### PR DESCRIPTION
Travis CI limits us to five tests at a time; since we have a Static Analysis GitHub Action, we do not also need to perform Static Analysis on Travis CI, reducing the wait on Travis CI resources when busy.