### PR TITLE
MERG CBUS Use memo PowerManager

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeWithMgrsCommandStation.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeWithMgrsCommandStation.java
@@ -95,10 +95,8 @@ public class CbusBasicNodeWithMgrsCommandStation extends CbusBasicNodeWithManage
     }
 
     private void setTrackPower(boolean powerOn) {
-        // TODO: Must use the PowerManager returned by _memo.get(), since it is
-        // not valid to assume the default power manager is a CbusPowerManager
-        ((CbusPowerManager) InstanceManager.getDefault(PowerManager.class))
-                .updatePower(powerOn ? PowerManager.ON : PowerManager.OFF);
+        CbusPowerManager pm = (CbusPowerManager) _memo.get(PowerManager.class);
+        pm.updatePower(powerOn ? PowerManager.ON : PowerManager.OFF);
     }
 
     private void checkSingleFlag(int flagNum, String errorText) {

--- a/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeWithMgrsCommandStationTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusBasicNodeWithMgrsCommandStationTest.java
@@ -45,9 +45,7 @@ public class CbusBasicNodeWithMgrsCommandStationTest {
     @Test
     public void testSetFlags() throws jmri.JmriException {
         
-        CbusPowerManager pwr = new CbusPowerManager(memo);
-        InstanceManager.setDefault(jmri.PowerManager.class,pwr);
-        
+        CbusPowerManager pwr = (CbusPowerManager) memo.get(PowerManager.class);
         t = new CbusBasicNodeWithMgrsCommandStation(memo,125);
         t.setCsNum(0); // default CS
         t.setStatResponseFlagsAccurate(true);
@@ -61,7 +59,6 @@ public class CbusBasicNodeWithMgrsCommandStationTest {
         assertThat(pwr.getPower()).isEqualTo(PowerManager.ON);
         
         t.dispose();
-        pwr.dispose();
     }
     
     private CbusBasicNodeWithMgrsCommandStation t;
@@ -75,6 +72,8 @@ public class CbusBasicNodeWithMgrsCommandStationTest {
         memo = new CanSystemConnectionMemo();
         tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
+        memo.setProtocol(jmri.jmrix.can.CanConfigurationManager.MERGCBUS);
+        memo.configureManagers();
     }
 
     @AfterEach


### PR DESCRIPTION
Use the memo PowerManager instead of Instance in CBUS Node Manager.
fixes #8533 