### PR TITLE
Update scripts to new form of ShutDownTask

### DIFF
--- a/java/src/jmri/implementation/AbstractMultiMeter.java
+++ b/java/src/jmri/implementation/AbstractMultiMeter.java
@@ -3,8 +3,6 @@ package jmri.implementation;
 import java.util.TimerTask;
 import jmri.MultiMeter;
 import jmri.beans.Bean;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Abstract base class for current meter objects.
@@ -124,6 +122,6 @@ abstract public class AbstractMultiMeter extends Bean implements MultiMeter {
         }
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AbstractMultiMeter.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractMultiMeter.class);
 
 }

--- a/java/src/jmri/implementation/AbstractShutDownTask.java
+++ b/java/src/jmri/implementation/AbstractShutDownTask.java
@@ -37,7 +37,7 @@ public abstract class AbstractShutDownTask implements ShutDownTask {
     @Override
     @SuppressWarnings("deprecation")
     public boolean isShutdownAllowed() {
-    	Log4JUtil.deprecationWarning(log, "isShutdownAllowed");
+        Log4JUtil.deprecationWarning(log, "isShutdownAllowed");
         return call();
     }
 
@@ -60,7 +60,7 @@ public abstract class AbstractShutDownTask implements ShutDownTask {
     @Override
     @SuppressWarnings("deprecation")
     public final boolean execute() {
-    	Log4JUtil.deprecationWarning(log, "execute");
+        Log4JUtil.deprecationWarning(log, "execute");
         run();
         return true;
     }
@@ -73,17 +73,17 @@ public abstract class AbstractShutDownTask implements ShutDownTask {
     @Override
     @SuppressWarnings("deprecation")
     public boolean isParallel() {
-    	Log4JUtil.deprecationWarning(log, "isParallel");
+        Log4JUtil.deprecationWarning(log, "isParallel");
         return false;
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public boolean isComplete() {
-    	Log4JUtil.deprecationWarning(log, "isComplete");
+        Log4JUtil.deprecationWarning(log, "isComplete");
         return !this.isParallel();
     }
-    
+
     /**
      * {@inheritDoc}
      * 

--- a/java/src/jmri/implementation/AbstractShutDownTask.java
+++ b/java/src/jmri/implementation/AbstractShutDownTask.java
@@ -4,6 +4,8 @@ import java.beans.PropertyChangeEvent;
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 import jmri.ShutDownTask;
 
+import jmri.util.Log4JUtil;
+
 /**
  * Abstract ShutDownTask implementation.
  * <p>
@@ -35,6 +37,7 @@ public abstract class AbstractShutDownTask implements ShutDownTask {
     @Override
     @SuppressWarnings("deprecation")
     public boolean isShutdownAllowed() {
+    	Log4JUtil.deprecationWarning(log, "isShutdownAllowed");
         return call();
     }
 
@@ -57,6 +60,7 @@ public abstract class AbstractShutDownTask implements ShutDownTask {
     @Override
     @SuppressWarnings("deprecation")
     public final boolean execute() {
+    	Log4JUtil.deprecationWarning(log, "execute");
         run();
         return true;
     }
@@ -69,12 +73,14 @@ public abstract class AbstractShutDownTask implements ShutDownTask {
     @Override
     @SuppressWarnings("deprecation")
     public boolean isParallel() {
+    	Log4JUtil.deprecationWarning(log, "isParallel");
         return false;
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public boolean isComplete() {
+    	Log4JUtil.deprecationWarning(log, "isComplete");
         return !this.isParallel();
     }
     
@@ -113,4 +119,6 @@ public abstract class AbstractShutDownTask implements ShutDownTask {
     public void setDoRun(boolean flag) {
         doRun = flag;
     }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractShutDownTask.class);
 }

--- a/jython/AC_PowerControl.py
+++ b/jython/AC_PowerControl.py
@@ -36,14 +36,14 @@ class ShutDown(jmri.implementation.AbstractShutDownTask):
 
 #---------------------------------------------------------------------------------
 # this is the code to be invoked when the program is shutting down
-    def execute(self):
+    def run(self):
         conn = httplib.HTTPConnection(deviceURL)
         conn.request("GET", "/io.cgi=?DOI1") # Open switch 1
         conn.close()
         conn = httplib.HTTPConnection(deviceURL)
         conn.request("GET", "/io.cgi=?DOI2") # Open switch 2
         conn.close()
-        return True # True to shutdown, False to abort shutdown
+        return
 
 #*********************************************************************************
 

--- a/jython/AutoDispatcher2.py
+++ b/jython/AutoDispatcher2.py
@@ -144,6 +144,7 @@ from jmri.jmrit import XmlFile
 
 from jmri.jmrit.consisttool import ConsistToolFrame
 
+# is this next import necessary?
 from jmri.implementation import AbstractShutDownTask
 
 # from jmri.jmrit.operations.locations import LocationManager

--- a/jython/IoT/JMRI_TcpPeripheral.py
+++ b/jython/IoT/JMRI_TcpPeripheral.py
@@ -327,7 +327,7 @@ class TcpPeripheral_ShutDown(jmri.implementation.AbstractShutDownTask):
 
 #---------------------------------------------------------------------------------
 # this is the code to be invoked when the program is shutting down
-    def execute(self):
+    def run(self):
         auxList = []
         for alias in TcpPeripheral_sockets:
             auxList.append(alias)
@@ -335,7 +335,7 @@ class TcpPeripheral_ShutDown(jmri.implementation.AbstractShutDownTask):
             TcpPeripheral_removeDevice(alias)
         TcpPeripheral_log.info("Shutting down 'TcpPeripheral'.")
         time.sleep(3) # wait 3 seconds for all sockets to close
-        return True # True to shutdown, False to abort shutdown
+        return
 
 #*********************************************************************************
 

--- a/jython/ShutDownExample.py
+++ b/jython/ShutDownExample.py
@@ -1,6 +1,6 @@
 # Schedule something to happen when a JMRI application ends
 #
-# Author: Bob Jacobsen, copyright 2008
+# Author: Bob Jacobsen, copyright 2008, 2020
 # Part of the JMRI distribution
 #
 
@@ -8,10 +8,10 @@ import jmri
 
 # Define the shutdown task
 class MyShutDownTask(jmri.implementation.AbstractShutDownTask):
-  def execute(self):
+  def run(self):
     # this is the code to be invoked when the program is shutting down
     print "Time to go!"
-    return True     # True to shutdown, False to abort shutdown
+    return
     
 shutdown.register(MyShutDownTask("Example"))
 

--- a/jython/TurnoutStatePersistence.py
+++ b/jython/TurnoutStatePersistence.py
@@ -44,7 +44,7 @@ class PersistTurnoutStateTask(jmri.implementation.AbstractShutDownTask):
     log = Logger.getLogger("jmri.jmrit.jython.exec.TurnoutStatePersistence.PersistTurnoutStateTask")
 
     # Define task to run at ShutDown
-    def execute(self):
+    def run(self):
 
         # Write an info entry to the log
         self.log.info("Write turnout state to file: '%s'" % turnoutFile)
@@ -95,7 +95,7 @@ class PersistTurnoutStateTask(jmri.implementation.AbstractShutDownTask):
         csvFile.close()
 
         # All done
-        return True     # True to allow ShutDown; False to abort
+        return
 
     # Function to convert state values to names
     def stateName(self, state):


### PR DESCRIPTION
This updates four scripts to the new form of the ShutDownTask. This fixes a regression, so it'll be included in a respin of JMRI 4.19.8

It also adds deprecation warnings to the deprecated methods of AbstractShutDownTask.

