### PR TITLE
MQTT: Allow UNKNOWN and INCONSISTENT status to be shown on panels

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -75,7 +75,7 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li></li>
+                <li>When status UNKNOWN is received from MQTT, the layout is now updated with this status.</li>
             </ul>
 
         <h4>MRC</h4>

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -35,6 +35,7 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
         private final static String closedText = "CLOSED";
         private final static String thrownText = "THROWN";
         private final static String unknownText = "UNKNOWN";
+        private final static String inconsistentText = "INCONSISTENT";
         @Override
         public void beanFromPayload(@Nonnull Turnout bean, @Nonnull String payload, @Nonnull String topic) {
             switch (payload) {
@@ -46,6 +47,9 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
                     break;
                 case unknownText:
                     newKnownState(UNKNOWN);
+                    break;
+                case inconsistentText:
+                    newKnownState(INCONSISTENT);
                     break;
                 default:
                     log.warn("Unknown state : {}", payload);

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -34,6 +34,7 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
     MqttContentParser<Turnout> parser = new MqttContentParser<Turnout>() {
         private final static String closedText = "CLOSED";
         private final static String thrownText = "THROWN";
+        private final static String unknownText = "UNKNOWN";
         @Override
         public void beanFromPayload(@Nonnull Turnout bean, @Nonnull String payload, @Nonnull String topic) {
             switch (payload) {
@@ -42,6 +43,9 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
                     break;
                 case thrownText:
                     newKnownState(THROWN);
+                    break;
+                case unknownText:
+                    newKnownState(UNKNOWN);
                     break;
                 default:
                     log.warn("Unknown state : {}", payload);


### PR DESCRIPTION
For object controller systems that has a MOVING state (for use with for example servo controlled turnouts), JMRI shows the target position after an other has been sent on MQTT. For such a system where it expects to be the master, it is not ideal that JMRI assumes that the turnout is already in position just because the order has been sent.
In a step to allow other systems to remain in control, this will allow them to update the JMRI layout until such time as the object has reached a known state again.
In a perfect world, JMRI would allow for a MOVING status - but I have not found any such status, thus this in an acceptable workaround with minimal impact.