### PR TITLE
fix: The dark and held signal head icons are being overridden.

### DIFF
--- a/java/src/jmri/jmrit/display/SignalHeadIcon.java
+++ b/java/src/jmri/jmrit/display/SignalHeadIcon.java
@@ -303,31 +303,32 @@ public class SignalHeadIcon extends PositionableIcon implements java.beans.Prope
         updateSize();
         if (getSignalHead() == null) {
             log.debug("Display state {}, disconnected", state);
-        } else {
-            log.debug("Display state {} for {}", state, getNameString());
-            if (getSignalHead().getHeld()) {
-                if (isText()) {
-                    super.setText(Bundle.getMessage("Held"));
-                }
-                if (isIcon()) {
-                    super.setIcon(_iconMap.get("SignalHeadStateHeld"));
-                }
-            } else if (getLitMode() && !getSignalHead().getLit()) {
-                if (isText()) {
-                    super.setText(Bundle.getMessage("Dark"));
-                }
-                if (isIcon()) {
-                    super.setIcon(_iconMap.get("SignalHeadStateDark"));
-                }
+            return;
+        }
+        log.debug("Display state {} for {}", state, getNameString());
+        if (getSignalHead().getHeld()) {
+            if (isText()) {
+                super.setText(Bundle.getMessage("Held"));
             }
-        }
-        if (isText()) {
-            super.setText(Bundle.getMessage(getSignalHead().getAppearanceKey(state)));
-        }
-        if (isIcon()) {
-            NamedIcon icon = _iconMap.get(getSignalHead().getAppearanceKey(state));
-            if (icon != null) {
-                super.setIcon(icon);
+            if (isIcon()) {
+                super.setIcon(_iconMap.get("SignalHeadStateHeld"));
+            }
+        } else if (getLitMode() && !getSignalHead().getLit()) {
+            if (isText()) {
+                super.setText(Bundle.getMessage("Dark"));
+            }
+            if (isIcon()) {
+                super.setIcon(_iconMap.get("SignalHeadStateDark"));
+            }
+        } else {
+            if (isText()) {
+                super.setText(Bundle.getMessage(getSignalHead().getAppearanceKey(state)));
+            }
+            if (isIcon()) {
+                NamedIcon icon = _iconMap.get(getSignalHead().getAppearanceKey(state));
+                if (icon != null) {
+                    super.setIcon(icon);
+                }
             }
         }
     }


### PR DESCRIPTION
`SignalHeadIcon#displayState()` sets the icon image for **dark** or **held** if necessary and then continues to set the appropriate icon for the current appearance.  The **_return_** statement for dark and held was removed in 4.17.5 which allows the fall through to occur.

The method also checked for a null condition, created a debug message and then proceeded to use the potential null value.