### PR TITLE
Don't restore window position and size if it shouldn't be stored

### DIFF
--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -117,7 +117,10 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         windowFrameRef = this.getClass().getName();
         if (!this.getClass().getName().equals(JmriJFrame.class.getName())) {
             generateWindowRef();
-            setFrameLocation();
+            
+            if (saveSize || savePosition) {
+                setFrameLocation();
+            }
         }
     }
 
@@ -156,7 +159,9 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
                 return;
             }
         }
-        setFrameLocation();
+        if (saveSize || savePosition) {
+            setFrameLocation();
+        }
     }
 
     /**


### PR DESCRIPTION
In LogixNG, I have JmriJFrames there the window size shouldn't be restored. But I have noticed that once the window size is stored, there is no way to undo that, unless I manually edit the profile. If I as a developer changes my mind about a JmriJFrame and decides that it should not save its size and position, the stored size and position will still be used.

This PR adds a check that if both saveSize and savePosition is false, then setFrameLocation() is not called.

I'm not sure what should happen if either of saveSize or savePosition is false, but not both. In that case, part of the window may be outside the screen, so it would be a more difficult case to handle.