### PR TITLE
Make package-info.java create a class file

### DIFF
--- a/java/src/apps/jmrit/package-info.java
+++ b/java/src/apps/jmrit/package-info.java
@@ -3,4 +3,6 @@
  * useful in the JMRI published applications, but are either not related to the
  * JMRI package, or are autonomous launchers for those tools.
  */
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
 package apps.jmrit;


### PR DESCRIPTION
A java file without code doesn't generate a class file. Therefore maven recompiles the file everytime since it doesn't know that it doesn't create a class file.