### PR TITLE
Remove reference from RosterFrame to apps

### DIFF
--- a/java/src/apps/gui3/dp3/DecoderPro3Window.java
+++ b/java/src/apps/gui3/dp3/DecoderPro3Window.java
@@ -1,5 +1,6 @@
 package apps.gui3.dp3;
 
+import apps.gui3.Apps3;
 import jmri.Application;
 import jmri.jmrit.roster.swing.RosterFrame;
 
@@ -33,4 +34,14 @@ public class DecoderPro3Window extends RosterFrame {
     public void remoteCalls(String[] args) {
         super.remoteCalls(args);
     }
+
+    @Override
+    protected void additionsToToolBar() {
+        //This value may return null if the DP3 window has been called from a the traditional JMRI menu frame
+        if (Apps3.buttonSpace() != null) {
+            getToolBar().add(Apps3.buttonSpace());
+        }
+        super.additionsToToolBar();
+    }
+
 }

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.roster.swing;
 
-import apps.gui3.Apps3;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -194,11 +193,7 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
     JButton throttleLabels = new JButton(Bundle.getMessage("ThrottleLabels"));
     JButton throttleLaunch = new JButton(Bundle.getMessage("Throttle"));
 
-    void additionsToToolBar() {
-        //This value may return null if the DP3 window has been called from a the traditional JMRI menu frame
-        if (Apps3.buttonSpace() != null) {
-            getToolBar().add(Apps3.buttonSpace());
-        }
+    protected void additionsToToolBar() {
         getToolBar().add(new LargePowerManagerButton(true));
         getToolBar().add(modePanel);
     }


### PR DESCRIPTION
Remove another reference from jmri to apps.

This PR moves some code from RosterFrame, that appears to only be used when a DecoderPro3Windows ( which extends RosterFrame) is instantiated, into DecoderPro3Window.