### PR TITLE
Fix link to JavaDoc classes in Sidebar

### DIFF
--- a/help/en/html/doc/Technical/Sidebar.shtml
+++ b/help/en/html/doc/Technical/Sidebar.shtml
@@ -46,7 +46,7 @@
 				<ul class="navigation">
 				<li><a href="/JavaDoc/doc/index-files/index-1.html">Name Index</a></li>
 				<li><a href="/JavaDoc/doc/index.html">Packages</a></li>
-				<li><a href="/JavaDoc/doc/allclasses-frame.html">Classes</a></li>
+				<li><a href="/JavaDoc/doc/allclasses-index.html">Classes</a></li>
 				</ul>
 			</ul>
 		</dd>


### PR DESCRIPTION
Found by @DanielBoudreau 