### PR TITLE
Layout Editor:Panels do not display properly

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
@@ -48,11 +48,13 @@ class LayoutEditorComponent extends JComponent {
             Graphics2D g2 = (Graphics2D) g;
 
             if (clipBounds != null) {
-                if ((clipBounds.getWidth() > 0) && (clipBounds.getHeight() > 0)) {
-                    if (!clipBounds.equals(g2.getClipBounds())) {
-                        //log.debug("LEComponent.paint(); clipBounds: {}, oldClipBounds: {}",
-                        //        clipBounds, g2.getClipBounds());
-                        g2.setClip(clipBounds);
+                if (!clipBounds.isEmpty()) {
+                    if ((clipBounds.getWidth() > 0) && (clipBounds.getHeight() > 0)) {
+                        if (!clipBounds.equals(g2.getClipBounds())) {
+                            //log.debug("LEComponent.paint(); clipBounds: {}, oldClipBounds: {}",
+                            //        clipBounds, g2.getClipBounds());
+                            g2.setClip(clipBounds);
+                        }
                     }
                 }
             }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
@@ -48,8 +48,12 @@ class LayoutEditorComponent extends JComponent {
             Graphics2D g2 = (Graphics2D) g;
 
             if (clipBounds != null) {
-                if (!clipBounds.equals(g2.getClipBounds())) {
-                    g2.setClip(clipBounds);
+                if ((clipBounds.getWidth() > 0) && (clipBounds.getHeight() > 0)) {
+                    if (!clipBounds.equals(g2.getClipBounds())) {
+                        log.error("LEComponent.paint(); clipBounds: {}, oldClipBounds: {}",
+                                clipBounds, g2.getClipBounds());
+                        g2.setClip(clipBounds);
+                    }
                 }
             }
             // Optional antialising, to eliminate (reduce) staircase on diagonal lines

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
@@ -50,8 +50,8 @@ class LayoutEditorComponent extends JComponent {
             if (clipBounds != null) {
                 if ((clipBounds.getWidth() > 0) && (clipBounds.getHeight() > 0)) {
                     if (!clipBounds.equals(g2.getClipBounds())) {
-                        log.error("LEComponent.paint(); clipBounds: {}, oldClipBounds: {}",
-                                clipBounds, g2.getClipBounds());
+                        //log.debug("LEComponent.paint(); clipBounds: {}, oldClipBounds: {}",
+                        //        clipBounds, g2.getClipBounds());
                         g2.setClip(clipBounds);
                     }
                 }


### PR DESCRIPTION
Initial getPanelScrollPane().getViewportBorderBounds() have negative width/height. (Why?)
Added code to not set clipBounds based on bogus width/height.
For issue [#8188](https://github.com/JMRI/JMRI/issues/8188)