### PR TITLE
XNetSimulator caches turnout states and emulates Lenz LZV100 + LI100 (serial) for turnout commands

### DIFF
--- a/java/src/jmri/jmrix/lenz/xnetsimulator/XNetSimulatorAdapter.java
+++ b/java/src/jmri/jmrix/lenz/xnetsimulator/XNetSimulatorAdapter.java
@@ -5,6 +5,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.util.BitSet;
 import jmri.jmrix.ConnectionStatus;
 import jmri.jmrix.lenz.LenzCommandStation;
 import jmri.jmrix.lenz.XNetConstants;
@@ -58,6 +59,17 @@ public class XNetSimulatorAdapter extends XNetSimulatorPortController implements
     private int momentaryGroup4 = 0;
     private int momentaryGroup5 = 0;
     
+    /**
+     * Accessory state cache. A "1" bit means THROWN, "0" means
+     * CLOSED. 
+     */
+    private final BitSet accessoryState = new BitSet(1024);
+    
+    /**
+     * Bit is set if the accessory was operated.
+     */
+    private final BitSet accessoryOperated = new BitSet(1024);
+
     public XNetSimulatorAdapter() {
         setPort(Bundle.getMessage("None"));
         try {
@@ -117,6 +129,10 @@ public class XNetSimulatorAdapter extends XNetSimulatorPortController implements
     public void configure() {
         // connect to a packetizing traffic controller
         XNetTrafficController packets = new XNetPacketizer(new LenzCommandStation());
+        configure(packets);
+    }
+    
+    protected void configure(XNetTrafficController packets) {
         packets.connectPort(this);
 
         // start operation
@@ -309,6 +325,8 @@ public class XNetSimulatorAdapter extends XNetSimulatorPortController implements
                 // LZ100 and LZV100 respond with an ACC_INFO_RESPONSE.
                 // but XpressNet standard says to no response (which causes
                 // the interface to send an OK reply).
+                reply = accReqReply(m);
+                break;
             case XNetConstants.ACC_INFO_REQ:
                 reply = accInfoReply(m);
                 break;
@@ -458,32 +476,143 @@ public class XNetSimulatorAdapter extends XNetSimulatorPortController implements
         return reply;
     }
 
-    // Create a reply to a request for the accessory device Status
-    private XNetReply accInfoReply(XNetMessage m) {
-        XNetReply reply = new XNetReply();
-        reply.setOpCode(XNetConstants.ACC_INFO_RESPONSE);
-        reply.setElement(1, m.getElement(1));
-           if (m.getOpCode() == XNetConstants.ACC_OPER_REQ || 
-               m.getElement(1) < 64) {
-              // treat as turnout feedback request.
-              if (m.getElement(2) == 0x80) {
-                 reply.setElement(2, 0x00);
-              } else {
-                 reply.setElement(2, 0x10);
-              }
-           } else {
-              // treat as feedback encoder request.
-              if (m.getElement(2) == 0x80) {
-                 reply.setElement(2, 0x40);
-              } else {
-                 reply.setElement(2, 0x50);
-              }
-           }
-           reply.setElement(3, 0x00);
-           reply.setParity();
-        return reply;
+    /**
+     * Return the turnout feedback type.
+     * <ul>
+     * <li>0x00 - turnout without feedback, ie DR5000
+     * <li>0x01 - turnout with feedback, ie NanoX
+     * <li>0x10 - feedback module
+     * </ul>
+     * @return the turnout type reported by this station.
+     */
+    protected int getTurnoutFeedbackType() {
+        return 0x01;
+    }
+    
+    /**
+     * Returns accessory state, in the Operation Info Reply bit format. If the
+     * accessory has not been operated yet, returns 00 (not operated).
+     * 
+     * @param a accessory number
+     * @return two bits representing the accessory state.
+     */
+    protected int getAccessoryStateBits(int a) {
+        if (!accessoryOperated.get(a)) {
+            return 0x00;
+        }
+        boolean state = accessoryState.get(a);
+        int zbits = state ? 0b10 : 0b01;
+        return zbits;
     }
 
+    protected XNetReply accInfoReply(XNetMessage m) {
+        if (m.getElement(1) >= 64) {
+            return feedbackInfoReply(m);
+        } else {
+            boolean nibble = (m.getElement(2) & 0x01) == 0x01;
+            int ba = m.getElement(1);
+            return accInfoReply(ba, nibble);
+        }
+    }
+    
+    protected XNetReply feedbackInfoReply(XNetMessage m) {
+        XNetReply reply = new XNetReply();
+       reply.setOpCode(XNetConstants.ACC_INFO_RESPONSE);
+        reply.setElement(1, m.getElement(1));
+        // treat as feedback encoder request.
+        if (m.getElement(2) == 0x80) {
+            reply.setElement(2, 0x40);
+        } else {
+            reply.setElement(2, 0x50);
+        }
+       reply.setElement(3, 0x00);
+       reply.setParity();
+       return reply;
+    }
+
+    /**
+     * Creates a reply packet for a turnout/accessory.
+     * @param baseAddress base address for the feedback, the 4-turnout block; numbered from 0
+     * @param nibble lower or upper nibble (2 turnout block) delivered in the reply
+     * @return constructed reply.
+     */
+    protected XNetReply accInfoReply(int baseAddress, boolean nibble) {
+        XNetReply r = new XNetReply();
+        r.setOpCode(XNetConstants.ACC_INFO_RESPONSE);
+        r.setElement(1, baseAddress);
+        int nibbleVal = 0;
+        int a = baseAddress * 4 + 1;
+        if (nibble) {
+            a += 2;
+        }
+        int zbits = getAccessoryStateBits(a++);
+        nibbleVal |= zbits;
+        zbits = getAccessoryStateBits(a++);
+        nibbleVal |= (zbits << 2);
+        r.setElement(2, // 0 << 7 |          // turnout movement completed, unsupported; always done
+            getTurnoutFeedbackType() << 5 | // two bits: accessory without feedback
+            (nibble ? 1 : 0) << 4 |         // upper / lower nibble
+            nibbleVal & 0x0f);
+        r.setElement(3, 0);
+        r.setParity();
+        return r;
+    }
+    
+    /**
+     * Generate reply to accessory request command.
+     * The returned XNetReply is the first to be returned by this simulated command station.
+     * @param address the accessory address
+     * @param output the output to be manipulated
+     * @param state true if output should be on, false for off
+     * @param previousAccessoryState the previous accessory state
+     * @return the reply instance.
+     */
+    protected XNetReply generateAccRequestReply(int address, int output, boolean state, boolean previousAccessoryState) {
+        XNetReply r;
+
+        if (state) {
+            if (accessoryOperated.get(address) && previousAccessoryState == (output != 0)) {
+                // just OK, the accessory is in the same state.
+                return okReply();
+            } else {
+                accessoryOperated.set(address);
+                r = accInfoReply(address);
+                r.setUnsolicited();
+            }
+        } else {
+            accessoryOperated.set(address);
+            // generate just OK to OFF
+            r = okReply();
+        }
+        return r;
+    }
+
+    /**
+     * Creates a reply for the specific turnout dcc address. 
+     * @param dccTurnoutAddress the turnout address
+     * @return a reply packet
+     */
+    protected XNetReply accInfoReply(int dccTurnoutAddress) {
+        dccTurnoutAddress--;
+        int baseAddress = dccTurnoutAddress / 4;
+        boolean upperNibble = dccTurnoutAddress % 4 >= 2;
+        return accInfoReply(baseAddress, upperNibble);
+    }
+
+    protected XNetReply accReqReply(XNetMessage m) {
+        int baseaddress = m.getElement(1);
+        int subaddress = (m.getElement(2) & 0x06) >> 1;
+        int address = (baseaddress * 4) + subaddress + 1;
+        int output = m.getElement(2) & 0x01;
+        boolean on = ((m.getElement(2) & 0x08)) == 0x08;
+        boolean oldState = accessoryState.get(address);
+        if (on) {
+            accessoryState.set(address, output != 0);
+        }
+        log.debug("Received command {} ... {}", m, m.toMonitorString());
+        return generateAccRequestReply(address, output, on, oldState);
+    }
+    
     private void writeReply(XNetReply r) {
         int i;
         int len = (r.getElement(0) & 0x0f) + 2;  // opCode+Nbytes+ECC
@@ -508,7 +637,7 @@ public class XNetSimulatorAdapter extends XNetSimulatorPortController implements
      * @return filled message
      * @throws IOException when presented by the input source.
      */
-    private XNetMessage loadChars() throws java.io.IOException {
+    protected XNetMessage loadChars() throws java.io.IOException {
         int i;
         byte char1;
         char1 = readByteProtected(inpipe);

--- a/java/test/jmri/jmrix/lenz/xnetsimulator/XNetSimulatorAdapterTest.java
+++ b/java/test/jmri/jmrix/lenz/xnetsimulator/XNetSimulatorAdapterTest.java
@@ -192,7 +192,8 @@ public class XNetSimulatorAdapterTest {
     @Test
     public void testGenerateAccOperRequestReply(){
         XNetReply r = getReplyForMessage(new XNetMessage("52 01 80 D3"));
-        Assert.assertEquals("Accessory Decoder Info Reply",new XNetReply("42 01 10 53"),r);
+        // this is an OFF message, which is responded to by OK.
+        Assert.assertEquals("Accessory Decoder Info Reply",new XNetReply("01 04 05"),r);
     }
 
     @Test


### PR DESCRIPTION
Following the e-mail thread "Lenz simulator not operating turnouts"

> Running Lenz simulator using JMRI 4.19.2 on a late 2015 iMac Mojave and Windows 10 tablet.
I used to use the Lenz simulator in the past for starting off panels etc. I now find that it no longer changes the turnouts, in the turnout table it says inconsistent and the xpressnet monitor says not operated.
I haven't used the simulator for a couple of updates but it used to operate XT turnouts so panels etc. could be seen to operate and could be seen in the xpressnet monitor.

I've realized I am too lazy and finally extracted another part of my xpressnet related code that could be useful.

If I read the history correctly, the simulator changed around 4.17.2 (probably faf2ad5deb3581) - before that, it always replied "OK", which was sufficient for operation requests both ON and OFF.  Since then, it responds with Feedback to OFF messages, which causes them never finish. In addition, since the MONITORING turnouts get always "not operated" reply - that means "inconsistent" for them, they will repeat their commands to XpressNet endlessly. CPU may go to 100% - especially after the `XNetSimulator` was fixed with `ImmediatePipedInputStream` which eliminated 1sec delay between messages.

Since 4.19.4(?) - the introduction of queues that also means that once operated turnout with pending OFF command (*OFFSENT*) state will never go *IDLE* so it won't accept further commands.

This changeset introduces a cache for turnout states and flags which turnout was operated. The replies sent are:
- OK for 'output OFF' message
- OK for command that switches the turnout to a position that it already has
- feedback with the new position otherwise
The behaviour should be exactly the same as with Lenz LZV100 + LI-100, perhaps the simplest station with feedback.

Note: the changes were extracted from larger work. There are some `protected` methods which need not to be protected at the moment. But if I may ask, I'd leave those protected, since I have simulations of LZV-100 / LI-USB, NanoX / LI-100 and DR5000 / LI-USB-Ethernet in the queue that will eventually use that `protected` interface.

The code was briefly tested with an existing panel with MONITORING turnouts and seems to display turnout positions and stop sending messages after some time.