### PR TITLE
MERG CBUS Node Manager bugfixes (from master)

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeTableOperations.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeTableOperations.java
@@ -37,7 +37,7 @@ public class CbusBasicNodeTableOperations extends CbusBasicNodeTable {
             setRequestNodeDisplay(node.getNodeNumber());
         }
         // notify the JTable object that a row has changed; do that in the Swing thread!
-        ThreadingUtil.runOnGUIEventually(() -> fireTableRowsInserted((getRowCount()-1), (getRowCount()-1)));
+        ThreadingUtil.runOnGUIEventually(() -> fireTableDataChanged() );
     }
     
     /**

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeConstants.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeConstants.java
@@ -55,7 +55,7 @@ public class CbusNodeConstants {
                 || node.getNodeParamManager().getParameter(3) == 12 // or CANBC
             ) { 
                 if ( node.getNodeParamManager().getParameter(7) == 4 ) { // v4 Firmware
-                    node.getNodeEventManager().resetNodeEvents(); // sets num events to 0 as does not respond to RQEVN
+                    node.getNodeEventManager().resetNodeEventsToZero(); // sets num events to 0 as does not respond to RQEVN
                     node.setStatResponseFlagsAccurate(false);
                 }
             }


### PR DESCRIPTION
For 4.19.8 if possible, apologies for late submittal.

https://groups.io/g/jmriusers/message/174081

Fixes multiple exceptions CBUS Node Manager on every CAN Frame which v quickly swamp the JMRI console and slow down system.
Sets MERG Command Station Firmware V4 events to 0, not null.