### PR TITLE
Prevent NumberFormatException in SplitVariableValue & subclasses.

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/SplitTextVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitTextVariableValue.java
@@ -238,12 +238,8 @@ public class SplitTextVariableValue extends SplitVariableValue {
      */
     @Override
     public void actionPerformed(ActionEvent e) {
-        if (log.isDebugEnabled()) {
-            log.debug("Variable={}; actionPerformed", _name);
-        }
-        byte[] newVal = getBytesFromText(_textField.getText());
-        updatedTextField();
-        prop.firePropertyChange("Value", null, newVal);
+        log.debug("Variable={}; actionPerformed", _name);
+        exitField();
     }
 
     @Override

--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -128,29 +128,29 @@ public class SplitVariableValue extends VariableValue
     /**
      * Subclasses can override this to pick up constructor-specific attributes
      * and perform other actions before cvList has been built.
-     * 
-     * @param name name.
-     * @param comment comment.
-     * @param cvName cv name.
-     * @param readOnly true for read only, else false.
-     * @param infoOnly true for info only, else false.
+     *
+     * @param name      name.
+     * @param comment   comment.
+     * @param cvName    cv name.
+     * @param readOnly  true for read only, else false.
+     * @param infoOnly  true for info only, else false.
      * @param writeOnly true for write only, else false.
-     * @param opsOnly true for ops only, else false.
-     * @param cvNum cv number.
-     * @param mask cv mask.
-     * @param minVal minimum value.
-     * @param maxVal maximum value.
-     * @param v hashmap of string and cv value.
-     * @param status status.
-     * @param stdname std name.
+     * @param opsOnly   true for ops only, else false.
+     * @param cvNum     cv number.
+     * @param mask      cv mask.
+     * @param minVal    minimum value.
+     * @param maxVal    maximum value.
+     * @param v         hashmap of string and cv value.
+     * @param status    status.
+     * @param stdname   std name.
      * @param pSecondCV second cv.
-     * @param pFactor factor.
-     * @param pOffset offset.
+     * @param pFactor   factor.
+     * @param pOffset   offset.
      * @param uppermask upper mask.
-     * @param extra1 extra 1.
-     * @param extra2 extra 2.
-     * @param extra3 extra 3.
-     * @param extra4 extra 4.
+     * @param extra1    extra 1.
+     * @param extra2    extra 2.
+     * @param extra3    extra 3.
+     * @param extra4    extra 4.
      */
     public void stepOneActions(String name, String comment, String cvName,
             boolean readOnly, boolean infoOnly, boolean writeOnly, boolean opsOnly,
@@ -283,7 +283,7 @@ public class SplitVariableValue extends VariableValue
         return "Split value";
     }
 
-    String oldContents = "";
+    String oldContents = "0";
 
     long getValueFromText(String s) {
         return (Long.parseUnsignedLong(s));
@@ -351,7 +351,12 @@ public class SplitVariableValue extends VariableValue
     void exitField() {
         // there may be a lost focus event left in the queue when disposed so protect
         if (_textField != null && !oldContents.equals(_textField.getText())) {
-            long newFieldVal = getValueFromText(_textField.getText());
+            long newFieldVal = 0;
+            try {
+                newFieldVal = getValueFromText(_textField.getText());
+            } catch (NumberFormatException e) {
+                _textField.setText(oldContents);
+            }
             log.debug("_minVal={};_maxVal={};newFieldVal={}",
                     Long.toUnsignedString(_minVal), Long.toUnsignedString(_maxVal), Long.toUnsignedString(newFieldVal));
             if (Long.compareUnsigned(newFieldVal, _minVal) < 0 || Long.compareUnsigned(newFieldVal, _maxVal) > 0) {
@@ -403,21 +408,14 @@ public class SplitVariableValue extends VariableValue
      * ActionListener implementations
      */
     /**
-     * Contains numeric-value specific code.
-     * <br><br>
-     * invokes {@link #updatedTextField updatedTextField()}
-     * <br><br>
-     * firePropertyChange for "Value" with new contents of _textField
+     * Invokes {@link #exitField exitField()}.
      *
      * @param e the action event
      */
     @Override
     public void actionPerformed(ActionEvent e) {
         log.debug("Variable='{}'; actionPerformed", _name);
-        long newVal = (getValueFromText(_textField.getText()) - mOffset) / mFactor;
-        log.debug("Enter updatedTextField from actionPerformed");
-        updatedTextField();
-        prop.firePropertyChange("Value", null, newVal);
+        exitField();
     }
 
     /**
@@ -511,7 +509,7 @@ public class SplitVariableValue extends VariableValue
             actionPerformed(null);
         }
         // PENDING: the code used to fire value * mFactor + mOffset, which is a text representation;
-        // but 'oldValue' was converted back using mOffset / mFactor making those two (new / old) 
+        // but 'oldValue' was converted back using mOffset / mFactor making those two (new / old)
         // using different scales. Probably a bug, but it has been there from well before
         // the extended spltVal. Because of the risk of breaking existing
         // behaviour somewhere, deferring correction until at least the next test release.
@@ -659,6 +657,7 @@ public class SplitVariableValue extends VariableValue
 
     /**
      * Assigns a priority value to a given state.
+     *
      * @param state State to be converted to a priority value
      * @return Priority value from state, with UNKNOWN numerically highest
      */

--- a/java/test/jmri/jmrit/symbolicprog/SplitHexVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/SplitHexVariableValueTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.symbolicprog;
 
+import java.awt.event.FocusEvent;
 import java.util.HashMap;
 import java.util.List;
 import javax.swing.JLabel;
@@ -227,6 +228,7 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
                 highCV, pFactor, pOffset, uppermask, displayCase, extra2, extra3, extra4);
         Assert.assertNotNull("makeVar returned null", var);
 
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
         CvValue[] cv = var.usesCVs();
 
         Assert.assertEquals("number of CVs is", 4, cv.length);
@@ -236,8 +238,9 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("cv[2] is", "277", cv[2].number());
         Assert.assertEquals("cv[3] is", "278", cv[3].number());
 
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("FFD2720F");  // to start with a value
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var full value", "FFD2720F", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
@@ -285,6 +288,7 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
                 highCV, pFactor, pOffset, uppermask, displayCase, extra2, extra3, extra4);
         Assert.assertNotNull("makeVar returned null", var);
 
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
         CvValue[] cv = var.usesCVs();
 
         Assert.assertEquals("number of CVs is", 4, cv.length);
@@ -294,8 +298,9 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("cv[2] is", "390", cv[2].number());
         Assert.assertEquals("cv[3] is", "389", cv[3].number());
 
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("FFD2720F");  // to start with a value
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var full value", "FFD2720F", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
@@ -399,14 +404,16 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
                 v, status, stdname,
                 highCV, pFactor, pOffset, uppermask, displayCase, extra2, extra3, extra4);
         Assert.assertNotNull("makeVar returned null", var);
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
 
         CvValue cv501 = v.get("501");
         CvValue cv502 = v.get("502");
         CvValue cv503 = v.get("503");
         CvValue cv504 = v.get("504");
 
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("FFD2720F");  // to start with a value
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "FFD2720F", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set var cv501", 0x0F, cv501.getValue());
         Assert.assertEquals("set var cv502", 0x72, cv502.getValue());
@@ -414,8 +421,9 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set var cv504", 0xFF, cv504.getValue());
 
         // change to shorter text
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("F837");  // to start with a value
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "F837", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set var cv501", 0x37, cv501.getValue());
         Assert.assertEquals("set var cv502", 0xF8, cv502.getValue());
@@ -454,14 +462,16 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
                 v, status, stdname,
                 highCV, pFactor, pOffset, uppermask, displayCase, extra2, extra3, extra4);
         Assert.assertNotNull("makeVar returned null", var);
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
 
         CvValue cv501 = v.get("501");
         CvValue cv502 = v.get("502");
         CvValue cv503 = v.get("503");
         CvValue cv504 = v.get("504");
 
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("FFD2720F");  // to start with a value
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "FFD2720F", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set var cv501", 0x0F, cv501.getValue());
         Assert.assertEquals("set var cv502", 0x72, cv502.getValue());
@@ -469,8 +479,9 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set var cv504", 0xFF, cv504.getValue());
 
         // change to shorter text
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("837");  // to start with a value
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "837", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set var cv501", 0x37, cv501.getValue());
         Assert.assertEquals("set var cv502", 0x08, cv502.getValue());
@@ -510,6 +521,7 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
                 highCV, pFactor, pOffset, uppermask, displayCase, extra2, extra3, extra4);
         Assert.assertNotNull("makeVar returned null", var);
 
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
         CvValue[] cv = var.usesCVs();
 
         Assert.assertEquals("number of CVs is", 8, cv.length);
@@ -523,8 +535,9 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("cv[6] is", "281", cv[6].number());
         Assert.assertEquals("cv[7] is", "282", cv[7].number());
 
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("7FD2720F");  // to start with a random value
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "7FD2720F", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
@@ -536,8 +549,9 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set CV" + cv[7].number(), 0x00, cv[7].getValue());
 
         // change to maximum unsigned value
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("FFFFFFFFFFFFFFFF");
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "FFFFFFFFFFFFFFFF", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0xFF, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0xFF, cv[1].getValue());
@@ -549,8 +563,9 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set CV" + cv[7].number(), 0xFF, cv[7].getValue());
 
         // change to one less than maximum unsigned value
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("FFFFFFFFFFFFFFFE");
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "FFFFFFFFFFFFFFFE", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0xFE, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0xFF, cv[1].getValue());
@@ -562,8 +577,9 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set CV" + cv[7].number(), 0xFF, cv[7].getValue());
 
         // change to last 63 bit unsigned value
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("7FFFFFFFFFFFFFFF");
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "7FFFFFFFFFFFFFFF", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0xFF, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0xFF, cv[1].getValue());
@@ -575,8 +591,9 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set CV" + cv[7].number(), 0x7F, cv[7].getValue());
 
         // change to first 64 bit unsigned value
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("8000000000000000");
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "8000000000000000", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0x00, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0x00, cv[1].getValue());
@@ -727,6 +744,96 @@ public class SplitHexVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
         Assert.assertEquals("set CV" + cv[7].number(), 0x80, cv[7].getValue());
         Assert.assertEquals("set var text value", "8000000000000000", ((JTextField) var.getCommonRep()).getText());
+
+    }
+
+    @Test
+    public void testTextInvalidHexValEntered() {
+        String name = "Hex Field";
+        String comment = "";
+        String cvName = "";
+        boolean readOnly = false;
+        boolean infoOnly = false;
+        boolean writeOnly = false;
+        boolean opsOnly = false;
+        String cvNum = "275:8";
+        String mask = "VVVVVVVV";
+        int minVal = 0;
+        int maxVal = 0;
+        HashMap<String, CvValue> v = createCvMap();
+        JLabel status = new JLabel();
+        String stdname = "";
+        String highCV = "";
+        int pFactor = 1;
+        int pOffset = 0;
+        String uppermask = "";
+        String displayCase = "upper";
+        String extra2 = null;
+        String extra3 = null;
+        String extra4 = null;
+        SplitHexVariableValue var = makeVar(name, comment, cvName,
+                readOnly, infoOnly, writeOnly, opsOnly,
+                cvNum, mask, minVal, maxVal,
+                v, status, stdname,
+                highCV, pFactor, pOffset, uppermask, displayCase, extra2, extra3, extra4);
+        Assert.assertNotNull("makeVar returned null", var);
+
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
+        CvValue[] cv = var.usesCVs();
+
+        Assert.assertEquals("number of CVs is", 8, cv.length);
+
+        Assert.assertEquals("cv[0] is", "275", cv[0].number());
+        Assert.assertEquals("cv[1] is", "276", cv[1].number());
+        Assert.assertEquals("cv[2] is", "277", cv[2].number());
+        Assert.assertEquals("cv[3] is", "278", cv[3].number());
+        Assert.assertEquals("cv[4] is", "279", cv[4].number());
+        Assert.assertEquals("cv[5] is", "280", cv[5].number());
+        Assert.assertEquals("cv[6] is", "281", cv[6].number());
+        Assert.assertEquals("cv[7] is", "282", cv[7].number());
+
+        var.focusGained(focusEvent);
+        ((JTextField) var.getCommonRep()).setText("7FD2720F");  // to start with a random value
+        var.focusLost(focusEvent);
+        Assert.assertEquals("set var text value", "7FD2720F", ((JTextField) var.getCommonRep()).getText());
+        Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
+        Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
+        Assert.assertEquals("set CV" + cv[2].number(), 0xD2, cv[2].getValue());
+        Assert.assertEquals("set CV" + cv[3].number(), 0x7F, cv[3].getValue());
+        Assert.assertEquals("set CV" + cv[4].number(), 0x00, cv[4].getValue());
+        Assert.assertEquals("set CV" + cv[5].number(), 0x00, cv[5].getValue());
+        Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
+        Assert.assertEquals("set CV" + cv[7].number(), 0x00, cv[7].getValue());
+
+        // change text to an invalid hex value
+        var.focusGained(focusEvent);
+        ((JTextField) var.getCommonRep()).setText("FFFFFFFGFFFFFFFF");
+        var.focusLost(focusEvent);
+        // ensure original text restored and value unchanged
+        Assert.assertEquals("set var text value", "7FD2720F", ((JTextField) var.getCommonRep()).getText());
+        Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
+        Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
+        Assert.assertEquals("set CV" + cv[2].number(), 0xD2, cv[2].getValue());
+        Assert.assertEquals("set CV" + cv[3].number(), 0x7F, cv[3].getValue());
+        Assert.assertEquals("set CV" + cv[4].number(), 0x00, cv[4].getValue());
+        Assert.assertEquals("set CV" + cv[5].number(), 0x00, cv[5].getValue());
+        Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
+        Assert.assertEquals("set CV" + cv[7].number(), 0x00, cv[7].getValue());
+
+        // change text to another invalid hex value
+        var.focusGained(focusEvent);
+        ((JTextField) var.getCommonRep()).setText("3H");
+        var.focusLost(focusEvent);
+        // ensure original text restored and value unchanged
+        Assert.assertEquals("set var text value", "7FD2720F", ((JTextField) var.getCommonRep()).getText());
+        Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
+        Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
+        Assert.assertEquals("set CV" + cv[2].number(), 0xD2, cv[2].getValue());
+        Assert.assertEquals("set CV" + cv[3].number(), 0x7F, cv[3].getValue());
+        Assert.assertEquals("set CV" + cv[4].number(), 0x00, cv[4].getValue());
+        Assert.assertEquals("set CV" + cv[5].number(), 0x00, cv[5].getValue());
+        Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
+        Assert.assertEquals("set CV" + cv[7].number(), 0x00, cv[7].getValue());
 
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/SplitTextVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/SplitTextVariableValueTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.symbolicprog;
 
+import java.awt.event.FocusEvent;
 import static java.nio.charset.Charset.defaultCharset;
 
 import java.util.HashMap;
@@ -277,7 +278,7 @@ public class SplitTextVariableValueTest extends AbstractVariableValueTestBase {
         int pFactor = 1;
         int pOffset = 0;
         String uppermask = "";
-        String match = "[a-zA-Z0-9]*";
+        String match = "[ a-zA-Z0-9]*";
         String termByteStr = "0";
         String padByteStr = "0";
         String charSet = defaultCharset().name();
@@ -312,7 +313,7 @@ public class SplitTextVariableValueTest extends AbstractVariableValueTestBase {
         resultStr = loadString(testStr, var, name);  // load a value, get the result
         checkResults(beforeStr, testStr, resultStr, cv, match, termByteStr, padByteStr, charSet);
 
-        testStr = "Test Invalid";
+        testStr = "Test Invalid.";
         beforeStr = ((JTextField) var.getCommonRep()).getText();  // get the current contents
         resultStr = loadString(testStr, var, name);  // load a value, get the result
         checkResults(beforeStr, testStr, resultStr, cv, match, termByteStr, padByteStr, charSet);
@@ -421,9 +422,12 @@ public class SplitTextVariableValueTest extends AbstractVariableValueTestBase {
      * @return The result after loading.
      */
     String loadString(String testStr, SplitTextVariableValue var, String name) {
+
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
+
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText(testStr);  // load a value
-        var.exitField();
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         return ((JTextField) var.getCommonRep()).getText();  // get the result
     }
 
@@ -448,6 +452,7 @@ public class SplitTextVariableValueTest extends AbstractVariableValueTestBase {
      */
     public void checkResults(String beforeStr, String testStr, String resultStr, CvValue[] cv,
             String match, String termByteStr, String padByteStr, String charSet) {
+        log.debug("checkResults with beforeStr='{}', testStr='{}', resultStr='{}'", beforeStr, testStr, resultStr);
 
         // check if match parameter applies and modify expectations accordingly
         if (match != null && !match.equals("") && !testStr.matches(match)) {

--- a/java/test/jmri/jmrit/symbolicprog/SplitVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/SplitVariableValueTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.symbolicprog;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.FocusEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -165,9 +167,11 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         SplitVariableValue var = new SplitVariableValue("name", "comment", "", false, false, false, false, lowCV,
                 "VVVVVVVV", 0, 255, v, null, null,
                 highCV, 1, 0, "VVVVVVVV", null, null, null, null);
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
 
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("1029");  // to tell if changed
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, ""));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var full value", "" + (1029), ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set var low bits", 5, cv1.getValue());
         Assert.assertEquals("set var high bits", 4, cv2.getValue());
@@ -193,9 +197,11 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         SplitVariableValue var = new SplitVariableValue("name", "comment", "", false, false, false, false, lowCV,
                 "XXXXVVVV", 0, 255, v, null, null,
                 highCV, 1, 0, "VVVVVVVV", null, null, null, null);
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
 
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("1029");  // to tell if changed
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, ""));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var full value", "" + (1029), ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set var low bits", 0xF5, cv1.getValue());
         Assert.assertEquals("set var high bits", 4 * 16, cv2.getValue());
@@ -221,9 +227,11 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         SplitVariableValue var = new SplitVariableValue("name", "comment", "", false, false, false, false, lowCV,
                 "VVVVVVVV", 0, 255, v, null, null,
                 highCV, 1, 0, "XXVVVVXX", null, null, null, null);
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
 
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("1029");  // to tell if changed
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, ""));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var full value", "" + (1029), ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set var low bits", 5, cv1.getValue());
         Assert.assertEquals("set var high bits", 0xC3 + 4 * 4, cv2.getValue());
@@ -249,9 +257,11 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         SplitVariableValue var = new SplitVariableValue("name", "comment", "", false, false, false, false, lowCV,
                 "XVVVVVVX", 0, 255, v, null, null,
                 highCV, 1, 0, "XVVVVVXX", null, null, null, null);
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
 
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("1029");  // to tell if changed
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, ""));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var full value", "" + (1029), ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set var low bits", 5 * 2 + 0x81, cv1.getValue());
         Assert.assertEquals("set var high bits", 0x83 + 0x40, cv2.getValue());
@@ -292,10 +302,12 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         };
         evtList = new ArrayList<>();
         var.addPropertyChangeListener(listen);
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
 
         // set to specific value
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("5");
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, ""));
+        var.focusLost(focusEvent);
 
         // read should get 123, 123 from CVs
         var.readAll();
@@ -333,8 +345,11 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         SplitVariableValue var = new SplitVariableValue("name", "comment", "", false, false, false, false,
                 lowCV, "XXVVVVVV", 0, 255, v, null, null,
                 highCV, 1, 0, "VVVVVVVV", null, null, null, null);
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
+
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("4797");
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, ""));
+        var.focusLost(focusEvent);
 
         var.writeAll();
         // wait for reply (normally, done by callback; will check that later)
@@ -381,6 +396,7 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
                 highCV, pFactor, pOffset, uppermask, extra1, extra2, extra3, extra4);
         Assert.assertNotNull("makeVar returned null", var);
 
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
         CvValue[] cv = var.usesCVs();
 
         Assert.assertEquals("number of CVs is", 8, cv.length);
@@ -395,8 +411,9 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("cv[7] is", "282", cv[7].number());
 
         // start with a random value
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("2144498191");
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "2144498191", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
@@ -408,8 +425,9 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set CV" + cv[7].number(), 0x00, cv[7].getValue());
 
         // change to maximum unsigned value
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("18446744073709551615");
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "18446744073709551615", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0xFF, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0xFF, cv[1].getValue());
@@ -421,8 +439,9 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set CV" + cv[7].number(), 0xFF, cv[7].getValue());
 
         // change to one less than maximum unsigned value
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("18446744073709551614");
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "18446744073709551614", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0xFE, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0xFF, cv[1].getValue());
@@ -434,8 +453,9 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set CV" + cv[7].number(), 0xFF, cv[7].getValue());
 
         // change to last 63 bit unsigned value
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("9223372036854775807");
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "9223372036854775807", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0xFF, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0xFF, cv[1].getValue());
@@ -447,8 +467,9 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set CV" + cv[7].number(), 0x7F, cv[7].getValue());
 
         // change to first 64 bit unsigned value
+        var.focusGained(focusEvent);
         ((JTextField) var.getCommonRep()).setText("9223372036854775808");
-        var.actionPerformed(new java.awt.event.ActionEvent(var, 0, name));
+        var.focusLost(focusEvent);
         Assert.assertEquals("set var text value", "9223372036854775808", ((JTextField) var.getCommonRep()).getText());
         Assert.assertEquals("set CV" + cv[0].number(), 0x00, cv[0].getValue());
         Assert.assertEquals("set CV" + cv[1].number(), 0x00, cv[1].getValue());
@@ -599,6 +620,189 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
         Assert.assertEquals("set CV" + cv[7].number(), 0x80, cv[7].getValue());
         Assert.assertEquals("set var text value", "9223372036854775808", ((JTextField) var.getCommonRep()).getText());
+
+    }
+
+    @Test
+    public void testTextInvalidLongValEnteredFocusLost() {
+        String name = "Decimal Field";
+        String comment = "";
+        String cvName = "";
+        boolean readOnly = false;
+        boolean infoOnly = false;
+        boolean writeOnly = false;
+        boolean opsOnly = false;
+        String cvNum = "275:8";
+        String mask = "VVVVVVVV";
+        int minVal = 0;
+        int maxVal = 0;
+        HashMap<String, CvValue> v = createCvMap();
+        JLabel status = new JLabel();
+        String stdname = "";
+        String highCV = "";
+        int pFactor = 1;
+        int pOffset = 0;
+        String uppermask = "";
+        String extra1 = "upper";
+        String extra2 = null;
+        String extra3 = null;
+        String extra4 = null;
+        SplitVariableValue var = makeVar(name, comment, cvName,
+                readOnly, infoOnly, writeOnly, opsOnly,
+                cvNum, mask, minVal, maxVal,
+                v, status, stdname,
+                highCV, pFactor, pOffset, uppermask, extra1, extra2, extra3, extra4);
+        Assert.assertNotNull("makeVar returned null", var);
+
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
+        CvValue[] cv = var.usesCVs();
+
+        Assert.assertEquals("number of CVs is", 8, cv.length);
+
+        Assert.assertEquals("cv[0] is", "275", cv[0].number());
+        Assert.assertEquals("cv[1] is", "276", cv[1].number());
+        Assert.assertEquals("cv[2] is", "277", cv[2].number());
+        Assert.assertEquals("cv[3] is", "278", cv[3].number());
+        Assert.assertEquals("cv[4] is", "279", cv[4].number());
+        Assert.assertEquals("cv[5] is", "280", cv[5].number());
+        Assert.assertEquals("cv[6] is", "281", cv[6].number());
+        Assert.assertEquals("cv[7] is", "282", cv[7].number());
+
+        // start with a random value
+        var.focusGained(focusEvent);
+        ((JTextField) var.getCommonRep()).setText("2144498191");
+        var.focusLost(focusEvent);
+        Assert.assertEquals("set var text value", "2144498191", ((JTextField) var.getCommonRep()).getText());
+        Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
+        Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
+        Assert.assertEquals("set CV" + cv[2].number(), 0xD2, cv[2].getValue());
+        Assert.assertEquals("set CV" + cv[3].number(), 0x7F, cv[3].getValue());
+        Assert.assertEquals("set CV" + cv[4].number(), 0x00, cv[4].getValue());
+        Assert.assertEquals("set CV" + cv[5].number(), 0x00, cv[5].getValue());
+        Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
+        Assert.assertEquals("set CV" + cv[7].number(), 0x00, cv[7].getValue());
+
+        // change text to an invalid long value
+        var.focusGained(focusEvent);
+        ((JTextField) var.getCommonRep()).setText("184467F4079551615");
+        var.focusLost(focusEvent);
+        // ensure original text restored and value unchanged
+        Assert.assertEquals("set var text value", "2144498191", ((JTextField) var.getCommonRep()).getText());
+        Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
+        Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
+        Assert.assertEquals("set CV" + cv[2].number(), 0xD2, cv[2].getValue());
+        Assert.assertEquals("set CV" + cv[3].number(), 0x7F, cv[3].getValue());
+        Assert.assertEquals("set CV" + cv[4].number(), 0x00, cv[4].getValue());
+        Assert.assertEquals("set CV" + cv[5].number(), 0x00, cv[5].getValue());
+        Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
+        Assert.assertEquals("set CV" + cv[7].number(), 0x00, cv[7].getValue());
+
+        // change text to another invalid long value
+        var.focusGained(focusEvent);
+        ((JTextField) var.getCommonRep()).setText("3G");
+        var.focusLost(focusEvent);
+        // ensure original text restored and value unchanged
+        Assert.assertEquals("set var text value", "2144498191", ((JTextField) var.getCommonRep()).getText());
+        Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
+        Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
+        Assert.assertEquals("set CV" + cv[2].number(), 0xD2, cv[2].getValue());
+        Assert.assertEquals("set CV" + cv[3].number(), 0x7F, cv[3].getValue());
+        Assert.assertEquals("set CV" + cv[4].number(), 0x00, cv[4].getValue());
+        Assert.assertEquals("set CV" + cv[5].number(), 0x00, cv[5].getValue());
+        Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
+        Assert.assertEquals("set CV" + cv[7].number(), 0x00, cv[7].getValue());
+
+    }
+
+    @Test
+    public void testTextInvalidLongValEnteredActionPerformed() {
+        String name = "Decimal Field";
+        String comment = "";
+        String cvName = "";
+        boolean readOnly = false;
+        boolean infoOnly = false;
+        boolean writeOnly = false;
+        boolean opsOnly = false;
+        String cvNum = "275:8";
+        String mask = "VVVVVVVV";
+        int minVal = 0;
+        int maxVal = 0;
+        HashMap<String, CvValue> v = createCvMap();
+        JLabel status = new JLabel();
+        String stdname = "";
+        String highCV = "";
+        int pFactor = 1;
+        int pOffset = 0;
+        String uppermask = "";
+        String extra1 = "upper";
+        String extra2 = null;
+        String extra3 = null;
+        String extra4 = null;
+        SplitVariableValue var = makeVar(name, comment, cvName,
+                readOnly, infoOnly, writeOnly, opsOnly,
+                cvNum, mask, minVal, maxVal,
+                v, status, stdname,
+                highCV, pFactor, pOffset, uppermask, extra1, extra2, extra3, extra4);
+        Assert.assertNotNull("makeVar returned null", var);
+
+        ActionEvent actionEvent = new ActionEvent(var.getCommonRep(), 0, name);
+        FocusEvent focusEvent = new FocusEvent(var.getCommonRep(), 0, true);
+        CvValue[] cv = var.usesCVs();
+
+        Assert.assertEquals("number of CVs is", 8, cv.length);
+
+        Assert.assertEquals("cv[0] is", "275", cv[0].number());
+        Assert.assertEquals("cv[1] is", "276", cv[1].number());
+        Assert.assertEquals("cv[2] is", "277", cv[2].number());
+        Assert.assertEquals("cv[3] is", "278", cv[3].number());
+        Assert.assertEquals("cv[4] is", "279", cv[4].number());
+        Assert.assertEquals("cv[5] is", "280", cv[5].number());
+        Assert.assertEquals("cv[6] is", "281", cv[6].number());
+        Assert.assertEquals("cv[7] is", "282", cv[7].number());
+
+        // start with a random value
+        var.focusGained(focusEvent);
+        ((JTextField) var.getCommonRep()).setText("2144498191");
+        var.actionPerformed(actionEvent);
+        Assert.assertEquals("set var text value", "2144498191", ((JTextField) var.getCommonRep()).getText());
+        Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
+        Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
+        Assert.assertEquals("set CV" + cv[2].number(), 0xD2, cv[2].getValue());
+        Assert.assertEquals("set CV" + cv[3].number(), 0x7F, cv[3].getValue());
+        Assert.assertEquals("set CV" + cv[4].number(), 0x00, cv[4].getValue());
+        Assert.assertEquals("set CV" + cv[5].number(), 0x00, cv[5].getValue());
+        Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
+        Assert.assertEquals("set CV" + cv[7].number(), 0x00, cv[7].getValue());
+
+        // change text to an invalid long value
+        var.focusGained(focusEvent);
+        ((JTextField) var.getCommonRep()).setText("184467F4079551615");
+        var.actionPerformed(actionEvent);
+        // ensure original text restored and value unchanged
+        Assert.assertEquals("set var text value", "2144498191", ((JTextField) var.getCommonRep()).getText());
+        Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
+        Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
+        Assert.assertEquals("set CV" + cv[2].number(), 0xD2, cv[2].getValue());
+        Assert.assertEquals("set CV" + cv[3].number(), 0x7F, cv[3].getValue());
+        Assert.assertEquals("set CV" + cv[4].number(), 0x00, cv[4].getValue());
+        Assert.assertEquals("set CV" + cv[5].number(), 0x00, cv[5].getValue());
+        Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
+        Assert.assertEquals("set CV" + cv[7].number(), 0x00, cv[7].getValue());
+
+        // change text to another invalid long value
+        var.focusGained(focusEvent);
+        ((JTextField) var.getCommonRep()).setText("3G");
+        var.actionPerformed(actionEvent);
+        // ensure original text restored and value unchanged
+        Assert.assertEquals("set var text value", "2144498191", ((JTextField) var.getCommonRep()).getText());
+        Assert.assertEquals("set CV" + cv[0].number(), 0x0F, cv[0].getValue());
+        Assert.assertEquals("set CV" + cv[1].number(), 0x72, cv[1].getValue());
+        Assert.assertEquals("set CV" + cv[2].number(), 0xD2, cv[2].getValue());
+        Assert.assertEquals("set CV" + cv[3].number(), 0x7F, cv[3].getValue());
+        Assert.assertEquals("set CV" + cv[4].number(), 0x00, cv[4].getValue());
+        Assert.assertEquals("set CV" + cv[5].number(), 0x00, cv[5].getValue());
+        Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
+        Assert.assertEquals("set CV" + cv[7].number(), 0x00, cv[7].getValue());
 
     }
 


### PR DESCRIPTION
Handles invalid number format entry by user, preventing NumberFormatException.

Brings SplitVariableValue & subclasses into line with DecVariableValue handling of invalid entry.