### PR TITLE
Ensure FBCache is first, reduces number of queries. Fix invalid mask for pending queries

### DIFF
--- a/java/src/jmri/jmrix/lenz/XNetFeedbackMessageCache.java
+++ b/java/src/jmri/jmrix/lenz/XNetFeedbackMessageCache.java
@@ -65,7 +65,7 @@ public class XNetFeedbackMessageCache implements XNetListener {
             }
              cached = messageCache[replyIndex];
              if (cached == null) {
-                messagePending[bitIdx] |= bitMask;
+                messagePending[bitIdx] |= (1 << bitMask);
              }
         }
         if (cached != null) {

--- a/java/src/jmri/jmrix/lenz/XNetTurnoutManager.java
+++ b/java/src/jmri/jmrix/lenz/XNetTurnoutManager.java
@@ -22,6 +22,9 @@ public class XNetTurnoutManager extends jmri.managers.AbstractTurnoutManager imp
     public XNetTurnoutManager(XNetSystemConnectionMemo memo) {
         super(memo);
         tc = memo.getXNetTrafficController();
+        // Force initialization, so it registers first and receives feedbacks before
+        // TurnoutManager autocreates turnout.
+        tc.getFeedbackMessageCache();
         tc.addXNetListener(XNetInterface.FEEDBACK, this);
     }
 


### PR DESCRIPTION
One bug from my refactoring: the "1" in bitmask for pending operation was not shifted. Resulted in unnecessary queries.

Second is a minor improvement: as The FeedbackCache registers _after_ TurnoutManager, when a feedback reply arrives, the manager FIRST creates a turnout, which queries the layout for initial state, and only after that the cache is populated. 
If the cache listener was hit first, it would have a value for the turnout already.