### PR TITLE
chore: remove SliderSnap from PanelPro-style apps

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -85,7 +85,6 @@ import jmri.util.ThreadingUtil;
 import jmri.util.WindowMenu;
 import jmri.util.iharder.dnd.URIDrop;
 import jmri.util.swing.JFrameInterface;
-import jmri.util.swing.SliderSnap;
 import jmri.util.swing.WindowInterface;
 import jmri.util.usb.RailDriverMenuItem;
 import jmri.web.server.WebServerAction;
@@ -125,9 +124,6 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         jmri.Application.setLogo(logo());
         log.trace("setURL");
         jmri.Application.setURL(line2());
-
-        // Enable proper snapping of JSliders
-        SliderSnap.init();
 
         // Get configuration profile
         log.trace("start to get configuration profile - locate files");

--- a/java/src/jmri/util/swing/SliderSnap.java
+++ b/java/src/jmri/util/swing/SliderSnap.java
@@ -63,7 +63,10 @@ import javax.swing.plaf.basic.BasicSliderUI;
  *
  * @author Michael Kneebone Copyright (c) 2007, 2011
  * @author Matthew Harris Copyright (c) 2011
+ * @deprecated since 4.21.1 without direct replacement as uses illegal
+ * reflective access
  */
+@Deprecated
 public class SliderSnap extends BasicSliderUI {
 
     /**


### PR DESCRIPTION
This was never used in DecoderPro3 and since JDK 9 has caused warnings that how it works will eventually be denied in a future JDK.