### PR TITLE
Remove notifyStealThrottleRequired from ThrottleListener Interface

### DIFF
--- a/java/src/jmri/ThrottleListener.java
+++ b/java/src/jmri/ThrottleListener.java
@@ -46,17 +46,6 @@ public interface ThrottleListener extends EventListener {
     }
     
     /**
-     * Get notification that a requested throttle is in use by another
-     * device, and a "steal" may be required.
-     * 
-     * @param address the address to steal
-     * @deprecated since 4.15.7; use
-     * #notifyDecisionRequired(LocoAddress, DecisionType) instead
-     */
-    @Deprecated
-    public void notifyStealThrottleRequired(LocoAddress address);
-
-    /**
      * Get notification that a throttle has been found as requested.
      *
      * @param t the throttle with the requested address

--- a/java/src/jmri/jmris/AbstractThrottleServer.java
+++ b/java/src/jmri/jmris/AbstractThrottleServer.java
@@ -159,18 +159,6 @@ abstract public class AbstractThrottleServer implements ThrottleListener {
      * No steal or share decisions made locally
      * <p>
      * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(LocoAddress address) {
-        InstanceManager.throttleManagerInstance().responseThrottleDecision(address, this, DecisionType.STEAL );
-    }
-
-    /**
-     * No steal or share decisions made locally
-     * <p>
-     * {@inheritDoc}
      */
     @Override
     public void notifyDecisionRequired(LocoAddress address, DecisionType question) {

--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -968,18 +968,6 @@ public class AbstractAutomaton implements Runnable {
                     self.notifyAll(); // should be only one thread waiting, but just in case
                 }
             }
-            
-            /**
-             * No steal or share decisions made locally
-             * <p>
-             * {@inheritDoc}
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Override
-            @Deprecated
-            public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-                InstanceManager.throttleManagerInstance().responseThrottleDecision(address, this, DecisionType.STEAL );
-            }
 
             /**
              * No steal or share decisions made locally
@@ -1052,18 +1040,6 @@ public class AbstractAutomaton implements Runnable {
                 synchronized (self) {
                     self.notifyAll(); // should be only one thread waiting, but just in case
                 }
-            }
-            
-            /**
-             * No steal or share decisions made locally
-             * <p>
-             * {@inheritDoc}
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Override
-            @Deprecated
-            public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-                InstanceManager.throttleManagerInstance().responseThrottleDecision(address, this, DecisionType.STEAL );
             }
             
             /**

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -348,16 +348,6 @@ public class AutoActiveTrain implements ThrottleListener {
     }
 
     /**
-     * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        InstanceManager.throttleManagerInstance().responseThrottleDecision(address, this, DecisionType.STEAL );
-    }
-
-    /**
      * No steal or share decisions made locally
      * <p>
      * {@inheritDoc}

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -922,16 +922,6 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
     }
 
     /**
-     * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        InstanceManager.throttleManagerInstance().responseThrottleDecision(address, this, DecisionType.STEAL );
-    }
-
-    /**
      * No steal or share decisions made locally
      * <p>
      * {@inheritDoc}

--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
@@ -635,21 +635,6 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
     }
     
     /**
-     * Profiling on a stolen or shared throttle is invalid
-     * <p>
-     * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        JOptionPane.showMessageDialog(null, Bundle.getMessage("ErrorNoStealing"));
-        InstanceManager.throttleManagerInstance().cancelThrottleRequest(address, this);
-        setButtonStates(true);
-        throttleState = -1;
-    }
-    
-    /**
     * Profiling on a stolen or shared throttle is invalid
     * <p>
     * {@inheritDoc}

--- a/java/src/jmri/jmrit/throttle/AddressPanel.java
+++ b/java/src/jmri/jmrit/throttle/AddressPanel.java
@@ -237,16 +237,6 @@ public class AddressPanel extends JInternalFrame implements ThrottleListener, Pr
     public void notifyFailedThrottleRequest(LocoAddress address, String reason) {
         javax.swing.JOptionPane.showMessageDialog(null, reason, Bundle.getMessage("FailedSetupRequestTitle"), javax.swing.JOptionPane.WARNING_MESSAGE);
     }
-    
-    /**
-     * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        notifyDecisionRequired(address, DecisionType.STEAL);
-    }
 
     /**
     * A decision is required for Throttle creation to continue.

--- a/java/src/jmri/jmrit/withrottle/ConsistFunctionController.java
+++ b/java/src/jmri/jmrit/withrottle/ConsistFunctionController.java
@@ -51,16 +51,6 @@ public class ConsistFunctionController implements ThrottleListener {
     }
 
     /**
-     * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        InstanceManager.throttleManagerInstance().responseThrottleDecision(address, this, DecisionType.STEAL );
-    }
-
-    /**
      * No steal or share decisions made locally
      */
     @Override

--- a/java/src/jmri/jmrit/withrottle/MultiThrottleController.java
+++ b/java/src/jmri/jmrit/withrottle/MultiThrottleController.java
@@ -251,16 +251,6 @@ public class MultiThrottleController extends ThrottleController {
             listener.sendPacketToDevice(message.toString());
         }
     }
-    
-    /**
-     * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        notifyDecisionRequired(address, DecisionType.STEAL);
-    }
 
     /**
      * A decision is required for Throttle creation to continue.

--- a/java/src/jmri/jmrit/withrottle/ThrottleController.java
+++ b/java/src/jmri/jmrit/withrottle/ThrottleController.java
@@ -217,16 +217,6 @@ public class ThrottleController implements ThrottleListener, PropertyChangeListe
             log.debug("Notify TCListener address declined in-use: {}", l.getClass());
         }
     }
-    
-    /**
-     * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        notifyDecisionRequired(address, DecisionType.STEAL);
-    }
 
     /**
      * calls notifyFailedThrottleRequest, Steal Required

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -295,16 +295,6 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
                 public void notifyThrottleFound(DccThrottle t) {
                 }
 
-                /**
-                 * {@inheritDoc}
-                 *
-                 * @deprecated since 4.15.7; use #notifyDecisionRequired
-                 */
-                @Override
-                @Deprecated
-                public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-                }
-
                 @Override
                 public void notifyDecisionRequired(LocoAddress address, DecisionType question) {
                 }

--- a/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
@@ -1782,18 +1782,6 @@ public class SpeedoConsoleFrame extends JmriJFrame implements SpeedoListener,
     @Override
     public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
     }
-          
-    /**
-     * Called when a throttle must be stolen for the requested address. Since this is a 
-     * an automatically stealing implementation, the throttle will be automatically stolen.
-     * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        InstanceManager.throttleManagerInstance().responseThrottleDecision(address, this, DecisionType.STEAL );
-    }
 
     /**
      * Called when we must decide to steal the throttle for the requested address. Since this is a 

--- a/java/src/jmri/jmrix/loconet/LocoNetConsist.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetConsist.java
@@ -491,16 +491,6 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
     }
 
     /**
-     * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        jmri.InstanceManager.throttleManagerInstance().responseThrottleDecision(address, this, DecisionType.STEAL );
-    }
-
-    /**
      * No steal or share decisions made locally
      * <p>
      * {@inheritDoc}

--- a/java/src/jmri/jmrix/rps/RpsBlock.java
+++ b/java/src/jmri/jmrix/rps/RpsBlock.java
@@ -89,16 +89,6 @@ public class RpsBlock implements java.beans.PropertyChangeListener, jmri.Throttl
     @Override
     public void notifyFailedThrottleRequest(LocoAddress address, String reason) {
     }
-    
-    /**
-     * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        jmri.InstanceManager.throttleManagerInstance().responseThrottleDecision(address, this, DecisionType.STEAL );
-    }
 
     /**
      * No steal or share decisions made locally

--- a/java/src/jmri/jmrix/rps/Transmitter.java
+++ b/java/src/jmri/jmrix/rps/Transmitter.java
@@ -106,16 +106,6 @@ public class Transmitter implements ThrottleListener {
     @Override
     public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
     }
-    
-    /**
-     * {@inheritDoc}
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        InstanceManager.throttleManagerInstance().responseThrottleDecision(address, this, DecisionType.STEAL );
-    }
 
     /**
      * No steal or share decisions made locally

--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -304,17 +304,6 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
     }
 
     /**
-     * {@inheritDoc}
-     * 
-     * @deprecated since 4.15.7; use #notifyDecisionRequired
-     */
-    @Override
-    @Deprecated
-    public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-        InstanceManager.throttleManagerInstance().responseThrottleDecision(address, this, DecisionType.STEAL);
-    }
-
-    /**
      * No steal or share decisions made locally
      * <p>
      * {@inheritDoc}

--- a/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
@@ -453,16 +453,6 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
         public void notifyFailedThrottleRequest(LocoAddress address, String reason){
             // throttleNotFoundResult = true;
         }
-       
-        /**
-         * {@inheritDoc}
-         * @deprecated since 4.15.7; use #notifyDecisionRequired
-         */
-        @Override
-        @Deprecated
-        public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-            notifyDecisionRequired(address,DecisionType.STEAL);
-        }
 
         @Override
         public void notifyDecisionRequired(LocoAddress address, DecisionType question) {
@@ -488,14 +478,6 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
             public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(LocoAddress address){
             }
 
             @Override
@@ -540,14 +522,6 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
             public void notifyFailedThrottleRequest(LocoAddress address, String reason) {
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(LocoAddress address){
             }
 
             @Override
@@ -635,14 +609,6 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(LocoAddress address){
-            }
 
             @Override
             public void notifyDecisionRequired(LocoAddress address, DecisionType question) {
@@ -708,14 +674,6 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
             public void notifyFailedThrottleRequest(LocoAddress address, String reason) {
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(LocoAddress address){
             }
 
             @Override
@@ -790,14 +748,6 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(LocoAddress address){
-            }
 
             @Override
             public void notifyDecisionRequired(LocoAddress address, DecisionType question) {
@@ -863,14 +813,6 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
             public void notifyFailedThrottleRequest(LocoAddress address, String reason) {
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(LocoAddress address){
             }
 
             @Override

--- a/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
@@ -54,15 +54,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
-            }
 
             @Override
             public void notifyDecisionRequired(jmri.LocoAddress address, DecisionType question) {
@@ -128,15 +119,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
             }
 
             @Override
@@ -225,15 +207,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
-            }
 
             @Override
             public void notifyDecisionRequired(jmri.LocoAddress address, DecisionType question) {
@@ -318,15 +291,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 failedThrottleRequest = true;
                 log.error("Throttle request failed for {} because {}", address, reason);
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
-            }
 
             @Override
             public void notifyDecisionRequired(jmri.LocoAddress address, DecisionType question) {
@@ -373,15 +337,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 failedThrottleRequest = true;
                 log.error("Throttle request failed for {} because {}", address, reason);
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
-            }
 
             @Override
             public void notifyDecisionRequired(jmri.LocoAddress address, DecisionType question) {
@@ -426,15 +381,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
                 failedThrottleRequest = true;
                 log.error("Throttle request failed for {} because {}", address, reason);
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
             }
 
             @Override
@@ -481,15 +427,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
             }
 
             @Override
@@ -539,15 +476,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
-            }
 
             @Override
             public void notifyDecisionRequired(jmri.LocoAddress address, DecisionType question) {
@@ -592,15 +520,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
             }
 
             @Override
@@ -656,15 +575,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
-            }
 
             @Override
             public void notifyDecisionRequired(jmri.LocoAddress address, DecisionType question) {
@@ -687,15 +597,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
                 log.error("Throttle2 request failed for {} because {}", address, reason);
                 failedThrottleRequest2 = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
             }
 
             @Override
@@ -780,15 +681,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
-            }
 
             @Override
             public void notifyDecisionRequired(jmri.LocoAddress address, DecisionType question) {
@@ -811,15 +703,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
                 log.error("Throttle2 request failed for {} because {}", address, reason);
                 failedThrottleRequest2 = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
             }
 
             @Override
@@ -924,15 +807,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
-            }
 
             @Override
             public void notifyDecisionRequired(jmri.LocoAddress address, DecisionType question) {
@@ -956,15 +830,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 log.error("Throttle2 request failed for {} because {}", address, reason);
                 failedThrottleRequest2 = true;
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
-            }
 
             @Override
             public void notifyDecisionRequired(jmri.LocoAddress address, DecisionType question) {
@@ -987,15 +852,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
                 log.error("Throttle3 request failed for {} because {}", address, reason);
                 failedThrottleRequest3 = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
             }
 
             @Override
@@ -1110,15 +966,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
                 log.error("Throttle request failed for {} because {}", address, reason);
                 failedThrottleRequest = true;
             }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
-            }
 
             @Override
             public void notifyDecisionRequired(jmri.LocoAddress address, DecisionType question) {
@@ -1142,15 +989,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
                 log.error("Throttle2 request failed for {} because {}", address, reason);
                 failedThrottleRequest2 = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
             }
 
             @Override
@@ -1251,15 +1089,6 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
             public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
                 log.error("Throttle4 request failed for {} because {}", address, reason);
                 failedThrottleRequest4 = true;
-            }
-            
-            /**
-             * @deprecated since 4.15.7; use #notifyDecisionRequired
-             */
-            @Deprecated
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address){
-                notifyDecisionRequired(address, DecisionType.STEAL);
             }
 
             @Override

--- a/java/test/jmri/managers/AbstractThrottleManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractThrottleManagerTestBase.java
@@ -49,16 +49,6 @@ public abstract class AbstractThrottleManagerTestBase {
         public void notifyFailedThrottleRequest(LocoAddress address, String reason){
             throttleNotFoundResult = true;
         }
-        
-        /**
-         * {@inheritDoc}
-         * @Deprecated since 4.15.7; use #notifyDecisionRequired
-         */
-        @Deprecated
-        @Override
-        public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-            notifyDecisionRequired(address,DecisionType.STEAL);
-        }
 
         @Override
         public void notifyDecisionRequired(LocoAddress address, DecisionType question) {

--- a/jython/Jynstruments/ThrottleWindowToolBar/DCCThrottle.jyn/DCCThrottle.py
+++ b/jython/Jynstruments/ThrottleWindowToolBar/DCCThrottle.jyn/DCCThrottle.py
@@ -135,9 +135,6 @@ class DCCThrottle(Jynstrument, PropertyChangeListener, AddressListener, jmri.Thr
             pass
         if ( jmri.InstanceManager.throttleManagerInstance().requestThrottle(listenToDCCThrottle, self) == False):
             print "Couldn't request a throttle for "+locoAddress
-            
-    def notifyStealThrottleRequired(LocoAddress):
-        pass # Throttle steal decisions are delegated to the Hardware
         
     def notifyDecisionRequired(LocoAddress, decision):
         pass # Throttle steal / share decisions are delegated to the ThrottleManager


### PR DESCRIPTION
deprecated since 4.15.7