### PR TITLE
Add some PR automation

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,17 +1,6 @@
 version: 2
 mergeable:
   - when: pull_request.opened
-    name: 'Check for release note'
-    validate:
-      - do: changeset
-        must_include:
-            regex: 'help/en/releasenotes/current-draft-note.shtml'
-    fail:
-      - do: comment
-        payload:
-          body: > 
-            Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
-  - when: pull_request.opened
     name: 'Ensure author assigned'
     validate:
       - do: assignee
@@ -25,4 +14,29 @@ mergeable:
         payload:
           title: 'Mergeable Run have been Completed!'
           summary: "All the validators have returned 'pass'! \n Here are some stats of the run: \n {{validationCount}} validations were ran"
+  - when: pull_request.opened
+    name: 'Check for release note if help, java/src, jython, resources, xml, or web
+    validate:
+      - do: changeset
+        or:  # passes if no library-like files are changed (only infrastructure changed), _or_ if there's a release note
+          - and:
+            - must_exclude:
+              regex: '^help/'
+            - must_exclude:
+              regex: '^java/src/'
+            - must_exclude:
+              regex: '^jython/'
+            - must_exclude:
+              regex: '^resources/'
+            - must_exclude:
+              regex: '^web/'
+            - must_exclude:
+              regex: '^xml/'
+          - must_include:
+            regex: 'help/en/releasenotes/current-draft-note.shtml'
+    fail:
+      - do: comment
+        payload:
+          body: > 
+            Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
        

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -4,11 +4,6 @@ mergeable:
     name: 'check for release note' # optional (but needed to create multiple checks) 
     validate:
       # list of validators. Specify one or more.
-      - do: dependent
-        changed:
-            file: help/en/releasenotes/current-draft-note.shtml
-    fail: # fail means file not modified
-      - do: comment
-        payload:
-          body: >
-            Thanks for the PR!  Could you please consider adding to the draft release note in the help/en/releasenotes/current-draft-note.shtml file?
+      - do: changeset
+        must_include:
+            regex: 'help/en/releasenotes/current-draft-note.shtml'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -10,5 +10,6 @@ mergeable:
     fail:
       - do: comment
         payload:
-          body: Thanks for the PR! Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
+          body: > 
+            Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
         

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -21,7 +21,7 @@ mergeable:
         or:  # passes if no lib files or is a release note
           - and: 
             - must_exclude:
-                regex: "help/"
+                regex: "^help/"
             - must_exclude:
                 regex: "^java/src/"
             - must_exclude:

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -19,20 +19,20 @@ mergeable:
     validate:
       - do: changeset
         or:  # passes if no lib files or is a release note
-          - and:
-            - must_exclude:
+          - and: 
+            - must_exclude: 
                 regex: '^help/'
-            - must_exclude:
+            - must_exclude: 
                 regex: '^java/src/'
-            - must_exclude:
+            - must_exclude: 
                 regex: '^jython/'
-            - must_exclude:
+            - must_exclude: 
                 regex: '^resources/'
-            - must_exclude:
+            - must_exclude: 
                 regex: '^web/'
-            - must_exclude:
+            - must_exclude: 
                 regex: '^xml/'
-          - must_include:
+          - must_include: 
               regex: 'help/en/releasenotes/current-draft-note.shtml'
     fail:
       - do: comment

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -18,7 +18,7 @@ mergeable:
     name: 'Check for release note if help, java/src, jython, resources, xml, or web
     validate:
       - do: changeset
-        or:  # passes if no library-like files are changed (only infrastructure changed), _or_ if there's a release note
+        or:  # passes if no lib files or is a release note
           - and:
             - must_exclude:
               regex: '^help/'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -12,11 +12,11 @@ mergeable:
           body: > 
             Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
   - when: pull_request.opened
-    name: 'Ensure assigned'
+    name: 'Ensure author assigned'
     validate:
       - do: assignee
         min:
-          count: 1 # Should be assigned to somebody
+          count: 1 # Should be assigned to somebody; if not, assign author
     fail:
       - do: assign
         assignees: [ '@author' ] 

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -15,28 +15,27 @@ mergeable:
           title: 'Mergeable Run have been Completed!'
           summary: "All the validators have returned 'pass'! \n Here are some stats of the run: \n {{validationCount}} validations were ran"
   - when: pull_request.opened
-    name: 'Check for release note if help, java/src, jython, resources, xml, or web
+    name: 'Check for release note if help, java/src, jython, resources, xml, or web'
     validate:
       - do: changeset
         or:  # passes if no lib files or is a release note
           - and: 
-            - must_exclude: 
-                regex: '^help/'
-            - must_exclude: 
-                regex: '^java/src/'
-            - must_exclude: 
-                regex: '^jython/'
-            - must_exclude: 
-                regex: '^resources/'
-            - must_exclude: 
-                regex: '^web/'
-            - must_exclude: 
-                regex: '^xml/'
-          - must_include: 
-              regex: 'help/en/releasenotes/current-draft-note.shtml'
+            - must_exclude:
+                regex: "help/"
+            - must_exclude:
+                regex: "^java/src/"
+            - must_exclude:
+                regex: "^jython/"
+            - must_exclude:
+                regex: "^resources/"
+            - must_exclude:
+                regex: "^web/"
+            - must_exclude:
+                regex: "^xml/"
+          - must_include:
+              regex: "help/en/releasenotes/current-draft-note.shtml"
     fail:
       - do: comment
         payload:
           body: > 
             Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
-       

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -21,19 +21,19 @@ mergeable:
         or:  # passes if no lib files or is a release note
           - and:
             - must_exclude:
-              regex: '^help/'
+                regex: '^help/'
             - must_exclude:
-              regex: '^java/src/'
+                regex: '^java/src/'
             - must_exclude:
-              regex: '^jython/'
+                regex: '^jython/'
             - must_exclude:
-              regex: '^resources/'
+                regex: '^resources/'
             - must_exclude:
-              regex: '^web/'
+                regex: '^web/'
             - must_exclude:
-              regex: '^xml/'
+                regex: '^xml/'
           - must_include:
-            regex: 'help/en/releasenotes/current-draft-note.shtml'
+              regex: 'help/en/releasenotes/current-draft-note.shtml'
     fail:
       - do: comment
         payload:

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -7,3 +7,8 @@ mergeable:
       - do: changeset
         must_include:
             regex: 'help/en/releasenotes/current-draft-note.shtml'
+    fail:
+      - do: comment
+        payload:
+          body: Thanks for the PR! Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
+        

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,9 +1,8 @@
 version: 2
 mergeable:
   - when: pull_request.opened
-    name: 'check for release note' # optional (but needed to create multiple checks) 
+    name: 'Check for release note'
     validate:
-      # list of validators. Specify one or more.
       - do: changeset
         must_include:
             regex: 'help/en/releasenotes/current-draft-note.shtml'
@@ -12,4 +11,18 @@ mergeable:
         payload:
           body: > 
             Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
-        
+  - when: pull_request.opened
+    name: 'Ensure assigned'
+    validate:
+      - do: assignee
+        min:
+          count: 1 # Should be assigned to somebody
+    fail:
+      - do: assign
+        assignees: [ '@author' ] 
+      - do: checks
+        status: 'success' # Supply the default actions, as if this passed.
+        payload:
+          title: 'Mergeable Run have been Completed!'
+          summary: "All the validators have returned 'pass'! \n Here are some stats of the run: \n {{validationCount}} validations were ran"
+       

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -535,5 +535,7 @@
                 jmri.SystemConnectionMemo or jmri.jmrix.DefaultSystemConnectionMemo
                 (it's easier to have you just try the two than to explain which 
                 one will work in which case)</li>
+            <li>Added PR automation to check for a comment in the release note when a PR
+                is opened, and to ensure that somebody has been assigned to the PR.</li>
         </ul>
 


### PR DESCRIPTION
This uses [Mergeable](https://github.com/mergeability/mergeable) to automate two parts of processing commits:

 - If there's no entry in the draft release note, add a reminder comment:

![image](https://user-images.githubusercontent.com/2774117/86483511-100f1280-bd09-11ea-8cea-7d669c51830c.png)

 - If the PR isn't assigned to anybody, assign it to the PR author. This isn't entirely necessary for the usual developers, but it's helpful for PRs from an otherwise-unknown contributor.

These run automatically when the PR is opened, doing their thing in a few seconds.  The result appears with the other CI items:

![image](https://user-images.githubusercontent.com/2774117/86483688-6c723200-bd09-11ea-81ac-5956d9eadae3.png)

The release-note item will show as in-process until a note is added; this doesn't prevent merging the PR. (We may decide to turn this off later so that the check reports OK status right away, but I'd like to see how this works for a while as a reminder)

In the longer term, this tooling may also provide useful compatibility checks for our (proposed) multiple branch system.

As an implementation note, this PR won't have any effect until it's been merged to master and the mergeable action is linked.  If you'd like to see how it works, check out the two successful test PRs at bobjacobsen/JMRI#31 and bobjacobsen/JMRI#32
