### PR TITLE
Fix problem with deprecation of StartupActionFactory

### DIFF
--- a/java/src/apps/startup/AbstractStartupActionFactory.java
+++ b/java/src/apps/startup/AbstractStartupActionFactory.java
@@ -9,7 +9,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * {@link jmri.util.startup.AbstractStartupActionFactory} instead
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 @SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Deprecated by refactoring; retaining unchanged until removal")
-public abstract class AbstractStartupActionFactory extends jmri.util.startup.AbstractStartupActionFactory {
+public abstract class AbstractStartupActionFactory extends jmri.util.startup.AbstractStartupActionFactory implements StartupActionFactory {
 
 }

--- a/java/src/apps/startup/Bundle.properties
+++ b/java/src/apps/startup/Bundle.properties
@@ -60,3 +60,6 @@ ScriptButtonModel.ScriptNotFound=Cannot create button for script {0}; script not
 TriggerRouteModel.RouteNotDefined=Unable to set route "{0}". Route not defined.
 #Error thrown when startup pause thread is interrupted.
 StartupPauseModel.Interrupted={0} second startup pause interrupted early.
+
+#Remove this string when the class StartupActionFactoryScaffold is removed
+String  = String

--- a/java/src/apps/startup/Bundle.properties
+++ b/java/src/apps/startup/Bundle.properties
@@ -60,6 +60,3 @@ ScriptButtonModel.ScriptNotFound=Cannot create button for script {0}; script not
 TriggerRouteModel.RouteNotDefined=Unable to set route "{0}". Route not defined.
 #Error thrown when startup pause thread is interrupted.
 StartupPauseModel.Interrupted={0} second startup pause interrupted early.
-
-#Remove this string when the class StartupActionFactoryScaffold is removed
-String  = String

--- a/java/test/apps/startup/StartupActionFactoryScaffold.java
+++ b/java/test/apps/startup/StartupActionFactoryScaffold.java
@@ -11,6 +11,11 @@ import org.openide.util.lookup.ServiceProvider;
  * This class will be removed when apps.startup.StartupActionFactory
  * and apps.startup.AbstractStartupActionFactory is removed.
  * 
+ * Important:
+ * When this class is removed, the string "String" in
+ * apps.startup.Bundle.properties should be removed. That string is needed
+ * for the AbstractActionModelTest test.
+ * 
  * @author Daniel Bergqvist Copyright (C) 2020
  */
 @SuppressWarnings("deprecation")

--- a/java/test/apps/startup/StartupActionFactoryScaffold.java
+++ b/java/test/apps/startup/StartupActionFactoryScaffold.java
@@ -1,0 +1,34 @@
+package apps.startup;
+
+import java.util.Locale;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * The purpose of this class is to test that a class that extends
+ * apps.startup.AbstractStartupActionFactory can use the service
+ * provider apps.startup.StartupActionFactory.
+ * 
+ * This class will be removed when apps.startup.StartupActionFactory
+ * and apps.startup.AbstractStartupActionFactory is removed.
+ * 
+ * @author Daniel Bergqvist Copyright (C) 2020
+ */
+@SuppressWarnings("deprecation")
+@ServiceProvider(service = StartupActionFactory.class)
+public class StartupActionFactoryScaffold extends AbstractStartupActionFactory {
+
+    @Override
+    public String getTitle(Class<?> clazz, Locale locale) throws IllegalArgumentException {
+        if (!clazz.equals(String.class)) {
+            throw new IllegalArgumentException();
+        }
+        return Bundle.getMessage(locale, "String"); // NOI18N
+    }
+
+    @Override
+    public Class<?>[] getActionClasses() {
+        return new Class[]{String.class};
+    }
+
+}
+

--- a/java/test/apps/startup/StartupActionFactoryScaffold.java
+++ b/java/test/apps/startup/StartupActionFactoryScaffold.java
@@ -11,11 +11,6 @@ import org.openide.util.lookup.ServiceProvider;
  * This class will be removed when apps.startup.StartupActionFactory
  * and apps.startup.AbstractStartupActionFactory is removed.
  * 
- * Important:
- * When this class is removed, the string "String" in
- * apps.startup.Bundle.properties should be removed. That string is needed
- * for the AbstractActionModelTest test.
- * 
  * @author Daniel Bergqvist Copyright (C) 2020
  */
 @SuppressWarnings("deprecation")
@@ -27,7 +22,7 @@ public class StartupActionFactoryScaffold extends AbstractStartupActionFactory {
         if (!clazz.equals(String.class)) {
             throw new IllegalArgumentException();
         }
-        return Bundle.getMessage(locale, "String"); // NOI18N
+        return "String"; // NOI18N
     }
 
     @Override


### PR DESCRIPTION
#8544 deprecated `apps.startup.StartupActionFactory` in a way that made a class using `apps.startup.AbstractStartupActionFactory` unable to use the service provider `apps.startup.StartupActionFactory`. This fixes the problem and adds a test to check this. The test will be removed when these two classes are removed.