### PR TITLE
Don't send LocoNet status update till after Initialization is complete

### DIFF
--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -589,10 +589,8 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
                     | LnConstants.DEC_MODE_128;
         }
         log.debug("New Slot Mode: {}", LnConstants.DEC_MODE(status));
-        if (mRefreshTimer != null) // the refresh timer isn't created until
-        // after initilization.  We only want to
-        // modify the slot after the initilization
-        // is complete.
+        if (isInitialized ) 
+            // check that the throttle is completely initialized.
         {
             network.sendLocoNetMessage(slot.writeMode(status));
         }


### PR DESCRIPTION
Check initialization is complete, the refresh timer is started before that event.
From #8758 