### PR TITLE
Two new ESU models, one name correction.

### DIFF
--- a/xml/decoders/ESU_LokPilot5.xml
+++ b/xml/decoders/ESU_LokPilot5.xml
@@ -22,6 +22,8 @@
     <version author="Dave Heap" version="3" lastUpdated="20200807"/>
     <!-- ver4 disable Reset to Defaults -->
     <version author="Dave Heap" version="4" lastUpdated="20200818"/>
+    <!-- ver5 replace "LokPilot 5 micro DCC Next18" with "LokPilot 5 Micro Next18 DCC" (probably transcription error) -->
+    <version author="Dave Heap" version="4" lastUpdated="20200924"/>
     <decoder>
         <family name="ESU LokPilot 5" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
             <model model="LokPilot 5" maxFnNum="31" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554600">
@@ -39,7 +41,7 @@
             <model model="LokPilot 5 micro Next18" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554604">
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
-            <model model="LokPilot 5 micro DCC Next18" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554605">
+            <model model="LokPilot 5 Micro Next18 DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554605">
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
             <model model="LokPilot 5 L" maxFnNum="31" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554609">
@@ -109,6 +111,9 @@
             </model>
             <model model="LokPilot 5 MKL DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554608">
                 <size length="51.0" width="40.0" height="14.0" units="mm"/>
+            </model>
+            <model show="no" model="LokPilot 5 micro DCC Next18" replacementModel="LokPilot 5 Micro Next18 DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="33554605">
+                <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
             <xi:include href="http://jmri.org/xml/decoders/esu/v5lpOutputLabels.xml"/>
             <functionlabels>

--- a/xml/decoders/ESU_LokSound5.xml
+++ b/xml/decoders/ESU_LokSound5.xml
@@ -19,11 +19,13 @@
     <!-- ver3 updates for new firmware and refactor -->
     <!-- ver4 updates for F29-F31 -->
     <!-- ver5 disable Reset to Defaults -->
+    <!-- ver6 add "LokSound 5 micro E24 DCC" and "LokSound 5 micro KATO" -->
     <version author="Dave Heap" version="1" lastUpdated="20190507"/>
     <version author="Dave Heap" version="2" lastUpdated="20200410"/>
     <version author="Dave Heap" version="3" lastUpdated="20200726"/>
     <version author="Dave Heap" version="4" lastUpdated="20200807"/>
     <version author="Dave Heap" version="5" lastUpdated="20200818"/>
+    <version author="Dave Heap" version="6" lastUpdated="20200924"/>
     <decoder>
         <family name="ESU LokSound 5" mfg="Electronic Solutions Ulm GmbH" lowVersionID="255" highVersionID="255">
             <model model="LokSound 5" maxFnNum="31" numOuts="20" maxMotorCurrent="1.5A" extFnsESU="V5" productID="33554582">
@@ -41,6 +43,9 @@
             <model model="LokSound 5 micro DCC Direct" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777370">
                 <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
+            <model model="LokSound 5 micro E24 DCC" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777404">
+                <size length="21.0" width="10.6" height="4.0" units="mm"/>
+            </model>
             <model model="LokSound 5 L" maxFnNum="31" numOuts="20" maxMotorCurrent="3A" extFnsESU="V5" productID="33554589">
                 <size length="51.8" width="25.4" height="14" units="mm"/>
             </model>
@@ -52,6 +57,9 @@
             </model>
             <model model="LokSound 5 MKL" maxFnNum="31" numOuts="20" maxMotorCurrent="5A" extFnsESU="V5" productID="33554598">
                 <size length="51.0" width="40.0" height="14.0" units="mm"/>
+            </model>
+            <model model="LokSound 5 micro KATO" maxFnNum="31" numOuts="20" maxMotorCurrent="0.75A" extFnsESU="V5" productID="16777405">
+                <size length="21.0" width="10.6" height="4.0" units="mm"/>
             </model>
             <xi:include href="http://jmri.org/xml/decoders/esu/v5lsOutputLabels.xml"/>
             <functionlabels>

--- a/xml/decoders/esu/v5standardCVs.xml
+++ b/xml/decoders/esu/v5standardCVs.xml
@@ -32,14 +32,14 @@
             <label xml:lang="ca">Voltatge Alt</label>
             <tooltip xml:lang="de">Festlegung der Höchstgeschwindigkeit der Lok</tooltip>
         </variable>
-        <variable CV="6" default="88" item="Vmid" include="LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 L DCC,LokPilot 5 DCC,LokPilot 5 micro DCC,LokPilot 5 micro DCC Next18,LokPilot 5 L DCC,LokPilot 5 MKL DCC">
+        <variable CV="6" default="88" item="Vmid" include="LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 micro E24 DCC,LokSound 5 micro KATO,LokSound 5 L DCC,LokPilot 5 DCC,LokPilot 5 micro DCC,LokPilot 5 micro DCC Next18,LokPilot 5 Micro Next18 DCC,LokPilot 5 L DCC,LokPilot 5 MKL DCC">
             <decVal min="1"/>
             <label>Vmid</label>
             <label xml:lang="de">Mittengeschwindigkeit</label>
             <label xml:lang="ca">VMitjana</label>
             <tooltip xml:lang="de">Festlegung der Geschwindigkeit der Lok bei mittlerer Fahrstufe</tooltip>
         </variable>
-        <variable CV="29" mask="XXXVXXXX" item="Speed Table Definition" include="LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 L DCC,LokPilot 5 DCC,LokPilot 5 micro DCC,LokPilot 5 micro DCC Next18,LokPilot 5 L DCC,LokPilot 5 MKL DCC">
+        <variable CV="29" mask="XXXVXXXX" item="Speed Table Definition" include="LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 micro E24 DCC,LokSound 5 micro KATO,LokSound 5 L DCC,LokPilot 5 DCC,LokPilot 5 micro DCC,LokPilot 5 micro DCC Next18,LokPilot 5 Micro Next18 DCC,LokPilot 5 L DCC,LokPilot 5 MKL DCC">
             <enumVal>
                 <enumChoice choice="Use Vstart, Vmid, Vhigh">
                     <choice>Use Vstart, Vmid, Vhigh</choice>
@@ -368,7 +368,7 @@
     </variables>
     <!-- end motor-dependent variables -->
     <!-- begin AC Analog variables -->
-    <variables exclude="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 L DCC,LokPilot 5 DCC,LokPilot 5 micro DCC,LokPilot 5 micro DCC Next18,LokPilot 5 L DCC,LokPilot 5 Fx micro DCC,LokPilot 5 Fx Micro Next18 DCC,LokPilot 5 MKL DCC ">
+    <variables exclude="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 micro E24 DCC,LokSound 5 micro KATO,LokSound 5 L DCC,LokPilot 5 DCC,LokPilot 5 micro DCC,LokPilot 5 micro DCC Next18,LokPilot 5 Micro Next18 DCC,LokPilot 5 L DCC,LokPilot 5 Fx micro DCC,LokPilot 5 Fx Micro Next18 DCC,LokPilot 5 MKL DCC ">
         <variable CV="50" mask="XXXXXXXV" default="1" item="Analog (AC) Mode">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label>AC Analog Mode</label>
@@ -389,7 +389,7 @@
         </variable>
     </variables>
     <!-- end AC Analog variables -->
-    <variable CV="3" default="40" item="Accel" exclude="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 L DCC">
+    <variable CV="3" default="40" item="Accel" exclude="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 micro E24 DCC,LokSound 5 micro KATO,LokSound 5 L DCC">
         <decVal/>
         <label>Acceleration</label>
         <label xml:lang="it">Accellerazione (0-255)</label>
@@ -399,7 +399,7 @@
         <tooltip>Value multiplied by 0.25 = Time from Stop to Full Speed.</tooltip>
         <tooltip xml:lang="de">Wert multipliziert mit 0.25 = Zeit vom Stop bis Maximalgeschwindigkeit.</tooltip>
     </variable>
-    <variable CV="3" default="11" item="Accel" include="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 L DCC">
+    <variable CV="3" default="11" item="Accel" include="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 micro E24 DCC,LokSound 5 micro KATO,LokSound 5 L DCC">
         <defaultItem default="30" include="Essential Sound Unit"/>
         <decVal/>
         <label>Acceleration</label>
@@ -410,7 +410,7 @@
         <tooltip>Value multiplied by 0.896 = Time from Stop to Full Speed.</tooltip>
         <tooltip xml:lang="de">Wert multipliziert mit 0.896 = Zeit vom Stop bis Maximalgeschwindigkeit.</tooltip>
     </variable>
-    <variable CV="4" default="40" item="Decel" exclude="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 L DCC">
+    <variable CV="4" default="40" item="Decel" exclude="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 micro E24 DCC,LokSound 5 micro KATO,LokSound 5 L DCC">
         <decVal/>
         <label>Deceleration</label>
         <label xml:lang="it">Decellerazione (0-255)</label>
@@ -420,7 +420,7 @@
         <tooltip>Value multiplied by 0.25 = Time from Full Speed to Stop.</tooltip>
         <tooltip xml:lang="de">Wert multipliziert mit 0.25 = Zeit von Maximalgeschwindigkeit bis Stop</tooltip>
     </variable>
-    <variable CV="4" default="11" item="Decel" include="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 L DCC">
+    <variable CV="4" default="11" item="Decel" include="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 micro E24 DCC,LokSound 5 micro KATO,LokSound 5 L DCC">
         <defaultItem default="50" include="Essential Sound Unit"/>
         <decVal/>
         <label>Deceleration</label>
@@ -629,7 +629,7 @@
         <label xml:lang="de">DCC Protokoll</label>
         <label xml:lang="ca">Protocol DCC</label>
     </variable>
-    <variables exclude="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 L DCC">
+    <variables exclude="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 micro E24 DCC,LokSound 5 micro KATO,LokSound 5 L DCC">
         <variable CV="47" mask="XXXXXXVX" default="1" item="ESU V4 Advanced Protocols M4">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label>M4 Protocol</label>
@@ -649,7 +649,7 @@
             <label xml:lang="ca">Protocol Selectrix</label>
         </variable>
     </variables>
-    <variable CV="49" mask="VXXXVXXX" default="0" exclude="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 L DCC" item="ESU V4 Advanced Protocols Additional Addresses">
+    <variable CV="49" mask="VXXXVXXX" default="0" exclude="Essential Sound Unit,LokSound 5 DCC,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 micro E24 DCC,LokSound 5 micro KATO,LokSound 5 L DCC" item="ESU V4 Advanced Protocols Additional Addresses">
         <enumVal>
             <enumChoice choice="No additional addresses" value="0">
                 <choice>No additional addresses</choice>
@@ -820,7 +820,7 @@
         <label xml:lang="de">Serielles Protokoll für C-Sinus</label>
         <label xml:lang="ca">SUSI</label>
     </variable>
-    <variable CV="124" mask="XXXVXXXX" default="1" item="ESU AUX10/Sensor" exclude="LokSound 5 micro,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 XL,LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC,LokPilot 5 micro Next18,LokPilot 5 micro DCC Next18,Essential Sound Unit">
+    <variable CV="124" mask="XXXVXXXX" default="1" item="ESU AUX10/Sensor" exclude="LokSound 5 micro,LokSound 5 micro DCC,LokSound 5 micro DCC Direct,LokSound 5 micro E24 DCC,LokSound 5 micro KATO,LokSound 5 XL,LokPilot 5 Fx micro,LokPilot 5 Fx micro DCC,LokPilot 5 micro Next18,LokPilot 5 micro DCC Next18,LokPilot 5 Micro Next18 DCC,Essential Sound Unit">
         <enumVal>
             <enumChoice value="1">
                 <choice>Use digital wheel sensor</choice>


### PR DESCRIPTION
Added "LokSound 5 micro E24 DCC" and "LokSound 5 micro KATO".

Replaced incorrectly-named "LokPilot 5 micro DCC Next18" with "LokPilot 5 Micro Next18 DCC".