### PR TITLE
WIP: Suppress persistent warnings

### DIFF
--- a/java/src/jmri/jmrix/DefaultSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/DefaultSystemConnectionMemo.java
@@ -198,9 +198,18 @@ public abstract class DefaultSystemConnectionMemo extends Bean implements System
         }
     }
 
+    // removeRegisteredObject requires a Class<T> argument, but 
+    // the classObjectMap member (and hence keySet here) contains
+    // a Class object.  
+    // It's not at all clear that type-safety is being 
+    // assured, as opposed to assumed, but to avoid warnings on every compile
+    // we'll annotate the assumption.
+    @SuppressWarnings("unchecked")  // foreach statement below assumes type-safety, see comment above.
     public void dispose() {
         Set<Class> keySet = new HashSet<>(classObjectMap.keySet());
+        
         keySet.forEach(this::removeRegisteredObject);
+        
         SystemConnectionMemoManager.getDefault().deregister(this);
     }
 


### PR DESCRIPTION
PR #8781 introduced persistent compile warnings:

```
java/src/jmri/jmrix/DefaultSystemConnectionMemo.java:203: warning: [unchecked] unchecked method invocation: method removeRegisteredObject in class DefaultSystemConnectionMemo is applied to given types
        keySet.forEach(this::removeRegisteredObject);
                       ^
  required: Class<T>
  found: Class
  where T is a type-variable:
    T extends Object declared in method <T>removeRegisteredObject(Class<T>)
    
java/src/jmri/jmrix/DefaultSystemConnectionMemo.java:203: warning: [unchecked] unchecked method invocation: method forEach in interface Iterable is applied to given types
        keySet.forEach(this::removeRegisteredObject);
                      ^
  required: Consumer<? super T>
  found: Consumer<Class>
  where T is a type-variable:
    T extends Object declared in interface Iterable
    
2 warnings
```

This PR adds `@Suppress("unchecked")` to prevent these from showing up every time during compilation, and adds a multi-line comment explaining the problem in this too-cute-to-live code.  I didn't take the time to fix it, as (a) the simple way to fix it right there involves a `for` loop and those are just so passé and (b) actually assuring type safety would require changing multiple methods who's interconnections were not immediately clear.  Perhaps somebody else will do one or the other of those.