### PR TITLE
doc: clarify Java requirements

### DIFF
--- a/help/en/html/setup/index.shtml
+++ b/help/en/html/setup/index.shtml
@@ -58,7 +58,7 @@
 
           <ul>
             <li><a href=
-            "https://jmri.org/install/Raspbian.shtml">RasPi</a></li>
+            "https://jmri.org/install/Raspbian.shtml">Raspberry Pi</a></li>
           </ul>
         </li>
       </ul>
@@ -67,15 +67,25 @@
 
       <ul>
         <li>Version 2.12 can run on any computer system that will
-        run Java 1.5 or later.</li>
+        run Java 1.5 through Java 8 (also known as Java 1.8).</li>
 
-        <li>Version 2.14.1 requires Java 1.5 (or 1.6 if you wish
-        for drag &amp; drop)</li>
+        <li>Version 2.14.1 requires Java 1.5 (or Java 1.6 to support
+        for drag &amp; drop) through Java 8.</li>
 
-        <li>Version 3.10.1 requires Java 1.7 or later.</li>
+        <li>Version 3.10.1 requires Java 1.7 through Java 8.</li>
 
-        <li>Version 4.2 requires Java 1.8.</li>
-      </ul><a name="startprog" id="startprog"></a>
+        <li>Version 4.2 requires Java 8.</li>
+      </ul>
+      
+      As of JMRI 4.20, JMRI is only fully supported when running on the
+      two most recent Java Long Term Support (LTS) releases (8 or 11 as of July 2020)
+      and will receive "best-effort" support on the latest Java release (14 as of July 2020).
+      The JMRI project recommends Java from <a href="https://adoptopenjdk.net">AdoptOpenJDK</a>
+      or the operating system vendor unless using Windows 8 or older, in which case
+      Java from <a href="https://java.com">Oracle</a> is recommended. See the
+      operating system-specific installation guidance for further details.
+      
+      <a name="startprog" id="startprog"></a>
 
       <h2>Starting the program</h2>
 

--- a/help/en/html/setup/index.shtml
+++ b/help/en/html/setup/index.shtml
@@ -83,8 +83,8 @@
           support on the latest Java release (14 as of July 2020). Support in
           this context means that problems found will be fixed or addressed in
           other means; "best effort" means that fixes to run on the latest Java
-          release that do not break compatibility with the oldest LTS release will
-          be considered.</p>
+          release that do not break compatibility with the oldest supported LTS
+          release will be considered.</p>
 
       <p>The JMRI project recommends Java from <a href="https://adoptopenjdk.net">AdoptOpenJDK</a>
           or the operating system vendor unless using Windows 8 or older, in which case

--- a/help/en/html/setup/index.shtml
+++ b/help/en/html/setup/index.shtml
@@ -80,11 +80,9 @@
       <p>As of JMRI 4.20, JMRI is only fully supported when running on the most
           current update possible to the two most recent Java Long Term Support
           (LTS) releases (8 or 11 as of July 2020) and will receive "best effort"
-          support on the latest Java release (14 as of July 2020). In this context,
-          "fully supported" means that problems found will be fixed or addressed in
-          other means; "best effort" means that fixes to run on the latest Java
-          release that do not break compatibility with the oldest supported LTS
-          release will be considered.</p>
+          support on the latest Java release (14 as of July 2020). Some problems
+          encountered while using a Java version that is "best effort" may only be
+          addressable by using a supported version.</p>
 
       <p>The JMRI project recommends Java from <a href="https://adoptopenjdk.net">AdoptOpenJDK</a>
           or the operating system vendor unless using Windows 8 or older, in which case

--- a/help/en/html/setup/index.shtml
+++ b/help/en/html/setup/index.shtml
@@ -77,14 +77,20 @@
         <li>Version 4.2 requires Java 8.</li>
       </ul>
       
-      As of JMRI 4.20, JMRI is only fully supported when running on the
-      two most recent Java Long Term Support (LTS) releases (8 or 11 as of July 2020)
-      and will receive "best-effort" support on the latest Java release (14 as of July 2020).
-      The JMRI project recommends Java from <a href="https://adoptopenjdk.net">AdoptOpenJDK</a>
-      or the operating system vendor unless using Windows 8 or older, in which case
-      Java from <a href="https://java.com">Oracle</a> is recommended. See the
-      operating system-specific installation guidance for further details.
-      
+      <p>As of JMRI 4.20, JMRI is only fully supported when running on the most
+          current update possible to the two most recent Java Long Term Support
+          (LTS) releases (8 or 11 as of July 2020) and will receive "best effort"
+          support on the latest Java release (14 as of July 2020). Support in
+          this context means that problems found will be fixed or addressed in
+          other means; "best effort" means that fixes to run on the latest Java
+          release that do not break compatibility with the oldest LTS release will
+          be considered.</p>
+
+      <p>The JMRI project recommends Java from <a href="https://adoptopenjdk.net">AdoptOpenJDK</a>
+          or the operating system vendor unless using Windows 8 or older, in which case
+          Java from <a href="https://java.com">Oracle</a> is recommended. See the
+          operating system-specific installation guidance for further details.</p>
+
       <a name="startprog" id="startprog"></a>
 
       <h2>Starting the program</h2>

--- a/help/en/html/setup/index.shtml
+++ b/help/en/html/setup/index.shtml
@@ -80,8 +80,8 @@
       <p>As of JMRI 4.20, JMRI is only fully supported when running on the most
           current update possible to the two most recent Java Long Term Support
           (LTS) releases (8 or 11 as of July 2020) and will receive "best effort"
-          support on the latest Java release (14 as of July 2020). Support in
-          this context means that problems found will be fixed or addressed in
+          support on the latest Java release (14 as of July 2020). In this context,
+          "fully supported" means that problems found will be fixed or addressed in
           other means; "best effort" means that fixes to run on the latest Java
           release that do not break compatibility with the oldest supported LTS
           release will be considered.</p>

--- a/help/en/parts/SidebarInstall.shtml
+++ b/help/en/parts/SidebarInstall.shtml
@@ -7,7 +7,7 @@
             <li><a href="/install/WindowsNew.shtml">Windows</a>
             <li><a href="/install/MacOSX.shtml">Mac OS X</a>
             <li><a href="/install/Linux.shtml">Linux (multiple vers)</a>
-            <li><a href="/install/Raspbian.shtml">Raspbian on RaspberryPi</a>
+            <li><a href="/install/Raspbian.shtml">Raspberry Pi OS on Raspberry Pi</a>
             <li><i><a href="/install/Debug.shtml">Debugging an installation</a></i>
 		    </ul>
 		</dd>


### PR DESCRIPTION
Clarify what versions of Java are required for older JMRI releases and what versions of Java will be considered supported under the Oracle LTS/non-LTS release cadence.

Depending on the operating system JMRI 4.2 or older may work with Java versions newer that 8, but these all definitely break on macOS with Java 11, may break on other operating systems with Java 11, and since there is no point in running these older versions if Java 11 can be used, I just capped the supported version for 4.2 or older at Java 8.