### PR TITLE
Reduce default output interval CAN Connections

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -66,7 +66,7 @@
 
         <h4>MERG CBUS</h4>
             <ul>
-                <li></li>
+                <li>Default Output Interval reduced to 100ms.</li>
             </ul>
 
         <h4>MQTT</h4>
@@ -91,7 +91,7 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a></h4>
             <ul>
-                <li></li>
+                <li>Default Output Interval reduced to 100ms.</li>
             </ul>
 
         <h4>RFID</h4>

--- a/java/src/jmri/SystemConnectionMemo.java
+++ b/java/src/jmri/SystemConnectionMemo.java
@@ -151,6 +151,13 @@ public interface SystemConnectionMemo extends jmri.beans.PropertyChangeProvider 
      * @return the output interval time in ms
      */
     int getOutputInterval();
+    
+    /**
+     * Get the Default connection specific OutputInterval to wait between/before commands
+     * are sent.
+     * @return the default output interval time in ms.
+     */
+    int getDefaultOutputInterval();
 
     void setOutputInterval(int newInterval);
 

--- a/java/src/jmri/jmrix/AbstractNetworkConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractNetworkConnectionConfig.java
@@ -393,14 +393,16 @@ abstract public class AbstractNetworkConnectionConfig extends AbstractConnection
 
         // connection (memo) specific output command delay option, calls jmri.jmrix.SystemConnectionMemo#setOutputInterval(int)
         outputIntervalLabel = new JLabel(Bundle.getMessage("OutputIntervalLabel"));
-        outputIntervalSpinner.setToolTipText(Bundle.getMessage("OutputIntervalTooltip"));
+        outputIntervalSpinner.setToolTipText(Bundle.getMessage("OutputIntervalTooltip",
+                adapter.getSystemConnectionMemo().getDefaultOutputInterval(),adapter.getManufacturer()));
         JTextField field = ((JSpinner.DefaultEditor) outputIntervalSpinner.getEditor()).getTextField();
         field.setColumns(6);
         outputIntervalSpinner.setMaximumSize(outputIntervalSpinner.getPreferredSize()); // set spinner JTextField width
         outputIntervalSpinner.setValue(adapter.getSystemConnectionMemo().getOutputInterval());
         outputIntervalSpinner.setEnabled(true);
         outputIntervalReset.addActionListener((ActionEvent event) -> {
-            outputIntervalSpinner.setValue(250);
+            outputIntervalSpinner.setValue(adapter.getSystemConnectionMemo().getDefaultOutputInterval());
+            adapter.getSystemConnectionMemo().setOutputInterval(adapter.getSystemConnectionMemo().getDefaultOutputInterval());
         });
 
         showAutoConfig.setFont(showAutoConfig.getFont().deriveFont(9f));

--- a/java/src/jmri/jmrix/AbstractSerialConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractSerialConnectionConfig.java
@@ -408,16 +408,16 @@ abstract public class AbstractSerialConnectionConfig extends AbstractConnectionC
         }
         // connection (memo) specific output command delay option, calls jmri.jmrix.SystemConnectionMemo#setOutputInterval(int)
         outputIntervalLabel = new JLabel(Bundle.getMessage("OutputIntervalLabel"));
-        outputIntervalSpinner.setToolTipText(Bundle.getMessage("OutputIntervalTooltip"));
+        outputIntervalSpinner.setToolTipText(Bundle.getMessage("OutputIntervalTooltip",
+                adapter.getSystemConnectionMemo().getDefaultOutputInterval(),adapter.getManufacturer()));
         JTextField field = ((JSpinner.DefaultEditor) outputIntervalSpinner.getEditor()).getTextField();
         field.setColumns(6);
         outputIntervalSpinner.setMaximumSize(outputIntervalSpinner.getPreferredSize()); // set spinner JTextField width
         outputIntervalSpinner.setValue(adapter.getSystemConnectionMemo().getOutputInterval());
         outputIntervalSpinner.setEnabled(true);
         outputIntervalReset.addActionListener((ActionEvent event) -> {
-            int defaultInterval = 250; // 250 was previously hard coded for Routes interval
-            outputIntervalSpinner.setValue(defaultInterval);
-            adapter.getSystemConnectionMemo().setOutputInterval(defaultInterval);
+            outputIntervalSpinner.setValue(adapter.getSystemConnectionMemo().getDefaultOutputInterval());
+            adapter.getSystemConnectionMemo().setOutputInterval(adapter.getSystemConnectionMemo().getDefaultOutputInterval());
         });
 
         showAdvanced.setFont(showAdvanced.getFont().deriveFont(9f));

--- a/java/src/jmri/jmrix/DefaultSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/DefaultSystemConnectionMemo.java
@@ -350,7 +350,16 @@ public abstract class DefaultSystemConnectionMemo extends Bean implements System
      * <p>
      * Change from e.g. connection config dialog and scripts using {@link #setOutputInterval(int)}
      */
-    private int _interval = 250;
+    private int _interval = getDefaultOutputInterval();
+    
+    /**
+     * Default interval 250ms.
+     * {@inheritDoc}
+     */
+    @Override
+    public int getDefaultOutputInterval(){
+        return 250;
+    }
 
     /**
      * Get the connection specific OutputInterval (in ms) to wait between/before commands

--- a/java/src/jmri/jmrix/JmrixBundle.properties
+++ b/java/src/jmri/jmrix/JmrixBundle.properties
@@ -102,7 +102,7 @@ ConnectionNameDialog    = Connection Name {0} is already assigned
 TipBaudRateFixed        = The baud rate is fixed for this protocol
 TipBaudRateMatch        = Must match the baud rate setting of your hardware
 OutputIntervalLabel     = Output Interval (ms):
-OutputIntervalTooltip   = <html>Enter the additional interval in milliseconds to wait before sending a following (Turnout) output Command<br>Default = 250 ms<br>Interval applies to this connection only, used in Routes and MatrixSignalMasts</html>
+OutputIntervalTooltip   = <html>Enter the additional interval in milliseconds to wait before sending a following (Turnout) output Command<br>Default = {0} ms<br>Interval applies to this {1} connection only, used in Routes and MatrixSignalMasts</html>
 
 # port controller reconnect
 ReconnectFail           = Failed to reconnect to port {0}

--- a/java/src/jmri/jmrix/JmrixBundle_de.properties
+++ b/java/src/jmri/jmrix/JmrixBundle_de.properties
@@ -120,7 +120,7 @@ BaudRateLabel           = Baudzahl:
 TipBaudRateFixed        = Die Baudzahl f\u00fcr dieses Protokoll is nicht einstellbar
 TipBaudRateMatch        = Soll die Baudzahl des Hardwaremoduls gleichen
 OutputIntervalLabel     = Ausgangsintervall (ms):
-OutputIntervalTooltip   = <html>Additioneller Pause in Millisekunden bevor das n\u00e4chste Schaltbericht versanden wird, zB. f\u00fcr Weichenstellung.<br>Normalwert = 250 ms<br>Intervall gilt nur f\u00fcr diese Verbindung, u.a. genutzt von Weichenstra\u00dfen und MatrixSignalMasten</html>
+OutputIntervalTooltip   = <html>Additioneller Pause in Millisekunden bevor das n\u00e4chste Schaltbericht versanden wird, zB. f\u00fcr Weichenstellung.<br>Normalwert = {0} ms<br>Intervall gilt nur f\u00fcr diese {1} Verbindung, u.a. genutzt von Weichenstra\u00dfen und MatrixSignalMasten</html>
 
 # serverframe shared items
 #Server status label

--- a/java/src/jmri/jmrix/JmrixBundle_nl.properties
+++ b/java/src/jmri/jmrix/JmrixBundle_nl.properties
@@ -99,7 +99,7 @@ ConnectionConcentratorRange = Concentratorbereik:
 TipBaudRateFixed        = Voor dit protocol ligt de baud rate vast
 TipBaudRateMatch        = Dient overeen te komen met de baud rate instelling van de hardware
 OutputIntervalLabel     = Uitgangsinterval (ms):
-OutputIntervalTooltip   = <html>Extra wachttijd in millisecondes voordat volgende instructie naar een (andere) uitgang, bijv. wissel, wordt verstuurd<br>Standaardwaarde = 250 ms<br>Interval instelbaar per verbinding, wordt o.a. gebruikt voor Wisselstraten en MatrixSeinMasten</html>
+OutputIntervalTooltip   = <html>Extra wachttijd in millisecondes voordat volgende instructie naar een (andere) uitgang, bijv. wissel, wordt verstuurd<br>Standaardwaarde = {0} ms<br>Interval instelbaar per {1} verbinding, wordt o.a. gebruikt voor Wisselstraten en MatrixSeinMasten</html>
 
 # serverframe shared items
 #Server status label

--- a/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
@@ -248,6 +248,15 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
     public boolean isRestartRequired() {
         return super.isRestartRequired() || protocolOptionsChanged;
     }
+    
+    /**
+     * Custom interval of 100ms.
+     * {@inheritDoc}
+     */
+    @Override
+    public int getDefaultOutputInterval(){
+        return 100;
+    }
 
     /**
      * {@inheritDoc }

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
@@ -354,6 +354,19 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         Assert.assertEquals("No auto system names",0,tcis.numListeners());
     }
     
+    @Test
+    @Override
+    public void testSetAndGetOutputInterval() {
+        Assert.assertEquals("default outputInterval", 100, l.getOutputInterval());
+        l.getMemo().setOutputInterval(21);
+        Assert.assertEquals("new outputInterval in memo", 21, l.getMemo().getOutputInterval()); // set & get in memo
+        Assert.assertEquals("new outputInterval via manager", 21, l.getOutputInterval()); // get via turnoutManager
+        l.setOutputInterval(50);
+        Assert.assertEquals("new outputInterval from manager", 50, l.getOutputInterval()); // interval stored in AbstractTurnoutManager
+        Assert.assertEquals("new outputInterval from manager", 50, l.getMemo().getOutputInterval()); // get from memo
+    }
+
+    
     private TrafficControllerScaffold tcis;
     private CanSystemConnectionMemo memo;
     

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutManagerTest.java
@@ -55,6 +55,18 @@ public class OlcbTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         Assert.assertNotNull("real object returned ", t);
         Assert.assertSame("system name correct ", t, l.getBySystemName(getSystemName(getNumToTest1())));
     }
+    
+    @Test
+    @Override
+    public void testSetAndGetOutputInterval() {
+        Assert.assertEquals("default outputInterval", 100, l.getOutputInterval());
+        l.getMemo().setOutputInterval(21);
+        Assert.assertEquals("new outputInterval in memo", 21, l.getMemo().getOutputInterval()); // set & get in memo
+        Assert.assertEquals("new outputInterval via manager", 21, l.getOutputInterval()); // get via turnoutManager
+        l.setOutputInterval(50);
+        Assert.assertEquals("new outputInterval from manager", 50, l.getOutputInterval()); // interval stored in AbstractTurnoutManager
+        Assert.assertEquals("new outputInterval from manager", 50, l.getMemo().getOutputInterval()); // get from memo
+    }
 
     @Override
     @BeforeEach


### PR DESCRIPTION
Adds method int getDefaultOutputInterval() to SystemConnectionMemo.
Default memo is 250ms, CAN 100ms.