### PR TITLE
Create Address Ranges jmrix getNextValidAddress

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -48,6 +48,12 @@
             <ul>
                 <li></li>
             </ul>
+            
+        <h4>Internal</h4>
+            <ul>
+                <li>Sensor, Turnout, Light and Reporter Address ranges do not have to be fully numeric, and will be incremented using the final number in an address.<br>
+                For example, a range can be created from "My Yard 77 Sensor 1" which would increment to "My Yard 77 Sensor 2"</li>
+            </ul>
 
         <h4>IPOCSMR</h4>
             <ul>
@@ -92,7 +98,9 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li></li>
+                <li>Added support for creating ranges of Turnouts and Lights.<br>
+                Sensor, Turnout and Light Address ranges do not have to be fully numeric,
+                and will be incremented using the final number in an address.</li>
             </ul>
 
         <h4>MRC</h4>
@@ -460,7 +468,7 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li></li>
+            <li>Increased address validation for multiple hardware types.</li>
         </ul>
 
     <h3>Scripting</h3>
@@ -469,6 +477,8 @@
             <li>The getSystemNameList() and getNamedBeanList() Manager methods have been fully deprecated.
             <br>Please update any code warnings re these methods to use getNamedBeanSet(), and 
                 post on the JMRI Users Group for any assistance with updating.</li>
+            <li>The Manager method getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) has been
+            deprecated, please use getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting)</li>
         </ul>
 
     <h3>Signals</h3>

--- a/java/src/jmri/LightManager.java
+++ b/java/src/jmri/LightManager.java
@@ -109,6 +109,7 @@ public interface LightManager extends ProvidingManager<Light> {
      */
     @CheckReturnValue
     @CheckForNull
+    @Override
     public Light getByUserName(@Nonnull String s);
 
     /**
@@ -119,6 +120,7 @@ public interface LightManager extends ProvidingManager<Light> {
      */
     @CheckReturnValue
     @CheckForNull
+    @Override
     public Light getBySystemName(@Nonnull String s);
 
     /**
@@ -180,5 +182,21 @@ public interface LightManager extends ProvidingManager<Light> {
      */
     @CheckReturnValue
     public boolean allowMultipleAdditions(@Nonnull String systemName);
+    
+    /**
+     * Get the Next valid hardware address.
+     * Used by the Turnout / Sensor / Reporter / Light Manager classes.
+     * <p>
+     * System-specific methods may want to override getIncrement() rather than this one.
+     * @param curAddress the starting hardware address to get the next valid from.
+     * @param prefix system prefix, just system name, not type letter.
+     * @param ignoreInitialExisting false to return the starting address if it 
+     *                          does not exist, else true to force an increment.
+     * @return the next valid system name, excluding both system name prefix and type letter.
+     * @throws JmriException    if unable to get the current / next address, 
+     *                          or more than 10 next addresses in use.
+     */
+    @Nonnull
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException;
 
 }

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -174,7 +174,7 @@ public interface Manager<E extends NamedBean> extends SilenceablePropertyChangeP
      * {@link #validateSystemNameFormat(java.lang.String, java.util.Locale)}
      * should be overridden instead.
      *
-     * @param name the system name to validate
+     * @param name the system name, including system prefix and Type Letter to validate
      * @return the system name unchanged from its input so that this method can
      *         be chained or used as an parameter to another method
      * @throws BadSystemNameException if the name is not valid with error

--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -475,6 +475,7 @@ InvalidSystemName                    = Invalid System Name "{0}"
 InvalidSystemNameMin1Number          = System name "{0}" must contain at least 1 number.
 # Ideally this kind of failure would be parsed into something more specific
 InvalidSystemNameFailedRegex         = "{0}" did not match regular expression "{1}".
+InvalidNextValidTenInUse             = 10 {0} starting at {1} up to {2} already in use.
 
 FeedbackModeJmri        = JMRI
 FeedbackModeLayout      = Layout

--- a/java/src/jmri/ReporterManager.java
+++ b/java/src/jmri/ReporterManager.java
@@ -9,7 +9,7 @@ import javax.annotation.Nonnull;
  * Reporter objects are obtained from a ReporterManager, which in turn is
  * generally located from the InstanceManager. A typical call sequence might be:
  * <pre>
- * Reporter device = InstanceManager.getDefault(jmri.ReporterManager.class).newReporter(null,"23");
+ * Reporter device = InstanceManager.getDefault(jmri.ReporterManager.class).newReporter("23",null);
  * </pre>
  * <p>
  * Each Reporter has a two names. The "user" name is entirely free form, and can
@@ -79,6 +79,7 @@ public interface ReporterManager extends ProvidingManager<Reporter> {
      * @return requested Reporter object or null if none exists
      */
     @CheckForNull
+    @Override
     public Reporter getBySystemName(@Nonnull String systemName);
 
     /**
@@ -89,6 +90,7 @@ public interface ReporterManager extends ProvidingManager<Reporter> {
      * @return requested Reporter object or null if none exists
      */
     @CheckForNull
+    @Override
     public Reporter getByUserName(@Nonnull String userName);
 
     /**
@@ -152,10 +154,26 @@ public interface ReporterManager extends ProvidingManager<Reporter> {
      * @return the next available address
      * @throws jmri.JmriException if unable to create a system name for the
      *                            given address, possibly due to invalid address
-     *                            format
+     *                            format or no free addresses 10 away.
+     * @deprecated since 4.21.3; use #getNextValidAddress(String, String, boolean) instead.
      */
+    @Deprecated
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException;
 
+    /**
+     * Get the Next valid Reporter address.
+     * <p>
+     * @param curAddress the starting hardware address to get the next valid from.
+     * @param prefix system prefix, just system name, not type letter.
+     * @param ignoreInitialExisting false to return the starting address if it 
+     *                          does not exist, else true to force an increment.
+     * @return the next valid system name, excluding both system name prefix and type letter.
+     * @throws JmriException    if unable to get the current / next address, 
+     *                          or more than 10 next addresses in use.
+     */
+    @Nonnull
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException;
+    
     /**
      * {@inheritDoc}
      */

--- a/java/src/jmri/SensorManager.java
+++ b/java/src/jmri/SensorManager.java
@@ -105,6 +105,7 @@ public interface SensorManager extends ProvidingManager<Sensor> {
      */
     @CheckReturnValue
     @CheckForNull
+    @Override
     public Sensor getByUserName(@Nonnull String name);
 
     /**
@@ -117,6 +118,7 @@ public interface SensorManager extends ProvidingManager<Sensor> {
      */
     @CheckReturnValue
     @CheckForNull
+    @Override
     public Sensor getBySystemName(@Nonnull String name);
 
     /**
@@ -149,14 +151,27 @@ public interface SensorManager extends ProvidingManager<Sensor> {
      * @param curAddress The hardware address of the sensor we wish to add
      * @param prefix     The System Prefix used to make up the systemName
      *                   check.
-     * @return null if the system name made from prefix and curAddress is in
-     *         use
-     * @throws jmri.JmriException if problem calculating next address
+     * @return next valid address.
+     * @throws jmri.JmriException if problem calculating next address or next 10 are in use.
+     * @deprecated since 4.21.3; use #getNextValidAddress(String, String, boolean) instead.
      */
-    @CheckReturnValue
-    @CheckForNull
+    @Deprecated
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException;
 
+    /**
+     * Get the Next valid Sensor address.
+     * <p>
+     * @param curAddress the starting hardware address to get the next valid from.
+     * @param prefix system prefix, just system name, not type letter.
+     * @param ignoreInitialExisting false to return the starting address if it 
+     *                          does not exist, else true to force an increment.
+     * @return the next valid system name, excluding both system name prefix and type letter.
+     * @throws JmriException    if unable to get the current / next address, 
+     *                          or more than 10 next addresses in use.
+     */
+    @Nonnull
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException;
+    
     /**
      * Get a system name for a given hardware address and system prefix.
      *

--- a/java/src/jmri/TurnoutManager.java
+++ b/java/src/jmri/TurnoutManager.java
@@ -1,7 +1,6 @@
 package jmri;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.CheckForNull;
 
@@ -88,6 +87,7 @@ public interface TurnoutManager extends ProvidingManager<Turnout> {
      * @return requested Turnout object or null if none exists
      */
     @CheckForNull
+    @Override
     public Turnout getBySystemName(@Nonnull String systemName);
 
     /**
@@ -98,6 +98,7 @@ public interface TurnoutManager extends ProvidingManager<Turnout> {
      * @return requested Turnout object or null if none exists
      */
     @CheckForNull
+    @Override
     public Turnout getByUserName(@Nonnull String userName);
 
     /**
@@ -228,22 +229,38 @@ public interface TurnoutManager extends ProvidingManager<Turnout> {
     public boolean allowMultipleAdditions(@Nonnull String systemName);
 
     /**
-     * Determine if the address supplied is valid and free, if not then it shall
-     * return the next free valid address up to a maximum of 10 addresses away
-     * from the initial address. Used when adding add a range of Turnouts.
+     * Get the next valid address.
+     * <p>
+     * Determine if the address supplied is valid and free. 
+     * If not then it shall return the next free valid address up to a maximum 
+     * of 10 addresses away from the initial address.
+     * Used when adding add a range of Turnouts.
      *
      * @param prefix     System prefix used in system name
      * @param curAddress desired hardware address
-     * @return the next available address or null if none available
+     * @return the next available address or null if next 10 addresses unavailable.
      * @throws jmri.JmriException if unable to provide a turnout at the desired
      *                            address due to invalid format for the current
-     *                            address or other reasons (some implementations
-     *                            do not throw an error, but notify the user via
-     *                            other means and return null)
+     *                            address or other reasons.
+     * @deprecated since 4.21.3; use #getNextValidAddress(String, String, boolean) instead.
      */
-    @CheckForNull
+    @Deprecated
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException;
 
+    /**
+     * Get the Next valid Turnout address.
+     * <p>
+     * @param curAddress the starting hardware address to get the next valid from.
+     * @param prefix system prefix, just system name, not type letter.
+     * @param ignoreInitialExisting false to return the starting address if it 
+     *                          does not exist, else true to force an increment.
+     * @return the next valid system name, excluding both system name prefix and type letter.
+     * @throws JmriException    if unable to get the current / next address, 
+     *                          or more than 10 next addresses in use.
+     */
+    @Nonnull
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException;
+    
     /**
      * Get a system name for a given hardware address and system prefix.
      *

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -370,24 +370,17 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
 
         // Add some entry pattern checking, before assembling sName and handing it to the ReporterManager
         String statusMessage = Bundle.getMessage("ItemCreateFeedback", Bundle.getMessage("BeanNameReporter"));
-        String errorMessage = null;
+        String errorMessage;
         String uName = userNameTextField.getText();
         for (int x = 0; x < numberOfReporters; x++) {
             try {
-                curAddress = reporterManager.getNextValidAddress(curAddress, reporterPrefix);
+                curAddress = reporterManager.getNextValidAddress(curAddress, reporterPrefix, false);
             } catch (jmri.JmriException ex) {
                 displayHwError(curAddress, ex);
                 // directly add to statusBarLabel (but never called?)
                 statusBarLabel.setText(Bundle.getMessage("ErrorConvertHW", curAddress));
                 statusBarLabel.setForeground(Color.red);
                 return;
-            }
-            if (curAddress == null) {
-                log.debug("Error converting HW or getNextValidAddress");
-                errorMessage = (Bundle.getMessage("WarningInvalidEntry"));
-                statusBarLabel.setForeground(Color.red);
-                // The next address returned an error, therefore we stop this attempt and go to the next address.
-                break;
             }
 
             // Compose the proposed system name from parts:
@@ -431,14 +424,9 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
 
             // end of for loop creating rangeCheckBox of Reporters
         }
-        // provide feedback to uName
-        if (errorMessage == null) {
-            statusBarLabel.setText(statusMessage);
-            statusBarLabel.setForeground(Color.gray);
-        } else {
-            statusBarLabel.setText(errorMessage);
-            // statusBarLabel.setForeground(Color.red); // handled when errorMassage is set to differentiate urgency
-        }
+        // provide success feedback to uName
+        statusBarLabel.setText(statusMessage);
+        statusBarLabel.setForeground(Color.gray);        
 
         pref.setComboBoxLastSelection(systemSelectionCombo, prefixBox.getSelectedItem().getMemo().getUserName());
         removePrefixBoxListener(prefixBox);

--- a/java/src/jmri/jmrit/beantable/SensorTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SensorTableAction.java
@@ -199,7 +199,7 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
         String errorMessage = null;
         for (int x = 0; x < numberOfSensors; x++) {
             try {
-                curAddress = InstanceManager.getDefault(SensorManager.class).getNextValidAddress(curAddress, sensorPrefix);
+                curAddress = InstanceManager.getDefault(SensorManager.class).getNextValidAddress(curAddress, sensorPrefix, false);
             } catch (jmri.JmriException ex) {
                 displayHwError(curAddress, ex);
                 // directly add to statusBarLabel (but never called?)
@@ -207,17 +207,10 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
                 statusBarLabel.setForeground(Color.red);
                 return;
             }
-            if (curAddress == null) {
-                log.debug("Error converting HW or getNextValidAddress");
-                errorMessage = (Bundle.getMessage("WarningInvalidEntry"));
-                statusBarLabel.setForeground(Color.red);
-                // The next address returned an error, therefore we stop this attempt and go to the next address.
-                break;
-            }
 
             // Compose the proposed system name from parts:
             sName = sensorPrefix + InstanceManager.getDefault(SensorManager.class).typeLetter() + curAddress;
-            Sensor s = null;
+            Sensor s;
             try {
                 s = InstanceManager.getDefault(SensorManager.class).provideSensor(sName);
             } catch (IllegalArgumentException ex) {
@@ -257,14 +250,9 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
             // end of for loop creating rangeBox of Sensors
         }
 
-        // provide feedback to user
-        if (errorMessage == null) {
-            statusBarLabel.setText(statusMessage);
-            statusBarLabel.setForeground(Color.gray);
-        } else {
-            statusBarLabel.setText(errorMessage);
-            // statusBarLabel.setForeground(Color.red); // handled when errorMassage is set to differentiate urgency
-        }
+        // provide success feedback to user
+        statusBarLabel.setText(statusMessage);
+        statusBarLabel.setForeground(Color.gray);
 
         p.setComboBoxLastSelection(systemSelectionCombo, prefixBox.getSelectedItem().getMemo().getUserName());
         removePrefixBoxListener(prefixBox);

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -17,39 +17,12 @@ import java.util.Vector;
 import javax.annotation.Nonnull;
 import javax.annotation.CheckForNull;
 import javax.imageio.ImageIO;
-import javax.swing.AbstractCellEditor;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.DefaultCellEditor;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JMenu;
-import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JSpinner;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.RowSorter;
-import javax.swing.SpinnerNumberModel;
+import javax.swing.*;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableModel;
-import jmri.InstanceManager;
-import jmri.Manager;
-import jmri.Sensor;
-import jmri.SensorManager;
-import jmri.Turnout;
-import jmri.TurnoutManager;
-import jmri.TurnoutOperation;
-import jmri.TurnoutOperationManager;
+import jmri.*;
 import jmri.NamedBean.DisplayOptions;
 import jmri.implementation.SignalSpeedMap;
 import jmri.jmrit.turnoutoperations.TurnoutOperationConfig;
@@ -1691,20 +1664,13 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
 
         for (int x = 0; x < numberOfTurnouts; x++) {
             try {
-                curAddress = InstanceManager.getDefault(TurnoutManager.class).getNextValidAddress(curAddress, prefix);
+                curAddress = InstanceManager.getDefault(TurnoutManager.class).getNextValidAddress(curAddress, prefix, false);
             } catch (jmri.JmriException ex) {
                 displayHwError(curAddress, ex);
                 // directly add to statusBarLabel (but never called?)
                 statusBarLabel.setText(Bundle.getMessage("ErrorConvertHW", curAddress));
                 statusBarLabel.setForeground(Color.red);
                 return;
-            }
-            if (curAddress == null) {
-                log.debug("Error converting HW or getNextValidAddress");
-                errorMessage = (Bundle.getMessage("WarningInvalidEntry"));
-                statusBarLabel.setForeground(Color.red);
-                // The next address returned an error, therefore we stop this attempt and go to the next address.
-                break;
             }
 
             lastSuccessfulAddress = curAddress;
@@ -1819,14 +1785,10 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
 
             // end of for loop creating rangeBox of Turnouts
         }
-        // provide feedback to uName
-        if (errorMessage == null) {
-            statusBarLabel.setText(statusMessage);
-            statusBarLabel.setForeground(Color.gray);
-        } else {
-            statusBarLabel.setText(errorMessage);
-            // statusBarLabel.setForeground(Color.red); // handled when errorMassage is set, to differentiate in urgency
-        }
+        
+        // provide successfeedback to uName
+        statusBarLabel.setText(statusMessage);
+        statusBarLabel.setForeground(Color.gray);
 
         pref.setComboBoxLastSelection(systemSelectionCombo, prefixBox.getSelectedItem().getMemo().getUserName()); // store user pref
         removePrefixBoxListener(prefixBox);

--- a/java/src/jmri/jmrix/can/cbus/CbusAddress.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusAddress.java
@@ -1,9 +1,12 @@
 package jmri.jmrix.can.cbus;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.annotation.CheckForNull;
+
 import javax.annotation.Nonnull;
+
+import jmri.JmriException;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.util.StringUtil;
@@ -265,11 +268,13 @@ public class CbusAddress {
      * Increments a CBUS address by 1 eg +123 to +124 eg -N123E456 to -N123E457
      *
      * @param testAddr initial CbusAddress String, eg -N123E456
-     * @return null if unable to make the address
+     * @return incremented address. 
+     * @throws jmri.JmriException if unable to make the address
      */
-    @CheckForNull
-    public static String getIncrement(@Nonnull String testAddr) {
+    @Nonnull
+    public static String getIncrement(@Nonnull String testAddr) throws JmriException{
         log.debug("testing address {}", testAddr);
+        validateSysName(testAddr);
         CbusAddress a = new CbusAddress(testAddr);
         CbusAddress[] v = a.split();
         String newString;
@@ -283,35 +288,46 @@ public class CbusAddress {
                 sb.append(StringUtil.replaceLast(v[1].toString(), String.valueOf(lastb), String.valueOf(lastb + 1)));
                 newString = sb.toString();
                 break;
-            default:
+            case 1:
                 // get last part and increment
                 int last = StringUtil.getLastIntFromString(v[0].toString());
                 newString = StringUtil.replaceLast(v[0].toString(), String.valueOf(last), String.valueOf(last + 1));
                 break;
+            default:
+                throw new JmriException("Unable to increment " + testAddr);
         }
         try {
             return validateSysName(newString);
         } catch (IllegalArgumentException e) {
-            log.error(e.toString());
+            throw new JmriException("Unable to increment " + testAddr + " " + e.getMessage());
         }
-        return null;
     }
 
+    // not A-F, N or X
+    private final static String[] invalidChars = {
+        "G","H","I","J","K","L","M","S","T","U","V","W","Y","Z",
+        "?",":","++","--",",","*","NN","XX"};
+    
     /**
-     * Work out the details for CBUS hardware address validation.
-     * Logging of handled cases no higher than WARN.
+     * Validate a CBUS hardware address validation.
      *
-     * @param address the hardware address to check
-     * @return same address if all OK
-     * @throws IllegalArgumentException when delimiter is not found 
+     * @param address the hardware address to check, excluding both system prefix and type letter.
+     * @return same address if all OK.
+     * @throws IllegalArgumentException when address is not validated.
      * or contains too many parts
      */
     public static String validateSysName(String address) throws IllegalArgumentException {
 
-        if (address == null) {
-            throw new IllegalArgumentException("No address Passed ");
+        if (address == null || address.isEmpty()) {
+            throw new IllegalArgumentException("No Address passed ");
         }
-
+        address=address.toUpperCase().trim();
+        for (String s : invalidChars) {
+            if (address.contains(s)) {
+                throw new jmri.NamedBean.BadSystemNameException(Locale.getDefault(), "InvalidSystemNameCharacter",address,s);
+            }
+        }
+        
         if (address.endsWith(";")) {
             throw new IllegalArgumentException("Should not end with ; " + address);
         }

--- a/java/src/jmri/jmrix/can/cbus/CbusAddress.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusAddress.java
@@ -321,7 +321,7 @@ public class CbusAddress {
         if (address == null || address.isEmpty()) {
             throw new IllegalArgumentException("No Address passed ");
         }
-        address=address.toUpperCase().trim();
+        // address=address.toUpperCase().trim();
         for (String s : invalidChars) {
             if (address.contains(s)) {
                 throw new jmri.NamedBean.BadSystemNameException(Locale.getDefault(), "InvalidSystemNameCharacter",address,s);

--- a/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
@@ -1,7 +1,6 @@
 package jmri.jmrix.can.cbus;
 
 import java.util.Locale;
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jmri.Light;
 import jmri.jmrix.can.CanSystemConnectionMemo;
@@ -41,20 +40,6 @@ public class CbusLightManager extends AbstractLightManager {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    @Nonnull
-    public Light provideLight(@Nonnull String name) {
-        //log.debug("passed name {}", name);
-        Light result = getLight(name);
-        if (result == null) {
-            return newLight(makeSystemName(name), null); // checks for validity
-        }
-        return result;
-    }
-
-    /**
      * Internal method to invoke the factory, after all the logic for returning
      * an existing method has been invoked.
      *
@@ -62,13 +47,14 @@ public class CbusLightManager extends AbstractLightManager {
      */
     @Override
     protected Light createNewLight(@Nonnull String systemName, String userName) {
-        String addr = systemName.substring(getSystemPrefix().length() + 1);
+        String addr;
         // first, check validity
-        try {
-            validateAddressFormat(addr);
+        try {            
+            validateSystemNameFormat(systemName);
+            addr = systemName.substring(getSystemNamePrefix().length());
         } catch (IllegalArgumentException e) {
-            log.error(e.toString());
-            throw e;
+            log.error(e.getMessage());
+            throw new IllegalArgumentException (e.getMessage());
         }
         // validate (will add "+" to unsigned int)
         String newAddress = CbusAddress.validateSysName(addr);
@@ -94,7 +80,7 @@ public class CbusLightManager extends AbstractLightManager {
     public String validateSystemNameFormat(@Nonnull String name, @Nonnull Locale locale) {
         validateSystemNamePrefix(name, locale);
         try {
-            validateAddressFormat(name.substring(getSystemNamePrefix().length()));
+            CbusAddress.validateSysName(name.substring(getSystemNamePrefix().length()));
         } catch (IllegalArgumentException ex) {
             throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCustom", ex.getMessage());
         }
@@ -109,27 +95,23 @@ public class CbusLightManager extends AbstractLightManager {
         String addr;
         try {
             addr = systemName.substring(getSystemPrefix().length() + 1); // get only the address part
-        } catch (StringIndexOutOfBoundsException e) {
-            return NameValidity.INVALID;
-        }
-        try {
-            validateAddressFormat(addr);
-        } catch (IllegalArgumentException e) {
+            CbusAddress.validateSysName(addr);
+        } catch (StringIndexOutOfBoundsException | IllegalArgumentException e) {
             return NameValidity.INVALID;
         }
         return NameValidity.VALID;
     }
-
+    
     /**
-     * Work out the details for Cbus hardware address validation. Logging of
-     * handled cases no higher than WARN.
-     *
-     * @param address the hardware address to check
-     * @throws IllegalArgumentException when delimiter is not found
+     * {@inheritDoc}
      */
-    void validateAddressFormat(@Nonnull String address) throws IllegalArgumentException {
-        String newAddress = CbusAddress.validateSysName(address);
-        log.debug("validated system name {}", newAddress);
+    @Override
+    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {
+        try {
+            return prefix + typeLetter() + CbusAddress.validateSysName(curAddress);
+        } catch (IllegalArgumentException e) {
+            throw new jmri.JmriException(e.getMessage());
+        }
     }
 
     /**
@@ -137,23 +119,17 @@ public class CbusLightManager extends AbstractLightManager {
      */
     @Override
     public boolean validSystemNameConfig(@Nonnull String systemName) {
-        String addr = systemName.substring(getSystemPrefix().length() + 1);
-        try {
-            validateAddressFormat(addr);
-        } catch (IllegalArgumentException e) {
-            log.debug("Warning: {}", e.getMessage());
-            return false;
-        }
-        return true;
+        return validSystemNameFormat(systemName) == NameValidity.VALID;
     }
-
+    
     /**
+     * Only increments by 1, which is fine for CBUS Lights.
      * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    @CheckForNull
-    public Light getBySystemName(@Nonnull String key) {
-        return _tsys.get(key);
+    protected String getIncrement(String curAddress, int increment) throws jmri.JmriException {
+        return CbusAddress.getIncrement(curAddress);
     }
 
     /**

--- a/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
@@ -2,10 +2,12 @@ package jmri.jmrix.can.cbus;
 
 import java.beans.PropertyChangeEvent;
 import java.util.Locale;
+
 import javax.annotation.Nonnull;
-import jmri.JmriException;
-import jmri.Sensor;
+
+import jmri.*;
 import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.cbus.Bundle;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,43 +32,23 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager {
 
     /**
      * {@inheritDoc}
-     */
-    @Override
-    @Nonnull
-    public CanSystemConnectionMemo getMemo() {
-        return (CanSystemConnectionMemo) memo;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void dispose() {
-        super.dispose();
-    }
-
-    // CBUS-specific methods
-
-    /**
-     * {@inheritDoc}
      *
      * @throws IllegalArgumentException if the system name is not in a valid format
      */
     @Override
     @Nonnull
     public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
-        String addr = systemName.substring(getSystemPrefix().length() + 1);
+        String addr = systemName.substring(getSystemNamePrefix().length());
         // first, check validity
+        String newAddress;
         try {
-            validateAddressFormat(addr);
+            newAddress = CbusAddress.validateSysName(addr);
         } catch (IllegalArgumentException e) {
-            log.error(e.toString());
+            log.error(e.getMessage());
             throw e;
         }
-        // validate (will add "+" to unsigned int)
-        String newAddress = CbusAddress.validateSysName(addr);
         // OK, make
-        Sensor s = new CbusSensor(getSystemPrefix(), newAddress, getMemo().getTrafficController());
+        Sensor s = new CbusSensor(getSystemPrefix(), newAddress, ((CanSystemConnectionMemo)getMemo()).getTrafficController());
         s.setUserName(userName);
         return s;
     }
@@ -75,16 +57,15 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager {
      * {@inheritDoc}
      */
     @Override
-    @Nonnull
     public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
         // first, check validity
+        String newAddress;
         try {
-            validateAddressFormat(curAddress);
-        } catch (IllegalArgumentException e) {
-            throw new JmriException(e.toString());
+            validateSystemNamePrefix(prefix + typeLetter() + curAddress, Locale.getDefault());
+            newAddress = CbusAddress.validateSysName(curAddress);
+         } catch (IllegalArgumentException  e) {
+             throw new JmriException(e.getMessage());
         }
-        // getSystemPrefix() unsigned int with "+" as service to user
-        String newAddress = CbusAddress.validateSysName(curAddress);
         return prefix + typeLetter() + newAddress;
     }
 
@@ -97,41 +78,13 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager {
     }
 
     /**
+     * Only increments by 1, which is fine for CBUS Sensors.
      * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
-        String testAddr = curAddress;
-        // make sure starting name is valid
-        try {
-            validateAddressFormat(testAddr);
-        } catch (IllegalArgumentException e) {
-            throw new JmriException(e.toString());
-        }
-        testAddr = CbusAddress.validateSysName(testAddr); // normalize Merg address
-        Sensor s = getBySystemName(prefix + typeLetter() + testAddr);
-        if (s != null) {
-            // build local addresses
-            for (int x = 1; x < 10; x++) {
-                testAddr = CbusAddress.getIncrement(testAddr); // getIncrement will perform a max check on the numbers
-                if (testAddr == null) {
-                    return null;
-                }
-                s = getBySystemName(getSystemPrefix() + typeLetter() + testAddr);
-                if (s == null) {
-                    // If the hardware address + x does not already exist,
-                    // then this can be considered the next valid address.
-                    return testAddr;
-                }
-            }
-            // feedback when next address is also in use
-            log.warn("10 hardware addresses starting at {} already in use. No new {} Sensors added", curAddress, getMemo().getUserName());
-            return null;
-        } else {
-            // If the initially requested hardware address does not already exist,
-            // then this can be considered the next valid address.
-            return testAddr;
-        }
+    protected String getIncrement(String curAddress, int increment) throws JmriException {
+        return CbusAddress.getIncrement(curAddress);
     }
 
     /**
@@ -142,7 +95,7 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager {
     public String validateSystemNameFormat(@Nonnull String name, @Nonnull Locale locale) {
         validateSystemNamePrefix(name, locale);
         try {
-            validateAddressFormat(name.substring(getSystemNamePrefix().length()));
+            CbusAddress.validateSysName(name.substring(getSystemNamePrefix().length()));
         } catch (IllegalArgumentException ex) {
             throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCustom", ex.getMessage());
         }
@@ -156,28 +109,12 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager {
     public NameValidity validSystemNameFormat(@Nonnull String systemName) {
         String addr;
         try {
-            addr = systemName.substring(getSystemPrefix().length() + 1); // get only the address part
-        } catch (StringIndexOutOfBoundsException e) {
-            return NameValidity.INVALID;
-        }
-        try {
-            validateAddressFormat(addr);
-        } catch (IllegalArgumentException e) {
+            addr = systemName.substring(getSystemNamePrefix().length()); // get only the address part
+            CbusAddress.validateSysName(addr);
+        } catch (StringIndexOutOfBoundsException | IllegalArgumentException e) {
             return NameValidity.INVALID;
         }
         return NameValidity.VALID;
-    }
-
-    /**
-     * Work out the details for Cbus hardware address validation. Logging of
-     * handled cases no higher than WARN.
-     *
-     * @param address the hardware address to check
-     * @throws IllegalArgumentException when delimiter is not found
-     */
-    void validateAddressFormat(String address) throws IllegalArgumentException {
-        String newAddress = CbusAddress.validateSysName(address);
-        log.debug("validated system name {}", newAddress);
     }
 
     /**

--- a/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
@@ -7,7 +7,6 @@ import javax.annotation.Nonnull;
 
 import jmri.*;
 import jmri.jmrix.can.CanSystemConnectionMemo;
-import jmri.jmrix.can.cbus.Bundle;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
@@ -35,28 +35,18 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
      * {@inheritDoc}
      */
     @Override
-    @Nonnull
-    public CanSystemConnectionMemo getMemo() {
-        return (CanSystemConnectionMemo) memo;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     protected Turnout createNewTurnout(@Nonnull String systemName, String userName) {
         String addr = systemName.substring(getSystemPrefix().length() + 1);
         // first, check validity
+        String newAddress;
         try {
-            validateAddressFormat(addr);
+            newAddress = CbusAddress.validateSysName(addr);
         } catch (IllegalArgumentException e) {
             log.error(e.getMessage());
             throw e;
         }
-        // validate (will add "+" to unsigned int)
-        String newAddress = CbusAddress.validateSysName(addr);
         // OK, make
-        Turnout t = new CbusTurnout(getSystemPrefix(), newAddress, getMemo().getTrafficController());
+        Turnout t = new CbusTurnout(getSystemPrefix(), newAddress, ((CanSystemConnectionMemo)getMemo()).getTrafficController());
         t.setUserName(userName);
         return t;
     }
@@ -83,40 +73,15 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
         }
         return prefix + typeLetter() + newAddress;
     }
-
+    
     /**
+     * Only increments by 1, which is fine for CBUS Turnouts.
      * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
-        String testAddr = curAddress;
-        // make sure starting name is valid
-        try {
-            validateAddressFormat(testAddr);
-        } catch (IllegalArgumentException e) {
-            throw new JmriException(e.getMessage());
-        }
-        testAddr = CbusAddress.validateSysName(testAddr); // normalize Merg address
-        Turnout t = getBySystemName(prefix + typeLetter() + testAddr);
-        if (t != null) {
-            // build local addresses
-            for (int x = 1; x < 10; x++) {
-                testAddr = CbusAddress.getIncrement(testAddr); // getIncrement will perform a max check on the numbers
-                t = getBySystemName(prefix + typeLetter() + testAddr);
-                if (t == null) {
-                    // If the hardware address + x does not already exist,
-                    // then this can be considered the next valid address.
-                    return testAddr;
-                }
-            }
-            // feedback when next address is also in use
-            log.warn("10 hardware addresses starting at {} already in use. No new {} Turnouts added", curAddress, getMemo().getUserName());
-            return null;
-        } else {
-            // If the initially requested hardware address does not already exist,
-            // then this can be considered the next valid address.
-            return testAddr;
-        }
+    protected String getIncrement(String curAddress, int increment) throws JmriException {
+        return CbusAddress.getIncrement(curAddress);
     }
 
     /**
@@ -127,7 +92,7 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
     public String validateSystemNameFormat(@Nonnull String name, @Nonnull Locale locale) {
         validateSystemNamePrefix(name, locale);
         try {
-            validateAddressFormat(name.substring(getSystemNamePrefix().length()));
+            CbusAddress.validateSysName(name.substring(getSystemNamePrefix().length()));
         } catch (IllegalArgumentException ex) {
             throw new jmri.NamedBean.BadSystemNameException(locale, "InvalidSystemNameCustom", ex.getMessage());
         }
@@ -146,23 +111,11 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
             return NameValidity.INVALID;
         }
         try {
-            validateAddressFormat(addr);
+            CbusAddress.validateSysName(addr);
         } catch (IllegalArgumentException e){
             return NameValidity.INVALID;
         }
         return NameValidity.VALID;
-    }
-
-    /**
-     * Work out the details for Cbus hardware address validation.
-     * Logging of handled cases no higher than WARN.
-     *
-     * @param address the hardware address to check
-     * @throws IllegalArgumentException when delimiter is not found
-     */
-    void validateAddressFormat(String address) throws IllegalArgumentException {
-        String newAddress = CbusAddress.validateSysName(address);
-        log.debug("validated system name {}", newAddress);
     }
 
     /**

--- a/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
@@ -172,8 +172,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
                 nAddress = Integer.parseInt(curAddress.substring(0, seperator));
                 bitNum = Integer.parseInt(curAddress.substring(seperator + 1));
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} Hardware Address to a number", curAddress);
-                throw new JmriException("Unable to convert " + curAddress + " to a valid Hardware Address");
+                throw new JmriException("Unable to convert " + curAddress + " to a number.");
             }
             tmpSName = getMemo().makeSystemName("S", nAddress, bitNum);
         } else if (curAddress.contains("B") || (curAddress.contains("b"))) {
@@ -184,8 +183,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
                 int b = (curAddress.toUpperCase()).indexOf("B") + 1;
                 Integer.parseInt(curAddress.substring(b));
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} Hardware Address to a number", curAddress);
-                throw new JmriException("Unable to convert " + curAddress + " to a valid Hardware Address");
+                throw new JmriException("Unable to convert " + curAddress + " to a number");
             }
             tmpSName = prefix + typeLetter() + curAddress;
             bitNum = getMemo().getBitFromSystemName(tmpSName);
@@ -195,7 +193,6 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
                 //We do this to simply check that the value passed is a number!
                 Integer.parseInt(curAddress);
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} Hardware Address to a number", curAddress);
                 throw new JmriException("Unable to convert " + curAddress + " to a valid Hardware Address");
             }
             tmpSName = prefix + typeLetter() + curAddress;
@@ -213,25 +210,15 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      * {@inheritDoc}
      */
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
         //If the hardware address passed does not already exist then this can
         //be considered the next valid address.
 
-        String tmpSName = "";
-        try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            log.error("Unable to convert {} Hardware Address to a number", curAddress);
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("ErrorTitle"),
-                            Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false);
-
-            return null;
-        }
+        String tmpSName = createSystemName(curAddress, prefix);
         //Check to determine if the systemName is in use, return null if it is,
         //otherwise return the next valid address.
         Sensor s = getBySystemName(tmpSName);
-        if (s != null) {
+        if (s != null || ignoreInitialExisting) {
             for (int x = 1; x < 10; x++) {
                 bitNum++;
                 tmpSName = getMemo().makeSystemName("S", nAddress, bitNum);
@@ -242,7 +229,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
                     return curAddress;
                 }
             }
-            return null;
+            throw new JmriException(Bundle.getMessage("InvalidNextValidTenInUse",getBeanTypeHandled(true),curAddress,tmpSName));
         } else {
             int seperator = tmpSName.lastIndexOf("S") + 1;
             curAddress = tmpSName.substring(seperator);

--- a/java/src/jmri/jmrix/cmri/serial/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialTurnoutManager.java
@@ -1,12 +1,14 @@
 package jmri.jmrix.cmri.serial;
 
 import java.util.Locale;
+
 import javax.annotation.Nonnull;
 import javax.swing.JOptionPane;
-import jmri.JmriException;
-import jmri.Turnout;
+
+import jmri.*;
 import jmri.jmrix.cmri.CMRISystemConnectionMemo;
 import jmri.managers.AbstractTurnoutManager;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -256,10 +258,6 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
             try {
                 bitNum = Integer.parseInt(curAddress.substring(seperator + 1));
             } catch (NumberFormatException ex) {
-                JOptionPane.showMessageDialog(null, Bundle.getMessage("ErrorAssignFormat2", curAddress) + "\n" +
-                        Bundle.getMessage("ErrorAssignFormatHelp"),
-                        Bundle.getMessage("ErrorAssignTitle"),
-                        JOptionPane.INFORMATION_MESSAGE, null);
                 throw new JmriException("Part 2 of " + curAddress + " is not an integer");
             }
             tmpSName = getMemo().makeSystemName("T", nAddress, bitNum);
@@ -281,11 +279,6 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
                 // We do this to simply check that the value passed is a number!
                 Integer.parseInt(curAddress);
             } catch (NumberFormatException ex) {
-                // show dialog to user
-                JOptionPane.showMessageDialog(null, Bundle.getMessage("ErrorAssignFormat", curAddress) + "\n" +
-                        Bundle.getMessage("ErrorAssignFormatHelp"),
-                        Bundle.getMessage("ErrorAssignTitle"),
-                        JOptionPane.INFORMATION_MESSAGE, null);
                 throw new JmriException("Address " + curAddress + " is not an integer");
             }
             tmpSName = prefix + "T" + curAddress;
@@ -302,50 +295,38 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
      * {@inheritDoc}
      */
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
         String tmpSName = "";
         try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            throw ex;
+            tmpSName = validateSystemNameFormat(createSystemName(curAddress, prefix));
+        } catch (JmriException | NamedBean.BadNameException ex) {
+            throw new JmriException(ex.getMessage());
         }
 
         //If the hardware address part does not already exist then this can
         //be considered the next valid address.
         Turnout t = getBySystemName(tmpSName);
-        if (t == null) {
+        if (t == null && !ignoreInitialExisting) {
             /* We look for the last instance of T, as the hardware address side
              of the system name should not contain the letter, however parts of the prefix might */
             int seperator = tmpSName.lastIndexOf("T") + 1;
-            curAddress = tmpSName.substring(seperator);
-            return curAddress;
+            return tmpSName.substring(seperator);
         }
 
         //The Number of Output Bits of the previous turnout will help determine the next
         //valid address.
-        bitNum = bitNum + t.getNumberOutputBits();
-        //Check to determine if the systemName is in use, return null if it is,
-        //otherwise return the next valid address.
-        tmpSName = getMemo().makeSystemName("T", nAddress, bitNum);
-        t = getBySystemName(tmpSName);
-        if (t != null) {
-            for (int x = 1; x < 10; x++) {
-                bitNum = bitNum + t.getNumberOutputBits();
-                //System.out.println("This should increment " + bitNum);
-                tmpSName = getMemo().makeSystemName("T", nAddress, bitNum);
-                t = getBySystemName(tmpSName);
-                if (t == null) {
-                    int seperator = tmpSName.lastIndexOf("T") + 1;
-                    curAddress = tmpSName.substring(seperator);
-                    return curAddress;
-                }
+        int increment = t==null ? 1 : t.getNumberOutputBits();
+        for (int x = 0; x < 10; x++) {
+            bitNum = bitNum + increment;
+            //System.out.println("This should increment " + bitNum);
+            tmpSName = getMemo().makeSystemName("T", nAddress, bitNum);
+            t = getBySystemName(tmpSName);
+            if (t == null) {
+                int seperator = tmpSName.lastIndexOf("T") + 1;
+                return tmpSName.substring(seperator);
             }
-            return null;
-        } else {
-            int seperator = tmpSName.lastIndexOf("T") + 1;
-            curAddress = tmpSName.substring(seperator);
-            return curAddress;
         }
+        throw new JmriException(Bundle.getMessage("InvalidNextValidTenInUse",getBeanTypeHandled(true),curAddress,tmpSName));
     }
 
     /**
@@ -353,7 +334,8 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
      */
     @Override
     @Nonnull
-    public String validateSystemNameFormat(@Nonnull String systemName, @Nonnull Locale locale) {
+    public String validateSystemNameFormat(@Nonnull String systemName, @Nonnull Locale locale) throws NamedBean.BadSystemNameException {
+        systemName = validateSystemNamePrefix(systemName, locale);
         return getMemo().validateSystemNameFormat(super.validateSystemNameFormat(systemName, locale), typeLetter(), locale);
     }
     

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcSensorManager.java
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcSensorManager.java
@@ -71,6 +71,7 @@ public class Dcc4PcSensorManager extends jmri.managers.AbstractSensorManager
 
     /**
      * This extracts the board id out from the system name.
+     * @param systemName including system prefix and type letter.
      */
     void extractBoardID(String systemName) {
         if (systemName.contains(":")) {

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcSensorManager.java
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcSensorManager.java
@@ -69,7 +69,7 @@ public class Dcc4PcSensorManager extends jmri.managers.AbstractSensorManager
         return s;
     }
 
-    /*
+    /**
      * This extracts the board id out from the system name.
      */
     void extractBoardID(String systemName) {
@@ -107,25 +107,21 @@ public class Dcc4PcSensorManager extends jmri.managers.AbstractSensorManager
             try {
                 board = Integer.parseInt(curAddress.substring(0, seperator));
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} into the cab and channel format of nn:xx", curAddress);
-                throw new JmriException("Hardware Address passed should be a number");
+                throw new JmriException("Unable to convert "+curAddress+" into the cab and channel format of nn:xx");
             }
 
             try {
                 channel = Integer.parseInt(curAddress.substring(seperator + 1));
                 if ((channel > 16) || (channel < 1)) {
-                    log.error("Channel number is out of range");
-                    throw new JmriException("Channel number should be in the range of 1 to 16");
+                    throw new JmriException("In Address "+curAddress+" Channel number should be in the range of 1 to 16");
                 }
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} into the cab and channel format of nn:xx", curAddress);
-                throw new JmriException("Hardware Address passed should be a number");
+                throw new JmriException("Unable to convert "+curAddress+" into the cab and channel format of nn:xx");
             }
             iName = curAddress;
             addBoard(board);
         } else {
-            log.error("Unable to convert {} Hardware Address to a number", curAddress);
-            throw new JmriException("Unable to convert " + curAddress + " Hardware Address to a number");
+            throw new JmriException("Unable to convert "+curAddress+" into the cab and channel format of nn:xx");
         }
         return prefix + typeLetter() + iName;
     }
@@ -134,23 +130,13 @@ public class Dcc4PcSensorManager extends jmri.managers.AbstractSensorManager
     private int channel;
 
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
 
-        String tmpSName = "";
-
-        try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("ErrorTitle"),
-                            Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false);
-            return null;
-        }
-
+        String tmpSName = createSystemName(curAddress, prefix);
         //Check to determine if the systemName is in use, return null if it is,
         //otherwise return the next valid address.
         Sensor s = getBySystemName(tmpSName);
-        if (s != null) {
+        if (s != null || ignoreInitialExisting) {
             for (int x = 1; x < 10; x++) {
                 if (channel < 16) {
                     channel++;
@@ -163,7 +149,7 @@ public class Dcc4PcSensorManager extends jmri.managers.AbstractSensorManager
                     return board + ":" + channel;
                 }
             }
-            return null;
+            throw new JmriException(Bundle.getMessage("InvalidNextValidTenInUse",getBeanTypeHandled(true),curAddress,board + ":" + channel));
         } else {
             return curAddress;
         }

--- a/java/src/jmri/jmrix/dccpp/DCCppLightManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppLightManager.java
@@ -48,7 +48,7 @@ public class DCCppLightManager extends AbstractLightManager {
      * @return null if the system name is not in a valid format
      */
     @Override
-    public Light createNewLight(String systemName, String userName) {
+    protected Light createNewLight(String systemName, String userName) {
         // check if the output bit is available
         int bitNum = getBitFromSystemName(systemName);
         if (bitNum == 0) {
@@ -89,14 +89,6 @@ public class DCCppLightManager extends AbstractLightManager {
             return 0;
         }
         return Integer.parseInt(systemName.substring(getSystemNamePrefix().length()));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean validSystemNameConfig(@Nonnull String systemName) {
-        return (true);
     }
 
     /**

--- a/java/src/jmri/jmrix/ecos/EcosTurnoutManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosTurnoutManager.java
@@ -70,10 +70,9 @@ public class EcosTurnoutManager extends jmri.managers.AbstractTurnoutManager
     public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
         int addr;
         try {
-            addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+            addr = Integer.parseInt(systemName.substring(getSystemNamePrefix().length()));
         } catch (java.lang.NumberFormatException e) {
-            log.error("failed to convert systemName '{}' to a turnout address", systemName);
-            return null;
+            throw new IllegalArgumentException("failed to convert systemName '"+systemName+"' to an Ecos turnout address");
         }
         Turnout t = new EcosTurnout(addr, getSystemPrefix(), tc, this);
         t.setUserName(userName);
@@ -682,6 +681,18 @@ public class EcosTurnoutManager extends jmri.managers.AbstractTurnoutManager
         }
     }
     
+    @Override
+    @Nonnull
+    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
+        int iName;
+        try {
+                iName = Integer.parseInt(curAddress);
+            } catch (NumberFormatException ex) {
+                throw new JmriException("Hardware Address passed "+curAddress+" should be a number.");
+            }
+        return prefix + typeLetter() + iName;
+    }
+    
     /**
      * Validates to contain at least 1 number . . .
      * <p>
@@ -691,7 +702,7 @@ public class EcosTurnoutManager extends jmri.managers.AbstractTurnoutManager
     @Override
     @Nonnull
     public String validateSystemNameFormat(@Nonnull String name, @Nonnull java.util.Locale locale) throws jmri.NamedBean.BadSystemNameException {
-        return validateTrimmedMin1NumberSystemNameFormat(name,locale);
+        return validateSystemNameFormatOnlyNumeric(name, locale);
     }
 
     private final static Logger log = LoggerFactory.getLogger(EcosTurnoutManager.class);

--- a/java/src/jmri/jmrix/internal/InternalReporterManager.java
+++ b/java/src/jmri/jmrix/internal/InternalReporterManager.java
@@ -31,12 +31,12 @@ public class InternalReporterManager extends jmri.managers.AbstractReporterManag
     }
 
     /**
+     * No validation for Internal Reporters.
      * {@inheritDoc}
      */
     @Override
-    @Nonnull
-    public InternalSystemConnectionMemo getMemo() {
-        return (InternalSystemConnectionMemo) memo;
+    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {
+        return prefix + typeLetter() + curAddress;
     }
 
 }

--- a/java/src/jmri/jmrix/internal/InternalSensorManager.java
+++ b/java/src/jmri/jmrix/internal/InternalSensorManager.java
@@ -75,44 +75,6 @@ public class InternalSensorManager extends jmri.managers.AbstractSensorManager {
         return Bundle.getMessage("AddInputEntryToolTip");
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
-        // If the hardware address passed does not already exist then this can
-        // be considered the next valid address.
-        Sensor s = getBySystemName(prefix + typeLetter() + curAddress);
-        if (s == null) {
-            return curAddress;
-        }
-
-        // This bit deals with handling the curAddress, and how to get the next
-        // address.
-        int iName = 0;
-        try {
-            iName = Integer.parseInt(curAddress);
-        } catch (NumberFormatException ex) {
-            log.error("Unable to convert {} Hardware Address to a number", curAddress);
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).showErrorMessage("Error",
-                    "Unable to convert " + curAddress + " to a valid Hardware Address", "" + ex, "", true, false);
-            return null;
-        }
-        // Check to determine if the systemName is in use, return null if it is,
-        // otherwise return the next valid address.
-        s = getBySystemName(prefix + typeLetter() + iName);
-        if (s != null) {
-            for (int x = 1; x < 10; x++) {
-                iName = iName + 1;
-                s = getBySystemName(prefix + typeLetter() + iName);
-                if (s == null) {
-                    return Integer.toString(iName);
-                }
-            }
-            return null;
-        } else {
-            return Integer.toString(iName);
-        }
-    }
-
     /**
      * {@inheritDoc}
      */
@@ -120,6 +82,15 @@ public class InternalSensorManager extends jmri.managers.AbstractSensorManager {
     @Nonnull
     public InternalSystemConnectionMemo getMemo() {
         return (InternalSystemConnectionMemo) memo;
+    }
+    
+    /**
+     * No validation for Internal Sensors.
+     * {@inheritDoc}
+     */
+    @Override
+    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {
+        return prefix + typeLetter() + curAddress;
     }
 
     private static final Logger log = LoggerFactory.getLogger(InternalSensorManager.class);

--- a/java/src/jmri/jmrix/internal/InternalTurnoutManager.java
+++ b/java/src/jmri/jmrix/internal/InternalTurnoutManager.java
@@ -56,11 +56,19 @@ public class InternalTurnoutManager extends AbstractTurnoutManager {
         };
     }
 
+    /**
+     * Multiple additions enabled for Internal Turnouts.
+     * {@inheritDoc}
+     */
     @Override
     public boolean allowMultipleAdditions(@Nonnull String systemName) {
         return true;
     }
 
+    /**
+     * No validation for Internal Turnouts.
+     * {@inheritDoc}
+     */
     @Override
     public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {
         return prefix + typeLetter() + curAddress;

--- a/java/src/jmri/jmrix/lenz/XNetSensorManager.java
+++ b/java/src/jmri/jmrix/lenz/XNetSensorManager.java
@@ -198,8 +198,7 @@ public class XNetSensorManager extends jmri.managers.AbstractSensorManager imple
                 encoderAddress = Integer.parseInt(curAddress.substring(0, seperator));
                 input = Integer.parseInt(curAddress.substring(seperator + 1));
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} into the cab and input format of nn:xx", curAddress);
-                throw new JmriException("Hardware Address passed should be a number");
+                throw new JmriException("Unable to convert "+curAddress+" into the cab and input format of nn:xx");
             }
             iName = ((encoderAddress - 1) * 8) + input;
         } else {
@@ -207,8 +206,7 @@ public class XNetSensorManager extends jmri.managers.AbstractSensorManager imple
             try {
                 iName = Integer.parseInt(curAddress);
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} Hardware Address to a number", curAddress);
-                throw new JmriException("Hardware Address passed should be a number");
+                throw new JmriException("Hardware Address "+curAddress+" should be a number or the cab and input format of nn:xx");
             }
         }
         return prefix + typeLetter() + iName;
@@ -220,23 +218,14 @@ public class XNetSensorManager extends jmri.managers.AbstractSensorManager imple
      * Does not enforce any rules on the encoder or input values.
      */
     @Override
-    synchronized public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
+    synchronized public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
 
-        String tmpSName;
-
-        try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("ErrorTitle"),
-                            Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false);
-            return null;
-        }
+        String tmpSName = createSystemName(curAddress, prefix);
 
         //Check to determine if the systemName is in use, return null if it is,
         //otherwise return the next valid address.
         Sensor s = getBySystemName(tmpSName);
-        if (s != null) {
+        if (s != null || ignoreInitialExisting) {
             for (int x = 1; x < 10; x++) {
                 iName = iName + 1;
                 s = getBySystemName(prefix + typeLetter() + iName);
@@ -244,7 +233,7 @@ public class XNetSensorManager extends jmri.managers.AbstractSensorManager imple
                     return Integer.toString(iName);
                 }
             }
-            return null;
+            throw new JmriException(Bundle.getMessage("InvalidNextValidTenInUse",getBeanTypeHandled(true),curAddress,iName));
         } else {
             return Integer.toString(iName);
         }

--- a/java/src/jmri/jmrix/loconet/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/LnSensorManager.java
@@ -160,15 +160,13 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
                 try {
                     board = Integer.parseInt(curAddress.substring(0, seperator));
                 } catch (NumberFormatException ex) {
-                    log.error("Unable to convert '{}' into the cab and channel format of nn:xx", curAddress); // NOI18N
-                    throw new JmriException("Hardware Address passed should be a number"); // NOI18N
+                    throw new JmriException("Unable to convert '"+curAddress+"' into the cab and channel format of nn:xx"); // NOI18N
                 }
             }
             try {
                 channel = Integer.parseInt(curAddress.substring(seperator + 1));
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert '{}' into the cab and channel format of nn:xx", curAddress); // NOI18N
-                throw new JmriException("Hardware Address passed should be a number"); // NOI18N
+                throw new JmriException("Unable to convert '"+curAddress+"' into the cab and channel format of nn:xx"); // NOI18N
             }
             if (turnout) {
                 iName = 2 * (channel - 1) + 1;
@@ -183,8 +181,7 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
             try {
                 iName = Integer.parseInt(curAddress);
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert '{}' Hardware Address to a number", curAddress); // NOI18N
-                throw new JmriException("Hardware Address passed should be a number"); // NOI18N
+                throw new JmriException("Hardware Address passed "+curAddress+" should be a number"); // NOI18N
             }
         }
         return prefix + typeLetter() + iName;
@@ -221,39 +218,6 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
             return 0;
         }
         return Integer.parseInt(systemName.substring(getSystemNamePrefix().length()));
-    }
-
-    @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
-
-        String tmpSName = "";
-
-        try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("ErrorTitle"),
-                            Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false); // I18N
-            return null;
-        }
-
-        // Check to determine if the systemName is in use, return null if it is,
-        // otherwise return the next valid address.
-        Sensor s = getBySystemName(tmpSName);
-        if (s != null) {
-            for (int x = 1; x < 10; x++) {
-                iName = iName + 1;
-                s = getBySystemName(prefix + typeLetter() + iName);
-                if (s == null) {
-                    return Integer.toString(iName);
-                }
-            }
-            // feedback when next 10 addresses are also in use
-            log.warn("10 hardware addresses starting at {} already in use. No new LocoNet Sensors added", curAddress);
-            return null;
-        } else {
-            return Integer.toString(iName);
-        }
     }
 
     /**

--- a/java/src/jmri/jmrix/maple/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/maple/SerialSensorManager.java
@@ -173,8 +173,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
                 sysNode = Integer.parseInt(curAddress.substring(0, seperator));
                 address = Integer.parseInt(curAddress.substring(seperator + 1));
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} into the cab and address format of nn:xx", curAddress);
-                throw new JmriException("Hardware Address passed should be a number");
+                throw new JmriException("Unable to convert "+curAddress+" into the cab and address format of nn:xx");
             }
             iName = (sysNode * 1000) + address;
         } else {
@@ -182,8 +181,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
             try {
                 iName = Integer.parseInt(curAddress);
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} Hardware Address to a number", curAddress);
-                throw new JmriException("Hardware Address passed should be a number");
+                throw new JmriException("Hardware Address passed "+curAddress+" should be a number or the cab and address format of nn:xx");
             }
         }
         return prefix + typeLetter() + iName;
@@ -194,22 +192,13 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     private int iName = 0;
 
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
 
-        String tmpSName = "";
-
-        try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("ErrorTitle"),
-                            Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false);
-            return null;
-        }
+        String tmpSName = createSystemName(curAddress, prefix);
         //Check to determine if the systemName is in use, return null if it is,
         //otherwise return the next valid address.
         Sensor s = getBySystemName(tmpSName);
-        if (s != null) {
+        if (s != null || ignoreInitialExisting) {
             for (int x = 1; x < 10; x++) {
                 iName = iName + 1;
                 s = getBySystemName(prefix + typeLetter() + iName);
@@ -217,7 +206,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
                     return Integer.toString(iName);
                 }
             }
-            return null;
+            throw new JmriException(Bundle.getMessage("InvalidNextValidTenInUse",getBeanTypeHandled(true),curAddress,iName));
         } else {
             return Integer.toString(iName);
         }

--- a/java/src/jmri/jmrix/marklin/MarklinSensorManager.java
+++ b/java/src/jmri/jmrix/marklin/MarklinSensorManager.java
@@ -88,11 +88,7 @@ public class MarklinSensorManager extends jmri.managers.AbstractSensorManager
     @Nonnull
     public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
         if (!curAddress.contains(":")) {
-            log.error("Unable to convert {} into the Module and port format of nn:xx", curAddress);
-            JOptionPane.showMessageDialog(null, Bundle.getMessage("WarningModuleAddress"),
-                    Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
-            // TODO prevent further execution, return error flag
-            throw new JmriException("Hardware Address should be passed in the form 'Module:port'");
+            throw new JmriException("Hardware Address "+curAddress+"should be passed in the form 'Module:port'");
         }
 
         //Address format passed is in the form of board:channel or T:turnout address
@@ -100,22 +96,16 @@ public class MarklinSensorManager extends jmri.managers.AbstractSensorManager
         try {
             board = Integer.parseInt(curAddress.substring(0, seperator));
         } catch (NumberFormatException ex) {
-            log.error("First part of {} in front of : should be a number", curAddress);
-            throw new JmriException("Module Address passed should be a number");
+            throw new JmriException("First part of "+curAddress+" in front of : should be a number");
         }
         try {
             port = Integer.parseInt(curAddress.substring(seperator + 1));
         } catch (NumberFormatException ex) {
-            log.error("Second part of {} after : should be a number", curAddress);
-            throw new JmriException("Port Address passed should be a number");
+            throw new JmriException("Second part of "+curAddress+" after : should be a number");
         }
 
         if (port == 0 || port > 16) {
-            log.error("Port number must be between 1 and 16");
-            JOptionPane.showMessageDialog(null, Bundle.getMessage("WarningPortRangeXY", 1, 16),
-                    Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
-            // TODO prevent further execution, return error flag
-            throw new JmriException("Port number must be between 1 and 16");
+            throw new JmriException("Port number "+port+" in "+curAddress+" must be between 1 and 16");
         }
         StringBuilder sb = new StringBuilder();
         sb.append(getSystemPrefix());
@@ -131,31 +121,22 @@ public class MarklinSensorManager extends jmri.managers.AbstractSensorManager
     private int port = 0;
 
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
+    public boolean allowMultipleAdditions(@Nonnull String systemName) {
+        return true;
+    }
+    
+    @Override
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
 
-        String tmpSName;
-
-        try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("ErrorTitle"), Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false);
-            return null;
-        }
+        String tmpSName = createSystemName(curAddress, prefix);
 
         // Check to determine if the System Name is in use, return null if it is,
         // otherwise return the next valid address.
         Sensor s = getBySystemName(tmpSName);
-        if (s != null) {
+        if (s != null || ignoreInitialExisting) {
             port++;
             while (port < 17) {
-                try {
-                    tmpSName = createSystemName(board + ":" + port, prefix);
-                } catch (JmriException e) {
-                    log.error("Error creating system name for {}:{}", board, port);
-                    JOptionPane.showMessageDialog(null, (Bundle.getMessage("ErrorCreateSystemName") +  " " + board + ":" + port),
-                            Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
-                }
+                tmpSName = createSystemName(board + ":" + port, prefix);
                 s = getBySystemName(tmpSName);
                 if (s == null) {
                     StringBuilder sb = new StringBuilder();
@@ -167,7 +148,7 @@ public class MarklinSensorManager extends jmri.managers.AbstractSensorManager
                 }
                 port++;
             }
-            return null;
+            throw new JmriException(Bundle.getMessage("InvalidNextValidTenInUse",getBeanTypeHandled(true),curAddress,tmpSName));
         } else {
             StringBuilder sb = new StringBuilder();
             sb.append(board);

--- a/java/src/jmri/jmrix/mqtt/MqttLightManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttLightManager.java
@@ -59,6 +59,12 @@ public class MqttLightManager extends jmri.managers.AbstractLightManager {
     public boolean validSystemNameConfig(String systemName) {
         return true;
     }
+    
+    /** {@inheritDoc} */
+    @Override
+    public boolean allowMultipleAdditions(String systemName) {
+        return true;
+    }
 
     /**
      * {@inheritDoc}

--- a/java/src/jmri/jmrix/mqtt/MqttSensorManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttSensorManager.java
@@ -3,7 +3,6 @@ package jmri.jmrix.mqtt;
 import javax.annotation.*;
 
 import jmri.*;
-import jmri.implementation.AbstractSensor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,43 +104,6 @@ public class MqttSensorManager extends jmri.managers.AbstractSensorManager {
     @Override
     public String getEntryToolTip() {
         return Bundle.getMessage("AddInputEntryToolTip");
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public String getNextValidAddress(String curAddress, String prefix) {
-        // If the hardware address passed does not already exist then this can
-        // be considered the next valid address.
-        Sensor s = getBySystemName(prefix + typeLetter() + curAddress);
-        if (s == null) {
-            return curAddress;
-        }
-
-        // This bit deals with handling the curAddress, and how to get the next address.
-        int iName = 0;
-        try {
-            iName = Integer.parseInt(curAddress);
-        } catch (NumberFormatException ex) {
-            log.error("Unable to convert " + curAddress + " Hardware Address to a number");
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage("Error", "Unable to convert " + curAddress + " to a valid Hardware Address", "" + ex, "", true, false);
-            return null;
-        }
-        //Check to determine if the systemName is in use, return null if it is,
-        //otherwise return the next valid address.
-        s = getBySystemName(prefix + typeLetter() + iName);
-        if (s != null) {
-            for (int x = 1; x < 10; x++) {
-                iName = iName + 1;
-                s = getBySystemName(prefix + typeLetter() + iName);
-                if (s == null) {
-                    return Integer.toString(iName);
-                }
-            }
-            return null;
-        } else {
-            return Integer.toString(iName);
-        }
     }
 
     public void setParser(MqttContentParser<Sensor> parser) {

--- a/java/src/jmri/jmrix/mqtt/MqttTurnoutManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnoutManager.java
@@ -89,6 +89,12 @@ public class MqttTurnoutManager extends jmri.managers.AbstractTurnoutManager {
     public String getEntryToolTip() {
         return "A string which will be inserted into \"" + sendTopicPrefix + "\" for transmission";
     }
+    
+    /** {@inheritDoc} */
+    @Override
+    public boolean allowMultipleAdditions(String systemName) {
+        return true;
+    }
 
     public void setParser(MqttContentParser<Turnout> parser) {
         this.parser = parser;

--- a/java/src/jmri/jmrix/nce/NceSensorManager.java
+++ b/java/src/jmri/jmrix/nce/NceSensorManager.java
@@ -377,8 +377,7 @@ public class NceSensorManager extends jmri.managers.AbstractSensorManager
                 aiucab = Integer.parseInt(curAddress.substring(0, seperator));
                 pin = Integer.parseInt(curAddress.substring(seperator + 1));
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} into the cab and pin format of nn:xx", curAddress);
-                throw new JmriException("Hardware Address passed should be a number");
+                throw new JmriException("Unable to convert "+curAddress+" into the cab and pin format of nn:xx");
             }
             iName = (aiucab - 1) * 16 + pin - 1;
 
@@ -387,23 +386,17 @@ public class NceSensorManager extends jmri.managers.AbstractSensorManager
             try {
                 iName = Integer.parseInt(curAddress);
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} Hardware Address to a number", curAddress);
-                throw new JmriException("Hardware Address passed should be a number");
+                throw new JmriException("Hardware Address passed "+curAddress+" should be a number or the cab and pin format of nn:xx");
             }
             pin = iName % 16 + 1;
             aiucab = iName / 16 + 1;
         }
         // only pins 1 through 14 are valid
         if (pin == 0 || pin > MAXPIN) {
-            log.error("NCE sensor {}} pin number {} is out of range; only pin numbers 1 - 14 are valid",
-                    curAddress, pin);
-            throw new JmriException("Sensor pin number is out of range");
+            throw new JmriException("Sensor pin number "+pin+" for address "+curAddress+" is out of range; only pin numbers 1 - 14 are valid");
         }
         if (aiucab == 0 || aiucab > MAXAIU) {
-            log.error("NCE sensor {} AIU number {} is out of range; only AIU 1 - 63 are valid",
-                    curAddress, aiucab);
-            throw new JmriException("AIU number is out of range");
-
+            throw new JmriException("AIU number "+aiucab+" for address "+curAddress+" is out of range; only AIU 1 - 63 are valid");
         }
         return prefix + typeLetter() + iName;
     }
@@ -413,34 +406,26 @@ public class NceSensorManager extends jmri.managers.AbstractSensorManager
     int iName = 0;
 
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
 
-        String tmpSName = "";
-
-        try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("ErrorTitle"), Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false);
-            return null;
-        }
+        String tmpSName = createSystemName(curAddress, prefix);
 
         // Check to determine if the systemName is in use, return null if it is,
         // otherwise return the next valid address.
         Sensor s = getBySystemName(tmpSName);
-        if (s != null) {
+        if (s != null || ignoreInitialExisting) {
             for (int x = 1; x < 10; x++) {
                 iName = iName + 1;
                 pin = pin + 1;
                 if (pin > MAXPIN) {
-                    return null;
+                    throw new JmriException("Unable to increment "+curAddress+" pin "+pin+" is greater than "+MAXPIN);
                 }
                 s = getBySystemName(prefix + typeLetter() + iName);
                 if (s == null) {
                     return Integer.toString(iName);
                 }
             }
-            return null;
+            throw new JmriException(Bundle.getMessage("InvalidNextValidTenInUse",getBeanTypeHandled(true),curAddress,iName));
         } else {
             return Integer.toString(iName);
         }

--- a/java/src/jmri/jmrix/openlcb/OlcbSensorManager.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSensorManager.java
@@ -159,7 +159,7 @@ public class OlcbSensorManager extends jmri.managers.AbstractSensorManager imple
     }
 
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) {
         // always return this (the current) name without change
         return curAddress;
     }

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnoutManager.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnoutManager.java
@@ -133,7 +133,7 @@ public class OlcbTurnoutManager extends AbstractTurnoutManager {
     }
 
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
         // always return this (the current) name without change
         try {
             OlcbAddress.validateSystemNameFormat(curAddress,Locale.getDefault(),prefix+"T");

--- a/java/src/jmri/jmrix/roco/z21/Z21SensorManager.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21SensorManager.java
@@ -184,8 +184,7 @@ public class Z21SensorManager extends jmri.managers.AbstractSensorManager implem
                     input = Integer.parseInt(curAddress.substring(seperator + 1));
                     return Z21CanBusAddress.buildHexSystemNameFromParts(getSystemPrefix(),typeLetter(),encoderAddress,input);
                 } catch (NumberFormatException ex1) {
-                    log.error("Unable to convert {} into the cab and input format of nn:xx", curAddress);
-                    throw new JmriException("Hardware Address passed should be a number");
+                    throw new JmriException("Unable to convert "+curAddress+" into the cab and input format of nn:xx");
                 }
             }
         } else {
@@ -194,8 +193,7 @@ public class Z21SensorManager extends jmri.managers.AbstractSensorManager implem
                 iName = Integer.parseInt(curAddress);
                 return getSystemPrefix() + typeLetter() + iName;
             } catch (NumberFormatException ex) {
-                log.error("Unable to convert {} Hardware Address to a number", curAddress);
-                throw new JmriException("Hardware Address passed should be a number");
+                throw new JmriException("Hardware Address "+curAddress+" passed should be a number or the cab and input format of nn:xx");
             }
         }
     }
@@ -206,23 +204,13 @@ public class Z21SensorManager extends jmri.managers.AbstractSensorManager implem
      * Does not enforce any rules on the encoder or input values.
      */
     @Override
-    public synchronized String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
+    public synchronized String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException{
 
-        String tmpSName;
-
-        try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("ErrorTitle"),
-                            Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false);
-            return null;
-        }
-
+        String tmpSName = createSystemName(curAddress, prefix);
         //Check to determine if the systemName is in use, return null if it is,
         //otherwise return the next valid address.
         Sensor s = getBySystemName(tmpSName);
-        if (s != null) {
+        if (s != null || ignoreInitialExisting) {
             for (int x = 1; x < 10; x++) {
                 iName = iName + 1;
                 s = getBySystemName(prefix + typeLetter() + iName);
@@ -230,7 +218,8 @@ public class Z21SensorManager extends jmri.managers.AbstractSensorManager implem
                     return Integer.toString(iName);
                 }
             }
-            return null;
+            log.warn(Bundle.getMessage("InvalidNextValidTenInUse",getBeanTypeHandled(true),curAddress,iName));
+            throw new JmriException(Bundle.getMessage("InvalidNextValidTenInUse",getBeanTypeHandled(true),curAddress,iName));
         } else {
             return Integer.toString(iName);
         }

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetTurnoutManager.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetTurnoutManager.java
@@ -69,6 +69,15 @@ public class Z21XNetTurnoutManager extends XNetTurnoutManager {
            t.message(l);
         }
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Nonnull
+    public String validateSystemNameFormat(@Nonnull String systemName, @Nonnull java.util.Locale locale) {
+        return this.validateSystemNameFormatOnlyNumeric(systemName, locale);
+    }
 
     private static final Logger log = LoggerFactory.getLogger(Z21XNetTurnoutManager.class);
 

--- a/java/src/jmri/jmrix/rps/RpsReporterManager.java
+++ b/java/src/jmri/jmrix/rps/RpsReporterManager.java
@@ -40,6 +40,7 @@ public class RpsReporterManager extends jmri.managers.AbstractReporterManager {
         return r;
     }
 
+    @Override
     public String createSystemName(String curAddress, String prefix) throws JmriException {
         if (!prefix.equals(getSystemPrefix())) {
             log.warn("prefix does not match memo.prefix");
@@ -50,7 +51,7 @@ public class RpsReporterManager extends jmri.managers.AbstractReporterManager {
         try {
             validSystemNameFormat(sys);
         } catch (IllegalArgumentException e) {
-            throw new JmriException(e.toString());
+            throw new JmriException(e.getMessage());
         }
         return sys;
     }
@@ -78,17 +79,6 @@ public class RpsReporterManager extends jmri.managers.AbstractReporterManager {
     @Override
     public String getEntryToolTip() {
         return Bundle.getMessage("AddReporterEntryToolTip");
-    }
-
-    /**
-     * Static function returning the RpsReporterManager instance to use.
-     *
-     * @return The registered RpsReporterManager instance for general use.
-     * @deprecated since 4.15.6
-     */
-    @Deprecated
-    static public RpsReporterManager instance() {
-        return null;
     }
 
     private final static Logger log = LoggerFactory.getLogger(RpsReporterManager.class);

--- a/java/src/jmri/jmrix/tams/TamsSensorManager.java
+++ b/java/src/jmri/jmrix/tams/TamsSensorManager.java
@@ -2,7 +2,6 @@ package jmri.jmrix.tams;
 
 import java.util.Hashtable;
 import javax.annotation.Nonnull;
-import javax.swing.JOptionPane;
 import jmri.JmriException;
 import jmri.Sensor;
 import org.slf4j.Logger;
@@ -125,11 +124,7 @@ public class TamsSensorManager extends jmri.managers.AbstractSensorManager imple
     @Nonnull
     public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
         if (!curAddress.contains(":")) {
-            log.error("Unable to convert {} into the Module and port format of nn:xx", curAddress);
-            JOptionPane.showMessageDialog(null, Bundle.getMessage("WarningModuleAddress"),
-                    Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
-            // TODO prevent further execution, return error flag
-            throw new JmriException("Hardware Address passed should be past in the form 'Module:port'");
+            throw new JmriException("Hardware Address passed should be past in the form 'Module:port', was " + curAddress);
         }
 
         //Address format passed is in the form of board:channel or T:turnout address
@@ -137,22 +132,16 @@ public class TamsSensorManager extends jmri.managers.AbstractSensorManager imple
         try {
             board = Integer.parseInt(curAddress.substring(0, seperator));
         } catch (NumberFormatException ex) {
-            log.error("First part of {} in front of : should be a number", curAddress);
-            throw new JmriException("Module Address passed should be a number");
+            throw new JmriException("First part of "+curAddress+" in front of : should be a number");
         }
         try {
             port = Integer.parseInt(curAddress.substring(seperator + 1));
         } catch (NumberFormatException ex) {
-            log.error("Second part of {} after : should be a number", curAddress);
-            throw new JmriException("Port Address passed should be a number");
+            throw new JmriException("Port Address, Second part of "+curAddress+" after : should be a number");
         }
 
         if (port == 0 || port > 16) {
-            log.error("Port number must be between 1 and 16");
-            JOptionPane.showMessageDialog(null, Bundle.getMessage("WarningPortRangeXY", 1, 16),
-                    Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
-            // TODO prevent further execution, return error flag
-            throw new JmriException("Port number must be between 1 and 16");
+            throw new JmriException("Port number in "+curAddress+" must be between 1 and 16");
         }
         StringBuilder sb = new StringBuilder();
         sb.append(getSystemPrefix());
@@ -180,28 +169,19 @@ public class TamsSensorManager extends jmri.managers.AbstractSensorManager imple
     int port = 0;
 
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
 
-        String tmpSName;
-
-        try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).showInfoMessage(Bundle.getMessage("ErrorTitle"),
-                    Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false);
-            return null;
-        }
-
+        String tmpSName = createSystemName(curAddress, prefix);
         //Check to determine if the systemName is in use, return null if it is,
         //otherwise return the next valid address.
         Sensor s = getBySystemName(tmpSName);
-        if (s != null) {
+        if (s != null || ignoreInitialExisting) {
             port++;
             while (port < 17) {
                 try {
                     tmpSName = createSystemName(board + ":" + port, prefix);
                 } catch (JmriException e) {
-                    log.error("Error creating system name for {}:{}", board, port);
+                    throw new JmriException("Error creating system name from "+curAddress+" for "+board+":"+port);
                 }
                 s = getBySystemName(tmpSName);
                 if (s == null) {
@@ -214,7 +194,7 @@ public class TamsSensorManager extends jmri.managers.AbstractSensorManager imple
                 }
                 port++;
             }
-            return null;
+            throw new JmriException("Error creating system name from "+curAddress+" , port needs to be less than 16");
         } else {
             StringBuilder sb = new StringBuilder();
             sb.append(board);

--- a/java/src/jmri/jmrix/tmcc/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/tmcc/SerialTurnoutManager.java
@@ -1,10 +1,13 @@
 package jmri.jmrix.tmcc;
 
 import java.util.Locale;
+
 import javax.annotation.Nonnull;
-import jmri.JmriException;
-import jmri.Turnout;
+
+import jmri.*;
+import jmri.jmrix.tmcc.Bundle;
 import jmri.managers.AbstractTurnoutManager;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,15 +73,6 @@ public class SerialTurnoutManager extends AbstractTurnoutManager implements Seri
     @Override
     public boolean allowMultipleAdditions(@Nonnull String systemName) {
         return true;
-    }
-
-    @Override
-    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
-        try {
-            return makeSystemName(curAddress);
-        } catch (IllegalArgumentException ex) {
-            throw new JmriException(ex);
-        }
     }
 
     /**

--- a/java/src/jmri/jmrix/tmcc/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/tmcc/SerialTurnoutManager.java
@@ -5,7 +5,6 @@ import java.util.Locale;
 import javax.annotation.Nonnull;
 
 import jmri.*;
-import jmri.jmrix.tmcc.Bundle;
 import jmri.managers.AbstractTurnoutManager;
 
 import org.slf4j.Logger;

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -5,18 +5,15 @@ import java.text.DecimalFormat;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+
 import javax.annotation.CheckReturnValue;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.OverridingMethodsMustInvokeSuper;
-import jmri.ConfigureManager;
-import jmri.InstanceManager;
-import jmri.Manager;
-import jmri.NamedBean;
-import jmri.NamedBean.DuplicateSystemNameException;
-import jmri.NamedBeanPropertyDescriptor;
+
+import jmri.*;
 import jmri.beans.VetoableChangeSupport;
-import jmri.SystemConnectionMemo;
+import jmri.NamedBean.DuplicateSystemNameException;
 
 /**
  * Abstract partial implementation for all Manager-type classes.
@@ -608,6 +605,129 @@ public abstract class AbstractManager<E extends NamedBean> extends VetoableChang
         String nextNumber = paddedNumber.format(nextAutoBlockRef);
         b.append(nextNumber);
         return b.toString();
+    }
+    
+    /**
+     * Create a System Name from hardware address and system letter prefix.
+     * AbstractManager performs no validation.
+     * @param curAddress hardware address, no system prefix or type letter.
+     * @param prefix - just system prefix, not including Type Letter.
+     * @return full system name with system prefix, type letter and hardware address.
+     * @throws JmriException if unable to create a system name.
+     */
+    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
+        return prefix + typeLetter() + curAddress;
+    }
+    
+    /**
+     * checks for numeric-only system names.
+     * @param curAddress the System name ( excluding both prefix and type letter) to check.
+     * @return unchanged if is numeric string.
+     * @throws JmriException if not numeric.
+     */
+    protected String checkNumeric(@Nonnull String curAddress) throws JmriException {
+        try {
+            Integer.parseInt(curAddress);
+        } catch (java.lang.NumberFormatException ex) {
+            throw new JmriException("Hardware Address passed "+curAddress+" should be a number");
+        }
+        return curAddress;
+    }
+    
+    /**
+     * Get the Next valid hardware address.
+     * Used by the Turnout / Sensor / Reporter / Light Manager classes.
+     * <p>
+     * @param curAddress the starting hardware address to get the next valid from.
+     * @param prefix system prefix, just system name, not type letter.
+     * @return the next valid system name, excluding both system name prefix and type letter.
+     * @throws JmriException    if unable to get the current / next address, 
+     *                          or more than 10 next addresses in use.
+     * @deprecated since 4.21.3; use #getNextValidAddress(String, String, boolean) instead.
+     */
+    @Nonnull
+    @Deprecated
+    public final String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
+        jmri.util.LoggingUtil.deprecationWarning(log, "getNextValidAddress");
+        return getNextValidAddress(curAddress, prefix, false);
+    }
+    
+    /**
+     * Get the Next valid hardware address.
+     * Used by the Turnout / Sensor / Reporter / Light Manager classes.
+     * <p>
+     * System-specific methods may want to override getIncrement() rather than this one.
+     * @param curAddress the starting hardware address to get the next valid from.
+     * @param prefix system prefix, just system name, not type letter.
+     * @param ignoreInitialExisting false to return the starting address if it 
+     *                          does not exist, else true to force an increment.
+     * @return the next valid system name, excluding both system name prefix and type letter.
+     * @throws JmriException    if unable to get the current / next address, 
+     *                          or more than 10 next addresses in use.
+     */
+    @Nonnull
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
+        log.debug("getNextValid for address {}", curAddress);
+        String testAddr;
+        NamedBean bean;
+        int increment;
+        // If hardware address passed does not already exist then this is the next valid address.
+        try {
+            // System.out.format("curaddress: "+curAddress);
+            testAddr = validateSystemNameFormat(createSystemName(curAddress,prefix));
+            // System.out.format("testaddr: "+testAddr);
+            bean = getBySystemName(testAddr);
+            increment = ( bean instanceof Turnout ? ((Turnout)bean).getNumberOutputBits() : 1);
+            testAddr = testAddr.substring(getSystemNamePrefix().length());
+            getIncrement(testAddr, increment);
+        }
+        catch ( NamedBean.BadSystemNameException | JmriException ex ){
+            throw new JmriException(ex.getMessage());
+        }
+        if (bean == null && !ignoreInitialExisting) {
+            log.debug("address {} not in use", curAddress);
+            return curAddress;
+        }
+        for (int i = 0; i <10; i++) {
+            testAddr = getIncrement(testAddr, increment);
+            bean = getBySystemName(validateSystemNameFormat(createSystemName(testAddr,prefix)));
+            if ( bean == null) {
+                return testAddr;
+            }
+        }
+        throw new JmriException(Bundle.getMessage("InvalidNextValidTenInUse",getBeanTypeHandled(true),curAddress,testAddr));
+    }
+    
+    /**
+     * Increment a hardware address.
+     * <p>
+     * Default is to increment only an existing number.
+     * Sub-classes may wish to override this.
+     * @param curAddress the address to increment, excluding both system name prefix and type letter.
+     * @param increment the amount to increment by.
+     * @return incremented address, no system prefix or type letter.
+     * @throws JmriException if unable to increment the address.
+     */
+    @Nonnull
+    protected String getIncrement(String curAddress, int increment) throws JmriException {
+        return getIncrementFromExistingNumber(curAddress,increment);
+    }
+    
+    /**
+     * Increment a hardware address with an existing number.
+     * <p>
+     * @param curAddress the address to increment, excluding both system name prefix and type letter
+     * @param increment the amount to increment by.
+     * @return incremented number.
+     * @throws JmriException if unable to increment the address.
+     */
+    @Nonnull
+    protected String getIncrementFromExistingNumber(String curAddress, int increment) throws JmriException {
+        String newIncrement = jmri.util.StringUtil.incrementLastNumberInString(curAddress, increment);
+        if (newIncrement==null) {
+            throw new JmriException("No existing number found when incrementing " + curAddress);
+        }
+        return newIncrement;
     }
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractManager.class);

--- a/java/src/jmri/managers/AbstractReporterManager.java
+++ b/java/src/jmri/managers/AbstractReporterManager.java
@@ -44,24 +44,14 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
     @Nonnull
     public Reporter provideReporter(@Nonnull String sName) {
         Reporter r = getReporter(sName);
-        if (r != null) {
-            return r;
-        }
-        if (sName.startsWith(getSystemPrefix() + typeLetter())) {
-            return newReporter(sName, null);
-        } else {
-            return newReporter(makeSystemName(sName), null);
-        }
+        return r == null ? newReporter(makeSystemName(sName, true), null) : r;
     }
 
     /** {@inheritDoc} */
     @Override
     public Reporter getReporter(@Nonnull String name) {
         Reporter r = getByUserName(name);
-        if (r != null) {
-            return r;
-        }
-        return getBySystemName(name);
+        return r == null ? getBySystemName(name) : r;
     }
 
     /** {@inheritDoc} */
@@ -82,31 +72,24 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
     /** {@inheritDoc} */
     @Override
     public Reporter getByDisplayName(@Nonnull String key) {
-        // First try to find it in the user list.
-        // If that fails, look it up in the system list
-        Reporter retv = this.getByUserName(key);
-        if (retv == null) {
-            retv = this.getBySystemName(key);
-        }
-        // If it's not in the system list, go ahead and return null
-        return (retv);
+        return getReporter(key);        
     }
 
     /** {@inheritDoc} */
     @Override
     @Nonnull
-    public Reporter newReporter(@Nonnull String systemName, @CheckForNull String userName) {
+    public Reporter newReporter(@Nonnull String systemName, @CheckForNull String userName) throws IllegalArgumentException {
         Objects.requireNonNull(systemName, "SystemName cannot be null. UserName was "
                + ((userName == null) ? "null" : userName));  // NOI18N
         log.debug("new Reporter: {} {}", systemName, userName);
 
        // is system name in correct format?
-        if (!systemName.startsWith(getSystemPrefix() + typeLetter())
-                || !(systemName.length() > (getSystemPrefix() + typeLetter()).length())) {
+        if (!systemName.startsWith(getSystemNamePrefix())
+                || !(systemName.length() > (getSystemNamePrefix()).length())) {
             log.error("Invalid system name for reporter: {} needed {}{}",
                     systemName, getSystemPrefix(), typeLetter());
             throw new IllegalArgumentException("Invalid system name for turnout: " + systemName
-                    + " needed " + getSystemPrefix() + typeLetter());
+                    + " needed " + getSystemNamePrefix());
         }
 
         // return existing if there is one
@@ -154,46 +137,6 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
     @Override
     public boolean allowMultipleAdditions(@Nonnull String systemName) {
         return false;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) {
-        // If the hardware address passed does not already exist then this can
-        // be considered the next valid address.
-        Reporter r = getBySystemName(prefix + typeLetter() + curAddress);
-        if (r == null) {
-            return curAddress;
-        }
-
-        // This bit deals with handling the curAddress, and how to get the next address.
-        int iName = 0;
-        try {
-            iName = Integer.parseInt(curAddress);
-        } catch (NumberFormatException ex) {
-            log.error("Unable to convert {} Hardware Address to a number", curAddress);
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("WarningTitle"), Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false);
-            return null;
-        }
-
-        // Check to determine if the systemName is in use, return null if it is,
-        // otherwise return the next valid address.
-        r = getBySystemName(prefix + typeLetter() + iName);
-        if (r != null) {
-            for (int x = 1; x < 10; x++) {
-                iName++;
-                r = getBySystemName(prefix + typeLetter() + iName);
-                if (r == null) {
-                    return Integer.toString(iName);
-                }
-            }
-            // feedback when next address is also in use
-            log.warn("10 hardware addresses starting at {} already in use. No new Reporters added", curAddress);
-            return null;
-        } else {
-            return Integer.toString(iName);
-        }
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -155,68 +155,16 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         return false;
     }
 
-    /** {@inheritDoc} */
-    @Override
+    /**
+     * Default Sensor ensures a numeric only system name.
+     * {@inheritDoc} 
+     */
     @Nonnull
-    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
-        try {
-            Integer.parseInt(curAddress);
-        } catch (java.lang.NumberFormatException ex) {
-            log.warn("Hardware Address passed should be a number, was {}", curAddress);
-            throw new JmriException("Hardware Address passed should be a number");
-        }
-        return prefix + typeLetter() + curAddress;
-    }
-
-    /** {@inheritDoc} */
     @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
-        // If the hardware address passed does not already exist then this can
-        // be considered the next valid address.
-        String tmpSName;
-
-        try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("WarningTitle"), Bundle.getMessage("ErrorConvertNumberX", curAddress), null, "", true, false);
-            return null;
-        }
-        Sensor s = getBySystemName(tmpSName);
-        if (s == null) {
-            return curAddress;
-        }
-
-        // This bit deals with handling the curAddress, and how to get the next address.
-        int iName;
-        try {
-            iName = Integer.parseInt(curAddress);
-        } catch (NumberFormatException ex) {
-            log.error("Unable to convert {} Hardware Address to a number", curAddress);
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("WarningTitle"), Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false);
-            return null;
-        }
-
-        // Check to determine if the systemName is in use, return null if it is,
-        // otherwise return the next valid address.
-        s = getBySystemName(prefix + typeLetter() + iName);
-        if (s != null) {
-            for (int x = 1; x < 10; x++) {
-                iName++;
-                s = getBySystemName(prefix + typeLetter() + iName);
-                if (s == null) {
-                    return Integer.toString(iName);
-                }
-            }
-            // feedback when next address is also in use
-            log.warn("10 hardware addresses starting at {} already in use. No new Sensors added", curAddress);
-            return null;
-        } else {
-            return Integer.toString(iName);
-        }
+    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
+        return prefix + typeLetter() + checkNumeric(curAddress);
     }
-
+    
     protected long sensorDebounceGoingActive = 0L;
     protected long sensorDebounceGoingInActive = 0L;
 
@@ -278,7 +226,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
     /** {@inheritDoc} */
     @Override
     public String getEntryToolTip() {
-        return Bundle.getMessage("EnterNumber1to9999ToolTip");
+        return "Enter a number from 1 to 9999"; // Basic number format help
     }
 
     private final static Logger log = LoggerFactory.getLogger(AbstractSensorManager.class);

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -226,7 +226,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
     /** {@inheritDoc} */
     @Override
     public String getEntryToolTip() {
-        return "Enter a number from 1 to 9999"; // Basic number format help
+        return Bundle.getMessage("EnterNumber1to9999ToolTip");
     }
 
     private final static Logger log = LoggerFactory.getLogger(AbstractSensorManager.class);

--- a/java/src/jmri/managers/AbstractTurnoutManager.java
+++ b/java/src/jmri/managers/AbstractTurnoutManager.java
@@ -76,12 +76,12 @@ public abstract class AbstractTurnoutManager extends AbstractManager<Turnout>
         log.debug("newTurnout: {};{}", systemName, userName);
 
         // is system name in correct format?
-        if (!systemName.startsWith(getSystemPrefix() + typeLetter())
-                || !(systemName.length() > (getSystemPrefix() + typeLetter()).length())) {
+        if (!systemName.startsWith(getSystemNamePrefix())
+                || !(systemName.length() > (getSystemNamePrefix()).length())) {
             log.error("Invalid system name for Turnout: {} needed {}{} followed by a suffix",
                     systemName, getSystemPrefix(), typeLetter());
             throw new IllegalArgumentException("Invalid system name for Turnout: " + systemName
-                    + " needed " + getSystemPrefix() + typeLetter());
+                    + " needed " + getSystemNamePrefix());
         }
 
         // return existing if there is one
@@ -211,7 +211,7 @@ public abstract class AbstractTurnoutManager extends AbstractManager<Turnout>
      * @param userName   the user name to use for the new Turnout
      * @return the new Turnout or null if unsuccessful
      */
-    abstract protected Turnout createNewTurnout(@Nonnull String systemName, String userName);
+    abstract protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException;
 
     /** {@inheritDoc} */
     @Override
@@ -237,71 +237,16 @@ public abstract class AbstractTurnoutManager extends AbstractManager<Turnout>
         return false;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * Default Turnout ensures a numeric only system name.
+     * {@inheritDoc} 
+     */
+    @Nonnull
     @Override
     public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
-        try {
-            Integer.parseInt(curAddress);
-        } catch (java.lang.NumberFormatException ex) {
-            log.warn("Hardware Address passed should be a number, was {}", curAddress);
-            throw new JmriException("Hardware Address passed should be a number");
-        }
-        return prefix + typeLetter() + curAddress;
+        return prefix + typeLetter() + checkNumeric(curAddress);
     }
-
-    /** {@inheritDoc} */
-    @Override
-    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
-        // If the hardware address passed does not already exist then this can
-        // be considered the next valid address.
-        log.debug("getNextValid for address {}", curAddress);
-        String tmpSName = "";
-        try {
-            tmpSName = createSystemName(curAddress, prefix);
-        } catch (JmriException ex) {
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("WarningTitle"), Bundle.getMessage("ErrorConvertNumberX", curAddress), null, "", true, false);
-            return null;
-        }
-
-        Turnout t = getBySystemName(tmpSName);
-        if (t == null) {
-            log.debug("address {} not in use", tmpSName);
-            return curAddress;
-        }
-
-        // This bit deals with handling the curAddress, and how to get the next address.
-        int iName = 0;
-        try {
-            iName = Integer.parseInt(curAddress);
-        } catch (NumberFormatException ex) {
-            log.error("Unable to convert {} Hardware Address to a number", curAddress);
-            jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                    showErrorMessage(Bundle.getMessage("WarningTitle"), Bundle.getMessage("ErrorConvertNumberX", curAddress), null, "", true, false);
-            return null;
-        }
-        // The Number of Output Bits of the previous turnout will help determine the next
-        // valid address.
-        iName = iName + t.getNumberOutputBits();
-        // Check to determine if the systemName is in use;
-        // return null if it is, otherwise return the next valid address.
-        t = getBySystemName(prefix + typeLetter() + iName);
-        if (t != null) {
-            for (int x = 1; x < 10; x++) {
-                iName = iName + t.getNumberOutputBits();
-                t = getBySystemName(prefix + typeLetter() + iName);
-                if (t == null) {
-                    return Integer.toString(iName);
-                }
-            }
-            // feedback when next address is also in use
-            log.warn("10 hardware addresses starting at {} already in use. No new Turnouts added", curAddress);
-            return null;
-        } else {
-            return Integer.toString(iName);
-        }
-    }
-
+    
     private String defaultClosedSpeed = "Normal";
     private String defaultThrownSpeed = "Restricted";
 

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -153,13 +153,18 @@ public class ProxyLightManager extends AbstractProvidingProxyManager<Light>
         LightManager m = (LightManager) getManager(systemName);
         return (m == null) ? false : m.allowMultipleAdditions(systemName);
     }
+    
+    @Override
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws jmri.JmriException {
+        return getNextValidAddress(curAddress, prefix, ignoreInitialExisting, typeLetter());
+    }
 
     /**
      * {@inheritDoc}
      */
     @Override
     public String getEntryToolTip() {
-        return "Enter a number from 1 to 9999"; // Basic number format help
+        return Bundle.getMessage("EnterNumber1to9999ToolTip");
     }
 
     @Override

--- a/java/src/jmri/managers/ProxyReporterManager.java
+++ b/java/src/jmri/managers/ProxyReporterManager.java
@@ -104,9 +104,15 @@ public class ProxyReporterManager extends AbstractProvidingProxyManager<Reporter
         return ((ReporterManager) getManagerOrDefault(systemName)).allowMultipleAdditions(systemName);
     }
 
+    @SuppressWarnings("deprecation") // user warned by actual manager class
     @Override
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {
         return getNextValidAddress(curAddress, prefix, typeLetter());
+    }
+    
+    @Override
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws jmri.JmriException {
+        return getNextValidAddress(curAddress, prefix, ignoreInitialExisting, typeLetter());
     }
 
     /**

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -100,9 +100,15 @@ public class ProxySensorManager extends AbstractProvidingProxyManager<Sensor>
         return createSystemName(curAddress, prefix, SensorManager.class);
     }
 
+    @SuppressWarnings("deprecation") // user warned by actual manager class
     @Override
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {
         return getNextValidAddress(curAddress, prefix, typeLetter());
+    }
+    
+    @Override
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws jmri.JmriException {
+        return getNextValidAddress(curAddress, prefix, ignoreInitialExisting, typeLetter());
     }
 
     /**

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -185,9 +185,15 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
         return createSystemName(curAddress, prefix, TurnoutManager.class);
     }
 
+    @SuppressWarnings("deprecation") // user warned by actual manager class
     @Override
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {
         return getNextValidAddress(curAddress, prefix, typeLetter());
+    }
+    
+    @Override
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws jmri.JmriException {
+        return getNextValidAddress(curAddress, prefix, ignoreInitialExisting, typeLetter());
     }
 
     @Override

--- a/java/src/jmri/util/StringUtil.java
+++ b/java/src/jmri/util/StringUtil.java
@@ -641,6 +641,18 @@ public class StringUtil {
         }
         return -1;
     }
+    
+    /**
+     * Increment the last number found in a string.
+     * @param str Initial string to increment.
+     * @param increment number to increment by.
+     * @return null if not possible, else incremented String.
+     */
+    @CheckForNull
+    public static String incrementLastNumberInString(@Nonnull String str, int increment){
+        int num = getLastIntFromString(str);
+        return ( (num == -1) ? null : replaceLast(str,String.valueOf(num),String.valueOf(num+increment)));
+    }
 
     /**
      * Replace the last occurance of string value within a String

--- a/java/test/jmri/jmrix/can/cbus/CbusAddressTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusAddressTest.java
@@ -312,7 +312,7 @@ public class CbusAddressTest {
     }
     
     @Test
-    public void testgetIncrement() {
+    public void testgetIncrement() throws jmri.JmriException {
         
         Assert.assertEquals("+N34E17;-N34E17","+N34E18;-N34E18",CbusAddress.getIncrement("+N34E17;-N34E17"));
         Assert.assertEquals("+N34E456;+N34E17","+N34E457;+N34E18",CbusAddress.getIncrement("+N34E456;+N34E17"));

--- a/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
@@ -74,14 +74,14 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
             l.provideLight(name1);
             Assert.fail("Expected exception not thrown");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Light: System name \"MLXABCDEF;XFEDCBA\" contains invalid character \"L\".");
+            JUnitAppender.assertErrorMessage("Invalid system name for Light: Wrong number of events in address: mlxabcdef;xfedcba");
         }
         String name2 = "ml+n1e77;-n1e45";
         try {
             l.provideLight(name2);
             Assert.fail("Expected exception not thrown");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Light: System name \"ml+n1e77;-n1e45\" contains invalid character \"M\".");
+            JUnitAppender.assertErrorMessage("Invalid system name for Light: Wrong number of events in address: ml+n1e77;-n1e45");
         }
     }
 

--- a/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
@@ -74,14 +74,14 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
             l.provideLight(name1);
             Assert.fail("Expected exception not thrown");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Light: Wrong number of events in address: mlxabcdef;xfedcba");
+            JUnitAppender.assertErrorMessage("Invalid system name for Light: System name \"MLXABCDEF;XFEDCBA\" contains invalid character \"L\".");
         }
         String name2 = "ml+n1e77;-n1e45";
         try {
             l.provideLight(name2);
             Assert.fail("Expected exception not thrown");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Light: Wrong number of events in address: ml+n1e77;-n1e45");
+            JUnitAppender.assertErrorMessage("Invalid system name for Light: System name \"ml+n1e77;-n1e45\" contains invalid character \"M\".");
         }
     }
 
@@ -186,30 +186,31 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
             l.provideLight("S+N156E77;+N15E6");
             Assert.fail("S Should have thrown an exception");
         } catch (IllegalArgumentException e) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Light: Wrong number of events in address: S+N156E77;+N15E6");
-            Assert.assertEquals("Wrong number of events in address: S+N156E77;+N15E6", e.getMessage());
+            JUnitAppender.assertErrorMessage("Invalid system name for Light: System name \"S+N156E77;+N15E6\" contains invalid character \"S\".");
+            Assert.assertEquals("System name \"S+N156E77;+N15E6\" contains invalid character \"S\".", e.getMessage());
         }
 
         try {
             l.provideLight("M+N156E77;+N15E6");
             Assert.fail("M Should have thrown an exception");
         } catch (IllegalArgumentException e) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Light: Wrong number of events in address: M+N156E77;+N15E6");
-            Assert.assertEquals("Wrong number of events in address: M+N156E77;+N15E6", e.getMessage());
+            JUnitAppender.assertErrorMessage("Invalid system name for Light: System name \"M+N156E77;+N15E6\" contains invalid character \"M\".");
+            Assert.assertEquals("System name \"M+N156E77;+N15E6\" contains invalid character \"M\".", e.getMessage());
         }
 
         try {
             l.provideLight("ML++N156E77");
             Assert.fail("++ Should have thrown an exception");
         } catch (IllegalArgumentException e) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Light: Wrong number of events in address: ++N156E77");
+            JUnitAppender.assertErrorMessage("Invalid system name for Light: System name \"++N156E77\" contains invalid character \"++\".");
+            Assert.assertEquals("System name \"++N156E77\" contains invalid character \"++\".", e.getMessage());
         }
 
         try {
             l.provideLight("ML--N156E77");
             Assert.fail("-- Should have thrown an exception");
         } catch (IllegalArgumentException e) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Light: Wrong number of events in address: --N156E77");
+            JUnitAppender.assertErrorMessage("Invalid system name for Light: System name \"--N156E77\" contains invalid character \"--\".");
         }
 
         try {
@@ -230,7 +231,7 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
             l.provideLight("MLXLKJK;XLKJK");
             Assert.fail("LKJK Should have thrown an exception");
         } catch (IllegalArgumentException e) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Light: Wrong number of events in address: XLKJK;XLKJK");
+            JUnitAppender.assertErrorMessage("Invalid system name for Light: System name \"XLKJK;XLKJK\" contains invalid character \"J\".");
         }
     }
 
@@ -326,24 +327,15 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
 
     @Test
     public void testcreateNewLightException() {
-        CbusLightManager c = (CbusLightManager) l;
-        try {
-            c.createNewLight("", null);
-            Assert.fail("Expected exception not thrown");
-        } catch (StringIndexOutOfBoundsException ex) {
-            Assert.assertEquals("String index out of range: -2", ex.getMessage());
-        }
+        Assert.assertThrows(IllegalArgumentException.class, () -> ((CbusLightManager)l).createNewLight("",null));
+        JUnitAppender.assertErrorMessageStartsWith("System name must start with \"ML\"");
+        
     }
 
     @Test
     public void testvalidSystemNameConfig() {
         Assert.assertTrue(l.validSystemNameConfig("ML+123"));
-        try {
-            boolean val = l.validSystemNameConfig("");
-            Assert.fail("Expected exception not thrown " + val);
-        } catch (StringIndexOutOfBoundsException ex) {
-            Assert.assertEquals("String index out of range: -2", ex.getMessage());
-        }
+        Assert.assertFalse(l.validSystemNameConfig(""));
     }
     
     private CanSystemConnectionMemo memo;

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
@@ -28,6 +28,11 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
     public String getSystemName(int i) {
         return "MSX0A;+N15E" + i;
     }
+    
+    @Override
+    protected String getASystemNameWithNoPrefix() {
+        return "+6";
+    }
 
     @Test
     @Override
@@ -62,14 +67,14 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor(name1);
             Assert.fail("Expected exception not thrown");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: Wrong number of events in address: ms+n1e77;-n1e45");
+            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: System name \"MS+N1E77;-N1E45\" contains invalid character \"M\".");
         }
         String name2 = "msxabcdef;xfedcba";
         try {
             l.provideSensor(name2);
             Assert.fail("Expected exception not thrown");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: Wrong number of events in address: msxabcdef;xfedcba");
+            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: System name \"MSXABCSEF;XFEDCBA\" contains invalid character \"M\".");
         }
     }
 
@@ -178,28 +183,28 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("S+N156E77;+N15E6");
             Assert.fail("S Should have thrown an exception");
         } catch (IllegalArgumentException e) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: Wrong number of events in address: S+N156E77;+N15E6");
+            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: System name \"S+N156E77;+N15E6\" contains invalid character \"S\".");
         }
 
         try {
             l.provideSensor("M+N156E77;+N15E6");
             Assert.fail("M Should have thrown an exception");
         } catch (IllegalArgumentException e) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: Wrong number of events in address: M+N156E77;+N15E6");
+            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: System name \"M+N156E77;+N15E6\" contains invalid character \"M\".");
         }
 
         try {
             l.provideSensor("MS++N156E77");
             Assert.fail("++ Should have thrown an exception");
         } catch (IllegalArgumentException e) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: Wrong number of events in address: ++N156E77");
+            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: System name \"++N156E77\" contains invalid character \"++\".");
         }
 
         try {
             l.provideSensor("MS--N156E77");
             Assert.fail("-- Should have thrown an exception");
         } catch (IllegalArgumentException e) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: Wrong number of events in address: --N156E77");
+            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: System name \"--N156E77\" contains invalid character \"--\".");
         }
 
         try {
@@ -220,7 +225,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MSXLKJK;XLKJK");
             Assert.fail("LKJK Should have thrown an exception");
         } catch (IllegalArgumentException e) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: Wrong number of events in address: XLKJK;XLKJK");
+            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: System name \"XLKJK;XLKJK\" contains invalid character \"J\".");
         }
 
         try {
@@ -352,21 +357,21 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
     @Test
     public void testgetNextValidAddress() throws JmriException {
 
-        Assert.assertEquals("+17", "+17", l.getNextValidAddress("+17", "M"));
+        Assert.assertEquals("+17", "+17", l.getNextValidAddress("+17", "M",false));
         Sensor t = l.provideSensor("MS+17");
         Assert.assertNotNull("exists", t);
-        Assert.assertEquals("+18", "+18", l.getNextValidAddress("+17", "M"));
+        Assert.assertEquals("+18", "+18", l.getNextValidAddress("+17", "M",false));
 
-        Assert.assertEquals("+N45E22", "+N45E22", l.getNextValidAddress("+N45E22", "M"));
+        Assert.assertEquals("+N45E22", "+N45E22", l.getNextValidAddress("+N45E22", "M",false));
         Sensor ta = l.provideSensor("MS+N45E22");
         Assert.assertNotNull("exists", ta);
-        Assert.assertEquals("+N45E23", "+N45E23", l.getNextValidAddress("+N45E22", "M"));
+        Assert.assertEquals("+N45E23", "+N45E23", l.getNextValidAddress("+N45E22", "M",false));
 
         try {
-            String val = l.getNextValidAddress("", "M");
+            String val = l.getNextValidAddress("", "M",false);
             Assert.assertNull(val);
         } catch (JmriException ex) {
-            Assert.assertEquals("java.lang.IllegalArgumentException: Address Too Short? : ", ex.getMessage());
+            Assert.assertEquals("System name \"MS\" is missing suffix.", ex.getMessage());
         }
     }
 
@@ -375,8 +380,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         Sensor t = l.provideSensor("MS+65535");
         Assert.assertNotNull("exists", t);
 
-        Assert.assertEquals("+65535", null, l.getNextValidAddress("+65535", "M"));
-        JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+        Assert.assertThrows(JmriException.class, () -> l.getNextValidAddress("+65535", "M",false));
     }
 
     @Test
@@ -385,7 +389,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         Sensor t = l.provideSensor("MS+10");
         Assert.assertNotNull("exists", t);
 
-        Assert.assertEquals("+10", "+11", l.getNextValidAddress("+10", "M"));
+        Assert.assertEquals("+10", "+11", l.getNextValidAddress("+10", "M",false));
     }
 
     @Test
@@ -396,7 +400,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         Assert.assertNotNull("exists", t);
         Assert.assertNotNull("exists", ta);
 
-        Assert.assertEquals(" null +9 +10", "+11", l.getNextValidAddress("+9", "M"));
+        Assert.assertEquals(" null +9 +10", "+11", l.getNextValidAddress("+9", "M",false));
     }
 
     @Test
@@ -407,15 +411,25 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         Assert.assertEquals("MS-N34E610", "MS-N34E610", l.createSystemName("-N34E610", "M"));
         Assert.assertEquals("MS+N34E610;-N987E654", "MS+N34E610;-N987E654", l.createSystemName("+N34E610;-N987E654", "M"));
 
-        Assert.assertEquals("M2S+10", "M2S+10", l.createSystemName("+10", "M2"));
-
-        Assert.assertEquals("ZZZZZZZZZS+10", "ZZZZZZZZZS+10", l.createSystemName("+10", "ZZZZZZZZZ"));
-
+        
         try {
             l.createSystemName("S", "M");
         } catch (JmriException ex) {
-            Assert.assertEquals("java.lang.IllegalArgumentException: Wrong number of events in address: S", ex.getMessage());
+            Assert.assertEquals("System name \"S\" contains invalid character \"S\".", ex.getMessage());
         }
+        
+        boolean contains = Assert.assertThrows(JmriException.class,
+            ()->{
+                l.createSystemName("+10", "M2");
+            }).getMessage().contains("System name must start with \"MS\"");
+        Assert.assertTrue("Exception message relevant", contains);
+        
+        contains = Assert.assertThrows(JmriException.class,
+            ()->{
+                l.createSystemName("+10", "ZZZZZZZZZ");
+            }).getMessage().contains("System name must start with \"MS\"");
+        Assert.assertTrue("Exception message relevant", contains);
+        
     }
     
     @Test

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
@@ -67,14 +67,14 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor(name1);
             Assert.fail("Expected exception not thrown");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: System name \"MS+N1E77;-N1E45\" contains invalid character \"M\".");
+            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: Wrong number of events in address: ms+n1e77;-n1e45");
         }
         String name2 = "msxabcdef;xfedcba";
         try {
             l.provideSensor(name2);
             Assert.fail("Expected exception not thrown");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: System name \"MSXABCSEF;XFEDCBA\" contains invalid character \"M\".");
+            JUnitAppender.assertErrorMessage("Invalid system name for Sensor: Wrong number of events in address: msxabcdef;xfedcba");
         }
     }
 

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
@@ -242,7 +242,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout(name);
             Assert.fail("Expected exception not thrown");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Turnout: System name \"MT+N1E77;-N1E45\" contains invalid character \"M\".");
+            JUnitAppender.assertErrorMessage("Invalid system name for Turnout: Wrong number of events in address: mt+n1e77;-n1e45");
         }
         Turnout t = l.provideTurnout(name.toUpperCase());
         Assert.assertNotNull(t);

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
@@ -33,7 +33,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     }
     
     @Override
-    protected String getSystemNameWithNoPrefix() {
+    protected String getASystemNameWithNoPrefix() {
         return "+6";
     }
 
@@ -171,8 +171,8 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("T+N156E77;+N123E456");
             Assert.fail("Missing M Should have thrown an exception");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Turnout: Wrong number of events in address: T+N156E77;+N123E456");
-            Assert.assertEquals("Wrong number of events in address: T+N156E77;+N123E456",
+            JUnitAppender.assertErrorMessage("Invalid system name for Turnout: System name \"T+N156E77;+N123E456\" contains invalid character \"T\".");
+            Assert.assertEquals("System name \"T+N156E77;+N123E456\" contains invalid character \"T\".",
                     ex.getMessage());
         }
     }
@@ -183,8 +183,8 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("M+N156E77;+N15E60");
             Assert.fail("M Should have thrown an exception");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Turnout: Wrong number of events in address: M+N156E77;+N15E60");
-            Assert.assertEquals("Wrong number of events in address: M+N156E77;+N15E60",
+            JUnitAppender.assertErrorMessage("Invalid system name for Turnout: System name \"M+N156E77;+N15E60\" contains invalid character \"M\".");
+            Assert.assertEquals("System name \"M+N156E77;+N15E60\" contains invalid character \"M\".",
                     ex.getMessage());
         }
     }
@@ -242,7 +242,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout(name);
             Assert.fail("Expected exception not thrown");
         } catch (IllegalArgumentException ex) {
-            JUnitAppender.assertErrorMessage("Invalid system name for Turnout: Wrong number of events in address: mt+n1e77;-n1e45");
+            JUnitAppender.assertErrorMessage("Invalid system name for Turnout: System name \"MT+N1E77;-N1E45\" contains invalid character \"M\".");
         }
         Turnout t = l.provideTurnout(name.toUpperCase());
         Assert.assertNotNull(t);
@@ -289,20 +289,20 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     @Test
     public void testgetNextValidAddress() throws JmriException {
         
-        Assert.assertEquals("+17", "+17", l.getNextValidAddress("+17", "M"));
+        Assert.assertEquals("+17", "+17", l.getNextValidAddress("+17", "M",false));
         Turnout t =  l.provideTurnout("MT+17");
         Assert.assertNotNull("exists", t);
-        Assert.assertEquals("+18", "+18", l.getNextValidAddress("+17", "M"));
+        Assert.assertEquals("+18", "+18", l.getNextValidAddress("+17", "M",false));
     
-        Assert.assertEquals("+N45E22", "+N45E22", l.getNextValidAddress("+N45E22", "M"));
+        Assert.assertEquals("+N45E22", "+N45E22", l.getNextValidAddress("+N45E22", "M",false));
         Turnout ta =  l.provideTurnout("MT+N45E22");
         Assert.assertNotNull("exists", ta);
-        Assert.assertEquals("+N45E23", "+N45E23", l.getNextValidAddress("+N45E22", "M"));        
+        Assert.assertEquals("+N45E23", "+N45E23", l.getNextValidAddress("+N45E22", "M",false));        
         
         try {
-            Assert.assertNull("null", l.getNextValidAddress("", "M"));
+            Assert.assertNull("null", l.getNextValidAddress("", "M",false));
         } catch (JmriException ex) {
-            Assert.assertEquals("Address Too Short? : ", ex.getMessage());
+            Assert.assertEquals("System name \"MT\" is missing suffix.", ex.getMessage());
         }
     }
 
@@ -310,9 +310,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     public void testgetNextValidAddressPt2() throws JmriException {
         Turnout t =  l.provideTurnout("MT+65535");
         Assert.assertNotNull("exists", t);
-            
-        Assert.assertEquals("+65535", null, l.getNextValidAddress("+65535", "M"));
-        JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+        Assert.assertThrows(JmriException.class, () -> l.getNextValidAddress("+65535", "M",false));        
     }
     
     @Test
@@ -321,7 +319,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         Turnout t =  l.provideTurnout("MT+10");
         Assert.assertNotNull("exists", t);
             
-        Assert.assertEquals("+10", "+11", l.getNextValidAddress("+10", "M"));
+        Assert.assertEquals("+10", "+11", l.getNextValidAddress("+10", "M",false));
     }
     
     @Test
@@ -332,7 +330,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         Assert.assertNotNull("exists", t);
         Assert.assertNotNull("exists", ta);
 
-        Assert.assertEquals(" null +9 +10", "+11", l.getNextValidAddress("+9", "M"));
+        Assert.assertEquals(" null +9 +10", "+11", l.getNextValidAddress("+9", "M",false));
     }
     
     @Test

--- a/java/test/jmri/jmrix/dcc4pc/Dcc4PcSensorManagerTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/Dcc4PcSensorManagerTest.java
@@ -17,6 +17,11 @@ public class Dcc4PcSensorManagerTest extends jmri.managers.AbstractSensorMgrTest
     public String getSystemName(int i) {
         return "DS0:" + i;
     }
+    
+    @Override
+    protected String getASystemNameWithNoPrefix() {
+        return "0:1";
+    }
 
     @Override
     @Test

--- a/java/test/jmri/jmrix/grapevine/SerialLightManagerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialLightManagerTest.java
@@ -41,7 +41,7 @@ public class SerialLightManagerTest extends jmri.managers.AbstractLightMgrTestBa
     }
     
     @Override
-    protected String getSystemNameWithNoPrefix() {
+    protected String getASystemNameWithNoPrefix() {
         return "1106";
     }
 

--- a/java/test/jmri/jmrix/grapevine/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialSensorManagerTest.java
@@ -26,7 +26,7 @@ public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest
     }
     
     @Override
-    protected String getSystemNameWithNoPrefix() {
+    protected String getASystemNameWithNoPrefix() {
         return "1008";
     }
 

--- a/java/test/jmri/jmrix/grapevine/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialTurnoutManagerTest.java
@@ -39,7 +39,7 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
     }
     
     @Override
-    protected String getSystemNameWithNoPrefix() {
+    protected String getASystemNameWithNoPrefix() {
         return "1107";
     }
 

--- a/java/test/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManagerTest.java
@@ -26,7 +26,7 @@ public class XBeeTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     }
     
     @Override
-    protected String getSystemNameWithNoPrefix() {
+    protected String getASystemNameWithNoPrefix() {
         return "2:2";
     }
     

--- a/java/test/jmri/jmrix/internal/InternalReporterManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalReporterManagerTest.java
@@ -18,6 +18,11 @@ public class InternalReporterManagerTest extends jmri.managers.AbstractReporterM
         return "IR" + i;
     }
     
+    @Override
+    protected String getASystemNameWithNoPrefix() {
+        return "My Reporter 6";
+    }
+    
     // No manager-specific system name validation at present
     @Test
     @Override

--- a/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
@@ -5,6 +5,7 @@ import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,6 +27,11 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
     @Override
     public String getSystemName(int i) {
         return "IS" + i;
+    }
+    
+    @Override
+    protected String getASystemNameWithNoPrefix() {
+        return "My Sensor 6";
     }
 
     @Test
@@ -292,6 +298,50 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
     @Test
     @Override
     public void testMakeSystemNameWithPrefixNotASystemName() {}
+    
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testDeprecatedGetNextValidAddress() throws JmriException {
+    
+        Assert.assertEquals("2", "My Sensor 2", l.getNextValidAddress("My Sensor 2", l.getSystemPrefix()));
+        JUnitAppender.assertWarnMessageStartingWith("getNextValidAddress is deprecated, please remove references to it");
+        
+    }
+    
+    @Test
+    public void testgetNextValidAddressMaxedOut() throws JmriException {
+
+        Assert.assertNotNull("Created S1", l.provide("My Sensor 1"));
+        Assert.assertEquals("2 false", "My Sensor 2", l.getNextValidAddress("My Sensor 1", l.getSystemPrefix(),false));
+        Assert.assertEquals("2 true", "My Sensor 2", l.getNextValidAddress("My Sensor 1", l.getSystemPrefix(),true));
+        
+
+        Assert.assertNotNull("Created S2", l.provide("My Sensor 2"));
+        Assert.assertNotNull("Created S3", l.provide("My Sensor 3"));
+        Assert.assertEquals("2", "My Sensor 4", l.getNextValidAddress("My Sensor 1", l.getSystemPrefix(),false));
+        
+        Assert.assertNotNull("Created S4", l.provide("My Sensor 4"));
+        Assert.assertNotNull("Created S5", l.provide("My Sensor 5"));
+        Assert.assertNotNull("Created S6", l.provide("My Sensor 6"));
+        Assert.assertNotNull("Created S7", l.provide("My Sensor 7"));
+        Assert.assertNotNull("Created S8", l.provide("My Sensor 8"));
+        Assert.assertEquals("9", "My Sensor 9", l.getNextValidAddress("My Sensor 1", l.getSystemPrefix(),false));
+        
+        Assert.assertNotNull("Created S9", l.provide("My Sensor 9"));
+        Assert.assertEquals("10", "My Sensor 10", l.getNextValidAddress("My Sensor 1", l.getSystemPrefix(),false));
+        
+        Assert.assertNotNull("Created S10", l.provide("My Sensor 10"));
+        Assert.assertEquals("11", "My Sensor 11", l.getNextValidAddress("My Sensor 1", l.getSystemPrefix(),false));
+        
+        Assert.assertNotNull("Created S11", l.provide("My Sensor 11"));
+        
+        Assert.assertThrows(JmriException.class, () -> l.getNextValidAddress("My Sensor 1",l.getSystemPrefix(),false));
+        
+        Assert.assertEquals("12", "My Sensor 12", l.getNextValidAddress("My Sensor 2", l.getSystemPrefix(),false));
+
+        Assert.assertEquals("99 true", "My Sensor 100", l.getNextValidAddress("My Sensor 99", l.getSystemPrefix(),true));
+                
+    }
 
     private static class CountingPropertyChangeListener implements PropertyChangeListener {
 

--- a/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
@@ -22,6 +22,11 @@ public class InternalTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgr
     public String getSystemName(int i) {
         return "IT" + i;
     }
+    
+    @Override
+    protected String getASystemNameWithNoPrefix() {
+        return "My Turnout 6";
+    }
 
     @Test
     public void testAsAbstractFactory() {

--- a/java/test/jmri/jmrix/openlcb/OlcbLightManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbLightManagerTest.java
@@ -29,7 +29,7 @@ public class OlcbLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
     }
     
     @Override
-    public String getSystemNameWithNoPrefix() {
+    public String getASystemNameWithNoPrefix() {
         return "x0102030405060701;x0102030405060702";
     }
     

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutManagerTest.java
@@ -27,7 +27,7 @@ public class OlcbTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     }
     
     @Override
-    protected String getSystemNameWithNoPrefix() {
+    protected String getASystemNameWithNoPrefix() {
         return "X0102030405060702;X0102030405060701";
     }
 

--- a/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
@@ -24,7 +24,7 @@ public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnout
     }
     
     @Override
-    protected String getSystemNameWithNoPrefix() {
+    protected String getASystemNameWithNoPrefix() {
         return "" + getNumToTest2();
     }
 

--- a/java/test/jmri/jmrix/powerline/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/powerline/SerialSensorManagerTest.java
@@ -133,7 +133,7 @@ public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest
     }
     
     @Override
-    protected String getSystemNameWithNoPrefix(){
+    protected String getASystemNameWithNoPrefix(){
         return "B2";
     }
 

--- a/java/test/jmri/jmrix/powerline/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/powerline/SerialTurnoutManagerTest.java
@@ -46,7 +46,7 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
     }
     
     @Override
-    protected String getSystemNameWithNoPrefix() {
+    protected String getASystemNameWithNoPrefix() {
         return "B2";
     }
 

--- a/java/test/jmri/jmrix/rps/RpsReporterManagerTest.java
+++ b/java/test/jmri/jmrix/rps/RpsReporterManagerTest.java
@@ -55,7 +55,7 @@ public class RpsReporterManagerTest extends jmri.managers.AbstractReporterMgrTes
     }
     
     @Override
-    protected String getSystemNameWithNoPrefix() {
+    protected String getASystemNameWithNoPrefix() {
         return getNameToTest1();
     }
 

--- a/java/test/jmri/jmrix/rps/RpsSensorManagerTest.java
+++ b/java/test/jmri/jmrix/rps/RpsSensorManagerTest.java
@@ -22,7 +22,7 @@ public class RpsSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBas
     }
     
     @Override
-    protected String getSystemNameWithNoPrefix() {
+    protected String getASystemNameWithNoPrefix() {
         return "(0,0,0);(1,0,0);(1,1,0);(0,1,0)";
     }
 

--- a/java/test/jmri/jmrix/tams/TamsSensorManagerTest.java
+++ b/java/test/jmri/jmrix/tams/TamsSensorManagerTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.tams;
 
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.*;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
@@ -14,6 +15,14 @@ public class TamsSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
     @Override
     public String getSystemName(int i){
        return "TS" + i;
+    }
+    
+    @Disabled("Tams SensorManager does not seem to increment correctly, "
+            + "ERROR - systemName is already registered. "
+            + "Current system name: TS1:1. New system name: TS1:01")
+    @ToDo("Someone with knowledge of Tams could test the expected output.")
+    @Override
+    public void testGetNextValidAddress(){
     }
 
     @Test

--- a/java/test/jmri/managers/AbstractLightMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractLightMgrTestBase.java
@@ -1,8 +1,11 @@
 package jmri.managers;
 
 import java.beans.PropertyChangeListener;
+
+import jmri.JmriException;
 import jmri.Light;
 import jmri.LightManager;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
@@ -123,6 +126,41 @@ public abstract class AbstractLightMgrTestBase extends AbstractProvidingManagerT
     public void TestGetEntryToolTip(){
         Assert.assertNotNull("getEntryToolTip not null", l.getEntryToolTip());
         Assert.assertTrue("Entry ToolTip Contains text",(l.getEntryToolTip().length()>5));
+    }
+    
+    @Test
+    public void testGetNextValidAddress() throws JmriException {
+        
+        if (!l.allowMultipleAdditions(l.getSystemNamePrefix())){
+            return;
+        }
+        
+        Assert.assertNotNull("next valid before OK", l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false));
+    
+        Assert.assertNotEquals("requesting ignore existing does not return same", 
+                l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),true),
+                l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false));
+        
+        Light t =  l.provide(getASystemNameWithNoPrefix());
+        Assert.assertNotNull("exists", t);
+        
+        String nextValidAddr = l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false);
+        Light nextValid =  l.provide(nextValidAddr);
+        Assert.assertNotNull("exists", nextValid);
+        Assert.assertNotEquals(nextValid, t);
+        
+    }
+    
+    @Test
+    public void testIncorrectGetNextValidAddress() {
+        if (!l.allowMultipleAdditions(l.getSystemNamePrefix())){
+            return;
+        }
+        boolean contains = Assert.assertThrows(JmriException.class,
+                ()->{
+                    l.getNextValidAddress("NOTANINCREMENTABLEADDRESS", l.getSystemPrefix(),false);
+                }).getMessage().contains("NOTANINCREMENTABLEADDRESS");
+        Assert.assertTrue("Exception contained incorrect address", contains);
     }
 
     /**

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -127,14 +127,14 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
 
     @Test
     public void testMakeSystemName() {
-        String s = l.makeSystemName(getSystemNameWithNoPrefix());
+        String s = l.makeSystemName(getASystemNameWithNoPrefix());
         Assert.assertNotNull(s);
         Assert.assertFalse(s.isEmpty());
     }
     
     @Test
     public void testMakeSystemNameWithPrefix() {
-        String s = l.makeSystemName(l.getSystemNamePrefix()+getSystemNameWithNoPrefix());
+        String s = l.makeSystemName(l.getSystemNamePrefix()+getASystemNameWithNoPrefix());
         Assert.assertNotNull(s);
         Assert.assertFalse(s.isEmpty());
     }
@@ -180,7 +180,7 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
         Assert.assertEquals(sysPrefix + ":AUTO:0103", m.getAutoSystemName());
     }
     
-    protected String getSystemNameWithNoPrefix() {
+    protected String getASystemNameWithNoPrefix() {
         return "1";
     }
 

--- a/java/test/jmri/managers/AbstractReporterMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractReporterMgrTestBase.java
@@ -2,6 +2,7 @@ package jmri.managers;
 
 import java.beans.PropertyChangeListener;
 
+import jmri.JmriException;
 import jmri.Reporter;
 import jmri.ReporterManager;
 
@@ -190,6 +191,42 @@ public abstract class AbstractReporterMgrTestBase extends AbstractProvidingManag
     public void TestGetEntryToolTip(){
         Assert.assertNotNull("getEntryToolTip not null", l.getEntryToolTip());
         Assert.assertTrue("Entry ToolTip Contains text",(l.getEntryToolTip().length()>5));
+    }
+    
+    @Test
+    public void testGetNextValidAddress() throws JmriException {
+        
+        if (!l.allowMultipleAdditions(l.getSystemNamePrefix())){
+            return;
+        }
+        
+        Assert.assertNotNull("next valid before OK", l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false));
+    
+        Assert.assertNotEquals("requesting ignore existing does not return same", 
+                l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),true),
+                l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false));
+        
+        
+        Reporter t =  l.provide(getASystemNameWithNoPrefix());
+        Assert.assertNotNull("exists", t);
+        
+        String nextValidAddr = l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false);
+        Reporter nextValid =  l.provide(nextValidAddr);
+        Assert.assertNotNull("exists", nextValid);
+        Assert.assertNotEquals(nextValid, t);
+        
+    }
+    
+    @Test
+    public void testIncorrectGetNextValidAddress() {
+        if (!l.allowMultipleAdditions(l.getSystemNamePrefix())){
+            return;
+        }
+        boolean contains = Assert.assertThrows(JmriException.class,
+                ()->{
+                    l.getNextValidAddress("NOTANINCREMENTABLEADDRESS", l.getSystemPrefix(),false);
+                }).getMessage().contains("NOTANINCREMENTABLEADDRESS");
+        Assert.assertTrue("Exception contained incorrect address", contains);
     }
 
     /**

--- a/java/test/jmri/managers/AbstractSensorMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractSensorMgrTestBase.java
@@ -7,8 +7,10 @@ package jmri.managers;
 
 import java.beans.PropertyChangeListener;
 
+import jmri.JmriException;
 import jmri.Sensor;
 import jmri.SensorManager;
+import jmri.util.JUnitAppender;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
@@ -195,7 +197,42 @@ public abstract class AbstractSensorMgrTestBase extends AbstractProvidingManager
         Assert.assertNotNull("getEntryToolTip not null", l.getEntryToolTip());
         Assert.assertTrue("Entry ToolTip Contains text",(l.getEntryToolTip().length()>5));
     }
-
+    
+    @Test
+    public void testGetNextValidAddress() throws JmriException {
+        
+        if (!l.allowMultipleAdditions(l.getSystemNamePrefix())){
+            return;
+        }
+        
+        Assert.assertNotNull("next valid before OK", l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false));
+    
+        Assert.assertNotEquals("requesting ignore existing does not return same", 
+                l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),true),
+                l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false));
+        
+        Sensor t =  l.provide(getASystemNameWithNoPrefix());
+        Assert.assertNotNull("exists", t);
+        
+        String nextValidAddr = l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false);
+        Sensor nextValid =  l.provide(nextValidAddr);
+        Assert.assertNotNull("exists", nextValid);
+        Assert.assertNotEquals(nextValid, t);
+        
+    }
+    
+    @Test
+    public void testIncorrectGetNextValidAddress() {
+        if (!l.allowMultipleAdditions(l.getSystemNamePrefix())){
+            return;
+        }
+        boolean contains = Assert.assertThrows(JmriException.class,
+                ()->{
+                    l.getNextValidAddress("NOTANINCREMENTABLEADDRESS", l.getSystemPrefix(),false);
+                }).getMessage().contains("NOTANINCREMENTABLEADDRESS");
+        Assert.assertTrue("Exception contained incorrect address", contains);
+    }
+    
     /**
      * Number of sensor to test. Made a separate method so it can be overridden
      * in subclasses that do or don't support various numbers

--- a/java/test/jmri/managers/AbstractTurnoutMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractTurnoutMgrTestBase.java
@@ -2,6 +2,7 @@ package jmri.managers;
 
 import java.beans.PropertyChangeListener;
 
+import jmri.JmriException;
 import jmri.Turnout;
 import jmri.TurnoutManager;
 import jmri.util.JUnitAppender;
@@ -79,15 +80,15 @@ public abstract class AbstractTurnoutMgrTestBase extends AbstractProvidingManage
     
     @Test
     public void testProvideWithoutWithPrefix() throws IllegalArgumentException {
-        Turnout psa = l.provide(""+getSystemNameWithNoPrefix());
-        Turnout psb = l.provide(l.getSystemPrefix()+"T"+getSystemNameWithNoPrefix());
+        Turnout psa = l.provide(""+getASystemNameWithNoPrefix());
+        Turnout psb = l.provide(l.getSystemPrefix()+"T"+getASystemNameWithNoPrefix());
         Assert.assertTrue("Provide Without then With Prefix", psa == psb);
     }
 
     @Test
     public void testProvideWithWithoutPrefix() throws IllegalArgumentException {
-        Turnout psa = l.provide(l.getSystemPrefix()+"T"+getSystemNameWithNoPrefix());
-        Turnout psb = l.provide(""+getSystemNameWithNoPrefix());
+        Turnout psa = l.provide(l.getSystemNamePrefix()+getASystemNameWithNoPrefix());
+        Turnout psb = l.provide(""+getASystemNameWithNoPrefix());
         Assert.assertTrue("Provide With then Without Prefix", psa == psb);
     }
     
@@ -175,9 +176,44 @@ public abstract class AbstractTurnoutMgrTestBase extends AbstractProvidingManage
     }
     
     @Test
-    public void TestGetEntryToolTip(){
+    public void testGetEntryToolTip(){
         Assert.assertNotNull("getEntryToolTip not null", l.getEntryToolTip());
         Assert.assertTrue("Entry ToolTip Contains text",(l.getEntryToolTip().length()>5));
+    }
+    
+    @Test
+    public void testGetNextValidAddress() throws JmriException {
+        
+        if (!l.allowMultipleAdditions(l.getSystemNamePrefix())){
+            return;
+        }
+        
+        Assert.assertNotNull("next valid before OK", l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false));
+    
+        Assert.assertNotEquals("requesting ignore existing does not return same", 
+                l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),true),
+                l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false));
+        
+        Turnout t =  l.provideTurnout(getASystemNameWithNoPrefix());
+        Assert.assertNotNull("exists", t);
+        
+        String nextValidAddr = l.getNextValidAddress(getASystemNameWithNoPrefix(), l.getSystemPrefix(),false);
+        Turnout nextValid =  l.provideTurnout(nextValidAddr);
+        Assert.assertNotNull("exists", nextValid);
+        Assert.assertNotEquals(nextValid, t);
+        
+    }
+    
+    @Test
+    public void testIncorrectGetNextValidAddress() {
+        if (!l.allowMultipleAdditions(l.getSystemNamePrefix())){
+            return;
+        }
+        boolean contains = Assert.assertThrows(JmriException.class,
+            ()->{
+                l.getNextValidAddress("NOTANINCREMENTABLEADDRESS", l.getSystemPrefix(),false);
+            }).getMessage().contains("NOTANINCREMENTABLEADDRESS");
+        Assert.assertTrue("Exception contained incorrect address", contains);
     }
 
     /**

--- a/java/test/jmri/managers/TurnoutManagerScaffold.java
+++ b/java/test/jmri/managers/TurnoutManagerScaffold.java
@@ -212,8 +212,14 @@ public class TurnoutManagerScaffold implements TurnoutManager {
         return NameValidity.VALID;
     }
 
+    @Deprecated  // will be removed when superclass method is removed due to @Override
     @Override
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException {
+        return curAddress;
+    }
+    
+    @Override
+    public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
         return curAddress;
     }
 

--- a/java/test/jmri/util/StringUtilTest.java
+++ b/java/test/jmri/util/StringUtilTest.java
@@ -477,6 +477,17 @@ public class StringUtilTest {
         Assert.assertEquals("255,256,257", "FF 00 01 ", StringUtil.hexStringFromInts(new int[] {255,256,257}) );
     }
     
+    @Test
+    public void testIncrementLastNumberInString(){
+        Assert.assertEquals("zero length str", null, StringUtil.incrementLastNumberInString("",7) );
+        Assert.assertEquals("no number in str", null, StringUtil.incrementLastNumberInString("NoNumberInString",1) );
+        Assert.assertEquals("123 0", "123", StringUtil.incrementLastNumberInString("123",0 ));
+        Assert.assertEquals("ABC123DEF 2", "ABC125DEF", StringUtil.incrementLastNumberInString("ABC123DEF",2) );
+        Assert.assertEquals("ABC99DEF 1", "ABC100DEF", StringUtil.incrementLastNumberInString("ABC99DEF",1) );
+        Assert.assertEquals("123ABC456 1", "123ABC457", StringUtil.incrementLastNumberInString("123ABC456",1) );
+        Assert.assertEquals("123ABC0001 1", "123ABC0002", StringUtil.incrementLastNumberInString("123ABC0001",1) );
+    }
+    
     @BeforeEach
     public void setUp() throws Exception {
         jmri.util.JUnitUtil.setUp();


### PR DESCRIPTION
A follow up PR to this is planned which will update the GUI Table Actions.
At which point, the code for Light ranges will be moved to the new getNextValidAddress method, replacing the existing numeric only code and enabling hardware-specific range creation overrides for Lights ( which started off this and other recent jmrix manager PRs ).

Adds getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting)
Deprecates getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix)

For existing behaviour, set the ignoreInitialExisting flag false.
If set true, any initial Bean found will be ignored and the address incremented nonetheless.
The future use for this will be for user feedback while creating address ranges BEFORE the range is actually created.

New getNextValidAddress added to Light interface.

Default getNextValidAddress method moved up to AbstractManager.
This method will now increment both pure numeric Strings and partial numeric ( using the last number in a String. )
Eg. Internal Sensors with address "My Sensor Yard 77 Route 4" would be incremented to "My Sensor Yard 77 Route 5".
"MyThing1234" increments to "MyThing1235".

Error logging / dialogue boxes, null pointers removed from all jmrix getNextValidAddress classes.
Improved exception text for many jmrix classes.

Added support for creating ranges of MQTT Turnouts / Lights ( given a number in the starting String ).

Renames test method in Abstract tests from getSystemNameWithNoPrefix() to getASystemNameWithNoPrefix()
Adds tests for getNextValidAddress to abstract Sensors, Turnouts, Lights, Reporters.