### PR TITLE
VSDecoder: use symbolic constants in locations tables

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsAction.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsAction.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import javax.swing.AbstractAction;
+import javax.swing.table.AbstractTableModel;
 import jmri.Block;
 import jmri.BlockManager;
 import jmri.PhysicalLocationReporter;
@@ -39,6 +40,18 @@ import org.slf4j.LoggerFactory;
  */
 public class ManageLocationsAction extends AbstractAction {
 
+    // Note: the four tables don't have the same structure
+    static final int SYSNAMECOL     = 0;             // system name
+    static final int NAMECOL        = 0;             // name (special case for Operations Locations)
+    static final int USERNAMECOL    = 1;             // user name
+    static final int USECOL         = 1;             // usage flag for Operations Locations and Listener
+    static final int XCOL           = 2;             // X value
+    static final int YCOL           = 3;             // Y value
+    static final int ZCOL           = 4;             // Z value
+    static final int TUNNELCOL      = 5;             // tunnel flag (not for Listener)
+    static final int BEARINGCOL     = 5;             // bearing attribute (Listener only)
+    static final int AZIMUTHCOL     = 6;             // azimuth attribute (Listener only)
+
     private ManageLocationsFrame f = null;
     private ListeningSpot listenerLoc;
 
@@ -53,7 +66,7 @@ public class ManageLocationsAction extends AbstractAction {
             listenerLoc = VSDecoderManager.instance().getVSDecoderPreferences().getListenerPosition();
 
             // Handle Reporters
-            ReporterManager rmgr = jmri.InstanceManager.getDefault(jmri.ReporterManager.class);
+            ReporterManager rmgr = jmri.InstanceManager.getDefault(ReporterManager.class);
             Set<Reporter> reporterSet = rmgr.getNamedBeanSet();
             Object[][] reporterTable = new Object[reporterSet.size()][7];
             int i = 0;
@@ -61,43 +74,41 @@ public class ManageLocationsAction extends AbstractAction {
                 if (r != null) {
                     if (r instanceof PhysicalLocationReporter) {
                         PhysicalLocation p = ((PhysicalLocationReporter) r).getPhysicalLocation();
-                        reporterTable[i][0] = r.getSystemName();
-                        reporterTable[i][1] = r.getDisplayName();
-                        reporterTable[i][2] = true;
-                        reporterTable[i][3] = p.getX();
-                        reporterTable[i][4] = p.getY();
-                        reporterTable[i][5] = p.getZ();
-                        reporterTable[i][6] = p.isTunnel();
+                        reporterTable[i][SYSNAMECOL] = r.getSystemName();
+                        reporterTable[i][USERNAMECOL] = r.getUserName();
+                        reporterTable[i][USECOL + 1] = true;
+                        reporterTable[i][XCOL + 1] = p.getX();
+                        reporterTable[i][YCOL + 1] = p.getY();
+                        reporterTable[i][ZCOL + 1] = p.getZ();
+                        reporterTable[i][TUNNELCOL + 1] = p.isTunnel();
                     } else {
-                        reporterTable[i][0] = r.getSystemName();
-                        reporterTable[i][1] = r.getDisplayName();
-                        reporterTable[i][2] = false;
-                        reporterTable[i][3] = Float.valueOf(0.0f);
-                        reporterTable[i][4] = Float.valueOf(0.0f);
-                        reporterTable[i][5] = Float.valueOf(0.0f);
-                        reporterTable[i][6] = false;
+                        reporterTable[i][SYSNAMECOL] = r.getSystemName();
+                        reporterTable[i][USERNAMECOL] = r.getUserName();
+                        reporterTable[i][USECOL + 1] = false;
+                        reporterTable[i][XCOL + 1] = Float.valueOf(0.0f);
+                        reporterTable[i][YCOL + 1] = Float.valueOf(0.0f);
+                        reporterTable[i][ZCOL + 1] = Float.valueOf(0.0f);
+                        reporterTable[i][TUNNELCOL + 1] = false;
                     }
                 }
                 i++;
             }
 
             // Handle Blocks
-            BlockManager bmgr = jmri.InstanceManager.getDefault(jmri.BlockManager.class);
+            BlockManager bmgr = jmri.InstanceManager.getDefault(BlockManager.class);
             Set<Block> blockSet = bmgr.getNamedBeanSet();
             Object[][] blockTable = new Object[blockSet.size()][7];
             i = 0;
             for (Block b : blockSet) {
-                // NOTE: Unlike Reporters, all Blocks are (now) PhysicalLocationReporters, so no need to do a check here.
-                // We'll keep the explicit cast for now, but it's not actually necessary.
                 if (b != null) {
                     PhysicalLocation p = ((PhysicalLocationReporter) b).getPhysicalLocation();
-                    blockTable[i][0] = b.getSystemName();
-                    blockTable[i][1] = b.getDisplayName();
-                    blockTable[i][2] = true;
-                    blockTable[i][3] = p.getX();
-                    blockTable[i][4] = p.getY();
-                    blockTable[i][5] = p.getZ();
-                    blockTable[i][6] = p.isTunnel();
+                    blockTable[i][SYSNAMECOL] = b.getSystemName();
+                    blockTable[i][USERNAMECOL] = b.getUserName();
+                    blockTable[i][USECOL + 1] = true;
+                    blockTable[i][XCOL + 1] = p.getX();
+                    blockTable[i][YCOL + 1] = p.getY();
+                    blockTable[i][ZCOL + 1] = p.getZ();
+                    blockTable[i][TUNNELCOL + 1] = p.isTunnel();
                 }
                 i++;
             }
@@ -110,17 +121,17 @@ public class ManageLocationsAction extends AbstractAction {
             i = 0;
             for (Location l : locations) {
                 log.debug("i: {}, MLA: {}, Name: {}, table: {}", i, l.getId(), l.getName(), java.util.Arrays.toString(opsTable[i]));
-                opsTable[i][0] = l.getName();
+                opsTable[i][NAMECOL] = l.getName();
                 PhysicalLocation p = l.getPhysicalLocation();
                 if (p == PhysicalLocation.Origin) {
-                    opsTable[i][1] = false;
+                    opsTable[i][USECOL] = false;
                 } else {
-                    opsTable[i][1] = true;
+                    opsTable[i][USECOL] = true;
                 }
-                opsTable[i][2] = p.getX();
-                opsTable[i][3] = p.getY();
-                opsTable[i][4] = p.getZ();
-                opsTable[i][5] = p.isTunnel();
+                opsTable[i][XCOL] = p.getX();
+                opsTable[i][YCOL] = p.getY();
+                opsTable[i][ZCOL] = p.getZ();
+                opsTable[i][TUNNELCOL] = p.isTunnel();
                 i++;
             }
 
@@ -131,4 +142,273 @@ public class ManageLocationsAction extends AbstractAction {
 
     private final static Logger log = LoggerFactory.getLogger(ManageLocationsAction.class);
 
+    /**
+     * class to serve as TableModel for Reporters and Blocks
+     */
+    static class ReporterBlockTableModel extends AbstractTableModel {
+
+        // These get internationalized at runtime in the constructor below.
+        private String[] columnNames = new String[7];
+        private Object[][] rowData;
+
+        public ReporterBlockTableModel(Object[][] dataMap) {
+            super();
+            // Use i18n-ized column titles.
+            columnNames[SYSNAMECOL] = Bundle.getMessage("Name");
+            columnNames[USERNAMECOL] = Bundle.getMessage("ColumnUserName");
+            columnNames[USECOL + 1] = Bundle.getMessage("FieldTableUseColumn");
+            columnNames[XCOL + 1] = Bundle.getMessage("FieldTableXColumn");
+            columnNames[YCOL + 1] = Bundle.getMessage("FieldTableYColumn");
+            columnNames[ZCOL + 1] = Bundle.getMessage("FieldTableZColumn");
+            columnNames[TUNNELCOL + 1] = Bundle.getMessage("FieldTableIsTunnelColumn");
+            rowData = dataMap;
+        }
+
+        public HashMap<String, PhysicalLocation> getDataMap() {
+            // Includes only the ones with the checkbox made
+            HashMap<String, PhysicalLocation> retv = new HashMap<>();
+            for (Object[] row : rowData) {
+                if ((Boolean) row[USECOL + 1]) {
+                    if (row[XCOL + 1] == null) { 
+                        row[XCOL + 1] = 0.0f;
+                    }
+                    if (row[YCOL + 1] == null) { 
+                        row[YCOL + 1] = 0.0f;
+                    }
+                    if (row[ZCOL + 1] == null) { 
+                        row[ZCOL + 1] = 0.0f;
+                    }
+                    retv.put((String) row[SYSNAMECOL], 
+                            new PhysicalLocation((Float) row[XCOL + 1], (Float) row[YCOL + 1], (Float) row[ZCOL + 1], (Boolean) row[TUNNELCOL + 1]));
+                }
+            }
+            return retv;
+        }
+
+        @Override
+        public String getColumnName(int col) {
+            return columnNames[col];
+        }
+
+        @Override
+        public int getRowCount() {
+            return rowData.length;
+        }
+
+        @Override
+        public int getColumnCount() {
+            return columnNames.length;
+        }
+
+        @Override
+        public Object getValueAt(int row, int col) {
+            return rowData[row][col];
+        }
+
+        @Override
+        public boolean isCellEditable(int row, int col) {
+            return true;
+        }
+
+        @Override
+        public void setValueAt(Object value, int row, int col) {
+            rowData[row][col] = value;
+            fireTableCellUpdated(row, col);
+        }
+
+        @Override
+        public Class<?> getColumnClass(int columnIndex) {
+            switch (columnIndex) {
+                case USECOL + 1:
+                case TUNNELCOL + 1:
+                    return Boolean.class;
+                case ZCOL + 1:
+                case YCOL + 1:
+                case XCOL + 1:
+                    return Float.class;
+                case USERNAMECOL:
+                case SYSNAMECOL:
+                default:
+                    return super.getColumnClass(columnIndex);
+            }
+        }
+    }
+
+    /**
+     * class to serve as TableModel for Ops Locations
+     */
+    static class LocationTableModel extends AbstractTableModel {
+
+        // These get internationalized at runtime in the constructor below.
+        private String[] columnNames = new String[6];
+        private Object[][] rowData;
+
+        public LocationTableModel(Object[][] dataMap) {
+            super();
+            // Use i18n-ized column titles.
+            columnNames[NAMECOL] = Bundle.getMessage("Name");
+            columnNames[USECOL] = Bundle.getMessage("FieldTableUseColumn");
+            columnNames[XCOL] = Bundle.getMessage("FieldTableXColumn");
+            columnNames[YCOL] = Bundle.getMessage("FieldTableYColumn");
+            columnNames[ZCOL] = Bundle.getMessage("FieldTableZColumn");
+            columnNames[TUNNELCOL] = Bundle.getMessage("FieldTableIsTunnelColumn");
+            rowData = dataMap;
+        }
+
+        public HashMap<String, PhysicalLocation> getDataMap() {
+            // Includes only the ones with the checkbox made
+            HashMap<String, PhysicalLocation> retv = new HashMap<>();
+            for (Object[] row : rowData) {
+                if ((Boolean) row[USECOL]) {
+                    if (row[XCOL] == null) { 
+                        row[XCOL] = 0.0f;
+                    }
+                    if (row[YCOL] == null) { 
+                        row[YCOL] = 0.0f;
+                    }
+                    if (row[ZCOL] == null) { 
+                        row[ZCOL] = 0.0f;
+                    }
+                    retv.put((String) row[NAMECOL], 
+                            new PhysicalLocation((Float) row[XCOL], (Float) row[YCOL], (Float) row[ZCOL], (Boolean) row[TUNNELCOL]));
+                }
+            }
+            return retv;
+        }
+
+        @Override
+        public String getColumnName(int col) {
+            return columnNames[col];
+        }
+
+        @Override
+        public int getRowCount() {
+            return rowData.length;
+        }
+
+        @Override
+        public int getColumnCount() {
+            return columnNames.length;
+        }
+
+        @Override
+        public Object getValueAt(int row, int col) {
+            return rowData[row][col];
+        }
+
+        @Override
+        public boolean isCellEditable(int row, int col) {
+            return true;
+        }
+
+        @Override
+        public void setValueAt(Object value, int row, int col) {
+            rowData[row][col] = value;
+            fireTableCellUpdated(row, col);
+        }
+
+        @Override
+        public Class<?> getColumnClass(int columnIndex) {
+            switch (columnIndex) {
+                case USECOL:
+                case TUNNELCOL:
+                    return Boolean.class;
+                case ZCOL:
+                case YCOL:
+                case XCOL:
+                    return Float.class;
+                case NAMECOL:
+                default:
+                    return super.getColumnClass(columnIndex);
+            }
+        }
+    }
+
+    /**
+     * class for use as TableModel for Listener Locations
+     */
+    static class ListenerTableModel extends AbstractTableModel {
+
+        // These get internationalized at runtime in the constructor below.
+        private String[] columnNames = new String[7];
+        private Object[][] rowData = null;
+
+        public ListenerTableModel(Object[][] dataMap) {
+            super();
+            // Use i18n-ized column titles.
+            columnNames[NAMECOL] = Bundle.getMessage("Name");
+            columnNames[USECOL] = Bundle.getMessage("FieldTableUseColumn");
+            columnNames[XCOL] = Bundle.getMessage("FieldTableXColumn");
+            columnNames[YCOL] = Bundle.getMessage("FieldTableYColumn");
+            columnNames[ZCOL] = Bundle.getMessage("FieldTableZColumn");
+            columnNames[BEARINGCOL] = Bundle.getMessage("FieldTableBearingColumn");
+            columnNames[AZIMUTHCOL] = Bundle.getMessage("FieldTableAzimuthColumn");
+            rowData = dataMap;
+        }
+
+        @SuppressWarnings("unused")
+        public HashMap<String, ListeningSpot> getDataMap() {
+            // Includes only the ones with the checkbox made
+            HashMap<String, ListeningSpot> retv = new HashMap<>();
+            ListeningSpot spot = null;
+            for (Object[] row : rowData) {
+                if ((Boolean) row[USECOL]) {
+                    spot = new ListeningSpot();
+                    spot.setName((String) row[NAMECOL]);
+                    spot.setLocation((Double) row[XCOL], (Double) row[YCOL], (Double) row[ZCOL]);
+                    spot.setOrientation((Double) row[BEARINGCOL], (Double) row[AZIMUTHCOL]);
+                    retv.put((String) row[NAMECOL], spot);
+                }
+            }
+            return retv;
+        }
+
+        @Override
+        public String getColumnName(int col) {
+            return columnNames[col];
+        }
+
+        @Override
+        public int getRowCount() {
+            return rowData.length;
+        }
+
+        @Override
+        public int getColumnCount() {
+            return columnNames.length;
+        }
+
+        @Override
+        public Object getValueAt(int row, int col) {
+            return rowData[row][col];
+        }
+
+        @Override
+        public boolean isCellEditable(int row, int col) {
+            return true;
+        }
+
+        @Override
+        public void setValueAt(Object value, int row, int col) {
+            rowData[row][col] = value;
+            fireTableCellUpdated(row, col);
+        }
+
+        @Override
+        public Class<?> getColumnClass(int columnIndex) {
+            switch (columnIndex) {
+                case USECOL:
+                    return Boolean.class;
+                case AZIMUTHCOL:
+                case BEARINGCOL:
+                case ZCOL:
+                case YCOL:
+                case XCOL:
+                    return Double.class;
+                case NAMECOL:
+                default:
+                    return super.getColumnClass(columnIndex);
+            }
+        }
+    }
 }

--- a/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsAction.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsAction.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import javax.swing.AbstractAction;
-import javax.swing.table.AbstractTableModel;
 import jmri.Block;
 import jmri.BlockManager;
 import jmri.PhysicalLocationReporter;
@@ -40,18 +39,6 @@ import org.slf4j.LoggerFactory;
  */
 public class ManageLocationsAction extends AbstractAction {
 
-    // Note: the four tables don't have the same structure
-    static final int SYSNAMECOL     = 0;             // system name
-    static final int NAMECOL        = 0;             // name (special case for Operations Locations)
-    static final int USERNAMECOL    = 1;             // user name
-    static final int USECOL         = 1;             // usage flag for Operations Locations and Listener
-    static final int XCOL           = 2;             // X value
-    static final int YCOL           = 3;             // Y value
-    static final int ZCOL           = 4;             // Z value
-    static final int TUNNELCOL      = 5;             // tunnel flag (not for Listener)
-    static final int BEARINGCOL     = 5;             // bearing attribute (Listener only)
-    static final int AZIMUTHCOL     = 6;             // azimuth attribute (Listener only)
-
     private ManageLocationsFrame f = null;
     private ListeningSpot listenerLoc;
 
@@ -74,21 +61,21 @@ public class ManageLocationsAction extends AbstractAction {
                 if (r != null) {
                     if (r instanceof PhysicalLocationReporter) {
                         PhysicalLocation p = ((PhysicalLocationReporter) r).getPhysicalLocation();
-                        reporterTable[i][SYSNAMECOL] = r.getSystemName();
-                        reporterTable[i][USERNAMECOL] = r.getUserName();
-                        reporterTable[i][USECOL + 1] = true;
-                        reporterTable[i][XCOL + 1] = p.getX();
-                        reporterTable[i][YCOL + 1] = p.getY();
-                        reporterTable[i][ZCOL + 1] = p.getZ();
-                        reporterTable[i][TUNNELCOL + 1] = p.isTunnel();
+                        reporterTable[i][ManageLocationsTableModel.SYSNAMECOL] = r.getSystemName();
+                        reporterTable[i][ManageLocationsTableModel.USERNAMECOL] = r.getDisplayName();
+                        reporterTable[i][ManageLocationsTableModel.USECOL + 1] = true;
+                        reporterTable[i][ManageLocationsTableModel.XCOL + 1] = p.getX();
+                        reporterTable[i][ManageLocationsTableModel.YCOL + 1] = p.getY();
+                        reporterTable[i][ManageLocationsTableModel.ZCOL + 1] = p.getZ();
+                        reporterTable[i][ManageLocationsTableModel.TUNNELCOL + 1] = p.isTunnel();
                     } else {
-                        reporterTable[i][SYSNAMECOL] = r.getSystemName();
-                        reporterTable[i][USERNAMECOL] = r.getUserName();
-                        reporterTable[i][USECOL + 1] = false;
-                        reporterTable[i][XCOL + 1] = Float.valueOf(0.0f);
-                        reporterTable[i][YCOL + 1] = Float.valueOf(0.0f);
-                        reporterTable[i][ZCOL + 1] = Float.valueOf(0.0f);
-                        reporterTable[i][TUNNELCOL + 1] = false;
+                        reporterTable[i][ManageLocationsTableModel.SYSNAMECOL] = r.getSystemName();
+                        reporterTable[i][ManageLocationsTableModel.USERNAMECOL] = r.getDisplayName();
+                        reporterTable[i][ManageLocationsTableModel.USECOL + 1] = false;
+                        reporterTable[i][ManageLocationsTableModel.XCOL + 1] = Float.valueOf(0.0f);
+                        reporterTable[i][ManageLocationsTableModel.YCOL + 1] = Float.valueOf(0.0f);
+                        reporterTable[i][ManageLocationsTableModel.ZCOL + 1] = Float.valueOf(0.0f);
+                        reporterTable[i][ManageLocationsTableModel.TUNNELCOL + 1] = false;
                     }
                 }
                 i++;
@@ -100,15 +87,17 @@ public class ManageLocationsAction extends AbstractAction {
             Object[][] blockTable = new Object[blockSet.size()][7];
             i = 0;
             for (Block b : blockSet) {
+                // NOTE: Unlike Reporters, all Blocks are (now) PhysicalLocationReporters, so no need to do a check here.
+                // We'll keep the explicit cast for now, but it's not actually necessary.
                 if (b != null) {
                     PhysicalLocation p = ((PhysicalLocationReporter) b).getPhysicalLocation();
-                    blockTable[i][SYSNAMECOL] = b.getSystemName();
-                    blockTable[i][USERNAMECOL] = b.getUserName();
-                    blockTable[i][USECOL + 1] = true;
-                    blockTable[i][XCOL + 1] = p.getX();
-                    blockTable[i][YCOL + 1] = p.getY();
-                    blockTable[i][ZCOL + 1] = p.getZ();
-                    blockTable[i][TUNNELCOL + 1] = p.isTunnel();
+                    blockTable[i][ManageLocationsTableModel.SYSNAMECOL] = b.getSystemName();
+                    blockTable[i][ManageLocationsTableModel.USERNAMECOL] = b.getDisplayName();
+                    blockTable[i][ManageLocationsTableModel.USECOL + 1] = true;
+                    blockTable[i][ManageLocationsTableModel.XCOL + 1] = p.getX();
+                    blockTable[i][ManageLocationsTableModel.YCOL + 1] = p.getY();
+                    blockTable[i][ManageLocationsTableModel.ZCOL + 1] = p.getZ();
+                    blockTable[i][ManageLocationsTableModel.TUNNELCOL + 1] = p.isTunnel();
                 }
                 i++;
             }
@@ -121,17 +110,17 @@ public class ManageLocationsAction extends AbstractAction {
             i = 0;
             for (Location l : locations) {
                 log.debug("i: {}, MLA: {}, Name: {}, table: {}", i, l.getId(), l.getName(), java.util.Arrays.toString(opsTable[i]));
-                opsTable[i][NAMECOL] = l.getName();
+                opsTable[i][ManageLocationsTableModel.NAMECOL] = l.getName();
                 PhysicalLocation p = l.getPhysicalLocation();
                 if (p == PhysicalLocation.Origin) {
-                    opsTable[i][USECOL] = false;
+                    opsTable[i][ManageLocationsTableModel.USECOL] = false;
                 } else {
-                    opsTable[i][USECOL] = true;
+                    opsTable[i][ManageLocationsTableModel.USECOL] = true;
                 }
-                opsTable[i][XCOL] = p.getX();
-                opsTable[i][YCOL] = p.getY();
-                opsTable[i][ZCOL] = p.getZ();
-                opsTable[i][TUNNELCOL] = p.isTunnel();
+                opsTable[i][ManageLocationsTableModel.XCOL] = p.getX();
+                opsTable[i][ManageLocationsTableModel.YCOL] = p.getY();
+                opsTable[i][ManageLocationsTableModel.ZCOL] = p.getZ();
+                opsTable[i][ManageLocationsTableModel.TUNNELCOL] = p.isTunnel();
                 i++;
             }
 
@@ -142,273 +131,4 @@ public class ManageLocationsAction extends AbstractAction {
 
     private final static Logger log = LoggerFactory.getLogger(ManageLocationsAction.class);
 
-    /**
-     * class to serve as TableModel for Reporters and Blocks
-     */
-    static class ReporterBlockTableModel extends AbstractTableModel {
-
-        // These get internationalized at runtime in the constructor below.
-        private String[] columnNames = new String[7];
-        private Object[][] rowData;
-
-        public ReporterBlockTableModel(Object[][] dataMap) {
-            super();
-            // Use i18n-ized column titles.
-            columnNames[SYSNAMECOL] = Bundle.getMessage("Name");
-            columnNames[USERNAMECOL] = Bundle.getMessage("ColumnUserName");
-            columnNames[USECOL + 1] = Bundle.getMessage("FieldTableUseColumn");
-            columnNames[XCOL + 1] = Bundle.getMessage("FieldTableXColumn");
-            columnNames[YCOL + 1] = Bundle.getMessage("FieldTableYColumn");
-            columnNames[ZCOL + 1] = Bundle.getMessage("FieldTableZColumn");
-            columnNames[TUNNELCOL + 1] = Bundle.getMessage("FieldTableIsTunnelColumn");
-            rowData = dataMap;
-        }
-
-        public HashMap<String, PhysicalLocation> getDataMap() {
-            // Includes only the ones with the checkbox made
-            HashMap<String, PhysicalLocation> retv = new HashMap<>();
-            for (Object[] row : rowData) {
-                if ((Boolean) row[USECOL + 1]) {
-                    if (row[XCOL + 1] == null) { 
-                        row[XCOL + 1] = 0.0f;
-                    }
-                    if (row[YCOL + 1] == null) { 
-                        row[YCOL + 1] = 0.0f;
-                    }
-                    if (row[ZCOL + 1] == null) { 
-                        row[ZCOL + 1] = 0.0f;
-                    }
-                    retv.put((String) row[SYSNAMECOL], 
-                            new PhysicalLocation((Float) row[XCOL + 1], (Float) row[YCOL + 1], (Float) row[ZCOL + 1], (Boolean) row[TUNNELCOL + 1]));
-                }
-            }
-            return retv;
-        }
-
-        @Override
-        public String getColumnName(int col) {
-            return columnNames[col];
-        }
-
-        @Override
-        public int getRowCount() {
-            return rowData.length;
-        }
-
-        @Override
-        public int getColumnCount() {
-            return columnNames.length;
-        }
-
-        @Override
-        public Object getValueAt(int row, int col) {
-            return rowData[row][col];
-        }
-
-        @Override
-        public boolean isCellEditable(int row, int col) {
-            return true;
-        }
-
-        @Override
-        public void setValueAt(Object value, int row, int col) {
-            rowData[row][col] = value;
-            fireTableCellUpdated(row, col);
-        }
-
-        @Override
-        public Class<?> getColumnClass(int columnIndex) {
-            switch (columnIndex) {
-                case USECOL + 1:
-                case TUNNELCOL + 1:
-                    return Boolean.class;
-                case ZCOL + 1:
-                case YCOL + 1:
-                case XCOL + 1:
-                    return Float.class;
-                case USERNAMECOL:
-                case SYSNAMECOL:
-                default:
-                    return super.getColumnClass(columnIndex);
-            }
-        }
-    }
-
-    /**
-     * class to serve as TableModel for Ops Locations
-     */
-    static class LocationTableModel extends AbstractTableModel {
-
-        // These get internationalized at runtime in the constructor below.
-        private String[] columnNames = new String[6];
-        private Object[][] rowData;
-
-        public LocationTableModel(Object[][] dataMap) {
-            super();
-            // Use i18n-ized column titles.
-            columnNames[NAMECOL] = Bundle.getMessage("Name");
-            columnNames[USECOL] = Bundle.getMessage("FieldTableUseColumn");
-            columnNames[XCOL] = Bundle.getMessage("FieldTableXColumn");
-            columnNames[YCOL] = Bundle.getMessage("FieldTableYColumn");
-            columnNames[ZCOL] = Bundle.getMessage("FieldTableZColumn");
-            columnNames[TUNNELCOL] = Bundle.getMessage("FieldTableIsTunnelColumn");
-            rowData = dataMap;
-        }
-
-        public HashMap<String, PhysicalLocation> getDataMap() {
-            // Includes only the ones with the checkbox made
-            HashMap<String, PhysicalLocation> retv = new HashMap<>();
-            for (Object[] row : rowData) {
-                if ((Boolean) row[USECOL]) {
-                    if (row[XCOL] == null) { 
-                        row[XCOL] = 0.0f;
-                    }
-                    if (row[YCOL] == null) { 
-                        row[YCOL] = 0.0f;
-                    }
-                    if (row[ZCOL] == null) { 
-                        row[ZCOL] = 0.0f;
-                    }
-                    retv.put((String) row[NAMECOL], 
-                            new PhysicalLocation((Float) row[XCOL], (Float) row[YCOL], (Float) row[ZCOL], (Boolean) row[TUNNELCOL]));
-                }
-            }
-            return retv;
-        }
-
-        @Override
-        public String getColumnName(int col) {
-            return columnNames[col];
-        }
-
-        @Override
-        public int getRowCount() {
-            return rowData.length;
-        }
-
-        @Override
-        public int getColumnCount() {
-            return columnNames.length;
-        }
-
-        @Override
-        public Object getValueAt(int row, int col) {
-            return rowData[row][col];
-        }
-
-        @Override
-        public boolean isCellEditable(int row, int col) {
-            return true;
-        }
-
-        @Override
-        public void setValueAt(Object value, int row, int col) {
-            rowData[row][col] = value;
-            fireTableCellUpdated(row, col);
-        }
-
-        @Override
-        public Class<?> getColumnClass(int columnIndex) {
-            switch (columnIndex) {
-                case USECOL:
-                case TUNNELCOL:
-                    return Boolean.class;
-                case ZCOL:
-                case YCOL:
-                case XCOL:
-                    return Float.class;
-                case NAMECOL:
-                default:
-                    return super.getColumnClass(columnIndex);
-            }
-        }
-    }
-
-    /**
-     * class for use as TableModel for Listener Locations
-     */
-    static class ListenerTableModel extends AbstractTableModel {
-
-        // These get internationalized at runtime in the constructor below.
-        private String[] columnNames = new String[7];
-        private Object[][] rowData = null;
-
-        public ListenerTableModel(Object[][] dataMap) {
-            super();
-            // Use i18n-ized column titles.
-            columnNames[NAMECOL] = Bundle.getMessage("Name");
-            columnNames[USECOL] = Bundle.getMessage("FieldTableUseColumn");
-            columnNames[XCOL] = Bundle.getMessage("FieldTableXColumn");
-            columnNames[YCOL] = Bundle.getMessage("FieldTableYColumn");
-            columnNames[ZCOL] = Bundle.getMessage("FieldTableZColumn");
-            columnNames[BEARINGCOL] = Bundle.getMessage("FieldTableBearingColumn");
-            columnNames[AZIMUTHCOL] = Bundle.getMessage("FieldTableAzimuthColumn");
-            rowData = dataMap;
-        }
-
-        @SuppressWarnings("unused")
-        public HashMap<String, ListeningSpot> getDataMap() {
-            // Includes only the ones with the checkbox made
-            HashMap<String, ListeningSpot> retv = new HashMap<>();
-            ListeningSpot spot = null;
-            for (Object[] row : rowData) {
-                if ((Boolean) row[USECOL]) {
-                    spot = new ListeningSpot();
-                    spot.setName((String) row[NAMECOL]);
-                    spot.setLocation((Double) row[XCOL], (Double) row[YCOL], (Double) row[ZCOL]);
-                    spot.setOrientation((Double) row[BEARINGCOL], (Double) row[AZIMUTHCOL]);
-                    retv.put((String) row[NAMECOL], spot);
-                }
-            }
-            return retv;
-        }
-
-        @Override
-        public String getColumnName(int col) {
-            return columnNames[col];
-        }
-
-        @Override
-        public int getRowCount() {
-            return rowData.length;
-        }
-
-        @Override
-        public int getColumnCount() {
-            return columnNames.length;
-        }
-
-        @Override
-        public Object getValueAt(int row, int col) {
-            return rowData[row][col];
-        }
-
-        @Override
-        public boolean isCellEditable(int row, int col) {
-            return true;
-        }
-
-        @Override
-        public void setValueAt(Object value, int row, int col) {
-            rowData[row][col] = value;
-            fireTableCellUpdated(row, col);
-        }
-
-        @Override
-        public Class<?> getColumnClass(int columnIndex) {
-            switch (columnIndex) {
-                case USECOL:
-                    return Boolean.class;
-                case AZIMUTHCOL:
-                case BEARINGCOL:
-                case ZCOL:
-                case YCOL:
-                case XCOL:
-                    return Double.class;
-                case NAMECOL:
-                default:
-                    return super.getColumnClass(columnIndex);
-            }
-        }
-    }
 }

--- a/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
@@ -32,7 +32,6 @@ import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.setup.Setup;
 import jmri.jmrit.vsdecoder.VSDecoderManager;
 import jmri.jmrit.vsdecoder.listener.ListeningSpot;
-import jmri.jmrit.vsdecoder.swing.ManageLocationsTableModel;
 import jmri.util.JmriJFrame;
 import jmri.util.PhysicalLocation;
 import org.slf4j.Logger;

--- a/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
@@ -32,6 +32,7 @@ import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.setup.Setup;
 import jmri.jmrit.vsdecoder.VSDecoderManager;
 import jmri.jmrit.vsdecoder.listener.ListeningSpot;
+import jmri.jmrit.vsdecoder.swing.ManageLocationsTableModel;
 import jmri.util.JmriJFrame;
 import jmri.util.PhysicalLocation;
 import org.slf4j.Logger;
@@ -81,10 +82,10 @@ public class ManageLocationsFrame extends JmriJFrame {
     private Object[][] opsData;       // positions of Operations Locations
     private Object[][] locData;       // positions of Listener Locations
     private Object[][] blockData;     // positions of Blocks
-    private ManageLocationsAction.ReporterBlockTableModel reporterModel;
-    private ManageLocationsAction.LocationTableModel opsModel;
-    private ManageLocationsAction.ListenerTableModel locModel;
-    private ManageLocationsAction.ReporterBlockTableModel blockModel;
+    private ManageLocationsTableModel.ReporterBlockTableModel reporterModel;
+    private ManageLocationsTableModel.LocationTableModel opsModel;
+    private ManageLocationsTableModel.ListenerTableModel locModel;
+    private ManageLocationsTableModel.ReporterBlockTableModel blockModel;
     private ListeningSpot listenerLoc;
 
     private HashMap<String, PhysicalLocation> data;
@@ -148,13 +149,13 @@ public class ManageLocationsFrame extends JmriJFrame {
 
         // Build Listener Locations Table
         locData = new Object[1][7];
-        locData[0][ManageLocationsAction.NAMECOL] = listenerLoc.getName();
-        locData[0][ManageLocationsAction.USECOL] = true;
-        locData[0][ManageLocationsAction.XCOL] = listenerLoc.getLocation().x;
-        locData[0][ManageLocationsAction.YCOL] = listenerLoc.getLocation().y;
-        locData[0][ManageLocationsAction.ZCOL] = listenerLoc.getLocation().z;
-        locData[0][ManageLocationsAction.BEARINGCOL] = listenerLoc.getBearing();
-        locData[0][ManageLocationsAction.AZIMUTHCOL] = listenerLoc.getAzimuth();
+        locData[0][ManageLocationsTableModel.NAMECOL] = listenerLoc.getName();
+        locData[0][ManageLocationsTableModel.USECOL] = true;
+        locData[0][ManageLocationsTableModel.XCOL] = listenerLoc.getLocation().x;
+        locData[0][ManageLocationsTableModel.YCOL] = listenerLoc.getLocation().y;
+        locData[0][ManageLocationsTableModel.ZCOL] = listenerLoc.getLocation().z;
+        locData[0][ManageLocationsTableModel.BEARINGCOL] = listenerLoc.getBearing();
+        locData[0][ManageLocationsTableModel.AZIMUTHCOL] = listenerLoc.getAzimuth();
 
         log.debug("Listener: {}", listenerLoc.toString());
         log.debug("locData:");
@@ -165,7 +166,7 @@ public class ManageLocationsFrame extends JmriJFrame {
         JPanel locPanel = new JPanel();
         locPanel.setLayout(new BoxLayout(locPanel, BoxLayout.LINE_AXIS));
         JScrollPane locScrollPanel = new JScrollPane();
-        locModel = new ManageLocationsAction.ListenerTableModel(locData);
+        locModel = new ManageLocationsTableModel.ListenerTableModel(locData);
         JTable locTable = new JTable(locModel);
         locTable.setFillsViewportHeight(true);
         locTable.setPreferredScrollableViewportSize(new Dimension(520, 200));
@@ -177,7 +178,7 @@ public class ManageLocationsFrame extends JmriJFrame {
         reporterPanel = new JPanel();
         reporterPanel.setLayout(new GridBagLayout());
         JScrollPane reporterScrollPanel = new JScrollPane();
-        reporterModel = new ManageLocationsAction.ReporterBlockTableModel(reporterData);
+        reporterModel = new ManageLocationsTableModel.ReporterBlockTableModel(reporterData);
         JTable reporterTable = new JTable(reporterModel);
         reporterTable.setFillsViewportHeight(true);
         reporterTable.setPreferredScrollableViewportSize(new Dimension(540, 200));
@@ -186,7 +187,7 @@ public class ManageLocationsFrame extends JmriJFrame {
         blockPanel = new JPanel();
         blockPanel.setLayout(new GridBagLayout());
         JScrollPane blockScrollPanel = new JScrollPane();
-        blockModel = new ManageLocationsAction.ReporterBlockTableModel(blockData);
+        blockModel = new ManageLocationsTableModel.ReporterBlockTableModel(blockData);
         JTable blockTable = new JTable(blockModel);
         blockTable.setFillsViewportHeight(true);
         blockTable.setPreferredScrollableViewportSize(new Dimension(540, 200));
@@ -196,7 +197,7 @@ public class ManageLocationsFrame extends JmriJFrame {
         opsPanel.setLayout(new GridBagLayout());
         opsPanel.revalidate();
         JScrollPane opsScrollPanel = new JScrollPane();
-        opsModel = new ManageLocationsAction.LocationTableModel(opsData);
+        opsModel = new ManageLocationsTableModel.LocationTableModel(opsData);
         JTable opsTable = new JTable(opsModel);
         opsTable.setFillsViewportHeight(true);
         opsTable.setPreferredScrollableViewportSize(new Dimension(520, 200));
@@ -274,18 +275,18 @@ public class ManageLocationsFrame extends JmriJFrame {
 
     @SuppressFBWarnings(value = "WMI_WRONG_MAP_ITERATOR", justification = "only in slow debug")
     private void saveTableValues() {
-        if ((Boolean) locModel.getValueAt(0, ManageLocationsAction.USECOL)) {
+        if ((Boolean) locModel.getValueAt(0, ManageLocationsTableModel.USECOL)) {
             // Don't accept Azimuth value 90 or -90 (they are not in the domain of definition)
-            if ((Double) locModel.getValueAt(0, ManageLocationsAction.AZIMUTHCOL) != null 
-                    && ((Double) locModel.getValueAt(0, ManageLocationsAction.AZIMUTHCOL) == 90.0d
-                    || (Double) locModel.getValueAt(0, ManageLocationsAction.AZIMUTHCOL) == -90.0d)) {
+            if ((Double) locModel.getValueAt(0, ManageLocationsTableModel.AZIMUTHCOL) != null 
+                    && ((Double) locModel.getValueAt(0, ManageLocationsTableModel.AZIMUTHCOL) == 90.0d
+                    || (Double) locModel.getValueAt(0, ManageLocationsTableModel.AZIMUTHCOL) == -90.0d)) {
                 JOptionPane.showMessageDialog(null, Bundle.getMessage("FieldTableAzimuthInvalidValue"));
             } else {
-                listenerLoc.setLocation((Double) locModel.getValueAt(0, ManageLocationsAction.XCOL),
-                        (Double) locModel.getValueAt(0, ManageLocationsAction.YCOL),
-                        (Double) locModel.getValueAt(0, ManageLocationsAction.ZCOL));
-                listenerLoc.setOrientation((Double) locModel.getValueAt(0, ManageLocationsAction.BEARINGCOL),
-                        (Double) locModel.getValueAt(0, ManageLocationsAction.AZIMUTHCOL));
+                listenerLoc.setLocation((Double) locModel.getValueAt(0, ManageLocationsTableModel.XCOL),
+                        (Double) locModel.getValueAt(0, ManageLocationsTableModel.YCOL),
+                        (Double) locModel.getValueAt(0, ManageLocationsTableModel.ZCOL));
+                listenerLoc.setOrientation((Double) locModel.getValueAt(0, ManageLocationsTableModel.BEARINGCOL),
+                        (Double) locModel.getValueAt(0, ManageLocationsTableModel.AZIMUTHCOL));
                 VSDecoderManager.instance().getVSDecoderPreferences().save();
                 VSDecoderManager.instance().getVSDecoderPreferences().setListenerPosition(listenerLoc);
             }

--- a/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
@@ -22,7 +22,6 @@ import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTable;
-import javax.swing.table.AbstractTableModel;
 import jmri.Block;
 import jmri.BlockManager;
 import jmri.Reporter;
@@ -82,10 +81,10 @@ public class ManageLocationsFrame extends JmriJFrame {
     private Object[][] opsData;       // positions of Operations Locations
     private Object[][] locData;       // positions of Listener Locations
     private Object[][] blockData;     // positions of Blocks
-    private ReporterBlockTableModel reporterModel;
-    private LocationTableModel opsModel;
-    private ListenerTableModel locModel;
-    private ReporterBlockTableModel blockModel;
+    private ManageLocationsAction.ReporterBlockTableModel reporterModel;
+    private ManageLocationsAction.LocationTableModel opsModel;
+    private ManageLocationsAction.ListenerTableModel locModel;
+    private ManageLocationsAction.ReporterBlockTableModel blockModel;
     private ListeningSpot listenerLoc;
 
     private HashMap<String, PhysicalLocation> data;
@@ -149,13 +148,13 @@ public class ManageLocationsFrame extends JmriJFrame {
 
         // Build Listener Locations Table
         locData = new Object[1][7];
-        locData[0][0] = listenerLoc.getName();
-        locData[0][1] = true;
-        locData[0][2] = listenerLoc.getLocation().x;
-        locData[0][3] = listenerLoc.getLocation().y;
-        locData[0][4] = listenerLoc.getLocation().z;
-        locData[0][5] = listenerLoc.getBearing();
-        locData[0][6] = listenerLoc.getAzimuth();
+        locData[0][ManageLocationsAction.NAMECOL] = listenerLoc.getName();
+        locData[0][ManageLocationsAction.USECOL] = true;
+        locData[0][ManageLocationsAction.XCOL] = listenerLoc.getLocation().x;
+        locData[0][ManageLocationsAction.YCOL] = listenerLoc.getLocation().y;
+        locData[0][ManageLocationsAction.ZCOL] = listenerLoc.getLocation().z;
+        locData[0][ManageLocationsAction.BEARINGCOL] = listenerLoc.getBearing();
+        locData[0][ManageLocationsAction.AZIMUTHCOL] = listenerLoc.getAzimuth();
 
         log.debug("Listener: {}", listenerLoc.toString());
         log.debug("locData:");
@@ -166,7 +165,7 @@ public class ManageLocationsFrame extends JmriJFrame {
         JPanel locPanel = new JPanel();
         locPanel.setLayout(new BoxLayout(locPanel, BoxLayout.LINE_AXIS));
         JScrollPane locScrollPanel = new JScrollPane();
-        locModel = new ListenerTableModel(locData);
+        locModel = new ManageLocationsAction.ListenerTableModel(locData);
         JTable locTable = new JTable(locModel);
         locTable.setFillsViewportHeight(true);
         locTable.setPreferredScrollableViewportSize(new Dimension(520, 200));
@@ -178,7 +177,7 @@ public class ManageLocationsFrame extends JmriJFrame {
         reporterPanel = new JPanel();
         reporterPanel.setLayout(new GridBagLayout());
         JScrollPane reporterScrollPanel = new JScrollPane();
-        reporterModel = new ReporterBlockTableModel(reporterData);
+        reporterModel = new ManageLocationsAction.ReporterBlockTableModel(reporterData);
         JTable reporterTable = new JTable(reporterModel);
         reporterTable.setFillsViewportHeight(true);
         reporterTable.setPreferredScrollableViewportSize(new Dimension(540, 200));
@@ -187,7 +186,7 @@ public class ManageLocationsFrame extends JmriJFrame {
         blockPanel = new JPanel();
         blockPanel.setLayout(new GridBagLayout());
         JScrollPane blockScrollPanel = new JScrollPane();
-        blockModel = new ReporterBlockTableModel(blockData);
+        blockModel = new ManageLocationsAction.ReporterBlockTableModel(blockData);
         JTable blockTable = new JTable(blockModel);
         blockTable.setFillsViewportHeight(true);
         blockTable.setPreferredScrollableViewportSize(new Dimension(540, 200));
@@ -197,7 +196,7 @@ public class ManageLocationsFrame extends JmriJFrame {
         opsPanel.setLayout(new GridBagLayout());
         opsPanel.revalidate();
         JScrollPane opsScrollPanel = new JScrollPane();
-        opsModel = new LocationTableModel(opsData);
+        opsModel = new ManageLocationsAction.LocationTableModel(opsData);
         JTable opsTable = new JTable(opsModel);
         opsTable.setFillsViewportHeight(true);
         opsTable.setPreferredScrollableViewportSize(new Dimension(520, 200));
@@ -275,24 +274,25 @@ public class ManageLocationsFrame extends JmriJFrame {
 
     @SuppressFBWarnings(value = "WMI_WRONG_MAP_ITERATOR", justification = "only in slow debug")
     private void saveTableValues() {
-        if ((Boolean) locModel.getValueAt(0, 1)) {
+        if ((Boolean) locModel.getValueAt(0, ManageLocationsAction.USECOL)) {
             // Don't accept Azimuth value 90 or -90 (they are not in the domain of definition)
-            if ((Double) locModel.getValueAt(0, 6) != null 
-                    && ((Double) locModel.getValueAt(0, 6) == 90.0d || (Double) locModel.getValueAt(0, 6) == -90.0d)) {
+            if ((Double) locModel.getValueAt(0, ManageLocationsAction.AZIMUTHCOL) != null 
+                    && ((Double) locModel.getValueAt(0, ManageLocationsAction.AZIMUTHCOL) == 90.0d
+                    || (Double) locModel.getValueAt(0, ManageLocationsAction.AZIMUTHCOL) == -90.0d)) {
                 JOptionPane.showMessageDialog(null, Bundle.getMessage("FieldTableAzimuthInvalidValue"));
             } else {
-                listenerLoc.setLocation((Double) locModel.getValueAt(0, 2),
-                        (Double) locModel.getValueAt(0, 3),
-                        (Double) locModel.getValueAt(0, 4));
-                listenerLoc.setOrientation((Double) locModel.getValueAt(0, 5),
-                        (Double) locModel.getValueAt(0, 6));
+                listenerLoc.setLocation((Double) locModel.getValueAt(0, ManageLocationsAction.XCOL),
+                        (Double) locModel.getValueAt(0, ManageLocationsAction.YCOL),
+                        (Double) locModel.getValueAt(0, ManageLocationsAction.ZCOL));
+                listenerLoc.setOrientation((Double) locModel.getValueAt(0, ManageLocationsAction.BEARINGCOL),
+                        (Double) locModel.getValueAt(0, ManageLocationsAction.AZIMUTHCOL));
                 VSDecoderManager.instance().getVSDecoderPreferences().save();
                 VSDecoderManager.instance().getVSDecoderPreferences().setListenerPosition(listenerLoc);
             }
         }
 
         data = reporterModel.getDataMap();
-        ReporterManager mgr = jmri.InstanceManager.getDefault(jmri.ReporterManager.class);
+        ReporterManager mgr = jmri.InstanceManager.getDefault(ReporterManager.class);
         for (String s : data.keySet()) {
             log.debug("Reporter: {}, Location: {}", s, data.get(s));
             Reporter r = mgr.getByDisplayName(s);
@@ -302,7 +302,7 @@ public class ManageLocationsFrame extends JmriJFrame {
         }
 
         data = blockModel.getDataMap();
-        BlockManager bmgr = jmri.InstanceManager.getDefault(jmri.BlockManager.class);
+        BlockManager bmgr = jmri.InstanceManager.getDefault(BlockManager.class);
         for (String s : data.keySet()) {
             log.debug("Block: {}, Location: {}", s, data.get(s));
             Block b = bmgr.getByDisplayName(s);
@@ -329,273 +329,4 @@ public class ManageLocationsFrame extends JmriJFrame {
 
     private final static Logger log = LoggerFactory.getLogger(ManageLocationsFrame.class);
 
-    /**
-     * Private class to serve as TableModel for Reporters and Blocks
-     */
-    private static class ReporterBlockTableModel extends AbstractTableModel {
-
-        // These get internationalized at runtime in the constructor below.
-        private String[] columnNames = new String[7];
-        private Object[][] rowData;
-
-        public ReporterBlockTableModel(Object[][] dataMap) {
-            super();
-            // Use i18n-ized column titles.
-            columnNames[0] = Bundle.getMessage("Name");
-            columnNames[1] = Bundle.getMessage("ColumnUserName");
-            columnNames[2] = Bundle.getMessage("FieldTableUseColumn");
-            columnNames[3] = Bundle.getMessage("FieldTableXColumn");
-            columnNames[4] = Bundle.getMessage("FieldTableYColumn");
-            columnNames[5] = Bundle.getMessage("FieldTableZColumn");
-            columnNames[6] = Bundle.getMessage("FieldTableIsTunnelColumn");
-            rowData = dataMap;
-        }
-
-        public HashMap<String, PhysicalLocation> getDataMap() {
-            // Includes only the ones with the checkbox made
-            HashMap<String, PhysicalLocation> retv = new HashMap<>();
-            for (Object[] row : rowData) {
-                if ((Boolean) row[2]) {
-                    if (row[3] == null) { 
-                        row[3] = 0.0f;
-                    }
-                    if (row[4] == null) { 
-                        row[4] = 0.0f;
-                    }
-                    if (row[5] == null) { 
-                        row[5] = 0.0f;
-                    }
-                    retv.put((String) row[0], 
-                            new PhysicalLocation((Float) row[3], (Float) row[4], (Float) row[5], (Boolean) row[6]));
-                }
-            }
-            return retv;
-        }
-
-        @Override
-        public String getColumnName(int col) {
-            return columnNames[col];
-        }
-
-        @Override
-        public int getRowCount() {
-            return rowData.length;
-        }
-
-        @Override
-        public int getColumnCount() {
-            return columnNames.length;
-        }
-
-        @Override
-        public Object getValueAt(int row, int col) {
-            return rowData[row][col];
-        }
-
-        @Override
-        public boolean isCellEditable(int row, int col) {
-            return true;
-        }
-
-        @Override
-        public void setValueAt(Object value, int row, int col) {
-            rowData[row][col] = value;
-            fireTableCellUpdated(row, col);
-        }
-
-        @Override
-        public Class<?> getColumnClass(int columnIndex) {
-            switch (columnIndex) {
-                case 2:
-                case 6:
-                    return Boolean.class;
-                case 5:
-                case 4:
-                case 3:
-                    return Float.class;
-                case 1:
-                case 0:
-                default:
-                    return super.getColumnClass(columnIndex);
-            }
-        }
-    }
-
-    /**
-     * Private class to serve as TableModel for Ops Locations
-     */
-    private static class LocationTableModel extends AbstractTableModel {
-
-        // These get internationalized at runtime in the constructor below.
-        private String[] columnNames = new String[6];
-        private Object[][] rowData;
-
-        public LocationTableModel(Object[][] dataMap) {
-            super();
-            // Use i18n-ized column titles.
-            columnNames[0] = Bundle.getMessage("Name");
-            columnNames[1] = Bundle.getMessage("FieldTableUseColumn");
-            columnNames[2] = Bundle.getMessage("FieldTableXColumn");
-            columnNames[3] = Bundle.getMessage("FieldTableYColumn");
-            columnNames[4] = Bundle.getMessage("FieldTableZColumn");
-            columnNames[5] = Bundle.getMessage("FieldTableIsTunnelColumn");
-            rowData = dataMap;
-        }
-
-        public HashMap<String, PhysicalLocation> getDataMap() {
-            // Includes only the ones with the checkbox made
-            HashMap<String, PhysicalLocation> retv = new HashMap<>();
-            for (Object[] row : rowData) {
-                if ((Boolean) row[1]) {
-                    if (row[2] == null) { 
-                        row[2] = 0.0f;
-                    }
-                    if (row[3] == null) { 
-                        row[3] = 0.0f;
-                    }
-                    if (row[4] == null) { 
-                        row[4] = 0.0f;
-                    }
-                    retv.put((String) row[0], 
-                            new PhysicalLocation((Float) row[2], (Float) row[3], (Float) row[4], (Boolean) row[5]));
-                }
-            }
-            return retv;
-        }
-
-        @Override
-        public String getColumnName(int col) {
-            return columnNames[col];
-        }
-
-        @Override
-        public int getRowCount() {
-            return rowData.length;
-        }
-
-        @Override
-        public int getColumnCount() {
-            return columnNames.length;
-        }
-
-        @Override
-        public Object getValueAt(int row, int col) {
-            return rowData[row][col];
-        }
-
-        @Override
-        public boolean isCellEditable(int row, int col) {
-            return true;
-        }
-
-        @Override
-        public void setValueAt(Object value, int row, int col) {
-            rowData[row][col] = value;
-            fireTableCellUpdated(row, col);
-        }
-
-        @Override
-        public Class<?> getColumnClass(int columnIndex) {
-            switch (columnIndex) {
-                case 1:
-                case 5:
-                    return Boolean.class;
-                case 4:
-                case 3:
-                case 2:
-                    return Float.class;
-                case 0:
-                default:
-                    return super.getColumnClass(columnIndex);
-            }
-        }
-    }
-
-    /**
-     * Private class for use as TableModel for Listener Locations
-     */
-    static private class ListenerTableModel extends AbstractTableModel {
-
-        // These get internationalized at runtime in the constructor below.
-        private String[] columnNames = new String[7];
-        private Object[][] rowData = null;
-
-        public ListenerTableModel(Object[][] dataMap) {
-            super();
-            // Use i18n-ized column titles.
-            columnNames[0] = Bundle.getMessage("Name");
-            columnNames[1] = Bundle.getMessage("FieldTableUseColumn");
-            columnNames[2] = Bundle.getMessage("FieldTableXColumn");
-            columnNames[3] = Bundle.getMessage("FieldTableYColumn");
-            columnNames[4] = Bundle.getMessage("FieldTableZColumn");
-            columnNames[5] = Bundle.getMessage("FieldTableBearingColumn");
-            columnNames[6] = Bundle.getMessage("FieldTableAzimuthColumn");
-            rowData = dataMap;
-        }
-
-        @SuppressWarnings("unused")
-        public HashMap<String, ListeningSpot> getDataMap() {
-            // Includes only the ones with the checkbox made
-            HashMap<String, ListeningSpot> retv = new HashMap<>();
-            ListeningSpot spot = null;
-            for (Object[] row : rowData) {
-                if ((Boolean) row[1]) {
-                    spot = new ListeningSpot();
-                    spot.setName((String) row[0]);
-                    spot.setLocation((Double) row[2], (Double) row[3], (Double) row[4]);
-                    spot.setOrientation((Double) row[5], (Double) row[6]);
-                    retv.put((String) row[0], spot);
-                }
-            }
-            return retv;
-        }
-
-        @Override
-        public String getColumnName(int col) {
-            return columnNames[col];
-        }
-
-        @Override
-        public int getRowCount() {
-            return rowData.length;
-        }
-
-        @Override
-        public int getColumnCount() {
-            return columnNames.length;
-        }
-
-        @Override
-        public Object getValueAt(int row, int col) {
-            return rowData[row][col];
-        }
-
-        @Override
-        public boolean isCellEditable(int row, int col) {
-            return true;
-        }
-
-        @Override
-        public void setValueAt(Object value, int row, int col) {
-            rowData[row][col] = value;
-            fireTableCellUpdated(row, col);
-        }
-
-        @Override
-        public Class<?> getColumnClass(int columnIndex) {
-            switch (columnIndex) {
-                case 1:
-                    return Boolean.class;
-                case 6:
-                case 5:
-                case 4:
-                case 3:
-                case 2:
-                    return Double.class;
-                case 0:
-                default:
-                    return super.getColumnClass(columnIndex);
-            }
-        }
-    }
 }

--- a/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsTableModel.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsTableModel.java
@@ -1,0 +1,310 @@
+package jmri.jmrit.vsdecoder.swing;
+
+import java.util.HashMap;
+import java.util.Set;
+import javax.swing.table.AbstractTableModel;
+import jmri.jmrit.vsdecoder.listener.ListeningSpot;
+import jmri.util.PhysicalLocation;
+
+/**
+ * Table Models for Loading of Reporters, Blocks, Locations and Listener.
+ *
+ * <hr>
+ * This file is part of JMRI.
+ * <p>
+ * JMRI is free software; you can redistribute it and/or modify it under 
+ * the terms of version 2 of the GNU General Public License as published 
+ * by the Free Software Foundation. See the "COPYING" file for a copy
+ * of this license.
+ * <p>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
+ * for more details.
+ *
+ * @author Klaus Killinger Copyright (C) 2020
+ */
+class ManageLocationsTableModel {
+
+    // Note: the four tables covered here do not have the same structure
+    static final int SYSNAMECOL     = 0;             // system name
+    static final int NAMECOL        = 0;             // name (special case for Operations Locations)
+    static final int USERNAMECOL    = 1;             // user name
+    static final int USECOL         = 1;             // usage flag for Operations Locations and Listener
+    static final int XCOL           = 2;             // X value
+    static final int YCOL           = 3;             // Y value
+    static final int ZCOL           = 4;             // Z value
+    static final int TUNNELCOL      = 5;             // tunnel flag (not for Listener)
+    static final int BEARINGCOL     = 5;             // bearing attribute (Listener only)
+    static final int AZIMUTHCOL     = 6;             // azimuth attribute (Listener only)
+
+    /**
+     * class to serve as TableModel for Reporters and Blocks
+     */
+    static class ReporterBlockTableModel extends AbstractTableModel {
+
+        // These get internationalized at runtime in the constructor below.
+        private String[] columnNames = new String[7];
+        private Object[][] rowData;
+
+        public ReporterBlockTableModel(Object[][] dataMap) {
+            super();
+            // Use i18n-ized column titles.
+            columnNames[SYSNAMECOL] = Bundle.getMessage("Name");
+            columnNames[USERNAMECOL] = Bundle.getMessage("ColumnUserName");
+            columnNames[USECOL + 1] = Bundle.getMessage("FieldTableUseColumn");
+            columnNames[XCOL + 1] = Bundle.getMessage("FieldTableXColumn");
+            columnNames[YCOL + 1] = Bundle.getMessage("FieldTableYColumn");
+            columnNames[ZCOL + 1] = Bundle.getMessage("FieldTableZColumn");
+            columnNames[TUNNELCOL + 1] = Bundle.getMessage("FieldTableIsTunnelColumn");
+            rowData = dataMap;
+        }
+
+        public HashMap<String, PhysicalLocation> getDataMap() {
+            // Includes only the ones with the checkbox made
+            HashMap<String, PhysicalLocation> retv = new HashMap<>();
+            for (Object[] row : rowData) {
+                if ((Boolean) row[USECOL + 1]) {
+                    if (row[XCOL + 1] == null) { 
+                        row[XCOL + 1] = 0.0f;
+                    }
+                    if (row[YCOL + 1] == null) { 
+                        row[YCOL + 1] = 0.0f;
+                    }
+                    if (row[ZCOL + 1] == null) { 
+                        row[ZCOL + 1] = 0.0f;
+                    }
+                    retv.put((String) row[SYSNAMECOL], 
+                            new PhysicalLocation((Float) row[XCOL + 1], (Float) row[YCOL + 1], (Float) row[ZCOL + 1], (Boolean) row[TUNNELCOL + 1]));
+                }
+            }
+            return retv;
+        }
+
+        @Override
+        public String getColumnName(int col) {
+            return columnNames[col];
+        }
+
+        @Override
+        public int getRowCount() {
+            return rowData.length;
+        }
+
+        @Override
+        public int getColumnCount() {
+            return columnNames.length;
+        }
+
+        @Override
+        public Object getValueAt(int row, int col) {
+            return rowData[row][col];
+        }
+
+        @Override
+        public boolean isCellEditable(int row, int col) {
+            return true;
+        }
+
+        @Override
+        public void setValueAt(Object value, int row, int col) {
+            rowData[row][col] = value;
+            fireTableCellUpdated(row, col);
+        }
+
+        @Override
+        public Class<?> getColumnClass(int columnIndex) {
+            switch (columnIndex) {
+                case USECOL + 1:
+                case TUNNELCOL + 1:
+                    return Boolean.class;
+                case ZCOL + 1:
+                case YCOL + 1:
+                case XCOL + 1:
+                    return Float.class;
+                case USERNAMECOL:
+                case SYSNAMECOL:
+                default:
+                    return super.getColumnClass(columnIndex);
+            }
+        }
+    }
+
+    /**
+     * class to serve as TableModel for Ops Locations
+     */
+    static class LocationTableModel extends AbstractTableModel {
+
+        // These get internationalized at runtime in the constructor below.
+        private String[] columnNames = new String[6];
+        private Object[][] rowData;
+
+        public LocationTableModel(Object[][] dataMap) {
+            super();
+            // Use i18n-ized column titles.
+            columnNames[NAMECOL] = Bundle.getMessage("Name");
+            columnNames[USECOL] = Bundle.getMessage("FieldTableUseColumn");
+            columnNames[XCOL] = Bundle.getMessage("FieldTableXColumn");
+            columnNames[YCOL] = Bundle.getMessage("FieldTableYColumn");
+            columnNames[ZCOL] = Bundle.getMessage("FieldTableZColumn");
+            columnNames[TUNNELCOL] = Bundle.getMessage("FieldTableIsTunnelColumn");
+            rowData = dataMap;
+        }
+
+        public HashMap<String, PhysicalLocation> getDataMap() {
+            // Includes only the ones with the checkbox made
+            HashMap<String, PhysicalLocation> retv = new HashMap<>();
+            for (Object[] row : rowData) {
+                if ((Boolean) row[USECOL]) {
+                    if (row[XCOL] == null) { 
+                        row[XCOL] = 0.0f;
+                    }
+                    if (row[YCOL] == null) { 
+                        row[YCOL] = 0.0f;
+                    }
+                    if (row[ZCOL] == null) { 
+                        row[ZCOL] = 0.0f;
+                    }
+                    retv.put((String) row[NAMECOL], 
+                            new PhysicalLocation((Float) row[XCOL], (Float) row[YCOL], (Float) row[ZCOL], (Boolean) row[TUNNELCOL]));
+                }
+            }
+            return retv;
+        }
+
+        @Override
+        public String getColumnName(int col) {
+            return columnNames[col];
+        }
+
+        @Override
+        public int getRowCount() {
+            return rowData.length;
+        }
+
+        @Override
+        public int getColumnCount() {
+            return columnNames.length;
+        }
+
+        @Override
+        public Object getValueAt(int row, int col) {
+            return rowData[row][col];
+        }
+
+        @Override
+        public boolean isCellEditable(int row, int col) {
+            return true;
+        }
+
+        @Override
+        public void setValueAt(Object value, int row, int col) {
+            rowData[row][col] = value;
+            fireTableCellUpdated(row, col);
+        }
+
+        @Override
+        public Class<?> getColumnClass(int columnIndex) {
+            switch (columnIndex) {
+                case USECOL:
+                case TUNNELCOL:
+                    return Boolean.class;
+                case ZCOL:
+                case YCOL:
+                case XCOL:
+                    return Float.class;
+                case NAMECOL:
+                default:
+                    return super.getColumnClass(columnIndex);
+            }
+        }
+    }
+
+    /**
+     * class for use as TableModel for Listener Locations
+     */
+    static class ListenerTableModel extends AbstractTableModel {
+
+        // These get internationalized at runtime in the constructor below.
+        private String[] columnNames = new String[7];
+        private Object[][] rowData = null;
+
+        public ListenerTableModel(Object[][] dataMap) {
+            super();
+            // Use i18n-ized column titles.
+            columnNames[NAMECOL] = Bundle.getMessage("Name");
+            columnNames[USECOL] = Bundle.getMessage("FieldTableUseColumn");
+            columnNames[XCOL] = Bundle.getMessage("FieldTableXColumn");
+            columnNames[YCOL] = Bundle.getMessage("FieldTableYColumn");
+            columnNames[ZCOL] = Bundle.getMessage("FieldTableZColumn");
+            columnNames[BEARINGCOL] = Bundle.getMessage("FieldTableBearingColumn");
+            columnNames[AZIMUTHCOL] = Bundle.getMessage("FieldTableAzimuthColumn");
+            rowData = dataMap;
+        }
+
+        @SuppressWarnings("unused")
+        public HashMap<String, ListeningSpot> getDataMap() {
+            // Includes only the ones with the checkbox made
+            HashMap<String, ListeningSpot> retv = new HashMap<>();
+            ListeningSpot spot = null;
+            for (Object[] row : rowData) {
+                if ((Boolean) row[USECOL]) {
+                    spot = new ListeningSpot();
+                    spot.setName((String) row[NAMECOL]);
+                    spot.setLocation((Double) row[XCOL], (Double) row[YCOL], (Double) row[ZCOL]);
+                    spot.setOrientation((Double) row[BEARINGCOL], (Double) row[AZIMUTHCOL]);
+                    retv.put((String) row[NAMECOL], spot);
+                }
+            }
+            return retv;
+        }
+
+        @Override
+        public String getColumnName(int col) {
+            return columnNames[col];
+        }
+
+        @Override
+        public int getRowCount() {
+            return rowData.length;
+        }
+
+        @Override
+        public int getColumnCount() {
+            return columnNames.length;
+        }
+
+        @Override
+        public Object getValueAt(int row, int col) {
+            return rowData[row][col];
+        }
+
+        @Override
+        public boolean isCellEditable(int row, int col) {
+            return true;
+        }
+
+        @Override
+        public void setValueAt(Object value, int row, int col) {
+            rowData[row][col] = value;
+            fireTableCellUpdated(row, col);
+        }
+
+        @Override
+        public Class<?> getColumnClass(int columnIndex) {
+            switch (columnIndex) {
+                case USECOL:
+                    return Boolean.class;
+                case AZIMUTHCOL:
+                case BEARINGCOL:
+                case ZCOL:
+                case YCOL:
+                case XCOL:
+                    return Double.class;
+                case NAMECOL:
+                default:
+                    return super.getColumnClass(columnIndex);
+            }
+        }
+    }
+}

--- a/java/test/jmri/jmrit/vsdecoder/swing/ManageLocationsTableModelTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/swing/ManageLocationsTableModelTest.java
@@ -1,0 +1,31 @@
+package jmri.jmrit.vsdecoder.swing;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+
+/**
+ * Test simple functioning of ManageLocationsTableModel
+ *
+ * Based on ThrottlesTableModelTest by Paul Bender
+ * @author Klaus Killinger Copyright (C) 2020
+ */
+public class ManageLocationsTableModelTest {
+
+    @Test
+    public void testCtor() {
+        ManageLocationsTableModel frame = new ManageLocationsTableModel();
+        Assert.assertNotNull("exists", frame);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+}


### PR DESCRIPTION
Use symbolic constants instead of distributed integer constants for columns. 
See [this comment](https://github.com/JMRI/JMRI/pull/8769#issuecomment-653787747) for the background.

No functional changes.