### PR TITLE
Set background color for test

### DIFF
--- a/java/test/jmri/jmrit/display/load/PanelEditorTest1.xml
+++ b/java/test/jmri/jmrit/display/load/PanelEditorTest1.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
     <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="Layer Name Test" x="20" y="22" height="226" width="204" editable="no" positionable="yes" controlling="yes" hide="yes" panelmenu="no">    
+    <positionablelabel x="35" y="100" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/whiteSquare100.png" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="95" y="100" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/whiteSquare100.png" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
         <positionablelabel forcecontroloff="false" fixed="false" showtooltip="true" class="jmri.jmrit.display.configurexml.PositionableLabelXml" x="40" y="130" level="5" text="Checks should be" size="13" style="0" />
         <positionablelabel forcecontroloff="false" fixed="false" showtooltip="true" class="jmri.jmrit.display.configurexml.PositionableLabelXml" x="51" y="149" level="5" text="in front of Xs" size="13" style="0" />
         <turnouticon turnout="IT1" x="45" y="55" level="10" closed="program:resources/icons/misc/Checkmark-green.gif" thrown="program:resources/icons/misc/Checkmark-green.gif" unknown="program:resources/icons/misc/Checkmark-green.gif" inconsistent="program:resources/icons/misc/Checkmark-green.gif" rotate="0" forcecontroloff="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml" />    

--- a/java/test/jmri/jmrit/display/load/PanelEditorTest1.xml
+++ b/java/test/jmri/jmrit/display/load/PanelEditorTest1.xml
@@ -11,8 +11,8 @@
         <rotation>0</rotation>
       </icon>
     </positionablelabel>
-        <positionablelabel forcecontroloff="false" fixed="false" showtooltip="true" class="jmri.jmrit.display.configurexml.PositionableLabelXml" x="40" y="130" level="5" text="Checks should be" size="13" style="0" />
-        <positionablelabel forcecontroloff="false" fixed="false" showtooltip="true" class="jmri.jmrit.display.configurexml.PositionableLabelXml" x="51" y="149" level="5" text="in front of Xs" size="13" style="0" />
+        <positionablelabel forcecontroloff="false" fixed="false" showtooltip="true" class="jmri.jmrit.display.configurexml.PositionableLabelXml" x="40" y="130" level="5" text="Checks should be" size="13" style="0" red="40" green="40" blue="40" hasBackground="no"/>
+        <positionablelabel forcecontroloff="false" fixed="false" showtooltip="true" class="jmri.jmrit.display.configurexml.PositionableLabelXml" x="51" y="149" level="5" text="in front of Xs" size="13" style="0" red="40" green="40" blue="40" hasBackground="no" />
         <turnouticon turnout="IT1" x="45" y="55" level="10" closed="program:resources/icons/misc/Checkmark-green.gif" thrown="program:resources/icons/misc/Checkmark-green.gif" unknown="program:resources/icons/misc/Checkmark-green.gif" inconsistent="program:resources/icons/misc/Checkmark-green.gif" rotate="0" forcecontroloff="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml" />    
         <sensoricon sensor="IS1" x="46" y="53" level="7" active="program:resources/icons/misc/X-red.gif" inactive="program:resources/icons/misc/X-red.gif" unknown="program:resources/icons/misc/X-red.gif" inconsistent="program:resources/icons/misc/X-red.gif" rotate="0" forcecontroloff="false" momentary="false" class="jmri.jmrit.display.configurexml.SensorIconXml" />
         <turnouticon turnout="IT1" x="136" y="53" level="7" closed="program:resources/icons/misc/X-red.gif" thrown="program:resources/icons/misc/X-red.gif" unknown="program:resources/icons/misc/X-red.gif" inconsistent="program:resources/icons/misc/X-red.gif" rotate="0" forcecontroloff="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml" />

--- a/java/test/jmri/jmrit/display/loadref/PanelEditorTest1.xml
+++ b/java/test/jmri/jmrit/display/loadref/PanelEditorTest1.xml
@@ -37,8 +37,8 @@
         <rotation>0</rotation>
       </icon>
     </positionablelabel>
-    <positionablelabel x="40" y="130" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" text="Checks should be" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="left" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
-    <positionablelabel x="51" y="149" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" text="in front of Xs" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="left" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
+    <positionablelabel x="40" y="130" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" text="Checks should be" size="13" style="0" red="40" green="40" blue="40" hasBackground="no" justification="left" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
+    <positionablelabel x="51" y="149" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" text="in front of Xs" size="13" style="0" red="40" green="40" blue="40" hasBackground="no" justification="left" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
     <turnouticon turnout="IT1" x="45" y="55" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" tristate="true" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
       <icons>
         <closed url="program:resources/icons/misc/Checkmark-green.gif" degrees="0" scale="1.0">

--- a/java/test/jmri/jmrit/display/loadref/PanelEditorTest1.xml
+++ b/java/test/jmri/jmrit/display/loadref/PanelEditorTest1.xml
@@ -27,8 +27,18 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="Layer Name Test" x="20" y="22" height="226" width="204" editable="no" positionable="yes" showtooltips="yes" controlling="yes" hide="yes" panelmenu="no" scrollable="both">
-    <positionablelabel x="40" y="130" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" text="Checks should be" size="13" style="0" red="51" green="51" blue="51" hasBackground="no" justification="left" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
-    <positionablelabel x="51" y="149" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" text="in front of Xs" size="13" style="0" red="51" green="51" blue="51" hasBackground="no" justification="left" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
+    <positionablelabel x="35" y="100" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/whiteSquare100.png" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="95" y="100" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/whiteSquare100.png" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="40" y="130" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" text="Checks should be" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="left" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
+    <positionablelabel x="51" y="149" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" text="in front of Xs" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="left" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
     <turnouticon turnout="IT1" x="45" y="55" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="false" tristate="true" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
       <icons>
         <closed url="program:resources/icons/misc/Checkmark-green.gif" degrees="0" scale="1.0">


### PR DESCRIPTION
The background color on a panel editor file (without a background image) varies with the computer setup because it's transparent.  This adds a white background to one panel test file so it works everywhere.