### PR TITLE
Add VariableLightManager

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -647,5 +647,10 @@
                 GitHub account to do the final submission.
                 There's more info on the 
                 <a href="https://jmri.org/help/en/package/apps/util/issuereporter/swing/IssueReporter.shtml">help page</a>.
+            <li>The interface jmri.Light has been split into jmri.Light and jmri.VariableLight. Lights
+                that supports variable intensity must now implement the jmri.VariableLight interface.
+                All lights are still managed by the jmri.LightManager, but a new manager jmri.VariableLightManager
+                has been added that keeps a copy of the VariableLights. But register and deregister of
+                all lights must still be done thru the LightManager.</li>
         </ul>
 

--- a/java/src/jmri/VariableLightManager.java
+++ b/java/src/jmri/VariableLightManager.java
@@ -1,0 +1,53 @@
+package jmri;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
+/**
+ * Interface for obtaining VariableLights.
+ * <p>
+ * This doesn't have a "new" method, as all VariableLights is also located in
+ * LightManager. Use LightManager to add or create new VariableLights.
+ * <hr>
+ * This file is part of JMRI.
+ * <p>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * <p>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Daniel Bergqvist Copyright (C) 2020
+ */
+public interface VariableLightManager extends Manager<VariableLight> {
+
+    /** {@inheritDoc} */
+    @Override
+    public void dispose();
+
+    /**
+     * Locate a VariableLight by its user name.
+     *
+     * @param s the user name
+     * @return the light or null if not found
+     */
+    @CheckReturnValue
+    @CheckForNull
+    @Override
+    public VariableLight getByUserName(@Nonnull String s);
+
+    /**
+     * Locate a VariableLight by its system name.
+     *
+     * @param s the system name
+     * @return the light or null if not found
+     */
+    @CheckReturnValue
+    @CheckForNull
+    @Override
+    public VariableLight getBySystemName(@Nonnull String s);
+
+}

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -412,6 +412,8 @@ abstract public class AbstractProxyManager<E extends NamedBean> extends Vetoable
         Manager<E> m = getManager(s.getSystemName());
         if (m != null) {
             m.register(s);
+        } else {
+            log.error("Unable to register {} in this proxy manager. No system specific manager supports this bean.", s.getSystemName());
         }
     }
 

--- a/java/src/jmri/managers/DefaultInstanceInitializer.java
+++ b/java/src/jmri/managers/DefaultInstanceInitializer.java
@@ -24,6 +24,7 @@ import jmri.SignalMastManager;
 import jmri.SignalSystemManager;
 import jmri.Timebase;
 import jmri.TurnoutManager;
+import jmri.VariableLightManager;
 import jmri.implementation.AbstractInstanceInitializer;
 import jmri.implementation.DefaultClockControl;
 import jmri.jmrit.audio.DefaultAudioManager;
@@ -77,6 +78,10 @@ public class DefaultInstanceInitializer extends AbstractInstanceInitializer {
 
         if (type == LightManager.class) {
             return new ProxyLightManager();
+        }
+
+        if (type == VariableLightManager.class) {
+            return new DefaultVariableLightManager(memo).init();
         }
 
         if (type == LogixManager.class) {
@@ -170,6 +175,7 @@ public class DefaultInstanceInitializer extends AbstractInstanceInitializer {
                 SignalSystemManager.class,
                 Timebase.class,
                 TurnoutManager.class,
+                VariableLightManager.class,
                 VSDecoderManager.class
         ));
         return set;

--- a/java/src/jmri/managers/DefaultVariableLightManager.java
+++ b/java/src/jmri/managers/DefaultVariableLightManager.java
@@ -122,6 +122,6 @@ public class DefaultVariableLightManager extends AbstractManager<VariableLight>
     }
 
 
-    private final static Logger log = LoggerFactory.getLogger(DefaultVariableLightManager.class);
+//    private final static Logger log = LoggerFactory.getLogger(DefaultVariableLightManager.class);
 
 }

--- a/java/src/jmri/managers/DefaultVariableLightManager.java
+++ b/java/src/jmri/managers/DefaultVariableLightManager.java
@@ -1,0 +1,127 @@
+package jmri.managers;
+
+import javax.annotation.*;
+import java.beans.PropertyChangeEvent;
+
+import jmri.InstanceManager;
+import jmri.Light;
+import jmri.LightManager;
+import jmri.Manager;
+import jmri.VariableLight;
+import jmri.VariableLightManager;
+import jmri.SystemConnectionMemo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract partial implementation of a VariableLightManager.
+ *
+ * @author Bob Jacobsen       Copyright (C) 2004
+ * @author Daniel Bergqvist   Copyright (C) 2020
+ */
+public class DefaultVariableLightManager extends AbstractManager<VariableLight>
+        implements VariableLightManager {
+
+    /**
+     * Create a new VariableLightManager instance.
+     * 
+     * @param memo the system connection
+     */
+    public DefaultVariableLightManager(SystemConnectionMemo memo) {
+        super(memo);
+    }
+
+    /**
+     * Initializes a new VariableLightManager instance.
+     * @return itself
+     */
+    public DefaultVariableLightManager init() {
+        LightManager lm = InstanceManager.getDefault(LightManager.class);
+        lm.addPropertyChangeListener("beans", this);
+        for (Light l : lm.getNamedBeanSet()) {
+            if (l instanceof VariableLight) {
+                super.register((VariableLight) l);
+            }
+        }
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void dispose() {
+        super.dispose();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getXMLOrder() {
+        return Manager.LIGHTS;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public char typeLetter() {
+        return 'L';
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Nonnull 
+    public String getBeanTypeHandled(boolean plural) {
+        return Bundle.getMessage(plural ? "BeanNameVariableLights" : "BeanNameVariableLight");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<VariableLight> getNamedBeanClass() {
+        return VariableLight.class;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void register(@Nonnull VariableLight s) {
+        throw new UnsupportedOperationException("Not supported. Use LightManager.register() instead");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void deregister(@Nonnull VariableLight s) {
+        throw new UnsupportedOperationException("Not supported. Use LightManager.deregister() instead");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void deleteBean(@Nonnull VariableLight n, @Nonnull String property) {
+        throw new UnsupportedOperationException("Not supported. Use LightManager.deleteBean() instead");
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent e) {
+        super.propertyChange(e);
+
+        if ("beans".equals(e.getPropertyName())) {
+
+            // A NamedBean is added
+            if ((e.getNewValue() != null)
+                    && (e.getNewValue() instanceof VariableLight)) {
+                super.register((VariableLight) e.getNewValue());
+            }
+
+            // A NamedBean is removed
+            if ((e.getOldValue() != null)
+                    && (e.getOldValue() instanceof VariableLight)) {
+                super.deregister((VariableLight) e.getOldValue());
+            }
+        }
+    }
+
+
+    private final static Logger log = LoggerFactory.getLogger(DefaultVariableLightManager.class);
+
+}

--- a/java/src/jmri/managers/DefaultVariableLightManager.java
+++ b/java/src/jmri/managers/DefaultVariableLightManager.java
@@ -11,11 +11,8 @@ import jmri.VariableLight;
 import jmri.VariableLightManager;
 import jmri.SystemConnectionMemo;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
- * Abstract partial implementation of a VariableLightManager.
+ * Default implementation of a VariableLightManager.
  *
  * @author Bob Jacobsen       Copyright (C) 2004
  * @author Daniel Bergqvist   Copyright (C) 2020
@@ -122,6 +119,6 @@ public class DefaultVariableLightManager extends AbstractManager<VariableLight>
     }
 
 
-//    private final static Logger log = LoggerFactory.getLogger(DefaultVariableLightManager.class);
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultVariableLightManager.class);
 
 }

--- a/java/test/jmri/managers/DefaultVariableLightManagerTest.java
+++ b/java/test/jmri/managers/DefaultVariableLightManagerTest.java
@@ -1,0 +1,200 @@
+package jmri.managers;
+
+import jmri.*;
+import jmri.implementation.AbstractVariableLight;
+import jmri.util.JUnitUtil;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test the DefaultVariableLightManager.
+ *
+ * @author  Daniel Bergqvist Copyright (C) 2020
+ */
+public class DefaultVariableLightManagerTest {
+
+    private VariableLight newVariableLight(String sysName, String userName) {
+        return new MyVariableLight(sysName, userName);
+    }
+
+    @Test
+    public void testDispose() {
+        VariableLightManager l = InstanceManager.getDefault(VariableLightManager.class);
+        l.dispose();  // all we're really doing here is making sure the method exists
+    }
+
+    @Test
+    public void testRegister() {
+        // create
+        VariableLight t = newVariableLight("L11", "mine");
+        
+        VariableLightManager l = InstanceManager.getDefault(VariableLightManager.class);
+        
+        Assert.assertThrows(UnsupportedOperationException.class, () -> l.register(t));
+        Assert.assertThrows(UnsupportedOperationException.class, () -> l.deregister(t));
+    }
+
+    @Test
+    public void testLights() {
+        // Test that the VariableLightManager registers variable lights but not
+        // lights that are not variable.
+
+        // When this light is created, the VariableLightManager isn't created yet.
+        Light light = new MyLight("IL1");
+        InstanceManager.getDefault(LightManager.class).register(light);
+        VariableLight variableLight = InstanceManager.getDefault(VariableLightManager.class).getBySystemName("IL1");
+        Assert.assertNull("light does not exists in VariableLightManager", variableLight);
+
+        // Check that we can deregister light without problem
+        InstanceManager.getDefault(LightManager.class).deregister(light);
+        variableLight = InstanceManager.getDefault(VariableLightManager.class).getBySystemName("IL1");
+        Assert.assertNull("light does not exists in VariableLightManager", variableLight);
+
+        // When this light is created, the VariableLightManager is created.
+        Light light2 = new MyLight("IL2");
+        InstanceManager.getDefault(LightManager.class).register(light2);
+        variableLight = InstanceManager.getDefault(VariableLightManager.class).getBySystemName("IL2");
+        Assert.assertNull("light does not exists in VariableLightManager", variableLight);
+
+        // Check that we can deregister light without problem
+        InstanceManager.getDefault(LightManager.class).deregister(light);
+        variableLight = InstanceManager.getDefault(VariableLightManager.class).getBySystemName("IL2");
+        Assert.assertNull("light does not exists in VariableLightManager", variableLight);
+    }
+
+    @Test
+    public void testVariableLights() {
+        // Test that the VariableLightManager registers variable lights.
+
+        // When this light is created, the VariableLightManager isn't created yet.
+        Light variableLight = new MyVariableLight("IL1", "MyLight");
+        InstanceManager.getDefault(LightManager.class).register(variableLight);
+        variableLight = InstanceManager.getDefault(VariableLightManager.class).getBySystemName("IL1");
+        Assert.assertNotNull("variable light exists in VariableLightManager", variableLight);
+
+        // Check that we can deregister light and that it get deregstered from VariableLightManager as well
+        InstanceManager.getDefault(LightManager.class).deregister(variableLight);
+        variableLight = InstanceManager.getDefault(VariableLightManager.class).getBySystemName("IL1");
+        Assert.assertNull("light does not exists in VariableLightManager", variableLight);
+
+        // When this light is created, the VariableLightManager is created.
+        Light variableLight2 = new MyVariableLight("IL2", "MyLight");
+        InstanceManager.getDefault(LightManager.class).register(variableLight2);
+        variableLight = InstanceManager.getDefault(VariableLightManager.class).getBySystemName("IL2");
+        Assert.assertNotNull("variable light exists in VariableLightManager", variableLight);
+
+        // Check that we can deregister light and that it get deregstered from VariableLightManager as well
+        InstanceManager.getDefault(LightManager.class).deregister(variableLight2);
+        variableLight = InstanceManager.getDefault(VariableLightManager.class).getBySystemName("IL2");
+        Assert.assertNull("light does not exists in VariableLightManager", variableLight);
+    }
+
+    @Test
+    public void testVariableLights_UserName() {
+        // Test that the VariableLightManager registers variable lights but not
+        // lights that are not variable.
+
+        Light light = new MyLight("IL1");
+        InstanceManager.getDefault(LightManager.class).register(light);
+        VariableLight variableLight = InstanceManager.getDefault(VariableLightManager.class).getByUserName("A light");
+        Assert.assertNull("light does not exists in VariableLightManager", variableLight);
+
+        // Check that we can deregister light without problem
+        InstanceManager.getDefault(LightManager.class).deregister(light);
+        variableLight = InstanceManager.getDefault(VariableLightManager.class).getByUserName("A light");
+        Assert.assertNull("light does not exists in VariableLightManager", variableLight);
+
+        Light variableLight2 = new MyVariableLight("IL2", "A variable light");
+        InstanceManager.getDefault(LightManager.class).register(variableLight2);
+        variableLight = InstanceManager.getDefault(VariableLightManager.class).getByUserName("A variable light");
+        Assert.assertNotNull("variableLight exists in VariableLightManager", variableLight);
+
+        // Check that we can deregister variableLight and that it get deregstered from VariableLightManager as well
+        InstanceManager.getDefault(LightManager.class).deregister(variableLight2);
+        variableLight = InstanceManager.getDefault(VariableLightManager.class).getByUserName("A variable light");
+        Assert.assertNull("variableLight does not exists in VariableLightManager", variableLight);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.initInternalLightManager();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+
+
+    private class MyLight extends jmri.implementation.AbstractLight {
+
+        public MyLight(String systemName) {
+            super(systemName);
+        }
+
+    }
+
+
+    private class MyVariableLight extends AbstractVariableLight {
+
+        double _value = 0.0;
+
+        public MyVariableLight(String sys, String userName) {
+            super(sys, userName);
+        }
+
+        @Override
+        public void setCommandedAnalogValue(double value) throws JmriException {
+            _value = value;
+        }
+
+        @Override
+        public double getCommandedAnalogValue() {
+            return _value;
+        }
+
+        @Override
+        public double getMin() {
+            return Float.MIN_VALUE;
+        }
+
+        @Override
+        public double getMax() {
+            return Float.MAX_VALUE;
+        }
+
+        @Override
+        public double getResolution() {
+            return 0.1;
+        }
+
+        @Override
+        public int getNumberOfSteps() {
+            return 10;
+        }
+
+        @Override
+        public AbsoluteOrRelative getAbsoluteOrRelative() {
+            return AbsoluteOrRelative.ABSOLUTE;
+        }
+
+        @Override
+        protected void sendIntensity(double intensity) {
+            // Do nothing
+        }
+        
+        @Override
+        protected void sendOnOffCommand(int newState) {
+            // Do nothing
+        }
+    }
+
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ProxyVariableLightManagerTest.class);
+
+}


### PR DESCRIPTION
Adds a `VariableLight` manager that listen to the `LightManager` and adds lights that extends `VariableLight`.

Note that `VariableLightManager.register()` and `VariableLightManager.deregister()` throws an `UnsupportedOperationException`. All registration of VariableLights must be thru the LightManager, not the VariableLightManager.