### PR TITLE
Defining Decoders that use Functions above F28.

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -77,6 +77,8 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
     public static final String DECODER_MODEL = "decodermodel"; // NOI18N
     public static final String DECODER_FAMILY = "decoderfamily"; // NOI18N
     public static final String DECODER_COMMENT = "decodercomment"; // NOI18N
+    public static final String DECODER_MAXFNNUM = "decodermaxFnNum"; // NOI18N
+    public static final String DEFAULT_MAXFNNUM = "28"; // NOI18N
     public static final String IMAGE_FILE_PATH = "imagefilepath"; // NOI18N
     public static final String ICON_FILE_PATH = "iconfilepath"; // NOI18N
     public static final String URL = "url"; // NOI18N
@@ -107,6 +109,7 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
     protected String _decoderModel = "";
     protected String _decoderFamily = "";
     protected String _decoderComment = "";
+    protected String _maxFnNum = DEFAULT_MAXFNNUM;
     protected String _dateUpdated = "";
     protected Date dateModified = null;
     protected int _maxSpeedPCT = 100;
@@ -117,13 +120,13 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
      * @deprecated 4.17.1 to be removed in ??
      */
     @Deprecated
-    public static final int MAXFNNUM = 28;
+    public static final int MAXFNNUM = Integer.parseInt(DEFAULT_MAXFNNUM);
 
     /**
      * Get the highest valid Fn key number for this roster entry.
      * <dl>
-     * <dt>The default value (28) will eventually be able to be overridden in a
-     * decoder definition file:</dt>
+     * <dt>The default value (28) can be overridden by a "maxFnNum" attribute in
+     * the "model" element of a decoder definition file</dt>
      * <dd><ul>
      * <li>A European standard (RCN-212) extends NMRA S9.2.1 up to F68.</li>
      * <li>ESU LokSound 5 already uses up to F31.</li>
@@ -135,7 +138,7 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
      * @see "http://normen.railcommunity.de/RCN-212.pdf"
      */
     public int getMAXFNNUM() {
-        return MAXFNNUM;
+        return Integer.parseInt(getMaxFnNum());
     }
 
     protected Map<Integer, String> functionLabels;
@@ -465,6 +468,16 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
         return _decoderComment;
     }
 
+    public void setMaxFnNum(String s) {
+        String old = _maxFnNum;
+        _maxFnNum = s;
+        firePropertyChange(RosterEntry.DECODER_MAXFNNUM, old, s);
+    }
+
+    public String getMaxFnNum() {
+        return _maxFnNum;
+    }
+
     @Override
     public DccLocoAddress getDccLocoAddress() {
         int n;
@@ -763,6 +776,9 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
             if ((a = d.getAttribute("comment")) != null) {
                 _decoderComment = a.getValue();
             }
+            if ((a = d.getAttribute("maxFnNum")) != null) {
+                _maxFnNum = a.getValue();
+            }
         }
 
         loadFunctions(e.getChild("functionlabels"), "RosterEntry");
@@ -915,7 +931,7 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
     }
 
     /**
-     * Set the label for a specific function
+     * Set the label for a specific function.
      *
      * @param fn    function number, starting with 0
      * @param label the label to use
@@ -1164,6 +1180,7 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
         d.setAttribute("model", getDecoderModel());
         d.setAttribute("family", getDecoderFamily());
         d.setAttribute("comment", getDecoderComment());
+        d.setAttribute("maxFnNum", getMaxFnNum());
 
         e.addContent(d);
         if (_dccAddress.isEmpty()) {
@@ -1517,7 +1534,7 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
      * @param w the HardcopyWriter used to print
      */
     public void printEntryDetails(Writer w) {
-        if (!(w instanceof HardcopyWriter)){
+        if (!(w instanceof HardcopyWriter)) {
             throw new IllegalArgumentException("No HardcopyWriter instance passed");
         }
         int linesadded = -1;

--- a/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle.properties
+++ b/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle.properties
@@ -187,6 +187,7 @@ UseExisting = Use existing roster entry:
 ReadAndSelect = Read address & select
 DecoderDefError = Error in decoder definition file
 UnsupportedCharset = Unsupported Charset "{0}" specified in "charSet" attribute for variable "{1}" in decoder definition file.
+StatusMaxFnNumUpdated = Family "{0}" Model "{1}" now supports up to F{2}. Please Save to update this Roster Entry .
 
 LabelMatched = Matched Only
 LabelAll = All

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
@@ -907,12 +907,14 @@ abstract public class PaneProgFrame extends JmriJFrame
             maxFnNumOld = re.getMaxFnNum();
             maxFnNumNew = a.getValue();
             if (!maxFnNumOld.equals(maxFnNumNew)) {
-                maxFnNumDirty = true;
-                log.info("maxFnNum for \"{}\" changed from {} to {}", re.getId(), maxFnNumOld, maxFnNumNew);
-                String message = java.text.MessageFormat.format(
-                        SymbolicProgBundle.getMessage("StatusMaxFnNumUpdated"),
-                        re.getDecoderFamily(), re.getDecoderModel(), maxFnNumNew);
-                progStatus.setText(message);
+                if (!re.getId().equals(Bundle.getMessage("LabelNewDecoder"))) {
+                    maxFnNumDirty = true;
+                    log.info("maxFnNum for \"{}\" changed from {} to {}", re.getId(), maxFnNumOld, maxFnNumNew);
+                    String message = java.text.MessageFormat.format(
+                            SymbolicProgBundle.getMessage("StatusMaxFnNumUpdated"),
+                            re.getDecoderFamily(), re.getDecoderModel(), maxFnNumNew);
+                    progStatus.setText(message);
+                }
                 re.setMaxFnNum(maxFnNumNew);
             }
         }

--- a/java/test/jmri/jmrit/decoderdefn/DecoderFileTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/DecoderFileTest.java
@@ -299,6 +299,7 @@ public class DecoderFileTest {
     // static variables for the test XML structures
     Element root = null;
     public Element decoder = null;
+    public Element model = null;
     Document doc = null;
 
     // provide a test document in the above static variables
@@ -315,6 +316,11 @@ public class DecoderFileTest {
                         .setAttribute("mfg", "Digitrax")
                         .setAttribute("defnVersion", "242")
                         .setAttribute("comment", "DH142 decoder: FX, transponding")
+                        .addContent(model = new Element("model")
+                                .setAttribute("model", "33")
+                                .setAttribute("maxFnNum", "31")
+                                .setAttribute("productID", "567")
+                        )
                 )
                 .addContent(new Element("programming")
                         .setAttribute("direct", "byteOnly")

--- a/java/test/jmri/jmrit/roster/RosterEntryTest.java
+++ b/java/test/jmri/jmrit/roster/RosterEntryTest.java
@@ -245,6 +245,7 @@ public class RosterEntryTest {
                 .addContent(new org.jdom2.Element("decoder")
                         .setAttribute("family", "91")
                         .setAttribute("model", "33")
+                        .setAttribute("comment", "decoder comment")
                 ); // end create element
 
         RosterEntry r = new RosterEntry(e) {
@@ -258,6 +259,8 @@ public class RosterEntryTest {
         Assert.assertEquals("XML Element ", e.toString(), o.toString());
         Assert.assertEquals("family ", "91", o.getChild("decoder").getAttribute("family").getValue());
         Assert.assertEquals("model ", "33", o.getChild("decoder").getAttribute("model").getValue());
+        Assert.assertEquals("comment", "decoder comment", o.getChild("decoder").getAttribute("comment").getValue());
+        Assert.assertEquals("default maxFnNum ", "28", o.getChild("decoder").getAttribute("maxFnNum").getValue());
     }
 
     @Test

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrameTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrameTest.java
@@ -8,6 +8,8 @@ import javax.swing.JPanel;
 
 import jmri.jmrit.decoderdefn.DecoderFile;
 import jmri.jmrit.roster.RosterEntry;
+import jmri.jmrit.symbolicprog.CvTableModel;
+import jmri.jmrit.symbolicprog.VariableTableModel;
 import jmri.util.JUnitUtil;
 
 import org.jdom2.DocType;
@@ -81,6 +83,104 @@ public class PaneProgFrameTest {
 
         JFrame f = jmri.util.JmriJFrame.getFrame("test frame");
         Assert.assertTrue("found frame", f != null);
+        p.dispatchEvent(new WindowEvent(p, WindowEvent.WINDOW_CLOSING));
+    }
+
+    @Test
+    public void testLoadDecoderFileUpdateMaxFnNum() {
+        // create test Element
+        org.jdom2.Element e = new org.jdom2.Element("locomotive")
+                .setAttribute("id", "our id 4")
+                .setAttribute("fileName", "file here")
+                .setAttribute("roadNumber", "431")
+                .setAttribute("roadName", "SP")
+                .setAttribute("mfg", "Athearn")
+                .setAttribute("dccAddress", "1234")
+                .addContent(new org.jdom2.Element("decoder")
+                        .setAttribute("family", "91")
+                        .setAttribute("model", "33")
+                        .setAttribute("comment", "decoder comment")
+                ); // end create element
+
+        RosterEntry r = new RosterEntry(e) { // a temporary storage, need to override some methods
+            @Override
+            protected void warnShortLong(String s) {
+            }
+
+            @Override
+            public void loadFunctions(Element e3, String source) {
+            }
+
+            @Override
+            public void loadSounds(Element e3, String source) {
+            }
+
+            @Override
+            public void updateFile() {
+            }
+
+            @Override
+            public void writeFile(CvTableModel cvModel, VariableTableModel variableModel) {
+            }
+        };
+
+        org.jdom2.Element o = r.store();
+
+        // check test attributes are loaded
+        Assert.assertEquals("XML Element ", e.toString(), o.toString());
+        Assert.assertEquals("family ", "91", o.getChild("decoder").getAttribute("family").getValue());
+        Assert.assertEquals("model ", "33", o.getChild("decoder").getAttribute("model").getValue());
+        Assert.assertEquals("comment", "decoder comment", o.getChild("decoder").getAttribute("comment").getValue());
+        Assert.assertEquals("default maxFnNum is loaded", "28", o.getChild("decoder").getAttribute("maxFnNum").getValue());
+
+        // ugly, temporary way to load the decoder info
+        jmri.jmrit.decoderdefn.DecoderFileTest t = new jmri.jmrit.decoderdefn.DecoderFileTest();
+        t.setupDecoder();
+        DecoderFile df = new DecoderFile() { // a temporary storage, need to override some methods
+            @Override
+            public String getFileName() {
+                return "0NMRA_test.xml";
+            }
+
+            @Override
+            public String getProductID() {
+                return getModelElement().getAttributeValue("productID");
+            }
+
+            @Override
+            public Element getModelElement() {
+                return t.model;
+            }
+        };
+
+        setupDoc();
+        PaneProgFrame p = new PaneProgFrame(null, new RosterEntry(),
+                "test frame", "programmers/Basic.xml",
+                new jmri.progdebugger.ProgDebugger(), false) {
+            // dummy implementations
+            @Override
+            protected JPanel getModePane() {
+                return null;
+            }
+
+            @Override
+            protected boolean checkDirtyDecoder() {
+                return false;
+            }
+
+            @Override
+            protected boolean checkDirtyFile() {
+                return false;
+            }
+        };
+
+        df.loadVariableModel(t.decoder, p.variableModel);
+        p.loadDecoderFile(df, r);
+        o = r.store();
+
+        Assert.assertEquals("model maxFnNum ", "31", t.model.getAttribute("maxFnNum").getValue());
+        Assert.assertEquals("roster entry maxFnNum ", "31", o.getChild("decoder").getAttribute("maxFnNum").getValue());
+
         p.dispatchEvent(new WindowEvent(p, WindowEvent.WINDOW_CLOSING));
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrameTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrameTest.java
@@ -88,6 +88,7 @@ public class PaneProgFrameTest {
 
     @Test
     public void testLoadDecoderFileUpdateMaxFnNum() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // create test Element
         org.jdom2.Element e = new org.jdom2.Element("locomotive")
                 .setAttribute("id", "our id 4")

--- a/xml/decoders/ESU_LokPilot5.xml
+++ b/xml/decoders/ESU_LokPilot5.xml
@@ -18,33 +18,35 @@
     <version author="Dave Heap" version="1" lastUpdated="20200410"/>
     <!-- ver2 refactor and add Fx micro Next18 variants -->
     <version author="Dave Heap" version="2" lastUpdated="20200726"/>
+    <!-- ver3 updates for F29-F31 -->
+    <version author="Dave Heap" version="3" lastUpdated="20200807"/>
     <decoder>
         <family name="ESU LokPilot 5" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
-            <model model="LokPilot 5" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554600">
+            <model model="LokPilot 5" maxFnNum="31" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554600">
                 <size length="30.5" width="15.5" height="5.5" units="mm"/>
             </model>
-            <model model="LokPilot 5 DCC" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554602">
+            <model model="LokPilot 5 DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554602">
                 <size length="30.5" width="15.5" height="5.5" units="mm"/>
             </model>
-            <model model="LokPilot 5 micro" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777390">
+            <model model="LokPilot 5 micro" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777390">
                 <size length="25.5" width="10.6" height="4.5" units="mm"/>
             </model>
-            <model model="LokPilot 5 micro DCC" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777391">
+            <model model="LokPilot 5 micro DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777391">
                 <size length="25.5" width="10.6" height="4.5" units="mm"/>
             </model>
-            <model model="LokPilot 5 micro Next18" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554604">
+            <model model="LokPilot 5 micro Next18" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554604">
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
-            <model model="LokPilot 5 micro DCC Next18" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554605">
+            <model model="LokPilot 5 micro DCC Next18" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554605">
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
-            <model model="LokPilot 5 L" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554609">
+            <model model="LokPilot 5 L" maxFnNum="31" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554609">
                 <size length="51.8" width="25.4" height="14" units="mm"/>
             </model>
-            <model model="LokPilot 5 L DCC" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554610">
+            <model model="LokPilot 5 L DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554610">
                 <size length="51.8" width="25.4" height="14" units="mm"/>
             </model>
-            <model model="LokPilot 5 Fx micro" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554611">
+            <model model="LokPilot 5 Fx micro" maxFnNum="31" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554611">
                 <output name="1,37" label="|"/> <!-- suppress unused item -->
                 <output name="1,38" label="|"/> <!-- suppress unused item -->
                 <output name="1,39" label="|"/> <!-- suppress unused item -->
@@ -64,7 +66,7 @@
                 <output name="4,1" label="|"/> <!-- suppress unused item -->
                 <size length="51.0" width="40.0" height="14.0" units="mm"/>
             </model>
-            <model model="LokPilot 5 Fx micro DCC" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554612">
+            <model model="LokPilot 5 Fx micro DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554612">
                 <output name="1,37" label="|"/> <!-- suppress unused item -->
                 <output name="1,38" label="|"/> <!-- suppress unused item -->
                 <output name="1,39" label="|"/> <!-- suppress unused item -->
@@ -84,7 +86,7 @@
                 <output name="4,1" label="|"/> <!-- suppress unused item -->
                 <size length="51.0" width="40.0" height="14.0" units="mm"/>
             </model>
-            <model model="LokPilot 5 Fx micro Next18" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554616">
+            <model model="LokPilot 5 Fx micro Next18" maxFnNum="31" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554616">
                 <output name="1,37" label="|"/> <!-- suppress unused item -->
                 <output name="1,38" label="|"/> <!-- suppress unused item -->
                 <output name="1,39" label="|"/> <!-- suppress unused item -->
@@ -92,7 +94,7 @@
                 <output name="4,1" label="|"/> <!-- suppress unused item -->
                 <size length="51.0" width="40.0" height="14.0" units="mm"/>
             </model>
-            <model model="LokPilot 5 Fx micro Next18 DCC" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554617">
+            <model model="LokPilot 5 Fx micro Next18 DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554617">
                 <output name="1,37" label="|"/> <!-- suppress unused item -->
                 <output name="1,38" label="|"/> <!-- suppress unused item -->
                 <output name="1,39" label="|"/> <!-- suppress unused item -->
@@ -100,10 +102,10 @@
                 <output name="4,1" label="|"/> <!-- suppress unused item -->
                 <size length="51.0" width="40.0" height="14.0" units="mm"/>
             </model>
-            <model model="LokPilot 5 MKL" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554601">
+            <model model="LokPilot 5 MKL" maxFnNum="31" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554601">
                 <size length="51.0" width="40.0" height="14.0" units="mm"/>
             </model>
-            <model model="LokPilot 5 MKL DCC" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554608">
+            <model model="LokPilot 5 MKL DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554608">
                 <size length="51.0" width="40.0" height="14.0" units="mm"/>
             </model>
             <xi:include href="http://jmri.org/xml/decoders/esu/v5lpOutputLabels.xml"/>

--- a/xml/decoders/ESU_LokSound5.xml
+++ b/xml/decoders/ESU_LokSound5.xml
@@ -17,36 +17,38 @@
     <!-- ver1 made from the ESU_LokSoundV4_0 file -->
     <!-- ver2 updates for new firmware and reorganise code shared with LokPilot 5 -->
     <!-- ver3 updates for new firmware and refactor -->
+    <!-- ver4 updates for F29-F31 -->
     <version author="Dave Heap" version="1" lastUpdated="20190507"/>
     <version author="Dave Heap" version="2" lastUpdated="20200410"/>
     <version author="Dave Heap" version="3" lastUpdated="20200726"/>
+    <version author="Dave Heap" version="4" lastUpdated="20200807"/>
     <decoder>
         <family name="ESU LokSound 5" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
-            <model model="LokSound 5" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554582">
+            <model model="LokSound 5" maxFnNum="31" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554582">
                 <size length="30.5" width="15.5" height="5.5" units="mm"/>
             </model>
-            <model model="LokSound 5 DCC" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554588">
+            <model model="LokSound 5 DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554588">
                 <size length="30.5" width="15.5" height="5.5" units="mm"/>
             </model>
-            <model model="LokSound 5 micro" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554587">
+            <model model="LokSound 5 micro" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554587">
                 <size length="25.5" width="10.6" height="4.5" units="mm"/>
             </model>
-            <model model="LokSound 5 micro DCC" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554590">
+            <model model="LokSound 5 micro DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554590">
                 <size length="25.5" width="10.6" height="4.5" units="mm"/>
             </model>
-            <model model="LokSound 5 micro DCC Direct" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777370">
+            <model model="LokSound 5 micro DCC Direct" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777370">
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
-            <model model="LokSound 5 L" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554589">
+            <model model="LokSound 5 L" maxFnNum="31" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554589">
                 <size length="51.8" width="25.4" height="14" units="mm"/>
             </model>
-            <model model="LokSound 5 L DCC" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554592">
+            <model model="LokSound 5 L DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554592">
                 <size length="51.8" width="25.4" height="14" units="mm"/>
             </model>
-            <model model="LokSound 5 XL" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554591">
+            <model model="LokSound 5 XL" maxFnNum="31" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554591">
                 <size length="51.0" width="40.0" height="14.0" units="mm"/>
             </model>
-            <model model="LokSound 5 MKL" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554598">
+            <model model="LokSound 5 MKL" maxFnNum="31" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554598">
                 <size length="51.0" width="40.0" height="14.0" units="mm"/>
             </model>
             <xi:include href="http://jmri.org/xml/decoders/esu/v5lsOutputLabels.xml"/>

--- a/xml/decoders/ESU_LokSoundV3_5.xml
+++ b/xml/decoders/ESU_LokSoundV3_5.xml
@@ -11,7 +11,7 @@
 <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
-<decoder-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xi="http://www.w3.org/2001/XInclude" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+<decoder-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xi="http://www.w3.org/2001/XInclude" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <!-- made from the ESU_LokSoundV3_0.file -->
   <!-- ver2 CV213 defined multiple times, fixed to 219,222,225,228,231,234 -->
   <!-- also added CV52,121,122,123,124 -->
@@ -42,9 +42,11 @@
   <version author="Dave Heap" version="13" lastUpdated="20171008"/>
   <!-- ver14 add new functionlabel with translation -->
   <version author="Ronald Kuhn" version="14" lastUpdated="20171215"/>
+    <!-- ver15 updates for F0-F15 -->
+    <version author="Dave Heap" version="15" lastUpdated="20200807"/>
   <decoder>
     <family name="ESU LokSound V3.5 Silent BEMF/Sound decoders" mfg="Electronic Solutions Ulm GmbH" lowVersionID="59" highVersionID="81">
-      <model model="LokSound V3.5" numOuts="6" maxMotorCurrent="1.1A" extFnsNmraF13="yes" productID="16777229,16777234,16777239,16777248">
+      <model model="LokSound V3.5" maxFnNum="15" numOuts="6" maxMotorCurrent="1.1A" extFnsNmraF13="yes" productID="16777229,16777234,16777239,16777248">
         <output name="1" label="Front|Light" maxcurrent="250mA">
           <label xml:lang="fr">Feux|avant</label>
           <label xml:lang="it">Luci|Frontali</label>
@@ -136,7 +138,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="LokSound Micro V3.5" numOuts="6" maxMotorCurrent="1.1A" extFnsNmraF13="yes" productID="16777241,16777246">
+      <model model="LokSound Micro V3.5" maxFnNum="15" numOuts="6" maxMotorCurrent="1.1A" extFnsNmraF13="yes" productID="16777241,16777246">
         <output name="1" label="Front|Light" maxcurrent="180mA">
           <label xml:lang="fr">Feux|avant</label>
           <label xml:lang="it">Luci|Frontali</label>
@@ -228,7 +230,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="LokSoundXL V3.5" numOuts="8" maxMotorCurrent="3.0A" extFnsNmraF13="yes" productID="16777230,16777236,16777252">
+      <model model="LokSoundXL V3.5" maxFnNum="15" numOuts="8" maxMotorCurrent="3.0A" extFnsNmraF13="yes" productID="16777230,16777236,16777252">
         <output name="1" label="Front|Light" maxcurrent="600mA">
           <label xml:lang="fr">Feux|avant</label>
           <label xml:lang="it">Luci|Frontali</label>
@@ -320,7 +322,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model show="no" model="LokSound Version 3.5" replacementModel="LokSound V3.5" replacementFamily="ESU LokSound V3.5 Silent BEMF/Sound decoders" numOuts="6" maxMotorCurrent="1.1A" extFnsNmraF13="yes" productID="LokSound V3.5">
+      <model show="no" model="LokSound Version 3.5" replacementModel="LokSound V3.5" replacementFamily="ESU LokSound V3.5 Silent BEMF/Sound decoders" maxFnNum="15" numOuts="6" maxMotorCurrent="1.1A" extFnsNmraF13="yes" productID="LokSound V3.5">
         <output name="1" label="Front|Light" maxcurrent="250mA">
           <label xml:lang="fr">Feux|avant</label>
           <label xml:lang="it">Luci|Frontali</label>
@@ -395,7 +397,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model show="no" model="LokSound Version 3.5 (21 pin)" replacementModel="LokSound V3.5" replacementFamily="ESU LokSound V3.5 Silent BEMF/Sound decoders" numOuts="6" numFns="12" maxMotorCurrent="1.1A" extFnsNmraF13="yes" productID="LokSound V3.5">
+      <model show="no" model="LokSound Version 3.5 (21 pin)" replacementModel="LokSound V3.5" replacementFamily="ESU LokSound V3.5 Silent BEMF/Sound decoders" maxFnNum="15" numOuts="6" numFns="12" maxMotorCurrent="1.1A" extFnsNmraF13="yes" productID="LokSound V3.5">
         <output name="1" label="Front|Light" maxcurrent="250mA">
           <label xml:lang="fr">Feux|avant</label>
           <label xml:lang="it">Luci|Frontali</label>
@@ -469,7 +471,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model show="no" model="LokSoundXL Version 3.5" replacementModel="LokSoundXL V3.5" numOuts="8" maxMotorCurrent="3.0A" extFnsNmraF13="yes">
+      <model show="no" model="LokSoundXL Version 3.5" replacementModel="LokSoundXL V3.5" maxFnNum="15" numOuts="8" maxMotorCurrent="3.0A" extFnsNmraF13="yes">
         <output name="1" label="Front|Light" maxcurrent="600mA">
           <label xml:lang="fr">Feux|avant</label>
           <label xml:lang="it">Luci|Frontali</label>

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -444,6 +444,14 @@
                     This optional attribute limits the total number of function mapping lines displayed. 
             </xs:documentation></xs:annotation>
           </xs:attribute>
+          <xs:attribute name="maxFnNum" type="xs:int" default="28">
+            <xs:annotation><xs:documentation>
+                This is the highest F key number that will appear in the Function Labels Pane and throttles:
+                    It was originally 28 as per NMRA standards. Many decoders didn't support the whole range F0-F28.
+                    European standards now allow up to 68, i.e. the range F0-F68.
+                Note that this is unrelated to "numFns", which limits the total number of function mapping lines displayed. 
+            </xs:documentation></xs:annotation>
+          </xs:attribute>
           <xs:attribute name="numOuts" type="xs:int" >
             <xs:annotation><xs:documentation>
                 Number of physical outputs (wires) on the decoder.

--- a/xml/schema/locomotive-config.xsd
+++ b/xml/schema/locomotive-config.xsd
@@ -178,6 +178,7 @@
     <xs:attribute name="family" type="xs:string" use="required"/>
     <xs:attribute name="model" type="xs:string" use="required"/>
     <xs:attribute name="comment" type="xs:string"/>
+    <xs:attribute name="maxFnNum" type="xs:int"/>
   </xs:complexType>
   
 


### PR DESCRIPTION
Addresses some of the issues raised in issue #8888 and https://groups.io/g/jmriusers/topic/75950593.

This PR provides a new optional `maxFnNum` attribute for Decoder Definitions:
- It specifies the highest F key supported by the decoder. The assumed default is "28".
- This value is used to build the Function Labels pane and intended to be used in future by throttles, etc.
- Note that `maxFnNum` is not to be confused with the existing `numFns`, a legacy attribute that limits the total number of function mapping lines displayed. Neither is derivable from the other.
- The first time the Roster is opened, the default value will be assumed for each existing entry. (It's not practical to reverse-search back through each roster entry to find and read its decoder definition and update from that.)
- When a new loco is created, any `maxFnNum` value in the definition (or else the default value) will be saved in the Roster Entry file and propagated to the Roster Index file.
- When any existing Roster Entry is opened (Program Track/Program on Main/Edit/Labels & Media) any `maxFnNum` value in the definition will update the Roster Entry, the entry will be marked as changed (needing a Save) and a message will appear in the Status Bar. The new value will be propagated to the Roster Index when the entry is saved.
- Can also specify decoders using fewer F keys than default (e.g. the included LokSound V3.5, which use only F0-F15).


**Note to testers & reviewers:**  This PR doesn't  include an updated decoder index for the included updated definitions (risk of merge conflict). So if you check this out for testing, you'll need to do an`ant remakedecoderindex`.

