### PR TITLE
Update Mergeable checks

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -39,7 +39,7 @@ mergeable: # see https://github.com/mergeability/mergeable
         payload:
           body: > 
             Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
-  - when: schedule.repository, pull_request.opened
+  - when: schedule.repository
     name: 'Allow merge after one day'
     validate:
       - do: stale

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,11 +1,14 @@
 version: 2
 mergeable: # see https://github.com/mergeability/mergeable
   - when: pull_request.opened
-    name: 'Ensure author assigned'
+    name: 'Attempt to assign author'
     validate:
       - do: assignee
         min:
           count: 1 # Should be assigned to somebody; if not, assign author
+    pass:
+      - do: checks
+        status: 'success'
     fail:
       - do: assign
         assignees: [ '@author' ] 
@@ -13,6 +16,12 @@ mergeable: # see https://github.com/mergeability/mergeable
         status: 'success' # Supply the default actions, as if this passed.
         payload:
           title: 'Author assigned'
+  - when: pull_request.opened
+    name: 'Author needs to be assigned'
+    validate:
+      - do: assignee
+        min:
+          count: 1 # Closest we can get to checking for author
   - when: pull_request.opened
     name: 'Check for release note if help, java/src, jython, resources, xml, or web'
     validate:
@@ -33,11 +42,16 @@ mergeable: # see https://github.com/mergeability/mergeable
                 regex: "^xml/"
           - must_include:
               regex: "help/en/releasenotes/current-draft-note.shtml"
+    pass:
+      - do: checks
+        status: 'success'
     fail:
       - do: comment
         payload:
           body: > 
             Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
+      - do: checks
+        status: 'success'
   - when: schedule.repository
     name: 'Allow merge after one day'
     validate:
@@ -45,7 +59,7 @@ mergeable: # see https://github.com/mergeability/mergeable
         days: 1
         type: pull_request
     pass:
-      - do: comment
+      - do: comment  # No initial event, can't actually block merge, so for now we're adding a comment.
         payload:
           body: This is one day old, and can now be merged if CI and reviews allow.
       - do: checks
@@ -60,7 +74,7 @@ mergeable: # see https://github.com/mergeability/mergeable
           title: 'PR too young'
           summary: "Waiting for the PR to be one day old."
   - when: pull_request.*, pull_request_review.*
-    name: 'Checking the approvals'
+    name: 'Approval received, no changes requested'
     validate:
       - do: approvals
         min:

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -12,7 +12,7 @@ mergeable: # see https://github.com/mergeability/mergeable
       - do: checks
         status: 'success' # Supply the default actions, as if this passed.
         payload:
-          title: 'Mergeable Run have been Completed!'
+          title: 'Author assigned'
           summary: "All the validators have returned 'pass'! \n Here are some stats of the run: \n {{validationCount}} validations were ran"
   - when: pull_request.opened
     name: 'Check for release note if help, java/src, jython, resources, xml, or web'
@@ -39,7 +39,7 @@ mergeable: # see https://github.com/mergeability/mergeable
         payload:
           body: > 
             Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
-  - when: schedule.repository
+  - when: schedule.repository, pull_request.opened
     name: 'Allow merge after one day'
     validate:
       - do: stale
@@ -48,4 +48,15 @@ mergeable: # see https://github.com/mergeability/mergeable
     pass:
       - do: comment
         payload:
-          body: This is one day old, and can now be merged if CI approvals OK.
+          body: This is one day old, and can now be merged if CI and reviews allow.
+      - do: checks
+        status: 'success'
+        payload:
+          title: 'PR old enough'
+          summary: "PR over one day old, can be merged."
+    fail:
+      - do: checks
+        status: 'fail'
+        payload:
+          title: 'PR too young'
+          summary: "Waiting for the PR to be one day old."

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -13,7 +13,6 @@ mergeable: # see https://github.com/mergeability/mergeable
         status: 'success' # Supply the default actions, as if this passed.
         payload:
           title: 'Author assigned'
-          summary: "All the validators have returned 'pass'! \n Here are some stats of the run: \n {{validationCount}} validations were ran"
   - when: pull_request.opened
     name: 'Check for release note if help, java/src, jython, resources, xml, or web'
     validate:
@@ -60,3 +59,16 @@ mergeable: # see https://github.com/mergeability/mergeable
         payload:
           title: 'PR too young'
           summary: "Waiting for the PR to be one day old."
+  - when: pull_request.*, pull_request_review.*
+    name: 'Checking the approvals'
+    validate:
+      - do: approvals
+        min:
+          count: 1 # Number of minimum reviewers. In this case 1.
+          message: 'Must have at least one review.'
+        block:
+          changes_requested: true # If true, block all approvals when one of the reviewers gave 'changes_requested' review
+          message: 'Merge blocked by request for changes.'
+        #limit:
+        #  teams: ['org/team_slug'] # when the option is present, only the approvals from the team members will count
+        #  owners: true # Optional boolean. When true, the file .github/CODEOWNER is read and only owners approval will count

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -39,3 +39,13 @@ mergeable: # see https://github.com/mergeability/mergeable
         payload:
           body: > 
             Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
+  - when: schedule.repository
+    name: 'Allow merge after one day'
+    validate:
+      - do: stale
+        days: 1
+        type: pull_request
+    pass:
+      - do: comment
+        payload:
+          body: This is one day old, and can now be merged if CI approvals OK.

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,6 +1,6 @@
 version: 2
 mergeable: # see https://github.com/mergeability/mergeable
-  - when: pull_request.opened
+  - when: pull_request.opened, pull_request.assigned, pull_request.unassiged
     name: 'Attempt to assign author'
     validate:
       - do: assignee
@@ -11,17 +11,11 @@ mergeable: # see https://github.com/mergeability/mergeable
         status: 'success'
     fail:
       - do: assign
-        assignees: [ '@author' ] 
+        assignees: [ '@author' ] # this is not assigning if author not a project member see mergeability/mergeable#359
       - do: checks
         status: 'success' # Supply the default actions, as if this passed.
         payload:
           title: 'Author assigned'
-  - when: pull_request.opened
-    name: 'Author needs to be assigned'
-    validate:
-      - do: assignee
-        min:
-          count: 1 # Closest we can get to checking for author
   - when: pull_request.opened
     name: 'Check for release note if help, java/src, jython, resources, xml, or web'
     validate:
@@ -86,3 +80,4 @@ mergeable: # see https://github.com/mergeability/mergeable
         #limit:
         #  teams: ['org/team_slug'] # when the option is present, only the approvals from the team members will count
         #  owners: true # Optional boolean. When true, the file .github/CODEOWNER is read and only owners approval will count
+


### PR DESCRIPTION
Updates the existing mergeable checks to:
 - add a check for at least one positive review and no changes-requested reviews.  This will allow _anybody_ to add the reviews, though we could narrow that if needed
 - Adds a comment to the PR once it's been open for a day.  A small reminder to wait on merges, not an effective gate, but perhaps more can be done later
 - minor clean up of other functions