### PR TITLE
Print roster list in sorted order

### DIFF
--- a/java/src/jmri/jmrit/roster/PrintListAction.java
+++ b/java/src/jmri/jmrit/roster/PrintListAction.java
@@ -3,11 +3,13 @@ package jmri.jmrit.roster;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import jmri.beans.BeanUtil;
 import jmri.jmrit.roster.rostergroup.RosterGroupSelector;
+import jmri.jmrit.roster.swing.RosterFrame;
 import jmri.util.FileUtil;
 import jmri.util.StringUtil;
 import jmri.util.davidflanagan.HardcopyWriter;
@@ -99,8 +101,15 @@ public class PrintListAction extends jmri.util.swing.JmriAbstractAction {
         }
 
         // Loop through the Roster, printing a 1 line list entry as needed
-        List<RosterEntry> l = r.matchingList(null, null, null, null, null, null, null); // take all
+        List<RosterEntry> l = null;
+
+        if ( BeanUtil.hasProperty(wi, "allRosterEntries")) {
+            l = Arrays.asList(((RosterFrame)wi).getAllRosterEntries());
+        } else {
+            l = r.matchingList(null, null, null, null, null, null, null); // take all
+        }
         log.debug("Roster list size: {}", l.size());
+
         // print table column headers, match column order + widths with RosterEntry#PrintEntryLine
         // fields copied from RosterTableModel#getColumnName(int)
         String headerText = "";

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -707,6 +707,11 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
         return Arrays.copyOf(entries, entries.length);
     }
 
+    public RosterEntry[] getAllRosterEntries() {
+        RosterEntry[] entries = rtable.getSortedRosterEntries();
+        return Arrays.copyOf(entries, entries.length);
+    }
+
     @Override
     public String getSelectedRosterGroup() {
         return groups.getSelectedRosterGroup();

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -75,7 +75,7 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
                 // clear sorted cache
                 sortedRosterEntries = null;
             }
-        });;
+        });
         dataTable = new JTable(dataModel);
         dataTable.setRowSorter(sorter);
         dataScroll = new JScrollPane(dataTable);

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -30,10 +30,6 @@ import javax.swing.event.RowSorterEvent;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jmri.InstanceManager;
 import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -26,9 +26,14 @@ import javax.swing.SortOrder;
 import javax.swing.border.Border;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
+import javax.swing.event.RowSorterEvent;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import jmri.InstanceManager;
 import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
@@ -53,6 +58,7 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
     private RosterGroupSelector rosterGroupSource = null;
     protected transient ListSelectionListener tableSelectionListener;
     private RosterEntry[] selectedRosterEntries = null;
+    private RosterEntry[] sortedRosterEntries = null;
     private RosterEntry re = null;
 
     public RosterTable() {
@@ -68,6 +74,12 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
         super();
         dataModel = new RosterTableModel(editable);
         sorter = new TableRowSorter<>(dataModel);
+        sorter.addRowSorterListener(rowSorterEvent -> {
+            if (rowSorterEvent.getType() ==  RowSorterEvent.Type.SORTED) {
+                // clear sorted cache
+                sortedRosterEntries = null;
+            }
+        });;
         dataTable = new JTable(dataModel);
         dataTable.setRowSorter(sorter);
         dataScroll = new JScrollPane(dataTable);
@@ -265,6 +277,18 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
             }
         }
         return Arrays.copyOf(selectedRosterEntries, selectedRosterEntries.length);
+    }
+
+    // cache getSortedRosterEntries so that multiple calls to this
+    // between selection changes will not require the creation of a new array
+    public RosterEntry[] getSortedRosterEntries() {
+        if (sortedRosterEntries == null) {
+            sortedRosterEntries = new RosterEntry[sorter.getModelRowCount()];
+            for (int idx = 0; idx < sorter.getModelRowCount(); idx++) {
+                sortedRosterEntries[idx] = Roster.getDefault().getEntryForId(dataModel.getValueAt(sorter.convertRowIndexToModel(idx), RosterTableModel.IDCOL).toString());
+            }
+        }
+        return Arrays.copyOf(sortedRosterEntries, sortedRosterEntries.length);
     }
 
     public void setEditable(boolean editable) {


### PR DESCRIPTION
#8861 
When printing a  roster list use the sort order of the grid if available, else do as now and print in natural order.