### PR TITLE
Instructions for changing some Digitrax 'Board ID's

### DIFF
--- a/help/en/html/hardware/loconet/Digitrax.shtml
+++ b/help/en/html/hardware/loconet/Digitrax.shtml
@@ -94,6 +94,7 @@
               <li><a href="#devicetoolhelp">JMRI LocoNet-specific Help pages</a>
 
               <li><a href="#loconetRoster">Configuring some LocoNet devices via "Roster" entries</a></li>
+              <li><a href="#deviceBoardId">Programming Board ID (Board Address) for some Digitrax devices</a></li>
               <li><a href="#devicetoollimits">Some JMRI LocoNet-specific device and feature limitations</a></li>
           </ul></li>
           <li><a href="#Support">Support</a></li>
@@ -1128,6 +1129,122 @@
         other tools or processes, it will be necessary to manually update the
         roster entry.</p>
 
+      <a name="deviceBoardId" id="deviceBoardId"></a><h3>Programming Board ID (Board Address) for some Digitrax devices</h3>
+      <p>Some Digitrax devices can be configured for "Board ID" number (sometimes called 
+          Board Address).  This value is typically used to influence which Turnout, 
+          Sensor, Reporter, and/or Power Manager section numbers are used by the 
+          device.</p>
+      <p>Digitrax devices which make use of "Board ID" numbers, but which cannot be
+      programatically configured, include:</p>
+      <ul>
+          <li>Digitrax DS64</li>
+          <li>Digitrax BDL16, BDL162, and BDL168</li>
+          <li>Digitrax PM4, PM42</li>
+          <li>Digitrax SE8C</li>
+          <li>Digitrax BXPA1</li>
+          <li>Digitrax BXP88</li>
+      </ul>
+      <p>For these devices, JMRI cannot configure the Board ID number under JMRI's
+          control without user intervention.  It is, however, possible to configure 
+          the Board ID number using JMRI and manual intervention.  The process is
+          to follow the directions found in the device manual for changing Board 
+          Address (Board ID), but use JMRI's "Turnout Control" tool instead of a 
+          LocoNet throttle.</p>
+      <p>Below is a table showing, on the left, the Digitrax instructions copied 
+          from the BDL168 manual, and, on the right, the instructions when using JMRI.  
+          Similar instructions may be used to configure other the Board Address 
+          (Board ID) on other Digitrax devices.</p>
+      <table border="3">
+          <tr><td style="width: 6%" align="center"><strong>Step</strong></td>
+              <td style="width: 47%" align="center"><strong>Digitrax Instructions 
+                      for changing BDL168 Board Address</strong></td>
+              <td style="width: 47%" align="center"><strong>Instructions for 
+                      changing Board Address (Board ID) when using JMRI</strong></td></tr>
+          <tr><td align="center">0</td><td colspan="2"><strong>(A step <em>not</em> included in Digitrax 
+                  documentation, but one that is necessary regardless of what 
+                  method you use!)</strong><br><br>0. Ensure that <em>NO OTHER ACTIVITY</em> is occurring on LocoNet!<br><br>
+                  If <em>anything</em> causes generation of a LocoNet Turnout Control 
+                  message after the device button has been pressed, but before you 
+                  issue the turnout control message to the specific number you 
+                  desire, then the board will be configured to use that unexpected 
+                  turnout number, leaving the board unmanageable at the Board ID 
+                  number you are expecting!<br><br>Be aware that movement of trains on 
+                  layouts where signaling is implemented can cause generation of
+                  LocoNet Turnout control messages!</td></tr>
+          <tr><td></td><td>Note: The steps below are from Section "<em>8.1 To set up the BDL168 board address</em>", with some comments added by JMRI developers.)</td><td></td></tr>
+          <tr><td align="center">0.25</td><td></td><td>Configure JMRI to communicate with with your LocoNet hardware.</td></tr>
+          <tr><td align="center">0.5</td><td></td><td>See <a href="#BoardIdNote1">Note 1</a> below before 
+                  proceeding.</td></tr>
+          <tr><td align="center">1</td><td>Power up your BDL168.</td><td>Power up your layout and start JMRI.</td></tr>
+          <tr><td align="center">2</td><td>Press the switch behind the green ID LED for about 1 second, 
+                  then release it. The green ID LED will blink. The red option LED 
+                  will not light. This let's you know that you are in board 
+                  address set up mode.<br><br><em>(Note: These instructions apply to BDL16, 
+                  BDL162, and BDL168 devices.  Other instructions, buttons, and LED color/flashing
+                  conditions may apply for other device types.  See the appropriate manual for device-specific
+                  instructions!)</em></td>
+              <td>Same as per Digitrax instructions.</td></tr>
+          <tr><td align="center">3</td><td>Connect a DT or UT series Digitrax throttle to the BDL168's 
+                  LocoNet connector. (This can only be done with a Digitrax 
+                  LocoNet throttle or equivalent software).</td>
+              <td>Open JMRI's "Turnout Control" tool, via "Tools->Turnout Control"</td></tr>
+          <tr><td align="center">4</td><td>Go into SWITCH mode on the throttle. Select the switch number 
+                  that corresponds to the board address you want to set and issue 
+                  a closed "c" command to set the board address. The board 
+                  address is changed as soon as you issue the SWITCH command. 
+                  See following instructions for using specific Digitrax throttles 
+                  for setting the address. (Those instructions are not included here!)</td>
+              <td>Enter the switch number which corresponds to the board address
+                  you want to set in the number entry box below "Turnout" at the top
+                  of the JMRI "Turnout Control" tool.  As an example, to set Board 
+                  Address (Board ID) to 4, enter "4" (without quotes".  Then 
+                  activate the window's "Closed" button.</td></tr>
+          <tr><td align="center">5</td><td colspan="2">(A JMRI-specific step, not included in Digitrax 
+                  documentation, which applies regardless of which method you use.)<br><br>See <a href="#BoardIdNote2">Note 2</a> and 
+                  <a href="#BoardIdNote3">Note 3</a> below for important information on
+                  JMRI behaviors which may influence how JMRI sees the device and may
+                  require changes to any pre-existing JMRI uses of affected 
+                  Turnout, Sensor, and/or Reporter configurations, and/or customized 
+                  scripts monitoring for LocoNet Power Management messages.</td>
+      </table>
+      <p>After completing the instructions as noted above, the device <em>should</em> be 
+          configured for the selected Device address.</p>
+      <h4>Notes on Board Address (Board ID)</h4>
+      <ul>
+          <li><a name="BoardIdNote1" id="BoardIdNote1">Note 1</a>: Some devices, 
+              by default, get their turnout control messages from 
+              the DCC track signal, and rely upon the command station to forward
+              the LocoNet turnout control messages as DCC track signal stationary 
+              decoder packets.  
+              <ul>
+                  <li>If you are connected via a Digitrax command station, then 
+                      it may be necessary to turn track power "On" (and <em>not</em> 
+                      "IdlE"!) before performing the steps shown above.</li>
+                  <li>If you are connected via a "Standalone LocoNet", then it 
+                      may be necessary to configure the device to get its control
+                      messages from LocoNet instead of RailSync.  This can be done 
+                      using the appropriate JMRI tool in the LocoNet directory, 
+                      if one is available for the device type, or, using the JMRI
+                      Roster, if the device type is supported in the Roster.</li></ul>
+          </li>
+          <li><a name="BoardIdNote2" id="BoardIdNote2">Note 2</a>: The Board ID 
+              number typically implies the Turnout, Sensor, Reporter, 
+          and/or power management "addresses" used by the device.  Changing the 
+          Board ID number typically forces the device to use different addresses.
+          This can mean a disruption to the JMRI functionality which worked before
+          the Board ID number was changed.  If you have used "User Names" to 
+          reference those items, it is usually sufficient to give a similar User Name
+          to each "relocated" Turnout, Sensor, or Reporter object, and then change
+          each reference to the old object User Name to reflect the new User Name.</li>
+          <li><a name="BoardIdNote3" id="BoardIdNote3">Note 3</a>: If JMRI has "pre-populated" the Turnouts or Sensors table
+          with information about the device, it will be necessary to quit and 
+          restart JMRI so that any information that was "pre-populated" from the 
+          device based on the old Board ID value will _not_ be remembered.  Restarting
+          JMRI causes JMRI to request the "pre-population" information, and if the
+          device responds to the request, the device should respond with its information
+          and the Turnouts and/or Sensors table should be pre-populated.</li>
+      </ul>
+      
       <a name="devicetoollimits" id="devicetoollimits"></a><h3>Some JMRI LocoNet-specific device and feature limitations</h3>
 
       <ul>

--- a/help/en/html/hardware/loconet/Digitrax.shtml
+++ b/help/en/html/hardware/loconet/Digitrax.shtml
@@ -1160,9 +1160,10 @@
                       for changing BDL168 Board Address</strong></td>
               <td style="width: 47%" align="center"><strong>Instructions for 
                       changing Board Address (Board ID) when using JMRI</strong></td></tr>
-          <tr><td align="center">0</td><td colspan="2"><strong>(A step <em>not</em> included in Digitrax 
-                  documentation, but one that is necessary regardless of what 
-                  method you use!)</strong><br><br>0. Ensure that <em>NO OTHER ACTIVITY</em> is occurring on LocoNet!<br><br>
+          <tr><td align="center">0</td><td colspan="2"><strong>(A step <em>not</em> 
+                  included in Digitrax documentation, but one that is necessary 
+                  regardless of what method you use!)</strong><br><br>0. Ensure 
+                  that <em>NO OTHER ACTIVITY</em> is occurring on LocoNet!<br><br>
                   If <em>anything</em> causes generation of a LocoNet Turnout Control 
                   message after the device button has been pressed, but before you 
                   issue the turnout control message to the specific number you 
@@ -1171,47 +1172,55 @@
                   number you are expecting!<br><br>Be aware that movement of trains on 
                   layouts where signaling is implemented can cause generation of
                   LocoNet Turnout control messages!</td></tr>
-          <tr><td></td><td>Note: The steps below are from Section "<em>8.1 To set up the BDL168 board address</em>", with some comments added by JMRI developers.)</td><td></td></tr>
-          <tr><td align="center">0.25</td><td></td><td>Configure JMRI to communicate with with your LocoNet hardware.</td></tr>
-          <tr><td align="center">0.5</td><td></td><td>See <a href="#BoardIdNote1">Note 1</a> below before 
-                  proceeding.</td></tr>
-          <tr><td align="center">1</td><td>Power up your BDL168.</td><td>Power up your layout and start JMRI.</td></tr>
-          <tr><td align="center">2</td><td>Press the switch behind the green ID LED for about 1 second, 
-                  then release it. The green ID LED will blink. The red option LED 
-                  will not light. This let's you know that you are in board 
-                  address set up mode.<br><br><em>(Note: These instructions apply to BDL16, 
-                  BDL162, and BDL168 devices.  Other instructions, buttons, and LED color/flashing
-                  conditions may apply for other device types.  See the appropriate manual for device-specific
-                  instructions!)</em></td>
+          <tr><td align="center">0.25</td><td></td><td>Configure JMRI to 
+                  communicate with with your LocoNet hardware.</td></tr>
+          <tr><td align="center">0.5</td><td colspan="2">See <a href="#BoardIdNote1">
+                  Note 1</a> below before proceeding. This step applies <em>both</em>
+                  for the Digitrax procedure and the JMRI-based procedure.</td></tr>
+          <tr><td rowspan="2" align="center">1</td><td align="center">Note: Steps 
+                  1 thru 4 of the Digitrax instructions are from Section "<em>8.1
+                  To set up the BDL168 board address</em>" of the Digitrax BDL168 
+                  manual, with some comments added by JMRI developers.)</td>
+              <td rowspan="2">Power up your layout, BDL168, and start JMRI.</td></tr>
+          <tr><td>Power up your BDL168.</td></tr>
+          <tr><td align="center">2</td><td>Press the switch behind the green ID 
+                  LED for about 1 second, then release it. The green ID LED will 
+                  blink. The red option LED will not light. This let's you know 
+                  that you are in board address set up mode.<br><br><em>(Note: 
+                  These instructions apply to BDL16, BDL162, and BDL168 devices.  
+                  Other instructions, buttons, and LED color/flashing conditions 
+                  may apply for other device types.  See the appropriate manual 
+                  for device-specific instructions!)</em></td>
               <td>Same as per Digitrax instructions.</td></tr>
-          <tr><td align="center">3</td><td>Connect a DT or UT series Digitrax throttle to the BDL168's 
-                  LocoNet connector. (This can only be done with a Digitrax 
-                  LocoNet throttle or equivalent software).</td>
+          <tr><td align="center">3</td><td>Connect a DT or UT series Digitrax 
+                  throttle to the BDL168's LocoNet connector. (This can only be 
+                  done with a Digitrax LocoNet throttle or equivalent software).</td>
               <td>Open JMRI's "Turnout Control" tool, via "Tools->Turnout Control"</td></tr>
-          <tr><td align="center">4</td><td>Go into SWITCH mode on the throttle. Select the switch number 
-                  that corresponds to the board address you want to set and issue 
-                  a closed "c" command to set the board address. The board 
-                  address is changed as soon as you issue the SWITCH command. 
-                  See following instructions for using specific Digitrax throttles 
-                  for setting the address. (Those instructions are not included here!)</td>
+          <tr><td align="center">4</td><td>Go into SWITCH mode on the throttle. 
+                  Select the switch number that corresponds to the board address 
+                  you want to set and issue a closed "c" command to set the 
+                  board address. The board address is changed as soon as you 
+                  issue the SWITCH command. See following instructions for using 
+                  specific Digitrax throttles for setting the address. <em>(Those 
+                  instructions omitted here.)</em></td>
               <td>Enter the switch number which corresponds to the board address
                   you want to set in the number entry box below "Turnout" at the top
                   of the JMRI "Turnout Control" tool.  As an example, to set Board 
                   Address (Board ID) to 4, enter "4" (without quotes".  Then 
                   activate the window's "Closed" button.</td></tr>
-          <tr><td align="center">5</td><td colspan="2">(A JMRI-specific step, not included in Digitrax 
-                  documentation, which applies regardless of which method you use.)<br><br>See <a href="#BoardIdNote2">Note 2</a> and 
-                  <a href="#BoardIdNote3">Note 3</a> below for important information on
-                  JMRI behaviors which may influence how JMRI sees the device and may
-                  require changes to any pre-existing JMRI uses of affected 
-                  Turnout, Sensor, and/or Reporter configurations, and/or customized 
-                  scripts monitoring for LocoNet Power Management messages.</td>
-      </table>
-      <p>After completing the instructions as noted above, the device <em>should</em> be 
-          configured for the selected Device address.</p>
-      <h4>Notes on Board Address (Board ID)</h4>
-      <ul>
-          <li><a name="BoardIdNote1" id="BoardIdNote1">Note 1</a>: Some devices, 
+          <tr><td align="center">5</td><td colspan="2">(A JMRI-specific step, not 
+                  included in Digitrax documentation, which applies regardless of 
+                  which method you use.)<br><br>See <a href="#BoardIdNote2">Note 
+                  2</a> below for important information on JMRI behaviors which 
+                  may influence how JMRI sees the device and which may require 
+                  changes to any pre-existing JMRI uses of affected Turnout, 
+                  Sensor, and/or Reporter configurations, and/or customized 
+                  scripts monitoring for LocoNet Power Management messages.</td></tr>
+          <tr><td align="center">6</td><td></td><td>Quit and Restart JMRI.  See <a href="#BoardIdNote3">
+                  Note 3</a> below, for more information on why this can be 
+                  important.</td></tr>
+          <tr><td align="center"><a name="BoardIdNote1" id="BoardIdNote1"><strong>Note 1</strong></a></td>
+              <td colspan="2">Some devices, 
               by default, get their turnout control messages from 
               the DCC track signal, and rely upon the command station to forward
               the LocoNet turnout control messages as DCC track signal stationary 
@@ -1225,9 +1234,9 @@
                       messages from LocoNet instead of RailSync.  This can be done 
                       using the appropriate JMRI tool in the LocoNet directory, 
                       if one is available for the device type, or, using the JMRI
-                      Roster, if the device type is supported in the Roster.</li></ul>
-          </li>
-          <li><a name="BoardIdNote2" id="BoardIdNote2">Note 2</a>: The Board ID 
+                      Roster, if the device type is supported in the Roster.</li></ul></td></tr>
+          <tr><td align="center"><a name="BoardIdNote2" id="BoardIdNote2"><strong>Note 2</strong></a></td>
+              <td colspan="2">The Board ID 
               number typically implies the Turnout, Sensor, Reporter, 
           and/or power management "addresses" used by the device.  Changing the 
           Board ID number typically forces the device to use different addresses.
@@ -1235,16 +1244,21 @@
           the Board ID number was changed.  If you have used "User Names" to 
           reference those items, it is usually sufficient to give a similar User Name
           to each "relocated" Turnout, Sensor, or Reporter object, and then change
-          each reference to the old object User Name to reflect the new User Name.</li>
-          <li><a name="BoardIdNote3" id="BoardIdNote3">Note 3</a>: If JMRI has "pre-populated" the Turnouts or Sensors table
-          with information about the device, it will be necessary to quit and 
-          restart JMRI so that any information that was "pre-populated" from the 
-          device based on the old Board ID value will _not_ be remembered.  Restarting
-          JMRI causes JMRI to request the "pre-population" information, and if the
+          each reference to the old object User Name to reflect the new User Name.</td></tr>
+          <tr><td align="center"><a name="BoardIdNote3" id="BoardIdNote3"><strong>Note 3</strong></a></td>
+              <td colspan="2">If JMRI has 
+              "pre-populated" the Turnouts or Sensors table with information about 
+              the device, it will be necessary to quit and restart JMRI so that 
+              any information that was "pre-populated" from the device based on 
+              its old Board ID value will _not_ be remembered.  Restarting JMRI 
+              causes JMRI to request the "pre-population" information, and if the
           device responds to the request, the device should respond with its information
-          and the Turnouts and/or Sensors table should be pre-populated.</li>
-      </ul>
-      
+          and the Turnouts and/or Sensors table should be pre-populated.</td></tr>
+          
+      </table>
+      <p>After completing the instructions as noted above, the device <em>should</em> be 
+          configured for the selected Device address.</p>
+     
       <a name="devicetoollimits" id="devicetoollimits"></a><h3>Some JMRI LocoNet-specific device and feature limitations</h3>
 
       <ul>

--- a/help/en/package/jmri/jmrix/loconet/bdl16/BDL16Frame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/bdl16/BDL16Frame.shtml
@@ -22,12 +22,13 @@
 <body>
   <!--#include virtual="/Header.shtml" -->
   <div class="nomenu" id="mBody">
+    <a href="BDL16xConfigTool.png"><img src="BDL16xConfigTool.png"
+    alt="BDL16x Configuration Tool Screen" width="386" height="423" 
+    style="float:right; margin: 5px;"></a>
+
     <div id="mainContent">
 
       <h1>Configure Digitrax BDL16x</h1>
-      <a href="BDL16xConfigTool.png"><img src="BDL16xConfigTool.png"
-      alt="BDL16x Configuration Tool Screen" width="386" height="423" align="right"></a>
-
       <p>The JMRI BDL16x programming tool lets you configure the
       internal options of a BDL16, BDL162, or BDL168 directly from
       your computer, when the board is connected to a JMRI LocoNet 
@@ -49,6 +50,12 @@
       
       <p>Any time that a Board ID number is typed into the Board ID text entry space,
       the number will be added to the list if it is not already present in the list.</p>
+      
+      <p>While it is possible to change the Board ID number using JMRI, it cannot
+          be done using this tool due to limitations of the BDL16x design.  Instead, 
+          follow the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
+          here</a>.  Those instructions are for programming a BDL168 board, but 
+          they are believed to apply also to BDL16 and BDL162 boards.</p>
       
       <h2>Reading and writing the OpSw settings</h2>
        
@@ -95,7 +102,7 @@
         Full Sheet" operation will write all OpSw values.</li>
 
         <li>This tool is able to access BDL16x boards with
-        addresses between 1 and 256. Users are advised to avoid
+        addresses between 1 and 128. Users are advised to avoid
         using the factory default board address (board address 1)
         as it will be difficult to program new boards with unique
         data if any in-service board is using the factory default
@@ -104,7 +111,10 @@
         <li>Because of the way the BDL16x board works, this tool
         can't change the basic address of the unit. The BDL16x
         documentation describes how to change the board
-        address.</li>
+        address.  It is possible to change the Board ID number using JMRI by 
+        following the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
+        here</a>. Those instructions are for programming a BDL168 board, but 
+        they are believed to apply also to BDL16 and BDL162 boards.</li>
       </ul>
 
       <h2>See Also</h2>

--- a/help/en/package/jmri/jmrix/loconet/ds64/DS64TabbedPanel.shtml
+++ b/help/en/package/jmri/jmrix/loconet/ds64/DS64TabbedPanel.shtml
@@ -24,12 +24,13 @@
 <body>
   <!--#include virtual="/Header.shtml" -->
   <div class="nomenu" id="mBody">
+    <a href="../../../../../html/hardware/loconet/images/DS64TabbedPanel.png">
+    <img src="../../../../../html/hardware/loconet/images/DS64TabbedPanel.png"
+         style="float:right; margin: 5px;" height="408" width="438" 
+         alt="Configure DS64 panel image"></a>
     <div id="mainContent">
 
-      <h1>Configure DS64</h1><a href=
-      "../../../../../html/hardware/loconet/images/DS64TabbedPanel.png"><img src="../../../../../html/hardware/loconet/images/DS64TabbedPanel.png"
-      align="right" height="408" width="438" alt=
-      "Configure DS64 panel image"></a>
+      <h1>Configure Digitrax DS64</h1>
 
       <p>The JMRI DS64 Configuration tool lets you configure the
       internal options of a Digitrax DS64 Stationary Decoder
@@ -46,6 +47,11 @@
       <p>Upon start-up, this tool queries LocoNet to create a list of DS64s.  Each 
           DS64 Board Id is listed in the pull-down selector.  New Board Id numbers
           may be typed into the box and will be added to the list.</p>
+      <p>While it is possible to change the Board ID number using JMRI, it cannot
+          be done using this tool due to limitations of the DS64 design.  Instead, 
+          follow the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
+          here</a>, but you must consult the DS64 manual and modify the JMRI-based process
+          to suit the DS64's buttons, button press time, and lamp flashes.</p>
 
       <h2>Configuring the basic operating modes</h2>
       <p>The basic operations are configured on the "Basic Settings" tab.  This tab 
@@ -109,7 +115,12 @@
       <h2>Limitations</h2>
       <ul>
           <li>Because of the way the DS64 board works, this tool can't change the 
-              basic address of the unit.</li>
+              basic address (the "Board ID") of the unit.  It is possible to change 
+              the Board ID number using JMRI by following the instructions found 
+              <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
+              here</a>. Note that it is necessary to consult the DS64 manual and 
+              modify the JMRI-based process shown at the link above to suit the 
+              DS64's buttons, button press time, and lamp flashes.</li>
           <li>This tool does not have the capability to save the DS64 configuration.</li>
           <li>The "Output Addresses" tab shows the state of the output <i>at the time
               that the "sheet" was last read from the DS64</i>.  This tool does not attempt

--- a/help/en/package/jmri/jmrix/loconet/pm4/PM4Frame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/pm4/PM4Frame.shtml
@@ -21,11 +21,13 @@
 <body>
   <!--#include virtual="/Header.shtml" -->
   <div class="nomenu" id="mBody">
+    <a href="PM4xConfigTool.png">
+    <img src="PM4xConfigTool.png" style="float:right; margin: 5px;" 
+         alt="PM4x Configuration Tool Screen Capture"></a>
+      
     <div id="mainContent">
 
-      <h1>Configure Digitrax PM4x</h1><a href=
-      "PM4xConfigTool.png"><img src="PM4xConfigTool.png" alt=
-      "PM4x Configuration Tool Screen Capture"></a>
+      <h1>Configure Digitrax PM4x</h1>
 
       <p>The JMRI PM4x programming tool lets you configure the
       internal options of a PM4 or PM42 directly from your
@@ -41,6 +43,15 @@
 
       <p>You can then, if you wish, change the checkboxes and click
       "Write to PM4x" to make your changes permanent.</p>
+      
+      <p>The tool relies upon each PM4x board to have a unique "Board ID" (Board
+      Address) in order to configure each device individually.  While it is 
+      possible to change the Board ID number using JMRI, it cannot be done using 
+      this tool due to limitations of the PM4x design.  Instead, 
+      follow the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
+      here</a>, but you must consult the appropriate PM4x manual and modify the 
+      JMRI-based process to suit the PM4x device's buttons, button press time, 
+      and lamp flashes.</p>
 
       <h2>Limitations</h2>
 
@@ -55,7 +66,11 @@
         <li>Because of the way the PM4x board works, this tool
         can't change the basic address of the unit. The PM4x
         documentation describes how to change the board
-        address.</li>
+        address.  It is possible to change the Board ID number using JMRI by 
+        following the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
+        here</a>. Note that it is necessary to consult the appropriate PM4x 
+        manual and modify the JMRI-based process shown at the link above to suit 
+        the PM4x's buttons, button press time, and lamp flashes.</li>
       </ul>
 
       <h2>See Also</h2>

--- a/help/en/package/jmri/jmrix/loconet/se8/SE8Frame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/se8/SE8Frame.shtml
@@ -21,11 +21,13 @@
 <body>
   <!--#include virtual="/Header.shtml" -->
   <div class="nomenu" id="mBody">
+    <a href="SE8cConfigTool.png"><img src="SE8cConfigTool.png"
+      alt="SE8c Configuration Tool Screen Capture" 
+      style="float:right; margin: 5px;"></a>
+      
     <div id="mainContent">
 
-      <h1>Configure Digitrax SE8c</h1><a href=
-      "SE8cConfigTool.png"><img src="SE8cConfigTool.png" alt=
-      "SE8c Configuration Tool Screen Capture"></a>
+      <h1>Configure Digitrax SE8c</h1>
 
       <p>The JMRI SE8c programming tool lets you configure the
       internal options of a Digitrax SE8c Signaling Decoder Board
@@ -42,11 +44,25 @@
       <p>You can then, if you wish, change the checkboxes and click
       "Write to SE8c" to make your changes permanent.</p>
 
+      <p>The tool relies upon each SE8C board to have a unique "Board ID" (Board
+      Address) in order to configure each device individually.  While it is 
+      possible to change the Board ID number using JMRI, it cannot be done using 
+      this tool due to limitations of the SE8C design.  Instead, 
+      follow the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
+      here</a>, but you must consult the SE8C manual and modify the 
+      JMRI-based process to suit the SE8C device's buttons, button press time, 
+      and lamp flashes.</p>
+
       <h2>Limitations</h2>
 
       <ul>
         <li>Because of the way the SE8c board works, this tool
-        can't change the basic address of the unit.</li>
+        can't change the basic address of the unit.  It is possible to change 
+              the Board ID number using JMRI by following the instructions found 
+              <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
+              here</a>. Note that it is necessary to consult the SE8C manual and 
+              modify the JMRI-based process shown at the link above to suit the 
+              SE8C's buttons, button press time, and lamp flashes.</li>
 
         <li>The SE8c can be configured to send Sensor status on the
         LocoNet in response to a "track power on" command. The SE8c

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -51,7 +51,10 @@
 
         <h4>LocoNet</h4>
             <ul>
-                <li></li>
+                <li><a href="https://www.jmri.org/help/en/html/hardware/loconet/Digitrax.shtml#deviceBoardId">
+                    Instructions</a> detailing how to change the Board ID (Board 
+                    Address) of certain Digitrax LocoNet-based devices using 
+                    JMRI have been added to the Digitrax hardware page.</li>
             </ul>
 
         <h4>Maple</h4>


### PR DESCRIPTION
Provide instructions on using JMRI to configure the Board ID number (Board Address) used by some Digitrax LocoNet-based boards.
