### PR TITLE
Digirails_Stationary.xml: fix mask for CV47

### DIFF
--- a/xml/decoders/Digirails_Stationary.xml
+++ b/xml/decoders/Digirails_Stationary.xml
@@ -108,7 +108,7 @@ xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" showEmpty
                 <tooltip>Read-Only, 42 = Digirails/Digikeijs</tooltip>
             </variable>
             <!-- CV29 via nmra include in line 79 -->
-            <variable item="Presets4018" CV="47" mask="XXXXXXVV" writeOnly="yes" default="0" include="4018">
+            <variable item="Presets4018" CV="47" mask="XXXXVVVV" writeOnly="yes" default="0" include="4018">
                 <enumVal>
                     <enumChoice choice="0">
                         <choice>8x Solenoid Turnout</choice>


### PR DESCRIPTION
I'm using a Digikeijs DR4018 (accessory DCC decoder) on a Roco z21 (white version).
I'm writing CV47 to change the setup of the decoder (tab "Module" in DecoderPro), using POM.
When I try to setup a value other than 0-3 (e.g. "2x8 Fluorescents", which has a value of 4), it is not set.

The problem is that the definition of variable for CV47 in
xml/decoders/Digirails_Stationary.xml has a wrong mask that does not allow values greater than 3.