### PR TITLE
Bugfix: Store correct value of enumVal in roster entry.

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
@@ -215,12 +215,13 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
     // and to read/write/hear parameter changes.
     @Override
     public String getValueString() {
-        return "" + _value.getSelectedIndex();
+        return Integer.toString(getIntValue());
     }
 
     @Override
     public void setIntValue(int i) {
-        selectValue(i);
+        // needs to fire Value property as well, as per suggestion by Svata Dedic.
+        setValue(i);
     }
 
     @Override

--- a/java/test/jmri/jmrit/symbolicprog/EnumVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/EnumVariableValueTest.java
@@ -147,6 +147,25 @@ public class EnumVariableValueTest extends AbstractVariableValueTestBase {
         Assert.assertEquals("one", "Reserved value 2", val.getTextValue());
     }
 
+    @Test
+    public void testGetValueString() {
+        EnumVariableValue val = createOutOfSequence();
+        val.setIntValue(0);
+        Assert.assertEquals("setIntValue zero", "0", val.getValueString());
+        val.setIntValue(5);
+        Assert.assertEquals("setIntValue five", "5", val.getValueString());
+        val.setIntValue(7);
+        Assert.assertEquals("setIntValue seven", "7", val.getValueString());
+        val.setIntValue(9);
+        Assert.assertEquals("setIntValue nine", "9", val.getValueString());
+        val.setIntValue(12);
+        Assert.assertEquals("setIntValue twelve", "12", val.getValueString());
+        val.setIntValue(1);
+        Assert.assertEquals("setIntValue one", "1", val.getValueString());
+        val.setIntValue(2);
+        Assert.assertEquals("setIntValue two", "2", val.getValueString());
+    }
+
     public EnumVariableValue createOutOfSequence() {
         // prepare
         HashMap<String, CvValue> v = createCvMap();


### PR DESCRIPTION
Fix for symptoms reported via direct email to me by @n3ix .

Bug: When a Roster Entry was saved, `EnumVariableValue` was storing the `SelectedIndex` in `varValue` rather than the true `value` for that index.

Result: When the Roster Entry was reopened, in some circumstances a spurious "Reserved Value xx" entry would be created as `varValue` was loaded, prior to the correct value being determined from loading `CVvalue`.