### PR TITLE
LayoutEditor:BUGFIX for SLIP_D stuck to cursor

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -177,7 +177,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     private final JMenuItem assignBlockToSelectionMenuItem = new JMenuItem(Bundle.getMessage("AssignBlockToSelectionTitle") + "...");
 
     // Selected point information
-    private final Point2D startDelta = new Point2D.Double(0.0, 0.0); // starting delta coordinates
+    private Point2D startDelta = new Point2D.Double(0.0, 0.0); // starting delta coordinates
     public Object selectedObject = null;       // selected object, null if nothing selected
     public Object prevSelectedObject = null;   // previous selected object, for undo
     private HitPointType selectedHitPointType = HitPointType.NONE;         // hit point type within the selected object
@@ -761,7 +761,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
      */
     private JMenu setupOptionMenu(@Nonnull JMenuBar menuBar) {
         assert menuBar != null;
-        
+
         JMenu optionMenu = new JMenu(Bundle.getMessage("MenuOptions"));
 
         optionMenu.setMnemonic(stringsToVTCodes.get(Bundle.getMessage("OptionsMnemonic")));
@@ -1829,7 +1829,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             double theZoom = getZoom();
             xLoc = (int) (mouseLoc.getX() / theZoom);
             yLoc = (int) (mouseLoc.getY() / theZoom);
-            dLoc.setLocation(xLoc, yLoc);
+            dLoc = new Point2D.Double(xLoc, yLoc);
 
             leToolBarPanel.xLabel.setText(Integer.toString(xLoc));
             leToolBarPanel.yLabel.setText(Integer.toString(yLoc));
@@ -2405,10 +2405,10 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             });
 
             _layoutTrackSelection.forEach(
-                (lt) -> { 
-                    LayoutTrackView ltv = getLayoutTrackView(lt);
-                    ltv.setCoordsCenter(MathUtil.add(ltv.getCoordsCenter(), undoDelta));
-                }
+                    (lt) -> {
+                        LayoutTrackView ltv = getLayoutTrackView(lt);
+                        ltv.setCoordsCenter(MathUtil.add(ltv.getCoordsCenter(), undoDelta));
+                    }
             );
 
             _layoutShapeSelection.forEach((ls) -> ls.setCoordsCenter(MathUtil.add(ls.getCoordsCenter(), undoDelta)));
@@ -2680,7 +2680,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         LayoutTurntable lt = new LayoutTurntable(name, this);
         LayoutTurntableView ltv = new LayoutTurntableView(lt, pt, this);
 
-        addLayoutTrack(lt,ltv);
+        addLayoutTrack(lt, ltv);
 
         lt.addRay(0.0);
         lt.addRay(90.0);
@@ -2751,7 +2751,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     private Point2D calcLocation(MouseEvent event, int dX, int dY) {
         xLoc = (int) ((event.getX() + dX) / getZoom());
         yLoc = (int) ((event.getY() + dY) / getZoom());
-        dLoc.setLocation(xLoc, yLoc);
+        dLoc = new Point2D.Double(xLoc, yLoc);
         return dLoc;
     }
 
@@ -2801,24 +2801,24 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                 if (findLayoutTracksHitPoint(dLoc)) {
                     selectedObject = foundTrack;
                     selectedHitPointType = foundHitPointType;
-                    startDelta.setLocation(MathUtil.subtract(foundLocation, dLoc));
+                    startDelta = MathUtil.subtract(foundLocation, dLoc);
                     foundTrack = null;
                     foundTrackView = null;
                 } else {
                     selectedObject = checkMarkerPopUps(dLoc);
                     if (selectedObject != null) {
                         selectedHitPointType = HitPointType.MARKER;
-                        startDelta.setLocation(MathUtil.subtract(((LocoIcon) selectedObject).getLocation(), dLoc));
+                        startDelta = MathUtil.subtract(((LocoIcon) selectedObject).getLocation(), dLoc);
                     } else {
                         selectedObject = checkClockPopUps(dLoc);
                         if (selectedObject != null) {
                             selectedHitPointType = HitPointType.LAYOUT_POS_JCOMP;
-                            startDelta.setLocation(MathUtil.subtract(((PositionableJComponent) selectedObject).getLocation(), dLoc));
+                            startDelta = MathUtil.subtract(((PositionableJComponent) selectedObject).getLocation(), dLoc);
                         } else {
                             selectedObject = checkMultiSensorPopUps(dLoc);
                             if (selectedObject != null) {
                                 selectedHitPointType = HitPointType.MULTI_SENSOR;
-                                startDelta.setLocation(MathUtil.subtract(((MultiSensorIcon) selectedObject).getLocation(), dLoc));
+                                startDelta = MathUtil.subtract(((MultiSensorIcon) selectedObject).getLocation(), dLoc);
                             }
                         }
                     }
@@ -2837,12 +2837,12 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
                         if (selectedObject != null) {
                             selectedHitPointType = HitPointType.LAYOUT_POS_LABEL;
-                            startDelta.setLocation(MathUtil.subtract(((PositionableLabel) selectedObject).getLocation(), dLoc));
+                            startDelta = MathUtil.subtract(((PositionableLabel) selectedObject).getLocation(), dLoc);
                             if (selectedObject instanceof MemoryIcon) {
                                 MemoryIcon pm = (MemoryIcon) selectedObject;
 
                                 if (pm.getPopupUtility().getFixedWidth() == 0) {
-                                    startDelta.setLocation((pm.getOriginalX() - dLoc.getX()),
+                                    startDelta = new Point2D.Double((pm.getOriginalX() - dLoc.getX()),
                                             (pm.getOriginalY() - dLoc.getY()));
                                 }
                             }
@@ -2851,7 +2851,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
                             if (selectedObject != null) {
                                 selectedHitPointType = HitPointType.LAYOUT_POS_LABEL;
-                                startDelta.setLocation(MathUtil.subtract(((PositionableLabel) selectedObject).getLocation(), dLoc));
+                                startDelta = MathUtil.subtract(((PositionableLabel) selectedObject).getLocation(), dLoc);
                             } else {
                                 // dragging a shape?
                                 ListIterator<LayoutShape> listIterator = layoutShapes.listIterator(layoutShapes.size());
@@ -2862,9 +2862,9 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                                     if (LayoutShape.isShapeHitPointType(selectedHitPointType)) {
                                         // log.warn("drag selectedObject: ", lt);
                                         selectedObject = ls;    // found one!
-                                        beginLocation.setLocation(dLoc);
-                                        currentLocation.setLocation(beginLocation);
-                                        startDelta.setLocation(MathUtil.zeroPoint2D);
+                                        beginLocation = dLoc;
+                                        currentLocation = beginLocation;
+                                        startDelta = MathUtil.zeroPoint2D;
                                         break;
                                     }
                                 }
@@ -2880,9 +2880,9 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                     // match to a free connection point
                     beginTrack = foundTrack;
                     beginHitPointType = foundHitPointType;
-                    beginLocation.setLocation(foundLocation);
+                    beginLocation = foundLocation;
                     // BUGFIX: prevents initial drawTrackSegmentInProgress to {0, 0}
-                    currentLocation.setLocation(beginLocation);
+                    currentLocation = beginLocation;
                 } else {
                     // TODO: auto-add anchor point?
                     beginTrack = null;
@@ -2895,8 +2895,8 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                     if (HitPointType.isShapePointOffsetHitPointType(selectedHitPointType)) {
                         // log.warn("extend selectedObject: ", lt);
                         selectedObject = ls;    // nope, we're extending
-                        beginLocation.setLocation(dLoc);
-                        currentLocation.setLocation(beginLocation);
+                        beginLocation = dLoc;
+                        currentLocation = beginLocation;
                         break;
                     }
                 }
@@ -2930,7 +2930,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             selectedObject = checkMarkerPopUps(dLoc);
             if (selectedObject != null) {
                 selectedHitPointType = HitPointType.MARKER;
-                startDelta.setLocation(MathUtil.subtract(((LocoIcon) selectedObject).getLocation(), dLoc));
+                startDelta = MathUtil.subtract(((LocoIcon) selectedObject).getLocation(), dLoc);
             }
         } else if (event.isPopupTrigger() && !event.isShiftDown()) {
             // not in edit mode - check if a marker popup menu is being requested
@@ -3025,21 +3025,22 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     }
 
     /**
-     * Internal (private) method to find the track closest to a point, 
-     * with some modifiers to the search.
-     * The {@link #foundTrack} and {@link #foundHitPointType}
-     * members are set from the search.
+     * Internal (private) method to find the track closest to a point, with some
+     * modifiers to the search. The {@link #foundTrack} and
+     * {@link #foundHitPointType} members are set from the search.
      * <p>
-     * This is a geometric search, and should be done with views.
-     * Hence this form is inevitably temporary.
+     * This is a geometric search, and should be done with views. Hence this
+     * form is inevitably temporary.
      *
-     * @param loc Point to search from
-     * @param requireUnconnected forwarded to {@link #getLayoutTrackView}; 
-     *                                  if true, return only free connections
-     * @param avoid Don't return this track, keep searching. Note that {@Link #selectedObject} is
-     *                  also always avoided automatically
-     * @returns true if values of {@link #foundTrack} and {@link #foundHitPointType} correct;
-     *                  note they may have changed even if false is returned.
+     * @param loc                Point to search from
+     * @param requireUnconnected forwarded to {@link #getLayoutTrackView}; if
+     *                           true, return only free connections
+     * @param avoid              Don't return this track, keep searching. Note
+     *                           that {@Link #selectedObject} is also always
+     *                           avoided automatically
+     * @returns true if values of {@link #foundTrack} and
+     * {@link #foundHitPointType} correct; note they may have changed even if
+     * false is returned.
      */
     private boolean findLayoutTracksHitPoint(@Nonnull Point2D loc,
             boolean requireUnconnected, @CheckForNull LayoutTrack avoid) {
@@ -3048,7 +3049,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         foundTrack = null;
         foundTrackView = null;
         foundHitPointType = HitPointType.NONE;
-        
+
         Optional<LayoutTrack> opt = getLayoutTracks().stream().filter(layoutTrack -> {  // != means can't (yet) loop over Views
             if ((layoutTrack != avoid) && (layoutTrack != selectedObject)) {
                 foundHitPointType = getLayoutTrackView(layoutTrack).findHitPointType(loc, false, requireUnconnected);
@@ -3064,7 +3065,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         if (layoutTrack != null) {
             foundTrack = layoutTrack;
             foundTrackView = this.getLayoutTrackView(layoutTrack);
-            
+
             // get screen coordinates
             foundLocation = foundTrackView.getCoordsForConnectionType(foundHitPointType);
             /// foundNeedsConnect = isDisconnected(foundHitPointType);
@@ -3075,7 +3076,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
     private TrackSegment checkTrackSegmentPopUps(@Nonnull Point2D loc) {
         assert loc != null;
-        
+
         TrackSegment result = null;
 
         // NOTE: Rather than calculate all the hit rectangles for all
@@ -3257,39 +3258,38 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
      * Get the coordinates for the connection type of the specified LayoutTrack
      * or subtype.
      * <p>
-     * This uses the current LayoutEditor object to map
-     * a LayoutTrack (no coordinates) object to _a_ specific
-     * LayoutTrackView object in the current LayoutEditor i.e. window.
-     * This allows the same model object in two windows, but not 
-     * twice in a single window.
+     * This uses the current LayoutEditor object to map a LayoutTrack (no
+     * coordinates) object to _a_ specific LayoutTrackView object in the current
+     * LayoutEditor i.e. window. This allows the same model object in two
+     * windows, but not twice in a single window.
      * <p>
-     * This is temporary, and needs to go away as
-     * the LayoutTrack doesn't logically have position; just the LayoutTrackView does,
-     * and multiple LayoutTrackViews can refer to one specific LayoutTrack.
+     * This is temporary, and needs to go away as the LayoutTrack doesn't
+     * logically have position; just the LayoutTrackView does, and multiple
+     * LayoutTrackViews can refer to one specific LayoutTrack.
      *
-     * @param trk    the object (LayoutTrack subclass)
+     * @param trk            the object (LayoutTrack subclass)
      * @param connectionType the type of connection
      * @return the coordinates for the connection type of the specified object
      */
     @Nonnull
     public Point2D getCoords(@Nonnull LayoutTrack trk, HitPointType connectionType) {
         assert trk != null;
-        
+
         return getCoords(getLayoutTrackView(trk), connectionType);
     }
 
     /**
-     * Get the coordinates for the connection type of the specified LayoutTrackView
-     * or subtype.
+     * Get the coordinates for the connection type of the specified
+     * LayoutTrackView or subtype.
      *
-     * @param trkv    the object (LayoutTrackView subclass)
+     * @param trkv           the object (LayoutTrackView subclass)
      * @param connectionType the type of connection
      * @return the coordinates for the connection type of the specified object
      */
     @Nonnull
     public Point2D getCoords(@Nonnull LayoutTrackView trkv, HitPointType connectionType) {
         assert trkv != null;
-        
+
         return trkv.getCoordsForConnectionType(connectionType);
     }
 
@@ -3924,7 +3924,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         beginTrack = lt;
 
         LayoutTurnoutView ltv = getLayoutTurnoutView(lt);
-        
+
         if (lt.getConnectA() == null) {
             if (lt instanceof LayoutSlip) {
                 beginHitPointType = HitPointType.SLIP_A;
@@ -4028,7 +4028,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                     }
 
                     // Assign a block to the new zero length track segment.
-                    ((LayoutTurnoutView)foundTrackView).setTrackSegmentBlock(foundHitPointType, true);
+                    ((LayoutTurnoutView) foundTrackView).setTrackSegmentBlock(foundHitPointType, true);
                     break;
                 }
 
@@ -4149,20 +4149,26 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     public List<LayoutShape> _layoutShapeSelection = new ArrayList<>();
 
     @Nonnull
-    public List<Positionable> getPositionalSelection() { return _positionableSelection; }
-    
+    public List<Positionable> getPositionalSelection() {
+        return _positionableSelection;
+    }
+
     @Nonnull
-    public List<LayoutTrack> getLayoutTrackSelection() { return _layoutTrackSelection; }
-    
+    public List<LayoutTrack> getLayoutTrackSelection() {
+        return _layoutTrackSelection;
+    }
+
     @Nonnull
-    public List<LayoutShape> getLayoutShapeSelection() { return _layoutShapeSelection; }
-    
+    public List<LayoutShape> getLayoutShapeSelection() {
+        return _layoutShapeSelection;
+    }
+
     private void createSelectionGroups() {
         Rectangle2D selectionRect = getSelectionRect();
 
         getContents().forEach((o) -> {
             if (selectionRect.contains(o.getLocation())) {
-            
+
                 log.trace("found item o of class {}", o.getClass());
                 if (!_positionableSelection.contains(o)) {
                     _positionableSelection.add(o);
@@ -4260,7 +4266,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
     private void amendSelectionGroup(@Nonnull Positionable p) {
         assert p != null;
-        
+
         if (_positionableSelection.contains(p)) {
             _positionableSelection.remove(p);
         } else {
@@ -4283,7 +4289,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
     public void amendSelectionGroup(@Nonnull LayoutShape ls) {
         assert ls != null;
-        
+
         if (_layoutShapeSelection.contains(ls)) {
             _layoutShapeSelection.remove(ls);
         } else {
@@ -4618,14 +4624,13 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                     _lastY = yLoc;
                 } else {
                     switch (selectedHitPointType) {
-                        case POS_POINT: 
-                        case TURNOUT_CENTER: 
+                        case POS_POINT:
+                        case TURNOUT_CENTER:
                         case LEVEL_XING_CENTER:
                         case SLIP_LEFT:
                         case SLIP_RIGHT:
-                        case TURNTABLE_CENTER:
-                        {
-                            getLayoutTrackView((LayoutTrack)selectedObject).setCoordsCenter(currentPoint);
+                        case TURNTABLE_CENTER: {
+                            getLayoutTrackView((LayoutTrack) selectedObject).setCoordsCenter(currentPoint);
                             isDragging = true;
                             break;
                         }
@@ -4712,7 +4717,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                         }
 
                         case TRACK_CIRCLE_CENTRE: {
-                            TrackSegmentView tv = getTrackSegmentView( (TrackSegment) selectedObject);
+                            TrackSegmentView tv = getTrackSegmentView((TrackSegment) selectedObject);
                             tv.reCalculateTrackSegmentAngle(currentPoint.getX(), currentPoint.getY());
                             break;
                         }
@@ -4740,7 +4745,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                     && event.isShiftDown()
                     && leToolBarPanel.trackButton.isSelected()) {
                 // dragging from first end of Track Segment
-                currentLocation.setLocation(xLoc, yLoc);
+                currentLocation = new Point2D.Double(xLoc, yLoc);
                 boolean needResetCursor = (foundTrack != null);
 
                 if (findLayoutTracksHitPoint(currentLocation, true)) {
@@ -4752,7 +4757,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             } else if (event.isShiftDown()
                     && leToolBarPanel.shapeButton.isSelected() && (selectedObject != null)) {
                 // dragging from end of shape
-                currentLocation.setLocation(xLoc, yLoc);
+                currentLocation = new Point2D.Double(xLoc, yLoc);
             } else if (selectionActive && !event.isShiftDown() && !isMetaDown(event)) {
                 selectionWidth = xLoc - selectionX;
                 selectionHeight = yLoc - selectionY;
@@ -4785,10 +4790,10 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
         // create object
         PositionablePoint o = new PositionablePoint(name,
-                                    PositionablePoint.PointType.ANCHOR, this);
-        PositionablePointView pv = new PositionablePointView(o,currentPoint, this);
+                PositionablePoint.PointType.ANCHOR, this);
+        PositionablePointView pv = new PositionablePointView(o, currentPoint, this);
         addLayoutTrack(o, pv);
-        
+
         setDirty();
 
         return o;
@@ -4822,7 +4827,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                 PositionablePoint.PointType.EDGE_CONNECTOR, this);
         PositionablePointView pv = new PositionablePointView(o, currentPoint, this);
         addLayoutTrack(o, pv);
-        
+
         setDirty();
     }
 
@@ -4841,7 +4846,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         TrackSegmentView tsv = new TrackSegmentView(
                 newTrack,
                 this
-            );
+        );
         addLayoutTrack(newTrack, tsv);
 
         setDirty();
@@ -4889,7 +4894,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         LevelXing o = new LevelXing(name, this);
         LevelXingView ov = new LevelXingView(o, currentPoint, this);
         addLayoutTrack(o, ov);
-        
+
         setDirty();
 
         // check on layout block
@@ -4949,13 +4954,13 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         LayoutSlip o;
         LayoutSlipView ov;
 
-        switch(type) {
-            case DOUBLE_SLIP :
+        switch (type) {
+            case DOUBLE_SLIP:
                 LayoutDoubleSlip lds = new LayoutDoubleSlip(name, this);
                 o = lds;
                 ov = new LayoutDoubleSlipView(lds, currentPoint, rot, this);
                 break;
-            case SINGLE_SLIP :
+            case SINGLE_SLIP:
                 LayoutSingleSlip lss = new LayoutSingleSlip(name, this);
                 o = lss;
                 ov = new LayoutSingleSlipView(lss, currentPoint, rot, this);
@@ -5058,48 +5063,48 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
         // create object - check all types, although not clear all actually reach here
         LayoutTurnout o;
-        LayoutTurnoutView ov; 
+        LayoutTurnoutView ov;
 
-        switch(type) {
+        switch (type) {
 
-            case RH_TURNOUT :
+            case RH_TURNOUT:
                 LayoutRHTurnout lrht = new LayoutRHTurnout(name, this);
                 o = lrht;
                 ov = new LayoutRHTurnoutView(lrht, currentPoint, rot, gContext.getXScale(), gContext.getYScale(), this);
                 break;
-            case LH_TURNOUT :
+            case LH_TURNOUT:
                 LayoutLHTurnout llht = new LayoutLHTurnout(name, this);
                 o = llht;
                 ov = new LayoutLHTurnoutView(llht, currentPoint, rot, gContext.getXScale(), gContext.getYScale(), this);
                 break;
-            case WYE_TURNOUT :
+            case WYE_TURNOUT:
                 LayoutWye lw = new LayoutWye(name, this);
                 o = lw;
                 ov = new LayoutWyeView(lw, currentPoint, rot, gContext.getXScale(), gContext.getYScale(), this);
                 break;
-            case DOUBLE_XOVER :
+            case DOUBLE_XOVER:
                 LayoutDoubleXOver ldx = new LayoutDoubleXOver(name, this);
                 o = ldx;
                 ov = new LayoutDoubleXOverView(ldx, currentPoint, rot, gContext.getXScale(), gContext.getYScale(), this);
                 break;
-            case RH_XOVER :
+            case RH_XOVER:
                 LayoutRHXOver lrx = new LayoutRHXOver(name, this);
                 o = lrx;
                 ov = new LayoutRHXOverView(lrx, currentPoint, rot, gContext.getXScale(), gContext.getYScale(), this);
                 break;
-            case LH_XOVER :
+            case LH_XOVER:
                 LayoutLHXOver llx = new LayoutLHXOver(name, this);
                 o = llx;
                 ov = new LayoutLHXOverView(llx, currentPoint, rot, gContext.getXScale(), gContext.getYScale(), this);
                 break;
 
-            case DOUBLE_SLIP :
+            case DOUBLE_SLIP:
                 LayoutDoubleSlip lds = new LayoutDoubleSlip(name, this);
                 o = lds;
                 ov = new LayoutDoubleSlipView(lds, currentPoint, rot, this);
                 log.error("Found SINGLE_SLIP in addLayoutTurnout for element {}", name);
                 break;
-            case SINGLE_SLIP :
+            case SINGLE_SLIP:
                 LayoutSingleSlip lss = new LayoutSingleSlip(name, this);
                 o = lss;
                 ov = new LayoutSingleSlipView(lss, currentPoint, rot, this);
@@ -5110,7 +5115,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                 log.error("can't create LayoutTrack {} with type {}", name, type);
                 return; // without creating
         }
-        
+
         addLayoutTrack(o, ov);
 
         setDirty();
@@ -5358,7 +5363,8 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
      * If the block name is a system name, then the user will have to supply a
      * user name for the block.
      * <p>
-     * Some, but not all, errors pop a Swing error dialog in addition to logging.
+     * Some, but not all, errors pop a Swing error dialog in addition to
+     * logging.
      *
      * @param inBlockName the entered name
      * @return the provided LayoutBlock
@@ -5926,7 +5932,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
         // remove connections if any
         LevelXingView ov = getLevelXingView(o);
-        
+
         TrackSegment t = (TrackSegment) o.getConnectA();
         if (t != null) {
             substituteAnchor(ov.getCoordsA(), o, t);
@@ -5996,7 +6002,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         }
 
         LayoutTurnoutView ov = getLayoutTurnoutView(o);
-        
+
         // remove from selection information
         if (selectedObject == o) {
             selectedObject = null;
@@ -6192,21 +6198,21 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             }
         }
     }
-    
+
     /**
-     * Depending on the given type, 
-     * and the real class of the given LayoutTrack,
-     * determine the connected LayoutTrack.  This provides a 
-     * variable-indirect form of e.g. trk.getLayoutBlockC() for example.
-     * Perhaps "Connected Block" captures the idea better, but that 
-     * method name is being used for something else.
+     * Depending on the given type, and the real class of the given LayoutTrack,
+     * determine the connected LayoutTrack. This provides a variable-indirect
+     * form of e.g. trk.getLayoutBlockC() for example. Perhaps "Connected Block"
+     * captures the idea better, but that method name is being used for
+     * something else.
      *
      *
-     * @param track  The track who's connected blocks are being examined
-     * @param type   This point to check for connected blocks, i.e. TURNOUT_B
-     * @return       The block at a particular point on the track object, or null if none.
+     * @param track The track who's connected blocks are being examined
+     * @param type  This point to check for connected blocks, i.e. TURNOUT_B
+     * @return The block at a particular point on the track object, or null if
+     *         none.
      */
-     // Temporary - this should certainly be a LayoutTrack method.
+    // Temporary - this should certainly be a LayoutTrack method.
     public LayoutBlock getAffectedBlock(@Nonnull LayoutTrack track, HitPointType type) {
         LayoutBlock result = null;
 
@@ -7769,55 +7775,69 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         LayoutTrackView lv = trkToView.get(trk);
         if (lv == null) {
             log.warn("No View found for {} class {}", trk, trk.getClass());
-            throw new IllegalArgumentException("No View found: "+trk.getClass());
+            throw new IllegalArgumentException("No View found: " + trk.getClass());
         }
         return lv;
     }
+
     // temporary
     final public LevelXingView getLevelXingView(LevelXing xing) {
         LayoutTrackView lv = trkToView.get(xing);
         if (lv == null) {
             log.warn("No View found for {} class {}", xing, xing.getClass());
-            throw new IllegalArgumentException("No View found: "+xing.getClass());
+            throw new IllegalArgumentException("No View found: " + xing.getClass());
         }
-        if (lv instanceof LevelXingView) return (LevelXingView) lv;
-        else log.error("wrong type {} {} found {}", xing, xing.getClass(), lv);
-        throw new IllegalArgumentException("Wrong type: "+xing.getClass());
+        if (lv instanceof LevelXingView) {
+            return (LevelXingView) lv;
+        } else {
+            log.error("wrong type {} {} found {}", xing, xing.getClass(), lv);
+        }
+        throw new IllegalArgumentException("Wrong type: " + xing.getClass());
     }
+
     // temporary
     final public LayoutTurnoutView getLayoutTurnoutView(LayoutTurnout to) {
         LayoutTrackView lv = trkToView.get(to);
         if (lv == null) {
             log.warn("No View found for {} class {}", to, to.getClass());
-            throw new IllegalArgumentException("No View found: "+to);
+            throw new IllegalArgumentException("No View found: " + to);
         }
-        if (lv instanceof LayoutTurnoutView) return (LayoutTurnoutView) lv;
-        else log.error("wrong type {} {} found {}", to, to.getClass(), lv);
-        throw new IllegalArgumentException("Wrong type: "+to.getClass());
+        if (lv instanceof LayoutTurnoutView) {
+            return (LayoutTurnoutView) lv;
+        } else {
+            log.error("wrong type {} {} found {}", to, to.getClass(), lv);
+        }
+        throw new IllegalArgumentException("Wrong type: " + to.getClass());
     }
-    
+
     // temporary
     final public LayoutTurntableView getLayoutTurntableView(LayoutTurntable to) {
         LayoutTrackView lv = trkToView.get(to);
         if (lv == null) {
             log.warn("No View found for {} class {}", to, to.getClass());
-            throw new IllegalArgumentException("No matching View found: "+to);
+            throw new IllegalArgumentException("No matching View found: " + to);
         }
-        if (lv instanceof LayoutTurntableView) return (LayoutTurntableView) lv;
-        else log.error("wrong type {} {} found {}", to, to.getClass(), lv);
-        throw new IllegalArgumentException("Wrong type: "+to.getClass());
+        if (lv instanceof LayoutTurntableView) {
+            return (LayoutTurntableView) lv;
+        } else {
+            log.error("wrong type {} {} found {}", to, to.getClass(), lv);
+        }
+        throw new IllegalArgumentException("Wrong type: " + to.getClass());
     }
-        
+
     // temporary
     final public LayoutSlipView getLayoutSlipView(LayoutSlip to) {
         LayoutTrackView lv = trkToView.get(to);
         if (lv == null) {
             log.warn("No View found for {} class {}", to, to.getClass());
-            throw new IllegalArgumentException("No matching View found: "+to);
+            throw new IllegalArgumentException("No matching View found: " + to);
         }
-        if (lv instanceof LayoutSlipView) return (LayoutSlipView) lv;
-        else log.error("wrong type {} {} found {}", to, to.getClass(), lv);
-        throw new IllegalArgumentException("Wrong type: "+to.getClass());
+        if (lv instanceof LayoutSlipView) {
+            return (LayoutSlipView) lv;
+        } else {
+            log.error("wrong type {} {} found {}", to, to.getClass(), lv);
+        }
+        throw new IllegalArgumentException("Wrong type: " + to.getClass());
     }
 
     // temporary
@@ -7825,40 +7845,48 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         LayoutTrackView lv = trkToView.get(to);
         if (lv == null) {
             log.warn("No View found for {} class {}", to, to.getClass());
-            throw new IllegalArgumentException("No matching View found: "+to);
+            throw new IllegalArgumentException("No matching View found: " + to);
         }
-        if (lv instanceof TrackSegmentView) return (TrackSegmentView) lv;
-        else log.error("wrong type {} {} found {}", to, to.getClass(), lv);
-        throw new IllegalArgumentException("Wrong type: "+to.getClass());
+        if (lv instanceof TrackSegmentView) {
+            return (TrackSegmentView) lv;
+        } else {
+            log.error("wrong type {} {} found {}", to, to.getClass(), lv);
+        }
+        throw new IllegalArgumentException("Wrong type: " + to.getClass());
     }
-        
+
     // temporary
     final public PositionablePointView getPositionablePointView(PositionablePoint to) {
         LayoutTrackView lv = trkToView.get(to);
         if (lv == null) {
             log.warn("No View found for {} class {}", to, to.getClass());
-            throw new IllegalArgumentException("No matching View found: "+to);
+            throw new IllegalArgumentException("No matching View found: " + to);
         }
-        if (lv instanceof PositionablePointView) return (PositionablePointView) lv;
-        else log.error("wrong type {} {} found {}", to, to.getClass(), lv);
-        throw new IllegalArgumentException("Wrong type: "+to.getClass());
+        if (lv instanceof PositionablePointView) {
+            return (PositionablePointView) lv;
+        } else {
+            log.error("wrong type {} {} found {}", to, to.getClass(), lv);
+        }
+        throw new IllegalArgumentException("Wrong type: " + to.getClass());
     }
-        
+
     /**
-     * Add a LayoutTrack and LayoutTrackView to the list of 
-     * LayoutTrack family objects.
+     * Add a LayoutTrack and LayoutTrackView to the list of LayoutTrack family
+     * objects.
      *
      * @param trk the layout track to add.
      */
     final public void addLayoutTrack(@Nonnull LayoutTrack trk, @Nonnull LayoutTrackView v) {
         log.trace("addLayoutTrack {}", trk);
-        if (layoutTrackList.contains(trk)) log.warn("LayoutTrack {} already being maintained", trk.getName());
-        
+        if (layoutTrackList.contains(trk)) {
+            log.warn("LayoutTrack {} already being maintained", trk.getName());
+        }
+
         layoutTrackList.add(trk);
         layoutTrackViewList.add(v);
         trkToView.put(trk, v);
         viewToTrk.put(v, trk);
-        
+
         unionToPanelBounds(v.getBounds()); // temporary - this should probably _not_ be in the topological part
     }
 
@@ -7922,32 +7950,32 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
     /**
      * {@inheritDoc}
-     *
-     * This implementation is temporary, using the 
-     * on-screen points from the LayoutTrackViews via @{link LayoutEditor#getCoords}.
+     * <p>
+     * This implementation is temporary, using the on-screen points from the
+     * LayoutTrackViews via @{link LayoutEditor#getCoords}.
      */
     @Override
     public int computeDirection(LayoutTrack trk1, HitPointType h1, LayoutTrack trk2, HitPointType h2) {
         return Path.computeDirection(
                 getCoords(trk1, h1),
                 getCoords(trk2, h2)
-            );    
+        );
     }
-    
+
     @Override
-    public int computeDirectionToCenter( @Nonnull LayoutTrack trk1, @Nonnull HitPointType h1, @Nonnull PositionablePoint p) {
+    public int computeDirectionToCenter(@Nonnull LayoutTrack trk1, @Nonnull HitPointType h1, @Nonnull PositionablePoint p) {
         return Path.computeDirection(
                 getCoords(trk1, h1),
                 getPositionablePointView(p).getCoordsCenter()
-            );    
+        );
     }
-    
+
     @Override
-    public int computeDirectionFromCenter( @Nonnull PositionablePoint p, @Nonnull LayoutTrack trk1, @Nonnull HitPointType h1) {
+    public int computeDirectionFromCenter(@Nonnull PositionablePoint p, @Nonnull LayoutTrack trk1, @Nonnull HitPointType h1) {
         return Path.computeDirection(
                 getPositionablePointView(p).getCoordsCenter(),
                 getCoords(trk1, h1)
-            );    
+        );
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
@@ -135,8 +135,8 @@ class LayoutEditorComponent extends JComponent {
 
         // draw horizontal lines
         for (int y = minY; y <= maxY; y += layoutEditor.gContext.getGridSize()) {
-            startPt.setLocation(minX, y);
-            stopPt.setLocation(maxX, y);
+            startPt = new Point2D.Double(minX, y);
+            stopPt = new Point2D.Double(maxX, y);
 
             if ((y % wideMod) < wideMin) {
                 g2.setStroke(wide);
@@ -149,8 +149,8 @@ class LayoutEditorComponent extends JComponent {
 
         // draw vertical lines
         for (int x = minX; x <= maxX; x += layoutEditor.gContext.getGridSize()) {
-            startPt.setLocation(x, minY);
-            stopPt.setLocation(x, maxY);
+            startPt = new Point2D.Double(x, minY);
+            stopPt = new Point2D.Double(x, maxY);
 
             if ((x % wideMod) < wideMin) {
                 g2.setStroke(wide);

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorComponent.java
@@ -125,8 +125,7 @@ class LayoutEditorComponent extends JComponent {
 
         log.debug("drawPanelGrid: minX: {}, minY: {}, maxX: {}, maxY: {}", minX, minY, maxX, maxY);
 
-        Point2D startPt = new Point2D.Double();
-        Point2D stopPt = new Point2D.Double();
+        Point2D startPt, stopPt;
         BasicStroke narrow = new BasicStroke(1.0F, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND);
         BasicStroke wide = new BasicStroke(2.0F, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND);
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnoutView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnoutView.java
@@ -22,27 +22,28 @@ import jmri.util.MathUtil;
 /**
  * MVC View component for the LayoutTurnout class.
  *
- * @author Bob Jacobsen  Copyright (c) 2020
- * 
+ * @author Bob Jacobsen Copyright (c) 2020
+ *
  */
 public class LayoutTurnoutView extends LayoutTrackView {
 
-    public LayoutTurnoutView(@Nonnull LayoutTurnout turnout, 
+    public LayoutTurnoutView(@Nonnull LayoutTurnout turnout,
             @Nonnull Point2D c, double rot,
             @Nonnull LayoutEditor layoutEditor) {
         this(turnout, c, rot, 1.0, 1.0, layoutEditor);
     }
-    
+
     /**
      * Constructor method.
-     * @param turnout the layout turnout to create the view for.
-     * @param c       where to put it
-     * @param rot     for display
-     * @param xFactor     for display
-     * @param yFactor     for display
+     *
+     * @param turnout      the layout turnout to create the view for.
+     * @param c            where to put it
+     * @param rot          for display
+     * @param xFactor      for display
+     * @param yFactor      for display
      * @param layoutEditor what layout editor panel to put it in
      */
-    public LayoutTurnoutView(@Nonnull LayoutTurnout turnout, 
+    public LayoutTurnoutView(@Nonnull LayoutTurnout turnout,
             @Nonnull Point2D c, double rot,
             double xFactor, double yFactor,
             @Nonnull LayoutEditor layoutEditor) {
@@ -54,56 +55,55 @@ public class LayoutTurnoutView extends LayoutTrackView {
         int version = turnout.getVersion();
 
         // adjust initial coordinates
-        
         if (turnout.getTurnoutType() == TurnoutType.LH_TURNOUT) {
-            dispB.setLocation(layoutEditor.getTurnoutBX(), 0.0);
-            dispA.setLocation(layoutEditor.getTurnoutCX(), -layoutEditor.getTurnoutWid());
+            dispB = new Point2D.Double(layoutEditor.getTurnoutBX(), 0.0);
+            dispA = new Point2D.Double(layoutEditor.getTurnoutCX(), -layoutEditor.getTurnoutWid());
         } else if (turnout.getTurnoutType() == TurnoutType.RH_TURNOUT) {
-            dispB.setLocation(layoutEditor.getTurnoutBX(), 0.0);
-            dispA.setLocation(layoutEditor.getTurnoutCX(), layoutEditor.getTurnoutWid());
+            dispB = new Point2D.Double(layoutEditor.getTurnoutBX(), 0.0);
+            dispA = new Point2D.Double(layoutEditor.getTurnoutCX(), layoutEditor.getTurnoutWid());
         } else if (turnout.getTurnoutType() == TurnoutType.WYE_TURNOUT) {
-            dispB.setLocation(layoutEditor.getTurnoutBX(), 0.5 * layoutEditor.getTurnoutWid());
-            dispA.setLocation(layoutEditor.getTurnoutBX(), -0.5 * layoutEditor.getTurnoutWid());
+            dispB = new Point2D.Double(layoutEditor.getTurnoutBX(), 0.5 * layoutEditor.getTurnoutWid());
+            dispA = new Point2D.Double(layoutEditor.getTurnoutBX(), -0.5 * layoutEditor.getTurnoutWid());
         } else if (turnout.getTurnoutType() == TurnoutType.DOUBLE_XOVER) {
             if (version == 2) {
                 super.setCoordsCenter(new Point2D.Double(layoutEditor.getXOverLong(), layoutEditor.getXOverHWid()));
-                pointB.setLocation(layoutEditor.getXOverLong() * 2, 0);
-                pointC.setLocation(layoutEditor.getXOverLong() * 2, (layoutEditor.getXOverHWid() * 2));
-                pointD.setLocation(0, (layoutEditor.getXOverHWid() * 2));
+                pointB = new Point2D.Double(layoutEditor.getXOverLong() * 2, 0);
+                pointC = new Point2D.Double(layoutEditor.getXOverLong() * 2, (layoutEditor.getXOverHWid() * 2));
+                pointD = new Point2D.Double(0, (layoutEditor.getXOverHWid() * 2));
                 super.setCoordsCenter(c);
             } else {
-                dispB.setLocation(layoutEditor.getXOverLong(), -layoutEditor.getXOverHWid());
-                dispA.setLocation(layoutEditor.getXOverLong(), layoutEditor.getXOverHWid());
+                dispB = new Point2D.Double(layoutEditor.getXOverLong(), -layoutEditor.getXOverHWid());
+                dispA = new Point2D.Double(layoutEditor.getXOverLong(), layoutEditor.getXOverHWid());
             }
         } else if (turnout.getTurnoutType() == TurnoutType.RH_XOVER) {
             if (version == 2) {
                 super.setCoordsCenter(new Point2D.Double(layoutEditor.getXOverLong(), layoutEditor.getXOverHWid()));
-                pointB.setLocation((layoutEditor.getXOverShort() + layoutEditor.getXOverLong()), 0);
-                pointC.setLocation(layoutEditor.getXOverLong() * 2, (layoutEditor.getXOverHWid() * 2));
-                pointD.setLocation((getCoordsCenter().getX() - layoutEditor.getXOverShort()), (layoutEditor.getXOverHWid() * 2));
+                pointB = new Point2D.Double((layoutEditor.getXOverShort() + layoutEditor.getXOverLong()), 0);
+                pointC = new Point2D.Double(layoutEditor.getXOverLong() * 2, (layoutEditor.getXOverHWid() * 2));
+                pointD = new Point2D.Double((getCoordsCenter().getX() - layoutEditor.getXOverShort()), (layoutEditor.getXOverHWid() * 2));
                 super.setCoordsCenter(c);
             } else {
-                dispB.setLocation(layoutEditor.getXOverShort(), -layoutEditor.getXOverHWid());
-                dispA.setLocation(layoutEditor.getXOverLong(), layoutEditor.getXOverHWid());
+                dispB = new Point2D.Double(layoutEditor.getXOverShort(), -layoutEditor.getXOverHWid());
+                dispA = new Point2D.Double(layoutEditor.getXOverLong(), layoutEditor.getXOverHWid());
             }
         } else if (turnout.getTurnoutType() == TurnoutType.LH_XOVER) {
             if (version == 2) {
                 super.setCoordsCenter(new Point2D.Double(layoutEditor.getXOverLong(), layoutEditor.getXOverHWid()));
 
-                pointA.setLocation((getCoordsCenter().getX() - layoutEditor.getXOverShort()), 0);
-                pointB.setLocation((layoutEditor.getXOverLong() * 2), 0);
-                pointC.setLocation(layoutEditor.getXOverLong() + layoutEditor.getXOverShort(), (layoutEditor.getXOverHWid() * 2));
-                pointD.setLocation(0, (layoutEditor.getXOverHWid() * 2));
+                pointA = new Point2D.Double((getCoordsCenter().getX() - layoutEditor.getXOverShort()), 0);
+                pointB = new Point2D.Double((layoutEditor.getXOverLong() * 2), 0);
+                pointC = new Point2D.Double(layoutEditor.getXOverLong() + layoutEditor.getXOverShort(), (layoutEditor.getXOverHWid() * 2));
+                pointD = new Point2D.Double(0, (layoutEditor.getXOverHWid() * 2));
 
                 super.setCoordsCenter(c);
             } else {
-                dispB.setLocation(layoutEditor.getXOverLong(), -layoutEditor.getXOverHWid());
-                dispA.setLocation(layoutEditor.getXOverShort(), layoutEditor.getXOverHWid());
+                dispB = new Point2D.Double(layoutEditor.getXOverLong(), -layoutEditor.getXOverHWid());
+                dispA = new Point2D.Double(layoutEditor.getXOverShort(), layoutEditor.getXOverHWid());
             }
         }
-                
+
         rotateCoords(rot);
-        
+
         // adjust size of new turnout
         Point2D pt = new Point2D.Double(Math.round(dispB.getX() * xFactor),
                 Math.round(dispB.getY() * yFactor));
@@ -211,7 +211,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
     public boolean hasEnteringDoubleTrack() {
         return turnout.hasEnteringDoubleTrack();
     }
-    
+
     // operational instance variables (not saved between sessions)
     public static final int UNKNOWN = Turnout.UNKNOWN;
     public static final int INCONSISTENT = Turnout.INCONSISTENT;
@@ -267,13 +267,15 @@ public class LayoutTurnoutView extends LayoutTrackView {
     public LinkType linkType = LinkType.NO_LINK;
 
     private final boolean useBlockSpeed = false;
-    
+
     // temporary reference to the Editor that will eventually be part of View
     protected jmri.jmrit.display.layoutEditor.LayoutEditorDialogs.LayoutTurnoutEditor editor;
 
     final private LayoutTurnout turnout;
-    
-    public final LayoutTurnout getLayoutTurnout() { return turnout; }  // getTurnout() gets the real Turnout in the LayoutTurnout
+
+    public final LayoutTurnout getLayoutTurnout() {
+        return turnout;
+    }  // getTurnout() gets the real Turnout in the LayoutTurnout
 
     /**
      * {@inheritDoc}
@@ -285,7 +287,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
         return "LayoutTurnout " + getName();
     }
 
-    // 
+    //
     // Accessor methods
     //
     public int getVersion() {
@@ -305,7 +307,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
         return turnout.getTurnoutName();
     }
 
-   // @CheckForNull - can this be null? or ""?
+    // @CheckForNull - can this be null? or ""?
     public String getSecondTurnoutName() {
         return turnout.getSecondTurnoutName();
     }
@@ -327,8 +329,8 @@ public class LayoutTurnoutView extends LayoutTrackView {
 
     @Nonnull
     public String getBlockDName() {
-       return turnout.getBlockDName();
-     }
+        return turnout.getBlockDName();
+    }
 
     @CheckForNull
     public SignalHead getSignalHead(Geometry loc) {
@@ -363,7 +365,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
         turnout.setSignalA2Name(signalHead);
     }
 
-   @CheckForNull
+    @CheckForNull
     public SignalHead getSignalA3() {
         return turnout.getSignalA3();
     }
@@ -373,7 +375,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
         return turnout.getSignalA3Name();
     }
 
-     public void setSignalA3Name(@CheckForNull String signalHead) {
+    public void setSignalA3Name(@CheckForNull String signalHead) {
         turnout.setSignalA3Name(signalHead);
     }
 
@@ -597,7 +599,6 @@ public class LayoutTurnoutView extends LayoutTrackView {
         turnout.setSensorD(sensorName);
     }
 
-
     public String getLinkedTurnoutName() {
         return turnout.getLinkedTurnoutName();
     }
@@ -611,7 +612,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
     }
 
     public void setLinkType(LinkType ltype) {
-         turnout.setLinkType(ltype);
+        turnout.setLinkType(ltype);
     }
 
     public TurnoutType getTurnoutType() {
@@ -635,7 +636,8 @@ public class LayoutTurnoutView extends LayoutTrackView {
     }
 
     /**
-     * @return null if no turnout set // temporary?  Might want to run all calls through this class; but this is getModel equiv
+     * @return null if no turnout set // temporary? Might want to run all calls
+     *         through this class; but this is getModel equiv
      */
     // @CheckForNull  temporary
     public Turnout getTurnout() {
@@ -858,7 +860,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
         double distBC = Math.hypot(bX - cX, bY - cY);
         if ((getTurnoutType() == TurnoutType.LH_TURNOUT)
                 || (getTurnoutType() == TurnoutType.RH_TURNOUT)) {
-                
+
             layoutEditor.setTurnoutBX(Math.round(lenB + 0.1));
             double xc = ((bX * cX) + (bY * cY)) / lenB;
             layoutEditor.setTurnoutCX(Math.round(xc + 0.1));
@@ -931,7 +933,9 @@ public class LayoutTurnoutView extends LayoutTrackView {
 
     /**
      * Set up Layout Block(s) for this Turnout.
-     * @param newLayoutBlock See {@link LayoutTurnout#setLayoutBlock} for definition
+     *
+     * @param newLayoutBlock See {@link LayoutTurnout#setLayoutBlock} for
+     *                       definition
      */
     public void setLayoutBlock(LayoutBlock newLayoutBlock) {
         turnout.setLayoutBlock(newLayoutBlock);
@@ -989,9 +993,9 @@ public class LayoutTurnoutView extends LayoutTrackView {
     }
 
     /**
-     * Update the block for a track segment that provides a (graphically) short connection
-     * between a turnout and another object, normally another turnout. These are
-     * hard to see and are frequently missed.
+     * Update the block for a track segment that provides a (graphically) short
+     * connection between a turnout and another object, normally another
+     * turnout. These are hard to see and are frequently missed.
      * <p>
      * Skip block changes if signal heads, masts or sensors have been assigned.
      * Only track segments with a length less than the turnout circle radius
@@ -1456,7 +1460,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
         double rotRAD = Math.toRadians(angleDEG);
         double sineRot = Math.sin(rotRAD);
         double cosineRot = Math.cos(rotRAD);
-        
+
         // rotate displacements around origin {0, 0}
         Point2D center_temp = getCoordsCenter();
         super.setCoordsCenter(MathUtil.zeroPoint2D);
@@ -1872,7 +1876,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
 
     public String[] getBlockBoundaries() {
         return turnout.getBlockBoundaries();
-    } 
+    }
 
     public ArrayList<LayoutBlock> getProtectedBlocks(jmri.NamedBean bean) {
         return turnout.getProtectedBlocks(bean);
@@ -1902,6 +1906,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
 
     /**
      * "active" means that the object is still displayed, and should be stored.
+     *
      * @return true if active
      */
     public boolean isActive() {
@@ -1945,11 +1950,12 @@ public class LayoutTurnoutView extends LayoutTrackView {
 
     /**
      * Draw track decorations.
-     * 
+     * <p>
      * This type of track has none, so this method is empty.
      */
     @Override
-    protected void drawDecorations(Graphics2D g2) {}
+    protected void drawDecorations(Graphics2D g2) {
+    }
 
     /**
      * {@inheritDoc}
@@ -3077,11 +3083,11 @@ public class LayoutTurnoutView extends LayoutTrackView {
             LayoutBlock prevLayoutBlock,
             LayoutBlock nextLayoutBlock,
             boolean suppress) {
-            
+
         return turnout.getConnectivityStateForLayoutBlocks(currLayoutBlock,
-                                                            prevLayoutBlock, 
-                                                            nextLayoutBlock,
-                                                            suppress);
+                prevLayoutBlock,
+                nextLayoutBlock,
+                suppress);
     }
 
     /**
@@ -3090,9 +3096,9 @@ public class LayoutTurnoutView extends LayoutTrackView {
     // TODO: on the cross-overs, check the internal boundary details.
     @Override
     public void reCheckBlockBoundary() {
-    
+
         turnout.reCheckBlockBoundary();
- 
+
     }
 
     /**
@@ -3128,7 +3134,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
     @Override
     public void checkForNonContiguousBlocks(
             @Nonnull HashMap<String, List<Set<String>>> blockNamesToTrackNameSetsMap) {
-            
+
         turnout.checkForNonContiguousBlocks(blockNamesToTrackNameSetsMap);
     }
 
@@ -3139,7 +3145,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
     public void collectContiguousTracksNamesInBlockNamed(
             @Nonnull String blockName,
             @Nonnull Set<String> TrackNameSet) {
-        
+
         turnout.collectContiguousTracksNamesInBlockNamed(blockName, TrackNameSet);
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegmentView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegmentView.java
@@ -425,7 +425,7 @@ public class TrackSegmentView extends LayoutTrackView {
         super.setCoordsCenter(MathUtil.multiply(getCoordsCenter(), factor));
         if (isBezier()) {
             for (Point2D p : bezierControlPoints) {
-                p = MathUtil.multiply(p, factor);
+                p.setLocation(MathUtil.multiply(p, factor));
             }
         }
     }
@@ -445,7 +445,7 @@ public class TrackSegmentView extends LayoutTrackView {
     public void rotateCoords(double angleDEG) {
         if (isBezier()) {
             for (Point2D p : bezierControlPoints) {
-                p = MathUtil.rotateDEG(p, getCoordsCenter(), angleDEG);
+                p.setLocation(MathUtil.rotateDEG(p, getCoordsCenter(), angleDEG));
             }
         }
     }
@@ -461,7 +461,7 @@ public class TrackSegmentView extends LayoutTrackView {
             if (isBezier()) {
                 Point2D delta = MathUtil.subtract(newCenterPoint, getCoordsCenter());
                 for (Point2D p : bezierControlPoints) {
-                    p = MathUtil.add(p, delta);
+                    p.setLocation(MathUtil.add(p, delta));
                 }
             }
             super.setCoordsCenter(newCenterPoint);

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegmentView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegmentView.java
@@ -19,7 +19,6 @@ import jmri.util.swing.JmriColorChooser;
 /**
  * MVC View component for the TrackSegment class.
  * <p>
- * <p>
  * Arrows and bumpers are visual, presentation aspects handled in the View.
  *
  * @author Bob Jacobsen Copyright (c) 2020

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegmentView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegmentView.java
@@ -18,11 +18,11 @@ import jmri.util.swing.JmriColorChooser;
 
 /**
  * MVC View component for the TrackSegment class.
- *
+ * <p>
  * <p>
  * Arrows and bumpers are visual, presentation aspects handled in the View.
- * 
- * @author Bob Jacobsen  Copyright (c) 2020
+ *
+ * @author Bob Jacobsen Copyright (c) 2020
  */
 public class TrackSegmentView extends LayoutTrackView {
 
@@ -34,29 +34,30 @@ public class TrackSegmentView extends LayoutTrackView {
         setupDefaultBumperSizes(layoutEditor);
         editor = new jmri.jmrit.display.layoutEditor.LayoutEditorDialogs.TrackSegmentEditor(layoutEditor);
     }
-    
+
     /**
      * constructor method.
-     * @param track the track segment to view
+     *
+     * @param track        the track segment to view
      * @param layoutEditor for reference to tools
-     * @param arc specify display
-     * @param flip specify display
-     * @param circle specify display
+     * @param arc          specify display
+     * @param flip         specify display
+     * @param circle       specify display
      */
     public TrackSegmentView(@Nonnull TrackSegment track, @Nonnull LayoutEditor layoutEditor,
-                                boolean arc, boolean flip, boolean circle
-                        ) {
+            boolean arc, boolean flip, boolean circle
+    ) {
         this(track, layoutEditor);
     }
 
     // persistent instances variables (saved between sessions)
     private boolean dashed = false;
-    
+
     private boolean arc = false;
     private boolean circle = false;
     private boolean flip = false;
     private double angle = 0.0D;
-    
+
     private boolean changed = false;
     private boolean bezier = false;
 
@@ -67,11 +68,13 @@ public class TrackSegmentView extends LayoutTrackView {
     private final jmri.jmrit.display.layoutEditor.LayoutEditorDialogs.TrackSegmentEditor editor;
 
     final private TrackSegment trackSegment;
- 
-     // temporary?
+
+    // temporary?
     @Nonnull
-    public TrackSegment getTrackSegment() { return trackSegment; }
-    
+    public TrackSegment getTrackSegment() {
+        return trackSegment;
+    }
+
     /**
      * Get debugging string for the TrackSegment.
      *
@@ -106,7 +109,7 @@ public class TrackSegmentView extends LayoutTrackView {
     }
 
     public LayoutTrack getConnect2() {
-        return trackSegment.getConnect2() ;
+        return trackSegment.getConnect2();
     }
 
     /**
@@ -134,7 +137,7 @@ public class TrackSegmentView extends LayoutTrackView {
      *
      * @param oldTrack the old track connection
      * @param newTrack the new track connection
-     * @param newType type of the new track connection
+     * @param newType  type of the new track connection
      * @return true if successful
      */
     public boolean replaceTrackConnection(@CheckForNull LayoutTrack oldTrack, @CheckForNull LayoutTrack newTrack, HitPointType newType) {
@@ -310,6 +313,7 @@ public class TrackSegmentView extends LayoutTrackView {
     /**
      * Determine if we need to redraw a curved piece of track. Saves having to
      * recalculate the circle details each time.
+     *
      * @return true means needs to be (re)drawn
      */
     public boolean trackNeedsRedraw() {
@@ -353,7 +357,8 @@ public class TrackSegmentView extends LayoutTrackView {
     }
 
     /**
-     * @param index If negative, this is index from the end i.e. -1 is the last element
+     * @param index If negative, this is index from the end i.e. -1 is the last
+     *              element
      * @return Reference to the indexed control point
      */
     public Point2D getBezierControlPoint(int index) {
@@ -368,8 +373,9 @@ public class TrackSegmentView extends LayoutTrackView {
     }
 
     /**
-     * @param p the location of the point to be set
-     * @param index If negative, this is index from the end i.e. -1 is the last element
+     * @param p     the location of the point to be set
+     * @param index If negative, this is index from the end i.e. -1 is the last
+     *              element
      */
     public void setBezierControlPoint(@CheckForNull Point2D p, int index) {
         if (index < 0) {
@@ -384,7 +390,7 @@ public class TrackSegmentView extends LayoutTrackView {
         }
     }
 
-    @Nonnull 
+    @Nonnull
     public ArrayList<Point2D> getBezierControlPoints() {
         return bezierControlPoints;
     }
@@ -419,7 +425,7 @@ public class TrackSegmentView extends LayoutTrackView {
         super.setCoordsCenter(MathUtil.multiply(getCoordsCenter(), factor));
         if (isBezier()) {
             for (Point2D p : bezierControlPoints) {
-                p.setLocation(MathUtil.multiply(p, factor));
+                p = MathUtil.multiply(p, factor);
             }
         }
     }
@@ -439,7 +445,7 @@ public class TrackSegmentView extends LayoutTrackView {
     public void rotateCoords(double angleDEG) {
         if (isBezier()) {
             for (Point2D p : bezierControlPoints) {
-                p.setLocation(MathUtil.rotateDEG(p, getCoordsCenter(), angleDEG));
+                p = MathUtil.rotateDEG(p, getCoordsCenter(), angleDEG);
             }
         }
     }
@@ -455,7 +461,7 @@ public class TrackSegmentView extends LayoutTrackView {
             if (isBezier()) {
                 Point2D delta = MathUtil.subtract(newCenterPoint, getCoordsCenter());
                 for (Point2D p : bezierControlPoints) {
-                    p.setLocation(MathUtil.add(p, delta));
+                    p = MathUtil.add(p, delta);
                 }
             }
             super.setCoordsCenter(newCenterPoint);
@@ -579,25 +585,25 @@ public class TrackSegmentView extends LayoutTrackView {
     private static final int MAX_ARROW_LINE_WIDTH = 5;
     private static final int MAX_ARROW_LENGTH = 60;
     private static final int MAX_ARROW_GAP = 40;
-    
+
     private static final int MAX_BRIDGE_LINE_WIDTH = 5;
     private static final int MIN_BRIDGE_LINE_WIDTH = 1;
-        
+
     private static final int MAX_BRIDGE_APPROACH_WIDTH = 100;
     private static final int MIN_BRIDGE_APPROACH_WIDTH = 8;
-    
+
     private static final int MAX_BRIDGE_DECK_WIDTH = 80;
     private static final int MIN_BRIDGE_DECK_WIDTH = 6;
-    
+
     private static final int MAX_BUMPER_LINE_WIDTH = 9;
     private static final int MIN_BUMPER_LINE_WIDTH = 1;
-    
+
     private static final int MAX_TUNNEL_FLOOR_WIDTH = 40;
     private static final int MIN_TUNNEL_FLOOR_WIDTH = 4;
-    
+
     private static final int MAX_TUNNEL_LINE_WIDTH = 9;
     private static final int MIN_TUNNEL_LINE_WIDTH = 1;
-    
+
     private static final int MAX_TUNNEL_ENTRANCE_WIDTH = 80;
     private static final int MIN_TUNNEL_ENTRANCE_WIDTH = 1;
 
@@ -661,7 +667,7 @@ public class TrackSegmentView extends LayoutTrackView {
         JMenuItem jmi = popupMenu.add(Bundle.getMessage("MakeLabel", info) + getName());
         jmi.setEnabled(false);
 
-        if ( getBlockName().isEmpty() ) {
+        if (getBlockName().isEmpty()) {
             jmi = popupMenu.add(Bundle.getMessage("NoBlock"));
         } else {
             jmi = popupMenu.add(Bundle.getMessage("MakeLabel", Bundle.getMessage("BeanNameBlock")) + getLayoutBlock().getDisplayName());
@@ -783,7 +789,7 @@ public class TrackSegmentView extends LayoutTrackView {
                     setArrowEndStop((getType2() == HitPointType.POS_POINT) && (((PositionablePoint) getConnect2()).getType() == PositionablePoint.PointType.EDGE_CONNECTOR));
                     setArrowStyle(n);
                 });
-                jcbmi.setSelected(arrowStyle == i);            
+                jcbmi.setSelected(arrowStyle == i);
             }
 
             if (hasEC1 && hasEC2) {
@@ -1346,7 +1352,7 @@ public class TrackSegmentView extends LayoutTrackView {
                 });
             }
         }
-        if (( !getBlockName().isEmpty()) && (jmri.InstanceManager.getDefault(LayoutBlockManager.class).isAdvancedRoutingEnabled())) {
+        if ((!getBlockName().isEmpty()) && (jmri.InstanceManager.getDefault(LayoutBlockManager.class).isAdvancedRoutingEnabled())) {
             popupMenu.add(new AbstractAction(Bundle.getMessage("ViewBlockRouting")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
@@ -1504,7 +1510,7 @@ public class TrackSegmentView extends LayoutTrackView {
                 newAnchor, HitPointType.POS_POINT,
                 getConnect2(), getType2(),
                 trackSegment.isMainline(), layoutEditor);
-        TrackSegmentView ntsv = new TrackSegmentView(newTrackSegment, 
+        TrackSegmentView ntsv = new TrackSegmentView(newTrackSegment,
                 layoutEditor);
         log.error("temporary: splitTrackSegment created track without view, didn't include isDashed() ");
         // add it to known tracks
@@ -1568,7 +1574,8 @@ public class TrackSegmentView extends LayoutTrackView {
 
     /**
      * Display popup menu for information and editing.
-     * @param e The original event causing this
+     *
+     * @param e            The original event causing this
      * @param hitPointType the type of the underlying hit
      */
     protected void showBezierPopUp(MouseEvent e, HitPointType hitPointType) {
@@ -1727,6 +1734,7 @@ public class TrackSegmentView extends LayoutTrackView {
     /**
      * Get state. "active" means that the object is still displayed, and should
      * be stored.
+     *
      * @return true if active
      */
     public boolean isActive() {
@@ -1750,13 +1758,14 @@ public class TrackSegmentView extends LayoutTrackView {
     /**
      * Method used by LayoutEditor.
      * <p>
-     * If the argument is 
+     * If the argument is
      * <ul>
      * <li>HIDECONALL then set HIDECONALL
      * <li>SHOWCON reset HIDECONALL is set, other wise set SHOWCON
      * <li>HIDECON or otherwise set HIDECON
      * </ul>
      * Then always redraw the LayoutEditor panel and set it dirty.
+     *
      * @param hide The specification i.e. HIDECONALL, SHOWCON et al
      */
     public void hideConstructionLines(int hide) {
@@ -1783,9 +1792,9 @@ public class TrackSegmentView extends LayoutTrackView {
     }
 
     /**
-     * The following are used only as a local store after a circle or arc
-     * has been calculated. This prevents the need to recalculate the values
-     * each time a re-draw is required.
+     * The following are used only as a local store after a circle or arc has
+     * been calculated. This prevents the need to recalculate the values each
+     * time a re-draw is required.
      */
     private Point2D pt1;
     private Point2D pt2;
@@ -2141,11 +2150,11 @@ public class TrackSegmentView extends LayoutTrackView {
                 MathUtil.drawBezier(g2, points);
             } else {
                 Point2D end1 = layoutEditor.getCoords(
-                                    getConnect1(), 
-                                    getType1());
+                        getConnect1(),
+                        getType1());
                 Point2D end2 = layoutEditor.getCoords(
-                                    getConnect2(), 
-                                    getType2());
+                        getConnect2(),
+                        getType2());
 
                 g2.draw(new Line2D.Double(end1, end2));
             }
@@ -2261,7 +2270,7 @@ public class TrackSegmentView extends LayoutTrackView {
     @Override
     protected void drawDecorations(Graphics2D g2) {
 
-        log.trace("TrackSegmentView: drawDecorations arrowStyle {}",arrowStyle);
+        log.trace("TrackSegmentView: drawDecorations arrowStyle {}", arrowStyle);
 // get end points and calculate start/stop angles (in radians)
         Point2D ep1 = layoutEditor.getCoords(getConnect1(), getType1());
         Point2D ep2 = layoutEditor.getCoords(getConnect2(), getType2());
@@ -2821,13 +2830,13 @@ public class TrackSegmentView extends LayoutTrackView {
     /*======================*\
     |* decoration accessors *|
     \*======================*/
-    
     // Although the superclass LayoutTrack stores decorators in a Map,
     // here we store them in specific variables like arrowStyle, bridgeSideRight, etc.
-    // We convert to and from the map during the getDecorations, setDecorations 
+    // We convert to and from the map during the getDecorations, setDecorations
     // and hasDecorations calls.
-    
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean hasDecorations() {
         return ((arrowStyle > 0)
@@ -2836,7 +2845,9 @@ public class TrackSegmentView extends LayoutTrackView {
                 || (tunnelSideLeft || tunnelSideRight));
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Map<String, String> getDecorations() {
         if (decorations == null) {
@@ -2954,9 +2965,11 @@ public class TrackSegmentView extends LayoutTrackView {
             decorations.put("tunnel", String.join(";", tunnelValues));
         }   // if (tunnelSideLeft || tunnelSideRight)
         return decorations;
-    } 
+    }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setDecorations(@Nonnull Map<String, String> decorations) {
         Color defaultTrackColor = layoutEditor.getDefaultTrackColorColor();
@@ -3188,22 +3201,22 @@ public class TrackSegmentView extends LayoutTrackView {
         } // if (decorathions != null)
     }   // setDirections
 
-    /** 
-     * Arrow decoration accessor.
-     * The 0 (none) and 1 through 5 arrow decorations are keyed to 
-     * files like program:resources/icons/decorations/ArrowStyle1.png
-     * et al.
+    /**
+     * Arrow decoration accessor. The 0 (none) and 1 through 5 arrow decorations
+     * are keyed to files like
+     * program:resources/icons/decorations/ArrowStyle1.png et al.
+     *
      * @return Style number
      */
     public int getArrowStyle() {
         return arrowStyle;
     }
 
-    /** 
-     * Set the arrow decoration.
-     * The 0 (none) and 1 through 5 arrow decorations are keyed to 
-     * files like program:resources/icons/decorations/ArrowStyle1.png
-     * et al.
+    /**
+     * Set the arrow decoration. The 0 (none) and 1 through 5 arrow decorations
+     * are keyed to files like
+     * program:resources/icons/decorations/ArrowStyle1.png et al.
+     *
      * @param newVal the new style number
      */
     public void setArrowStyle(int newVal) {
@@ -3786,6 +3799,6 @@ public class TrackSegmentView extends LayoutTrackView {
     public void setAllLayoutBlocks(LayoutBlock layoutBlock) {
         setLayoutBlock(layoutBlock);
     }
-    
+
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TrackSegmentView.class);
 }


### PR DESCRIPTION
Found bugs where an assigned Point2D variable was later .setLocation()'d causing the orginal variable to be changed:

        Point2D pointA = new Point2D.Double(10, 10);
        Point2D pointB = pointA;
        pointB.setLocation(20, 20);
        log.error("pointA: " + MathUtil.point2DToString(pointA));
Output: pointA: {20, 20}

Proposed solution: avoid Point2D.setLocation().