### PR TITLE
Allow disabling of 'Reset to Defaults' button for some decoders.

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle.properties
+++ b/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle.properties
@@ -8,6 +8,8 @@ LabelNewDecoder = <new loco>
 
 ButtonSave = Save to Roster
 ButtonResetDefaults = Reset to defaults
+TipButtonResetDefaults = Reset pane contents to JMRI-provided defaults. Does not reset the decoder.
+TipButtonResetDefaultsDisabled = Disabled as JMRI cannot provide appropriate defaults for this decoder.
 
 ButtonReadType = Read type from decoder
 ButtonReadChangesAllSheets = Read changes on all sheets

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
@@ -74,6 +74,7 @@ abstract public class PaneProgFrame extends JmriJFrame
     String filename = null;
     String programmerShowEmptyPanes = "";
     String decoderShowEmptyPanes = "";
+    String decoderAllowResetDefaults = "";
 
     // GUI member declarations
     JTabbedPane tabPane = new JTabbedPane();
@@ -883,14 +884,21 @@ abstract public class PaneProgFrame extends JmriJFrame
 
         // get the showEmptyPanes attribute, if yes/no update our state
         if (decoderRoot.getAttribute("showEmptyPanes") != null) {
-            if (log.isDebugEnabled()) {
-                log.debug("Found in decoder {}", decoderRoot.getAttribute("showEmptyPanes").getValue());
-            }
+            log.debug("Found in decoder showEmptyPanes={}", decoderRoot.getAttribute("showEmptyPanes").getValue());
             decoderShowEmptyPanes = decoderRoot.getAttribute("showEmptyPanes").getValue();
         } else {
             decoderShowEmptyPanes = "";
         }
         log.debug("decoderShowEmptyPanes={}", decoderShowEmptyPanes);
+
+        // get the allowResetDefaults attribute, if yes/no update our state
+        if (decoderRoot.getAttribute("allowResetDefaults") != null) {
+            log.debug("Found in decoder allowResetDefaults={}", decoderRoot.getAttribute("allowResetDefaults").getValue());
+            decoderAllowResetDefaults = decoderRoot.getAttribute("allowResetDefaults").getValue();
+        } else {
+            decoderAllowResetDefaults = "yes";
+        }
+        log.debug("decoderAllowResetDefaults={}", decoderAllowResetDefaults);
 
         // save the pointer to the model element
         modelElem = df.getModelElement();
@@ -1189,12 +1197,18 @@ abstract public class PaneProgFrame extends JmriJFrame
         // add the reset button
         JButton reset = new JButton(Bundle.getMessage("ButtonResetDefaults"));
         reset.setAlignmentX(JLabel.CENTER_ALIGNMENT);
-        reset.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                resetToDefaults();
-            }
-        });
+        if (decoderAllowResetDefaults.equals("no")) {
+            reset.setEnabled(false);
+            reset.setToolTipText(Bundle.getMessage("TipButtonResetDefaultsDisabled"));
+        } else {
+            reset.setToolTipText(Bundle.getMessage("TipButtonResetDefaults"));
+            reset.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(java.awt.event.ActionEvent e) {
+                    resetToDefaults();
+                }
+            });
+        }
 
         int sizeX = Math.max(reset.getPreferredSize().width, store.getPreferredSize().width);
         int sizeY = Math.max(reset.getPreferredSize().height, store.getPreferredSize().height);

--- a/xml/decoders/ESU_LokPilot5.xml
+++ b/xml/decoders/ESU_LokPilot5.xml
@@ -13,13 +13,15 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd" allowResetDefaults="no">
     <!-- ver1 made from the ESU_LokPilotV4_0 file -->
     <version author="Dave Heap" version="1" lastUpdated="20200410"/>
     <!-- ver2 refactor and add Fx micro Next18 variants -->
     <version author="Dave Heap" version="2" lastUpdated="20200726"/>
     <!-- ver3 updates for F29-F31 -->
     <version author="Dave Heap" version="3" lastUpdated="20200807"/>
+    <!-- ver4 disable Reset to Defaults -->
+    <version author="Dave Heap" version="4" lastUpdated="20200818"/>
     <decoder>
         <family name="ESU LokPilot 5" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
             <model model="LokPilot 5" maxFnNum="31" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554600">

--- a/xml/decoders/ESU_LokPilotV4.0.xml
+++ b/xml/decoders/ESU_LokPilotV4.0.xml
@@ -13,7 +13,7 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd" allowResetDefaults="no">
     <!-- based on the ESU software LokProgrammer V4.1.5 and the ESU manuals: -->
     <!-- 51981 LokPilot_V40 Betriebsanleitung_Auflage_3 -->
     <!-- 51982 LokPilot_V40 User-manual_Edition_2 -->
@@ -61,6 +61,8 @@
     <version author="Dave Heap" version="14" lastUpdated="20190507"/>
     <!-- ver 15 refactor -->
     <version author="Dave Heap" version="15" lastUpdated="20200726"/>
+    <!-- ver 16 disable Reset to Defaults -->
+    <version author="Dave Heap" version="16" lastUpdated="20200818"/>
     <decoder>
         <family name="ESU LokPilot V4.0" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
             <model model="LokPilot V4.0" numOuts="12" numFns="32" maxMotorCurrent="1.1A" extFnsESU="V4" productID="33554495,33554564">

--- a/xml/decoders/ESU_LokSound5.xml
+++ b/xml/decoders/ESU_LokSound5.xml
@@ -13,15 +13,17 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd" allowResetDefaults="no">
     <!-- ver1 made from the ESU_LokSoundV4_0 file -->
     <!-- ver2 updates for new firmware and reorganise code shared with LokPilot 5 -->
     <!-- ver3 updates for new firmware and refactor -->
     <!-- ver4 updates for F29-F31 -->
+    <!-- ver5 disable Reset to Defaults -->
     <version author="Dave Heap" version="1" lastUpdated="20190507"/>
     <version author="Dave Heap" version="2" lastUpdated="20200410"/>
     <version author="Dave Heap" version="3" lastUpdated="20200726"/>
     <version author="Dave Heap" version="4" lastUpdated="20200807"/>
+    <version author="Dave Heap" version="5" lastUpdated="20200818"/>
     <decoder>
         <family name="ESU LokSound 5" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
             <model model="LokSound 5" maxFnNum="31" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554582">

--- a/xml/decoders/ESU_LokSoundV3_5.xml
+++ b/xml/decoders/ESU_LokSoundV3_5.xml
@@ -11,7 +11,7 @@
 <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
-<decoder-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xi="http://www.w3.org/2001/XInclude" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+<decoder-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xi="http://www.w3.org/2001/XInclude" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd" allowResetDefaults="no">
   <!-- made from the ESU_LokSoundV3_0.file -->
   <!-- ver2 CV213 defined multiple times, fixed to 219,222,225,228,231,234 -->
   <!-- also added CV52,121,122,123,124 -->
@@ -44,6 +44,8 @@
   <version author="Ronald Kuhn" version="14" lastUpdated="20171215"/>
     <!-- ver15 updates for F0-F15 -->
     <version author="Dave Heap" version="15" lastUpdated="20200807"/>
+    <!-- ver16 disable Reset to Defaults -->
+    <version author="Dave Heap" version="16" lastUpdated="20200818"/>
   <decoder>
     <family name="ESU LokSound V3.5 Silent BEMF/Sound decoders" mfg="Electronic Solutions Ulm GmbH" lowVersionID="59" highVersionID="81">
       <model model="LokSound V3.5" maxFnNum="15" numOuts="6" maxMotorCurrent="1.1A" extFnsNmraF13="yes" productID="16777229,16777234,16777239,16777248">

--- a/xml/decoders/ESU_LokSoundV4_0.xml
+++ b/xml/decoders/ESU_LokSoundV4_0.xml
@@ -13,7 +13,7 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd" allowResetDefaults="no">
     <!-- made from the ESU_LokSound_Select.file -->
     <!-- ver1 new file -->
     <!-- ver2 Added CV16, fixed CV 474.3, fixed light effect type, moved some var to other panes -->
@@ -68,6 +68,8 @@
     <version author="Dave Heap" version="22" lastUpdated="20190507"/>
     <!-- ver23 refactor -->
     <version author="Dave Heap" version="23" lastUpdated="20200726"/>
+    <!-- ver24 disable Reset to Defaults -->
+    <version author="Dave Heap" version="24" lastUpdated="20200818"/>
     <decoder>
         <family name="ESU LokSound V4.0" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
             <model model="LokSound V4.0" numOuts="12" maxMotorCurrent="1.1A" extFnsESU="V4" productID="33554493,33554503,33554538">

--- a/xml/decoders/ESU_LokSound_Select.xml
+++ b/xml/decoders/ESU_LokSound_Select.xml
@@ -11,7 +11,7 @@
 <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
-<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd" allowResetDefaults="no">
     <!-- made from the ESU_LokSoundV3_5.file -->
     <!-- ver1 new file -->
     <version author="Michael Mosher" version="1" lastUpdated="20100301"/>
@@ -64,6 +64,8 @@
     <version author="Dave Heap" version="21" lastUpdated="20190507"/>
     <!-- ver22 refactor and add SUSI Map pane-->
     <version author="Dave Heap" version="22" lastUpdated="20200726"/>
+    <!-- ver23 disable Reset to Defaults-->
+    <version author="Dave Heap" version="23" lastUpdated="20200818"/>
     <decoder>
         <family name="ESU LokSound Select" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
             <model model="LokSound Select" numOuts="12" maxMotorCurrent="1.1A" extFnsESU="V4" productID="33554492,33554511,33554527,33554569">

--- a/xml/decoders/ESU_LokSound_Select_Steam.xml
+++ b/xml/decoders/ESU_LokSound_Select_Steam.xml
@@ -11,7 +11,7 @@
 <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
-<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd" allowResetDefaults="no">
     <!-- made from the ESU_LokSound_Select.xml Ver 2 file -->
     <!-- ver1 new file -->
     <version author="Michael Mosher" version="1" lastUpdated="20101020"/>
@@ -60,6 +60,8 @@
     <version author="Dave Heap" version="19" lastUpdated="20170819"/>
     <!-- ver20 refactor -->
     <version author="Dave Heap" version="20" lastUpdated="20190507"/>
+    <!-- ver21 disable Reset to Defaults -->
+    <version author="Dave Heap" version="21" lastUpdated="20200818"/>
     <decoder>
         <family name="ESU LokSound Select" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
             <model show="no" model="LokSound Select Steam Generic" numOuts="12" maxMotorCurrent="1.1A" extFnsESU="V4" productID="Steam Generic">

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -200,6 +200,7 @@
         <xs:element name="pane"    type="PaneType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="showEmptyPanes" type="yesNoType"/>
+      <xs:attribute name="allowResetDefaults" type="yesNoType"/>
     </xs:complexType>
   </xs:element>
   


### PR DESCRIPTION
For various reasons, It's not possible for JMRI to provide a reasonable set of defaults for some decoders. Using the "Reset to defaults" button  on the main Roster Entry pane with these decoders has caused grief for some users.

This PR provides for an optional "allowResetDefaults" attribute in the decoder-config file. Setting it to "no" disables the "Reset to defaults" button and provides an explanatory tooltip.

There's also sometimes confusion between this button and the "Resets" menu so the enabled-state tooltip attempts to point that out.