### PR TITLE
fix: associate a memo with startup action stored within memo prefix

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -1,7 +1,11 @@
 
     <h3>Hardware Support</h3>
         <ul>
-          <li></li>
+          <li>A number of hardware-specific actions now require the system
+          connection be associated with them when used as a startup action.
+          In many cases, these actions will continue to "just work", but it is
+          recommended that actions be verified to be associated with the
+          correct connection in the Startup Actions Preferences.</li>
         </ul>
 
 	    <h4>Anyma DMX512</h4>

--- a/help/en/releasenotes/current-draft-warnings.shtml
+++ b/help/en/releasenotes/current-draft-warnings.shtml
@@ -1,5 +1,7 @@
 
     <!-- contains new warnings for the release under development -->
-    <li>
-        None yet
-    </li>
+    <li>A number of hardware-specific actions now require the system
+        connection be associated with them when used as a startup action.
+        In many cases, these actions will continue to "just work", but it is
+        recommended that actions be verified to be associated with the
+        correct connection in the Startup Actions Preferences.</li>

--- a/java/src/apps/ActionListBundle.properties
+++ b/java/src/apps/ActionListBundle.properties
@@ -9,7 +9,7 @@
 # Deprecated, but still used in JMRI applications. It is preferable and
 # recommended to create a class that extends apps.startup.StartupActionFactory
 # and to register that class by listing it in
-# META-INF/services/apps.startup.StartupActionFactory
+# META-INF/services/jmri.util.startup.StartupActionFactory
 
 # some "popular" ones go right at the top
 

--- a/java/src/apps/ActionListBundle_ca.properties
+++ b/java/src/apps/ActionListBundle_ca.properties
@@ -9,7 +9,7 @@
 # Deprecated, but still used in JMRI applications. It is preferable and
 # recommended to create a class that extends apps.startup.StartupActionFactory
 # and to register that class by listing it in
-# META-INF/services/apps.startup.StartupActionFactory
+# META-INF/services/jmri.util.startup.StartupActionFactory
 #
 # Catalan Translation Joan de Castro <joan276dca@yahoo.es> 20110206
 # Catalan Translation Luis Zamora (eldelinux)<eldelinux@gmail.com> 2020/01/12

--- a/java/src/apps/ActionListBundle_da.properties
+++ b/java/src/apps/ActionListBundle_da.properties
@@ -9,7 +9,7 @@
 # Deprecated, but still used in JMRI applications. It is preferable and
 # recommended to create a class that extends apps.startup.StartupActionFactory
 # and to register that class by listing it in
-# META-INF/services/apps.startup.StartupActionFactory
+# META-INF/services/jmri.util.startup.StartupActionFactory
 
 # some "popular" ones go right at the top
 

--- a/java/src/apps/ActionListBundle_nl.properties
+++ b/java/src/apps/ActionListBundle_nl.properties
@@ -10,7 +10,7 @@
 # Deprecated, but still used in JMRI applications. It is preferable and
 # recommended to create a class that extends apps.startup.StartupActionFactory
 # and to register that class by listing it in
-# META-INF/services/apps.startup.StartupActionFactory
+# META-INF/services/jmri.util.startup.StartupActionFactory
 
 # some "popular" ones go right at the top
 

--- a/java/src/apps/configurexml/CreateButtonModelXml.java
+++ b/java/src/apps/configurexml/CreateButtonModelXml.java
@@ -2,7 +2,10 @@ package apps.configurexml;
 
 import apps.CreateButtonModel;
 import apps.StartupActionsManager;
+import java.lang.reflect.InvocationTargetException;
 import jmri.InstanceManager;
+import jmri.jmrix.SystemConnectionMemo;
+import jmri.jmrix.swing.SystemConnectionAction;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,12 +60,36 @@ public class CreateButtonModelXml extends jmri.configurexml.AbstractXmlAdapter {
         String className = shared.getAttribute("name").getValue();
         CreateButtonModel model = new CreateButtonModel();
         model.setClassName(className);
-        for (Element child : shared.getChildren("property")) { // NOI18N
+        shared.getChildren("property").forEach(child -> { // NOI18N
+            String value = child.getAttributeValue("value"); // NOI18N
             if (child.getAttributeValue("name").equals("systemPrefix") // NOI18N
-                    && child.getAttributeValue("value") != null) { // NOI18N
-                model.setSystemPrefix(child.getAttributeValue("value")); // NOI18N
+                    && value != null) {
+                // handle the situation where the model expects a system prefix
+                // but was not saved with one in a pre-4.19.7 JMRI instance
+                // TODO: at some point (June 2022 release?) change entire
+                // try/catch block to just "model.setSystemPrefix(value);"
+                try {
+                    Class<?> ac = Class.forName(className);
+                    if (value.isEmpty() && SystemConnectionAction.class.isAssignableFrom(ac)) {
+                        SystemConnectionAction<?> a = (SystemConnectionAction<?>) ac.getConstructor().newInstance();
+                        InstanceManager.getList(SystemConnectionMemo.class)
+                                .forEach(memo -> a.getSystemConnectionMemoClasses().stream()
+                                .filter(mc -> memo.getClass().isAssignableFrom(mc))
+                                .forEach(mc -> model.setSystemPrefix(memo.getSystemPrefix())));
+                    } else {
+                        model.setSystemPrefix(value);
+                    }
+                } catch (ClassNotFoundException
+                        | InstantiationException
+                        | IllegalAccessException
+                        | IllegalArgumentException
+                        | InvocationTargetException
+                        | NoSuchMethodException
+                        | SecurityException ex) {
+                    // ignore to allow manager to handle later
+                }
             }
-        }
+        });
         InstanceManager.getDefault(StartupActionsManager.class).addAction(model);
         return result;
     }

--- a/java/src/apps/configurexml/PerformActionModelXml.java
+++ b/java/src/apps/configurexml/PerformActionModelXml.java
@@ -1,11 +1,16 @@
 package apps.configurexml;
 
-import apps.PerformActionModel;
-import apps.StartupActionsManager;
-import jmri.InstanceManager;
+import java.lang.reflect.InvocationTargetException;
+
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import apps.PerformActionModel;
+import apps.StartupActionsManager;
+import jmri.InstanceManager;
+import jmri.jmrix.SystemConnectionMemo;
+import jmri.jmrix.swing.SystemConnectionAction;
 
 /**
  * Handle XML persistence of PerformActionModel objects.
@@ -16,6 +21,7 @@ import org.slf4j.LoggerFactory;
 public class PerformActionModelXml extends jmri.configurexml.AbstractXmlAdapter {
 
     public PerformActionModelXml() {
+        // no state to set
     }
 
     /**
@@ -57,12 +63,36 @@ public class PerformActionModelXml extends jmri.configurexml.AbstractXmlAdapter 
         String className = shared.getAttribute("name").getValue();
         PerformActionModel model = new PerformActionModel();
         model.setClassName(className);
-        for (Element child : shared.getChildren("property")) { // NOI18N
+        shared.getChildren("property").forEach(child -> { // NOI18N
+            String value = child.getAttributeValue("value"); // NOI18N
             if (child.getAttributeValue("name").equals("systemPrefix") // NOI18N
-                    && child.getAttributeValue("value") != null) { // NOI18N
-                model.setSystemPrefix(child.getAttributeValue("value")); // NOI18N
+                    && value != null) {
+                // handle the situation where the model expects a system prefix
+                // but was not saved with one in a pre-4.19.7 JMRI instance
+                // TODO: at some point (June 2022 release?) change entire
+                // try/catch block to just "model.setSystemPrefix(value);"
+                try {
+                    Class<?> ac = Class.forName(className);
+                    if (value.isEmpty() && SystemConnectionAction.class.isAssignableFrom(ac)) {
+                        SystemConnectionAction<?> a = (SystemConnectionAction<?>) ac.getConstructor().newInstance();
+                        InstanceManager.getList(SystemConnectionMemo.class)
+                                .forEach(memo -> a.getSystemConnectionMemoClasses().stream()
+                                .filter(mc -> memo.getClass().isAssignableFrom(mc))
+                                .forEach(mc -> model.setSystemPrefix(memo.getSystemPrefix())));
+                    } else {
+                        model.setSystemPrefix(value);
+                    }
+                } catch (ClassNotFoundException
+                        | InstantiationException
+                        | IllegalAccessException
+                        | IllegalArgumentException
+                        | InvocationTargetException
+                        | NoSuchMethodException
+                        | SecurityException ex) {
+                    // ignore to allow manager to handle later
+                }
             }
-        }
+        });
         InstanceManager.getDefault(StartupActionsManager.class).addAction(model);
         return result;
     }
@@ -77,7 +107,8 @@ public class PerformActionModelXml extends jmri.configurexml.AbstractXmlAdapter 
     public void load(Element element, Object o) {
         log.error("Unexpected call of load(Element, Object)");
     }
+
     // initialize logging
-    private final static Logger log = LoggerFactory.getLogger(PerformActionModelXml.class);
+    private static final Logger log = LoggerFactory.getLogger(PerformActionModelXml.class);
 
 }

--- a/java/src/apps/startup/AbstractActionModel.java
+++ b/java/src/apps/startup/AbstractActionModel.java
@@ -127,10 +127,10 @@ public abstract class AbstractActionModel implements StartupModel {
             }
             jmri.util.ThreadingUtil.runOnLayout(() -> {
                 try {
-                 this.performAction(action);
+                    this.performAction(action);
                 } catch (JmriException ex) {
                     log.error("Error while performing startup action for class: {}", className, ex);
-               }
+                }
             });
         } catch (ClassNotFoundException ex) {
             log.error("Could not find specified class: {}", className);


### PR DESCRIPTION
If an action that needs a specific connection to act on is stored without a valid identifier for that connection, we should treat is as invalid action; however, there is a special case that needs to be supported for historical reasons--we never made most actions that act on a specific connection do so until #8544; they simply acted on the last connection of a specific type (regardless of the number of connections of a specific type).

Fixes #8582
Fixes #8583