### PR TITLE
Update some help docs with broken sidebar links and related...

### DIFF
--- a/help/en/html/doc/Technical/Help.shtml
+++ b/help/en/html/doc/Technical/Help.shtml
@@ -122,12 +122,13 @@
         <li>When you create a new page, start with a copy of either the help/en/TemplateBar.shtml
         or help/en/TemplatePlain.shtml template file, depending on whether or not you want to include
         a "sidebar" (via a file named Sidebar.shtml). This template will put the proper top and bottom
-        matter in place to get the page properly displayed.</li>
+        matter in place to get the page properly displayed.
+        </li>
         
         <li>In general, all help files in the html directory tree use a sidebar.  In general, files
-        in the package part of the tree do not. If you are using a sidebar, you may find one that suits
-        your purpose in the specific subdirectory in which you are working, in its parent directory, or,
-        in rare cases, you can use the one in the html directory itself (either /help/en/html or /help/fr/html).
+         in the package part of the tree do not. If you are using a sidebar, you may find one that suits
+         your purpose in the specific subdirectory in which you are working, in its parent directory, or,
+         in rare cases, you can use the one in the html directory itself (either /help/en/html or /help/fr/html).
         
         <p> If none of these meet your needs (or do not exist), you may create a Sidebar.shtml in the subdirectory,
          in which case, you should follow the format of other Sidebar.shtml files in other subdirectories at the 
@@ -139,13 +140,10 @@
          as Hardware or Tool. This use of local part files allows Sidebar.shtml files in terminal subdirectories
          to use identical code, something that makes maintenance significantly easier.</p>
 
-        <p> If you do not need a local part, use the Sidebar.shtml in the parent directory by including
-        the following statement in your help file:
-        <pre style="font-family: monospace;">
-     &lt;!--#include virtual="../Sidebar.shtml" --&gt;
-        </pre>
-        This line exists in the help template files but does not have the "../". Note also there is no space 
-        before the hash sign and a space after the final quote.        
+        <p class="noted"> If you do not need a local part, you can include the Sidebar.shtml from the parent directory 
+         but ONLY if that file does not have any relative URLs (URLs with "../" and similar). It is does, the sidebar 
+         links will not work when incorporated into your page. Look at the contents of Sidebar.shtml in the parent 
+         directory before attempting to reference it.</p>
         </li>
 
         <li>All the page formatting on JMRI help and other web pages is done through included CSS
@@ -153,8 +151,10 @@
         Includes (SSI).  The main file is at <a href="../../../../../css/default.css">/css/default.css</a>
         and works with a few other files in that same directory. Because JavaHelp ignores SSI, the
         CSS formatting is ignored when JavaHelp is displaying the pages within the JMRI itself. In 
-        that case, JavaHelp provides the formatting.</li>
-     </ul>
+        that case, JavaHelp provides the formatting.
+        </li>
+ 
+       </ul>
 
              <p><a href="#helpTop">[Go to top of page]</a></p>
        </div>

--- a/help/en/html/doc/Technical/Sidebar.shtml
+++ b/help/en/html/doc/Technical/Sidebar.shtml
@@ -72,7 +72,7 @@
 			<ul class="navigation">
 			<li><a href="Help.shtml">Providing Help using JavaHelp</a></li>
 			<li><a href="WebSite.shtml">The JMRI Web Site</a></li>
-                        <li><a href="webupdate/UpdatingDocs.shtml">Updating JMRI Web and Help</a></li>
+                        <li><a href="UpdatingDocs.shtml">Updating JMRI Web and Help</a></li>
                         <li><a href="Help.shtml#hwhelp">Creating Help for New Hardware</a></li>
 			<li><a href="Javadoc.shtml">Program Documentation Using Javadoc</a></li>
 			</ul>

--- a/help/en/html/doc/Technical/UpdatingDocs.shtml
+++ b/help/en/html/doc/Technical/UpdatingDocs.shtml
@@ -28,7 +28,7 @@
 <body>
   <!--#include virtual="/Header.shtml" -->
 <div id="mBody">
-    <!--#include virtual="../Sidebar.shtml" -->
+    <!--#include virtual="Sidebar.shtml" -->
     <div id="mainContent">
 
       <h1>How to update the JMRI Documentation</h1>
@@ -104,7 +104,7 @@
       distro doesn't already have a default application that
       supports the use of the &lt;<code>Print Screen></code>&gt; and
       &lt;<code>Alt + Print Screen</code>&gt; keys you can install
-      <a href="http://www.kde.org/">KSnapshot</a> or your favorite
+      <a href="http://www.kde.org/" target="_blank">KSnapshot</a> or your favorite
       application to do your screen grabbing.
 
       <h3>For macOS</h3>
@@ -117,12 +117,12 @@
 
       <h3>Using a Third-Party Application</h3>
       <p>On macOS we nowadays often use Evernote
-      <a href="https://evernote.com/intl/nl/products/skitch">Skitch</a>
+      <a href="https://evernote.com/intl/nl/products/skitch" target="_blank">Skitch</a>
       to grab and touch up screen shots. Here's an example of that style:<br>
-      <img src="../images/GitHubPencil.png" width="285" height="101">
+      <img src="../images/GitHubPencil.png" width="285" height="101" alt="GitHub Pencil">
       </p>
       <p>We also love <a href=
-      "http://www.irfanview.com">IrFanView</a>
+      "http://www.irfanview.com" target="_blank">IrFanView</a>
       for screenshots, and it is free. With it, you can also
       include your mouse cursor in your snapshot. You can also take
       a series of shots easily, and even make a slideshow of them.
@@ -170,10 +170,10 @@
       <h3>Send to GitHub</h3>
 
       <p>You can view the current <a href=
-      "https://github.com/JMRI/JMRI">JMRI repository on GitHub</a>.
+      "https://github.com/JMRI/JMRI" target="_blank">JMRI repository on GitHub</a>.
       To learn how to make changes to connect to GitHub and
       contribute your changes, please read <a href=
-      "../getgitcode.shtml">Using Git</a>.
+      "getgitcode.shtml">Using Git</a>.
       </p>
       <!--#include virtual="/Footer.shtml" -->
     </div>

--- a/help/en/html/doc/Technical/WebSite.shtml
+++ b/help/en/html/doc/Technical/WebSite.shtml
@@ -37,7 +37,7 @@
         <p>
         If you just want to know how to make a small change to a web or
         help page, please see the
-        <a href="webupdate/UpdatingDocs.shtml">Updating JMRI Documentation instructions</a>.</p>
+        <a href="UpdatingDocs.shtml">Updating JMRI Documentation instructions</a>.</p>
 
         <h2>Structure of Information</h2>
 

--- a/help/en/html/tools/Sidebar.shtml
+++ b/help/en/html/tools/Sidebar.shtml
@@ -10,9 +10,10 @@
 
         <!--#include virtual="../../parts/SidebarLayoutAutomation.shtml" -->
 	    
-        <dt><h3 style="padding-left: 1em;"><a href="../hardware/">Supported Hardware</a></h3></dt>
+        <dt><h3 style="padding-left: 1em;"><a href="help/en/html/hardware/">Supported Hardware</a></h3></dt>
+	<!-- THE ABOVE MUST BE AN ABSOLUTE ADDRESS LINK SO THIS SIDEBAR CAN BE REFERENCED AT MULTIPLE LEVELS IN THE DIRECTORY HIERARCHY -->
         <dd>JMRI supports a wide range of DCC systems, command stations and protocols.</dd>
-	<!-- If someday we want to show the whole list, use #include virtual="../../parts/SidebarSupportedHardware.shtml" -->    
+	<!-- If someday we want to show the whole list, replace the link above with #include virtual="../../parts/SidebarSupportedHardware.shtml" -->    
 	
         <!--#include virtual="../../parts/SidebarApplications.shtml" -->
 

--- a/help/en/html/tools/Sidebar.shtml
+++ b/help/en/html/tools/Sidebar.shtml
@@ -10,7 +10,7 @@
 
         <!--#include virtual="../../parts/SidebarLayoutAutomation.shtml" -->
 	    
-        <dt><h3 style="padding-left: 1em;"><a href="help/en/html/hardware/">Supported Hardware</a></h3></dt>
+        <dt><h3 style="padding-left: 1em;"><a href="/help/en/html/hardware/">Supported Hardware</a></h3></dt>
 	<!-- THE ABOVE MUST BE AN ABSOLUTE ADDRESS LINK SO THIS SIDEBAR CAN BE REFERENCED AT MULTIPLE LEVELS IN THE DIRECTORY HIERARCHY -->
         <dd>JMRI supports a wide range of DCC systems, command stations and protocols.</dd>
 	<!-- If someday we want to show the whole list, replace the link above with #include virtual="../../parts/SidebarSupportedHardware.shtml" -->    

--- a/help/en/html/tools/signaling/Sidebar.shtml
+++ b/help/en/html/tools/signaling/Sidebar.shtml
@@ -15,7 +15,8 @@
 
            <!--#include virtual="../../../parts/SidebarLayoutAutomation.shtml" -->
              
-           <dt><h3 style="padding-left: 1em;"><a href="../../hardware/">Supported Hardware</a></h3></dt>
+           <dt><h3 style="padding-left: 1em;"><a href="/help/en/html/hardware/">Supported Hardware</a></h3></dt>
+           <!-- ABOVE LINE IS AN ABSOLUTE ADDRESS LINK TO ALLOW FILES IN LOWER LEVEL DIRECTORIES TO REFERENCE THIS SIDEBAR FILE -->
            <dd>JMRI supports a wide range of DCC systems, command stations and protocols.</dd>    
            <!-- If someday we want to show the whole list, use #include virtual="../../../parts/SidebarSupportedHardware.shtml" -->    
 


### PR DESCRIPTION
…html to help/en/html/doc/Technical/UpdatingDocs.shtml

To avoid having to create a new sidebar file just for this one page.