### PR TITLE
Store last checkbox status in preferences

### DIFF
--- a/java/src/jmri/UserPreferencesManager.java
+++ b/java/src/jmri/UserPreferencesManager.java
@@ -56,6 +56,37 @@ public interface UserPreferencesManager {
     void setSimplePreferenceState(String name, boolean state);
 
     /**
+     * Enquire as to the state of a user preference.
+     * <p>
+     * Preferences that have not been set will be considered to be defaultState.
+     * <p>
+     * The name is free-form, but to avoid ambiguity it should start with the
+     * package name (package.Class) for the primary using class.
+     *
+     * @param name the name of the preference
+     * @param defaultState the default state if not set
+     * @return the state or defaultState if never set
+     */
+    boolean getCheckboxPreferenceState(String name, boolean defaultState);
+
+    /**
+     * This is used to remember the last selected state of a checkBox and thus
+     * allow that checkBox to be set to a true state when it is next
+     * initialized. This can also be used anywhere else that a simple yes/no,
+     * true/false type preference needs to be stored.
+     * <p>
+     * It should not be used for remembering if a user wants to suppress a
+     * message as there is no means in the GUI for the user to reset the flag.
+     * setPreferenceState() should be used in this instance The name is
+     * free-form, but to avoid ambiguity it should start with the package name
+     * (package.Class) for the primary using class.
+     *
+     * @param name  A unique name to identify the state being stored
+     * @param state simple boolean
+     */
+    void setCheckboxPreferenceState(String name, boolean state);
+
+    /**
      * Returns an ArrayList of the check box states set as true.
      *
      * @return list of simple preferences names

--- a/java/src/jmri/managers/JmriUserPreferencesManager.java
+++ b/java/src/jmri/managers/JmriUserPreferencesManager.java
@@ -415,7 +415,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
     public void setCheckboxPreferenceState(String name, boolean state) {
         checkBoxLastSelection.put(name, state);
         setChangeMade(false);
-        this.saveComboBoxLastSelections();
+        this.saveCheckBoxLastSelections();
     }
 
     public synchronized boolean getChangeMade() {

--- a/java/src/jmri/managers/JmriUserPreferencesManager.java
+++ b/java/src/jmri/managers/JmriUserPreferencesManager.java
@@ -63,6 +63,8 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
     private static final String CLASSPREFS_ELEMENT = "classPreferences"; // NOI18N
     private static final String COMBOBOX_NAMESPACE = "http://jmri.org/xml/schema/auxiliary-configuration/combobox-4-3-5.xsd"; // NOI18N
     private static final String COMBOBOX_ELEMENT = "comboBoxLastValue"; // NOI18N
+    private static final String CHECKBOX_NAMESPACE = "http://jmri.org/xml/schema/auxiliary-configuration/checkbox-4-21-3.xsd"; // NOI18N
+    private static final String CHECKBOX_ELEMENT = "checkBoxLastValue"; // NOI18N
     private static final String SETTINGS_NAMESPACE = "http://jmri.org/xml/schema/auxiliary-configuration/settings-4-3-5.xsd"; // NOI18N
     private static final String SETTINGS_ELEMENT = "settings"; // NOI18N
     private static final String WINDOWS_NAMESPACE = "http://jmri.org/xml/schema/auxiliary-configuration/window-details-4-3-5.xsd"; // NOI18N
@@ -83,6 +85,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
     //sessionList is used for messages to be suppressed for the current JMRI session only
     private final ArrayList<String> sessionPreferenceList = new ArrayList<>();
     protected final HashMap<String, String> comboBoxLastSelection = new HashMap<>();
+    protected final HashMap<String, Boolean> checkBoxLastSelection = new HashMap<>();
     private final HashMap<String, WindowLocations> windowDetails = new HashMap<>();
     private final HashMap<String, ClassPreferences> classPreferenceList = new HashMap<>();
     private File file;
@@ -399,6 +402,18 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
     @Override
     public void setComboBoxLastSelection(String comboBoxName, String lastValue) {
         comboBoxLastSelection.put(comboBoxName, lastValue);
+        setChangeMade(false);
+        this.saveComboBoxLastSelections();
+    }
+
+    @Override
+    public boolean getCheckboxPreferenceState(String name, boolean defaultState) {
+        return this.checkBoxLastSelection.getOrDefault(name, defaultState);
+    }
+
+    @Override
+    public void setCheckboxPreferenceState(String name, boolean state) {
+        checkBoxLastSelection.put(name, state);
         setChangeMade(false);
         this.saveComboBoxLastSelections();
     }
@@ -835,6 +850,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
             file = perNodeConfig;
             log.debug("  start perNodeConfig file: {}", file.getPath());
             this.readComboBoxLastSelections();
+            this.readCheckBoxLastSelections();
             this.readPreferencesState();
             this.readSimplePreferenceState();
             this.readWindowDetails();
@@ -885,6 +901,31 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
                 combo.setAttribute("name", cbls.getKey());
                 combo.setAttribute("lastSelected", cbls.getValue());
                 return combo;
+            }).forEach(element::addContent);
+            this.saveElement(element);
+            this.resetChangeMade();
+        }
+    }
+
+    private void readCheckBoxLastSelections() {
+        Element element = this.readElement(CHECKBOX_ELEMENT, CHECKBOX_NAMESPACE);
+        if (element != null) {
+            element.getChildren("checkBox").stream().forEach(checkbox ->
+                checkBoxLastSelection.put(checkbox.getAttributeValue("name"), "yes".equals(checkbox.getAttributeValue("lastChecked"))));
+        }
+    }
+
+    private void saveCheckBoxLastSelections() {
+        this.setChangeMade(false);
+        if (this.allowSave && !comboBoxLastSelection.isEmpty()) {
+            Element element = new Element(CHECKBOX_ELEMENT, CHECKBOX_NAMESPACE);
+            // Do not store blank last entered/selected values
+            checkBoxLastSelection.entrySet().stream().
+                    filter(cbls -> (cbls.getValue() != null)).map(cbls -> {
+                Element checkbox = new Element("checkBox");
+                checkbox.setAttribute("name", cbls.getKey());
+                checkbox.setAttribute("lastChecked", cbls.getValue() ? "yes" : "no");
+                return checkbox;
             }).forEach(element::addContent);
             this.saveElement(element);
             this.resetChangeMade();
@@ -1090,6 +1131,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
 
     private void savePreferences() {
         this.saveComboBoxLastSelections();
+        this.saveCheckBoxLastSelections();
         this.savePreferencesState();
         this.saveSimplePreferenceState();
         this.saveWindowDetails();

--- a/java/src/jmri/managers/JmriUserPreferencesManager.java
+++ b/java/src/jmri/managers/JmriUserPreferencesManager.java
@@ -917,7 +917,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
 
     private void saveCheckBoxLastSelections() {
         this.setChangeMade(false);
-        if (this.allowSave && !comboBoxLastSelection.isEmpty()) {
+        if (this.allowSave && !checkBoxLastSelection.isEmpty()) {
             Element element = new Element(CHECKBOX_ELEMENT, CHECKBOX_NAMESPACE);
             // Do not store blank last entered/selected values
             checkBoxLastSelection.entrySet().stream().

--- a/xml/schema/auxiliary-configuration/checkbox-4-21-3.xsd
+++ b/xml/schema/auxiliary-configuration/checkbox-4-21-3.xsd
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../../schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2016.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+>
+    <xs:element name="checkBoxLastValue">
+        <xs:annotation>
+            <xs:documentation>
+                This is the schema representing checkbox last states.
+                <p/>
+                This version of the schema is for files created by JMRI
+                version 4.21.3 and later.  
+                It is the current development version.
+            </xs:documentation>
+            <xs:appinfo>
+                <jmri:usingclass configurexml="false">jmri.managers.JmriUserMessagePreferences</jmri:usingclass>
+            </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="comboBox" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:attribute name="name" type="xs:string" />
+                        <xs:attribute name="lastChecked" type="yesNoType"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/xml/schema/auxiliary-configuration/checkbox-4-21-3.xsd
+++ b/xml/schema/auxiliary-configuration/checkbox-4-21-3.xsd
@@ -29,8 +29,7 @@
                 This is the schema representing checkbox last states.
                 <p/>
                 This version of the schema is for files created by JMRI
-                version 4.21.3 and later.  
-                It is the current development version.
+                version 4.21.3 and later.
             </xs:documentation>
             <xs:appinfo>
                 <jmri:usingclass configurexml="false">jmri.managers.JmriUserMessagePreferences</jmri:usingclass>


### PR DESCRIPTION
This adds the methods `setCheckboxPreferenceState()` and `getCheckboxPreferenceState()` to `UserPreferencesManager`.

In LogixNG, I have several sub types that are NamedBeans, and each sub type has it's own sub prefix. For example, a Digital Action has the system prefix IQDA, where I = internal, Q = LogixNG, D = digital and A = action. (The letter I is the default for internal, but can be changed).

Since LogixNG has several sub types with their own sub prefix, it's recommended that the user always uses auto system names for the sub types of LogixNG, but the user may if he want still enter his own system name if preferred.

The problem with `UserPreferencesManager` is that the method `getSimplePreferenceState()` defaults to false if the preference is not known. This PR makes it possible to decide if the default should be true or false.