### PR TITLE
Remove the loco from DCCppThrottleManagers internal list of throttles on last release

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
@@ -167,6 +167,7 @@ public class DCCppThrottleManager extends AbstractThrottleManager implements DCC
             tc.getCommandStation().releaseRegister(t.getLocoAddress().getNumber());
             if (t instanceof DCCppThrottle) {
                 DCCppThrottle lnt = (DCCppThrottle) t;
+                throttles.remove(lnt.getLocoAddress()); // remove from throttles map.
                 lnt.throttleDispose();
                 return true;
             }

--- a/java/test/jmri/jmrix/dccpp/DCCppThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppThrottleManagerTest.java
@@ -1,8 +1,16 @@
 package jmri.jmrix.dccpp;
 
 import jmri.util.JUnitUtil;
+import jmri.DccLocoAddress;
+import jmri.DccThrottle;
+import jmri.InstanceManager;
+import jmri.ThrottleListener;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * DCCppThrottleManagerTest.java
@@ -14,22 +22,68 @@ import org.junit.jupiter.api.*;
  */
 public class DCCppThrottleManagerTest extends jmri.managers.AbstractThrottleManagerTestBase {
 
+    private DccThrottle throttle;
+    boolean failedThrottleRequest = false;
+    DCCppCommandStation cs = null;
+
     @Override
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        DCCppCommandStation cs = new DCCppCommandStation();
+        cs = new DCCppCommandStation();
         cs.setCommandStationMaxNumSlots(12); // the "traditional" value for DCC++
         DCCppInterfaceScaffold tc = new DCCppInterfaceScaffold(cs);
         tm = new DCCppThrottleManager(new DCCppSystemConnectionMemo(tc));
     }
 
+    @Test
+    public void testCreateLnThrottleRunAndRelease() {
+        ThrottleListener throtListen = new ThrottleListener() {
+            @Override
+            public void notifyThrottleFound(DccThrottle t) {
+                throttle = t;
+                log.error("created a throttle");
+            }
+
+            @Override
+            public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
+                log.error("Throttle request failed for {} because {}", address, reason);
+                failedThrottleRequest = true;
+            }
+
+            @Override
+            public void notifyDecisionRequired(jmri.LocoAddress address, DecisionType question) {
+                // this is a never-stealing impelementation.
+                InstanceManager.throttleManagerInstance().cancelThrottleRequest(address, this);
+            }
+        };
+        DccLocoAddress locoAddress = new DccLocoAddress(1203,true);
+        tm.requestThrottle(1203, throtListen,true);
+
+        Assert.assertNotNull("have created a throttle", throttle);
+        Assert.assertEquals("is DCCppThrottle", throttle.getClass(), jmri.jmrix.dccpp.DCCppThrottle.class);
+        Assert.assertEquals(true, (((DCCppThrottleManager)tm).throttles.containsKey(locoAddress))); // now you see it
+        Assert.assertEquals(1,tm.getThrottleUsageCount(locoAddress));
+        Assert.assertEquals(1, cs.getRegisterNum(1203));  // now you see it
+        jmri.util.JUnitAppender.assertErrorMessage("created a throttle");
+
+        tm.releaseThrottle(throttle, throtListen);
+        Assert.assertEquals(0,tm.getThrottleUsageCount(locoAddress));
+        Assert.assertEquals(false, (((DCCppThrottleManager)tm).throttles.containsKey(locoAddress))); //now you dont
+        Assert.assertEquals(-1, cs.getRegisterNum(1203)); //now you dont
+
+    }
+
     @AfterEach
     public void tearDown() {
+        tm =null;
+        cs = null;
         JUnitUtil.resetWindows(false, false);
         JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
 
     }
+
+    private final static Logger log = LoggerFactory.getLogger(DCCppThrottleManagerTest.class);
 
 }


### PR DESCRIPTION
Current when a DCCppThrottle is released it is cleared from the register but not the has map of DCCppThrottles, so when it asks for that address again it ives it a registry number of negative 1.
This should fix this.