### PR TITLE
Fix 'Where Used' tool NPE on Dark OBlocks

### DIFF
--- a/java/src/jmri/jmrit/logix/OBlock.java
+++ b/java/src/jmri/jmrit/logix/OBlock.java
@@ -939,7 +939,10 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
         List<NamedBeanUsageReport> report = new ArrayList<>();
         List<NamedBean> duplicateCheck = new ArrayList<>();
         if (bean != null) {
-            log.debug("oblock: {}, sensor = {}", getDisplayName(), getSensor().getDisplayName());  // NOI18N
+            if (log.isDebugEnabled()) {
+                Sensor s = getSensor();
+                log.debug("oblock: {}, sensor = {}", getDisplayName(), (s==null?"Dark OBlock":s.getDisplayName()));  // NOI18N
+            }
             if (bean.equals(getSensor())) {
                 report.add(new NamedBeanUsageReport("OBlockSensor"));  // NOI18N
             }

--- a/java/test/jmri/jmrit/whereused/OBlockWhereUsedTest.java
+++ b/java/test/jmri/jmrit/whereused/OBlockWhereUsedTest.java
@@ -1,7 +1,14 @@
 package jmri.jmrit.whereused;
 
 import jmri.util.JUnitUtil;
+
+import java.util.List;
+
 import org.junit.*;
+
+import jmri.NamedBean;
+import jmri.NamedBeanUsageReport;
+import jmri.jmrit.logix.OBlock;
 
 /**
  * Tests for the OBlockWhereUsed Class
@@ -14,6 +21,11 @@ public class OBlockWhereUsedTest {
     public void testOBlockWhereUsed() {
         OBlockWhereUsed ctor = new OBlockWhereUsed();
         Assert.assertNotNull("exists", ctor);
+        
+        // Pay the ransom to free PR#8715 to be merged
+        OBlock b = new OBlock("OB1");
+        List<NamedBeanUsageReport> list = b.getUsageReport(b);
+        Assert.assertNotNull("exists", list);
     }
 
     @Before

--- a/java/test/jmri/jmrit/whereused/OBlockWhereUsedTest.java
+++ b/java/test/jmri/jmrit/whereused/OBlockWhereUsedTest.java
@@ -2,11 +2,8 @@ package jmri.jmrit.whereused;
 
 import jmri.util.JUnitUtil;
 
-import java.util.List;
-
 import org.junit.*;
 
-import jmri.NamedBeanUsageReport;
 import jmri.jmrit.logix.OBlock;
 
 /**
@@ -24,7 +21,7 @@ public class OBlockWhereUsedTest {
         // Pay the ransom to free PR#8715 to be merged
         OBlock b = new OBlock("OB1");
         try {
-            List<NamedBeanUsageReport> list = b.getUsageReport(b);
+            b.getUsageReport(b);
         } catch (java.lang.NullPointerException npe) {
             Assert.assertFalse("NullPointerException", true);
         }

--- a/java/test/jmri/jmrit/whereused/OBlockWhereUsedTest.java
+++ b/java/test/jmri/jmrit/whereused/OBlockWhereUsedTest.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import org.junit.*;
 
-import jmri.NamedBean;
 import jmri.NamedBeanUsageReport;
 import jmri.jmrit.logix.OBlock;
 
@@ -24,8 +23,11 @@ public class OBlockWhereUsedTest {
         
         // Pay the ransom to free PR#8715 to be merged
         OBlock b = new OBlock("OB1");
-        List<NamedBeanUsageReport> list = b.getUsageReport(b);
-        Assert.assertNotNull("exists", list);
+        try {
+            List<NamedBeanUsageReport> list = b.getUsageReport(b);
+        } catch (java.lang.NullPointerException npe) {
+            Assert.assertFalse("NullPointerException", true);
+        }
     }
 
     @Before


### PR DESCRIPTION
Any panel containing a Dark OBlock (i.e. no sensor) would NPE at line 942 searching any item from the panel.