### PR TITLE
Provide a hook to shutdownJMRI and the OS

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -964,16 +964,6 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
     }
 
     /**
-     * The application decided to restart, handle that.
-     *
-     * @return true if successfully ran all shutdown tasks and can quit with code shutdownOS; false
-     *         otherwise
-     */
-    static public boolean handleShutdownSystem() {
-        return AppsBase.handleShutdownSystem();
-    }
-
-    /**
      * Set up the configuration file name at startup.
      * <p>
      * The Configuration File name variable holds the name used to load the

--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -964,6 +964,16 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
     }
 
     /**
+     * The application decided to restart, handle that.
+     *
+     * @return true if successfully ran all shutdown tasks and can quit with code shutdownOS; false
+     *         otherwise
+     */
+    static public boolean handleShutdownSystem() {
+        return AppsBase.handleShutdownSystem();
+    }
+
+    /**
      * Set up the configuration file name at startup.
      * <p>
      * The Configuration File name variable holds the name used to load the

--- a/java/src/apps/AppsBase.java
+++ b/java/src/apps/AppsBase.java
@@ -422,4 +422,21 @@ public abstract class AppsBase {
         }
         return false;
     }
+
+    /**
+     * The application decided to shutdown  jmri and OS, handle that.
+     *
+     * @return true if successfully ran all shutdown tasks and can quit with code shudownOS; false
+     *         otherwise
+     */
+    static public boolean handleShutdownSystem() {
+        log.debug("Start handleRestart");
+        try {
+            return InstanceManager.getDefault(jmri.ShutDownManager.class).shutdownOS();
+        } catch (Exception e) {
+            log.error("Continuing after error in shutDownSystem", e);
+        }
+        return false;
+    }
+
 }

--- a/java/src/apps/AppsBase.java
+++ b/java/src/apps/AppsBase.java
@@ -423,20 +423,5 @@ public abstract class AppsBase {
         return false;
     }
 
-    /**
-     * The application decided to shutdown  jmri and OS, handle that.
-     *
-     * @return true if successfully ran all shutdown tasks and can quit with code shudownOS; false
-     *         otherwise
-     */
-    static public boolean handleShutdownSystem() {
-        log.debug("Start handleRestart");
-        try {
-            return InstanceManager.getDefault(jmri.ShutDownManager.class).shutdownOS();
-        } catch (Exception e) {
-            log.error("Continuing after error in shutDownSystem", e);
-        }
-        return false;
-    }
 
 }

--- a/java/src/jmri/ShutDownManager.java
+++ b/java/src/jmri/ShutDownManager.java
@@ -120,6 +120,22 @@ public interface ShutDownManager extends PropertyChangeProvider {
     public boolean restart();
 
     /**
+     * Run the shutdown tasks, and then terminate the program with status 200 if
+     * not aborted. Does not return under normal circumstances. Returns false if
+     * the shutdown was aborted by the user, in which case the program should
+     * continue to operate.
+     * <p>
+     * By exiting the program with status 200, the batch file (MS Windows) or
+     * shell script (Linux/macOS/UNIX) can catch the exit status and shutdown the OS
+     * <p>
+     * <b>NOTE</b> If the macOS {@literal application->quit} menu item is used,
+     * this must return false to abort the shutdown.
+     *
+     * @return false if any shutdown task aborts restarting the application
+     */
+    public boolean shutdownOS();
+
+    /**
      * Run the shutdown tasks, and then terminate the program with status 0 if
      * not aborted. Does not return under normal circumstances. Returns false if
      * the shutdown was aborted by the user, in which case the program should

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -193,6 +193,15 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @SuppressFBWarnings(value = "DM_EXIT", justification = "OK to directly exit standalone main")
+    @Override
+    public boolean shutdownOS() {
+        return shutdown(200, true);
+    }
+
+    /**
      * First asks the shutdown tasks if shutdown is allowed. If not return
      * false.
      * <p>

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -561,6 +561,6 @@ while [ "${EXIT_STATUS}" -eq "${RESTART_CODE}" ] ; do
     [ -n "${DEBUG}" ] && echo Exit Status: "${EXIT_STATUS}" | tee -a ${launcher_log}
 done
 if [ $EXIT_STATUS -eq 200 ] ; then
-    sudo shutdown -h 
+    sudo shutdown -h now
 fi
 exit $EXIT_STATUS

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -560,5 +560,7 @@ while [ "${EXIT_STATUS}" -eq "${RESTART_CODE}" ] ; do
     EXIT_STATUS=$?
     [ -n "${DEBUG}" ] && echo Exit Status: "${EXIT_STATUS}" | tee -a ${launcher_log}
 done
-
+if [ $EXIT_STATUS -eq 200 ] ; then
+    sudo shutdown -h 
+fi
 exit $EXIT_STATUS


### PR DESCRIPTION
@mstevetodd 
This will shutdown and leave a return code of 200, which the script will see and run "sudo shutdown -h"
I noticed the restart uses a return code of 100, which can be returned by the jvm as an error code!
Its basically the same as shutdown, but with the return code.
This differs from ^C or kill -s HUP pid, in that if the user cancels when prompted due to unsaved changes it will honour that. ^C ignores the user response. All ways of cancelling will hang on a user respose if unsaved changes, which isnt good.