### PR TITLE
Ensure STLR NamedBeans dispose of listeners

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusReporter.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusReporter.java
@@ -132,6 +132,7 @@ public class CbusReporter extends AbstractReporter implements CanListener {
     @Override
     public void dispose() {
         tc.removeCanListener(this);
+        super.dispose();
     }
 
     private static final Logger log = LoggerFactory.getLogger(CbusReporter.class);

--- a/java/src/jmri/jmrix/rfid/RfidSensor.java
+++ b/java/src/jmri/jmrix/rfid/RfidSensor.java
@@ -83,11 +83,6 @@ public class RfidSensor extends AbstractSensor
     }
 
     @Override
-    public void dispose() {
-//        Model.instance().removeRegion(region);
-    }
-
-    @Override
     public void requestUpdateFromLayout() {
     }
 

--- a/java/src/jmri/jmrix/rps/RpsReporter.java
+++ b/java/src/jmri/jmrix/rps/RpsReporter.java
@@ -110,8 +110,8 @@ public class RpsReporter extends AbstractReporter implements MeasurementListener
 
     @Override
     public void dispose() {
-        super.dispose();
         Model.instance().removeRegion(region);
+        super.dispose();
     }
 
     // Methods to support PhysicalLocationReporter interface

--- a/java/src/jmri/jmrix/rps/RpsReporter.java
+++ b/java/src/jmri/jmrix/rps/RpsReporter.java
@@ -110,6 +110,7 @@ public class RpsReporter extends AbstractReporter implements MeasurementListener
 
     @Override
     public void dispose() {
+        super.dispose();
         Model.instance().removeRegion(region);
     }
 

--- a/java/src/jmri/jmrix/rps/RpsSensor.java
+++ b/java/src/jmri/jmrix/rps/RpsSensor.java
@@ -119,6 +119,7 @@ public class RpsSensor extends AbstractSensor
     @Override
     public void dispose() {
         Model.instance().removeRegion(region);
+        super.dispose();
     }
 
     @Override

--- a/java/src/jmri/jmrix/secsi/SerialSensor.java
+++ b/java/src/jmri/jmrix/secsi/SerialSensor.java
@@ -19,10 +19,6 @@ public class SerialSensor extends AbstractSensor {
         _knownState = UNKNOWN;
     }
 
-    @Override
-    public void dispose() {
-    }
-
     /**
      * Request an update on status.
      * <p>

--- a/java/test/jmri/implementation/AbstractLightTestBase.java
+++ b/java/test/jmri/implementation/AbstractLightTestBase.java
@@ -85,7 +85,7 @@ public abstract class AbstractLightTestBase {
         try {
             Assert.assertTrue("controller listeners remaining < 1", t.getNumPropertyChangeListeners() < 1);
         }
-        catch ( Exception e){
+        catch ( RuntimeException e){
             Assert.assertTrue("Either <1 listeners or exception expected", true);
         }
     }

--- a/java/test/jmri/implementation/AbstractLightTestBase.java
+++ b/java/test/jmri/implementation/AbstractLightTestBase.java
@@ -75,6 +75,20 @@ public abstract class AbstractLightTestBase {
         t.dispose();
         Assert.assertEquals("controller listeners remaining", 0, numListeners());
     }
+    
+    @Test
+    public void testRemoveListenerOnDispose() {
+        Assert.assertEquals("starts 0 listeners", 0, t.getNumPropertyChangeListeners());
+        t.addPropertyChangeListener(new Listen());
+        Assert.assertEquals("controller listener added", 1, t.getNumPropertyChangeListeners());
+        t.dispose();
+        try {
+            Assert.assertTrue("controller listeners remaining < 1", t.getNumPropertyChangeListeners() < 1);
+        }
+        catch ( Exception e){
+            Assert.assertTrue("Either <1 listeners or exception expected", true);
+        }
+    }
 
     @Test
     public void testCommandOff() {

--- a/java/test/jmri/implementation/AbstractReporterTestBase.java
+++ b/java/test/jmri/implementation/AbstractReporterTestBase.java
@@ -81,10 +81,11 @@ abstract public class AbstractReporterTestBase {
     
     @Test
     public void testDispose() {
+        Assert.assertEquals("starts 0 listeners", 0, r.getNumPropertyChangeListeners());
         r.addPropertyChangeListener(new TestReporterListener());
         Assert.assertEquals("controller listener added", 1, r.getNumPropertyChangeListeners());
         r.dispose();
-        Assert.assertEquals("controller listeners remaining", 0, r.getNumPropertyChangeListeners());
+        Assert.assertTrue("controller listeners remaining < 1", r.getNumPropertyChangeListeners() < 1);
     }
 
     protected boolean currentReportSeen = false;

--- a/java/test/jmri/implementation/AbstractReporterTestBase.java
+++ b/java/test/jmri/implementation/AbstractReporterTestBase.java
@@ -80,12 +80,17 @@ abstract public class AbstractReporterTestBase {
     }
     
     @Test
-    public void testDispose() {
+    public void testAddRemoveListener() {
         Assert.assertEquals("starts 0 listeners", 0, r.getNumPropertyChangeListeners());
         r.addPropertyChangeListener(new TestReporterListener());
         Assert.assertEquals("controller listener added", 1, r.getNumPropertyChangeListeners());
         r.dispose();
-        Assert.assertTrue("controller listeners remaining < 1", r.getNumPropertyChangeListeners() < 1);
+        try {
+            Assert.assertTrue("controller listeners remaining < 1", r.getNumPropertyChangeListeners() < 1);
+        }
+        catch ( Exception e){
+            Assert.assertTrue("Either <1 listeners or exception expected", true);
+        }
     }
 
     protected boolean currentReportSeen = false;

--- a/java/test/jmri/implementation/AbstractReporterTestBase.java
+++ b/java/test/jmri/implementation/AbstractReporterTestBase.java
@@ -78,6 +78,14 @@ abstract public class AbstractReporterTestBase {
         // Check that LastReport was not seen (no change on null)
         Assert.assertFalse("LastReport seen after null", lastReportSeen);
     }
+    
+    @Test
+    public void testDispose() {
+        r.addPropertyChangeListener(new TestReporterListener());
+        Assert.assertEquals("controller listener added", 1, r.getNumPropertyChangeListeners());
+        r.dispose();
+        Assert.assertEquals("controller listeners remaining", 0, r.getNumPropertyChangeListeners());
+    }
 
     protected boolean currentReportSeen = false;
     protected boolean lastReportSeen = false;

--- a/java/test/jmri/implementation/AbstractReporterTestBase.java
+++ b/java/test/jmri/implementation/AbstractReporterTestBase.java
@@ -88,7 +88,7 @@ abstract public class AbstractReporterTestBase {
         try {
             Assert.assertTrue("controller listeners remaining < 1", r.getNumPropertyChangeListeners() < 1);
         }
-        catch ( Exception e){
+        catch ( RuntimeException e){
             Assert.assertTrue("Either <1 listeners or exception expected", true);
         }
     }

--- a/java/test/jmri/implementation/AbstractSensorTestBase.java
+++ b/java/test/jmri/implementation/AbstractSensorTestBase.java
@@ -93,7 +93,7 @@ public abstract class AbstractSensorTestBase {
         try {
             Assert.assertTrue("controller listeners remaining < 1", t.getNumPropertyChangeListeners() < 1);
         }
-        catch ( Exception e){
+        catch ( RuntimeException e){
             Assert.assertTrue("Either <1 listeners or exception expected", true);
         }
     }

--- a/java/test/jmri/implementation/AbstractSensorTestBase.java
+++ b/java/test/jmri/implementation/AbstractSensorTestBase.java
@@ -83,6 +83,20 @@ public abstract class AbstractSensorTestBase {
         t.dispose();
         Assert.assertEquals("controller listeners remaining", 0, numListeners());
     }
+    
+    @Test
+    public void testRemoveListenerOnDispose() {
+        Assert.assertEquals("starts 0 listeners", 0, t.getNumPropertyChangeListeners());
+        t.addPropertyChangeListener(new Listen());
+        Assert.assertEquals("controller listener added", 1, t.getNumPropertyChangeListeners());
+        t.dispose();
+        try {
+            Assert.assertTrue("controller listeners remaining < 1", t.getNumPropertyChangeListeners() < 1);
+        }
+        catch ( Exception e){
+            Assert.assertTrue("Either <1 listeners or exception expected", true);
+        }
+    }
 
     @Test
     public void testCommandInactive() throws JmriException {

--- a/java/test/jmri/implementation/AbstractTurnoutTestBase.java
+++ b/java/test/jmri/implementation/AbstractTurnoutTestBase.java
@@ -100,6 +100,20 @@ public abstract class AbstractTurnoutTestBase {
         t.dispose();
         Assert.assertEquals("controller listeners remaining", 0, numListeners());
     }
+    
+    @Test
+    public void testRemoveListenerOnDispose() {
+        int startListeners =  t.getNumPropertyChangeListeners();
+        t.addPropertyChangeListener(new Listen());
+        Assert.assertEquals("controller listener added", startListeners+1, t.getNumPropertyChangeListeners());
+        t.dispose();
+        try {
+            Assert.assertTrue("controller listeners remaining < 1", t.getNumPropertyChangeListeners() < 1);
+        }
+        catch ( Exception e){
+            Assert.assertTrue("Either <1 listeners or exception expected", true);
+        }
+    }
 
     @Test
     public void testCommandClosed() throws InterruptedException {

--- a/java/test/jmri/implementation/AbstractTurnoutTestBase.java
+++ b/java/test/jmri/implementation/AbstractTurnoutTestBase.java
@@ -110,7 +110,7 @@ public abstract class AbstractTurnoutTestBase {
         try {
             Assert.assertTrue("controller listeners remaining < 1", t.getNumPropertyChangeListeners() < 1);
         }
-        catch ( Exception e){
+        catch ( RuntimeException  e){
             Assert.assertTrue("Either <1 listeners or exception expected", true);
         }
     }


### PR DESCRIPTION
Not caught by AbstractNamedBean dispose method @OverridingMethodsMustInvokeSuper .