### PR TITLE
MERG CBUS - Add Reporter options CANRC522 / CANRCOM

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -98,7 +98,9 @@
 
         <h4>MERG CBUS</h4>
             <ul>
-                <li></li>
+                <li>CBUS RFID Reporters now act similar to other JMRI Reporters, ie with a timeout following the report.</li>
+                <li>CBUS Reporters can set a Sensor to follow the active IDTag status, set via CBUS Reporter Table.</li>
+                <li>CBUS Reporters will default to classic RFID ( 5 byte unique tags ), with option for in-development CANRC522 / CANRCOM format, set via CBUS Reporter Table.</li>
             </ul>
 
         <h4>MQTT</h4>

--- a/java/src/jmri/BooleanPropertyDescriptor.java
+++ b/java/src/jmri/BooleanPropertyDescriptor.java
@@ -4,7 +4,6 @@ package jmri;
  * Implementation of NamedBeanPropertyDescriptor for true/false properties.
  * @author Balazs Racz Copyright (C) 2018
  */
-
 public abstract class BooleanPropertyDescriptor extends NamedBeanPropertyDescriptor<Boolean> {
     public BooleanPropertyDescriptor(String key, boolean defVal) {
         super(key, defVal);

--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -96,6 +96,9 @@ LightStateTransitioningHigher    = Transitioning Higher
 LightStateTransitioningLower     = Transitioning Lower
 LightStateTransitioningToFullOff = Transitioning to Full Off
 
+IdTagReporterStateSeen           = ID Tag Seen
+IdTagReporterStateUnSeen         = No Recent ID Tag
+
 TurnoutStateClosed               = Closed
 StateClosedShort                 = C
 TurnoutStateThrown               = Thrown

--- a/java/src/jmri/NamedBeanPropertyDescriptor.java
+++ b/java/src/jmri/NamedBeanPropertyDescriptor.java
@@ -1,18 +1,22 @@
 package jmri;
 
 /**
- * Describes metadata about a given property key for a NamedBean. This metadata is used by the
+ * Describes metadata about a given property key for a NamedBean.
+ * <p>
+ * This metadata is used by the
  * BeanTable actions to display and edit the properties in question.
  *
+ * @param <E> class of describer, e.g. Boolean.class
  * @author Balazs Racz Copyright (C) 2018
  */
-
 public abstract class NamedBeanPropertyDescriptor<E> {
+    
     /**
      * Key of the property, to be used in the setProperty and getProperty functions on the
      * NamedBean.
      */
     public final String propertyKey;
+    
     /** What should be displayed when a given Bean does not have this property set. */
     public final E defaultValue;
 
@@ -35,10 +39,16 @@ public abstract class NamedBeanPropertyDescriptor<E> {
      */
     public abstract boolean isEditable(NamedBean bean);
 
-    /** @return Class for the property values. This class is used to find a matching Renderer for
-     the BeanTable column to display and edit the value of this property. For example returning
-     Boolean.class will show a checkbox.  */
-    public Class getValueClass() {
+    /** 
+     * Get the Class of the property.
+     * <p>
+     * This class is used to find a matching Renderer for
+     * the BeanTable column to display and edit the value of this property. 
+     * For example returning Boolean.class will show a checkbox.
+     * @return Class for the property values.
+     */
+    public Class<?> getValueClass() {
         return defaultValue.getClass();
     }
+    
 }

--- a/java/src/jmri/SelectionPropertyDescriptor.java
+++ b/java/src/jmri/SelectionPropertyDescriptor.java
@@ -1,0 +1,59 @@
+package jmri;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.swing.JComboBox;
+
+/**
+ * Implementation of NamedBeanPropertyDescriptor for multiple choice properties.
+ * @author Steve Young Copyright (C) 2020
+ * @since 4.21.3
+ */
+public abstract class SelectionPropertyDescriptor extends NamedBeanPropertyDescriptor<String> {
+    
+    private final String[] values;
+    private final String[] valueToolTips;
+    
+    /**
+     * Create a new SelectionPropertyDescriber.
+     * @param key Property Key - used to identify the property in Bean.getProperty(String).
+     * @param options Options for the property in String array.
+     * @param optionTips Tool-tips for options of the property in String array.
+     * @param defVal Default property value.
+     */
+    public SelectionPropertyDescriptor(String key, String[] options, String[] optionTips, String defVal ) {
+        super(key, defVal );
+        values = options;
+        valueToolTips = optionTips;
+    }
+    
+    /** 
+     * Get the Class of the property.
+     * <p>
+     * SelectionPropertyDescriber uses JComboBox.class
+     * @return JComboBox.class.
+     */
+    @Override
+    public Class<?> getValueClass() {
+        return JComboBox.class;
+    }
+    
+    /**
+     * Get the property options.
+     * Should be same length as getOptionToolTips()
+     * @return copy of the property options.
+     */
+    public String[] getOptions(){
+        return Arrays.copyOf(values,values.length);
+    }
+    
+    /**
+     * Get Tool-tips for the options.
+     * Should be same length as getOptions()
+     * @return list of tool-tips.
+     */
+    public List<String> getOptionToolTips(){
+        return Arrays.asList(valueToolTips);
+    }
+    
+}

--- a/java/src/jmri/implementation/AbstractIdTag.java
+++ b/java/src/jmri/implementation/AbstractIdTag.java
@@ -2,7 +2,6 @@ package jmri.implementation;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
 import javax.annotation.Nonnull;
 
 import jmri.*;
@@ -86,13 +85,12 @@ public abstract class AbstractIdTag extends AbstractNamedBean implements IdTag, 
         }
 
         // check to see if any properties have been added
-        Set keySet = getPropertyKeys();
-        // we have properties, so append the values to the
+        // If we have properties, so append the values to the
         // end of the report, seperated by spaces.
-        for( Object s : keySet) {
+        getPropertyKeys().forEach(s -> {
             sb.append(" ");
-            sb.append(getProperty((String)s));
-        }
+            sb.append(getProperty(s));
+        });
         return sb.toString();
     }
 

--- a/java/src/jmri/implementation/AbstractRailComReporter.java
+++ b/java/src/jmri/implementation/AbstractRailComReporter.java
@@ -23,13 +23,13 @@ public class AbstractRailComReporter extends AbstractIdTagReporter {
     }
 
     // Methods to support PhysicalLocationReporter interface
+    
     /**
-     * getLocoAddress()
-     *
-     * get the locomotive address we're reporting about from the current report.
+     * Get the locomotive address we're reporting about from the current report.
      *
      * Note: We ignore the string passed in, because RailCom Reporters don't send
      * String type reports.
+     * {@inheritDoc}
      */
     @Override
     public LocoAddress getLocoAddress(String rep) {

--- a/java/src/jmri/implementation/decorators/TimeoutReporter.java
+++ b/java/src/jmri/implementation/decorators/TimeoutReporter.java
@@ -53,8 +53,6 @@ public class TimeoutReporter extends AbstractNamedBeanDecorator implements Repor
      */
     private TimeoutThread timeoutThread = null;
 
-    private final boolean logDebug = log.isDebugEnabled();
-
     public TimeoutReporter(Reporter reporter) {
         super(reporter);
         this.reporter = reporter;
@@ -142,9 +140,7 @@ public class TimeoutReporter extends AbstractNamedBeanDecorator implements Repor
                 }
             }
             reporter.setReport(null);
-            if (logDebug) {
-                log.debug("Timeout-{}", getSystemName());
-            }
+            log.debug("Timeout-{}", getSystemName());
             cleanUpTimeout();
         }
     }

--- a/java/src/jmri/jmrit/beantable/AbstractTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableAction.java
@@ -220,7 +220,7 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
      * @param comboBox     the combo box to configure
      * @param manager      the current manager
      * @param managerClass the implemented manager class for the current
-     *                     mananger; this is the class used by
+     *                     manager; this is the class used by
      *                     {@link InstanceManager#getDefault(Class)} to get the
      *                     default manager, which may or may not be the current
      *                     manager

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -395,7 +395,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
                     break;
                 }
                 if (value instanceof JComboBox) {
-                    value = (String) ((JComboBox<?>) value).getSelectedItem();
+                    value = ((JComboBox<?>) value).getSelectedItem();
                 }                
                 NamedBean b = getBySystemName(sysNameList.get(row));
                 b.setProperty(desc.propertyKey, value);

--- a/java/src/jmri/jmrit/beantable/BlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/BlockTableAction.java
@@ -207,6 +207,7 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                     } else if (b.getCurvature() == Block.SEVERE) {
                         c.setSelectedItem(severeText);
                     }
+                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == LENGTHCOL) {
                     double len = 0.0;
@@ -227,6 +228,7 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                     JComboBox<String> c = new JComboBox<>(speedList);
                     c.setEditable(true);
                     c.setSelectedItem(speed);
+                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == STATECOL) {
                     switch (b.getState()) {
@@ -247,6 +249,7 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                         name = sensor.getDisplayName();
                     }
                     c.setSelectedItem(name);
+                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == REPORTERCOL) {
                     Reporter reporter = b.getReporter();
@@ -256,6 +259,7 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                         name = reporter.getDisplayName();
                     }
                     rs.setSelectedItem(name);
+                    rs.addActionListener(super::comboBoxAction);
                     return rs;
                 } else if (col == CURRENTREPCOL) {
                     return Boolean.valueOf(b.isReportingCurrent());
@@ -503,8 +507,6 @@ public class BlockTableAction extends AbstractTableAction<Block> {
 
             @Override
             public void configureTable(JTable table) {
-                table.setDefaultRenderer(JComboBox.class, new jmri.jmrit.symbolicprog.ValueRenderer());
-                table.setDefaultEditor(JComboBox.class, new jmri.jmrit.symbolicprog.ValueEditor());
                 table.setDefaultRenderer(Boolean.class, new EnablingCheckboxRenderer());
                 jmri.InstanceManager.sensorManagerInstance().addPropertyChangeListener(this);
                 jmri.InstanceManager.getDefault(jmri.ReporterManager.class).addPropertyChangeListener(this);

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -4,14 +4,7 @@ import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import javax.annotation.Nonnull;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JSpinner;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.SpinnerNumberModel;
+import javax.swing.*;
 import jmri.InstanceManager;
 import jmri.Manager;
 import jmri.Reporter;
@@ -42,7 +35,7 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
 
         // disable ourself if there is no primary Reporter manager available
         if (reporterManager == null) {
-            setEnabled(false);
+            super.setEnabled(false);
         }
     }
 
@@ -154,7 +147,7 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
              */
             @Override
             public int getColumnCount() {
-                return LASTREPORTCOL + 1;
+                return LASTREPORTCOL + getPropertyColumnCount() +1;
             }
 
             /**
@@ -278,20 +271,20 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
         return "package.jmri.jmrit.beantable.ReporterTable";
     }
 
-    JmriJFrame addFrame = null;
-    JTextField hardwareAddressTextField = new JTextField(20);
-    JTextField userNameTextField = new JTextField(20);
-    ManagerComboBox<Reporter> prefixBox = new ManagerComboBox<>();
-    SpinnerNumberModel rangeSpinner = new SpinnerNumberModel(1, 1, 100, 1); // maximum 100 items
-    JSpinner numberToAddSpinner = new JSpinner(rangeSpinner);
-    JCheckBox rangeCheckBox = new JCheckBox(Bundle.getMessage("AddRangeBox"));
-    String systemSelectionCombo = this.getClass().getName() + ".SystemSelected";
-    JButton addButton;
-    JLabel statusBarLabel = new JLabel(Bundle.getMessage("HardwareAddStatusEnter"), JLabel.LEADING);
-    String userNameError = this.getClass().getName() + ".DuplicateUserName"; // only used in this package
-    Manager<Reporter> connectionChoice = null;
-    jmri.UserPreferencesManager pref;
-    SystemNameValidator hardwareAddressValidator;
+    private JmriJFrame addFrame = null;
+    private final JTextField hardwareAddressTextField = new JTextField(20);
+    private final JTextField userNameTextField = new JTextField(20);
+    private final ManagerComboBox<Reporter> prefixBox = new ManagerComboBox<>();
+    private final SpinnerNumberModel rangeSpinner = new SpinnerNumberModel(1, 1, 100, 1); // maximum 100 items
+    private final JSpinner numberToAddSpinner = new JSpinner(rangeSpinner);
+    private final JCheckBox rangeCheckBox = new JCheckBox(Bundle.getMessage("AddRangeBox"));
+    private final String systemSelectionCombo = this.getClass().getName() + ".SystemSelected";
+    private JButton addButton;
+    private final JLabel statusBarLabel = new JLabel(Bundle.getMessage("HardwareAddStatusEnter"), JLabel.LEADING);
+    private final String userNameError = this.getClass().getName() + ".DuplicateUserName"; // only used in this package
+    private Manager<Reporter> connectionChoice = null;
+    private jmri.UserPreferencesManager pref;
+    private SystemNameValidator hardwareAddressValidator;
 
     /**
      * {@inheritDoc}

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -342,14 +342,9 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                         return Bundle.getMessage("BeanStateUnknown"); // "Unknown"
                     }
                 } else if (col == MODECOL) {
-                    JComboBox<String> c = new JComboBox<String>(t.getValidFeedbackNames());
+                    JComboBox<String> c = new JComboBox<>(t.getValidFeedbackNames());
                     c.setSelectedItem(t.getFeedbackModeName());
-                    c.addActionListener(new ActionListener() {
-                        @Override
-                        public void actionPerformed(ActionEvent e) {
-                            comboBoxAction(e);
-                        }
-                    });
+                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == SENSOR1COL) {
                     return t.getFirstSensor();
@@ -364,18 +359,13 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                 } else if (col == LOCKDECCOL) {
                     JComboBox<String> c;
                     if ((t.getPossibleLockModes() & Turnout.PUSHBUTTONLOCKOUT) != 0) {
-                        c = new JComboBox<String>(t.getValidDecoderNames());
+                        c = new JComboBox<>(t.getValidDecoderNames());
                     } else {
-                        c = new JComboBox<String>(new String[]{t.getDecoderName()});
+                        c = new JComboBox<>(new String[]{t.getDecoderName()});
                     }
 
                     c.setSelectedItem(t.getDecoderName());
-                    c.addActionListener(new ActionListener() {
-                        @Override
-                        public void actionPerformed(ActionEvent e) {
-                            comboBoxAction(e);
-                        }
-                    });
+                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == LOCKOPRCOL) {
                     java.util.Vector<String> lockOperations = new java.util.Vector<>();  // Vector is a JComboBox ctor; List is not
@@ -390,7 +380,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                         lockOperations.add(pushbutText);
                     }
                     lockOperations.add(noneText);
-                    JComboBox<String> c = new JComboBox<String>(lockOperations);
+                    JComboBox<String> c = new JComboBox<>(lockOperations);
 
                     if (t.canLock(Turnout.CABLOCKOUT) && t.canLock(Turnout.PUSHBUTTONLOCKOUT)) {
                         c.setSelectedItem(bothText);
@@ -401,12 +391,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                     } else {
                         c.setSelectedItem(noneText);
                     }
-                    c.addActionListener(new ActionListener() {
-                        @Override
-                        public void actionPerformed(ActionEvent e) {
-                            comboBoxAction(e);
-                        }
-                    });
+                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == STRAIGHTCOL) {
 
@@ -414,10 +399,10 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                     if (!speedListClosed.contains(speed)) {
                         speedListClosed.add(speed);
                     }
-                    JComboBox<String> c = new JComboBox<String>(speedListClosed);
+                    JComboBox<String> c = new JComboBox<>(speedListClosed);
                     c.setEditable(true);
                     c.setSelectedItem(speed);
-
+                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == DIVERGCOL) {
 
@@ -425,9 +410,10 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                     if (!speedListThrown.contains(speed)) {
                         speedListThrown.add(speed);
                     }
-                    JComboBox<String> c = new JComboBox<String>(speedListThrown);
+                    JComboBox<String> c = new JComboBox<>(speedListThrown);
                     c.setEditable(true);
                     c.setSelectedItem(speed);
+                    c.addActionListener(super::comboBoxAction);
                     return c;
                     // } else if (col == VALUECOL && _graphicState) { // not neeeded as the
                     //  graphic ImageIconRenderer uses the same super.getValueAt(row, col) as
@@ -616,8 +602,6 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                 table = tbl;
 
                 table.setDefaultRenderer(Boolean.class, new EnablingCheckboxRenderer());
-                table.setDefaultRenderer(JComboBox.class, new jmri.jmrit.symbolicprog.ValueRenderer());
-                table.setDefaultEditor(JComboBox.class, new jmri.jmrit.symbolicprog.ValueEditor());
                 setColumnToHoldButton(table, OPSEDITCOL, editButton());
                 setColumnToHoldButton(table, EDITCOL, editButton());
                 //Hide the following columns by default
@@ -666,13 +650,6 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                     return true;
                 } else {
                     return super.matchPropertyName(e);
-                }
-            }
-
-            public void comboBoxAction(ActionEvent e) {
-                log.debug("Combobox change");
-                if (table != null && table.getCellEditor() != null) {
-                    table.getCellEditor().stopCellEditing();
                 }
             }
 

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -4,7 +4,6 @@ import jmri.util.gui.GuiLafPreferencesManager;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Image;
-import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
@@ -327,9 +326,7 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
             case PULLUPCOL:
                 PullResistanceComboBox c = new PullResistanceComboBox(Sensor.PullResistance.values());
                 c.setSelectedItem(s.getPullResistance());
-                c.addActionListener((ActionEvent e) -> {
-                    comboBoxAction(e);
-                });
+                c.addActionListener(super::comboBoxAction);
                 return c;
             case FORGETCOL:
                 return Bundle.getMessage("StateForgetButton");
@@ -601,8 +598,6 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
         this.table = table;
         showDebounce(false);
         showPullUp(false);
-        this.table.setDefaultRenderer(JComboBox.class, new jmri.jmrit.symbolicprog.ValueRenderer());
-        this.table.setDefaultEditor(JComboBox.class, new jmri.jmrit.symbolicprog.ValueEditor());
         showStateForgetAndQuery(false);
         super.configureTable(table);
     }
@@ -646,15 +641,6 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
 //    public static final ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrit.beantable.BeanTableBundle");
     public String getClassDescription() {
         return Bundle.getMessage("TitleSensorTable");
-    }
-
-    public void comboBoxAction(ActionEvent e) {
-        if (log.isDebugEnabled()) {
-            log.debug("Combobox change");
-        }
-        if (table != null && table.getCellEditor() != null) {
-            table.getCellEditor().stopCellEditing();
-        }
     }
 
     @Override

--- a/java/src/jmri/jmrix/can/cbus/CbusReporter.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusReporter.java
@@ -66,7 +66,7 @@ public class CbusReporter extends AbstractRailComReporter implements CanListener
      */
     public CbusReporter(String address, CanSystemConnectionMemo memo) {  // a human-readable Reporter number must be specified!
         super(memo.getSystemPrefix() + "R" + address);  // can't use prefix here, as still in construction
-        _number = Integer.valueOf(  address);
+        _number = Integer.parseInt(  address);
         _memo = memo;
         // At construction, register for messages
         tc = memo.getTrafficController(); // can be removed when former constructor removed
@@ -124,23 +124,23 @@ public class CbusReporter extends AbstractRailComReporter implements CanListener
         }
         if ((m.getElement(1) << 8) + m.getElement(2) == _number) { // correct reporter number
             if (m.getOpCode() == CbusConstants.CBUS_DDES && !getCbusReporterType().equals(CbusReporterManager.CBUS_REPORTER_TYPE_CLASSIC)  ) {
-                DdesReport(m);
+                ddesReport(m);
             } else {
-                ClassicRFIDReport(m);
+                classicRFIDReport(m);
             }
         }
     }
     
-    private void DdesReport(CanReply m) {
+    private void ddesReport(CanReply m) {
         int least_significant_bit = m.getElement(3) & 1;
         if ( least_significant_bit ==0 ) {
-            CanRc522Report(m);
+            canRc522Report(m);
         } else {
-            CanRcomReport(m);
+            canRcomReport(m);
         }
     }
 
-    private void ClassicRFIDReport(CanReply m) {
+    private void classicRFIDReport(CanReply m) {
         String buf = toClassicTag(m.getElement(3), m.getElement(4), m.getElement(5), m.getElement(6), m.getElement(7));
         log.debug("Reporter {} {} RFID tag read of tag: {}", this,getCbusReporterType(),buf);
         IdTag tag = InstanceManager.getDefault(IdTagManager.class).provideIdTag(buf);
@@ -149,7 +149,7 @@ public class CbusReporter extends AbstractRailComReporter implements CanListener
     }
     
     // no DCC address correction to allow full 0-65535 range of tags on rolling stock
-    private void CanRc522Report(CanReply m){
+    private void canRc522Report(CanReply m){
         String tagId = String.valueOf((m.getElement(4)<<8)+ m.getElement(5));
         log.debug("Reporter {} RFID tag read of tag: {}",this, tagId);
         IdTag tag = InstanceManager.getDefault(IdTagManager.class).provideIdTag("ID"+tagId);
@@ -160,7 +160,7 @@ public class CbusReporter extends AbstractRailComReporter implements CanListener
     }
     
     // DCC address correction 0-10239 range
-    private void CanRcomReport(CanReply m) {
+    private void canRcomReport(CanReply m) {
         int railcom_id = (m.getElement(3)>>4);
         log.warn("CANRCOM support still in development.");
         log.info("{} detected RailCom ID {}",this,railcom_id);

--- a/java/src/jmri/jmrix/can/cbus/CbusReporter.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusReporter.java
@@ -1,18 +1,17 @@
 package jmri.jmrix.can.cbus;
 
-import jmri.IdTag;
-import jmri.IdTagManager;
-import jmri.InstanceManager;
-import jmri.implementation.AbstractReporter;
-import jmri.jmrix.can.CanListener;
-import jmri.jmrix.can.CanMessage;
-import jmri.jmrix.can.CanReply;
-import jmri.jmrix.can.TrafficController;
+import javax.annotation.Nonnull;
+
+import jmri.*;
+import jmri.implementation.AbstractRailComReporter;
+import jmri.jmrix.can.*;
+import jmri.util.ThreadingUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Extend jmri.AbstractReporter for CBUS controls.
+ * Extend jmri.AbstractRailComReporter for CBUS controls.
  * <hr>
  * This file is part of JMRI.
  * <p>
@@ -25,40 +24,81 @@ import org.slf4j.LoggerFactory;
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  * <p>
  *
+ * CBUS Reporters can accept 
+ * 5-byte unique Classic RFID on DDES or ACDAT OPCs,
+ * CANRC522 / CANRCOM DDES OPCs.
+ * 
  * @author Mark Riddoch Copyright (C) 2015
- * @author Steve Young Copyright (c) 2019
+ * @author Steve Young Copyright (c) 2019, 2020
  *
  */
-public class CbusReporter extends AbstractReporter implements CanListener {
+public class CbusReporter extends AbstractRailComReporter implements CanListener {
 
     private final int _number;
-    private final TrafficController tc;
-
+    private final TrafficController tc; // can be removed when former constructor removed
+    private final CanSystemConnectionMemo _memo;
+    
+    /**
+     * Create a new CbusReporter.
+     * @param number reporter address number.
+     * @param tco CAN Traffic controller.
+     * @param prefix system prefix.
+     * @deprecated since 4.21.3; use CbusReporter(String,memo,prefix) instead.
+     */
+    @Deprecated
     public CbusReporter(int number, TrafficController tco, String prefix) {  // a human-readable Reporter number must be specified!
         super(prefix + "R" + number);  // can't use prefix here, as still in construction
         _number = number;
         // At construction, register for messages
         tc = tco;
         addTc(tc);
+        _memo = null;
         log.debug("Added new reporter {}R{}", prefix, number);
+        log.warn("Deprecated Constructor - Please use CbusReporter(String,CanSystemConnectionMemo,String) ");
+    }
+    
+    /**
+     * Create a new CbusReporter.
+     * <p>
+     * 
+     * @param address Reporter address, currently in String number format. No system prefix or type letter.
+     * @param memo System connection.
+     */
+    public CbusReporter(String address, CanSystemConnectionMemo memo) {  // a human-readable Reporter number must be specified!
+        super(memo.getSystemPrefix() + "R" + address);  // can't use prefix here, as still in construction
+        _number = Integer.valueOf(  address);
+        _memo = memo;
+        // At construction, register for messages
+        tc = memo.getTrafficController(); // can be removed when former constructor removed
+        addTc(memo.getTrafficController());
+        log.debug("Added new reporter {}R{}", memo.getSystemPrefix(), address);
     }
 
-    private int state = UNKNOWN;
-
     /**
+     * Set the CbusReporter State.
+     * <p>
+     * May also provide / update a CBUS Sensor State, depending on property.
      * {@inheritDoc}
      */
     @Override
     public void setState(int s) {
-        state = s;
+        super.setState(s);
+        if ( getMaintainSensor() ) {
+            SensorManager sm = (SensorManager) _memo.get(SensorManager.class);
+            sm.provide("+"+_number).setCommandedState( s==IdTag.SEEN ? Sensor.ACTIVE : Sensor.INACTIVE );
+        }        
     }
 
     /**
      * {@inheritDoc}
+     * Resets report briefly back to null so Sensor Listeners are updated.
      */
     @Override
-    public int getState() {
-        return state;
+    public void notify(IdTag id){
+        if ( this.getCurrentReport()!=null && id!=null ){
+            super.notify(null); // 
+        }
+        super.notify(id);
     }
 
     /**
@@ -67,8 +107,7 @@ public class CbusReporter extends AbstractReporter implements CanListener {
      */
     @Override
     public void message(CanMessage m) {
-        CanReply mNew = new CanReply(m);
-        reply(mNew);
+        reply(new CanReply(m));
     }
 
     /**
@@ -83,54 +122,96 @@ public class CbusReporter extends AbstractReporter implements CanListener {
         if ( m.getOpCode() != CbusConstants.CBUS_DDES && m.getOpCode() != CbusConstants.CBUS_ACDAT) {
             return;
         }
-        RFIDReport(m);
-    }
-
-    public void clear() {
-        log.debug("reporter {} set to clear",toString());
-        setReport(null);
-        setState(IdTag.UNSEEN);
-    }
-
-    private void RFIDReport(CanReply m) {
-        int addr = (m.getElement(1) << 8) + m.getElement(2);
-        if (addr == _number) {
-            log.debug("CBusReporter found for addr:{}", addr);
-            String buf = toTag(m.getElement(3), m.getElement(4), m.getElement(5), m.getElement(6), m.getElement(7));
-            log.debug("Report RFID tag read of tag: {}", buf);
-            IdTag tag = InstanceManager.getDefault(IdTagManager.class).provideIdTag(buf);
-            clearPreviousReporter(tag);
-            tag.setWhereLastSeen(this);
-            setReport(tag);
-            setState(IdTag.SEEN);
-        }
-    }
-
-    private String toTag(int b1, int b2, int b3, int b4, int b5) {
-        String rval;
-        rval = String.format("%02X", b1) + String.format("%02X", b2) + String.format("%02X", b3)
-                + String.format("%02X", b4) + String.format("%02X", b5);
-        return rval;
-    }
-    
-    // clear all previous reporter of the ID tag location
-    // there is no "exit" area message in CBUS
-    private void clearPreviousReporter(IdTag tag) {
-        log.debug("clear previous reporter for tag {}",tag);
-        CbusReporter r = (CbusReporter) tag.getWhereLastSeen();
-        if (r != null) {
-            log.debug("previous reporter {} found",r);
-            if (r != this && r.getCurrentReport() == tag) {
-                r.clear();
+        if ((m.getElement(1) << 8) + m.getElement(2) == _number) { // correct reporter number
+            if (m.getOpCode() == CbusConstants.CBUS_DDES && !getCbusReporterType().equals(CbusReporterManager.CBUS_REPORTER_TYPE_CLASSIC)  ) {
+                DdesReport(m);
+            } else {
+                ClassicRFIDReport(m);
             }
         }
     }
+    
+    private void DdesReport(CanReply m) {
+        int least_significant_bit = m.getElement(3) & 1;
+        if ( least_significant_bit ==0 ) {
+            CanRc522Report(m);
+        } else {
+            CanRcomReport(m);
+        }
+    }
+
+    private void ClassicRFIDReport(CanReply m) {
+        String buf = toClassicTag(m.getElement(3), m.getElement(4), m.getElement(5), m.getElement(6), m.getElement(7));
+        log.debug("Reporter {} {} RFID tag read of tag: {}", this,getCbusReporterType(),buf);
+        IdTag tag = InstanceManager.getDefault(IdTagManager.class).provideIdTag(buf);
+        notify(tag);
+        startTimeout(tag);
+    }
+    
+    // no DCC address correction to allow full 0-65535 range of tags on rolling stock
+    private void CanRc522Report(CanReply m){
+        String tagId = String.valueOf((m.getElement(4)<<8)+ m.getElement(5));
+        log.debug("Reporter {} RFID tag read of tag: {}",this, tagId);
+        IdTag tag = InstanceManager.getDefault(IdTagManager.class).provideIdTag("ID"+tagId);
+        tag.setProperty("DDES Dat3", m.getElement(6));
+        tag.setProperty("DDES Dat4", m.getElement(7));
+        notify(tag);
+        startTimeout(tag);
+    }
+    
+    // DCC address correction 0-10239 range
+    private void CanRcomReport(CanReply m) {
+        int railcom_id = (m.getElement(3)>>4);
+        log.warn("CANRCOM support still in development.");
+        log.info("{} detected RailCom ID {}",this,railcom_id);
+    }
+
+    private String toClassicTag(int b1, int b2, int b3, int b4, int b5) {
+        return String.format("%02X", b1) + String.format("%02X", b2) + String.format("%02X", b3)
+            + String.format("%02X", b4) + String.format("%02X", b5);
+    }
+    
+    /**
+     * Get the Reporter Listener format type.
+     * <p>
+     * Defaults to Classic RfID, 5 byte unique. 
+     * @return reporter format type.
+     */
+    @Nonnull
+    public String getCbusReporterType() {
+        Object returnVal = getProperty(CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY);
+        return (returnVal==null ? CbusReporterManager.CBUS_DEFAULT_REPORTER_TYPE : returnVal.toString());
+    }
+    
+    /**
+     * Get if the Reporter should provide / update a CBUS Sensor, following Reporter Status.
+     * <p>
+     * Defaults to false.
+     * @return true if the reporter should maintain the Sensor.
+     */
+    public boolean getMaintainSensor() {
+        Boolean returnVal = (Boolean) getProperty(CbusReporterManager.CBUS_MAINTAIN_SENSOR_DESCRIPTOR_KEY);
+        return (returnVal==null ? false : returnVal);
+    }
+    
+    // delay can be set to non-null memo when older constructor fully deprecated.
+    private void startTimeout(IdTag tag){
+        int delay = (_memo==null ? 2000 : ((CbusReporterManager)_memo.get(jmri.ReporterManager.class)).getTimeout() );
+        ThreadingUtil.runOnLayoutDelayed( () -> {
+            if (!disposed && getCurrentReport() == tag) {
+                notify(null);
+            }
+        },delay);
+    }
+    
+    private boolean disposed = false;
     
     /**
      * {@inheritDoc}
      */
     @Override
     public void dispose() {
+        disposed = true;
         tc.removeCanListener(this);
         super.dispose();
     }

--- a/java/src/jmri/jmrix/can/cbus/CbusReporterManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusReporterManager.java
@@ -1,9 +1,14 @@
 package jmri.jmrix.can.cbus;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.annotation.Nonnull;
-import jmri.Reporter;
+
+import jmri.*;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.managers.AbstractReporterManager;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,10 +42,10 @@ public class CbusReporterManager extends AbstractReporterManager {
      * {@inheritDoc}
      */
     @Override
-    public Reporter createNewReporter(@Nonnull String systemName, String userName) {
+    protected Reporter createNewReporter(@Nonnull String systemName, String userName) {
         log.debug("ReporterManager create new CbusReporter: {}", systemName);
-        int addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
-        Reporter t = new CbusReporter(addr, getMemo().getTrafficController(), getSystemPrefix());
+        String addr = systemName.substring(getSystemNamePrefix().length());
+        Reporter t = new CbusReporter(addr, getMemo());
         t.setUserName(userName);
         t.addPropertyChangeListener(this);
         return t;
@@ -54,10 +59,6 @@ public class CbusReporterManager extends AbstractReporterManager {
     public NameValidity validSystemNameFormat(@Nonnull String systemName) {
         // name must be in the MSnnnnn format (M is user configurable); no + or ; or - for Reporter address
         log.debug("Checking system name: {}", systemName);
-        if ( systemName == null ) {
-            log.debug("Null system name");
-            return NameValidity.INVALID;
-        }
         try {
             // try to parse the string; success returns true
             int testnum = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1, systemName.length()));
@@ -106,6 +107,69 @@ public class CbusReporterManager extends AbstractReporterManager {
     @Nonnull
     public String validateSystemNameFormat(@Nonnull String name, @Nonnull java.util.Locale locale) throws jmri.NamedBean.BadSystemNameException {
         return validateSystemNameFormatOnlyNumeric(name,locale);
+    }
+    
+    protected final static String CBUS_REPORTER_DESCRIPTOR_KEY = "CBUS Reporter Type"; // NOI18N
+    
+    protected final static String CBUS_REPORTER_TYPE_CLASSIC = "Classic RFID"; // NOI18N
+    
+    protected final static String CBUS_REPORTER_TYPE_DDES_DESCRIBING = "CANRC522 / CANRCOM"; // NOI18N
+    
+    protected final static String[] CBUS_REPORTER_TYPES = {
+        CBUS_REPORTER_TYPE_CLASSIC,CBUS_REPORTER_TYPE_DDES_DESCRIBING};
+    
+    protected final static String[] CBUS_REPORTER_TYPE_TIPS = {
+        "DDES / ACDAT 5 byte unique tag.","DDES self-describing ( Writeable CANRC522 / Railcom )"}; // NOI18N
+    
+    protected final static String CBUS_DEFAULT_REPORTER_TYPE = CBUS_REPORTER_TYPES[0];
+    
+    protected final static String CBUS_MAINTAIN_SENSOR_DESCRIPTOR_KEY = "Maintain CBUS Sensor"; // NOI18N
+    
+    @Override
+    @Nonnull
+    public List<NamedBeanPropertyDescriptor<?>> getKnownBeanProperties() {
+        List<NamedBeanPropertyDescriptor<?>> l = new ArrayList<>();
+        l.add(new SelectionPropertyDescriptor(
+            CBUS_REPORTER_DESCRIPTOR_KEY, CBUS_REPORTER_TYPES, CBUS_REPORTER_TYPE_TIPS, CBUS_DEFAULT_REPORTER_TYPE) {
+            @Override
+            public String getColumnHeaderText() {
+                return CBUS_REPORTER_DESCRIPTOR_KEY;
+            }
+            @Override
+            public boolean isEditable(NamedBean bean) {
+                return (bean instanceof CbusReporter);
+            }
+        });
+        l.add(new BooleanPropertyDescriptor(
+            CBUS_MAINTAIN_SENSOR_DESCRIPTOR_KEY, false) {
+            @Override
+            public String getColumnHeaderText() {
+                return CBUS_MAINTAIN_SENSOR_DESCRIPTOR_KEY;
+            }
+            @Override
+            public boolean isEditable(NamedBean bean) {
+                return (bean instanceof CbusReporter);
+            }
+        });
+        return l;
+    }
+    
+    private int _timeout=2000; // same default as TimeoutReporter
+    
+    /**
+     * Set the Reporter timeout.
+     * @param timeout time in milliseconds that CbusReporters stay at IdTag.SEEN after hearing an ID Tag.
+     */
+    public void setTimeout(int timeout){
+        _timeout = timeout;
+    }
+    
+    /**
+     * Get the Reporter Timeout.
+     * @return milliseconds for CbusReporters to return to IdTag.UNSEEN
+     */
+    public int getTimeout(){
+        return _timeout;
     }
 
     private static final Logger log = LoggerFactory.getLogger(CbusReporterManager.class);

--- a/java/src/jmri/jmrix/can/cbus/CbusSensor.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensor.java
@@ -1,7 +1,5 @@
 package jmri.jmrix.can.cbus;
 
-import java.beans.PropertyChangeEvent;
-import jmri.Reporter;
 import jmri.Sensor;
 import jmri.implementation.AbstractSensor;
 import jmri.jmrix.can.CanListener;
@@ -27,7 +25,6 @@ public class CbusSensor extends AbstractSensor implements CanListener, CbusEvent
         init(address);
     }
     
-    private Reporter reporter = null;
     private final TrafficController tc;
 
     /**
@@ -206,44 +203,6 @@ public class CbusSensor extends AbstractSensor implements CanListener, CbusEvent
         } else if (addrInactive.match(f)) {
             setOwnState(!getInverted() ? Sensor.INACTIVE : Sensor.ACTIVE);
         }
-    }
-    
-    /**
-     * {@inheritDoc}
-     *
-     * When a reporter is attached to the sensor, the sensor will go
-     * active when ID tags are present ( assuming Sensor not inverted ),
-     * inactive when no ID tags are present, ie all previously announced
-     * ID tags have since been announced by other reporters.
-     */
-    @Override
-    public void setReporter(Reporter er) {
-        reporter = er;
-        if (reporter!=null) {
-            log.debug("attached to reporter",reporter);
-            reporter.addPropertyChangeListener((PropertyChangeEvent e) -> {
-                log.debug("Report {} property {} new value {}",reporter, e.getPropertyName(), e.getNewValue());
-                if (e.getPropertyName().equals("state")) {
-                    try {
-                        if ( (int) e.getNewValue()==jmri.IdTag.SEEN) {
-                            setKnownState(Sensor.ACTIVE); // setKnownState does any inversion
-                        } else {
-                            setKnownState(Sensor.INACTIVE); // setKnownState does any inversion
-                        }
-                    } catch (jmri.JmriException ex) {
-                        log.error("Reporter {} unable to change sensor status",reporter);
-                    }
-                }
-            });
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Reporter getReporter() {
-        return reporter;
     }
     
     /**

--- a/java/test/jmri/SelectionPropertyDescriptorTest.java
+++ b/java/test/jmri/SelectionPropertyDescriptorTest.java
@@ -1,0 +1,80 @@
+package jmri;
+
+import java.util.Arrays;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import static org.junit.Assert.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ *
+ * @author Steve
+ */
+public class SelectionPropertyDescriptorTest {
+    
+    @Test
+    public void testCTor() {
+        SelectionPropertyDescriptorImpl t = new SelectionPropertyDescriptorImpl();
+        Assert.assertNotNull("exists",t);
+    }
+
+    @Test
+    public void testGetValueClass() {
+        SelectionPropertyDescriptorImpl t = new SelectionPropertyDescriptorImpl();
+        assertEquals(javax.swing.JComboBox.class, t.getValueClass());
+    }
+
+    @Test
+    public void testGetOptions() {
+        SelectionPropertyDescriptorImpl t = new SelectionPropertyDescriptorImpl();
+        assertArrayEquals(new String[]{"A","B","C"}, t.getOptions());
+    }
+
+    @Test
+    public void testGetOptionToolTips() {
+        SelectionPropertyDescriptorImpl t = new SelectionPropertyDescriptorImpl();
+        assertEquals(Arrays.asList(new String[]{"A Tip","B Tip","C Tip"}), t.getOptionToolTips());
+    }
+    
+    @Test
+    public void testPassThroughSuper() {
+        SelectionPropertyDescriptorImpl t = new SelectionPropertyDescriptorImpl();
+        Assert.assertEquals("Default property option","B",t.defaultValue);
+        Assert.assertEquals("property key set","TEST_PROPERTY_KEY",t.propertyKey);
+        Assert.assertEquals("editable set true",true,t.isEditable(null));
+        Assert.assertEquals("column header set","Column Header Text",t.getColumnHeaderText());
+    }
+
+    private class SelectionPropertyDescriptorImpl extends SelectionPropertyDescriptor {
+
+        public SelectionPropertyDescriptorImpl() {
+            super("TEST_PROPERTY_KEY", new String[]{"A","B","C"}, new String[]{"A Tip","B Tip","C Tip"}, "B");
+        }
+        
+        @Override
+        public boolean isEditable(NamedBean bean){
+            return true;
+        }
+        
+        @Override
+        public String getColumnHeaderText(){
+            return "Column Header Text";
+        }
+        
+    }
+    
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+    
+}

--- a/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
@@ -1,5 +1,8 @@
 package jmri.jmrix.can.cbus;
 
+import java.util.List;
+
+import jmri.*;
 import jmri.Manager.NameValidity;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
@@ -46,7 +49,6 @@ public class CbusReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
         Assert.assertEquals("MR",NameValidity.INVALID,l.validSystemNameFormat("MR"));
         Assert.assertEquals("no value",NameValidity.INVALID,l.validSystemNameFormat(""));
         Assert.assertEquals("Str ing",NameValidity.INVALID,l.validSystemNameFormat("Jon Smith"));
-        Assert.assertEquals("null",NameValidity.INVALID,l.validSystemNameFormat(null));
     }
     
 
@@ -59,6 +61,38 @@ public class CbusReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
     @Override
     public void testAutoSystemNames() {
         Assert.assertEquals("No auto system names",0,tcis.numListeners());
+    }
+    
+    @Test
+    public void testGetSetDefaultTimeout() {
+        Assert.assertEquals("Default timeout",2000,((CbusReporterManager) l).getTimeout());
+        ((CbusReporterManager) l).setTimeout(5);
+        Assert.assertEquals("New timeout 5",5,((CbusReporterManager) l).getTimeout());
+    }
+    
+    @Test
+    public void testGetKnownBeanProperties() {
+    
+        List<NamedBeanPropertyDescriptor<?>> cbrepproplist =  l.getKnownBeanProperties();
+        Assert.assertEquals("2 properties at present",2,cbrepproplist.size());
+        
+        NamedBeanPropertyDescriptor<?> nbpd = cbrepproplist.get(0);
+        Assert.assertEquals("Column Header matches descriptor key",CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY,nbpd.getColumnHeaderText());
+        Assert.assertEquals("Editable if CBUS Reporter",true,nbpd.isEditable(l.provideReporter("123")));
+        Assert.assertEquals("Not Editable if null",false,nbpd.isEditable(null));
+        Assert.assertEquals("Default reporter type set in properties",CbusReporterManager.CBUS_DEFAULT_REPORTER_TYPE,(String)nbpd.defaultValue);
+        Assert.assertEquals("reporter property key set",CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY,nbpd.propertyKey);
+
+        Assert.assertEquals("Currently 2 options",2,((SelectionPropertyDescriptor)nbpd).getOptions().length);
+        Assert.assertEquals("Currently 2 option tooltips",2,((SelectionPropertyDescriptor)nbpd).getOptionToolTips().size());
+        
+        nbpd = cbrepproplist.get(1);
+        Assert.assertEquals("Column Header matches sensor follower descriptor key",CbusReporterManager.CBUS_MAINTAIN_SENSOR_DESCRIPTOR_KEY,nbpd.getColumnHeaderText());
+        Assert.assertEquals("sensor follower Editable if CBUS Reporter",true,nbpd.isEditable(l.provideReporter("123")));
+        Assert.assertEquals("sensor follower Not Editable if null",false,nbpd.isEditable(null));
+        Assert.assertFalse("Default reporter sensor follower set in properties", (Boolean) nbpd.defaultValue);
+        Assert.assertEquals("sensor follower key set",CbusReporterManager.CBUS_MAINTAIN_SENSOR_DESCRIPTOR_KEY,nbpd.propertyKey);
+        
     }
     
     private CanSystemConnectionMemo memo;

--- a/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
@@ -80,7 +80,7 @@ public class CbusReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
         Assert.assertEquals("Column Header matches descriptor key",CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY,nbpd.getColumnHeaderText());
         Assert.assertEquals("Editable if CBUS Reporter",true,nbpd.isEditable(l.provideReporter("123")));
         Assert.assertEquals("Not Editable if null",false,nbpd.isEditable(null));
-        Assert.assertEquals("Default reporter type set in properties",CbusReporterManager.CBUS_DEFAULT_REPORTER_TYPE,(String)nbpd.defaultValue);
+        Assert.assertEquals("Default reporter type set in properties",CbusReporterManager.CBUS_DEFAULT_REPORTER_TYPE,nbpd.defaultValue);
         Assert.assertEquals("reporter property key set",CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY,nbpd.propertyKey);
 
         Assert.assertEquals("Currently 2 options",2,((SelectionPropertyDescriptor)nbpd).getOptions().length);

--- a/java/test/jmri/jmrix/can/cbus/CbusReporterTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusReporterTest.java
@@ -1,13 +1,15 @@
 package jmri.jmrix.can.cbus;
 
 import jmri.IdTag;
-import jmri.jmrix.can.CanMessage;
-import jmri.jmrix.can.CanReply;
-import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.*;
 import jmri.util.JUnitUtil;
+import jmri.util.JUnitAppender;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
+
+// import org.slf4j.Logger;
+// import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -20,12 +22,23 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
         return new jmri.implementation.DefaultIdTag("ID0413276BC1", "Test Tag");
     }
     
+    @SuppressWarnings("deprecation")
     @Test
-    public void respondToCanReply(){
+    public void testDeprecatedConstructor(){
+        CbusReporter oldType = new CbusReporter(123,tcis,"M");
+        Assert.assertNotNull("old reporter created",oldType);
+        JUnitAppender.assertWarnMessageStartingWith("Deprecated Constructor - Please use");
+    }
+    
+    @Test
+    public void testRespondToClassicRfidCanReply(){
         
         // a new tag provided by Reporter4 then moves to Reporter 5
-        CbusReporter r4 = new CbusReporter(4,tcis,"Reporter 4");
-        CbusReporter r5 = new CbusReporter(5,tcis,"Reporter 5");
+        CbusReporter r4 = new CbusReporter("4",memo);
+        CbusReporter r5 = new CbusReporter("5",memo);
+        
+        Assert.assertNotEquals("messages should be different", 
+   r.describeState(IdTag.UNSEEN), r.describeState(IdTag.SEEN));
 
         CanReply m = new CanReply(tcis.getCanid());
         m.setNumDataElements(8);
@@ -43,18 +56,18 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
         // tag unseen = 2
         // tag seen = 3
 
-        Assert.assertEquals("r4 state set",IdTag.SEEN,r4.getState());
+        Assert.assertEquals("r4 state set",r4.describeState(IdTag.SEEN),r4.describeState(r4.getState()));
         Assert.assertNotNull("r4 report set",r4.getCurrentReport());
-        Assert.assertEquals("r5 state unset",IdTag.UNKNOWN,r5.getState());
+        Assert.assertEquals("r5 state unset",r5.describeState(IdTag.UNKNOWN),r5.describeState(r5.getState()));
         Assert.assertEquals("r5 report unset",null,r5.getCurrentReport());
 
         m.setElement(2, 0x05); // ev lo
         r4.reply(m);
         r5.reply(m);
 
-        Assert.assertEquals("r5 tag seen",IdTag.SEEN,r5.getState());
+        Assert.assertEquals("r5 tag seen",r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()));
         Assert.assertNotNull("r5 report set",r5.getCurrentReport());
-        Assert.assertEquals("r4 tag gone",IdTag.UNSEEN,r4.getState());
+        Assert.assertEquals("r4 tag gone",r4.describeState(IdTag.UNSEEN),r4.describeState(r4.getState()));
         Assert.assertEquals("r4 report unset",null,r4.getCurrentReport());
         
         CanReply m2 = new CanReply(tcis.getCanid());
@@ -71,32 +84,32 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
         r4.reply(m2);
         r5.reply(m2);
         
-        Assert.assertEquals("r4 state set CBUS_ACDAT",IdTag.SEEN,r4.getState());
+        Assert.assertEquals("r4 state set CBUS_ACDAT",r4.describeState(IdTag.SEEN),r4.describeState(r4.getState()));
         Assert.assertNotNull("r4 report set CBUS_ACDAT",r4.getCurrentReport());
-        Assert.assertEquals("r5 state unset CBUS_ACDAT",IdTag.UNSEEN,r5.getState());
+        Assert.assertEquals("r5 state unset CBUS_ACDAT",r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()));
         Assert.assertEquals("r5 report unset CBUS_ACDAT",null,r5.getCurrentReport());
         
         m2.setElement(2, 0x05); // ev lo
         
         m2.setExtended(true);
         r5.reply(m2);
-        Assert.assertEquals("r5 state unset extended",IdTag.UNSEEN,r5.getState());
+        Assert.assertEquals("r5 state unset extended",r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()));
         
         m2.setExtended(false);
         m2.setRtr(true);
         r5.reply(m2);
-        Assert.assertEquals("r5 state unset rtr",IdTag.UNSEEN,r5.getState());
+        Assert.assertEquals("r5 state unset rtr",r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()));
         
         m2.setRtr(false);
         m2.setElement(0, 0x05); // random OPC not related to reporters
         r5.reply(m2);
-        Assert.assertEquals("r5 state unset random opc",IdTag.UNSEEN,r5.getState());
+        Assert.assertEquals("r5 state unset random opc",r5.describeState(IdTag.UNSEEN),r5.describeState(r5.getState()));
         
         m2.setElement(0, CbusConstants.CBUS_DDES); // put it back
         r5.reply(m2);
-        Assert.assertEquals("r5 state set ok after incorrect msgs",IdTag.SEEN,r5.getState());
+        Assert.assertEquals("r5 state set ok after incorrect msgs",r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()));
         
-        Assert.assertEquals("r4 state unseen",IdTag.UNSEEN,r4.getState());
+        Assert.assertEquals("r4 state unseen",r4.describeState(IdTag.UNSEEN),r4.describeState(r4.getState()));
         
         CanMessage m3 = new CanMessage(tcis.getCanid());
         m3.setNumDataElements(8);
@@ -113,23 +126,158 @@ public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBa
         
         Assert.assertEquals("r4 seen after CBUS_ACDAT outgoing message",IdTag.SEEN,r4.getState());
         
-        r.dispose();
+        r4.dispose();
+        r5.dispose();
+    }
+    
+    @Test
+    public void testGetCbusReporterType(){
+        Assert.assertEquals("Classic RfID default type",CbusReporterManager.CBUS_DEFAULT_REPORTER_TYPE,((CbusReporter)r).getCbusReporterType());
+    
+        r.setProperty(CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY, CbusReporterManager.CBUS_REPORTER_TYPES[1]);
+        Assert.assertEquals("type changed",CbusReporterManager.CBUS_REPORTER_TYPES[1],((CbusReporter)r).getCbusReporterType());
+    }
+    
+    @Test
+    public void testMaintainSensorDefaultSetGet(){
+        Assert.assertFalse("maintain sensor default",((CbusReporter)r).getMaintainSensor());
+        r.setProperty(CbusReporterManager.CBUS_MAINTAIN_SENSOR_DESCRIPTOR_KEY, true);
+        Assert.assertTrue("sensor maintained flag set true",((CbusReporter)r).getMaintainSensor());
+    }
+    
+    @Test
+    public void testRespondToDdesRc522CanReply(){
+    
+        // a new tag provided by Reporter4 then moves to Reporter 5
+        CbusReporter r4 = new CbusReporter("4",memo);
+        r4.setProperty(CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY, CbusReporterManager.CBUS_REPORTER_TYPES[1]);
+        CbusReporter r5 = new CbusReporter("65534",memo);
+        r5.setProperty(CbusReporterManager.CBUS_REPORTER_DESCRIPTOR_KEY, CbusReporterManager.CBUS_REPORTER_TYPES[1]);
+
+        CanReply m = new CanReply(tcis.getCanid());
+        m.setNumDataElements(8);
+        m.setElement(0, CbusConstants.CBUS_DDES);
+        m.setElement(1, 0x00); // ev hi
+        m.setElement(2, 0x04); // ev lo
+        m.setElement(3, 0x00); // rc522
+        m.setElement(4, 0x00); // tag ID hi
+        m.setElement(5, 0x01); // tag ID lo
+        m.setElement(6, 0xff); // ddes3
+        m.setElement(7, 0xAB); // ddes4
+        r4.reply(m);
+        r5.reply(m);
+        
+        Assert.assertEquals("r4 state set",r4.describeState(IdTag.SEEN),r4.describeState(r4.getState()));
+        Assert.assertNotNull("r4 report set",r4.getCurrentReport());
+        Assert.assertEquals("r5 state unset",r5.describeState(IdTag.UNKNOWN),r5.describeState(r5.getState()));
+        Assert.assertNull("r5 report unset",r5.getCurrentReport());
+        
+        IdTag tag = jmri.InstanceManager.getDefault(jmri.IdTagManager.class).getByTagID("1");
+        Assert.assertNotNull("tag created",tag);
+
+        m.setElement(1, 0xff); // ev hi
+        m.setElement(2, 0xfe); // ev lo
+        r4.reply(m);
+        r5.reply(m);
+
+        Assert.assertEquals("r5 tag seen",r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()));
+        Assert.assertNotNull("r5 report set",r5.getCurrentReport());
+        Assert.assertEquals("r4 tag gone",r4.describeState(IdTag.UNSEEN),r4.describeState(r4.getState()));
+        Assert.assertNull("r4 report unset",r4.getCurrentReport());
+        
+        r5.reply(m); // same tag
+        Assert.assertEquals("r5 tag seen",r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()));
+        Assert.assertNotNull("r5 report set",r5.getCurrentReport());
+        
+        
+        m.setElement(4, 0xff); // tag ID hi
+        m.setElement(5, 0xff); // tag ID lo
+        r5.reply(m); // same tag
+        Assert.assertEquals("r5 tag seen",r5.describeState(IdTag.SEEN),r5.describeState(r5.getState()));
+        Assert.assertNotNull("r5 report set",r5.getCurrentReport());
+        
+        tag = jmri.InstanceManager.getDefault(jmri.IdTagManager.class).getByTagID("65535");
+        Assert.assertNotNull("tag 65535 created",tag);
+        Assert.assertEquals("r5 tag seen 65535",tag,r5.getCurrentReport());
+        Assert.assertEquals("r5 tag seen 65535",r5,tag.getWhereLastSeen());
+        
+        
+        r4.dispose();
+        r5.dispose();
+        
+    }
+    
+    
+    @Test
+    public void testSensorFollowing() throws jmri.JmriException {
+        
+        CbusReporter r2 = new CbusReporter("2",memo);
+        
+        r.setProperty(CbusReporterManager.CBUS_MAINTAIN_SENSOR_DESCRIPTOR_KEY, true);
+        
+        jmri.SensorManager sm = memo.get(jmri.SensorManager.class);
+        jmri.Sensor followerSensor = sm.getBySystemName(sm.createSystemName("+1",sm.getSystemPrefix()));
+        Assert.assertNull("No sensor at start",followerSensor);
+        
+        CbusReporterManager rm = (CbusReporterManager) memo.get(jmri.ReporterManager.class);
+        rm.setTimeout(30); // ms for testing
+        
+        
+        CanReply m = new CanReply(tcis.getCanid());
+        m.setNumDataElements(8);
+        m.setElement(0, CbusConstants.CBUS_DDES);
+        m.setElement(1, 0x00); // ev hi
+        m.setElement(2, 0x01); // ev lo
+        m.setElement(3, 0x30); // tag1
+        m.setElement(4, 0x39); // tag2
+        m.setElement(5, 0x31); // tag3
+        m.setElement(6, 0x30); // tag4
+        m.setElement(7, 0xAB); // tag5
+        ((CbusReporter)r).reply(m);
+        r2.reply(m);
+        
+        followerSensor = sm.getBySystemName(sm.createSystemName("+1",sm.getSystemPrefix()));
+        Assert.assertNotNull("Sensor created by reporter",followerSensor);
+        Assert.assertEquals("sensor active", jmri.Sensor.ACTIVE, followerSensor.getState());
+    
+        m.setElement(2, 0x02); // ev lo
+        ((CbusReporter)r).reply(m);
+        r2.reply(m);
+        
+        final int status = followerSensor.getState();
+        JUnitUtil.waitFor(() -> {
+            return (status==jmri.Sensor.INACTIVE);
+        }, "sensor triggered to inactive when spot report complete");
+        
     }
     
     private TrafficControllerScaffold tcis;
+    private CanSystemConnectionMemo memo;
 
+    // ((CbusReporterManager)memo.get(jmri.ReporterManager.class));
+    
     @BeforeEach
     @Override
     public void setUp() {
         JUnitUtil.setUp();
         tcis = new TrafficControllerScaffold();
-        r = new CbusReporter(1, tcis, "Test");
+        memo = new CanSystemConnectionMemo();
+        memo.setTrafficController(tcis);
+        
+        memo.setProtocol(ConfigurationManager.MERGCBUS);
+        memo.configureManagers();
+        r = new CbusReporter("1", memo);
     }
 
     @AfterEach
     @Override
     public void tearDown() {
         jmri.InstanceManager.getDefault(jmri.IdTagManager.class).dispose();
+        if (r!=null) {
+            r.dispose();
+        }
+        memo.dispose();
+        memo = null;
         tcis.terminateThreads();
         tcis = null;
         r = null;


### PR DESCRIPTION
CBUS RFID Reporters now act similar to other JMRI Reporters, ie with a timeout following the report.
CBUS Reporters can set a Sensor to follow the active IDTag status, set via CBUS Reporter Table.
CBUS Reporters will default to classic RFID ( 5 byte unique tags ), with option for in-development CANRC522 / CANRCOM format ( 2 byte unique tags ), set via Reporter Table.

Adds jmri.SelectionPropertyDescriptor , which extends jmri.NamedBeanPropertyDescriptor for multi-choice String values.

Adds SelectionPropertyDescriptor  ( JComboBox with Tooltips ) support to jmrit.beantable.BeanTableDataModel.

![cbus-jmri-reporter-dev-0 3](https://user-images.githubusercontent.com/39652002/96247227-c25da380-0fa1-11eb-86d0-997f346a8a96.jpg)


Adds JComboBox listener for selection changes to
Block Table - Curvature
Block Table - Speed List
Block Table - Sensor
Block Table - Reporter
Turnout Table - Closed Speed
Turnout Table - Thrown Speed

Adds describeState(int state) to AbstractIdTagReporter - vastly improves error messages in CbusReporter unit testing.

Minor Javadoc tweaks