### PR TITLE
Fix broken link in scripting/Examples.shtml

### DIFF
--- a/help/en/html/tools/scripting/Examples.shtml
+++ b/help/en/html/tools/scripting/Examples.shtml
@@ -9,16 +9,9 @@
 
   <title>JMRI: Scripting Examples</title>
   <meta name="author" content="Bob Jacobsen">
-  <!-- Style -->
-  <meta http-equiv="content-type" content=
-  "text/html; charset=us-ascii">
-  <link rel="stylesheet" type="text/css" href="/css/default.css"
-  media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css"
-  media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-  <!-- /Style -->
+
+  <!--#include virtual="/Style.shtml" -->
+
 </head>
 
 <body>
@@ -62,7 +55,7 @@
       window that loads a script file</p>
 
       <p><a href=
-      "../../../../../jython/AddButton.py">AlarmClock.py</a></p>
+      "../../../../../jython/AlarmClock.py">AlarmClock.py</a></p>
 
       <p>This is an example script to pulse an output based on a
       Fast Clock.</p>


### PR DESCRIPTION
Noticed this when tracing down info provided in arduini user group response #872.

Also replace style header info with Style.shtml include.