### PR TITLE
LocoNet interrogate process improvements, javadocs

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -72,7 +72,12 @@
                   "Voltage/Current Meter" tool. Further information may be found at the
                   <a href="../html/hardware/loconet/DigitraxMeters.shtml">
                       Digitrax "Meters"</a> web page.</li>
-                <li></li>
+                <li>Start-up "Interrogation" of LocoNet Sensor and Turnout state
+                    has re-worked to provide better operation for LocoNet connections
+                    with large numbers of Sensors and/or Turnouts.  The JMRI 
+                    interrogation mechanism now implements a minimum delay from
+                    the last Sensor Report, Turnout Report or Interrogate Query 
+                    message before sending the next Interrogate Query message.</li>
             </ul>
 
         <h4>Maple</h4>

--- a/java/src/jmri/jmrix/loconet/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/LnSensorManager.java
@@ -129,7 +129,7 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
                     default:
                         break;
                 }
-
+            //$FALL-THROUGH$
             default:  // here we didn't find an interesting command
                 return;
         }
@@ -350,7 +350,7 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
                 int restingTime) {
             this.sm = sm;
             this.tc = tc;
-            this.restingTime = java.time.Duration.ofMillis((long)restingTime);
+            this.restingTime = java.time.Duration.ofMillis(restingTime);
         }
 
         /**

--- a/java/src/jmri/jmrix/loconet/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/LnSensorManager.java
@@ -6,25 +6,51 @@ import jmri.JmriException;
 import jmri.Sensor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.time.temporal.ChronoUnit;
+import java.time.Instant;
 
 /**
  * Manage the LocoNet-specific Sensor implementation.
  * System names are "LSnnn", where L is the user configurable system prefix,
- * nnn is the sensor number without padding.
+ * nnn is the sensor number without padding.  Valid sensor numbers are in the
+ * range 1 to 2048, inclusive.
+ *
+ * Provides a mechanism to perform the LocoNet "Interrogate" process in order
+ * to get initial values from those LocoNet devices which support the process
+ * and provide LocoNet Sensor (and/or LocoNet Turnout) functionality.
  *
  * @author Bob Jacobsen Copyright (C) 2001
+ * @author B. Milhaupt  Copyright (C) 2020
  */
 public class LnSensorManager extends jmri.managers.AbstractSensorManager implements LocoNetListener {
 
     protected final LnTrafficController tc;
 
+    /**
+     * Minimum amount of time since previous LocoNet Sensor State report or
+     * previous LocoNet Turnout State report or previous LocoNet "interrogate"
+     * message.
+     */
+    protected int restingTime;
+
+    /**
+     * Instant at which last LocoNet Sensor State message or LocoNet Turnout state
+     * message or LocoNet Interrogation request message was received.
+     *
+     */
+    private volatile Instant lastSensTurnInterrog;
+
     public LnSensorManager(LocoNetSystemConnectionMemo memo) {
         super(memo);
+        this.restingTime = 1250;
         tc = memo.getLnTrafficController();
         if (tc == null) {
             log.error("SensorManager Created, yet there is no Traffic Controller");
             return;
         }
+        lastSensTurnInterrog = Instant.now();   // a baseline starting-point for
+                    // interrogation timing
+
         // ctor has to register for LocoNet events
         tc.addLocoNetListener(~0, this);
 
@@ -34,9 +60,7 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
         updateAll();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @Nonnull
     public LocoNetSystemConnectionMemo getMemo() {
@@ -44,6 +68,7 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
     }
 
     // to free resources when no longer used
+    /** {@inheritDoc} */
     @Override
     public void dispose() {
         tc.removeLocoNetListener(~0, this);
@@ -63,16 +88,17 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
 
     // LocoNet-specific methods
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @Nonnull
     public Sensor createNewSensor(@Nonnull String systemName, String userName) {
         return new LnSensor(systemName, userName, tc, getSystemPrefix());
     }
 
-    // listen for sensors, creating them as needed
+    /**
+     * Listen for sensor messages, creating them as needed.
+     * @param l LocoNet message to be examined
+     */
     @Override
     public void message(LocoNetMessage l) {
         // parse message type
@@ -85,7 +111,25 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
                 int sw2 = l.getElement(2);
                 a = new LnSensorAddress(sw1, sw2, getSystemPrefix());
                 log.debug("INPUT_REP received with address {}", a);
+                lastSensTurnInterrog = Instant.now();
                 break;
+            case LnConstants.OPC_SW_REP:
+                lastSensTurnInterrog = Instant.now();
+                return;
+            case LnConstants.OPC_SW_REQ:
+            case LnConstants.OPC_SW_ACK:
+                int address = ((l.getElement(1)& 0x7f) + 128*(l.getElement(2) & 0x0f));
+                switch (address) {
+                    case 0x3F8:
+                    case 0x3F9:
+                    case 0x3FA:
+                    case 0x3FB:
+                        lastSensTurnInterrog = Instant.now();
+                        return;
+                    default:
+                        break;
+                }
+
             default:  // here we didn't find an interesting command
                 return;
         }
@@ -111,8 +155,8 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
     public void updateAll() {
         if (!busy) {
             setUpdateBusy();
-            thread = new LnSensorUpdateThread(this, tc);
-            thread.setName("LnSensorUpdateThread");
+            thread = new LnSensorUpdateThread(this, tc, getRestingTime());
+            thread.setName("LnSensorUpdateThread"); // NOI18N
             thread.start();
         }
     }
@@ -134,27 +178,29 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
 
     private boolean busy = false;
 
+    /** {@inheritDoc} */
     @Override
     public boolean allowMultipleAdditions(@Nonnull String systemName) {
         return true;
     }
 
+    /** {@inheritDoc} */
     @Override
     @Nonnull
     public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
-        if (curAddress.contains(":")) {
-            
-            // NOTE: This format is deprecated in JMRI 4.17.4 on account the 
-            // "byte:bit" format cannot be used under normal JMRI usage 
-            // circumstances.  It is retained for the normal deprecation period 
+        if (curAddress.contains(":")) { // NOI18N
+
+            // NOTE: This format is deprecated in JMRI 4.17.4 on account the
+            // "byte:bit" format cannot be used under normal JMRI usage
+            // circumstances.  It is retained for the normal deprecation period
             // in order to support any atypical usage patterns.
-            
+
             int board = 0;
             int channel = 0;
             // Address format passed is in the form of board:channel or T:turnout address
-            int seperator = curAddress.indexOf(":");
+            int seperator = curAddress.indexOf(":"); // NOI18N
             boolean turnout = false;
-            if (curAddress.substring(0, seperator).toUpperCase().equals("T")) {
+            if (curAddress.substring(0, seperator).toUpperCase().equals("T")) { // NOI18N
                 turnout = true;
             } else {
                 try {
@@ -175,8 +221,8 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
             } else {
                 iName = 16 * board + channel - 16;
             }
-            jmri.util.LoggingUtil.warnOnce(log, 
-                    "LnSensorManager.createSystemName(curAddress, prefix) support for curAddress using the '{}' format is deprecated as of JMRI 4.17.4 and will be removed in a future JMRI release.  Use the curAddress format '{}' instead.",
+            jmri.util.LoggingUtil.warnOnce(log,
+                    "LnSensorManager.createSystemName(curAddress, prefix) support for curAddress using the '{}' format is deprecated as of JMRI 4.17.4 and will be removed in a future JMRI release.  Use the curAddress format '{}' instead.",  // NOI18N
                     curAddress, iName);
         } else {
             // Entered in using the old format
@@ -192,17 +238,13 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
 
     int iName;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public NameValidity validSystemNameFormat(@Nonnull String systemName) {
         return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     @Nonnull
     public String validateSystemNameFormat(@Nonnull String systemName, @Nonnull Locale locale) {
@@ -223,6 +265,7 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
         return Integer.parseInt(systemName.substring(getSystemNamePrefix().length()));
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
 
@@ -256,40 +299,75 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritDoc} */
     @Override
     public String getEntryToolTip() {
         return Bundle.getMessage("AddInputEntryToolTip");
     }
 
     /**
-     * Class providing a thread to update sensor states.
+     * Set "resting time" for the Interrogation process.
+     *
+     * A minimum of 500 (milliseconds) and a maximum of 200000 (milliseconds) is
+     * implemented.  Values below this lower limit are forced to the lower
+     * limit, and values above this upper limit are forced to the upper limit.
+     *
+     * @param rest Number of milliseconds (minimum) before sending next
+     *      LocoNet Interrogate message.
      */
-    static class LnSensorUpdateThread extends Thread {
+    public void setRestingTime(int rest) {
+        if (rest < 500) {
+            rest = 500;
+        } else if (rest > 200000) {
+            rest = 200000;
+        }
+        restingTime = rest;
+    }
+
+    /**
+     * get Interrogation process's "resting time"
+     * @return Resting time, in milliseconds
+     */
+    public int getRestingTime() {
+        return restingTime;
+    }
+
+    /**
+     * Class providing a thread to query LocoNet Sensor and Turnout states.
+     */
+    class LnSensorUpdateThread extends Thread {
+        private LnSensorManager sm = null;
+        private LnTrafficController tc = null;
+        private java.time.Duration restingTime;
 
         /**
          * Constructs the thread
          * @param sm SensorManager to use
          * @param tc TrafficController to use
+         * @param restingTime Min time before next LN query message sent
          */
-        public LnSensorUpdateThread(LnSensorManager sm, LnTrafficController tc) {
+        public LnSensorUpdateThread(LnSensorManager sm, LnTrafficController tc,
+                int restingTime) {
             this.sm = sm;
             this.tc = tc;
+            this.restingTime = java.time.Duration.ofMillis((long)restingTime);
         }
 
         /**
          * Runs the thread - sends 8 commands to query status of all stationary
-         * sensors per LocoNet PE Specs, page 12-13.
-         * Thread waits 500 msec between commands.
+         * sensors (per LocoNet PE Specs, page 12-13).
+         *
+         * Timing between query messages is determined by certain previous LocoNet
+         * traffic (as noted by lastSensTurnInterrog) and restingTime.
          */
         @Override
         public void run() {
             sm.setUpdateBusy();
             while (!tc.status()) {
                 try {
-                    // Delay 500 mSec to allow init of traffic controller, listeners.
+                    // Delay 500 mSec to allow init of traffic controller,
+                    // listeners, and to limit amount of LocoNet traffic at
+                    // JMRI start-up.
                     Thread.sleep(500);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt(); // retain if needed later
@@ -303,26 +381,40 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
             LocoNetMessage msg = new LocoNetMessage(4);
             msg.setOpCode(LnConstants.OPC_SW_REQ);
             for (int k = 0; k < 8; k++) {
-                try {
-                    // Delay 500 mSec to allow init of traffic controller, listeners.
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt(); // retain if needed later
-                    sm.setUpdateNotBusy();
-                    return; // and stop work
+                Instant n = Instant.now();
+                Instant n2 = lastSensTurnInterrog.plus(restingTime);
+                int result = n.compareTo(n2);
+                log.debug("Interrogation phase {}: now {}, lastSensInterrog {}, target{}, time compare result {}",
+                        k, n, lastSensTurnInterrog, n2, result);
+                while (result < 0) {
+                    try {
+                        // Delay 100 mSec
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt(); // retain if needed later
+                        sm.setUpdateNotBusy();
+                        return; // and stop work
+                    }
+                    n = Instant.now();
+                    result = n.compareTo(n2);
+                    log.debug("Interrogation phase {}: now {}, lastSensInterrog {}, target{}, time compare result {}",
+                            k, n, lastSensTurnInterrog, n2, result);
                 }
                 msg.setElement(1, sw1[k]);
                 msg.setElement(2, sw2[k]);
 
                 tc.sendLocoNetMessage(msg);
+
+                /* lastSensTurnInterrog needs to be updated here to prevent quick
+                 * sending of the next query message.  (It will be updated upon
+                 * reception of the LocoNet "echo".)
+                 */
+                lastSensTurnInterrog = Instant.now();
+
                 log.debug("LnSensorUpdate sent");
             }
             sm.setUpdateNotBusy();
         }
-
-        private LnSensorManager sm = null;
-        private LnTrafficController tc = null;
-
     }
 
     private final static Logger log = LoggerFactory.getLogger(LnSensorManager.class);

--- a/java/test/jmri/jmrix/loconet/LnSensorManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnSensorManagerTest.java
@@ -105,6 +105,24 @@ public class LnSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase
                 "LnSensorManager.createSystemName(curAddress, prefix) support for curAddress using the '3:5' format is deprecated as of JMRI 4.17.4 and will be removed in a future JMRI release.  Use the curAddress format '37' instead.");
     }
 
+    @Test
+    public void testSetGetRestingTime() {
+        Assert.assertEquals("check default resting time", 1250, ((LnSensorManager)l).getRestingTime());
+
+        ((LnSensorManager)l).setRestingTime(600);
+        Assert.assertEquals("check 1st set of resting time", 600, ((LnSensorManager)l).getRestingTime());
+        
+        ((LnSensorManager)l).setRestingTime(500);
+        Assert.assertEquals("check 2nd set of resting time", 500, ((LnSensorManager)l).getRestingTime());
+        
+        ((LnSensorManager)l).setRestingTime(499);
+        Assert.assertEquals("check 1st range check on set of resting time", 500, ((LnSensorManager)l).getRestingTime());
+        
+        ((LnSensorManager)l).setRestingTime(200001);
+        Assert.assertEquals("check 2nd range check on set of resting time", 200000, ((LnSensorManager)l).getRestingTime());
+        
+    }
+
     @Override
     @BeforeEach
     public void setUp() {
@@ -119,7 +137,7 @@ public class LnSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase
         l = new LnSensorManager(memo);
         jmri.InstanceManager.setSensorManager(l);
     }
-
+    
     @AfterEach
     public void tearDown() {
         l.dispose();


### PR DESCRIPTION
Modifies LocoNet "Interrogate" mechanism to wait a fixed delay after the most-recent:
- LocoNet "Interrogate" message;
- LocoNet "Sensor Status" message;
or
- LocoNet "Turnout Status" message.

This attempts to reduce issues seen on some layouts with many LocoNet devices where JMRI would send one of the LocoNet "interrogate" messages before reception of all of the responses caused by a previous "interrogate" message. 

The effect on typical small LocoNet installations is to increase the run-time of the JMRI "interrogation" process from a minimum of about 3.5 seconds to a minimum of about 8.75 seconds, measured from transmission of the first LocoNet "interrogate" message to transmission of the eighth LocoNet "interrogate" message.

Also allows for script users, and those who use JMRI as a "library", to configure the delay from 500 mSec to 200000 mSec to better suit individual layout LocoNet performance.