### PR TITLE
Improve  LnPacketizer.status()

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizer.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
  * Inc for separate permission.
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2018
+ * @author B. Milhaupt  Copyright (C) 2020
  */
 public class LnPacketizer extends LnTrafficController {
 
@@ -50,7 +51,11 @@ public class LnPacketizer extends LnTrafficController {
      */
     @Override
     public boolean status() {
-        return (ostream != null && istream != null && xmtThread != null && rcvThread != null);
+        boolean returnVal = ( ostream != null && istream != null
+                && xmtThread != null && xmtThread.isAlive() && xmtHandler != null
+                && rcvThread != null && rcvThread.isAlive() && rcvHandler != null
+                );
+        return returnVal;
     }
 
     /**
@@ -98,12 +103,12 @@ public class LnPacketizer extends LnTrafficController {
 
         log.debug("queue LocoNet packet: {}", m);
         // We need to queue the request and wake the xmit thread in an atomic operation
-        // But the thread might not be running, in which case the request is just 
+        // But the thread might not be running, in which case the request is just
         // queued up.
         try {
             synchronized (xmtHandler) {
                 xmtList.addLast(msg);
-                xmtHandler.notifyAll(); 
+                xmtHandler.notifyAll();
             }
         } catch (RuntimeException e) {
             log.warn("passing to xmit: unexpected exception: ", e);
@@ -219,12 +224,12 @@ public class LnPacketizer extends LnTrafficController {
                 try {
                     // start by looking for command -  skip if bit not set
                     while (((opCode = (readByteProtected(istream) & 0xFF)) & 0x80) == 0) { // the real work is in the loop check
-                        if (log.isTraceEnabled()) { // avoid building string 
+                        if (log.isTraceEnabled()) { // avoid building string
                             log.trace("Skipping: {}", Integer.toHexString(opCode)); // NOI18N
                         }
                     }
                     // here opCode is OK. Create output message
-                    if (log.isTraceEnabled()) { // avoid building string 
+                    if (log.isTraceEnabled()) { // avoid building string
                         log.trace(" (RcvHandler) Start message with opcode: {}", Integer.toHexString(opCode)); // NOI18N
                     }
                     LocoNetMessage msg = null;
@@ -232,7 +237,7 @@ public class LnPacketizer extends LnTrafficController {
                         try {
                             // Capture 2nd byte, always present
                             int byte2 = readByteProtected(istream) & 0xFF;
-                            if (log.isTraceEnabled()) { // avoid building string 
+                            if (log.isTraceEnabled()) { // avoid building string
                                 log.trace("Byte2: {}", Integer.toHexString(byte2)); // NOI18N
                             }                            // Decide length
                             int len = 2;
@@ -467,7 +472,7 @@ public class LnPacketizer extends LnTrafficController {
 
     Thread rcvThread;
     Thread xmtThread;
-    
+
     /**
      * {@inheritDoc}
      */
@@ -504,7 +509,7 @@ public class LnPacketizer extends LnTrafficController {
                 // interrupted during cleanup.
             }
         }
-        
+
         if (rcvThread != null) {
             rcvThread.interrupt();
             try {
@@ -512,14 +517,14 @@ public class LnPacketizer extends LnTrafficController {
             } catch (InterruptedException ie){
                 // interrupted during cleanup.
             }
-        }    
+        }
     }
-    
+
     /**
      * Flag that threads should terminate as soon as they can.
      */
     protected volatile boolean threadStopRequest = false;
-    
+
     private final static Logger log = LoggerFactory.getLogger(LnPacketizer.class);
 
 }

--- a/java/src/jmri/jmrix/loconet/LnTrafficController.java
+++ b/java/src/jmri/jmrix/loconet/LnTrafficController.java
@@ -56,7 +56,9 @@ public abstract class LnTrafficController implements LocoNetInterface {
         return memo;
     }
 
-    // Abstract methods for the LocoNetInterface
+    /**
+     * {@inheritDoc}
+     */
     @Override
     abstract public boolean status();
 

--- a/java/src/jmri/jmrix/loconet/LocoNetInterface.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetInterface.java
@@ -63,8 +63,11 @@ public interface LocoNetInterface {
      */
     void removeLocoNetListener(int mask, LocoNetListener listener);
 
-    /*
-     * Check whether an implementation is operational. True indicates OK.
+    /**
+     * Check whether an implementation is operational.  Returns true if
+     * operational.
+     * 
+     * @return true if implementation is operational.
      */
     public boolean status();
 


### PR DESCRIPTION
Modifies `LnPacketizer.status()` to be additionally sensitive to `xmtHandler,` `xmtThread.isAlive()`, `rcvHandler`, `rcvThread.isAlive()`.  This reduces the possibility of certain start-up issues, including NPE caused by early transmit attempt, during connection establishment.

Closes #9052.