### PR TITLE
Move tests to Travis Intermittent

### DIFF
--- a/java/test/jmri/jmrit/beantable/signalmast/AddSignalMastPanelTest.java
+++ b/java/test/jmri/jmrit/beantable/signalmast/AddSignalMastPanelTest.java
@@ -33,6 +33,7 @@ public class AddSignalMastPanelTest {
 
     @Test
     public void testIssueWarningUserName() {
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // show and cancel each of the error dialogs
         AddSignalMastPanel a = new AddSignalMastPanel();
@@ -44,6 +45,7 @@ public class AddSignalMastPanelTest {
     
     @Test
     public void testIssueWarningUserNameAsSystem() {
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // show and cancel each of the error dialogs
         AddSignalMastPanel a = new AddSignalMastPanel();
@@ -55,6 +57,7 @@ public class AddSignalMastPanelTest {
     
     @Test
     public void testIssueNoUserNameGiven() {
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // show and cancel each of the error dialogs
         AddSignalMastPanel a = new AddSignalMastPanel();
@@ -65,6 +68,7 @@ public class AddSignalMastPanelTest {
     
     @Test
     public void testIssueDialogFailMessage() {
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // show and cancel each of the error dialogs
         AddSignalMastPanel a = new AddSignalMastPanel();
@@ -76,6 +80,7 @@ public class AddSignalMastPanelTest {
     
     @Test
     public void testSearch() throws Exception {
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         try {
             AddSignalMastPanel a = new AddSignalMastPanel();
 
@@ -94,6 +99,8 @@ public class AddSignalMastPanelTest {
 
     @Test
     public void testCheckUserName() throws Exception {
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        
         AddSignalMastPanel a = new AddSignalMastPanel();
         
         VirtualSignalMast s1 = new VirtualSignalMast("IF$vsm:basic:one-searchlight($1)", "user name");


### PR DESCRIPTION
Travis has had a lot of errors `No output has been received in the last 10m0s` there the last class to test has been `jmri.jmrit.beantable.signalmast.AddSignalMastPanelTest`.

This moves some tests in that class to Travis Intermittent.