### PR TITLE
VSDecoder: improve Block Value detection

### DIFF
--- a/help/en/manual/DecoderPro/Main_VSD.shtml
+++ b/help/en/manual/DecoderPro/Main_VSD.shtml
@@ -99,7 +99,7 @@
         <li>Configure the new VSDecoder
 
           <ul>
-            <li>Select a loco from the Roster or enter an address
+            <li>Select a locomotive from the Roster or enter an address
             Manually</li>
 
             <li>Click <em>Load VSD File</em> and load the
@@ -199,6 +199,8 @@
       <ul>
         <li>Digitrax Transponding (tested)</li>
 
+        <li>Occupancy Sensors and JMRI Blocks (tested)</li>
+
         <li>ESU ECoS (not tested)</li>
 
         <li>RFID (not tested)</li>
@@ -214,11 +216,7 @@
       "https://groups.io/g/jmriusers">JMRI users Groups.io group</a>.
       More systems will be added in the future.</p>
 
-      <p>For details on setting up Location Following, see the
-      <a href="VSD_LocationsMgr.shtml">Manage VSD Locations</a>
-      instructions.</p>
-
-      <p>When you have followed the above setup steps, launch a
+      <p>When you have setup the location following, launch a
       VSDecoder window, assign a locomotive and run it. As your
       locomotive moves around the layout, the sound will follow the
       locomotive's reported position.</p>
@@ -226,7 +224,18 @@
       <p><em>Note:</em> The sound will appear to "jump" from
       location to location as the locomotive's reported location
       changes. This effect will be smaller with additional and more
-      closely spaced reporters.</p>
+      closely spaced reporters or sensors.</p>
+
+      <h5>Location Following using Occupancy Sensors and JMRI Blocks</h5>
+
+      <p>Since JMRI Test Release 4.21.1 the "Location Following"
+      with JMRI Blocks and occupancy sensors is available.<br>
+      When you provide a locomotive address as a numeric Block value, then the 
+      sound follows the locations as the locomotive moves from
+      block to block.<br>
+      For more details, see the
+      <a href="VSD_LocationsMgr.shtml">Manage VSD Locations</a>
+      instructions.</p>
 
       <h5>Location Following using JMRI Operations</h5>
 
@@ -237,12 +246,9 @@
       <p>To set the Operations locations:</p>
 
       <ol>
-        <li>Select Operations-&gt;Settings</li>
+        <li>Select Tools-&gt;Operations-&gt;Locations</li>
 
-        <li>Select Tools-&gt;Options</li>
-
-        <li>Check the "Enable physical locations for Virtual Sound
-        Decoder" option, and save the changes.</li>
+        <li>Create Operations Locations within JMRI Operations</li>
 
         <li>Follow the directions in <a href=
         "VSD_LocationsMgr.shtml">Manage VSD Locations</a> to assign
@@ -265,9 +271,9 @@
 
       <p>Since JMRI Test Release 4.13.2 the "Advanced Location
       Following" is available. The Advanced Location Following
-      calculates the position of a loco within a location and
+      calculates the position of a locomotive within a location and
       sets the sound position continuously. This lets the sound
-      following the loco smoothly without a "jump".</p>
+      following the locomotive smoothly without a "jump".</p>
 
       <p>For details on setting up Advanced Location Following,
       see the

--- a/help/en/manual/DecoderPro/VSD_LocationsMgr.shtml
+++ b/help/en/manual/DecoderPro/VSD_LocationsMgr.shtml
@@ -62,7 +62,8 @@
       <p>The Blocks tab shows a list of all currently defined
       Blocks. This is intended for use with Digitrax
       Transponding or other similar locomotive tracking hardware
-      systems.</p>
+      systems. Using occupancy sensors it's possible to track
+      exactly one loco.</p>
 
 
       <h5>Operations Locations</h5><img src=
@@ -97,6 +98,8 @@
       <ul>
         <li>Digitrax Transponding (tested)</li>
 
+        <li>Occupancy Sensors and JMRI Blocks (tested)</li>
+
         <li>ESU ECoS (not tested)</li>
 
         <li>RFID (not tested)</li>
@@ -114,17 +117,18 @@
 
       <ol>
         <li>Follow the directions appropriate to your hardware
-        system for 
+        system for setting up
         <!-- link below should point to the HELP page for Reporters -->
-         <a href="../../html/tools/Reporters.shtml">setting up
-        Reporters</a>.</li>
+        <!-- klk32003: it is the HELP page (part 2) for Reporters -->
+         <a href="../../html/tools/Reporters.shtml">Reporters</a> or
+         <a href="../../html/tools/Sensors.shtml">Sensors</a>.</li>
 
         <li>Select Debug-&gt;Virtual Sound Decoder-&gt;Manage VSD
         Locations</li>
 
         <li>In the dialog, set X / Y / Z coordinates for each
-        reporter you wish to use for VSD location following.
-        Uncheck the "Use Location" box for Reporters you do not
+        Reporter (or other Objects) you wish to use for VSD location following.
+        Uncheck the "Use Location" box for Objects you do not
         wish to use for VSD tracking.</li>
 
         <li>Click "Save" to store the new values.</li>
@@ -133,10 +137,10 @@
         part of a Panel</li>
       </ol>
 
-      <p><em>Note:</em> Reporters are not added to the Manage VSD
-      Locations "live". If you add new Reporters, you must close
-      and re-open the Manage VSD Locations window to make the new
-      Reporters appear.</p>
+      <p><em>Note:</em> Reporters and Blocks are not added to the Manage
+      VSD Locations "live". If you add new Reporters or Blocks, you must
+      close and re-open the Manage VSD Locations window to make the new
+      Reporters or Blocks appear.</p>
 
       <h5>Coordinate System</h5>
 
@@ -181,7 +185,7 @@
       and/or orientation, go to the Listeners tab and set the X / Y
       / Z coordinates of the Listener's location. The coordinates
       and units must be the same as those used for the
-      Reporters.</p>
+      Reporters or other Objects.</p>
 
       <p>The Bearing and Azimuth values set the orientation of the
       Listener, or the direction the Listener is facing. Bearing is
@@ -202,7 +206,24 @@
       <p><em>Note:</em> The sound will appear to "jump" from
       location to location as the locomotive's reported location
       changes. This effect will be smaller with additional and more
-      closely spaced reporters.</p>
+      closely spaced reporters or blocks.</p>
+
+      <h5>Location Following using Occupancy Sensors and JMRI Blocks</h5>
+
+      <p>If you have installed occupancy sensors, you can use
+      JMRI Blocks to enable a location following.</p>
+
+      <p>A convenient way to do the setup is creating a Panel with
+      the JMRI Layout Editor. A Layout Editor guidance can be found
+      <a href="https://www.jmri.org/help/en/package/jmri/jmrit/display/LayoutEditor.shtml">
+	  here</a>.</p>
+
+      <p>Your Panel should have all the Blocks and attached Sensors you need.
+      Test and store the Panel.<br>
+      Then launch the VSDecoder Manager window and create a VSDecoder.<br>
+      To start the location following enter the number of the VSDecoder locomotive address into 
+      the Value field of your starting block (Tools-&gt;Tables-&gt;Block). This sets the new sound position.
+      Now run your locomotive.</p>
 
       <h5>Location Following using JMRI Operations</h5>
 
@@ -213,12 +234,7 @@
       <p>To set the Operations locations:</p>
 
       <ol>
-        <li>Select Operations-&gt;Settings</li>
-
-        <li>Select Tools-&gt;Options</li>
-
-        <li>Check the "Enable physical locations for Virtual Sound
-        Decoder" option, and save the changes.</li>
+        <li>Select Tools-&gt;Operations-&gt;Locations</li>
 
         <li>Create Operations Locations within JMRI Operations</li>
 
@@ -280,7 +296,7 @@
       <p>The general attributes are:</p>
       <ul>
         <li>layout scale (default: N)</li>
-        <li>check time (interval for calculating a new loco position; minimum: 500, maximum: 5000, default: 2000 milliseconds).</li>
+        <li>check time (interval for calculating a new locomotive position; minimum: 500, maximum: 5000, default: 2000 milliseconds).</li>
       </ul>
 
       <p>The attributes for each location are:</p>
@@ -296,7 +312,7 @@
          point (rotate-xpos value, rotate-ypos value) must be provided</li>
         <li>end-position (endpoint) of the location (last location only)
          <br>
-         if the loco is running in a circle, the starting point of the first location and the
+         if the locomotive is running in a circle, the starting point of the first location and the
          endpoint must be identical</li>
       </ul>
 
@@ -314,8 +330,8 @@
       The described route should go away from the left to the right in forward direction, or in case of a
       circle, in clock-wise forward direction.</p>
 
-      <p>The Advanced Location Following allows up to four locos. Normally only one
-      loco can be detected in a tracking section. If you want to run more than one loco, you may create
+      <p>The Advanced Location Following allows up to four locomotives. Normally only one
+      locomotive can be detected in a tracking section. If you want to run more than one locomotive, you may create
       a JMRI Route (again, up to four for VSD purposes) and add the Route to a Train. Please 
       choose the predetermined Route names VSDRoute1 (default), VSDRoute2, VSDRoute3 or VSDRoute4.
       On the "Virtual Sound Decoder Manager" window you'll find an "Option" button on each
@@ -342,7 +358,7 @@
           VSD File-&gt;File name: Class64.vsd-&gt;Select a Profile: Class64-&gt;OK-&gt;Start Engine</li>
         <li>Simulate an incoming Reporter: LocoNet-&gt;Send LocoNet Packet-&gt;Packet:
          d0 20 00 7d 03 00-&gt;Send-&gt;close the window</li>
-        <li>Run the loco and hear the sound wandering from the left to the right</li>
+        <li>Run the locomotive and hear the sound wandering from the left to the right</li>
       </ol>
 
       <p><em>Note:</em> If you choose a Diesel VSD file you might want to add a <strong>top-speed</strong>
@@ -358,7 +374,7 @@
 
       <p>Once you have a working setup, you can activate an option in your
       VSD configuration file to print the calculated position points describing the
-      route of your loco. Please see the "Create XY coordinates output in
+      route of your locomotive. Please see the "Create XY coordinates output in
       console for a VSDecoder" option
       <a href="VSD_File_and_Config.shtml#xy">for details</a>.</p>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -519,7 +519,10 @@
    <h3>Virtual Sound Decoder</h3>
         <a id="VSD" name="VSD"></a>
         <ul>
-            <li></li>
+            <li>VSD now supports the "Location Following" (sound follows loco) with occupancy
+                sensors and JMRI Blocks. See the 
+				<a href="https://jmri.org/help/en/manual/DecoderPro/Main_VSD.shtml#VSDLocations">
+                documentation</a> for details.</li>
         </ul>
 
     <h3>Miscellaneous</h3>

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
@@ -678,14 +678,14 @@ public class VSDecoderManager implements PropertyChangeListener {
                 if (event.getNewValue() instanceof String) {
                     repVal = event.getNewValue().toString();
                     // Is the new event value a valid VSDecoder address? If OK, set the sound position
-                    if (! repVal.trim().isEmpty()) {
-                        int address = Integer.parseInt(repVal);
-                        if (decoderInBlock.containsKey(address)) {
+                    if (org.apache.commons.lang3.StringUtils.isNumeric(repVal)) {
+                        int locoAddress = Integer.parseInt(repVal);
+                        if (decoderInBlock.containsKey(locoAddress)) {
                             if (blk.getPhysicalLocation() == null) {
                                 log.warn("Block {} has no physical location!", blk.getSystemName());
                             } else {
                                 log.debug("Block value: {}, physical location: {}", event.getNewValue(), blk.getPhysicalLocation());
-                                decoderInBlock.get(address).setPosition(blk.getPhysicalLocation());
+                                decoderInBlock.get(locoAddress).setPosition(blk.getPhysicalLocation());
                             }
                         } else {
                             log.warn("Block value \"{}\" is not a valid VSDecoder address", event.getNewValue());

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
@@ -642,38 +642,61 @@ public class VSDecoderManager implements PropertyChangeListener {
                 // Need to decide which reporter it is, so we can use different methods
                 // to extract the address and the location.
                 if ((Integer) event.getNewValue() == Block.OCCUPIED) {
-                    // Get this Block's Reporter's current/last report value.  need to fix this - it could be
-                    /// an idtag type reporter.
+                    // Is there a Block's Reporter?
                     if (blk.getReporter() == null) {
                         log.debug("Block {} has no reporter!  Skipping state-type report", blk.getSystemName());
                         return;
                     }
+                    // Get this Block's Reporter's current/last report value
                     if (blk.isReportingCurrent()) {
                         Object currentReport = blk.getReporter().getCurrentReport();
                         if ( currentReport != null) {
-                           if(currentReport instanceof jmri.Reportable) {
-                              repVal = ((jmri.Reportable)currentReport).toReportString();
-                           } else {
-                              repVal = currentReport.toString();
-                           }
+                            if(currentReport instanceof jmri.Reportable) {
+                                repVal = ((jmri.Reportable)currentReport).toReportString();
+                            } else {
+                                repVal = currentReport.toString();
+                            }
                         }
                     } else {
                         Object lastReport = blk.getReporter().getLastReport();
                         if ( lastReport != null) {
-                           if(lastReport instanceof jmri.Reportable) {
-                              repVal = ((jmri.Reportable)lastReport).toReportString();
-                           } else {
-                              repVal = lastReport.toString();
-                           }
+                            if(lastReport instanceof jmri.Reportable) {
+                                repVal = ((jmri.Reportable)lastReport).toReportString();
+                            } else {
+                                repVal = lastReport.toString();
+                            }
                         }
                     }
                 } else {
                     log.debug("Ignoring report. not an OCCUPIED event.");
                     return;
                 }
-            } else if (eventName.equals("value")) {
+            } else if (eventName.equals("value")) { // NOI18N
+                if (event.getNewValue() == null ) {
+                    return; // block value was cleared, nothing to do
+                }
                 if (event.getNewValue() instanceof String) {
                     repVal = event.getNewValue().toString();
+                    // Is the new event value a valid VSDecoder address? If OK, set the sound position
+                    if (! repVal.trim().isEmpty()) {
+                        int address = Integer.parseInt(repVal);
+                        if (decoderInBlock.containsKey(address)) {
+                            if (blk.getPhysicalLocation() == null) {
+                                log.warn("Block {} has no physical location!", blk.getSystemName());
+                            } else {
+                                log.debug("Block value: {}, physical location: {}", event.getNewValue(), blk.getPhysicalLocation());
+                                decoderInBlock.get(address).setPosition(blk.getPhysicalLocation());
+                            }
+                        } else {
+                            log.warn("Block value \"{}\" is not a valid VSDecoder address", event.getNewValue());
+                        }
+                        return;
+                    }
+                } else if (event.getNewValue() instanceof jmri.jmrix.loconet.TranspondingTag) {
+                    repVal = ((jmri.Reportable) event.getNewValue()).toReportString();
+                    log.info("Block Value TranspondingTag {} found", repVal);
+                } else {
+                    log.warn("Block Value \"{}\" found - unsupported object!", event.getNewValue());
                 }
                 // Else it will still be null from the declaration/assignment above.
             } else {
@@ -682,7 +705,7 @@ public class VSDecoderManager implements PropertyChangeListener {
             }  // Type of eventName.
             // Set the decoder's position.
             if (repVal == null) {
-                log.warn("Report from Block {} is null!", blk.getUserName());
+                log.warn("Report from Block {} is null!", blk.getSystemName());
             }
             if (blk.getDirection(repVal) == PhysicalLocationReporter.Direction.ENTER) {
                 setDecoderPositionByAddr(blk.getLocoAddress(repVal), blk.getPhysicalLocation());


### PR DESCRIPTION
After Next Production Release

This PR is a solution for an enhancement request from VSD users, discussed at [jmriusers](https://groups.io/g/jmriusers/topic/audio_vsdecoder/74999540).

The goal is "to bypass the requirement for Reporters and the associated hardware to notify JMRI what train is occupying a block and enabling the spatial sound feature..."