### PR TITLE
Temp. fix Throttle Duplicate Prop Change Listeners

### DIFF
--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -260,6 +260,16 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
         firePropertyChange("ReleaseEnabled", _releaseEnabled, _releaseEnabled = newVal); // NOI18N
     }
 
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener l) {
+        for (PropertyChangeListener pcl : getPropertyChangeListeners()) {
+            if ( pcl == l ){ // duplicate changelistener
+                return;
+            }
+        }
+        super.addPropertyChangeListener(l);
+    }
+    
     /**
      * {@inheritDoc}
      */

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -260,12 +260,18 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
         firePropertyChange("ReleaseEnabled", _releaseEnabled, _releaseEnabled = newVal); // NOI18N
     }
 
+    /**
+     * Temporary behaviour only allowing unique PCLs.
+     * To support Throttle PCL's ( eg. WiThrottle Server ) that rely on the 
+     * previous behaviour of only allowing 1 unique PCL instance.
+     * To be removed when WiThrottle Server has been updated.
+     * {@inheritDoc}
+     */
     @Override
     public void addPropertyChangeListener(PropertyChangeListener l) {
-        for (PropertyChangeListener pcl : getPropertyChangeListeners()) {
-            if ( pcl == l ){ // duplicate changelistener
-                return;
-            }
+        if ( Arrays.asList(getPropertyChangeListeners()).contains(l) ){
+            log.warn("Preventing {} adding duplicate PCL",l);
+            return;
         }
         super.addPropertyChangeListener(l);
     }


### PR DESCRIPTION
WiThrottle server ( and potentially other property change listeners ) rely on the previous behaviour of AbstractThrottle only allowing unique PCLs.

PCLs which are still listening prevent JMRI releasing Throttles.

Provides temporary fix for #8745 until WiThrottle server is updated.

Temporarily restores Add Throttle PCL behaviour to 4.19.4 , stopped being checked for duplicates in https://github.com/JMRI/JMRI/commit/9a8aaa2d8eba8433bc97479199d79461be1cb239#diff-82534fa9afa38651ab2c0f05a2de8358#L753