### PR TITLE
Simulate shutdown

### DIFF
--- a/java/src/jmri/ShutDownManager.java
+++ b/java/src/jmri/ShutDownManager.java
@@ -103,6 +103,23 @@ public interface ShutDownManager extends PropertyChangeProvider {
     public List<Runnable> getRunnables();
 
     /**
+     * Set whenether shutdown should be executed or only simulated.
+     * <P>
+     * This method is used by tests which want to execute the shutdown() methods
+     * without actually shutdown the computer.
+     * @param simulate true if shutdown() and execute() should only simulate
+     * execution. false otherwise.
+     */
+    public void setSimulateShutdown(boolean simulate);
+
+    /**
+     * Get whenether shutdown should be executed or only simulated.
+     * @return true if shutdown() and execute() should only simulate
+     * execution. false otherwise.
+     */
+    public boolean getSimulateShutdown();
+
+    /**
      * Run the shutdown tasks, and then terminate the program with status 100 if
      * not aborted. Does not return under normal circumstances. Returns false if
      * the shutdown was aborted by the user, in which case the program should
@@ -114,6 +131,8 @@ public interface ShutDownManager extends PropertyChangeProvider {
      * <p>
      * <b>NOTE</b> If the macOS {@literal application->quit} menu item is used,
      * this must return false to abort the shutdown.
+     * <p>
+     * If shutdown is simulated, this method throws RestartOSException.
      *
      * @return false if any shutdown task aborts restarting the application
      */
@@ -128,6 +147,8 @@ public interface ShutDownManager extends PropertyChangeProvider {
      * By exiting the program with status 210, the batch file (MS Windows) or
      * shell script (Linux/macOS/UNIX) can catch the exit status and tell the 
      * operating system to restart.
+     * <p>
+     * If shutdown is simulated, this method throws RestartException.
      *
      * @return false if any shutdown task aborts restarting the application
      */
@@ -144,6 +165,8 @@ public interface ShutDownManager extends PropertyChangeProvider {
      * <p>
      * <b>NOTE</b> If the macOS {@literal application->quit} menu item is used,
      * this must return false to abort the shutdown.
+     * <p>
+     * If shutdown is simulated, this method throws ShutdownOSException.
      *
      * @return false if any shutdown task aborts restarting the application
      */
@@ -157,6 +180,8 @@ public interface ShutDownManager extends PropertyChangeProvider {
      * <p>
      * <b>NOTE</b> If the macOS {@literal application->quit} menu item is used,
      * this must return false to abort the shutdown.
+     * <p>
+     * If shutdown is simulated, this method throws ShutdownException.
      *
      * @return false if any shutdown task aborts the shutdown or if anything
      *         goes wrong.
@@ -171,4 +196,30 @@ public interface ShutDownManager extends PropertyChangeProvider {
      * @return true if shutting down or restarting
      */
     public boolean isShuttingDown();
+    
+    
+    /**
+     * Exception thrown by restartOS() when simulating shutdown.
+     */
+    public static class RestartOSException extends RuntimeException {
+    }
+    
+    /**
+     * Exception thrown by restart() when simulating shutdown.
+     */
+    public static class RestartException extends RuntimeException {
+    }
+    
+    /**
+     * Exception thrown by shutdownOS() when simulating shutdown.
+     */
+    public static class ShutdownOSException extends RuntimeException {
+    }
+    
+    /**
+     * Exception thrown by shutdown() when simulating shutdown.
+     */
+    public static class ShutdownException extends RuntimeException {
+    }
+    
 }

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -59,6 +59,7 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
     private final Set<Callable<Boolean>> callables = new HashSet<>();
     private final Set<Runnable> runnables = new HashSet<>();
     protected final Thread shutdownHook;
+    private boolean simulateShutdown = false;
     // use up to 8 threads for parallel tasks
     private static final RequestProcessor RP = new RequestProcessor("On Start/Stop", 8); // NOI18N
     private static final String NO_NULL_TASK = "Shutdown task cannot be null."; // NOI18N
@@ -177,9 +178,26 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
     /**
      * {@inheritDoc}
      */
+    @Override
+    public void setSimulateShutdown(boolean simulate) {
+        simulateShutdown = simulate;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getSimulateShutdown() {
+        return simulateShutdown;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @SuppressFBWarnings(value = "DM_EXIT", justification = "OK to directly exit standalone main")
     @Override
     public boolean shutdown() {
+        if (simulateShutdown) throw new ShutdownException();
         return shutdown(0, true);
     }
 
@@ -189,6 +207,7 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
     @SuppressFBWarnings(value = "DM_EXIT", justification = "OK to directly exit standalone main")
     @Override
     public boolean restart() {
+        if (simulateShutdown) throw new RestartException();
         return shutdown(100, true);
     }
 
@@ -198,6 +217,7 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
     @SuppressFBWarnings(value = "DM_EXIT", justification = "OK to directly exit standalone main")
     @Override
     public boolean restartOS() {
+        if (simulateShutdown) throw new RestartOSException();
         return shutdown(210, true);
     }
 
@@ -207,6 +227,7 @@ public class DefaultShutDownManager extends Bean implements ShutDownManager {
     @SuppressFBWarnings(value = "DM_EXIT", justification = "OK to directly exit standalone main")
     @Override
     public boolean shutdownOS() {
+        if (simulateShutdown) throw new ShutdownOSException();
         return shutdown(200, true);
     }
 

--- a/java/test/jmri/managers/DefaultShutDownManagerTest.java
+++ b/java/test/jmri/managers/DefaultShutDownManagerTest.java
@@ -198,6 +198,15 @@ public class DefaultShutDownManagerTest {
         assertThat(InstanceManager.getNullableDefault(ShutDownManager.class)).isNotNull();
     }
     
+    @Test
+    public void testSimulate() {
+        dsdm.setSimulateShutdown(true);
+        Assert.assertThrows(ShutDownManager.ShutdownException.class, () -> dsdm.shutdown());
+        Assert.assertThrows(ShutDownManager.ShutdownOSException.class, () -> dsdm.shutdownOS());
+        Assert.assertThrows(ShutDownManager.RestartException.class, () -> dsdm.restart());
+        Assert.assertThrows(ShutDownManager.RestartOSException.class, () -> dsdm.restartOS());
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();


### PR DESCRIPTION
This PR lets tests run shutdown() and restart() without actually shutting down JMRI.

I added this feature since LogixNG has an action that can shutdown JMRI and the computer. This may be useful if JMRI is running on a Raspberry Pi and the user wants a button on the panel connected to a sensor to shutdown the Raspberry Pi. With LogixNG, the sensor can execute the action that shuts down JMRI and the computer.

I want to be able to test this feature of LogixNG, but it becomes a bit problematic if the test shuts down the computer   ;-)