### PR TITLE
Webthrottle get loco session by roster

### DIFF
--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -141,13 +141,12 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
             throttle = new JsonThrottle(address, server);
             if (entry!=null) {
                 if (!manager.requestThrottle(entry, throttle)) {
-                    log.error("Unable to get rostered throttle for \"{}\".", address);
+                    log.error("Unable to get rostered throttle for \"{}\".", entry.getId());
                     throw new JsonException(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, Bundle
-                            .getMessage(server.getConnection().getLocale(), "ErrorThrottleUnableToGetThrottle", address),
+                            .getMessage(server.getConnection().getLocale(), "ErrorThrottleUnableToGetThrottle", entry.getId()),
                             id);
                 }
-            }
-            else {
+            } else {
                 if (!manager.requestThrottle(address, throttle)) {
                     log.error("Unable to get throttle for \"{}\".", address);
                     throw new JsonException(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, Bundle

--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -139,17 +139,25 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
                     manager.getServers(throttle).size()));
         } else {
             throttle = new JsonThrottle(address, server);
-            if (!manager.requestThrottle(address, throttle)) {
-                log.error("Unable to get throttle for \"{}\".", address);
-                throw new JsonException(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, Bundle
-                        .getMessage(server.getConnection().getLocale(), "ErrorThrottleUnableToGetThrottle", address),
-                        id);
+            if (entry!=null) {
+                if (!manager.requestThrottle(entry, throttle)) {
+                    log.error("Unable to get rostered throttle for \"{}\".", address);
+                    throw new JsonException(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, Bundle
+                            .getMessage(server.getConnection().getLocale(), "ErrorThrottleUnableToGetThrottle", address),
+                            id);
+                }
+            }
+            else {
+                if (!manager.requestThrottle(address, throttle)) {
+                    log.error("Unable to get throttle for \"{}\".", address);
+                    throw new JsonException(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, Bundle
+                            .getMessage(server.getConnection().getLocale(), "ErrorThrottleUnableToGetThrottle", address),
+                            id);
+                }
+                    
             }
             manager.put(address, throttle);
             manager.put(throttle, server);
-        }
-        if (entry != null) {
-            throttle.throttle.setRosterEntry(entry);
         }
         return throttle;
     }
@@ -217,6 +225,7 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
                 case ADDRESS:
                 case NAME:
                 case THROTTLE:
+                case ROSTER_ENTRY:
                     // no action for address, name, or throttle property
                     break;
                 default:

--- a/java/src/jmri/server/json/throttle/JsonThrottleManager.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottleManager.java
@@ -75,6 +75,10 @@ public class JsonThrottleManager implements InstanceManagerAutoDefault {
     public boolean requestThrottle(DccLocoAddress address, ThrottleListener listener) {
         return InstanceManager.getDefault(ThrottleManager.class).requestThrottle(address, listener, false);
     }
+    
+    public boolean requestThrottle(jmri.BasicRosterEntry rosterEntry, ThrottleListener listener) {
+        return InstanceManager.getDefault(ThrottleManager.class).requestThrottle(rosterEntry, listener, false);
+    }
 
     /**
      * Make the JsonThrottle listen to the given address.

--- a/web/js/jquery.jmriConnect.js
+++ b/web/js/jquery.jmriConnect.js
@@ -198,9 +198,7 @@
 			};
 			jmri.setJMRI = function(type, name, args) {
 				if (!heartbeat) {jmri.error(0, 'The JMRI WebSocket service is not ready.\nSolve the problem and refresh web page.'); return;}
-				var lp;
-				if (type == 'throttle') lp = (name) ? {"throttle":name} : {};
-				else lp = (name) ? {"name":name} : {};
+				var lp = (name) ? {"name":name} : {};
 				jmri.toSend(JSON.stringify({"type":type,"data":jmri.jsonConcat(lp, args)}));
 				jmri.socket.send(type, jmri.jsonConcat(lp, args));
 			};

--- a/web/js/webThrottle.js
+++ b/web/js/webThrottle.js
@@ -663,7 +663,7 @@ var jmriReady = function(jsonVersion, jmriVersion, railroadName) {
 					img.attr('src', '/roster/' + encodeURIComponent(loco.name) + '/' + (icon ? 'icon' : 'image') + '?maxHeight=' + $cellHeightRef);
 				}
 				$locoAddress = '' + loco.dccAddress;
-				$jmri.setJMRI('throttle', $locoAddress, {"address":loco.dccAddress});
+                                $jmri.setJMRI('throttle', $locoAddress, {"rosterEntry":loco.name});
 			} else smoothAlert('Loco \'' + $paramLocoName + '\' doesn\'t exist.\nReopen the web page with a valid loco name.');
 			break;
 		case 'turnouts':

--- a/web/js/webThrottle.js
+++ b/web/js/webThrottle.js
@@ -663,7 +663,7 @@ var jmriReady = function(jsonVersion, jmriVersion, railroadName) {
 					img.attr('src', '/roster/' + encodeURIComponent(loco.name) + '/' + (icon ? 'icon' : 'image') + '?maxHeight=' + $cellHeightRef);
 				}
 				$locoAddress = '' + loco.dccAddress;
-                                $jmri.setJMRI('throttle', $locoAddress, {"rosterEntry":loco.name});
+                $jmri.setJMRI('throttle', $locoAddress, {"rosterEntry":loco.name});
 			} else smoothAlert('Loco \'' + $paramLocoName + '\' doesn\'t exist.\nReopen the web page with a valid loco name.');
 			break;
 		case 'turnouts':


### PR DESCRIPTION
For 4.21.1, not required in 4.19.9
Uses JSON "rosterEntry" instead of "address" to get loco sessions.

Stops 
`throttle.JsonThrottleSocketService    WARN  - JSON throttle "414" requested using "throttle" instead of "name"`
warnings from WebThrottle.

Update JsonThrottle to request Throttle via RosterEntry