### PR TITLE
VSDecoder: improve block value detection 2

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -543,7 +543,8 @@
    <h3>Virtual Sound Decoder</h3>
         <a id="VSD" name="VSD"></a>
         <ul>
-            <li></li>
+            <li>The "Location Following" (sound follows loco) with occupancy sensors and JMRI Blocks
+            now also works with a RosterEntry or RosterId as Block value.</li>
         </ul>
 
    <h3>Meters and MeterFrames</h3>


### PR DESCRIPTION
This PR enables VSD Block tracking using a RosterEntry or a RosterId as a token. It's an enhancement for JMRI Dispatcher users, e.g. see https://groups.io/g/jmriusers/topic/75376939