### PR TITLE
Split AbstractProxyManager

### DIFF
--- a/java/src/jmri/managers/AbstractProvidingProxyManager.java
+++ b/java/src/jmri/managers/AbstractProvidingProxyManager.java
@@ -1,0 +1,111 @@
+package jmri.managers;
+
+import jmri.*;
+
+/**
+ * Implementation of a Manager that can serves as a proxy for multiple
+ * system-specific implementations.
+ * <p>
+ * Automatically includes an Internal system, which need not be separately added
+ * any more.
+ * <p>
+ * Encapsulates access to the "Primary" manager, used by default, which is the
+ * first one provided.
+ * <p>
+ * Internally, this is done by using an ordered list of all non-Internal
+ * managers, plus a separate reference to the internal manager and default
+ * manager.
+ *
+ * @param <E> the supported type of NamedBean
+ * @author Bob Jacobsen      Copyright (C) 2003, 2010, 2018
+ * @author Daniel Bergqvist  Copyright (C) 2020
+ */
+abstract public class AbstractProvidingProxyManager<E extends NamedBean> extends AbstractProxyManager<E> implements ProvidingManager<E> {
+
+    /**
+     * Locate via user name, then system name if needed. If that fails, create a
+     * new NamedBean: If the name is a valid system name, it will be used for
+     * the new NamedBean. Otherwise, the makeSystemName method will attempt to
+     * turn it into a valid system name. Subclasses use this to create provider methods such as
+     * getSensor or getTurnout via casts.
+     *
+     * @param name the user name or system name of the bean
+     * @return an existing or new NamedBean
+     * @throws IllegalArgumentException if name is not usable in a bean
+     */
+    protected E provideNamedBean(String name) throws IllegalArgumentException {
+        // make sure internal present
+        initInternal();
+
+        E t = getNamedBean(name);
+        if (t != null) {
+            return t;
+        }
+        // Doesn't exist. If the systemName was specified, find that system
+        Manager<E> manager = getManager(name);
+        if (manager != null) {
+            return makeBean(manager, name, null);
+        }
+        log.debug("provideNamedBean did not find manager for name {}, defer to default", name); // NOI18N
+        return makeBean(getDefaultManager(), getDefaultManager().makeSystemName(name), null);
+    }
+
+    /**
+     * Return an instance with the specified system and user names. Note that
+     * two calls with the same arguments will get the same instance; there is
+     * i.e. only one Sensor object representing a given physical sensor and
+     * therefore only one with a specific system or user name.
+     * <p>
+     * This will always return a valid object reference for a valid request; a
+     * new object will be created if necessary. In that case:
+     * <ul>
+     * <li>If a null reference is given for user name, no user name will be
+     * associated with the NamedBean object created; a valid system name must be
+     * provided
+     * <li>If a null reference is given for the system name, a system name will
+     * _somehow_ be inferred from the user name. How this is done is system
+     * specific. Note: a future extension of this interface will add an
+     * exception to signal that this was not possible.
+     * <li>If both names are provided, the system name defines the hardware
+     * access of the desired turnout, and the user address is associated with
+     * it.
+     * </ul>
+     * Note that it is possible to make an inconsistent request if both
+     * addresses are provided, but the given values are associated with
+     * different objects. This is a problem, and we don't have a good solution
+     * except to issue warnings. This will mostly happen if you're creating
+     * NamedBean when you should be looking them up.
+     *
+     * @param systemName the system name
+     * @param userName   the user name
+     * @return requested NamedBean object (never null)
+     */
+    public E newNamedBean(String systemName, String userName) {
+        // make sure internal present
+        initInternal();
+
+        // if the systemName is specified, find that system
+        Manager<E> m = getManager(systemName);
+        if (m != null) {
+            return makeBean(m, systemName, userName);
+        }
+
+        // did not find a manager, allow it to default to the primary
+        log.debug("Did not find manager for system name {}, delegate to primary", systemName); // NOI18N
+        return makeBean(getDefaultManager(), systemName, userName);
+    }
+
+    /**
+     * Defer creation of the proper type to the subclass.
+     *
+     * @param manager    the manager to invoke
+     * @param systemName the system name
+     * @param userName   the user name
+     * @return a bean
+     */
+    abstract protected E makeBean(Manager<E> manager, String systemName, String userName);
+
+    // initialize logging
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractProvidingProxyManager.class);
+
+}

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -5,17 +5,17 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
 import java.util.*;
+
 import javax.annotation.CheckReturnValue;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.OverridingMethodsMustInvokeSuper;
+
 import jmri.*;
 import jmri.beans.VetoableChangeSupport;
 import jmri.SystemConnectionMemo;
 import jmri.jmrix.internal.InternalSystemConnectionMemo;
 import jmri.util.NamedBeanComparator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of a Manager that can serves as a proxy for multiple
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2003, 2010, 2018
  */
 @SuppressWarnings("deprecation")
-abstract public class AbstractProxyManager<E extends NamedBean> extends VetoableChangeSupport implements ProxyManager<E>, ProvidingManager<E>, PropertyChangeListener, Manager.ManagerDataListener<E> {
+abstract public class AbstractProxyManager<E extends NamedBean> extends VetoableChangeSupport implements ProxyManager<E>, PropertyChangeListener, Manager.ManagerDataListener<E> {
 
     /**
      * List of names of bound properties requested to be listened to by
@@ -128,7 +128,7 @@ abstract public class AbstractProxyManager<E extends NamedBean> extends Vetoable
         log.debug("added manager {}", m.getClass());
     }
 
-    private Manager<E> initInternal() {
+    protected Manager<E> initInternal() {
         if (internalManager == null) {
             log.debug("create internal manager when first requested"); // NOI18N
             internalManager = makeInternalManager();
@@ -156,44 +156,6 @@ abstract public class AbstractProxyManager<E extends NamedBean> extends Vetoable
         }
         return getBySystemName(name);
     }
-
-    /**
-     * Locate via user name, then system name if needed. If that fails, create a
-     * new NamedBean: If the name is a valid system name, it will be used for
-     * the new NamedBean. Otherwise, the makeSystemName method will attempt to
-     * turn it into a valid system name. Subclasses use this to create provider methods such as
-     * getSensor or getTurnout via casts.
-     *
-     * @param name the user name or system name of the bean
-     * @return an existing or new NamedBean
-     * @throws IllegalArgumentException if name is not usable in a bean
-     */
-    protected E provideNamedBean(String name) throws IllegalArgumentException {
-        // make sure internal present
-        initInternal();
-
-        E t = getNamedBean(name);
-        if (t != null) {
-            return t;
-        }
-        // Doesn't exist. If the systemName was specified, find that system
-        Manager<E> manager = getManager(name);
-        if (manager != null) {
-            return makeBean(manager, name, null);
-        }
-        log.debug("provideNamedBean did not find manager for name {}, defer to default", name); // NOI18N
-        return makeBean(getDefaultManager(), getDefaultManager().makeSystemName(name), null);
-    }
-
-    /**
-     * Defer creation of the proper type to the subclass.
-     *
-     * @param manager    the manager to invoke
-     * @param systemName the system name
-     * @param userName   the user name
-     * @return a bean
-     */
-    abstract protected E makeBean(Manager<E> manager, String systemName, String userName);
 
     /** {@inheritDoc} */
     @Override
@@ -250,51 +212,6 @@ abstract public class AbstractProxyManager<E extends NamedBean> extends Vetoable
     public NameValidity validSystemNameFormat(@Nonnull String systemName) {
         Manager m = getManager(systemName);
         return m == null ? NameValidity.INVALID : m.validSystemNameFormat(systemName);
-    }
-
-    /**
-     * Return an instance with the specified system and user names. Note that
-     * two calls with the same arguments will get the same instance; there is
-     * i.e. only one Sensor object representing a given physical sensor and
-     * therefore only one with a specific system or user name.
-     * <p>
-     * This will always return a valid object reference for a valid request; a
-     * new object will be created if necessary. In that case:
-     * <ul>
-     * <li>If a null reference is given for user name, no user name will be
-     * associated with the NamedBean object created; a valid system name must be
-     * provided
-     * <li>If a null reference is given for the system name, a system name will
-     * _somehow_ be inferred from the user name. How this is done is system
-     * specific. Note: a future extension of this interface will add an
-     * exception to signal that this was not possible.
-     * <li>If both names are provided, the system name defines the hardware
-     * access of the desired turnout, and the user address is associated with
-     * it.
-     * </ul>
-     * Note that it is possible to make an inconsistent request if both
-     * addresses are provided, but the given values are associated with
-     * different objects. This is a problem, and we don't have a good solution
-     * except to issue warnings. This will mostly happen if you're creating
-     * NamedBean when you should be looking them up.
-     *
-     * @param systemName the system name
-     * @param userName   the user name
-     * @return requested NamedBean object (never null)
-     */
-    public E newNamedBean(String systemName, String userName) {
-        // make sure internal present
-        initInternal();
-
-        // if the systemName is specified, find that system
-        Manager<E> m = getManager(systemName);
-        if (m != null) {
-            return makeBean(m, systemName, userName);
-        }
-
-        // did not find a manager, allow it to default to the primary
-        log.debug("Did not find manager for system name {}, delegate to primary", systemName); // NOI18N
-        return makeBean(getDefaultManager(), systemName, userName);
     }
 
     /** {@inheritDoc} */
@@ -730,6 +647,6 @@ abstract public class AbstractProxyManager<E extends NamedBean> extends Vetoable
     }
 
     // initialize logging
-    private final static Logger log = LoggerFactory.getLogger(AbstractProxyManager.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractProxyManager.class);
 
 }

--- a/java/src/jmri/managers/ProxyIdTagManager.java
+++ b/java/src/jmri/managers/ProxyIdTagManager.java
@@ -20,7 +20,7 @@ import jmri.jmrix.internal.InternalSystemConnectionMemo;
  * @author Dave Duchamp Copyright (C) 2004
  * @author Paul Bender Copyright (C) 2019
  */
-public class ProxyIdTagManager extends AbstractProxyManager<IdTag>
+public class ProxyIdTagManager extends AbstractProvidingProxyManager<IdTag>
         implements IdTagManager {
 
     public ProxyIdTagManager() {

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -12,7 +12,7 @@ import jmri.Manager;
  * @author Bob Jacobsen Copyright (C) 2010, 2018
  * @author Dave Duchamp Copyright (C) 2004
  */
-public class ProxyLightManager extends AbstractProxyManager<Light>
+public class ProxyLightManager extends AbstractProvidingProxyManager<Light>
         implements LightManager {
 
     public ProxyLightManager() {

--- a/java/src/jmri/managers/ProxyReporterManager.java
+++ b/java/src/jmri/managers/ProxyReporterManager.java
@@ -11,7 +11,7 @@ import jmri.ReporterManager;
  *
  * @author Bob Jacobsen Copyright (C) 2003, 2010
  */
-public class ProxyReporterManager extends AbstractProxyManager<Reporter> implements ReporterManager {
+public class ProxyReporterManager extends AbstractProvidingProxyManager<Reporter> implements ReporterManager {
 
     public ProxyReporterManager() {
         super();

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -12,7 +12,7 @@ import jmri.SensorManager;
  *
  * @author Bob Jacobsen Copyright (C) 2003, 2010
  */
-public class ProxySensorManager extends AbstractProxyManager<Sensor>
+public class ProxySensorManager extends AbstractProvidingProxyManager<Sensor>
         implements SensorManager {
 
     public ProxySensorManager() {

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2003, 2010
  */
-public class ProxyTurnoutManager extends AbstractProxyManager<Turnout> implements TurnoutManager {
+public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> implements TurnoutManager {
 
     public ProxyTurnoutManager() {
         super();


### PR DESCRIPTION
Splits AbstractProxyManager into AbstractProxyManager and AbstractProvidingProxyManager. This allows a manager to use AbstractProxyManager without being able to provide new named beans.

This is part of #8645. I'm going to split that PR into two. The next and final PR will have the AnalogIOManager and StringIOManager and their implementations.