### PR TITLE
Move method to AbstractXmlAdapter

### DIFF
--- a/java/src/apps/configurexml/FileLocationPaneXml.java
+++ b/java/src/apps/configurexml/FileLocationPaneXml.java
@@ -84,16 +84,6 @@ public class FileLocationPaneXml extends jmri.configurexml.AbstractXmlAdapter {
 
     }
 
-    /**
-     * Update static data from XML file
-     *
-     * @param element Top level Element to unpack.
-     * @param o       ignored
-     */
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Unexpected call of load(Element, Object)");
-    }
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(FileLocationPaneXml.class);
 

--- a/java/src/apps/configurexml/FileLocationPaneXml.java
+++ b/java/src/apps/configurexml/FileLocationPaneXml.java
@@ -85,6 +85,6 @@ public class FileLocationPaneXml extends jmri.configurexml.AbstractXmlAdapter {
     }
 
     // initialize logging
-    private final static Logger log = LoggerFactory.getLogger(FileLocationPaneXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(FileLocationPaneXml.class);
 
 }

--- a/java/src/apps/configurexml/GuiLafConfigPaneXml.java
+++ b/java/src/apps/configurexml/GuiLafConfigPaneXml.java
@@ -156,16 +156,6 @@ public class GuiLafConfigPaneXml extends jmri.configurexml.AbstractXmlAdapter {
         }
     }
 
-    /**
-     * Update static data from XML file
-     *
-     * @param element Top level Element to unpack.
-     * @param o       ignored
-     */
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Unexpected call of load(Element, Object)");
-    }
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(GuiLafConfigPaneXml.class);
 

--- a/java/src/apps/configurexml/PerformFileModelXml.java
+++ b/java/src/apps/configurexml/PerformFileModelXml.java
@@ -61,16 +61,6 @@ public class PerformFileModelXml extends jmri.configurexml.AbstractXmlAdapter {
         return result;
     }
 
-    /**
-     * Update static data from XML file
-     *
-     * @param element Top level Element to unpack.
-     * @param o       ignored
-     */
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Unexpected call of load(Element, Object)");
-    }
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(PerformFileModelXml.class);
 

--- a/java/src/apps/configurexml/PerformFileModelXml.java
+++ b/java/src/apps/configurexml/PerformFileModelXml.java
@@ -62,6 +62,6 @@ public class PerformFileModelXml extends jmri.configurexml.AbstractXmlAdapter {
     }
 
     // initialize logging
-    private final static Logger log = LoggerFactory.getLogger(PerformFileModelXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(PerformFileModelXml.class);
 
 }

--- a/java/src/apps/configurexml/SystemConsoleConfigPanelXml.java
+++ b/java/src/apps/configurexml/SystemConsoleConfigPanelXml.java
@@ -99,16 +99,6 @@ public class SystemConsoleConfigPanelXml extends jmri.configurexml.AbstractXmlAd
         return result;
     }
 
-    /**
-     * Update static data from XML file
-     *
-     * @param element Top level Element to unpack.
-     * @param o       ignored
-     */
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Unexpected call of load(Element, Object)");
-    }
     // initialize logging
     private static final Logger log = LoggerFactory.getLogger(SystemConsoleConfigPanelXml.class);
 

--- a/java/src/apps/startup/configurexml/StartupActionsPreferencesPanelXml.java
+++ b/java/src/apps/startup/configurexml/StartupActionsPreferencesPanelXml.java
@@ -17,11 +17,6 @@ public class StartupActionsPreferencesPanelXml extends AbstractXmlAdapter {
 
     private final static Logger log = LoggerFactory.getLogger(StartupActionsPreferencesPanelXml.class);
 
-    @Override
-    public void load(Element e, Object o) {
-        log.error("Unexpected call of load(Element, Object)");
-    }
-
     /**
      * Arrange for all {@link jmri.util.startup.StartupModel} objects to be stored.
      *

--- a/java/src/apps/startup/configurexml/StartupPauseModelXml.java
+++ b/java/src/apps/startup/configurexml/StartupPauseModelXml.java
@@ -59,9 +59,4 @@ public class StartupPauseModelXml extends AbstractXmlAdapter {
         return result;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Unexpected call of load(Element, Object)");
-    }
-
 }

--- a/java/src/apps/startup/configurexml/StartupPauseModelXml.java
+++ b/java/src/apps/startup/configurexml/StartupPauseModelXml.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StartupPauseModelXml extends AbstractXmlAdapter {
 
-    private final static Logger log = LoggerFactory.getLogger(StartupPauseModelXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(StartupPauseModelXml.class);
 
     public StartupPauseModelXml() {
     }

--- a/java/src/jmri/configurexml/AbstractXmlAdapter.java
+++ b/java/src/jmri/configurexml/AbstractXmlAdapter.java
@@ -38,6 +38,12 @@ public abstract class AbstractXmlAdapter implements XmlAdapter {
 
     /** {@inheritDoc} */
     @Override
+    public void load(Element e, Object o) throws JmriConfigureXmlException {
+        log.error("Invalid method called");
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public boolean load(@Nonnull Element shared, Element perNode) throws JmriConfigureXmlException { // may not need exception
         return this.load(shared);
     }

--- a/java/src/jmri/configurexml/LocoAddressXml.java
+++ b/java/src/jmri/configurexml/LocoAddressXml.java
@@ -65,10 +65,5 @@ public class LocoAddressXml extends jmri.configurexml.AbstractXmlAdapter {
         return new jmri.DccLocoAddress(addr, prot);
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     private final static Logger log = LoggerFactory.getLogger(LocoAddressXml.class);
 }

--- a/java/src/jmri/configurexml/TransitManagerXml.java
+++ b/java/src/jmri/configurexml/TransitManagerXml.java
@@ -117,11 +117,6 @@ public class TransitManagerXml extends jmri.managers.configurexml.AbstractNamedB
         transits.setAttribute("class", "jmri.configurexml.TransitManagerXml");
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     /**
      * Create a TransitManager object of the correct class, then register and
      * fill it.

--- a/java/src/jmri/configurexml/TurnoutOperationManagerXml.java
+++ b/java/src/jmri/configurexml/TurnoutOperationManagerXml.java
@@ -21,11 +21,6 @@ public class TurnoutOperationManagerXml extends jmri.configurexml.AbstractXmlAda
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element sharedOperations, Element perNodeOperations) {
         boolean result = true;
         TurnoutOperationManager manager = InstanceManager.getDefault(TurnoutOperationManager.class);

--- a/java/src/jmri/configurexml/XmlAdapter.java
+++ b/java/src/jmri/configurexml/XmlAdapter.java
@@ -1,14 +1,10 @@
 package jmri.configurexml;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.awt.GraphicsEnvironment;
 import javax.annotation.Nonnull;
 import javax.annotation.CheckForNull;
 import jmri.configurexml.swing.DialogErrorHandler;
 import org.jdom2.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Interface assumed during configuration operations.
@@ -154,5 +150,4 @@ public interface XmlAdapter {
         }
         return new DialogErrorHandler();
     }
-
 }

--- a/java/src/jmri/configurexml/XmlAdapter.java
+++ b/java/src/jmri/configurexml/XmlAdapter.java
@@ -62,9 +62,7 @@ public interface XmlAdapter {
      * @throws JmriConfigureXmlException when a error prevents creating the objects as as
      *                   required by the input XML
      */
-    default public void load(Element e, Object o) throws JmriConfigureXmlException {
-        log.error("Invalid method called");
-    }
+    public void load(Element e, Object o) throws JmriConfigureXmlException;
 
     /**
      * Create a set of configured objects from their XML description, using an
@@ -157,7 +155,4 @@ public interface XmlAdapter {
         return new DialogErrorHandler();
     }
 
-    @SuppressFBWarnings(value = "SLF4J_LOGGER_SHOULD_BE_PRIVATE",
-            justification = "variable cannot be private in interface")
-    final static Logger log = LoggerFactory.getLogger(XmlAdapter.class);
 }

--- a/java/src/jmri/configurexml/XmlAdapter.java
+++ b/java/src/jmri/configurexml/XmlAdapter.java
@@ -5,6 +5,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.CheckForNull;
 import jmri.configurexml.swing.DialogErrorHandler;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Interface assumed during configuration operations.
@@ -58,7 +60,9 @@ public interface XmlAdapter {
      * @throws JmriConfigureXmlException when a error prevents creating the objects as as
      *                   required by the input XML
      */
-    public void load(Element e, Object o) throws JmriConfigureXmlException;
+    default public void load(Element e, Object o) throws JmriConfigureXmlException {
+        log.error("Invalid method called");
+    }
 
     /**
      * Create a set of configured objects from their XML description, using an
@@ -150,4 +154,6 @@ public interface XmlAdapter {
         }
         return new DialogErrorHandler();
     }
+
+    final static Logger log = LoggerFactory.getLogger(XmlAdapter.class);
 }

--- a/java/src/jmri/configurexml/XmlAdapter.java
+++ b/java/src/jmri/configurexml/XmlAdapter.java
@@ -157,7 +157,7 @@ public interface XmlAdapter {
         return new DialogErrorHandler();
     }
 
-    @SuppressFBWarnings(value = "SL4J_LOGGER_SHOULD_BE_PRIVATE",
+    @SuppressFBWarnings(value = "SLF4J_LOGGER_SHOULD_BE_PRIVATE",
             justification = "variable cannot be private in interface")
     final static Logger log = LoggerFactory.getLogger(XmlAdapter.class);
 }

--- a/java/src/jmri/configurexml/XmlAdapter.java
+++ b/java/src/jmri/configurexml/XmlAdapter.java
@@ -1,5 +1,7 @@
 package jmri.configurexml;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.awt.GraphicsEnvironment;
 import javax.annotation.Nonnull;
 import javax.annotation.CheckForNull;
@@ -155,5 +157,7 @@ public interface XmlAdapter {
         return new DialogErrorHandler();
     }
 
+    @SuppressFBWarnings(value = "SL4J_LOGGER_SHOULD_BE_PRIVATE",
+            justification = "variable cannot be private in interface")
     final static Logger log = LoggerFactory.getLogger(XmlAdapter.class);
 }

--- a/java/src/jmri/configurexml/turnoutoperations/TurnoutOperationXml.java
+++ b/java/src/jmri/configurexml/turnoutoperations/TurnoutOperationXml.java
@@ -52,11 +52,6 @@ public abstract class TurnoutOperationXml extends jmri.configurexml.AbstractXmlA
         return result;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     /**
      * common part of store - create the element and store the name and the
      * class

--- a/java/src/jmri/implementation/configurexml/DccSignalMastXml.java
+++ b/java/src/jmri/implementation/configurexml/DccSignalMastXml.java
@@ -134,10 +134,5 @@ public class DccSignalMastXml
         return true;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     private final static Logger log = LoggerFactory.getLogger(DccSignalMastXml.class);
 }

--- a/java/src/jmri/implementation/configurexml/DoubleTurnoutSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/DoubleTurnoutSignalHeadXml.java
@@ -137,11 +137,6 @@ public class DoubleTurnoutSignalHeadXml extends jmri.managers.configurexml.Abstr
         }
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     private final static Logger log = LoggerFactory.getLogger(DoubleTurnoutSignalHeadXml.class);
 
 }

--- a/java/src/jmri/implementation/configurexml/SE8cSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/SE8cSignalHeadXml.java
@@ -134,11 +134,6 @@ public class SE8cSignalHeadXml extends jmri.managers.configurexml.AbstractNamedB
         }
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     private final static Logger log = LoggerFactory.getLogger(SE8cSignalHeadXml.class);
 
 }

--- a/java/src/jmri/implementation/configurexml/SingleTurnoutSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/SingleTurnoutSignalHeadXml.java
@@ -153,11 +153,6 @@ public class SingleTurnoutSignalHeadXml extends jmri.managers.configurexml.Abstr
         }
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     private int getIntFromColour(String colour) {
         switch (colour.toLowerCase()) {
             case "red":

--- a/java/src/jmri/implementation/configurexml/TurnoutSignalMastXml.java
+++ b/java/src/jmri/implementation/configurexml/TurnoutSignalMastXml.java
@@ -146,10 +146,5 @@ public class TurnoutSignalMastXml
         return true;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     private final static Logger log = LoggerFactory.getLogger(TurnoutSignalMastXml.class);
 }

--- a/java/src/jmri/implementation/configurexml/VirtualSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/VirtualSignalHeadXml.java
@@ -65,11 +65,6 @@ public class VirtualSignalHeadXml extends jmri.managers.configurexml.AbstractNam
         return true;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     private final static Logger log = LoggerFactory.getLogger(VirtualSignalHeadXml.class);
 
 }

--- a/java/src/jmri/implementation/configurexml/VirtualSignalMastXml.java
+++ b/java/src/jmri/implementation/configurexml/VirtualSignalMastXml.java
@@ -102,10 +102,5 @@ public class VirtualSignalMastXml
         return true;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     private final static Logger log = LoggerFactory.getLogger(VirtualSignalMastXml.class);
 }

--- a/java/src/jmri/jmrit/display/controlPanelEditor/configurexml/ControlPanelEditorXml.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/configurexml/ControlPanelEditorXml.java
@@ -104,11 +104,6 @@ public class ControlPanelEditorXml extends AbstractXmlAdapter {
         return element;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     /**
      * Create a ControlPanelEditor object, then register and fill it, then pop
      * it in a JFrame

--- a/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
+++ b/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
@@ -83,11 +83,6 @@ public class PanelEditorXml extends AbstractXmlAdapter {
         return panel;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     /**
      * Create a PanelEditor object, then register and fill it, then pop it in a
      * JFrame.

--- a/java/src/jmri/jmrit/entryexit/configurexml/EntryExitPairsXml.java
+++ b/java/src/jmri/jmrit/entryexit/configurexml/EntryExitPairsXml.java
@@ -172,11 +172,6 @@ public class EntryExitPairsXml extends AbstractXmlAdapter {
         messages.setAttribute("class", "jmri.jmrit.entryexit.configurexml.EntryExitPairsXml");  // NOI18N
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");  // NOI18N
-    }
-
     /**
      * Load, starting with the layoutBlock element, then all the value-icon
      * pairs.

--- a/java/src/jmri/jmrit/logix/configurexml/WarrantManagerXml.java
+++ b/java/src/jmri/jmrit/logix/configurexml/WarrantManagerXml.java
@@ -328,11 +328,6 @@ public class WarrantManagerXml extends jmri.configurexml.AbstractXmlAdapter {
         return true;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("load called. Invalid method.");
-    }
-
     private static void loadTrain(Element elem, Warrant warrant) {
         SpeedUtil speedUtil = warrant.getSpeedUtil();
         if (elem.getAttribute("trainId") != null) {

--- a/java/src/jmri/jmrit/simpleclock/configurexml/SimpleTimebaseXml.java
+++ b/java/src/jmri/jmrit/simpleclock/configurexml/SimpleTimebaseXml.java
@@ -219,17 +219,6 @@ public class SimpleTimebaseXml extends jmri.configurexml.AbstractXmlAdapter {
     // The Locale needs to be always US, irrelevant from computer's and program's settings!
     final SimpleDateFormat format = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US);
 
-    /**
-     * Update static data from XML file
-     *
-     * @param element Top level Element to unpack.
-     * @param o       ignored
-     */
-    @Override
-    public void load(Element element, Object o) {
-        log.error("load(Element, Object) called unexpectedly");
-    }
-
     @Override
     public int loadOrder() {
         return jmri.Manager.TIMEBASE;

--- a/java/src/jmri/jmrix/acela/configurexml/AcelaSignalHeadXml.java
+++ b/java/src/jmri/jmrix/acela/configurexml/AcelaSignalHeadXml.java
@@ -86,10 +86,5 @@ public class AcelaSignalHeadXml extends jmri.managers.configurexml.AbstractNamed
         return true;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     private final static Logger log = LoggerFactory.getLogger(AcelaSignalHeadXml.class);
 }

--- a/java/src/jmri/jmrix/acela/configurexml/AcelaSignalHeadXml.java
+++ b/java/src/jmri/jmrix/acela/configurexml/AcelaSignalHeadXml.java
@@ -86,5 +86,5 @@ public class AcelaSignalHeadXml extends jmri.managers.configurexml.AbstractNamed
         return true;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AcelaSignalHeadXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(AcelaSignalHeadXml.class);
 }

--- a/java/src/jmri/jmrix/anyma/configurexml/UsbLightManagerXml.java
+++ b/java/src/jmri/jmrix/anyma/configurexml/UsbLightManagerXml.java
@@ -38,14 +38,6 @@ public class UsbLightManagerXml extends AbstractLightManagerConfigXML {
      * {@inheritDoc}
      */
     @Override
-    public void load(@Nonnull Element element, @Nonnull Object o) {
-        log.error("Invalid AnymaDMX_LightManagerXml.load() method called");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public boolean load(@Nonnull Element shared, @Nonnull Element perNode) {
         log.debug("*   AnymaDMX_LightManagerXml.load() called");
         // load individual lights

--- a/java/src/jmri/jmrix/can/cbus/configurexml/CbusLightManagerXml.java
+++ b/java/src/jmri/jmrix/can/cbus/configurexml/CbusLightManagerXml.java
@@ -30,14 +30,6 @@ public class CbusLightManagerXml extends jmri.managers.configurexml.AbstractLigh
      * {@inheritDoc}
      */
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual lights
         return loadLights(shared);

--- a/java/src/jmri/jmrix/can/cbus/configurexml/CbusLightManagerXml.java
+++ b/java/src/jmri/jmrix/can/cbus/configurexml/CbusLightManagerXml.java
@@ -35,7 +35,7 @@ public class CbusLightManagerXml extends jmri.managers.configurexml.AbstractLigh
         return loadLights(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(CbusLightManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(CbusLightManagerXml.class);
 }
 
 

--- a/java/src/jmri/jmrix/configurexml/AbstractConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/configurexml/AbstractConnectionConfigXml.java
@@ -203,14 +203,6 @@ abstract public class AbstractConnectionConfigXml extends AbstractXmlAdapter {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void load(Element element, Object o) {
-        log.error("method with two args invoked");
-    }
-
-    /**
      * Service routine to look through "parameter" child elements to find a
      * particular parameter value
      *

--- a/java/src/jmri/jmrix/dcc4pc/configurexml/Dcc4PcReporterManagerXml.java
+++ b/java/src/jmri/jmrix/dcc4pc/configurexml/Dcc4PcReporterManagerXml.java
@@ -25,11 +25,6 @@ public class Dcc4PcReporterManagerXml extends jmri.managers.configurexml.Abstrac
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // create the master object
         //Dcc4PcReporterManager.instance();

--- a/java/src/jmri/jmrix/dcc4pc/configurexml/Dcc4PcReporterManagerXml.java
+++ b/java/src/jmri/jmrix/dcc4pc/configurexml/Dcc4PcReporterManagerXml.java
@@ -32,5 +32,5 @@ public class Dcc4PcReporterManagerXml extends jmri.managers.configurexml.Abstrac
         return loadReporters(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Dcc4PcReporterManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(Dcc4PcReporterManagerXml.class);
 }

--- a/java/src/jmri/jmrix/dcc4pc/configurexml/Dcc4PcSensorManagerXml.java
+++ b/java/src/jmri/jmrix/dcc4pc/configurexml/Dcc4PcSensorManagerXml.java
@@ -26,11 +26,6 @@ public class Dcc4PcSensorManagerXml extends jmri.managers.configurexml.AbstractS
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // create the master object
         //Dcc4PcSensorManager.instance();

--- a/java/src/jmri/jmrix/dcc4pc/configurexml/Dcc4PcSensorManagerXml.java
+++ b/java/src/jmri/jmrix/dcc4pc/configurexml/Dcc4PcSensorManagerXml.java
@@ -33,5 +33,5 @@ public class Dcc4PcSensorManagerXml extends jmri.managers.configurexml.AbstractS
         return loadSensors(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Dcc4PcSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(Dcc4PcSensorManagerXml.class);
 }

--- a/java/src/jmri/jmrix/dccpp/configurexml/DCCppLightManagerXml.java
+++ b/java/src/jmri/jmrix/dccpp/configurexml/DCCppLightManagerXml.java
@@ -27,11 +27,6 @@ public class DCCppLightManagerXml extends jmri.managers.configurexml.AbstractLig
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element lights) {
         // load individual lights
         return loadLights(lights);

--- a/java/src/jmri/jmrix/dccpp/configurexml/DCCppLightManagerXml.java
+++ b/java/src/jmri/jmrix/dccpp/configurexml/DCCppLightManagerXml.java
@@ -37,6 +37,6 @@ public class DCCppLightManagerXml extends jmri.managers.configurexml.AbstractLig
         return loadLights(shared);
     }
     
-    private final static Logger log = LoggerFactory.getLogger(DCCppLightManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(DCCppLightManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/dccpp/configurexml/DCCppSensorManagerXml.java
+++ b/java/src/jmri/jmrix/dccpp/configurexml/DCCppSensorManagerXml.java
@@ -31,7 +31,7 @@ public class DCCppSensorManagerXml extends jmri.managers.configurexml.AbstractSe
         return loadSensors(sensors);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DCCppSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(DCCppSensorManagerXml.class);
 
     @Override
     public boolean load(Element sharedSensors, Element perNodeSensors) throws JmriConfigureXmlException {

--- a/java/src/jmri/jmrix/dccpp/configurexml/DCCppSensorManagerXml.java
+++ b/java/src/jmri/jmrix/dccpp/configurexml/DCCppSensorManagerXml.java
@@ -26,11 +26,6 @@ public class DCCppSensorManagerXml extends jmri.managers.configurexml.AbstractSe
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element sensors) throws jmri.configurexml.JmriConfigureXmlException {
         // load individual sensors
         return loadSensors(sensors);

--- a/java/src/jmri/jmrix/ecos/configurexml/EcosLocoAddressManagerXml.java
+++ b/java/src/jmri/jmrix/ecos/configurexml/EcosLocoAddressManagerXml.java
@@ -18,11 +18,6 @@ public class EcosLocoAddressManagerXml extends jmri.managers.configurexml.Abstra
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         return true;
     }

--- a/java/src/jmri/jmrix/ecos/configurexml/EcosLocoAddressManagerXml.java
+++ b/java/src/jmri/jmrix/ecos/configurexml/EcosLocoAddressManagerXml.java
@@ -26,5 +26,6 @@ public class EcosLocoAddressManagerXml extends jmri.managers.configurexml.Abstra
     public Element store(Object o) {
         return null;
     }
-    private final static Logger log = LoggerFactory.getLogger(EcosLocoAddressManagerXml.class);
+
+//    private final static Logger log = LoggerFactory.getLogger(EcosLocoAddressManagerXml.class);
 }

--- a/java/src/jmri/jmrix/ecos/configurexml/EcosPreferencesXml.java
+++ b/java/src/jmri/jmrix/ecos/configurexml/EcosPreferencesXml.java
@@ -40,5 +40,5 @@ public class EcosPreferencesXml extends jmri.configurexml.AbstractXmlAdapter /*e
         return true;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EcosPreferencesXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(EcosPreferencesXml.class);
 }

--- a/java/src/jmri/jmrix/ecos/configurexml/EcosPreferencesXml.java
+++ b/java/src/jmri/jmrix/ecos/configurexml/EcosPreferencesXml.java
@@ -24,11 +24,6 @@ public class EcosPreferencesXml extends jmri.configurexml.AbstractXmlAdapter /*e
         return null;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     protected void register() {
         //log.error("unexpected call to register()", new Exception());
         ConfigureManager cm = jmri.InstanceManager.getNullableDefault(jmri.ConfigureManager.class);

--- a/java/src/jmri/jmrix/ecos/configurexml/EcosReporterManagerXml.java
+++ b/java/src/jmri/jmrix/ecos/configurexml/EcosReporterManagerXml.java
@@ -29,6 +29,6 @@ public class EcosReporterManagerXml extends jmri.managers.configurexml.AbstractR
         return loadReporters(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EcosReporterManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(EcosReporterManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/ecos/configurexml/EcosReporterManagerXml.java
+++ b/java/src/jmri/jmrix/ecos/configurexml/EcosReporterManagerXml.java
@@ -24,11 +24,6 @@ public class EcosReporterManagerXml extends jmri.managers.configurexml.AbstractR
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual Reporters
         return loadReporters(shared);

--- a/java/src/jmri/jmrix/grapevine/configurexml/SerialLightManagerXml.java
+++ b/java/src/jmri/jmrix/grapevine/configurexml/SerialLightManagerXml.java
@@ -31,6 +31,6 @@ public class SerialLightManagerXml extends jmri.managers.configurexml.AbstractLi
         return loadLights(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialLightManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(SerialLightManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/grapevine/configurexml/SerialLightManagerXml.java
+++ b/java/src/jmri/jmrix/grapevine/configurexml/SerialLightManagerXml.java
@@ -26,11 +26,6 @@ public class SerialLightManagerXml extends jmri.managers.configurexml.AbstractLi
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual lights
         return loadLights(shared);

--- a/java/src/jmri/jmrix/grapevine/configurexml/SerialSensorManagerXml.java
+++ b/java/src/jmri/jmrix/grapevine/configurexml/SerialSensorManagerXml.java
@@ -25,11 +25,6 @@ public class SerialSensorManagerXml extends jmri.managers.configurexml.AbstractS
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // load individual sensors
         return loadSensors(shared);

--- a/java/src/jmri/jmrix/grapevine/configurexml/SerialSensorManagerXml.java
+++ b/java/src/jmri/jmrix/grapevine/configurexml/SerialSensorManagerXml.java
@@ -30,6 +30,6 @@ public class SerialSensorManagerXml extends jmri.managers.configurexml.AbstractS
         return loadSensors(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(SerialSensorManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/grapevine/configurexml/SerialSignalHeadXml.java
+++ b/java/src/jmri/jmrix/grapevine/configurexml/SerialSignalHeadXml.java
@@ -62,10 +62,5 @@ public class SerialSignalHeadXml extends AbstractNamedBeanManagerConfigXML {
         return true;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     private final static Logger log = LoggerFactory.getLogger(SerialSignalHeadXml.class);
 }

--- a/java/src/jmri/jmrix/grapevine/configurexml/SerialSignalHeadXml.java
+++ b/java/src/jmri/jmrix/grapevine/configurexml/SerialSignalHeadXml.java
@@ -62,5 +62,5 @@ public class SerialSignalHeadXml extends AbstractNamedBeanManagerConfigXML {
         return true;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialSignalHeadXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(SerialSignalHeadXml.class);
 }

--- a/java/src/jmri/jmrix/ieee802154/xbee/configurexml/XBeeSensorManagerXml.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/configurexml/XBeeSensorManagerXml.java
@@ -25,11 +25,6 @@ public class XBeeSensorManagerXml extends jmri.managers.configurexml.AbstractSen
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // load individual sensors
         return loadSensors(shared);

--- a/java/src/jmri/jmrix/ieee802154/xbee/configurexml/XBeeSensorManagerXml.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/configurexml/XBeeSensorManagerXml.java
@@ -30,5 +30,5 @@ public class XBeeSensorManagerXml extends jmri.managers.configurexml.AbstractSen
         return loadSensors(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(XBeeSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(XBeeSensorManagerXml.class);
 }

--- a/java/src/jmri/jmrix/internal/configurexml/InternalLightManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalLightManagerXml.java
@@ -25,11 +25,6 @@ public class InternalLightManagerXml extends jmri.managers.configurexml.Abstract
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual lights
         loadLights(shared);

--- a/java/src/jmri/jmrix/internal/configurexml/InternalLightManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalLightManagerXml.java
@@ -31,5 +31,5 @@ public class InternalLightManagerXml extends jmri.managers.configurexml.Abstract
         return true;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(InternalLightManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(InternalLightManagerXml.class);
 }

--- a/java/src/jmri/jmrix/internal/configurexml/InternalReporterManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalReporterManagerXml.java
@@ -31,5 +31,5 @@ public class InternalReporterManagerXml extends jmri.managers.configurexml.Abstr
         return loadReporters(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(InternalReporterManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(InternalReporterManagerXml.class);
 }

--- a/java/src/jmri/jmrix/internal/configurexml/InternalReporterManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalReporterManagerXml.java
@@ -26,11 +26,6 @@ public class InternalReporterManagerXml extends jmri.managers.configurexml.Abstr
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual reporters
         return loadReporters(shared);

--- a/java/src/jmri/jmrix/internal/configurexml/InternalSensorManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalSensorManagerXml.java
@@ -25,11 +25,6 @@ public class InternalSensorManagerXml extends jmri.managers.configurexml.Abstrac
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public Element store(Object o) {
         Element sensors = new Element("sensors");
 

--- a/java/src/jmri/jmrix/internal/configurexml/InternalSensorManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalSensorManagerXml.java
@@ -69,5 +69,5 @@ public class InternalSensorManagerXml extends jmri.managers.configurexml.Abstrac
         return load;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(InternalSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(InternalSensorManagerXml.class);
 }

--- a/java/src/jmri/jmrix/internal/configurexml/InternalTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalTurnoutManagerXml.java
@@ -30,6 +30,6 @@ public class InternalTurnoutManagerXml extends jmri.managers.configurexml.Abstra
         return loadTurnouts(shared, perNode);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(InternalTurnoutManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(InternalTurnoutManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/internal/configurexml/InternalTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalTurnoutManagerXml.java
@@ -25,11 +25,6 @@ public class InternalTurnoutManagerXml extends jmri.managers.configurexml.Abstra
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual turnouts
         return loadTurnouts(shared, perNode);

--- a/java/src/jmri/jmrix/jmriclient/configurexml/JMRIClientTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/jmriclient/configurexml/JMRIClientTurnoutManagerXml.java
@@ -25,11 +25,6 @@ public class JMRIClientTurnoutManagerXml extends jmri.managers.configurexml.Abst
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual turnouts
         return loadTurnouts(shared, perNode);

--- a/java/src/jmri/jmrix/jmriclient/configurexml/JMRIClientTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/jmriclient/configurexml/JMRIClientTurnoutManagerXml.java
@@ -31,5 +31,5 @@ public class JMRIClientTurnoutManagerXml extends jmri.managers.configurexml.Abst
     }
 
     // initialize logging
-    private final static Logger log = LoggerFactory.getLogger(JMRIClientTurnoutManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(JMRIClientTurnoutManagerXml.class);
 }

--- a/java/src/jmri/jmrix/lenz/configurexml/XNetLightManagerXml.java
+++ b/java/src/jmri/jmrix/lenz/configurexml/XNetLightManagerXml.java
@@ -29,6 +29,6 @@ public class XNetLightManagerXml extends jmri.managers.configurexml.AbstractLigh
         return loadLights(shared);
     }
 
-    private static final Logger log = LoggerFactory.getLogger(XNetLightManagerXml.class);
+//    private static final Logger log = LoggerFactory.getLogger(XNetLightManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/lenz/configurexml/XNetLightManagerXml.java
+++ b/java/src/jmri/jmrix/lenz/configurexml/XNetLightManagerXml.java
@@ -24,11 +24,6 @@ public class XNetLightManagerXml extends jmri.managers.configurexml.AbstractLigh
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual lights
         return loadLights(shared);

--- a/java/src/jmri/jmrix/lenz/configurexml/XNetSensorManagerXml.java
+++ b/java/src/jmri/jmrix/lenz/configurexml/XNetSensorManagerXml.java
@@ -30,6 +30,6 @@ public class XNetSensorManagerXml extends jmri.managers.configurexml.AbstractSen
         return loadSensors(shared);
     }
 
-    private static final Logger log = LoggerFactory.getLogger(XNetSensorManagerXml.class);
+//    private static final Logger log = LoggerFactory.getLogger(XNetSensorManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/lenz/configurexml/XNetSensorManagerXml.java
+++ b/java/src/jmri/jmrix/lenz/configurexml/XNetSensorManagerXml.java
@@ -25,11 +25,6 @@ public class XNetSensorManagerXml extends jmri.managers.configurexml.AbstractSen
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // load individual sensors
         return loadSensors(shared);

--- a/java/src/jmri/jmrix/lenz/configurexml/XNetTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/lenz/configurexml/XNetTurnoutManagerXml.java
@@ -29,6 +29,6 @@ public class XNetTurnoutManagerXml extends jmri.managers.configurexml.AbstractTu
         return loadTurnouts(shared, perNode);
     }
 
-    private static final Logger log = LoggerFactory.getLogger(XNetTurnoutManagerXml.class);
+//    private static final Logger log = LoggerFactory.getLogger(XNetTurnoutManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/lenz/configurexml/XNetTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/lenz/configurexml/XNetTurnoutManagerXml.java
@@ -24,11 +24,6 @@ public class XNetTurnoutManagerXml extends jmri.managers.configurexml.AbstractTu
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual turnouts
         return loadTurnouts(shared, perNode);

--- a/java/src/jmri/jmrix/lenz/hornbyelite/configurexml/EliteXNetTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/configurexml/EliteXNetTurnoutManagerXml.java
@@ -24,11 +24,6 @@ public class EliteXNetTurnoutManagerXml extends jmri.managers.configurexml.Abstr
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual turnouts
         return loadTurnouts(shared, perNode);

--- a/java/src/jmri/jmrix/lenz/hornbyelite/configurexml/EliteXNetTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/configurexml/EliteXNetTurnoutManagerXml.java
@@ -29,6 +29,6 @@ public class EliteXNetTurnoutManagerXml extends jmri.managers.configurexml.Abstr
         return loadTurnouts(shared, perNode);
     }
 
-    private static final Logger log = LoggerFactory.getLogger(EliteXNetTurnoutManagerXml.class);
+//    private static final Logger log = LoggerFactory.getLogger(EliteXNetTurnoutManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/loconet/configurexml/LnReporterManagerXml.java
+++ b/java/src/jmri/jmrix/loconet/configurexml/LnReporterManagerXml.java
@@ -29,6 +29,6 @@ public class LnReporterManagerXml extends jmri.managers.configurexml.AbstractRep
         return loadReporters(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LnReporterManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(LnReporterManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/loconet/configurexml/LnReporterManagerXml.java
+++ b/java/src/jmri/jmrix/loconet/configurexml/LnReporterManagerXml.java
@@ -24,11 +24,6 @@ public class LnReporterManagerXml extends jmri.managers.configurexml.AbstractRep
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual Reporters
         return loadReporters(shared);

--- a/java/src/jmri/jmrix/loconet/configurexml/LnSensorManagerXml.java
+++ b/java/src/jmri/jmrix/loconet/configurexml/LnSensorManagerXml.java
@@ -31,5 +31,5 @@ public class LnSensorManagerXml extends jmri.managers.configurexml.AbstractSenso
         return true;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LnSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(LnSensorManagerXml.class);
 }

--- a/java/src/jmri/jmrix/loconet/configurexml/LnSensorManagerXml.java
+++ b/java/src/jmri/jmrix/loconet/configurexml/LnSensorManagerXml.java
@@ -25,11 +25,6 @@ public class LnSensorManagerXml extends jmri.managers.configurexml.AbstractSenso
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // load individual sensors
         loadSensors(shared);

--- a/java/src/jmri/jmrix/maple/configurexml/SerialLightManagerXml.java
+++ b/java/src/jmri/jmrix/maple/configurexml/SerialLightManagerXml.java
@@ -31,5 +31,5 @@ public class SerialLightManagerXml extends jmri.managers.configurexml.AbstractLi
         return loadLights(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialLightManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(SerialLightManagerXml.class);
 }

--- a/java/src/jmri/jmrix/maple/configurexml/SerialLightManagerXml.java
+++ b/java/src/jmri/jmrix/maple/configurexml/SerialLightManagerXml.java
@@ -26,11 +26,6 @@ public class SerialLightManagerXml extends jmri.managers.configurexml.AbstractLi
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual lights
         return loadLights(shared);

--- a/java/src/jmri/jmrix/maple/configurexml/SerialSensorManagerXml.java
+++ b/java/src/jmri/jmrix/maple/configurexml/SerialSensorManagerXml.java
@@ -30,5 +30,5 @@ public class SerialSensorManagerXml extends jmri.managers.configurexml.AbstractS
         return loadSensors(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(SerialSensorManagerXml.class);
 }

--- a/java/src/jmri/jmrix/maple/configurexml/SerialSensorManagerXml.java
+++ b/java/src/jmri/jmrix/maple/configurexml/SerialSensorManagerXml.java
@@ -25,11 +25,6 @@ public class SerialSensorManagerXml extends jmri.managers.configurexml.AbstractS
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // load individual sensors
         return loadSensors(shared);

--- a/java/src/jmri/jmrix/marklin/configurexml/MarklinSensorManagerXml.java
+++ b/java/src/jmri/jmrix/marklin/configurexml/MarklinSensorManagerXml.java
@@ -25,11 +25,6 @@ public class MarklinSensorManagerXml extends jmri.managers.configurexml.Abstract
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // create the master object
         //MarklinSensorManager.instance();

--- a/java/src/jmri/jmrix/marklin/configurexml/MarklinSensorManagerXml.java
+++ b/java/src/jmri/jmrix/marklin/configurexml/MarklinSensorManagerXml.java
@@ -32,5 +32,5 @@ public class MarklinSensorManagerXml extends jmri.managers.configurexml.Abstract
         return loadSensors(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(MarklinSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(MarklinSensorManagerXml.class);
 }

--- a/java/src/jmri/jmrix/mqtt/configurexml/MqttTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/mqtt/configurexml/MqttTurnoutManagerXml.java
@@ -24,11 +24,6 @@ public class MqttTurnoutManagerXml extends jmri.managers.configurexml.AbstractTu
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual turnouts
         return loadTurnouts(shared, perNode);

--- a/java/src/jmri/jmrix/mqtt/configurexml/MqttTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/mqtt/configurexml/MqttTurnoutManagerXml.java
@@ -30,5 +30,5 @@ public class MqttTurnoutManagerXml extends jmri.managers.configurexml.AbstractTu
     }
 
     // initialize logging
-    private final static Logger log = LoggerFactory.getLogger(MqttTurnoutManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(MqttTurnoutManagerXml.class);
 }

--- a/java/src/jmri/jmrix/nce/configurexml/NceLightManagerXml.java
+++ b/java/src/jmri/jmrix/nce/configurexml/NceLightManagerXml.java
@@ -24,11 +24,6 @@ public class NceLightManagerXml extends jmri.managers.configurexml.AbstractLight
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual lights
         return loadLights(shared);

--- a/java/src/jmri/jmrix/nce/configurexml/NceLightManagerXml.java
+++ b/java/src/jmri/jmrix/nce/configurexml/NceLightManagerXml.java
@@ -29,5 +29,5 @@ public class NceLightManagerXml extends jmri.managers.configurexml.AbstractLight
         return loadLights(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(NceLightManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(NceLightManagerXml.class);
 }

--- a/java/src/jmri/jmrix/nce/configurexml/NceSensorManagerXml.java
+++ b/java/src/jmri/jmrix/nce/configurexml/NceSensorManagerXml.java
@@ -25,11 +25,6 @@ public class NceSensorManagerXml extends jmri.managers.configurexml.AbstractSens
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // load individual sensors
         return loadSensors(shared);

--- a/java/src/jmri/jmrix/nce/configurexml/NceSensorManagerXml.java
+++ b/java/src/jmri/jmrix/nce/configurexml/NceSensorManagerXml.java
@@ -30,5 +30,5 @@ public class NceSensorManagerXml extends jmri.managers.configurexml.AbstractSens
         return loadSensors(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(NceSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(NceSensorManagerXml.class);
 }

--- a/java/src/jmri/jmrix/openlcb/configurexml/OlcbLightManagerXml.java
+++ b/java/src/jmri/jmrix/openlcb/configurexml/OlcbLightManagerXml.java
@@ -51,5 +51,5 @@ public class OlcbLightManagerXml extends jmri.managers.configurexml.AbstractLigh
         return result;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(OlcbLightManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(OlcbLightManagerXml.class);
 }

--- a/java/src/jmri/jmrix/openlcb/configurexml/OlcbLightManagerXml.java
+++ b/java/src/jmri/jmrix/openlcb/configurexml/OlcbLightManagerXml.java
@@ -29,11 +29,6 @@ public class OlcbLightManagerXml extends jmri.managers.configurexml.AbstractLigh
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(@Nonnull Element shared, Element perNode) {
         boolean result;
         // We tell the Light managers that we will be loading Lights from XML and they should

--- a/java/src/jmri/jmrix/openlcb/configurexml/OlcbSensorManagerXml.java
+++ b/java/src/jmri/jmrix/openlcb/configurexml/OlcbSensorManagerXml.java
@@ -29,11 +29,6 @@ public class OlcbSensorManagerXml extends jmri.managers.configurexml.AbstractSen
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         boolean result;
         // We tell the Sensor managers that we will be loading Sensors from XML and they should

--- a/java/src/jmri/jmrix/openlcb/configurexml/OlcbSensorManagerXml.java
+++ b/java/src/jmri/jmrix/openlcb/configurexml/OlcbSensorManagerXml.java
@@ -51,5 +51,5 @@ public class OlcbSensorManagerXml extends jmri.managers.configurexml.AbstractSen
         return result;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(OlcbSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(OlcbSensorManagerXml.class);
 }

--- a/java/src/jmri/jmrix/openlcb/configurexml/OlcbTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/openlcb/configurexml/OlcbTurnoutManagerXml.java
@@ -27,11 +27,6 @@ public class OlcbTurnoutManagerXml extends jmri.managers.configurexml.AbstractTu
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // We tell the Turnout managers that we will be loading turnouts from XML and they should
         // expect additional property set sequences. This is somewhat tricky in the face of

--- a/java/src/jmri/jmrix/openlcb/configurexml/OlcbTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/openlcb/configurexml/OlcbTurnoutManagerXml.java
@@ -47,6 +47,6 @@ public class OlcbTurnoutManagerXml extends jmri.managers.configurexml.AbstractTu
         return ret;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(OlcbTurnoutManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(OlcbTurnoutManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/pi/configurexml/RaspberryPiTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/pi/configurexml/RaspberryPiTurnoutManagerXml.java
@@ -25,11 +25,6 @@ public class RaspberryPiTurnoutManagerXml extends jmri.managers.configurexml.Abs
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual turnouts
         return loadTurnouts(shared, perNode);

--- a/java/src/jmri/jmrix/pi/configurexml/RaspberryPiTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/pi/configurexml/RaspberryPiTurnoutManagerXml.java
@@ -30,6 +30,6 @@ public class RaspberryPiTurnoutManagerXml extends jmri.managers.configurexml.Abs
         return loadTurnouts(shared, perNode);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(RaspberryPiTurnoutManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(RaspberryPiTurnoutManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/powerline/configurexml/SerialLightManagerXml.java
+++ b/java/src/jmri/jmrix/powerline/configurexml/SerialLightManagerXml.java
@@ -31,5 +31,5 @@ public class SerialLightManagerXml extends jmri.managers.configurexml.AbstractLi
         return loadLights(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialLightManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(SerialLightManagerXml.class);
 }

--- a/java/src/jmri/jmrix/powerline/configurexml/SerialLightManagerXml.java
+++ b/java/src/jmri/jmrix/powerline/configurexml/SerialLightManagerXml.java
@@ -26,11 +26,6 @@ public class SerialLightManagerXml extends jmri.managers.configurexml.AbstractLi
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual lights
         return loadLights(shared);

--- a/java/src/jmri/jmrix/powerline/configurexml/SerialSensorManagerXml.java
+++ b/java/src/jmri/jmrix/powerline/configurexml/SerialSensorManagerXml.java
@@ -30,5 +30,5 @@ public class SerialSensorManagerXml extends jmri.managers.configurexml.AbstractS
         return loadSensors(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(SerialSensorManagerXml.class);
 }

--- a/java/src/jmri/jmrix/powerline/configurexml/SerialSensorManagerXml.java
+++ b/java/src/jmri/jmrix/powerline/configurexml/SerialSensorManagerXml.java
@@ -25,11 +25,6 @@ public class SerialSensorManagerXml extends jmri.managers.configurexml.AbstractS
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // load individual sensors
         return loadSensors(shared);

--- a/java/src/jmri/jmrix/powerline/configurexml/SerialTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/powerline/configurexml/SerialTurnoutManagerXml.java
@@ -29,5 +29,5 @@ public class SerialTurnoutManagerXml extends jmri.managers.configurexml.Abstract
         return loadTurnouts(shared, perNode);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerXml.class);
 }

--- a/java/src/jmri/jmrix/powerline/configurexml/SerialTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/powerline/configurexml/SerialTurnoutManagerXml.java
@@ -24,11 +24,6 @@ public class SerialTurnoutManagerXml extends jmri.managers.configurexml.Abstract
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual turnouts
         return loadTurnouts(shared, perNode);

--- a/java/src/jmri/jmrix/rfid/configurexml/RfidReporterManagerXml.java
+++ b/java/src/jmri/jmrix/rfid/configurexml/RfidReporterManagerXml.java
@@ -26,11 +26,6 @@ public class RfidReporterManagerXml extends jmri.managers.configurexml.AbstractR
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual sensors
         return loadReporters(shared);

--- a/java/src/jmri/jmrix/rfid/configurexml/RfidReporterManagerXml.java
+++ b/java/src/jmri/jmrix/rfid/configurexml/RfidReporterManagerXml.java
@@ -31,5 +31,5 @@ public class RfidReporterManagerXml extends jmri.managers.configurexml.AbstractR
         return loadReporters(shared);
     }
 
-    private static final Logger log = LoggerFactory.getLogger(RfidReporterManagerXml.class);
+//    private static final Logger log = LoggerFactory.getLogger(RfidReporterManagerXml.class);
 }

--- a/java/src/jmri/jmrix/rfid/configurexml/RfidSensorManagerXml.java
+++ b/java/src/jmri/jmrix/rfid/configurexml/RfidSensorManagerXml.java
@@ -27,11 +27,6 @@ public class RfidSensorManagerXml extends jmri.managers.configurexml.AbstractSen
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // load individual sensors
         return loadSensors(shared);

--- a/java/src/jmri/jmrix/rfid/configurexml/RfidSensorManagerXml.java
+++ b/java/src/jmri/jmrix/rfid/configurexml/RfidSensorManagerXml.java
@@ -32,5 +32,5 @@ public class RfidSensorManagerXml extends jmri.managers.configurexml.AbstractSen
         return loadSensors(shared);
     }
 
-    private static final Logger log = LoggerFactory.getLogger(RfidSensorManagerXml.class);
+//    private static final Logger log = LoggerFactory.getLogger(RfidSensorManagerXml.class);
 }

--- a/java/src/jmri/jmrix/roco/z21/configurexml/Z21SensorManagerXml.java
+++ b/java/src/jmri/jmrix/roco/z21/configurexml/Z21SensorManagerXml.java
@@ -28,11 +28,6 @@ public class Z21SensorManagerXml extends jmri.managers.configurexml.AbstractSens
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // load individual sensors
         return loadSensors(shared);

--- a/java/src/jmri/jmrix/roco/z21/configurexml/Z21SensorManagerXml.java
+++ b/java/src/jmri/jmrix/roco/z21/configurexml/Z21SensorManagerXml.java
@@ -33,5 +33,5 @@ public class Z21SensorManagerXml extends jmri.managers.configurexml.AbstractSens
         return loadSensors(shared);
     }
 
-    private static final Logger log = LoggerFactory.getLogger(Z21SensorManagerXml.class);
+//    private static final Logger log = LoggerFactory.getLogger(Z21SensorManagerXml.class);
 }

--- a/java/src/jmri/jmrix/rps/configurexml/RpsReporterManagerXml.java
+++ b/java/src/jmri/jmrix/rps/configurexml/RpsReporterManagerXml.java
@@ -25,11 +25,6 @@ public class RpsReporterManagerXml extends jmri.managers.configurexml.AbstractRe
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual sensors
         return loadReporters(shared);

--- a/java/src/jmri/jmrix/rps/configurexml/RpsReporterManagerXml.java
+++ b/java/src/jmri/jmrix/rps/configurexml/RpsReporterManagerXml.java
@@ -30,6 +30,6 @@ public class RpsReporterManagerXml extends jmri.managers.configurexml.AbstractRe
         return loadReporters(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(RpsReporterManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(RpsReporterManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/rps/configurexml/RpsSensorManagerXml.java
+++ b/java/src/jmri/jmrix/rps/configurexml/RpsSensorManagerXml.java
@@ -30,6 +30,6 @@ public class RpsSensorManagerXml extends jmri.managers.configurexml.AbstractSens
         return loadSensors(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(RpsSensorManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(RpsSensorManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/rps/configurexml/RpsSensorManagerXml.java
+++ b/java/src/jmri/jmrix/rps/configurexml/RpsSensorManagerXml.java
@@ -25,11 +25,6 @@ public class RpsSensorManagerXml extends jmri.managers.configurexml.AbstractSens
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
         // load individual sensors
         return loadSensors(shared);

--- a/java/src/jmri/jmrix/secsi/configurexml/SerialLightManagerXml.java
+++ b/java/src/jmri/jmrix/secsi/configurexml/SerialLightManagerXml.java
@@ -31,5 +31,5 @@ public class SerialLightManagerXml extends jmri.managers.configurexml.AbstractLi
         return loadLights(shared);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialLightManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(SerialLightManagerXml.class);
 }

--- a/java/src/jmri/jmrix/secsi/configurexml/SerialLightManagerXml.java
+++ b/java/src/jmri/jmrix/secsi/configurexml/SerialLightManagerXml.java
@@ -26,11 +26,6 @@ public class SerialLightManagerXml extends jmri.managers.configurexml.AbstractLi
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual lights
         return loadLights(shared);

--- a/java/src/jmri/jmrix/secsi/configurexml/SerialTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/secsi/configurexml/SerialTurnoutManagerXml.java
@@ -29,5 +29,5 @@ public class SerialTurnoutManagerXml extends jmri.managers.configurexml.Abstract
         return loadTurnouts(shared, perNode);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerXml.class);
 }

--- a/java/src/jmri/jmrix/secsi/configurexml/SerialTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/secsi/configurexml/SerialTurnoutManagerXml.java
@@ -24,11 +24,6 @@ public class SerialTurnoutManagerXml extends jmri.managers.configurexml.Abstract
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual turnouts
         return loadTurnouts(shared, perNode);

--- a/java/src/jmri/jmrix/tams/configurexml/TamsTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/tams/configurexml/TamsTurnoutManagerXml.java
@@ -33,5 +33,5 @@ public class TamsTurnoutManagerXml extends jmri.managers.configurexml.AbstractTu
         return loadTurnouts(shared, perNode);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TamsTurnoutManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(TamsTurnoutManagerXml.class);
 }

--- a/java/src/jmri/jmrix/tams/configurexml/TamsTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/tams/configurexml/TamsTurnoutManagerXml.java
@@ -26,11 +26,6 @@ public class TamsTurnoutManagerXml extends jmri.managers.configurexml.AbstractTu
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // create the master object
         //TamsTurnoutManager.instance();

--- a/java/src/jmri/jmrix/tmcc/configurexml/SerialTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/tmcc/configurexml/SerialTurnoutManagerXml.java
@@ -24,11 +24,6 @@ public class SerialTurnoutManagerXml extends jmri.managers.configurexml.Abstract
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual turnouts
         return loadTurnouts(shared, perNode);

--- a/java/src/jmri/jmrix/tmcc/configurexml/SerialTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/tmcc/configurexml/SerialTurnoutManagerXml.java
@@ -29,6 +29,6 @@ public class SerialTurnoutManagerXml extends jmri.managers.configurexml.Abstract
         return loadTurnouts(shared, perNode);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerXml.class);
 
 }

--- a/java/src/jmri/jmrix/ztc/ztc611/configurexml/ZTC611XNetTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/ztc/ztc611/configurexml/ZTC611XNetTurnoutManagerXml.java
@@ -25,11 +25,6 @@ public class ZTC611XNetTurnoutManagerXml extends jmri.managers.configurexml.Abst
     }
 
     @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
-    @Override
     public boolean load(Element shared, Element perNode) {
         // load individual turnouts
         return loadTurnouts(shared, perNode);

--- a/java/src/jmri/jmrix/ztc/ztc611/configurexml/ZTC611XNetTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/ztc/ztc611/configurexml/ZTC611XNetTurnoutManagerXml.java
@@ -30,6 +30,6 @@ public class ZTC611XNetTurnoutManagerXml extends jmri.managers.configurexml.Abst
         return loadTurnouts(shared, perNode);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ZTC611XNetTurnoutManagerXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(ZTC611XNetTurnoutManagerXml.class);
 
 }

--- a/java/src/jmri/managers/configurexml/AbstractAudioManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractAudioManagerConfigXML.java
@@ -252,11 +252,6 @@ public abstract class AbstractAudioManagerConfigXML extends AbstractNamedBeanMan
      */
     abstract public void setStoreElementClass(Element audio);
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     /**
      * Utility method to load the individual Audio objects. If there's no
      * additional info needed for a specific Audio type, invoke this with the

--- a/java/src/jmri/managers/configurexml/AbstractMemoryManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractMemoryManagerConfigXML.java
@@ -88,11 +88,6 @@ public abstract class AbstractMemoryManagerConfigXML extends AbstractNamedBeanMa
      */
     abstract public void setStoreElementClass(Element memories);
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     /**
      * Create a MemoryManager object of the correct class, then register and
      * fill it.

--- a/java/src/jmri/managers/configurexml/AbstractSignalHeadManagerXml.java
+++ b/java/src/jmri/managers/configurexml/AbstractSignalHeadManagerXml.java
@@ -97,11 +97,6 @@ public class AbstractSignalHeadManagerXml extends AbstractNamedBeanManagerConfig
         return true;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     /**
      * Utility method to load the individual SignalHead objects. If there's no
      * additional info needed for a specific signal head type, invoke this with

--- a/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
@@ -153,11 +153,6 @@ public class DefaultConditionalManagerXml extends jmri.managers.configurexml.Abs
         conditionals.setAttribute("class", this.getClass().getName());  // NOI18N
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");  // NOI18N
-    }
-
     /**
      * Create a ConditionalManager object of the correct class, then register
      * and fill it.

--- a/java/src/jmri/managers/configurexml/DefaultRouteManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultRouteManagerXml.java
@@ -209,11 +209,6 @@ public class DefaultRouteManagerXml extends jmri.managers.configurexml.AbstractN
         routes.setAttribute("class", this.getClass().getName());
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     /**
      * Create a RouteManager object of the correct class, then register and fill
      * it.

--- a/java/src/jmri/managers/configurexml/DefaultSignalGroupManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultSignalGroupManagerXml.java
@@ -218,11 +218,6 @@ public class DefaultSignalGroupManagerXml
         return true;
     }
 
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Invalid method called");
-    }
-
     private int getIntFromColour(String color) {
         switch (color) {
             case "RED":

--- a/java/src/jmri/managers/configurexml/ManagerDefaultSelectorXml.java
+++ b/java/src/jmri/managers/configurexml/ManagerDefaultSelectorXml.java
@@ -71,16 +71,6 @@ public class ManagerDefaultSelectorXml extends AbstractXmlAdapter {
         return true;
     }
 
-    /**
-     * Doesn't need to do anything, shouldn't get invoked
-     *
-     * @param element Top level Element to unpack.
-     * @param o       PanelEditor as an Object
-     */
-    @Override
-    public void load(Element element, Object o) {
-    }
-
     //private final static Logger log = LoggerFactory.getLogger(ManagerDefaultSelectorXml.class);
 
 }

--- a/java/src/jmri/util/startup/configurexml/PerformActionModelXml.java
+++ b/java/src/jmri/util/startup/configurexml/PerformActionModelXml.java
@@ -98,17 +98,6 @@ public class PerformActionModelXml extends jmri.configurexml.AbstractXmlAdapter 
         return result;
     }
 
-    /**
-     * Update static data from XML file
-     *
-     * @param element Top level Element to unpack.
-     * @param o       ignored
-     */
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Unexpected call of load(Element, Object)");
-    }
-
     // initialize logging
     private static final Logger log = LoggerFactory.getLogger(PerformActionModelXml.class);
 

--- a/java/src/jmri/util/startup/configurexml/PerformFileModelXml.java
+++ b/java/src/jmri/util/startup/configurexml/PerformFileModelXml.java
@@ -61,16 +61,6 @@ public class PerformFileModelXml extends jmri.configurexml.AbstractXmlAdapter {
         return result;
     }
 
-    /**
-     * Update static data from XML file
-     *
-     * @param element Top level Element to unpack.
-     * @param o       ignored
-     */
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Unexpected call of load(Element, Object)");
-    }
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(PerformFileModelXml.class);
 

--- a/java/src/jmri/util/startup/configurexml/PerformFileModelXml.java
+++ b/java/src/jmri/util/startup/configurexml/PerformFileModelXml.java
@@ -62,6 +62,6 @@ public class PerformFileModelXml extends jmri.configurexml.AbstractXmlAdapter {
     }
 
     // initialize logging
-    private final static Logger log = LoggerFactory.getLogger(PerformFileModelXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(PerformFileModelXml.class);
 
 }

--- a/java/src/jmri/util/startup/configurexml/PerformScriptModelXml.java
+++ b/java/src/jmri/util/startup/configurexml/PerformScriptModelXml.java
@@ -62,16 +62,6 @@ public class PerformScriptModelXml extends jmri.configurexml.AbstractXmlAdapter 
         return result;
     }
 
-    /**
-     * Update static data from XML file
-     *
-     * @param element Top level Element to unpack.
-     * @param o       ignored
-     */
-    @Override
-    public void load(Element element, Object o) {
-        log.error("Unexpected call of load(Element, Object)");
-    }
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(PerformScriptModelXml.class);
 

--- a/java/src/jmri/util/startup/configurexml/PerformScriptModelXml.java
+++ b/java/src/jmri/util/startup/configurexml/PerformScriptModelXml.java
@@ -63,6 +63,6 @@ public class PerformScriptModelXml extends jmri.configurexml.AbstractXmlAdapter 
     }
 
     // initialize logging
-    private final static Logger log = LoggerFactory.getLogger(PerformScriptModelXml.class);
+//    private final static Logger log = LoggerFactory.getLogger(PerformScriptModelXml.class);
 
 }


### PR DESCRIPTION
`jmri.configurexml.XmlAdapter` has the method `load(Element, Object)` which in a lot of cases only logs an error. This PR moves the code to `AbstractXmlAdapter` and removes the implementation from the concrete classes:
```
public void load(Element e, Object o) throws JmriConfigureXmlException {
    log.error("Invalid method called");
}
```

In some cases, the error message is changed due to this, but since it's only a message to the log, I don't think that would be a problem.

Note `jmri.managers.configurexml.ManagerDefaultSelectorXml` which didn't log a message at all, but now does due to this change.