### PR TITLE
Xnet turnout monitor outbound

### DIFF
--- a/java/src/jmri/jmrix/lenz/FeedbackItem.java
+++ b/java/src/jmri/jmrix/lenz/FeedbackItem.java
@@ -30,10 +30,11 @@ public class FeedbackItem {
 
     /**
      * Resets the unsolicited flag in the reply.
-     * @see XNetReply#resetUnsolicited()
+     * @deprecated since 4.21.1 without replacement
      */
+    @Deprecated
     public void resetUnsolicited() {
-        reply.resetUnsolicited();
+       // deprecated, take no action.
     }
     
     /**

--- a/java/src/jmri/jmrix/lenz/XNetMessage.java
+++ b/java/src/jmri/jmrix/lenz/XNetMessage.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.lenz;
 
 import java.io.Serializable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import jmri.SpeedStepMode;
@@ -1642,7 +1643,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
                                LenzCommandStation.calcLocoAddress(getElement(2), getElement(3)));
                         break;
                     } else if ((getElement(4) & 0xE8) == 0xE8) {
-                        String message = "";
+                        String message;
                         if ((getElement(6) & 0x10) == 0x10) {
                             message ="XNetMessageOpsModeBitVerify";
                         } else {

--- a/java/src/jmri/jmrix/lenz/XNetSensor.java
+++ b/java/src/jmri/jmrix/lenz/XNetSensor.java
@@ -113,14 +113,10 @@ public class XNetSensor extends AbstractSensor implements XNetListener {
         if (log.isDebugEnabled()) {
             log.debug("received message: {}", l);
         }
-        Boolean opt = l.selectModuleFeedback(address);
+        boolean opt = l.selectModuleFeedback(address);
         if (opt != null) {
             if (log.isDebugEnabled()) {
                         log.debug("Message for sensor {} (Address {} position {})", systemName, baseaddress, address - (baseaddress * 8));
-            }
-            if (statusRequested && l.isUnsolicited()) {
-                l.resetUnsolicited();
-                statusRequested = false;
             }
             if (opt ^ _inverted) {
                 setOwnState(Sensor.ACTIVE);
@@ -136,6 +132,7 @@ public class XNetSensor extends AbstractSensor implements XNetListener {
      */
     @Override
     public void message(XNetMessage l) {
+        // not currently listening for outgoing messages.
     }
 
     /**
@@ -145,13 +142,8 @@ public class XNetSensor extends AbstractSensor implements XNetListener {
     @Override
     public void notifyTimeout(XNetMessage msg) {
         if (log.isDebugEnabled()) {
-            log.debug("Notified of timeout on message: {}", msg.toString());
+            log.debug("Notified of timeout on message: {}", msg);
         }
-    }
-
-    @Override
-    public void dispose() {
-        super.dispose();
     }
 
     /**

--- a/java/src/jmri/jmrix/lenz/XNetSensor.java
+++ b/java/src/jmri/jmrix/lenz/XNetSensor.java
@@ -113,7 +113,7 @@ public class XNetSensor extends AbstractSensor implements XNetListener {
         if (log.isDebugEnabled()) {
             log.debug("received message: {}", l);
         }
-        boolean opt = l.selectModuleFeedback(address);
+        Boolean opt = l.selectModuleFeedback(address);
         if (opt != null) {
             if (log.isDebugEnabled()) {
                         log.debug("Message for sensor {} (Address {} position {})", systemName, baseaddress, address - (baseaddress * 8));

--- a/java/src/jmri/jmrix/lenz/XNetTrafficController.java
+++ b/java/src/jmri/jmrix/lenz/XNetTrafficController.java
@@ -45,14 +45,6 @@ public abstract class XNetTrafficController extends AbstractMRTrafficController 
     // Abstract methods for the XNetInterface
 
     /**
-     * Forward a preformatted XNetMessage to the actual interface.
-     *
-     * @param m Message to send; will be updated with CRC
-     */
-    @Override
-    abstract public void sendXNetMessage(XNetMessage m, XNetListener reply);
-
-    /**
      * Make connection to existing PortController object.
      */
     @Override
@@ -102,18 +94,18 @@ public abstract class XNetTrafficController extends AbstractMRTrafficController 
                 ((XNetListener) client).message((XNetReply) m);
             } else if ((mask & XNetInterface.COMMINFO)
                     == XNetInterface.COMMINFO
-                    && (((XNetReply) m).getElement(0)
+                    && (m.getElement(0)
                     == XNetConstants.LI_MESSAGE_RESPONSE_HEADER)) {
                 ((XNetListener) client).message((XNetReply) m);
             } else if ((mask & XNetInterface.CS_INFO)
                     == XNetInterface.CS_INFO
-                    && (((XNetReply) m).getElement(0)
+                    && (m.getElement(0)
                     == XNetConstants.CS_INFO
-                    || ((XNetReply) m).getElement(0)
+                    || m.getElement(0)
                     == XNetConstants.CS_SERVICE_MODE_RESPONSE
-                    || ((XNetReply) m).getElement(0)
+                    || m.getElement(0)
                     == XNetConstants.CS_REQUEST_RESPONSE
-                    || ((XNetReply) m).getElement(0)
+                    || m.getElement(0)
                     == XNetConstants.BC_EMERGENCY_STOP)) {
                 ((XNetListener) client).message((XNetReply) m);
             } else if ((mask & XNetInterface.FEEDBACK)
@@ -131,9 +123,9 @@ public abstract class XNetTrafficController extends AbstractMRTrafficController 
                 ((XNetListener) client).message((XNetReply) m);
             } else if ((mask & XNetInterface.INTERFACE)
                     == XNetInterface.INTERFACE
-                    && (((XNetReply) m).getElement(0)
+                    && (m.getElement(0)
                     == XNetConstants.LI_VERSION_RESPONSE
-                    || ((XNetReply) m).getElement(0)
+                    || m.getElement(0)
                     == XNetConstants.LI101_REQUEST)) {
                 ((XNetListener) client).message((XNetReply) m);
             }
@@ -237,7 +229,7 @@ public abstract class XNetTrafficController extends AbstractMRTrafficController 
 
     @Override
     protected boolean endOfMessage(AbstractMRReply msg) {
-        int len = (((XNetReply) msg).getElement(0) & 0x0f) + 2;  // opCode+Nbytes+ECC
+        int len = (msg.getElement(0) & 0x0f) + 2;  // opCode+Nbytes+ECC
         log.debug("Message Length {} Current Size {}", len, msg.getNumDataElements());
         return msg.getNumDataElements() >= len;
     }
@@ -278,6 +270,14 @@ public abstract class XNetTrafficController extends AbstractMRTrafficController 
         super.handleTimeout(msg, l);
         if (l != null) {
             ((XNetListener) l).notifyTimeout((XNetMessage) msg);
+        }
+    }
+
+    @Override
+    protected void notifyMessage(AbstractMRMessage m, AbstractMRListener notMe) {
+        super.notifyMessage(m, notMe);
+        if(notMe!=null) {
+            forwardMessage(notMe, m);
         }
     }
 

--- a/java/src/jmri/jmrix/lenz/XNetTurnout.java
+++ b/java/src/jmri/jmrix/lenz/XNetTurnout.java
@@ -350,7 +350,7 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
      * Listen for the messages to the LI100/LI101.
      */
     @Override
-    public void message(XNetMessage l) {
+    public synchronized void message(XNetMessage l) {
         log.debug("received outgoing message {} for turnout {}",l,getSystemName());
         // we want to verify this is the last message we sent
         // so use == not .equals

--- a/java/src/jmri/jmrix/lenz/XNetTurnout.java
+++ b/java/src/jmri/jmrix/lenz/XNetTurnout.java
@@ -111,9 +111,10 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
     protected static final int OFFSENT = 1;
     protected static final int COMMANDSENT = 2;
     protected static final int STATUSREQUESTSENT = 4;
+    protected static final int QUEUEDMESSAGE = 8;
     protected static final int IDLE = 0;
     protected int internalState = IDLE;
-    
+
     /* Static arrays to hold Lenz specific feedback mode information */
     static String[] modeNames = null;
     static int[] modeValues = null;
@@ -123,8 +124,18 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
     @GuardedBy("this")
     protected int _mClosed = jmri.Turnout.CLOSED;
 
-    protected String _prefix = "X"; // default
-    protected XNetTrafficController tc = null;
+    protected int mNumber;   // XpressNet turnout number
+    final XNetTurnoutStateListener _stateListener;  // Internal class object
+
+    // A queue to hold outstanding messages
+    @GuardedBy("this")
+    protected final Queue<RequestMessage> requestList;
+
+    @GuardedBy("this")
+    protected RequestMessage lastMsg = null;
+
+    protected final String _prefix; // default
+    protected final XNetTrafficController tc;
 
     public XNetTurnout(String prefix, int pNumber, XNetTrafficController controller) {  // a human-readable turnout number must be specified!
         super(prefix + "T" + pNumber);
@@ -134,7 +145,7 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
 
         requestList = new LinkedList<>();
 
-        /* Add additiona feedback types information */
+        /* Add additional feedback types information */
         _validFeedbackTypes |= MONITORING | EXACT | SIGNAL;
 
         // Default feedback mode is MONITORING
@@ -340,6 +351,15 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
      */
     @Override
     public void message(XNetMessage l) {
+        log.debug("received outgoing message {} for turnout {}",l,getSystemName());
+        // we want to verify this is the last message we sent
+        // so use == not .equals
+        if(lastMsg!=null && l == lastMsg.msg){
+            //if this is the last message we sent, set the state appropriately
+            internalState = lastMsg.getState();
+            // and set lastMsg to null
+            lastMsg = null;
+        }
     }
 
     /**
@@ -377,10 +397,6 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
          */
 
         log.debug("Handle Message for turnout {} in DIRECT feedback mode   ", mNumber);
-        if (internalState == STATUSREQUESTSENT && l.isUnsolicited()) {
-            // set the reply as being solicited
-            l.resetUnsolicited();
-        }
         if (getCommandedState() != getKnownState() || internalState == COMMANDSENT) {
             if (l.isOkMessage()) {
                 // Finally, we may just receive an OK message.
@@ -391,10 +407,6 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
                     return;
                 }
                 log.debug("Turnout {} DIRECT feedback mode - directed reply received.", mNumber);
-                // set the reply as being solicited
-                if (l.isUnsolicited()) {
-                    l.resetUnsolicited();
-                }
             }
             sendOffMessage();
             // Explicitly send two off messages in Direct Mode
@@ -526,19 +538,9 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
             log.debug("Current Thread ID: {} Thread Name {}", java.lang.Thread.currentThread().getId(), java.lang.Thread.currentThread().getName());
         }
         XNetMessage msg = getOffMessage();
-        // Set the known state to the commanded state.
-        // To avoid some of the command station busy
-        // messages, add a short delay before sending the
-        // first off message.
-            if (internalState != OFFSENT) {
-            jmri.util.ThreadingUtil.runOnLayoutDelayed( () ->
-               tc.sendHighPriorityXNetMessage(msg, this), 30);
-            newKnownState(getCommandedState());
-            internalState = OFFSENT;
-            return;
-        }
+        lastMsg = new RequestMessage(msg,OFFSENT,this);
+        this.internalState = OFFSENT;
         newKnownState(getCommandedState());
-        internalState = OFFSENT;
         // Then send the message.
         tc.sendHighPriorityXNetMessage(msg, this);
     }
@@ -560,9 +562,6 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
      */
     private synchronized boolean parseFeedbackMessage(FeedbackItem l) {
         log.debug("Message for turnout {}", mNumber);
-        if (internalState != IDLE && l.isUnsolicited()) {
-            l.resetUnsolicited();
-        }
         switch (l.getTurnoutStatus()) {
             case THROWN:
                 newKnownState(_mThrown);
@@ -594,7 +593,7 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
      */
     private static class XNetTurnoutStateListener implements java.beans.PropertyChangeListener {
 
-        XNetTurnout _turnout = null;
+        final XNetTurnout _turnout;
 
         XNetTurnoutStateListener(XNetTurnout turnout) {
             _turnout = turnout;
@@ -620,8 +619,8 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
                     // Check to see if this is a change in the status
                     // triggered by a device on the layout, or a change in
                     // status we triggered.
-                    int oldKnownState = ((Integer) event.getOldValue()).intValue();
-                    int curKnownState = ((Integer) event.getNewValue()).intValue();
+                    int oldKnownState = (Integer) event.getOldValue();
+                    int curKnownState = (Integer) event.getNewValue();
                     log.debug("propertyChange KnownState - old value {} new value {}", oldKnownState, curKnownState);
                     if (curKnownState != INCONSISTENT
                             && _turnout.getCommandedState() == oldKnownState) {
@@ -649,30 +648,26 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
 
     }
 
-    // data members
-    protected int mNumber;   // XpressNet turnout number
-    XNetTurnoutStateListener _stateListener;  // Internal class object
-
-    // A queue to hold outstanding messages
-    @GuardedBy("this")
-    protected final Queue<RequestMessage> requestList;
-
     /**
      * Send message from queue.
      */
     protected synchronized void sendQueuedMessage() {
 
-        RequestMessage msg = null;
+        lastMsg = null;
         // check to see if the queue has a message in it, and if it does,
         // remove the first message
-        msg = requestList.poll();
+        lastMsg = requestList.poll();
         // if the queue is not empty, remove the first message
         // from the queue, send the message, and set the state machine
-        // to the requried state.
-        if (msg != null) {
+        // to the required state.
+        if (lastMsg != null) {
             log.debug("sending message to traffic controller");
-            internalState = msg.getState();
-            tc.sendXNetMessage(msg.getMsg(), msg.getListener());
+            if(lastMsg.listener!=null) {
+                internalState = QUEUEDMESSAGE;
+            } else {
+                internalState = lastMsg.state;
+            }
+            tc.sendXNetMessage(lastMsg.getMsg(), lastMsg.getListener());
         } else {
             log.debug("message queue empty");
             // if the queue is empty, set the state to idle.
@@ -703,9 +698,9 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
      */
     protected static class RequestMessage {
 
-        private int state;
-        private XNetMessage msg;
-        private XNetListener listener;
+        private final int state;
+        private final XNetMessage msg;
+        private final XNetListener listener;
 
         RequestMessage(XNetMessage m, int s, XNetListener listener) {
             state = s;

--- a/java/test/jmri/implementation/AbstractTurnoutTestBase.java
+++ b/java/test/jmri/implementation/AbstractTurnoutTestBase.java
@@ -50,7 +50,7 @@ public abstract class AbstractTurnoutTestBase {
     static protected boolean listenerResult = false;
     static protected int listenStatus = Turnout.UNKNOWN;
 
-    public class Listen implements PropertyChangeListener {
+    public static class Listen implements PropertyChangeListener {
 
         @Override
         public void propertyChange(java.beans.PropertyChangeEvent e) {
@@ -106,10 +106,10 @@ public abstract class AbstractTurnoutTestBase {
         t.setCommandedState(Turnout.CLOSED);
         // check
         Assert.assertEquals("commanded state 1", Turnout.CLOSED, t.getCommandedState());
+        checkClosedMsgSent();
         ((AbstractTurnout)t).setKnownStateToCommanded();
         Assert.assertEquals("commanded state 2", Turnout.CLOSED, t.getState());
         Assert.assertEquals("commanded state 3", "Closed", t.describeState(t.getState()));
-        checkClosedMsgSent();
     }
 
     @Test
@@ -117,13 +117,13 @@ public abstract class AbstractTurnoutTestBase {
         t.setCommandedState(Turnout.THROWN);
         // check
         Assert.assertEquals("commanded state 1", Turnout.THROWN, t.getCommandedState());
+        checkThrownMsgSent();
         ((AbstractTurnout)t).setKnownStateToCommanded();
         Assert.assertEquals("commanded state 2", Turnout.THROWN, t.getState());
         Assert.assertEquals("commanded state 3", "Thrown", t.describeState(t.getState()));
-        checkThrownMsgSent();
     }
 
-    class TestSensor extends AbstractSensor {
+    static class TestSensor extends AbstractSensor {
             public boolean request = false;
 
             public TestSensor(String sysName, String userName){
@@ -181,10 +181,10 @@ public abstract class AbstractTurnoutTestBase {
         t.setCommandedState(Turnout.CLOSED);
         // check
         Assert.assertEquals("commanded state 1", Turnout.CLOSED, t.getCommandedState());
+        checkThrownMsgSent();
         ((AbstractTurnout)t).setKnownStateToCommanded();
         Assert.assertEquals("commanded state 2", Turnout.CLOSED, t.getState());
         Assert.assertEquals("commanded state 3", "Closed", t.describeState(t.getState()));
-        checkThrownMsgSent();
     }
 
     @Test
@@ -194,10 +194,10 @@ public abstract class AbstractTurnoutTestBase {
         t.setCommandedState(Turnout.THROWN);
         // check
         Assert.assertEquals("commanded state 1", Turnout.THROWN, t.getCommandedState());
+        checkClosedMsgSent();
         ((AbstractTurnout)t).setKnownStateToCommanded();
         Assert.assertEquals("commanded state 2", Turnout.THROWN, t.getState());
         Assert.assertEquals("commanded state 3", "Thrown", t.describeState(t.getState()));
-        checkClosedMsgSent();
     }
 
     @Test
@@ -242,9 +242,7 @@ public abstract class AbstractTurnoutTestBase {
         s1.setKnownState(Sensor.ACTIVE);
         s2.setKnownState(Sensor.INACTIVE);
 
-        JUnitUtil.waitFor( () -> {
-            return t.getKnownState() != Turnout.UNKNOWN;
-        });
+        JUnitUtil.waitFor( () -> t.getKnownState() != Turnout.UNKNOWN);
 
         Assert.assertEquals("state changed by TWOSENSOR feedback (Active, Inactive)", Turnout.THROWN, t.getKnownState());
 
@@ -281,12 +279,12 @@ public abstract class AbstractTurnoutTestBase {
         // Check that state changes appropriately
         t.setCommandedState(Turnout.THROWN);
         checkThrownMsgSent();
-        Assert.assertEquals(t.getState(), Turnout.THROWN);
+        Assert.assertEquals(Turnout.THROWN,t.getState());
         Assert.assertEquals("listener notified of change for DIRECT feedback", Turnout.THROWN, listenStatus);
 
         t.setCommandedState(Turnout.CLOSED);
         checkClosedMsgSent();
-        Assert.assertEquals(t.getState(), Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED,t.getState());
         Assert.assertEquals("listener notified of change for DIRECT feedback", Turnout.CLOSED, listenStatus);
     }
 

--- a/java/test/jmri/jmrix/lenz/XNetReplyTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetReplyTest.java
@@ -43,7 +43,7 @@ public class XNetReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testStringCtorEmptyString() {
         Assert.assertEquals("length", 0, msg.getNumDataElements());
-        Assert.assertTrue("empty reply",msg.toString().equals(""));
+        assertEquals("empty reply", "", msg.toString());
     }
 
     // Test the copy constructor.
@@ -83,40 +83,40 @@ public class XNetReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     public void testParity() {
         msg = new XNetReply("21 21 00");
         Assert.assertEquals("parity set test 1", 0, msg.getElement(2));
-        Assert.assertEquals("parity check test 1", true, msg.checkParity());
+        assertTrue("parity check test 1", msg.checkParity());
 
         msg = new XNetReply("21 21 00");
         msg.setElement(0, 0x21);
         msg.setElement(1, ~0x21);
         msg.setParity();
         Assert.assertEquals("parity set test 2", 0xFF, msg.getElement(2));
-        Assert.assertEquals("parity check test 2", true, msg.checkParity());
+        assertTrue("parity check test 2", msg.checkParity());
 
         msg = new XNetReply("21 21 00");
         msg.setElement(0, 0x18);
         msg.setElement(1, 0x36);
         msg.setParity();
         Assert.assertEquals("parity set test 3", 0x2E, msg.getElement(2));
-        Assert.assertEquals("parity check test 3", true, msg.checkParity());
+        assertTrue("parity check test 3", msg.checkParity());
 
         msg = new XNetReply("21 21 00");
         msg.setElement(0, 0x87);
         msg.setElement(1, 0x31);
         msg.setParity();
         Assert.assertEquals("parity set test 4", 0xB6, msg.getElement(2));
-        Assert.assertEquals("parity check test 4", true, msg.checkParity());
+        assertTrue("parity check test 4", msg.checkParity());
 
         msg = new XNetReply("21 21 00");
         msg.setElement(0, 0x18);
         msg.setElement(1, 0x36);
         msg.setElement(2, 0x0e);
-        Assert.assertEquals("parity check test 5", false, msg.checkParity());
+        assertFalse("parity check test 5", msg.checkParity());
 
         msg = new XNetReply("21 21 00");
         msg.setElement(0, 0x18);
         msg.setElement(1, 0x36);
         msg.setElement(2, 0x8e);
-        Assert.assertEquals("parity check test 6", false, msg.checkParity());
+        assertFalse("parity check test 6", msg.checkParity());
     }
 
     // test accessor methods for elements.
@@ -132,7 +132,7 @@ public class XNetReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetElementBCD(){
        msg=new XNetReply("63 14 01 04 72");
-       Assert.assertEquals("getElementBCD Return Value",(long)14,(long)msg.getElementBCD(1));
+       Assert.assertEquals("getElementBCD Return Value", 14,(long)msg.getElementBCD(1));
     }
 
     // check skipPrefix
@@ -1096,9 +1096,7 @@ public class XNetReplyTest extends jmri.jmrix.AbstractMessageTestBase {
         Assert.assertTrue(r.isUnsolicited());
         // feedback message.
         r = new XNetReply("42 05 48 0f");
-        Assert.assertTrue(r.isUnsolicited());
-        r.resetUnsolicited();
-        Assert.assertFalse(r.isUnsolicited()); 
+        Assert.assertFalse(r.isUnsolicited());
     }
 
     // check toMonitor string for informational messages from the command station
@@ -1500,7 +1498,6 @@ public class XNetReplyTest extends jmri.jmrix.AbstractMessageTestBase {
         FeedbackItem oddItem = selected.get();
 
         assertTrue("Motion completed", oddItem.isMotionComplete());
-        assertTrue("Initially unsolicited", oddItem.isUnsolicited());
         assertTurnoutFeedbackData(r, 1, 21, 0, 1, oddItem);
         
         selected = r.selectTurnoutFeedback(22);
@@ -1509,8 +1506,6 @@ public class XNetReplyTest extends jmri.jmrix.AbstractMessageTestBase {
         FeedbackItem evenItem = selected.get();
         assertTurnoutFeedbackData(r, 1, 22, 2, 1, evenItem);
         
-        // make solicited:
-        oddItem.resetUnsolicited();
         assertFalse(r.isUnsolicited());
         
         // 5 * 4, upper nibble = 23 (C) + 24 (T)

--- a/java/test/jmri/jmrix/lenz/XNetTurnoutTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetTurnoutTest.java
@@ -26,18 +26,28 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
     }
 
+    protected void checkClosedOffSent() {
+        Assert.assertEquals("closed message OFF", "52 05 80 D7",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        ((jmri.jmrix.lenz.XNetTurnout) t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
+    }
+
     @Override
     public void checkThrownMsgSent() {
         Assert.assertEquals("thrown message", "52 05 89 DE",
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
     }
 
+    protected void checkThrownOffSent() {
+        Assert.assertEquals("thrown message OFF", "52 05 81 D6",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        ((jmri.jmrix.lenz.XNetTurnout) t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
+    }
+
     @Test
     public void checkIncoming() {
         t.setFeedbackMode(Turnout.MONITORING);
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return t.getFeedbackMode() == Turnout.MONITORING;
-        }, "Feedback mode set");
+        jmri.util.JUnitUtil.waitFor(() -> t.getFeedbackMode() == Turnout.MONITORING, "Feedback mode set");
 
         listenStatus = Turnout.UNKNOWN;
         t.addPropertyChangeListener(new Listen());
@@ -45,18 +55,14 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
         // notify the object that somebody else changed it...
         XNetReply m = new XNetReply("42 05 01 46"); // set CLOSED
         ((XNetTurnout) t).message(m);
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return listenStatus != Turnout.UNKNOWN;
-        }, "Turnout state changed");
+        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
         Assert.assertEquals("state after CLOSED message", Turnout.CLOSED, t.getKnownState());
 
         listenStatus = Turnout.UNKNOWN;
 
         m = new XNetReply("42 05 02 45"); // set THROWN
         ((XNetTurnout) t).message(m);
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return listenStatus != Turnout.UNKNOWN;
-        }, "Turnout state changed");
+        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
         Assert.assertEquals("state after THROWN message", Turnout.THROWN, t.getKnownState());
     }
 
@@ -71,10 +77,11 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
             log.error("TO exception: {}", e);
         }
 
-        Assert.assertTrue(t.getCommandedState() == Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, t.getCommandedState());
 
         Assert.assertEquals("on message sent", "52 05 88 DF",
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        ((jmri.jmrix.lenz.XNetTurnout) t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
 
         // notify that the command station received the reply
         XNetReply m = new XNetReply();
@@ -92,6 +99,9 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
         // outbound size to change.
         Assert.assertEquals("off message sent", "52 05 80 D7",
                 lnis.outbound.elementAt(n).toString());
+        ((jmri.jmrix.lenz.XNetTurnout) t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
+
+        ((jmri.jmrix.lenz.XNetTurnout) t).message(lnis.outbound.elementAt(n-1));
 
         // the turnout will not set its state until it sees an OK message.
         m = new XNetReply();
@@ -99,16 +109,14 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
         m.setElement(1, 0x04);
         m.setElement(2, 0x05);
 
-        n = lnis.outbound.size();
-
         ((jmri.jmrix.lenz.XNetTurnout) t).message(m);
 
-        while (n == lnis.outbound.size()) {
-        } // busy loop.  Wait for
+      //  while (n == lnis.outbound.size()) {
+      //  } // busy loop.  Wait for
         // outbound size to change.
 
-        Assert.assertEquals("off message sent", "52 05 80 D7",
-                lnis.outbound.elementAt(n).toString());
+        checkClosedOffSent();
+        ((jmri.jmrix.lenz.XNetTurnout) t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
 
         m = new XNetReply();
         m.setElement(0, 0x01);
@@ -119,7 +127,7 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
 
         // no wait here.  The last reply should cause the turnout to
         // set it's state, but it will not cause another reply.
-        Assert.assertTrue(t.getKnownState() == Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, t.getKnownState());
     }
 
     // Test that property change events are properly sent from the parent
@@ -133,7 +141,7 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
         } catch (Exception e) {
             log.error("TO exception: {}", e);
         }
-        Assert.assertTrue(t.getCommandedState() == Turnout.THROWN);
+        Assert.assertEquals(Turnout.THROWN, t.getCommandedState());
 
         t.setFeedbackMode(Turnout.ONESENSOR);
         jmri.Sensor s = jmri.InstanceManager.sensorManagerInstance().provideSensor("IS1");
@@ -149,9 +157,7 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
             log.error("TO exception: {}", x);
         }
         // check to see if the turnout state changes.
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return t.getKnownState() == Turnout.THROWN;
-        }, "Turnout goes THROWN");
+        jmri.util.JUnitUtil.waitFor(() -> t.getKnownState() == Turnout.THROWN, "Turnout goes THROWN");
     }
 
     @Override
@@ -166,7 +172,7 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
 
     @Test
     @Override
-    public void testDirectFeedback() throws jmri.JmriException {
+    public void testDirectFeedback() {
         t.setFeedbackMode(Turnout.DIRECT);
         Assert.assertEquals("Feedback Mode after set", Turnout.DIRECT, t.getFeedbackMode());
 
@@ -176,28 +182,30 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
         // Check that state changes appropriately
         t.setCommandedState(Turnout.THROWN);
         checkThrownMsgSent();
+        ((jmri.jmrix.lenz.XNetTurnout) t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
+        checkThrownOffSent();
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return listenStatus != Turnout.UNKNOWN;
-        }, "Turnout state changed");
-        Assert.assertEquals(t.getState(), Turnout.THROWN);
+        checkThrownOffSent();
+        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
+        Assert.assertEquals(Turnout.THROWN,t.getState());
         Assert.assertEquals("listener notified of change for DIRECT feedback", Turnout.THROWN, listenStatus);
 
         listenStatus = Turnout.UNKNOWN;
         t.setCommandedState(Turnout.CLOSED);
         checkClosedMsgSent();
+        ((jmri.jmrix.lenz.XNetTurnout) t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
+        checkClosedOffSent();
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return listenStatus != Turnout.UNKNOWN;
-        }, "Turnout state changed");
-        Assert.assertEquals(t.getState(), Turnout.CLOSED);
+        checkClosedOffSent();
+        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
+        Assert.assertEquals(Turnout.CLOSED,t.getState());
         Assert.assertEquals("listener notified of change for DIRECT feedback", Turnout.CLOSED, listenStatus);
     }
 
     @Test
-    public void testMonitoringFeedback() throws jmri.JmriException {
+    public void testMonitoringFeedback() {
         Assert.assertEquals("Feedback Mode after set", Turnout.MONITORING, t.getFeedbackMode());
 
         listenStatus = Turnout.UNKNOWN;
@@ -206,25 +214,28 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
         // Check that state changes appropriately
         t.setCommandedState(Turnout.THROWN);
         checkThrownMsgSent();
+        ((jmri.jmrix.lenz.XNetTurnout) t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
         ((XNetTurnout) t).message(new XNetReply("42 05 02 46"));
+        checkThrownOffSent();
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
+        checkThrownOffSent();
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return listenStatus != Turnout.UNKNOWN;
-        }, "Turnout state changed");
-        Assert.assertEquals(t.getState(), Turnout.THROWN);
+        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
+        Assert.assertEquals(Turnout.THROWN,t.getState());
         Assert.assertEquals("listener notified of change for DIRECT feedback", Turnout.THROWN, listenStatus);
 
         listenStatus = Turnout.UNKNOWN;
         t.setCommandedState(Turnout.CLOSED);
         checkClosedMsgSent();
+        ((jmri.jmrix.lenz.XNetTurnout) t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
         ((XNetTurnout) t).message(new XNetReply("42 05 01 46"));
+        checkClosedOffSent();
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
+        checkClosedOffSent();
         ((XNetTurnout) t).message(new XNetReply("01 04 05"));
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return listenStatus != Turnout.UNKNOWN;
-        }, "Turnout state changed");
-        Assert.assertEquals(t.getState(), Turnout.CLOSED);
+        checkClosedOffSent();
+        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
+        Assert.assertEquals(Turnout.CLOSED,t.getState());
         Assert.assertEquals("listener notified of change for DIRECT feedback", Turnout.CLOSED, listenStatus);
     }
 
@@ -244,8 +255,10 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
 
     @After
     public void tearDown() {
+        lnis.terminateThreads();
+        lnis = null;
+        t.dispose();
         t = null;
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutTest.java
@@ -27,6 +27,16 @@ public class EliteXNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
     }
 
+    @Override
+    protected void checkClosedOffSent() {
+        // We do not send off messages to the Elite
+    }
+
+    @Override
+    protected void checkThrownOffSent() {
+        // We do not send off messages to the Elite
+    }
+
     // Test the XNetTurnout message sequence.
     @Test
     @Override
@@ -39,7 +49,7 @@ public class EliteXNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
             log.error("TO exception: {}", e);
         }
 
-        Assert.assertTrue(t.getCommandedState() == jmri.Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, t.getCommandedState());
 
         Assert.assertEquals("on message sent", "52 05 8A DD",
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
@@ -55,16 +65,14 @@ public class EliteXNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
 
         // no wait here.  The last reply should cause the turnout to
         // set it's state, but it will not cause another reply.
-        Assert.assertTrue(t.getKnownState() == jmri.Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, t.getKnownState());
     }
 
     @Test
     @Override
     public void checkIncoming() {
         t.setFeedbackMode(Turnout.MONITORING);
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return t.getFeedbackMode() == Turnout.MONITORING;
-        }, "Feedback mode set");
+        jmri.util.JUnitUtil.waitFor(() -> t.getFeedbackMode() == Turnout.MONITORING, "Feedback mode set");
 
         listenStatus = Turnout.UNKNOWN;
         t.addPropertyChangeListener(new Listen());
@@ -72,18 +80,14 @@ public class EliteXNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
         // notify the object that somebody else changed it...
         XNetReply m = new XNetReply("42 05 04 43"); // set CLOSED
         ((EliteXNetTurnout) t).message(m);
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return listenStatus != Turnout.UNKNOWN;
-        }, "Turnout state changed");
+        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
         Assert.assertEquals("state after CLOSED message", Turnout.CLOSED, t.getKnownState());
 
         listenStatus = Turnout.UNKNOWN;
 
         m = new XNetReply("42 05 08 4F"); // set THROWN
         ((EliteXNetTurnout) t).message(m);
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return listenStatus != Turnout.UNKNOWN;
-        }, "Turnout state changed");
+        jmri.util.JUnitUtil.waitFor(() -> listenStatus != Turnout.UNKNOWN, "Turnout state changed");
         Assert.assertEquals("state after THROWN message", Turnout.THROWN, t.getKnownState());
     }
 
@@ -103,7 +107,7 @@ public class EliteXNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
     @Override
     @After
     public void tearDown() {
-        lnis.getSystemConnectionMemo().getXNetTrafficController().terminateThreads();
+        lnis.terminateThreads();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetTurnoutTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetTurnoutTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.roco.z21;
 
+import jmri.Turnout;
 import jmri.jmrix.lenz.XNetInterfaceScaffold;
 import jmri.jmrix.lenz.XNetReply;
 import jmri.util.JUnitUtil;
@@ -42,10 +43,12 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
         } catch (Exception e) {
             log.error("TO exception: {}", e);
         }
-        Assert.assertTrue(t.getCommandedState() == jmri.Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, t.getCommandedState());
 
         Assert.assertEquals("on message sent", "53 00 14 88 CF",
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+
+        ((Z21XNetTurnout)t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
 
         // notify that the command station received the reply
         XNetReply m = new XNetReply();
@@ -65,6 +68,8 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
         Assert.assertEquals("off message sent", "53 00 14 80 C7",
                 lnis.outbound.elementAt(n).toString());
 
+        ((Z21XNetTurnout)t).message(lnis.outbound.elementAt(lnis.outbound.size()-1));
+
         // the turnout will not set its state until it sees a reply message.
         m = new XNetReply();
         m.setElement(0, 0x43);
@@ -77,7 +82,7 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
 
         // no wait here.  The last reply should cause the turnout to 
         // set it's state, but it will not cause another reply.
-        Assert.assertTrue(t.getKnownState() == jmri.Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, t.getKnownState());
     }
 
     // Test that property change events are properly sent from the parent
@@ -97,7 +102,7 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
         } catch (Exception e) {
             log.error("TO exception: {}", e);
         }
-        Assert.assertTrue(t.getCommandedState() == jmri.Turnout.THROWN);
+        Assert.assertEquals(Turnout.THROWN, t.getCommandedState());
 
         t.setFeedbackMode(jmri.Turnout.ONESENSOR);
         jmri.Sensor s = jmri.InstanceManager.sensorManagerInstance().provideSensor("IS1");
@@ -113,7 +118,7 @@ public class Z21XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest {
             log.error("TO exception: {}", x);
         }
         // check to see if the turnout state changes.
-        Assert.assertTrue(t.getKnownState() == jmri.Turnout.THROWN);
+        Assert.assertEquals(Turnout.THROWN, t.getKnownState());
     }
 
     @Test

--- a/java/test/jmri/jmrix/ztc/ztc611/ZTC611XNetTurnoutTest.java
+++ b/java/test/jmri/jmrix/ztc/ztc611/ZTC611XNetTurnoutTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.ztc.ztc611;
 
+import jmri.Turnout;
 import jmri.jmrix.lenz.LenzCommandStation;
 import jmri.jmrix.lenz.XNetInterfaceScaffold;
 import jmri.jmrix.lenz.XNetReply;
@@ -15,6 +16,16 @@ import org.slf4j.LoggerFactory;
  */
 public class ZTC611XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest{
 
+    @Override
+    protected void checkClosedOffSent() {
+        // We do not send off messages to the ZTC 611
+    }
+
+    @Override
+    protected void checkThrownOffSent() {
+        // We do not send off messages to the ZTC 611
+    }
+
     // Test the XNetTurnout message sequence.
     @Test
     @Override
@@ -27,10 +38,12 @@ public class ZTC611XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest{
             log.error("TO exception: {}", e);
         }
 
-        Assert.assertTrue(t.getCommandedState() == jmri.Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, t.getCommandedState());
 
         Assert.assertEquals("on message sent", "52 05 88 DF",
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+
+        ((ZTC611XNetTurnout)t).message(lnis.outbound.elementAt(lnis.outbound.size() - 1));
 
         // notify that the command station received the reply
         XNetReply m = new XNetReply();
@@ -43,7 +56,7 @@ public class ZTC611XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest{
 
         // no wait here.  The last reply should cause the turnout to
         // set it's state, but it will not cause another reply.
-        Assert.assertTrue(t.getKnownState() == jmri.Turnout.CLOSED);
+        Assert.assertEquals(Turnout.CLOSED, t.getKnownState());
     }
 
     @Override
@@ -62,9 +75,10 @@ public class ZTC611XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest{
     @Override
     @After
     public void tearDown() {
+        t.dispose();
         t = null;
+        lnis.terminateThreads();
         lnis = null;
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
 
     }


### PR DESCRIPTION
@svatoun convinced me that it was necessary to adjust the internal state machine for XpressNet turnouts.

The code in this PR forces the turnout to not change state when a message is dispatched to the traffic controller, but to instead change state when the turnout sees the last message it queued echoed back to it by the traffic controller.

This simplified some of the feedback processing logic, since we no longer have to be worry, in the turnout, about whether or not we triggered the feedback.