### PR TITLE
The nullness annotation @Nonnull is not applicable for the primitive …

### DIFF
--- a/java/src/jmri/implementation/AbstractAnalogIO.java
+++ b/java/src/jmri/implementation/AbstractAnalogIO.java
@@ -89,7 +89,6 @@ public abstract class AbstractAnalogIO extends AbstractNamedBean implements Anal
 
     /** {@inheritDoc} */
     @Override
-    @Nonnull
     public double getCommandedAnalogValue() {
         return _commandedValue;
     }


### PR DESCRIPTION
The nullness annotation @Nonnull is not applicable for the primitive  type double. Again.