### PR TITLE
Add createSystemName to LightManager / ReporterManager interfaces

### DIFF
--- a/java/src/jmri/LightManager.java
+++ b/java/src/jmri/LightManager.java
@@ -199,4 +199,18 @@ public interface LightManager extends ProvidingManager<Light> {
     @Nonnull
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException;
 
+    /**
+     * Get a system name for a given hardware address and system prefix.
+     *
+     * @param curAddress desired hardware address
+     * @param prefix     system prefix used in system name, excluding Bean type-letter..
+     * @return the complete Light system name for the prefix and current
+     *         address
+     * @throws jmri.JmriException if unable to create a system name for the
+     *                            given address, possibly due to invalid address
+     *                            format
+     */
+    @Nonnull
+    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException;
+    
 }

--- a/java/src/jmri/ReporterManager.java
+++ b/java/src/jmri/ReporterManager.java
@@ -175,6 +175,20 @@ public interface ReporterManager extends ProvidingManager<Reporter> {
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException;
     
     /**
+     * Get a system name for a given hardware address and system prefix.
+     *
+     * @param curAddress desired hardware address
+     * @param prefix     system prefix used in system name, excluding Bean type-letter..
+     * @return the complete Reporter system name for the prefix and current
+     *         address
+     * @throws jmri.JmriException if unable to create a system name for the
+     *                            given address, possibly due to invalid address
+     *                            format
+     */
+    @Nonnull
+    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException;
+    
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -266,19 +266,26 @@ abstract public class AbstractProxyManager<E extends NamedBean> extends Vetoable
      *
      * @param curAddress base address to use
      * @param prefix system prefix to use
-     * @param managerType BeanType manager (method is used for Turnout and Sensor Managers)
+     * @param beanType Bean Type for manager (method is used for Turnout and Sensor Managers)
      * @return a valid system name for this connection
      * @throws JmriException if systemName cannot be created
      */
-    String createSystemName(String curAddress, String prefix, Class<?> managerType) throws JmriException {
+    String createSystemName(String curAddress, String prefix, Class<?> beanType) throws JmriException {
         for (Manager<E> m : mgrs) {
-            if (prefix.equals(m.getSystemPrefix()) && managerType.equals(m.getClass())) {
+            if (prefix.equals(m.getSystemPrefix()) && beanType.equals(m.getNamedBeanClass())) {
                 try {
-                    if (managerType == TurnoutManager.class) {
+                    if (beanType == Turnout.class) {
                         return ((TurnoutManager) m).createSystemName(curAddress, prefix);
-                    } else if (managerType == SensorManager.class) {
+                    } else if (beanType == Sensor.class) {
                         return ((SensorManager) m).createSystemName(curAddress, prefix);
-                    } else {
+                    } 
+                    else if (beanType == Light.class) {
+                        return ((LightManager) m).createSystemName(curAddress, prefix);
+                    }
+                    else if (beanType == Reporter.class) {
+                        return ((ReporterManager) m).createSystemName(curAddress, prefix);
+                    }
+                    else {
                         log.warn("createSystemName requested for incompatible Manager");
                     }
                 } catch (jmri.JmriException ex) {
@@ -287,6 +294,11 @@ abstract public class AbstractProxyManager<E extends NamedBean> extends Vetoable
             }
         }
         throw new jmri.JmriException("Manager could not be found for System Prefix " + prefix);
+    }
+    
+    @Nonnull
+    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {
+        return createSystemName(curAddress, prefix, getNamedBeanClass());
     }
 
     @SuppressWarnings("deprecation") // user warned by actual manager class

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -94,12 +94,6 @@ public class ProxySensorManager extends AbstractProvidingProxyManager<Sensor>
         return ((SensorManager) getManagerOrDefault(systemName)).allowMultipleAdditions(systemName);
     }
 
-    @Override
-    @Nonnull
-    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {
-        return createSystemName(curAddress, prefix, SensorManager.class);
-    }
-
     @SuppressWarnings("deprecation") // user warned by actual manager class
     @Override
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -180,11 +180,6 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
         return ((TurnoutManager) getManagerOrDefault(systemName)).allowMultipleAdditions(systemName);
     }
 
-    @Override
-    public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {
-        return createSystemName(curAddress, prefix, TurnoutManager.class);
-    }
-
     @SuppressWarnings("deprecation") // user warned by actual manager class
     @Override
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix) throws jmri.JmriException {


### PR DESCRIPTION
Adds @Nonnull public String createSystemName(@Nonnull String curAddress, @Nonnull String prefix) throws JmriException
to LightManager and ReporterManager Interfaces.

Fixes AbstractProxyManager createSystemName(String curAddress, String prefix, Class<?> managerType)
managerType class being passed eg. ( jmri.SensorManager ) would not equal the manager in the search loop ( CbusSensorManager or InternalSensorManager ).  Instead, pass the bean Class.