### PR TITLE
Separate topic strings for MQTT turnout send and receive

### DIFF
--- a/help/en/html/hardware/mqtt/index.shtml
+++ b/help/en/html/hardware/mqtt/index.shtml
@@ -98,7 +98,16 @@
         
         <p>You can change the type-specific
         part of the prepended string using the other fields
-        in the preferences.  Save the preferences
+        in the preferences.  There are separate fields
+        for specifying what JMRI should send (the "transmit" field)
+        and what JMRI should recognize back from the layout (the "receive" field).
+        If you enter a string, the suffix of the Turnout's system name will be appended:
+        "track/turnout/" for MT123 will result in a topic of "/trains/track/turnout/123".
+        If you include "{0}" in the string, the suffix will be expanded there, which 
+        allows you to do things like enter  "track/turnout/{0}/state" and 
+        have that expand to "track/turnout/123/state".
+        
+        Save the preferences
         and restart JMRI to put changes into effect.
         <p>
         You can also change the type-specific part of the prepended string using

--- a/help/en/html/hardware/mqtt/index.shtml
+++ b/help/en/html/hardware/mqtt/index.shtml
@@ -105,8 +105,7 @@
         "track/turnout/" for MT123 will result in a topic of "/trains/track/turnout/123".
         If you include "{0}" in the string, the suffix will be expanded there, which 
         allows you to do things like enter  "track/turnout/{0}/state" and 
-        have that expand to "track/turnout/123/state".
-        
+        have that expand to "track/turnout/123/state".s
         Save the preferences
         and restart JMRI to put changes into effect.
         <p>

--- a/java/src/jmri/jmrix/mqtt/Bundle.properties
+++ b/java/src/jmri/jmrix/mqtt/Bundle.properties
@@ -9,11 +9,30 @@ AddOutputEntryToolTip = abc123<br>\
 AddInputEntryToolTip = abc123<br>\
 (any string except $, :, \\).
 
+# following are the names of the default topic segments
+
+NameTopicBase=Channel:
+
+NameTopicTurnoutSend=Turnout send topic:
+NameTopicTurnoutRcv=Turnout receive topic:
+
+NameTopicSensor=Sensor receive topic:
+
+NameTopicLight=Light receive topic:
+
+NameTopicReporter=Reporter receive topic:
+
+NameTopicSignalHead=SignalHead receive topic:
+
+NameTopicSignalMast=SignalMast receive topic:
+
 # The following are default topic segments - may not need to be translated
 
 TopicBase=/trains/
 
-TopicTurnout=track/turnout/
+TopicTurnoutSend=track/turnout/
+TopicTurnoutRcv=track/turnout/
+
 TopicSensor=track/sensor/
 TopicLight=track/light/
 TopicReporter=track/reporter/

--- a/java/src/jmri/jmrix/mqtt/Bundle.properties
+++ b/java/src/jmri/jmrix/mqtt/Bundle.properties
@@ -16,7 +16,8 @@ NameTopicBase=Channel:
 NameTopicTurnoutSend=Turnout send topic:
 NameTopicTurnoutRcv=Turnout receive topic:
 
-NameTopicSensor=Sensor receive topic:
+NameTopicSensorSend=Sensor send topic:
+NameTopicSensorRcv=Sensor receive topic:
 
 NameTopicLight=Light receive topic:
 
@@ -33,7 +34,9 @@ TopicBase=/trains/
 TopicTurnoutSend=track/turnout/
 TopicTurnoutRcv=track/turnout/
 
-TopicSensor=track/sensor/
+TopicSensorSend=track/sensor/
+TopicSensorRcv=track/sensor/
+
 TopicLight=track/light/
 TopicReporter=track/reporter/
 TopicSignalHead=track/signalhead/

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -47,9 +47,19 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
         super(new MqttSystemConnectionMemo());
         log.debug("Doing ctor...");
         option2Name = "0 MQTTchannel"; // 0 to get it to the front of the list
-        options.put(option2Name, new Option("MQTT channel: ", new String[]{baseTopic}, Option.Type.TEXT));
-        options.put("10", new Option("Turnout topic :",     new String[]{Bundle.getMessage("TopicTurnout")},  Option.Type.TEXT));
-        options.put("11", new Option("Sensor topic :",      new String[]{Bundle.getMessage("TopicSensor")},   Option.Type.TEXT));
+        
+        options.put(option2Name, new Option(Bundle.getMessage("NameTopicBase"), 
+                                            new String[]{baseTopic}, Option.Type.TEXT));
+                                            
+        options.put("10.3", new Option(Bundle.getMessage("NameTopicTurnoutSend"),    
+                new String[]{Bundle.getMessage("TopicTurnoutSend")},  Option.Type.TEXT));
+        options.put("10.5", new Option(Bundle.getMessage("NameTopicTurnoutRcv"),     
+                new String[]{Bundle.getMessage("TopicTurnoutRcv")},  Option.Type.TEXT));
+        
+        
+        options.put("11", new Option(Bundle.getMessage("NameTopicSensor"),
+                                            new String[]{Bundle.getMessage("TopicSensor")},   Option.Type.TEXT));
+                                            
         options.put("12", new Option("Light topic :",       new String[]{Bundle.getMessage("TopicLight")},    Option.Type.TEXT));
         options.put("13", new Option("Reporter topic :",    new String[]{Bundle.getMessage("TopicReporter")}, Option.Type.TEXT));
         options.put("14", new Option("Signal Head topic :", new String[]{Bundle.getMessage("TopicSignalHead")}, Option.Type.TEXT));

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -57,8 +57,10 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
                 new String[]{Bundle.getMessage("TopicTurnoutRcv")},  Option.Type.TEXT));
         
         
-        options.put("11", new Option(Bundle.getMessage("NameTopicSensor"),
-                                            new String[]{Bundle.getMessage("TopicSensor")},   Option.Type.TEXT));
+        options.put("11.3", new Option(Bundle.getMessage("NameTopicSensorSend"),
+                                            new String[]{Bundle.getMessage("TopicSensorSend")},   Option.Type.TEXT));
+        options.put("11.5", new Option(Bundle.getMessage("NameTopicSensorRcv"),
+                                            new String[]{Bundle.getMessage("TopicSensorRcv")},   Option.Type.TEXT));
                                             
         options.put("12", new Option("Light topic :",       new String[]{Bundle.getMessage("TopicLight")},    Option.Type.TEXT));
         options.put("13", new Option("Reporter topic :",    new String[]{Bundle.getMessage("TopicReporter")}, Option.Type.TEXT));

--- a/java/src/jmri/jmrix/mqtt/MqttSensor.java
+++ b/java/src/jmri/jmrix/mqtt/MqttSensor.java
@@ -20,7 +20,8 @@ public class MqttSensor extends AbstractSensor implements MqttEventListener {
      * Requires, but does not check, that the system name and topic be consistent
      * @param ma Adapter to specific connection
      * @param systemName System Name for this Sensor
-     * @param topic Topic string to be used in communications
+     * @param sendTopic Topic string to be used when sending from JMRI
+     * @param rcvTopic Topic string to be used when receiving by JMRI
      */
     MqttSensor(MqttAdapter ma, String systemName, String sendTopic, String rcvTopic) {
         super(systemName);

--- a/java/src/jmri/jmrix/mqtt/MqttSensorManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttSensorManager.java
@@ -27,10 +27,17 @@ public class MqttSensorManager extends jmri.managers.AbstractSensorManager {
         return (MqttSystemConnectionMemo) memo;
     }
 
-    public void setTopicPrefix(@Nonnull String topicPrefix) {
-        this.topicPrefix = topicPrefix;
+    public void setSendTopicPrefix(@Nonnull String sendTopicPrefix) {
+        this.sendTopicPrefix = sendTopicPrefix;
     }
-    @Nonnull public String topicPrefix = "track/sensor/"; // for constructing topic; public for script access
+    public void setRcvTopicPrefix(@Nonnull String rcvTopicPrefix) {
+        this.rcvTopicPrefix = rcvTopicPrefix;
+    }
+
+    @Nonnull
+    public String sendTopicPrefix = "track/turnout/"; // for constructing topic; public for script access
+    @Nonnull
+    public String rcvTopicPrefix = "track/turnout/"; // for constructing topic; public for script access
     
     /** {@inheritDoc} */
     @Override
@@ -58,9 +65,16 @@ public class MqttSensorManager extends jmri.managers.AbstractSensorManager {
     protected Sensor createNewSensor(String systemName, String userName) {
         MqttSensor s;
         String suffix = systemName.substring(getSystemPrefix().length() + 1);
-        String topic = topicPrefix+suffix;
 
-        s = new MqttSensor(getMemo().getMqttAdapter(), systemName, topic);
+
+        String sendTopic = java.text.MessageFormat.format(
+                            sendTopicPrefix.contains("{0}") ? sendTopicPrefix : sendTopicPrefix+"{0}",
+                            suffix);
+        String rcvTopic = java.text.MessageFormat.format(
+                            rcvTopicPrefix.contains("{0}") ? rcvTopicPrefix : rcvTopicPrefix+"{0}",
+                            suffix);
+
+        s = new MqttSensor(getMemo().getMqttAdapter(), systemName, sendTopic, rcvTopic);
         s.setUserName(userName);
 
         if (parser != null) s.setParser(parser);

--- a/java/src/jmri/jmrix/mqtt/MqttSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/mqtt/MqttSystemConnectionMemo.java
@@ -63,7 +63,8 @@ public class MqttSystemConnectionMemo extends DefaultSystemConnectionMemo implem
         }
         return (MqttSensorManager) classObjectMap.computeIfAbsent(SensorManager.class,(Class c) -> {
                     MqttSensorManager t = new MqttSensorManager(this);
-                    t.setTopicPrefix(getMqttAdapter().getOptionState("11"));
+                    t.setSendTopicPrefix(getMqttAdapter().getOptionState("11.3"));
+                    t.setRcvTopicPrefix(getMqttAdapter().getOptionState("11.5"));
                     return t;
                 });
     }

--- a/java/src/jmri/jmrix/mqtt/MqttSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/mqtt/MqttSystemConnectionMemo.java
@@ -50,7 +50,8 @@ public class MqttSystemConnectionMemo extends DefaultSystemConnectionMemo implem
         }
         return (MqttTurnoutManager) classObjectMap.computeIfAbsent(TurnoutManager.class,(Class c) -> {
                     MqttTurnoutManager t = new MqttTurnoutManager(this);
-                    t.setTopicPrefix(getMqttAdapter().getOptionState("10"));
+                    t.setSendTopicPrefix(getMqttAdapter().getOptionState("10.3"));
+                    t.setRcvTopicPrefix(getMqttAdapter().getOptionState("10.5"));
                     return t;
                 });
                 

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -63,7 +63,7 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
         public void beanFromPayload(@Nonnull Turnout bean, @Nonnull String payload, @Nonnull String topic) {
             int state = stateFromString(payload);
             
-            boolean couldBeSendMessage = topic.endsWith(sendTopic);
+            boolean couldBeSendMessage = topic.endsWith(sendTopic); // not listening for send messages, but can get them anyway
             boolean couldBeRcvMessage = topic.endsWith(rcvTopic);
             
             if (couldBeSendMessage) {

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -12,83 +12,81 @@ import jmri.implementation.AbstractTurnout;
 public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
 
     private final MqttAdapter mqttAdapter;
-    private final String topic;
-    private final static String stateTopicPrefix = "state/";
-    private final static String commandTopicPrefix = "command/";
+    private final String sendTopic;
+    private final String rcvTopic;
 
     /**
      * Requires, but does not check, that the system name and topic be consistent
      * @param ma Adapter to reference for connection
      * @param systemName System name of turnout
-     * @param topic MQTT topic being used
+     * @param sendTopicFormat MQTT topic to use when sending (full string, including systemName part)
+     * @param sendTopicFormat MQTT topic to use when receiving (full string, including systemName part)
      */
-    MqttTurnout(MqttAdapter ma, String systemName, String topic) {
+    MqttTurnout(MqttAdapter ma, String systemName, String sendTopic, String rcvTopic) {
         super(systemName);
-        this.topic = topic;
+        this.sendTopic = sendTopic;
+        this.rcvTopic  = rcvTopic;
         mqttAdapter = ma;
-        mqttAdapter.subscribe(getStateTopicPrefix() + topic, this);
-        _validFeedbackNames = new String[] {"DIRECT", "ONESENSOR", "TWOSENSOR", "DELAYED", "MONITORING", "EXACT"};
-        _validFeedbackModes = new int[] {DIRECT, ONESENSOR, TWOSENSOR, DELAYED, MONITORING, EXACT};
+        mqttAdapter.subscribe(rcvTopic, this);  // only receive receive topic, not send one
+        _validFeedbackNames = new String[] {"DIRECT", "ONESENSOR", "TWOSENSOR", "DELAYED", "MONITORING"};
+        _validFeedbackModes = new int[] {DIRECT, ONESENSOR, TWOSENSOR, DELAYED, MONITORING};
         _validFeedbackTypes = DIRECT | ONESENSOR | TWOSENSOR | DELAYED | MONITORING;
-    }
-
-    private String getStateTopicPrefix() {
-        return (getFeedbackMode() == EXACT ? stateTopicPrefix : "");
-    }
-
-    private String getCommandTopicPrefix() {
-        return (getFeedbackMode() == EXACT ? commandTopicPrefix : "");
-    }
-
-    @Override
-    public void setFeedbackMode(int mode) throws IllegalArgumentException {
-        mqttAdapter.unsubscribe(getStateTopicPrefix() + topic, this);
-        try {
-            super.setFeedbackMode(mode);
-        } finally {
-            mqttAdapter.subscribe(getStateTopicPrefix() + topic, this);
-        }
     }
 
     public void setParser(MqttContentParser<Turnout> parser) {
         this.parser = parser;
     }
-    
+        
     MqttContentParser<Turnout> parser = new MqttContentParser<Turnout>() {
         private final static String closedText = "CLOSED";
         private final static String thrownText = "THROWN";
         private final static String unknownText = "UNKNOWN";
         private final static String inconsistentText = "INCONSISTENT";
-        private final static String movingText = "MOVING";
 
-        private void setExtraWithCheck(int newMode, String payload) {
-            if (getFeedbackMode() == MONITORING || getFeedbackMode() == EXACT) {
-                newKnownState(newMode);
-            } else {
-                log.warn("Received state is not valid in current operating mode: {}", payload);
-            }
-        }
-
-        @Override
-        public void beanFromPayload(@Nonnull Turnout bean, @Nonnull String payload, @Nonnull String topic) {
+        int stateFromString(String payload) {
             switch (payload) {
                 case closedText:                
-                    newKnownState(CLOSED);
-                    break;
+                    return CLOSED;
                 case thrownText:
-                    newKnownState(THROWN);
-                    break;
+                    return THROWN;
                 case unknownText:
-                    setExtraWithCheck(UNKNOWN, payload);
-                    break;
-                case movingText:
+                    return UNKNOWN;
                 case inconsistentText:
-                    setExtraWithCheck(INCONSISTENT, payload);
-                    break;
+                    return INCONSISTENT;
                 default:
-                    log.warn("Unknown state : {}", payload);
-                    break;
+                    log.warn("Unknown state : {}, substitute UNKNOWN", payload);
+                    return UNKNOWN;
             }
+        }
+        
+        @Override
+        public void beanFromPayload(@Nonnull Turnout bean, @Nonnull String payload, @Nonnull String topic) {
+            int state = stateFromString(payload);
+            
+            boolean couldBeSendMessage = topic.endsWith(sendTopic);
+            boolean couldBeRcvMessage = topic.endsWith(rcvTopic);
+            
+            if (couldBeSendMessage) {
+                // always accept as commadn
+                newCommandedState(state);
+                
+                // when needed, do feedback
+                if (getFeedbackMode() == DIRECT || getFeedbackMode() == MONITORING) newKnownState(state);
+                
+                return;
+            }
+            
+            if (couldBeRcvMessage) {
+
+                // if MONITORING, do feedback
+                if (getFeedbackMode() == DIRECT || getFeedbackMode() == MONITORING) newKnownState(state);
+                
+                return;
+            }
+
+            // really shouldn't have gotten here
+            log.warn("expected failure to decode topic {} {}", topic, payload);
+            return;
         }
         
         @Override
@@ -128,23 +126,23 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
         sendMessage(payload);
     }
 
-    @Override
-    protected void turnoutPushbuttonLockout(boolean _pushButtonLockout) {
-        log.debug("Send command to {} Pushbutton BT{} not yet coded", (_pushButtonLockout ? "Lock" : "Unlock"), topic);
-    }
-
     private void sendMessage(String c) {
-        mqttAdapter.publish(getCommandTopicPrefix() + this.topic, c.getBytes());
+        mqttAdapter.publish(sendTopic, c);
     }
 
     @Override
     public void notifyMqttMessage(String receivedTopic, String message) {
-        if (!receivedTopic.endsWith(topic)) {
-            log.error("Got a message whose topic ({}) wasn't for me ({})", receivedTopic, topic);
+        if (! ( receivedTopic.endsWith(rcvTopic) || receivedTopic.endsWith(sendTopic) ) ) {
+            log.error("Got a message whose topic ({}) wasn't for me ({})", receivedTopic, rcvTopic);
             return;
         }
         
         parser.beanFromPayload(this, message, receivedTopic);
+    }
+
+    @Override
+    protected void turnoutPushbuttonLockout(boolean _pushButtonLockout) {
+        log.warn("Send command to {} Pushbutton in {} not yet coded", (_pushButtonLockout ? "Lock" : "Unlock"), getSystemName());
     }
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(MqttTurnout.class);

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -19,8 +19,8 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
      * Requires, but does not check, that the system name and topic be consistent
      * @param ma Adapter to reference for connection
      * @param systemName System name of turnout
-     * @param sendTopicFormat MQTT topic to use when sending (full string, including systemName part)
-     * @param sendTopicFormat MQTT topic to use when receiving (full string, including systemName part)
+     * @param sendTopic MQTT topic to use when sending (full string, including systemName part)
+     * @param rcvTopic MQTT topic to use when receiving (full string, including systemName part)
      */
     MqttTurnout(MqttAdapter ma, String systemName, String sendTopic, String rcvTopic) {
         super(systemName);

--- a/java/test/jmri/jmrix/mqtt/MqttSensorTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttSensorTest.java
@@ -37,7 +37,7 @@ public class MqttSensorTest extends jmri.implementation.AbstractSensorTestBase {
                     savePayload = payload;
                 }
             };
-        t = new MqttSensor(a, "MS1", "track/sensor/1");
+        t = new MqttSensor(a, "MS1", "track/sensor/1", "track/sensor/1");
         JUnitAppender.assertWarnMessage("Trying to subscribe before connect/configure is done");
     }
 

--- a/java/test/jmri/jmrix/mqtt/MqttTurnoutTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttTurnoutTest.java
@@ -37,7 +37,7 @@ public class MqttTurnoutTest extends AbstractTurnoutTestBase {
                 }
             };
 
-        t = new MqttTurnout(a, "MT2", "track/turnout/2");
+        t = new MqttTurnout(a, "MT2", "track/turnout/2", "track/turnout/2/foo");
         JUnitAppender.assertWarnMessage("Trying to subscribe before connect/configure is done");
     }
 
@@ -100,20 +100,33 @@ public class MqttTurnoutTest extends AbstractTurnoutTestBase {
 
     @Test
     public void testParserModes() {
+
+        t.setFeedbackMode(Turnout.DIRECT);
+    
         ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "CLOSED");
         Assert.assertEquals("state", Turnout.CLOSED, t.getKnownState());
         ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "THROWN");
         Assert.assertEquals("state", Turnout.THROWN, t.getKnownState());
         ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "UNKNOWN");
+        Assert.assertEquals("state", Turnout.UNKNOWN, t.getKnownState());
+        
+        t.setFeedbackMode(Turnout.MONITORING);
+        
+        ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "CLOSED");
+        Assert.assertEquals("state", Turnout.CLOSED, t.getKnownState());
+        ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "THROWN");
         Assert.assertEquals("state", Turnout.THROWN, t.getKnownState());
-
-        ((MqttTurnout)t).setFeedbackMode(Turnout.EXACT);
         ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "UNKNOWN");
         Assert.assertEquals("state", Turnout.UNKNOWN, t.getKnownState());
-        ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "INCONSISTENT");
-        Assert.assertEquals("state", Turnout.INCONSISTENT, t.getKnownState());
 
-        JUnitAppender.assertWarnMessage("Trying to unsubscribe before connect/configure is done");
+        t.setFeedbackMode(Turnout.ONESENSOR);
+        ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "CLOSED");
+        Assert.assertEquals("state", Turnout.UNKNOWN, t.getKnownState());
+
+        t.setFeedbackMode(Turnout.TWOSENSOR);
+        ((MqttTurnout)t).notifyMqttMessage("track/turnout/2", "CLOSED");
+        Assert.assertEquals("state", Turnout.UNKNOWN, t.getKnownState());
+
     }
     
     
@@ -129,25 +142,4 @@ public class MqttTurnoutTest extends AbstractTurnoutTestBase {
         Assert.assertEquals("topic", "CLOSED", new String(savePayload));
     }
 
-
-    @Override
-    @Test
-    public void testRequestUpdate() throws jmri.JmriException {
-        super.testRequestUpdate();
-        JUnitAppender.assertWarnMessage("Trying to unsubscribe before connect/configure is done");
-    }
-
-    @Override
-    @Test
-    public void testOneSensorFeedback() throws jmri.JmriException {
-        super.testOneSensorFeedback();
-        JUnitAppender.assertWarnMessage("Trying to unsubscribe before connect/configure is done");
-    }
-
-    @Override
-    @Test
-    public void testTwoSensorFeedback() throws jmri.JmriException {
-        super.testTwoSensorFeedback();
-        JUnitAppender.assertWarnMessage("Trying to unsubscribe before connect/configure is done");
-    }
 }

--- a/jython/SetMqttPrefix.py
+++ b/jython/SetMqttPrefix.py
@@ -1,4 +1,4 @@
-# Example of how to define a new prefix for the MQTT Turnouts
+# Example of how to define new send and receive topics strings for the MQTT Turnouts
 #
 # The script before should be run before loading the panels.
 # It only sets the prefix for Turnouts created _after_ this is run.
@@ -24,7 +24,8 @@ if( m is None ):
 
 # Now set a sample prefix
 if( m is not None ):
-    m.setTopicPrefix("foo/bar/jmri-sample-prefix/")  # can be anything but should have a / at end but not at start
-    print( "MQTT prefix updated" )
+    m.setSendTopicPrefix("foo/bar/jmri-sample-prefix/")  # can be anything but should have a / at end but not at start
+    m.setRcvTopicPrefix("foo/bar/jmri-sample-prefix/")
+    print( "MQTT prefixes updated" )
 else:
-    print( "MQTT prefix not updated" )
+    print( "MQTT prefixes not updated" )


### PR DESCRIPTION
This adds the ability to separately specify the MQTT topics for "from" and "to" JMRI communications for Turnouts. It follows from Jmriusers discussions and #8902, #8903.
