### PR TITLE
CbusThrottle - Do not send Speed Step if unchanged

### DIFF
--- a/java/src/jmri/Throttle.java
+++ b/java/src/jmri/Throttle.java
@@ -33,10 +33,19 @@ import jmri.beans.PropertyChangeProvider;
 public interface Throttle extends PropertyChangeProvider {
 
     /**
+     * Constant used in getThrottleInfo.
+     */
+    public static final String SPEEDSTEPMODE = "SpeedStepsMode"; // speed steps NOI18N
+    
+    /**
      * Properties strings sent to property change listeners
      */
+    
+    /**
+     * Constant sent by Throttle on Property Change.
+     */
     public static final String SPEEDSTEPS = "SpeedSteps"; // speed steps NOI18N
-    public static final String SPEEDSTEPMODE = "SpeedStepsMode"; // speed steps NOI18N
+    
     public static final String SPEEDSETTING = "SpeedSetting"; // speed setting NOI18N
     public static final String ISFORWARD = "IsForward"; // direction setting NOI18N
     public static final String SPEEDINCREMENT = "SpeedIncrement"; // direction setting NOI18N

--- a/java/src/jmri/jmrix/can/cbus/CbusThrottle.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusThrottle.java
@@ -39,7 +39,6 @@ public class CbusThrottle extends AbstractThrottle {
             log.error("{} is not a DccLocoAddress",address);
             return;
         }
-        log.debug("Throttle created");
         cs = (CbusCommandStation) adapterMemo.get(jmri.CommandStation.class);
         _handle = handle;
         _isStolen = false;
@@ -50,21 +49,9 @@ public class CbusThrottle extends AbstractThrottle {
         // Functions 0-28 default to false
         this.dccAddress = (DccLocoAddress) address;
         this.isForward = true;
-
-//        switch(slot.decoderType())
-//        {
-//            case CbusConstants.DEC_MODE_128:
-//            case CbusConstants.DEC_MODE_128A: this.speedIncrement = 1; break;
-//            case CbusConstants.DEC_MODE_28:
-//            case CbusConstants.DEC_MODE_28A:
-//            case CbusConstants.DEC_MODE_28TRI: this.speedIncrement = 4; break;
-//            case CbusConstants.DEC_MODE_14: this.speedIncrement = 8; break;
-//        }
-        // Only 128 speed step supported at the moment
         this.speedStepMode = SpeedStepMode.NMRA_DCC_128;
 
-        // start periodically sending keep alives, to keep this
-        // attached
+        // start periodically sending keep alives, to keep this attached
         log.debug("Start Throttle refresh");
         startRefresh();
 
@@ -91,16 +78,20 @@ public class CbusThrottle extends AbstractThrottle {
      * setSpeedStepMode - set the speed step value.
      * <p>
      * Overridden to capture mode changes to be forwarded to the hardware.
-     * New throttles default to 128 step mode
+     * New throttles default to 128 step mode.
+     * CBUS Command stations also default to 128SS so this does not
+     * need to be sent if unchanged.
      *
      * @param Mode the current speed step mode - default should be 128
      *              speed step mode in most cases
      */
     @Override
     public void setSpeedStepMode(SpeedStepMode Mode) {
+        if (speedStepMode==Mode){
+            return;
+        }
+        super.setSpeedStepMode(Mode);
         int mode;
-        speedStepMode = Mode;
-        super.setSpeedStepMode(speedStepMode);
         switch (speedStepMode) {
             case NMRA_DCC_28:
                 mode = CbusConstants.CBUS_SS_28;
@@ -132,8 +123,7 @@ public class CbusThrottle extends AbstractThrottle {
     }
 
     /**
-     * Send the CBUS message to set the state of locomotive direction and
-     * functions F0, F1, F2, F3, F4
+     * Send the CBUS message to set the state of functions F0, F1, F2, F3, F4.
      */
     @Override
     protected void sendFunctionGroup1() {
@@ -141,7 +131,7 @@ public class CbusThrottle extends AbstractThrottle {
     }
 
     /**
-     * Send the CBUS message to set the state of functions F5, F6, F7, F8
+     * Send the CBUS message to set the state of functions F5, F6, F7, F8.
      */
     @Override
     protected void sendFunctionGroup2() {
@@ -149,7 +139,7 @@ public class CbusThrottle extends AbstractThrottle {
     }
 
     /**
-     * Send the CBUS message to set the state of functions F9, F10, F11, F12
+     * Send the CBUS message to set the state of functions F9, F10, F11, F12.
      */
     @Override
     protected void sendFunctionGroup3() {
@@ -222,6 +212,7 @@ public class CbusThrottle extends AbstractThrottle {
         }
     }
     
+    // TODO - use intSpeed( speedSetting, SPEED_STEPS )
     // following a speed or direction change, sends to layout
     private void sendToLayout(){
         int new_spd = intSpeed(this.speedSetting);

--- a/java/test/jmri/jmrix/can/cbus/CbusThrottleTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusThrottleTest.java
@@ -897,7 +897,7 @@ public class CbusThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     
 
     @Test
-    public void changeSpeedSteps(){
+    public void testChangeSpeedSteps(){
         
         int outFrames = tc.outbound.size();
         

--- a/java/test/jmri/jmrix/can/cbus/CbusThrottleTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusThrottleTest.java
@@ -886,7 +886,60 @@ public class CbusThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     
     }
     
+    @Test
+    public void testDefaultSpeedSteps(){
+        Assert.assertEquals("default 128 SS", jmri.SpeedStepMode.NMRA_DCC_128, instance.getSpeedStepMode());
+    }
+    
+    private int propChangeCount = 0;
+    private jmri.SpeedStepMode newMode;
+    private jmri.SpeedStepMode oldMode;
+    
 
+    @Test
+    public void changeSpeedSteps(){
+        
+        int outFrames = tc.outbound.size();
+        
+        propChangeCount = 0;
+        PropertyChangeListener l = (PropertyChangeEvent evt) -> {
+            propChangeCount++;
+            oldMode = (SpeedStepMode) evt.getOldValue();
+            newMode = (SpeedStepMode) evt.getNewValue();
+        };
+        instance.addPropertyChangeListener(jmri.Throttle.SPEEDSTEPS, l);
+        
+        instance.setSpeedStepMode(SpeedStepMode.NMRA_DCC_128);
+        Assert.assertEquals(outFrames, tc.outbound.size());
+        Assert.assertEquals(0, propChangeCount);
+        
+        instance.setSpeedStepMode(SpeedStepMode.NMRA_DCC_14);
+        Assert.assertEquals("14 SS", SpeedStepMode.NMRA_DCC_14, instance.getSpeedStepMode());
+        Assert.assertEquals(outFrames+1, tc.outbound.size());
+        Assert.assertEquals("[78] 44 64 01", tc.outbound.elementAt(tc.outbound.size()-1).getToString());
+        Assert.assertEquals(1, propChangeCount);
+        Assert.assertEquals(SpeedStepMode.NMRA_DCC_128,oldMode);
+        Assert.assertEquals(SpeedStepMode.NMRA_DCC_14,newMode);
+        
+        instance.setSpeedStepMode(SpeedStepMode.NMRA_DCC_128);
+        Assert.assertEquals("128 SS", SpeedStepMode.NMRA_DCC_128, instance.getSpeedStepMode());
+        Assert.assertEquals(outFrames+2, tc.outbound.size());
+        Assert.assertEquals("[78] 44 64 00", tc.outbound.elementAt(tc.outbound.size()-1).getToString());
+        Assert.assertEquals(2, propChangeCount);
+        Assert.assertEquals(SpeedStepMode.NMRA_DCC_14,oldMode);
+        Assert.assertEquals(SpeedStepMode.NMRA_DCC_128,newMode);
+        
+        instance.setSpeedStepMode(SpeedStepMode.NMRA_DCC_28);
+        Assert.assertEquals("28 SS", SpeedStepMode.NMRA_DCC_28, instance.getSpeedStepMode());
+        Assert.assertEquals(outFrames+3, tc.outbound.size());
+        Assert.assertEquals("[78] 44 64 03", tc.outbound.elementAt(tc.outbound.size()-1).getToString());
+        Assert.assertEquals(3, propChangeCount);
+        Assert.assertEquals(SpeedStepMode.NMRA_DCC_128,oldMode);
+        Assert.assertEquals(SpeedStepMode.NMRA_DCC_28,newMode);
+        
+        instance.removePropertyChangeListener(l);
+    }
+    
     private TrafficControllerScaffold tc;
     private CanSystemConnectionMemo memo;
 


### PR DESCRIPTION
No need for Speed step message on CBUS Throttle obtaining session if already using default.
Unit tests for CbusThrottle Speed Step changes PCL / CanFrame