### PR TITLE
fix cast exception during panel load

### DIFF
--- a/java/src/jmri/jmrit/display/EditorManager.java
+++ b/java/src/jmri/jmrit/display/EditorManager.java
@@ -84,7 +84,7 @@ public class EditorManager extends Bean implements PropertyChangeListener, Insta
     @Nonnull
     public <T extends Editor> SortedSet<T> getAll(@Nonnull Class<T> type) {
         return set.stream()
-                .filter(e -> e.getClass().isAssignableFrom(type))
+                .filter(e -> type.isAssignableFrom(e.getClass()))
                 .map(type::cast)
                 .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(Editor::getTitle))));
     }


### PR DESCRIPTION
Fixes a problem where the order of storing can sometimes result in a CastClassException on load.

From a[ jmriusers thread](https://groups.io/g/jmriusers/message/174370).