### PR TITLE
LayoutEditor:Make Point2D variables that use .setLocation(...) final.

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -3218,7 +3218,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             // released the mouse with shift down... see what we're adding
             if (!event.isPopupTrigger() && !isMetaDown(event) && event.isShiftDown()) {
 
-                currentPoint.setLocation((double) xLoc, (double) yLoc);
+                currentPoint.setLocation(xLoc, yLoc);
 
                 if (snapToGridOnAdd != snapToGridInvert) {
                     // this snaps the current point to the grid

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -86,8 +86,8 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
     // end of main panel controls
     private boolean delayedPopupTrigger = false;
-    private Point2D currentPoint = new Point2D.Double(100.0, 100.0);
-    private Point2D dLoc = new Point2D.Double(0.0, 0.0);
+    private final Point2D currentPoint = new Point2D.Double(100.0, 100.0);
+    private final Point2D dLoc = new Point2D.Double(0.0, 0.0);
 
     private int toolbarHeight = 100;
     private int toolbarWidth = 100;
@@ -184,14 +184,14 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     private HitPointType selectedHitPointType = HitPointType.NONE;         // hit point type within the selected object
 
     public LayoutTrack foundTrack = null;      // found object, null if nothing found
-    private Point2D foundLocation = new Point2D.Double(0.0, 0.0); // location of found object
+    private final Point2D foundLocation = new Point2D.Double(0.0, 0.0); // location of found object
     public HitPointType foundHitPointType = HitPointType.NONE;          // connection type within the found object
 
     public LayoutTrack beginTrack = null;      // begin track segment connection object, null if none
-    public Point2D beginLocation = new Point2D.Double(0.0, 0.0); // location of begin object
+    public final Point2D beginLocation = new Point2D.Double(0.0, 0.0); // location of begin object
     private HitPointType beginHitPointType = HitPointType.NONE; // connection type within begin connection object
 
-    public Point2D currentLocation = new Point2D.Double(0.0, 0.0); // current location
+    public final Point2D currentLocation = new Point2D.Double(0.0, 0.0); // current location
 
     // Lists of items that describe the Layout, and allow it to be drawn
     // Each of the items must be saved to disk over sessions
@@ -3022,7 +3022,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
         if (layoutTrack != null) {
             foundTrack = layoutTrack;
-            foundLocation = layoutTrack.getCoordsForConnectionType(foundHitPointType);
+            foundLocation.setLocation(layoutTrack.getCoordsForConnectionType(foundHitPointType));
             /// foundNeedsConnect = isDisconnected(foundHitPointType);
             result = true;
         }
@@ -3218,11 +3218,11 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             // released the mouse with shift down... see what we're adding
             if (!event.isPopupTrigger() && !isMetaDown(event) && event.isShiftDown()) {
 
-                currentPoint = new Point2D.Double(xLoc, yLoc);
+                currentPoint.setLocation((double) xLoc, (double) yLoc);
 
                 if (snapToGridOnAdd != snapToGridInvert) {
                     // this snaps the current point to the grid
-                    currentPoint = MathUtil.granulize(currentPoint, gContext.getGridSize());
+                    currentPoint.setLocation(MathUtil.granulize(currentPoint, gContext.getGridSize()));
                     xLoc = (int) currentPoint.getX();
                     yLoc = (int) currentPoint.getY();
                     leToolBarPanel.xLabel.setText(Integer.toString(xLoc));
@@ -3827,7 +3827,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             } else {
                 beginHitPointType = HitPointType.TURNOUT_A;
             }
-            dLoc = lt.getCoordsA();
+            dLoc.setLocation(lt.getCoordsA());
             hitPointCheckLayoutTurnoutSubs(dLoc);
         }
 
@@ -3837,7 +3837,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             } else {
                 beginHitPointType = HitPointType.TURNOUT_B;
             }
-            dLoc = lt.getCoordsB();
+            dLoc.setLocation(lt.getCoordsB());
             hitPointCheckLayoutTurnoutSubs(dLoc);
         }
 
@@ -3847,7 +3847,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             } else {
                 beginHitPointType = HitPointType.TURNOUT_C;
             }
-            dLoc = lt.getCoordsC();
+            dLoc.setLocation(lt.getCoordsC());
             hitPointCheckLayoutTurnoutSubs(dLoc);
         }
 
@@ -3857,7 +3857,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             } else {
                 beginHitPointType = HitPointType.TURNOUT_D;
             }
-            dLoc = lt.getCoordsD();
+            dLoc.setLocation(lt.getCoordsD());
             hitPointCheckLayoutTurnoutSubs(dLoc);
         }
         beginTrack = null;
@@ -4418,9 +4418,9 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             leToolBarPanel.xLabel.setText(Integer.toString(xLoc));
             leToolBarPanel.yLabel.setText(Integer.toString(yLoc));
         }
-        currentPoint = MathUtil.add(dLoc, startDelta);
+        currentPoint.setLocation(MathUtil.add(dLoc, startDelta));
         // don't allow negative placement, objects could become unreachable
-        currentPoint = MathUtil.max(currentPoint, MathUtil.zeroPoint2D);
+        currentPoint.setLocation(MathUtil.max(currentPoint, MathUtil.zeroPoint2D));
 
         if ((selectedObject != null) && (isMetaDown(event) || event.isAltDown())
                 && (selectedHitPointType == HitPointType.MARKER)) {
@@ -4436,7 +4436,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             if ((selectedObject != null) && isMetaDown(event) && allPositionable()) {
                 if (snapToGridOnMove != snapToGridInvert) {
                     // this snaps currentPoint to the grid
-                    currentPoint = MathUtil.granulize(currentPoint, gContext.getGridSize());
+                    currentPoint.setLocation(MathUtil.granulize(currentPoint, gContext.getGridSize()));
                     xLoc = (int) currentPoint.getX();
                     yLoc = (int) currentPoint.getY();
                     leToolBarPanel.xLabel.setText(Integer.toString(xLoc));

--- a/java/src/jmri/util/MathUtil.java
+++ b/java/src/jmri/util/MathUtil.java
@@ -853,6 +853,17 @@ public final class MathUtil {
     }
 
     /**
+     * point2DToString return a string to represent a point
+     *
+     * @param p the Point2D
+     * @return the string
+     */
+    @Nonnull
+    public static String point2DToString(@Nonnull Point2D p) {
+        return String.format("{%.2f, %.2f}", p.getX(), p.getY());
+    }
+
+    /**
      * rectangle2DToString return a string to represent a rectangle
      *
      * @param r the rectangle2D


### PR DESCRIPTION
Found bugs where an assigned Point2D variable was later .setLocation()'d causing the orginal variable to be changed:

            Point2D pointA = new Point2D.Double(10, 10);
            Point2D pointB = pointA;
            pointB.setLocation(20, 20);
            log.error("pointA: " + MathUtil.point2DToString(pointA));

Output: pointA: {20, 20}

Fixed this by making any Point2D variables that use .setLocation final and then changing all assignments to use setLocation also.