### PR TITLE
Allow change of constants during test

### DIFF
--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -78,20 +78,36 @@ public class JUnitUtil {
     static final public int DEFAULT_RELEASETHREAD_DELAY = 50;
     
     /**
+     * Default standard time step (in mSec) when looping in a waitFor operation.
+     */    
+    static final private int DEFAULT_WAITFOR_DELAY_STEP = 5;
+
+    /**
      * Standard time step (in mSec) when looping in a waitFor operation.
      * <p>
      * Public in case modification is needed from a test or script.
+     * This value is always reset to {@value #DEFAULT_WAITFOR_DELAY_STEP}
+     * during setUp().
      */    
-    static final public int WAITFOR_DELAY_STEP = 5;
+    static public int WAITFOR_DELAY_STEP = DEFAULT_WAITFOR_DELAY_STEP;
+
+    /**
+     * Default maximum time to wait before failing a waitFor operation.
+     * <p>
+     * The default value is really long, but that only matters when the test
+     * is failing anyway, and some of the LayoutEditor/SignalMastLogic tests
+     * are slow. But too long will cause CI jobs to time out before this logs
+     * the error....
+     */    
+    static final private int DEFAULT_WAITFOR_MAX_DELAY = 10000;
+
     /**
      * Maximum time to wait before failing a waitFor operation.
-     * The default value is really long, but that only matters when the test is failing anyway, 
-     * and some of the LayoutEditor/SignalMastLogic tests are slow. But too long will cause CI jobs
-     * to time out before this logs the error....
      * <p>
      * Public in case modification is needed from a test or script.
+     * This value is always reset to {@value #DEFAULT_WAITFOR_MAX_DELAY} during setUp().
      */    
-    static final public int WAITFOR_MAX_DELAY = 10000;
+    static public int WAITFOR_MAX_DELAY = DEFAULT_WAITFOR_MAX_DELAY;
 
     /**
      * When true, prints each setUp method to help identify which tests include a failure.
@@ -249,6 +265,9 @@ public class JUnitUtil {
      * be present in the {@code @Before} routine.
      */
     public static void setUp() {
+        WAITFOR_DELAY_STEP = DEFAULT_WAITFOR_DELAY_STEP;
+        WAITFOR_MAX_DELAY = DEFAULT_WAITFOR_MAX_DELAY;
+        
         // all the setup for a MockInstanceManager applies
         setUpLoggingAndCommonProperties();
 


### PR DESCRIPTION
Allow WAITFOR_DELAY_STEP and WAITFOR_MAX_DELAY to be changed during test.
These are always reset by JUnitUtil.setUp().

While I took a look at #8978, I tried to increase DEFAULT_WAITFOR_MAX_DELAY in the test, but I discovered that that was not possible since the field was final. I changed it to non final, but that could have lead to other tests being impacted by a change of this value, so I made setUp() always restore the default value.