### PR TITLE
Fix SprogThrottle 28 step mode EStop

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -137,7 +137,7 @@
 
         <h4>SPROG</h4>
             <ul>
-                <li></li>
+                <li>EStop for 28 Step mode is now sent correctly</li>
             </ul>
 
         <h4>TAMS</h4>

--- a/java/src/jmri/jmrix/sprog/SprogThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogThrottle.java
@@ -176,7 +176,7 @@ public class SprogThrottle extends AbstractThrottle {
                 value = 31;      // max possible speed
             }
             if (value < 0) {
-                value = 0;        // emergency stop
+                value = 1;        // emergency stop
             }
             String step = "" + value;
 


### PR DESCRIPTION
SprogThrottle setSpeedSetting() was incorrectly using a value of 0 for EStop when in 28 Step mode.  0 results in a normal stop, while 1 (or 3) results in an EStop.  The comments in the code are correct, just the actual value used was incorrect.  This PR corrects the code to use a value of 1 for EStop in 28 Step mode.

Note: The existing code uses the correct EStop value for 128 Step mode.