### PR TITLE
WIP: Update package names to match directory names

### DIFF
--- a/java/src/jmri/server/json/block/JsonBlockHttpService.java
+++ b/java/src/jmri/server/json/block/JsonBlockHttpService.java
@@ -3,7 +3,7 @@ package jmri.server.json.block;
 import static jmri.server.json.JSON.VALUE;
 import static jmri.server.json.block.JsonBlock.BLOCK;
 import static jmri.server.json.block.JsonBlock.BLOCKS;
-import static jmri.server.json.idtag.JsonIdTag.IDTAG;
+import static jmri.server.json.idTag.JsonIdTag.IDTAG;
 import static jmri.server.json.reporter.JsonReporter.REPORTER;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -27,7 +27,7 @@ import jmri.server.json.JSON;
 import jmri.server.json.JsonException;
 import jmri.server.json.JsonNamedBeanHttpService;
 import jmri.server.json.JsonRequest;
-import jmri.server.json.idtag.JsonIdTagHttpService;
+import jmri.server.json.idTag.JsonIdTagHttpService;
 import jmri.server.json.reporter.JsonReporter;
 import jmri.server.json.reporter.JsonReporterHttpService;
 import jmri.server.json.roster.JsonRosterHttpService;

--- a/java/src/jmri/server/json/idtag/Bundle.java
+++ b/java/src/jmri/server/json/idtag/Bundle.java
@@ -1,4 +1,4 @@
-package jmri.server.json.idtag;
+package jmri.server.json.idTag;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Locale;

--- a/java/src/jmri/server/json/idtag/JsonIdTag.java
+++ b/java/src/jmri/server/json/idtag/JsonIdTag.java
@@ -1,4 +1,4 @@
-package jmri.server.json.idtag;
+package jmri.server.json.idTag;
 
 /**
  * Constants used by the internal JMRI JSON IdTag service.

--- a/java/src/jmri/server/json/idtag/JsonIdTagHttpService.java
+++ b/java/src/jmri/server/json/idtag/JsonIdTagHttpService.java
@@ -1,11 +1,11 @@
-package jmri.server.json.idtag;
+package jmri.server.json.idTag;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 
-import static jmri.server.json.idtag.JsonIdTag.IDTAG;
+import static jmri.server.json.idTag.JsonIdTag.IDTAG;
 
 import java.util.Date;
 import javax.servlet.http.HttpServletResponse;

--- a/java/src/jmri/server/json/idtag/JsonIdTagServiceFactory.java
+++ b/java/src/jmri/server/json/idtag/JsonIdTagServiceFactory.java
@@ -1,10 +1,10 @@
-package jmri.server.json.idtag;
+package jmri.server.json.idTag;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
 import jmri.spi.JsonServiceFactory;
 
-import static jmri.server.json.idtag.JsonIdTag.IDTAG;
+import static jmri.server.json.idTag.JsonIdTag.IDTAG;
 
 import org.openide.util.lookup.ServiceProvider;
 

--- a/java/src/jmri/server/json/idtag/JsonIdTagSocketService.java
+++ b/java/src/jmri/server/json/idtag/JsonIdTagSocketService.java
@@ -1,4 +1,4 @@
-package jmri.server.json.idtag;
+package jmri.server.json.idTag;
 
 import jmri.IdTag;
 import jmri.server.json.JsonConnection;

--- a/java/src/jmri/server/json/memory/JsonMemoryHttpService.java
+++ b/java/src/jmri/server/json/memory/JsonMemoryHttpService.java
@@ -4,7 +4,7 @@ import static jmri.server.json.JSON.DATA;
 import static jmri.server.json.JSON.VALUE;
 import static jmri.server.json.memory.JsonMemory.MEMORIES;
 import static jmri.server.json.memory.JsonMemory.MEMORY;
-import static jmri.server.json.idtag.JsonIdTag.IDTAG;
+import static jmri.server.json.idTag.JsonIdTag.IDTAG;
 import static jmri.server.json.reporter.JsonReporter.REPORTER;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -20,7 +20,7 @@ import jmri.ProvidingManager;
 import jmri.server.json.JsonException;
 import jmri.server.json.JsonNamedBeanHttpService;
 import jmri.server.json.JsonRequest;
-import jmri.server.json.idtag.JsonIdTagHttpService;
+import jmri.server.json.idTag.JsonIdTagHttpService;
 import jmri.server.json.reporter.JsonReporterHttpService;
 import jmri.server.json.roster.JsonRosterHttpService;
 

--- a/java/src/jmri/server/json/signalhead/Bundle.java
+++ b/java/src/jmri/server/json/signalhead/Bundle.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalhead;
+package jmri.server.json.signalHead;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Locale;

--- a/java/src/jmri/server/json/signalhead/JsonSignalHead.java
+++ b/java/src/jmri/server/json/signalhead/JsonSignalHead.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalhead;
+package jmri.server.json.signalHead;
 
 /**
  * Constants used by the {@link jmri.server.json.signalhead} package.

--- a/java/src/jmri/server/json/signalhead/JsonSignalHead.java
+++ b/java/src/jmri/server/json/signalhead/JsonSignalHead.java
@@ -1,7 +1,7 @@
 package jmri.server.json.signalHead;
 
 /**
- * Constants used by the {@link jmri.server.json.signalhead} package.
+ * Constants used by the {@link jmri.server.json.signalHead} package.
  *
  * @author Randall Wood 2016
  */

--- a/java/src/jmri/server/json/signalhead/JsonSignalHeadHttpService.java
+++ b/java/src/jmri/server/json/signalhead/JsonSignalHeadHttpService.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalhead;
+package jmri.server.json.signalHead;
 
 import static jmri.server.json.JSON.APPEARANCE;
 import static jmri.server.json.JSON.APPEARANCE_NAME;
@@ -6,8 +6,8 @@ import static jmri.server.json.JSON.DATA;
 import static jmri.server.json.JSON.LIT;
 import static jmri.server.json.JSON.STATE;
 import static jmri.server.json.JSON.TOKEN_HELD;
-import static jmri.server.json.signalhead.JsonSignalHead.SIGNAL_HEAD;
-import static jmri.server.json.signalhead.JsonSignalHead.SIGNAL_HEADS;
+import static jmri.server.json.signalHead.JsonSignalHead.SIGNAL_HEAD;
+import static jmri.server.json.signalHead.JsonSignalHead.SIGNAL_HEADS;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/java/src/jmri/server/json/signalhead/JsonSignalHeadServiceFactory.java
+++ b/java/src/jmri/server/json/signalhead/JsonSignalHeadServiceFactory.java
@@ -1,11 +1,11 @@
-package jmri.server.json.signalhead;
+package jmri.server.json.signalHead;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
 import jmri.spi.JsonServiceFactory;
 
-import static jmri.server.json.signalhead.JsonSignalHead.SIGNAL_HEAD;
-import static jmri.server.json.signalhead.JsonSignalHead.SIGNAL_HEADS;
+import static jmri.server.json.signalHead.JsonSignalHead.SIGNAL_HEAD;
+import static jmri.server.json.signalHead.JsonSignalHead.SIGNAL_HEADS;
 
 import org.openide.util.lookup.ServiceProvider;
 

--- a/java/src/jmri/server/json/signalhead/JsonSignalHeadSocketService.java
+++ b/java/src/jmri/server/json/signalhead/JsonSignalHeadSocketService.java
@@ -1,10 +1,10 @@
-package jmri.server.json.signalhead;
+package jmri.server.json.signalHead;
 
 import static jmri.server.json.JSON.GET;
 import static jmri.server.json.JSON.NAME;
 import static jmri.server.json.JSON.PUT;
-import static jmri.server.json.signalhead.JsonSignalHead.SIGNAL_HEAD;
-import static jmri.server.json.signalhead.JsonSignalHead.SIGNAL_HEADS;
+import static jmri.server.json.signalHead.JsonSignalHead.SIGNAL_HEAD;
+import static jmri.server.json.signalHead.JsonSignalHead.SIGNAL_HEADS;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.beans.PropertyChangeEvent;

--- a/java/src/jmri/server/json/signalmast/Bundle.java
+++ b/java/src/jmri/server/json/signalmast/Bundle.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalmast;
+package jmri.server.json.signalMast;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Locale;

--- a/java/src/jmri/server/json/signalmast/JsonSignalMast.java
+++ b/java/src/jmri/server/json/signalmast/JsonSignalMast.java
@@ -1,7 +1,7 @@
 package jmri.server.json.signalMast;
 
 /**
- * Constants used by the {@link jmri.server.json.signalmast} package.
+ * Constants used by the {@link jmri.server.json.signalMast} package.
  *
  * @author Randall Wood 2016
  */

--- a/java/src/jmri/server/json/signalmast/JsonSignalMast.java
+++ b/java/src/jmri/server/json/signalmast/JsonSignalMast.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalmast;
+package jmri.server.json.signalMast;
 
 /**
  * Constants used by the {@link jmri.server.json.signalmast} package.

--- a/java/src/jmri/server/json/signalmast/JsonSignalMastHttpService.java
+++ b/java/src/jmri/server/json/signalmast/JsonSignalMastHttpService.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalmast;
+package jmri.server.json.signalMast;
 
 import static jmri.server.json.JSON.ASPECT;
 import static jmri.server.json.JSON.ASPECT_DARK;
@@ -8,8 +8,8 @@ import static jmri.server.json.JSON.DATA;
 import static jmri.server.json.JSON.LIT;
 import static jmri.server.json.JSON.STATE;
 import static jmri.server.json.JSON.TOKEN_HELD;
-import static jmri.server.json.signalmast.JsonSignalMast.SIGNAL_MAST;
-import static jmri.server.json.signalmast.JsonSignalMast.SIGNAL_MASTS;
+import static jmri.server.json.signalMast.JsonSignalMast.SIGNAL_MAST;
+import static jmri.server.json.signalMast.JsonSignalMast.SIGNAL_MASTS;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/java/src/jmri/server/json/signalmast/JsonSignalMastServiceFactory.java
+++ b/java/src/jmri/server/json/signalmast/JsonSignalMastServiceFactory.java
@@ -1,11 +1,11 @@
-package jmri.server.json.signalmast;
+package jmri.server.json.signalMast;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
 import jmri.spi.JsonServiceFactory;
 
-import static jmri.server.json.signalmast.JsonSignalMast.SIGNAL_MAST;
-import static jmri.server.json.signalmast.JsonSignalMast.SIGNAL_MASTS;
+import static jmri.server.json.signalMast.JsonSignalMast.SIGNAL_MAST;
+import static jmri.server.json.signalMast.JsonSignalMast.SIGNAL_MASTS;
 
 import org.openide.util.lookup.ServiceProvider;
 

--- a/java/src/jmri/server/json/signalmast/JsonSignalMastSocketService.java
+++ b/java/src/jmri/server/json/signalmast/JsonSignalMastSocketService.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalmast;
+package jmri.server.json.signalMast;
 
 import jmri.SignalMast;
 import jmri.server.json.JsonConnection;

--- a/java/test/jmri/server/json/idtag/BundleTest.java
+++ b/java/test/jmri/server/json/idtag/BundleTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.idtag;
+package jmri.server.json.idTag;
 
 import java.util.Locale;
 import org.junit.Assert;

--- a/java/test/jmri/server/json/idtag/JsonIdTagHttpServiceTest.java
+++ b/java/test/jmri/server/json/idtag/JsonIdTagHttpServiceTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.idtag;
+package jmri.server.json.idTag;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;

--- a/java/test/jmri/server/json/idtag/JsonIdTagSocketServiceTest.java
+++ b/java/test/jmri/server/json/idtag/JsonIdTagSocketServiceTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.idtag;
+package jmri.server.json.idTag;
 
 import com.fasterxml.jackson.databind.JsonNode;
 

--- a/java/test/jmri/server/json/idtag/JsonIdTagTest.java
+++ b/java/test/jmri/server/json/idtag/JsonIdTagTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.idtag;
+package jmri.server.json.idTag;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;

--- a/java/test/jmri/server/json/signalhead/BundleTest.java
+++ b/java/test/jmri/server/json/signalhead/BundleTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalhead;
+package jmri.server.json.signalHead;
 
 import java.util.Locale;
 import org.junit.Assert;

--- a/java/test/jmri/server/json/signalhead/JsonSignalHeadHttpServiceTest.java
+++ b/java/test/jmri/server/json/signalhead/JsonSignalHeadHttpServiceTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalhead;
+package jmri.server.json.signalHead;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;

--- a/java/test/jmri/server/json/signalhead/JsonSignalHeadSocketServiceTest.java
+++ b/java/test/jmri/server/json/signalhead/JsonSignalHeadSocketServiceTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalhead;
+package jmri.server.json.signalHead;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/java/test/jmri/server/json/signalhead/JsonSignalHeadTest.java
+++ b/java/test/jmri/server/json/signalhead/JsonSignalHeadTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalhead;
+package jmri.server.json.signalHead;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;

--- a/java/test/jmri/server/json/signalmast/BundleTest.java
+++ b/java/test/jmri/server/json/signalmast/BundleTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalmast;
+package jmri.server.json.signalMast;
 
 import java.util.Locale;
 import org.junit.Assert;

--- a/java/test/jmri/server/json/signalmast/JsonSignalMastHttpServiceTest.java
+++ b/java/test/jmri/server/json/signalmast/JsonSignalMastHttpServiceTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalmast;
+package jmri.server.json.signalMast;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;

--- a/java/test/jmri/server/json/signalmast/JsonSignalMastSocketServiceTest.java
+++ b/java/test/jmri/server/json/signalmast/JsonSignalMastSocketServiceTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalmast;
+package jmri.server.json.signalMast;
 
 import com.fasterxml.jackson.databind.JsonNode;
 

--- a/java/test/jmri/server/json/signalmast/JsonSignalMastTest.java
+++ b/java/test/jmri/server/json/signalmast/JsonSignalMastTest.java
@@ -1,4 +1,4 @@
-package jmri.server.json.signalmast;
+package jmri.server.json.signalMast;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;


### PR DESCRIPTION
Several sub-directories of jmri/server/json have mixed-case names:  idTag, signalHead, signalMast.  However, various package and import statements and fully-qualified references use the all-lower-case version of these.

Java handles this OK by default on a non-case-sensitive file system.  On a case-sensitive file system,  Java still handles it fine, but CheckStyle fails these lines hence fails builds.

This PR changes the package and import statements and fully-qualified references statements to match the file names.

Note that GitHub is also non-case-sensitive:  The file names shown for changes here will show _lower_ _case_ versions of the directory names.  But if you look at the actual files in a checkout, you'll see the capital letters in the names.

An alternative (and perhaps preferable) solution would be to change the directory names to all lower case to match the statements in the source.  Unfortunately, on case-insensitive file systems this can badly confuse Git when merging into existing checked-out directories; how to handle that here would require some careful consideration and perhaps testing before making the change.
