### PR TITLE
Small Jenkins cleanup

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1878,10 +1878,10 @@
                  package="yes"
                  use="true"
                  failonerror="true"
-                 failonwarning="true"
+                 failonwarning="false" 
                  source="8"
                  windowtitle="JMRI API"
-            >
+            > <!-- failonwarning="false"  because always warns on cyclic redundancy with JDK11 -->
 
             <packageset dir="${source}" defaultexcludes="yes">
                 <include name="jmri/**"/>

--- a/help/en/html/doc/Technical/CI-status.shtml
+++ b/help/en/html/doc/Technical/CI-status.shtml
@@ -63,6 +63,7 @@
 		</tr><tr><td align="right">
 		<a href="https://builds.jmri.org/jenkins/job/WebSite/">Web Site</a>:</td><td>
 		<a href='https://builds.jmri.org/jenkins/job/WebSite/job/generate-website/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=WebSite/generate-website' title="generate website"></a>
+        <a href='https://builds.jmri.org/jenkins/job/WebSite/job/java-11-javadoc-tests/'><img src='https://builds.jmri.org/jenkins/buildStatus/icon?job=website%2Fjava-11-javadoc-tests' title="generate Javadoc UML"></a>
 		<a href='https://builds.jmri.org/jenkins/job/WebSite/job/JMRI_repository/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=WebSite/jmri-repository' title="JMRI repository"></a>
 		<a href='https://builds.jmri.org/jenkins/job/WebSite/job/website_repository/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=WebSite/website-repository' title="website repository"></a>
 		<a href='https://builds.jmri.org/jenkins/job/WebSite/job/website-legal_repository/'><img src='http://builds.jmri.org/jenkins/buildStatus/icon?job=WebSite/website-legal-repository' title="website-legal"></a>
@@ -75,7 +76,8 @@
         <a href="https://coveralls.io/github/JMRI/JMRI?branch=master">Coveralls:</a>
 		<a href='https://coveralls.io/github/JMRI/JMRI?branch=master'><img src='https://coveralls.io/repos/github/JMRI/JMRI/badge.svg?branch=master' title="Coveralls`"></a>
         </td></tr>
-        <tr><td>
+        <tr><td align="right">
+        <a href="https://github.org/JMRI/JMRI">GitHub:</a></td><td>
             <a href="https://github.com/JMRI/JMRI/actions?query=workflow%3A%22Windows+CI+Tests%22"><img src="https://github.com/JMRI/JMRI/workflows/Windows%20CI%20Tests/badge.svg" title="Windows CI Tests"></a>
             <a href="https://github.com/JMRI/JMRI/actions?query=workflow%3A%22Static+Analysis%22"><img src="https://github.com/JMRI/JMRI/workflows/Static%20Analysis/badge.svg" title="Static Analysis"></a>
         </td></tr>


### PR DESCRIPTION
 - add badge for JDK11 Javadoc to CI-status page
 - Accept Javadoc warnings on JDK11 Javadoc, as it warns on cyclic dependencies and we have lots of them.