### PR TITLE
Disallow 0 address for DCC++, enable input by default

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
@@ -44,17 +44,15 @@ public class DCCppThrottleManager extends AbstractThrottleManager implements DCC
     @Override
     public void requestThrottleSetup(LocoAddress address, boolean control) {
         DCCppThrottle throttle;
-        if (log.isDebugEnabled()) {
-            log.debug("Requesting Throttle: {}", address);
-        }
+        log.debug("Requesting Throttle: {}", address);
         if (throttles.containsKey(address)) {
             notifyThrottleKnown(throttles.get(address), address);
         } else {
             if (tc.getCommandStation().requestNewRegister(address.getNumber()) == DCCppConstants.NO_REGISTER_FREE) {
-            // TODO: Eventually add something more robust here.
-            log.error("No Register available for Throttle. Address = {}", address);
-            return;
-        }
+                failedThrottleRequest(address, "No Register available for Throttle. Address="+ address);
+                log.error("No Register available for Throttle. Address = {}", address);
+                return;
+            }
             throttle = new DCCppThrottle((DCCppSystemConnectionMemo) adapterMemo, address, tc);
             throttles.put(address, throttle);
             notifyThrottleKnown(throttle, address);

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
@@ -91,12 +91,12 @@ public class DCCppThrottleManager extends AbstractThrottleManager implements DCC
     }
 
     /**
-     * Address 127 and below is a short address
+     * Address between 1 and 127 is a short address
      *
      */
     @Override
     public boolean canBeShortAddress(int address) {
-        return !isLongAddress(address);
+        return (address >= 1 && !isLongAddress(address));
     }
 
     /**

--- a/java/src/jmri/jmrix/dccpp/network/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/dccpp/network/ConnectionConfig.java
@@ -57,8 +57,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
         hostNameField.setText(adapter.getHostName());
         portFieldLabel.setText(Bundle.getMessage("CommunicationPortLabel"));
         portField.setText(String.valueOf(adapter.getPort()));
-        portField.setEnabled(false); // we can't change this now.
-        //opt1Box.setEnabled(false); // we can't change this now.
+        portField.setEnabled(true);
     }
 
     @Override


### PR DESCRIPTION
DCC++ does not support address zero so prevent selection,
DCC++ Ethernet Communication Port input should default to enabled (currently requires toggling the "Automatic" flag.)
DCC++ throttle window, show Register error to user