### PR TITLE
Update SpeedProfilePanel.java

### DIFF
--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
@@ -444,6 +444,7 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
             }
         }
 
+        throttleState = 0;
         re = reBox.getSelectedRosterEntries()[0];
         boolean ok = InstanceManager.throttleManagerInstance().requestThrottle(re, this, true); // we have a mechanism for steal / share
         if (!ok) {
@@ -452,7 +453,6 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
             return;
         }
         // Wait for throttle be correct and then run the profile
-        throttleState = 0;
         jmri.util.ThreadingUtil.newThread(new Runnable() {
                 @Override
                 public void run() {


### PR DESCRIPTION
Original code resets throttleState to zero 'after' requestThrottle call (line 448) has set it up, so subsequent code (specifically loop starting in line 461) always causes failure.