### PR TITLE
Bugfix: Possible splitTextVal data corruption when reading CVs.

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/SplitTextVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitTextVariableValue.java
@@ -230,8 +230,7 @@ public class SplitTextVariableValue extends SplitVariableValue {
     /**
      * Contains byte-value specific code.
      * <br><br>
-     * invokes {@link #updatedTextField updatedTextField()}
-     * <br><br>
+     * invokes {@link #exitField exitField()} to process text and
      * firePropertyChange for "Value" with new contents of _textField
      *
      * @param e the action event
@@ -249,6 +248,12 @@ public class SplitTextVariableValue extends SplitVariableValue {
     }
 
     @Override
+    public long getLongValue() {
+        log.error("getLongValue doesn't make sense for a split text value");
+        return 0;
+    }
+
+    @Override
     public void setValue(String value) {
         if (log.isDebugEnabled()) {
             log.debug("Variable={}; enter setValue {}", _name, value);
@@ -258,9 +263,9 @@ public class SplitTextVariableValue extends SplitVariableValue {
             log.debug("Variable={}; setValue with new value {} old value {}", _name, value, oldVal);
         }
         _textField.setText(value);
-        if (!oldVal.equals(value) || getState() == VariableValue.UNKNOWN) {
-            actionPerformed(null);
-        }
+//        if (!oldVal.equals(value) || getState() == VariableValue.UNKNOWN) {
+//            actionPerformed(null);
+//        }
         prop.firePropertyChange("Value", oldVal, value);
         if (log.isDebugEnabled()) {
             log.debug("Variable={}; exit setValue {}", _name, value);
@@ -271,6 +276,11 @@ public class SplitTextVariableValue extends SplitVariableValue {
     @Override
     public void setIntValue(int i) {
         log.warn("setIntValue doesn't make sense for a split text value: {}", i);
+    }
+
+    @Override
+    public void setLongValue(long i) {
+        log.warn("setLongValue doesn't make sense for a split text value: {}", i);
     }
 
     // initialize logging

--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -405,10 +405,9 @@ public class SplitVariableValue extends VariableValue
     }
 
     /**
-     * ActionListener implementations
-     */
-    /**
-     * Invokes {@link #exitField exitField()}.
+     * ActionListener implementation.
+     * <p>
+     * Invokes {@link #exitField exitField()}
      *
      * @param e the action event
      */
@@ -419,7 +418,7 @@ public class SplitVariableValue extends VariableValue
     }
 
     /**
-     * FocusListener implementations
+     * FocusListener implementations.
      */
     @Override
     public void focusGained(FocusEvent e) {
@@ -694,8 +693,10 @@ public class SplitVariableValue extends VariableValue
                 log.debug("getState() = {}", (cvList.get(Math.abs(_progState) - 1).thisCV).getState());
             }
 
-            if (_progState == IDLE) { // no, just a CV update
-                log.error("Variable={}; Busy goes false with state IDLE", _name);
+            if (_progState == IDLE) { // State machine is idle, so "Busy" transition is the result of a CV update by another source.
+                // The source would be a Read/Write from either the CVs pane or another Variable with one or more overlapping CV(s).
+                // It is definitely not an error condition, but needs to be ignored by this variable's state machine.
+                log.debug("Variable={}; Busy goes false with state IDLE", _name);
             } else if (_progState >= READING_FIRST) {   // reading CVs
                 if ((cvList.get(Math.abs(_progState) - 1).thisCV).getState() == READ) {   // was the last read successful?
                     retry = 0;


### PR DESCRIPTION
Branched from 4.19.7. For JMRI:release-4.19.8

(@bobjacobsen Is this the right way to do it? Both are same commit ba9b4aa)