### PR TITLE
fix: add missing resource

### DIFF
--- a/java/src/jmri/util/startup/Bundle.properties
+++ b/java/src/jmri/util/startup/Bundle.properties
@@ -61,3 +61,4 @@ TriggerRouteModel.RouteNotDefined=Unable to set route "{0}". Route not defined.
 #Error thrown when startup pause thread is interrupted.
 StartupPauseModel.Interrupted={0} second startup pause interrupted early.
 StartupActionsManager.RefusalToInitialize=Unable to run startup actions due to earlier failures.
+StartupActionsOverriddenClasses=<html>Startup action class {0} has been updated to {1}.<br>Please save preferences to make this permanent.</html>

--- a/java/src/jmri/util/startup/Bundle_ca.properties
+++ b/java/src/jmri/util/startup/Bundle_ca.properties
@@ -65,3 +65,4 @@ TriggerRouteModel.RouteNotDefined=No s'ha pogut activar la ruta "{0}". Ruta no d
 #Error thrown when startup pause thread is interrupted.
 StartupPauseModel.Interrupted={0} la segona pausa d'inici es va interrompre prematurament.
 StartupActionsManager.RefusalToInitialize=No es poden executar accions d'inici per errors anteriors.
+StartupActionsOverriddenClasses=<html>Startup action class {0} has been updated to {1}.<br>Please save preferences to make this permanent.</html>

--- a/java/src/jmri/util/startup/Bundle_cs.properties
+++ b/java/src/jmri/util/startup/Bundle_cs.properties
@@ -64,3 +64,4 @@ AbstractActionModel.UnknownClass=Vytvo\u0159it instanci t\u0159\u00eddy {0}
 AbstractActionModel.InvalidClass=Nemohu naj\u00edt t\u0159\u00eddu {0}
 AbstractActionModel.InvalidAction=Akce {0} nen\u00ed platn\u00e1
 StartupActionsManager.RefusalToInitialize=Nemohu spustit akce spou\u0161t\u011bn\u00ed z d\u016fvodu d\u0159\u00edv\u011bj\u0161\u00edch selh\u00e1n\u00ed.
+StartupActionsOverriddenClasses=<html>T\u0159\u00edda Akce po spu\u0161t\u011bn\u00ed {0} byla aktualizov\u00e1na na {1}.<br>Pros\u00edm ulo\u017ete p\u0159edvolby, aby se zm\u011bna ulo\u017eila.</html>

--- a/java/src/jmri/util/startup/Bundle_da.properties
+++ b/java/src/jmri/util/startup/Bundle_da.properties
@@ -61,3 +61,4 @@ TriggerRouteModel.RouteNotDefined=Unable to set route "{0}". Route not defined.
 #Error thrown when startup pause thread is interrupted.
 StartupPauseModel.Interrupted={0} second startup pause interrupted early.
 StartupActionsManager.RefusalToInitialize=Unable to run startup actions due to earlier failures.
+StartupActionsOverriddenClasses=<html>Startup action class {0} has been updated to {1}.<br>Please save preferences to make this permanent.</html>

--- a/java/src/jmri/util/startup/Bundle_de.properties
+++ b/java/src/jmri/util/startup/Bundle_de.properties
@@ -40,3 +40,4 @@ TriggerRouteModel.RouteNotDefined=Unable to set route "{0}". Route not defined.
 #Error thrown when startup pause thread is interrupted.
 StartupPauseModel.Interrupted={0} second startup pause interrupted early.
 StartupActionsManager.RefusalToInitialize=Durch Fehler werden die Aufstartverhalten nicht aktiviert.
+StartupActionsOverriddenClasses=<html>Aufstartverhalten {0} wurde \u00fcberarbeitet nach {1}.<br>Bitte die Voreinstellungen speichern um dauerhaft durch zu f\u00fchren.</html>

--- a/java/src/jmri/util/startup/Bundle_es.properties
+++ b/java/src/jmri/util/startup/Bundle_es.properties
@@ -1,1 +1,2 @@
 StartupActionsManager.RefusalToInitialize=Unable to run startup actions due to earlier failures.
+StartupActionsOverriddenClasses=<html>Startup action class {0} has been updated to {1}.<br>Please save preferences to make this permanent.</html>

--- a/java/src/jmri/util/startup/Bundle_fr.properties
+++ b/java/src/jmri/util/startup/Bundle_fr.properties
@@ -1,1 +1,2 @@
 StartupActionsManager.RefusalToInitialize=Impossible de lancer les actions au d\u00e9marrage du fait d'erreurs pr\u00e9c\u00e9dentes.
+StartupActionsOverriddenClasses=<html>La classe {0} d'action au d\u00e9marrage a \u00e9t\u00e9 actualis\u00e9e {1}.<br>SVP Sauvegarder les pr\u00e9f\u00e9rences pour les rendre permanentes.</html>

--- a/java/src/jmri/util/startup/Bundle_it.properties
+++ b/java/src/jmri/util/startup/Bundle_it.properties
@@ -1,1 +1,2 @@
 StartupActionsManager.RefusalToInitialize=Unable to run startup actions due to earlier failures.
+StartupActionsOverriddenClasses=<html>Startup action class {0} has been updated to {1}.<br>Please save preferences to make this permanent.</html>

--- a/java/src/jmri/util/startup/Bundle_ja.properties
+++ b/java/src/jmri/util/startup/Bundle_ja.properties
@@ -1,1 +1,2 @@
 StartupActionsManager.RefusalToInitialize=Unable to run startup actions due to earlier failures.
+StartupActionsOverriddenClasses=<html>Startup action class {0} has been updated to {1}.<br>Please save preferences to make this permanent.</html>

--- a/java/src/jmri/util/startup/Bundle_ja_JP.properties
+++ b/java/src/jmri/util/startup/Bundle_ja_JP.properties
@@ -1,1 +1,2 @@
 StartupActionsManager.RefusalToInitialize=Unable to run startup actions due to earlier failures.
+StartupActionsOverriddenClasses=<html>Startup action class {0} has been updated to {1}.<br>Please save preferences to make this permanent.</html>

--- a/java/src/jmri/util/startup/Bundle_nl.properties
+++ b/java/src/jmri/util/startup/Bundle_nl.properties
@@ -66,3 +66,4 @@ TriggerRouteModel.RouteNotDefined=Kan Route "{0}" niet instellen. Route niet ged
 #Error thrown when startup pause thread is interrupted.
 StartupPauseModel.Interrupted=opstartpauze van {0} secondes is vroegtijdig afgebroken.
 StartupActionsManager.RefusalToInitialize=Door eerdere fouten kunnen de opstartacties niet worden uitgevoerd.
+StartupActionsOverriddenClasses=<html>Opstartactie type {0} is bijgewerkt naar {1}.<br>Bewaar je Voorkeuren om dit definitief te maken.</html>


### PR DESCRIPTION
Copy a resource string from `apps` to `jmri.util.startup`. This resource string is used when running a profile generated before #8659 was merged that includes startup items.