### PR TITLE
Adjust CI test thresholds

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,13 +2,13 @@ version: "2" # CodeClimate API version is a string, not a number
 checks:
   argument-count:
     config:
-      threshold: 4 # CodeClimate default
+      threshold: 5 # CodeClimate default
   complex-logic:
     config:
-      threshold: 4 # CodeClimate default
+      threshold: 5 # CodeClimate default
   file-lines:
     config:
-      threshold: 250 # CodeClimate default
+      threshold: 300 # CodeClimate default
   method-complexity:
     config:
       threshold: 20 # AKA Cognitive Complexity. 5 is CodeClimate default
@@ -20,10 +20,10 @@ checks:
       threshold: 25 # CodeClimate default
   nested-control-flow:
     config:
-      threshold: 4 # CodeClimate default
+      threshold: 6 # CodeClimate default
   return-statements:
     config:
-      threshold: 4 # CodeClimate default
+      threshold: 6 # CodeClimate default
   similar-code:
     config:
       threshold: 40 # language-specific defaults. an override will affect all languages.

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,16 +2,17 @@ codecov:
   ci:
     - !appveyor # ignore CI builds by AppVeyor
 coverage:
+  # number of decimal places to display
   precision: 1
   round: up
   status:
     project:
       default:
-        # allow a 1% project drop to reduce noise
-        threshold: 1%
+        # allow a 2% project drop to reduce noise
+        threshold: 2%
     patch:
       default:
-        # allow a 1% drop to reduce noise
-        threshold: 1%
+        # this is the coverage of the patch code only, don't hold to high average
+        threshold: 20%
   
 # see https://docs.codecov.io/docs/codecov-yaml#section-default-yaml for defaults


### PR DESCRIPTION
More than 50% of CI runs end up like this:

![image](https://user-images.githubusercontent.com/2774117/90041120-b261d480-dc7d-11ea-9a78-5eb07f05c1fa.png)

This is approved and old enough, but is X'd out.  When you look in detail, you see that it's actually ready to go:

![image](https://user-images.githubusercontent.com/2774117/90041232-df15ec00-dc7d-11ea-9234-4bf9ee531031.png)
![image](https://user-images.githubusercontent.com/2774117/90041276-ee953500-dc7d-11ea-86ff-af19ddea0336.png)

Approved, all required tests passed, no conflicts.  Only the non-required tests are marking it as X. 

The high (>50% all totaled) positive rate of those means that PRs are X'd out, and either have to be carefully examined, or end up being skipped over when reading the list to decide what to comment on, what to review, and what to merge.

This PR reduces the thresholds that appear to be most likely to cause these.

The change that's most arguable is reducing the lines-tested threshold for the changed code.  Previously change coverage had to be as big as the previous average; this had the desirable effect of ratcheting the test coverage up.  (We separately test to ensure that new code has at least some test coverage).  Allowing a smaller threshold would allow the test coverage to slowly decrease. But the metric is very noisy for small changes, and people have clearly learned not to pay attention to it (In the last 25 PRs I could find no example of somebody adding test coverage after the first push that could reasonably have been due to this; there were a couple that were due to "zero coverage" check failure). Unless we insisted on "every change needs test coverage", and maybe even then, having this be so tight seem to be more noise than signal.

