### PR TITLE
Fix Store Clock Settings button labels

### DIFF
--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -756,7 +756,7 @@ public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListen
                 : Bundle.getMessage("StoreClockString") );
         
         // remind to save
-        Object[] options = {Bundle.getMessage("ButtonSaveUser"), Bundle.getMessage("ButtonSaveConfig"),
+        Object[] options = {Bundle.getMessage("ButtonSaveConfig"), Bundle.getMessage("ButtonSaveUser"),
                 Bundle.getMessage("ButtonCancel")};
         int retval = javax.swing.JOptionPane.showOptionDialog(this,
                 messageString,


### PR DESCRIPTION
Store Config Only / Config + panel buttons show correct labels.

This PR moves 8640 to the release-4.19.8 branch.