### PR TITLE
Bugfix: Incorrect handling of complex bitmasks by splitVal.

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -99,15 +99,12 @@ public class SplitVariableValue extends VariableValue
         for (int i = 0; i < cvCount; i++) {
             cvList.get(i).startOffset = currentOffset;
             String t = cvList.get(i).cvMask;
-            while (t.length() > 0) {
-                if (t.startsWith("V")) {
-                    currentOffset++;
-                }
-                t = t.substring(1);
+            if (t.contains("V")) {
+                currentOffset = currentOffset + t.lastIndexOf("V") - t.indexOf("V") + 1;
+            } else {
+                log.error("Variable={};cvName={};cvMask={} is an invalid bitmask", _name, cvList.get(i).cvName, cvList.get(i).cvMask);
             }
-            if (log.isDebugEnabled()) {
-                log.debug("cvName={};cvMask={};startOffset={}", cvList.get(i).cvName, cvList.get(i).cvMask, cvList.get(i).startOffset);
-            }
+            log.debug("Variable={};cvName={};cvMask={};startOffset={};currentOffset={}", _name, cvList.get(i).cvName, cvList.get(i).cvMask, cvList.get(i).startOffset, currentOffset);
 
             // connect CV for notification
             CvValue cv = (_cvMap.get(cvList.get(i).cvName));

--- a/java/test/jmri/jmrit/symbolicprog/SplitVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/SplitVariableValueTest.java
@@ -5,8 +5,10 @@ import java.awt.event.FocusEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+
 import javax.swing.JLabel;
 import javax.swing.JTextField;
+
 import jmri.progdebugger.ProgDebugger;
 import jmri.util.CvUtil;
 import jmri.util.JUnitUtil;
@@ -502,7 +504,7 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         int pFactor = 1;
         int pOffset = 0;
         String uppermask = "";
-        String extra1 = "upper";
+        String extra1 = null;
         String extra2 = null;
         String extra3 = null;
         String extra4 = null;
@@ -620,6 +622,278 @@ public class SplitVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("set CV" + cv[6].number(), 0x00, cv[6].getValue());
         Assert.assertEquals("set CV" + cv[7].number(), 0x80, cv[7].getValue());
         Assert.assertEquals("set var text value", "9223372036854775808", ((JTextField) var.getCommonRep()).getText());
+
+    }
+
+    @Test
+    public void testCvChangesMaskedBits0() {
+        String name = "Servo16";
+        String comment = "";
+        String cvName = "";
+        boolean readOnly = false;
+        boolean infoOnly = false;
+        boolean writeOnly = false;
+        boolean opsOnly = false;
+        String lowCVnum = "11";
+        String mask = "XXXVXXVX";
+        int minVal = 0;
+        int maxVal = 0;
+        JLabel status = new JLabel();
+        String stdname = "";
+        String highCVnum = "12";
+        int pFactor = 1;
+        int pOffset = 0;
+        String uppermask = "XXXXVXXX";
+        String extra1 = null;
+        String extra2 = null;
+        String extra3 = null;
+        String extra4 = null;
+        HashMap<String, CvValue> v = createCvMap();
+        CvValue cv1 = new CvValue(lowCVnum, p);
+        CvValue cv2 = new CvValue(highCVnum, p);
+        cv1.setValue(0);
+        cv2.setValue(0);
+        v.put(lowCVnum, cv1);
+        v.put(highCVnum, cv2);
+        // create a variable pointed at CVs
+        SplitVariableValue var = new SplitVariableValue(name, comment, cvName,
+                readOnly, infoOnly, writeOnly, opsOnly,
+                lowCVnum, mask, minVal, maxVal,
+                v, status, stdname,
+                highCVnum, pFactor, pOffset, uppermask, extra1, extra2, extra3, extra4);
+        Assert.assertNotNull("makeVar returned null", var);
+
+        CvValue[] cv = var.usesCVs();
+
+        Assert.assertEquals("number of CVs is", 2, cv.length);
+
+        Assert.assertEquals("cv[0] is", lowCVnum, cv[0].number());
+        Assert.assertEquals("cv[1] is", highCVnum, cv[1].number());
+
+        // Start with all zero values
+        var.setLongValue(0x00);
+        cv[0].setValue(0x00);
+        cv[1].setValue(0x00);
+        Assert.assertEquals("get CV" + cv[0].number(), 0x00, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 0x00, cv[1].getValue());
+        Assert.assertEquals("get Value", 0x00, var.getLongValue());
+        Assert.assertEquals("get text value", "0", ((JTextField) var.getCommonRep()).getText());
+
+        // Following samples provided by Robin Becker
+        cv[0].setValue(255);
+        cv[1].setValue(0);
+        Assert.assertEquals("get CV" + cv[0].number(), 255, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 0, cv[1].getValue());
+        Assert.assertEquals("get Value", 9, var.getLongValue());
+        Assert.assertEquals("get text value", "9", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(0);
+        cv[1].setValue(255);
+        Assert.assertEquals("get CV" + cv[0].number(), 0, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 255, cv[1].getValue());
+        Assert.assertEquals("get Value", 16, var.getLongValue());
+        Assert.assertEquals("get text value", "16", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(2);
+        cv[1].setValue(255);
+        Assert.assertEquals("get CV" + cv[0].number(), 2, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 255, cv[1].getValue());
+        Assert.assertEquals("get Value", 17, var.getLongValue());
+        Assert.assertEquals("get text value", "17", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(255);
+        cv[1].setValue(2);
+        Assert.assertEquals("get CV" + cv[0].number(), 255, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 2, cv[1].getValue());
+        Assert.assertEquals("get Value", 9, var.getLongValue());
+        Assert.assertEquals("get text value", "9", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(255);
+        cv[1].setValue(255);
+        Assert.assertEquals("get CV" + cv[0].number(), 255, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 255, cv[1].getValue());
+        Assert.assertEquals("get Value", 25, var.getLongValue());
+        Assert.assertEquals("get text value", "25", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(1);
+        cv[1].setValue(240);
+        Assert.assertEquals("get CV" + cv[0].number(), 1, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 240, cv[1].getValue());
+        Assert.assertEquals("get Value", 0, var.getLongValue());
+        Assert.assertEquals("get text value", "0", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(4);
+        cv[1].setValue(240);
+        Assert.assertEquals("get CV" + cv[0].number(), 4, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 240, cv[1].getValue());
+        Assert.assertEquals("get Value", 0, var.getLongValue());
+        Assert.assertEquals("get text value", "0", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(7);
+        cv[1].setValue(240);
+        Assert.assertEquals("get CV" + cv[0].number(), 7, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 240, cv[1].getValue());
+        Assert.assertEquals("get Value", 1, var.getLongValue());
+        Assert.assertEquals("get text value", "1", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(2);
+        cv[1].setValue(240);
+        Assert.assertEquals("get CV" + cv[0].number(), 2, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 240, cv[1].getValue());
+        Assert.assertEquals("get Value", 1, var.getLongValue());
+        Assert.assertEquals("get text value", "1", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(0);
+        cv[1].setValue(15);
+        Assert.assertEquals("get CV" + cv[0].number(), 0, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 15, cv[1].getValue());
+        Assert.assertEquals("get Value", 16, var.getLongValue());
+        Assert.assertEquals("get text value", "16", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(15);
+        cv[1].setValue(15);
+        Assert.assertEquals("get CV" + cv[0].number(), 15, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 15, cv[1].getValue());
+        Assert.assertEquals("get Value", 17, var.getLongValue());
+        Assert.assertEquals("get text value", "17", ((JTextField) var.getCommonRep()).getText());
+
+    }
+
+    @Test
+    public void testCvChangesMaskedBits1() {
+        String name = "Servo16";
+        String comment = "";
+        String cvName = "";
+        boolean readOnly = false;
+        boolean infoOnly = false;
+        boolean writeOnly = false;
+        boolean opsOnly = false;
+        String lowCVnum = "11";
+        String mask = "XXXVXXVX";
+        int minVal = 0;
+        int maxVal = 0;
+        JLabel status = new JLabel();
+        String stdname = "";
+        String highCVnum = "12";
+        int pFactor = 1;
+        int pOffset = 0;
+        String uppermask = "XXXXVXXX";
+        String extra1 = null;
+        String extra2 = null;
+        String extra3 = null;
+        String extra4 = null;
+        HashMap<String, CvValue> v = createCvMap();
+        CvValue cv1 = new CvValue(lowCVnum, p);
+        CvValue cv2 = new CvValue(highCVnum, p);
+        cv1.setValue(0);
+        cv2.setValue(0);
+        v.put(lowCVnum, cv1);
+        v.put(highCVnum, cv2);
+        // create a variable pointed at CVs
+        SplitVariableValue var = new SplitVariableValue(name, comment, cvName,
+                readOnly, infoOnly, writeOnly, opsOnly,
+                lowCVnum, mask, minVal, maxVal,
+                v, status, stdname,
+                highCVnum, pFactor, pOffset, uppermask, extra1, extra2, extra3, extra4);
+        Assert.assertNotNull("makeVar returned null", var);
+
+        CvValue[] cv = var.usesCVs();
+
+        Assert.assertEquals("number of CVs is", 2, cv.length);
+
+        Assert.assertEquals("cv[0] is", lowCVnum, cv[0].number());
+        Assert.assertEquals("cv[1] is", highCVnum, cv[1].number());
+
+        // We will set all ignored bits in the CVs to check that they don't affect the result.
+        int lowIgnored = ~var.maskValAsInt(mask) & 0xFF;
+        int highIgnored = ~var.maskValAsInt(uppermask) & 0xFF;
+
+        // Start with all zero values
+        var.setLongValue(0x00);
+        cv[0].setValue(0x00 | lowIgnored);
+        cv[1].setValue(0x00 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 0x00 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 0x00 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 0x00, var.getLongValue());
+        Assert.assertEquals("get text value", "0", ((JTextField) var.getCommonRep()).getText());
+
+        // Following samples provided by Robin Becker
+        cv[0].setValue(255 | lowIgnored);
+        cv[1].setValue(0 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 255 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 0 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 9, var.getLongValue());
+        Assert.assertEquals("get text value", "9", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(0 | lowIgnored);
+        cv[1].setValue(255 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 0 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 255 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 16, var.getLongValue());
+        Assert.assertEquals("get text value", "16", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(2 | lowIgnored);
+        cv[1].setValue(255 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 2 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 255 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 17, var.getLongValue());
+        Assert.assertEquals("get text value", "17", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(255 | lowIgnored);
+        cv[1].setValue(2 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 255 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 2 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 9, var.getLongValue());
+        Assert.assertEquals("get text value", "9", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(255 | lowIgnored);
+        cv[1].setValue(255 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 255 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 255 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 25, var.getLongValue());
+        Assert.assertEquals("get text value", "25", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(1 | lowIgnored);
+        cv[1].setValue(240 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 1 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 240 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 0, var.getLongValue());
+        Assert.assertEquals("get text value", "0", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(4 | lowIgnored);
+        cv[1].setValue(240 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 4 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 240 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 0, var.getLongValue());
+        Assert.assertEquals("get text value", "0", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(7 | lowIgnored);
+        cv[1].setValue(240 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 7 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 240 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 1, var.getLongValue());
+        Assert.assertEquals("get text value", "1", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(2 | lowIgnored);
+        cv[1].setValue(240 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 2 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 240 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 1, var.getLongValue());
+        Assert.assertEquals("get text value", "1", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(0 | lowIgnored);
+        cv[1].setValue(15 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 0 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 15 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 16, var.getLongValue());
+        Assert.assertEquals("get text value", "16", ((JTextField) var.getCommonRep()).getText());
+
+        cv[0].setValue(15 | lowIgnored);
+        cv[1].setValue(15 | highIgnored);
+        Assert.assertEquals("get CV" + cv[0].number(), 15 | lowIgnored, cv[0].getValue());
+        Assert.assertEquals("get CV" + cv[1].number(), 15 | highIgnored, cv[1].getValue());
+        Assert.assertEquals("get Value", 17, var.getLongValue());
+        Assert.assertEquals("get text value", "17", ((JTextField) var.getCommonRep()).getText());
 
     }
 


### PR DESCRIPTION
Complex bitmasks (e.g. "XXXVXXVX") were being handled incorrectly by splitVal.

Reported by @n3ix in private communication.