### PR TITLE
Don't group imports

### DIFF
--- a/nb-configuration.xml
+++ b/nb-configuration.xml
@@ -36,5 +36,6 @@ Any value defined here will override the pom.xml file value but is only applicab
         <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.generateParagraphTagOnBlankLines>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.generateParagraphTagOnBlankLines>
         <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.countForUsingStarImport>3</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.countForUsingStarImport>
         <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.allowConvertToStarImport>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.allowConvertToStarImport>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.separateImportGroups>false</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.separateImportGroups>
     </properties>
 </project-shared-configuration>


### PR DESCRIPTION
NetBeans has started to group the imports. Should it do that? I find it irritating.

This PR reverts that change.