### PR TITLE
Fix baud rate not being set

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -4,6 +4,11 @@
           <li></li>
         </ul>
 
+        <h4>Acela CTI</h4>
+            <ul>
+                <li>Fixed issue unable to initialise adapter</li>
+            </ul>
+
 	    <h4>Anyma DMX512</h4>
             <ul>
                 <li></li>

--- a/java/src/jmri/jmrix/acela/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/acela/serialdriver/SerialDriverAdapter.java
@@ -149,6 +149,11 @@ public class SerialDriverAdapter extends AcelaPortController {
         return new int[]{9600};
     }
 
+    @Override
+    public int defaultBaudIndex() {
+        return 0;
+    }
+
     // private control members
     private boolean opened = false;
     InputStream serialStream = null;


### PR DESCRIPTION
Seems that the Acela CTI interface configuration wasn't setting the default baud rate combo box correctly.

As reported in https://groups.io/g/jmriusers/message/179896