### PR TITLE
MQTT extend turnout with two feedback modes

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -75,7 +75,9 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li>When status UNKNOWN or INCONSISTENT is received from MQTT and the turnout operating mode is MONITORING, the layout is now updated with this status.</li>
+                <li>MQTT Turnouts now support MONITORING and EXACT feedback modes</li>
+                <li>When status UNKNOWN or INCONSISTENT is received from MQTT and the turnout operating mode is MONITORING or EXACT, the layout is now updated with this status</li>
+                <li>When EXACT feedback mode is selected, two different MQTT topics will be used - one for commands and one for state</li>
             </ul>
 
         <h4>MRC</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -75,7 +75,7 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li>When status UNKNOWN is received from MQTT, the layout is now updated with this status.</li>
+                <li>When status UNKNOWN or INCONSISTENT is received from MQTT and the turnout operating mode is MONITORING, the layout is now updated with this status.</li>
             </ul>
 
         <h4>MRC</h4>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -75,7 +75,7 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li></li>
+                <li>When status UNKNOWN is received from MQTT, the layout is now updated with this status.</li>
             </ul>
 
         <h4>MRC</h4>

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -98,6 +98,7 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
             mels.add(mel);
             mqttEventListeners.put(fullTopic, mels);
             mqttClient.subscribe(fullTopic);
+            log.debug("Subscribed : \"{}\"", fullTopic);
         } catch (MqttException ex) {
             log.error("Can't subscribe : ", ex);
         }
@@ -105,11 +106,16 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
 
     public void unsubscribe(String topic, MqttEventListener mel) {
         String fullTopic = baseTopic + topic;
+        if (mqttEventListeners == null || mqttClient == null) {
+            jmri.util.LoggingUtil.warnOnce(log, "Trying to unsubscribe before connect/configure is done");
+            return;
+        }
         mqttEventListeners.get(fullTopic).remove(mel);
         if (mqttEventListeners.get(fullTopic).isEmpty()) {
             try {
                 mqttClient.unsubscribe(fullTopic);
                 mqttEventListeners.remove(fullTopic);
+                log.debug("Unsubscribed : \"{}\"", fullTopic);
             } catch (MqttException ex) {
                 log.error("Can't unsubscribe : ", ex);
             }

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -60,6 +60,15 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
         private final static String unknownText = "UNKNOWN";
         private final static String inconsistentText = "INCONSISTENT";
         private final static String movingText = "MOVING";
+
+        private void setExtraWithCheck(int newMode, String payload) {
+            if (getFeedbackMode() == MONITORING || getFeedbackMode() == EXACT) {
+                newKnownState(newMode);
+            } else {
+                log.warn("Received state is not valid in current operating mode: {}", payload);
+            }
+        }
+
         @Override
         public void beanFromPayload(@Nonnull Turnout bean, @Nonnull String payload, @Nonnull String topic) {
             switch (payload) {
@@ -70,19 +79,11 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
                     newKnownState(THROWN);
                     break;
                 case unknownText:
-                    if (getFeedbackMode() == MONITORING || getFeedbackMode() == EXACT) {
-                        newKnownState(UNKNOWN);
-                    } else {
-                        log.warn("Received state is not valid in current operating mode: {}", payload);
-                    }
+                    setExtraWithCheck(UNKNOWN, payload);
                     break;
                 case movingText:
                 case inconsistentText:
-                    if (getFeedbackMode() == MONITORING || getFeedbackMode() == EXACT) {
-                        newKnownState(INCONSISTENT);
-                    } else {
-                        log.warn("Received state is not valid in current operating mode: {}", payload);
-                    }
+                    setExtraWithCheck(INCONSISTENT, payload);
                     break;
                 default:
                     log.warn("Unknown state : {}", payload);

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -25,6 +25,9 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
         this.topic = topic;
         mqttAdapter = ma;
         mqttAdapter.subscribe(this.topic, this);
+        _validFeedbackNames = new String[] {"DIRECT", "ONESENSOR", "TWOSENSOR", "DELAYED", "MONITORING"};
+        _validFeedbackModes = new int[] {DIRECT, ONESENSOR, TWOSENSOR, DELAYED, MONITORING};
+        _validFeedbackTypes = DIRECT | ONESENSOR | TWOSENSOR | DELAYED | MONITORING;
     }
 
     public void setParser(MqttContentParser<Turnout> parser) {
@@ -46,10 +49,18 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
                     newKnownState(THROWN);
                     break;
                 case unknownText:
-                    newKnownState(UNKNOWN);
+                    if (getFeedbackMode() == MONITORING) {
+                        newKnownState(UNKNOWN);
+                    } else {
+                        log.warn("Received state is not valid in current operating mode: {}", payload);
+                    }
                     break;
                 case inconsistentText:
-                    newKnownState(INCONSISTENT);
+                    if (getFeedbackMode() == MONITORING) {
+                        newKnownState(INCONSISTENT);
+                    } else {
+                        log.warn("Received state is not valid in current operating mode: {}", payload);
+                    }
                     break;
                 default:
                     log.warn("Unknown state : {}", payload);

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -35,6 +35,7 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
         private final static String closedText = "CLOSED";
         private final static String thrownText = "THROWN";
         private final static String unknownText = "UNKNOWN";
+        private final static String inconsistentText = "INCONSISTENT";
         @Override
         public void beanFromPayload(@Nonnull Turnout bean, @Nonnull String payload, @Nonnull String topic) {
             switch (payload) {
@@ -46,6 +47,9 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
                     break;
                 case unknownText:
                     newKnownState(UNKNOWN);
+                    break;
+                case inconsistentText:
+                    newKnownState(INCONSISTENT);
                     break;
                 default:
                     log.warn("Unknown state : {}", payload);

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -34,6 +34,7 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
     MqttContentParser<Turnout> parser = new MqttContentParser<Turnout>() {
         private final static String closedText = "CLOSED";
         private final static String thrownText = "THROWN";
+        private final static String unknownText = "UNKNOWN";
         @Override
         public void beanFromPayload(@Nonnull Turnout bean, @Nonnull String payload, @Nonnull String topic) {
             switch (payload) {
@@ -42,6 +43,9 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
                     break;
                 case thrownText:
                     newKnownState(THROWN);
+                    break;
+                case unknownText:
+                    newKnownState(UNKNOWN);
                     break;
                 default:
                     log.warn("Unknown state : {}", payload);

--- a/java/test/jmri/jmrix/mqtt/MqttTurnoutTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttTurnoutTest.java
@@ -97,6 +97,22 @@ public class MqttTurnoutTest extends AbstractTurnoutTestBase {
         Assert.assertEquals("topic", "BAR", new String(savePayload));
         
     }
+
+    @Test
+    public void testParserModes() {
+        ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "CLOSED");
+        Assert.assertEquals("state", Turnout.CLOSED, t.getKnownState());
+        ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "THROWN");
+        Assert.assertEquals("state", Turnout.THROWN, t.getKnownState());
+        ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "UNKNOWN");
+        Assert.assertEquals("state", Turnout.THROWN, t.getKnownState());
+
+        ((MqttTurnout)t).setFeedbackMode(Turnout.EXACT);
+        ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "UNKNOWN");
+        Assert.assertEquals("state", Turnout.UNKNOWN, t.getKnownState());
+        ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "INCONSISTENT");
+        Assert.assertEquals("state", Turnout.INCONSISTENT, t.getKnownState());
+    }
     
     
     @Override


### PR DESCRIPTION
With this MqttTurnout adds the MONITORING feedback mode and the ability to recieve states INCONSISTENT (to show a turnout under movement) and UNKNOWN (e.g. to show a turnout that failed to reach position).