### PR TITLE
Make PermissiveSmlDisabled a bound property

### DIFF
--- a/java/src/jmri/implementation/AbstractSignalMast.java
+++ b/java/src/jmri/implementation/AbstractSignalMast.java
@@ -130,6 +130,7 @@ public abstract class AbstractSignalMast extends AbstractNamedBean
     @Override
     public void setPermissiveSmlDisabled(boolean disabled) {
         disablePermissiveSignalMastLogic = disabled;
+        firePropertyChange("PermissiveSmlDisabled", null, disabled);
     }
     /**
      * {@inheritDoc }


### PR DESCRIPTION
@dsand47 
I'm implementing `permissive disabled` in LogixNG, both for expressions (Conditional variables) and actions (Conditional actions). To support `permissive disabled` for expressions, I need it to be a bound property and that's the reason for this PR.