### PR TITLE
chore: consolidate dependencies on JavaHelp to one class

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -27,7 +27,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.EventObject;
 import java.util.Locale;
-import javax.help.SwingHelpUtilities;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.Box;
@@ -685,7 +684,7 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         JMenu helpMenu = HelpUtil.makeHelpMenu(mainWindowHelpID(), true);
 
         // tell help to use default browser for external types
-        SwingHelpUtilities.setContentViewerUI("jmri.util.ExternalLinkContentViewerUI");
+        HelpUtil.setContentViewerUI("jmri.util.ExternalLinkContentViewerUI");
 
         // use as main help menu
         menuBar.add(helpMenu);

--- a/java/src/apps/AppsLaunchFrame.java
+++ b/java/src/apps/AppsLaunchFrame.java
@@ -4,7 +4,6 @@ import java.awt.Dimension;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.EventObject;
-import javax.help.SwingHelpUtilities;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JComponent;
@@ -268,7 +267,7 @@ public class AppsLaunchFrame extends jmri.util.JmriJFrame {
         JMenu helpMenu = HelpUtil.makeHelpMenu(containedPane.windowHelpID(), true);
 
         // tell help to use default browser for external types
-        SwingHelpUtilities.setContentViewerUI("jmri.util.ExternalLinkContentViewerUI");
+        HelpUtil.setContentViewerUI("jmri.util.ExternalLinkContentViewerUI");
 
         // use as main help menu
         menuBar.add(helpMenu);

--- a/java/src/apps/gui3/Apps3.java
+++ b/java/src/apps/gui3/Apps3.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.EventObject;
-import javax.help.SwingHelpUtilities;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -134,7 +133,7 @@ public abstract class Apps3 extends AppsBase {
         HelpUtil.initOK();
 
         // tell help to use default browser for external types
-        SwingHelpUtilities.setContentViewerUI("jmri.util.ExternalLinkContentViewerUI");
+        HelpUtil.setContentViewerUI("jmri.util.ExternalLinkContentViewerUI");
 
         // help items are set in the various Tree/Menu/Toolbar constructors
     }

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
-import javax.help.SwingHelpUtilities;
 import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -789,7 +788,7 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
         // create menu and standard items
         JMenu helpMenu = HelpUtil.makeHelpMenu("package.apps.gui3.dp3.DecoderPro3", true);
         // tell help to use default browser for external types
-        SwingHelpUtilities.setContentViewerUI("jmri.util.ExternalLinkContentViewerUI");
+        HelpUtil.setContentViewerUI("jmri.util.ExternalLinkContentViewerUI");
         // use as main help menu
         menuBar.add(helpMenu);
     }

--- a/java/src/jmri/util/ExternalLinkContentViewerUI.java
+++ b/java/src/jmri/util/ExternalLinkContentViewerUI.java
@@ -54,7 +54,7 @@ public class ExternalLinkContentViewerUI extends BasicContentViewerUI {
     public static void activateURL(URL u) throws IOException, URISyntaxException {
         if (u.getProtocol().equalsIgnoreCase("mailto") || u.getProtocol().equalsIgnoreCase("http")
                 || u.getProtocol().equalsIgnoreCase("ftp")) {
-            URI uri = new URI(u.toString());
+            URI uri = u.toURI();
             log.debug("defer protocol {} to browser via {}", u.getProtocol(), uri);
             Desktop.getDesktop().browse(uri);
         } else if (u.getProtocol().equalsIgnoreCase("file") && (u.getFile().endsWith("jpg")
@@ -66,7 +66,7 @@ public class ExternalLinkContentViewerUI extends BasicContentViewerUI {
             // ("file:"+System.getProperty("user.dir")+"/"+u.getFile()) 
             // but that duplicated the path information; JavaHelp seems to provide
             // full pathnames here.
-            URI uri = new URI(u.toString());
+            URI uri = u.toURI();
             log.debug("defer content of {} to browser with {}", u.getFile(), uri);
             Desktop.getDesktop().browse(uri);
         } else if (u.getProtocol().equalsIgnoreCase("file")) {

--- a/java/src/jmri/util/HelpUtil.java
+++ b/java/src/jmri/util/HelpUtil.java
@@ -211,6 +211,12 @@ public class HelpUtil {
         };
     }
 
+    /**
+     * Set the default content viewer UI.
+     *
+     * @param ui full class name of the content viewer UI
+     * @see SwingHelpUtilities#setContentViewerUI(java.lang.String)
+     */
     public static void setContentViewerUI(String ui) {
         SwingHelpUtilities.setContentViewerUI(ui);
     }

--- a/java/src/jmri/util/HelpUtil.java
+++ b/java/src/jmri/util/HelpUtil.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import javax.help.HelpBroker;
 import javax.help.HelpSet;
 import javax.help.HelpSetException;
+import javax.help.SwingHelpUtilities;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.Icon;
@@ -208,6 +209,10 @@ public class HelpUtil {
                 globalHelpBroker.setDisplayed(true);
             }
         };
+    }
+
+    public static void setContentViewerUI(String ui) {
+        SwingHelpUtilities.setContentViewerUI(ui);
     }
 
     static HelpSet globalHelpSet;


### PR DESCRIPTION
This should make any potential replacement of JavaHelp completely transparent to anything needing to provide help in JMRI.