### PR TITLE
Remove unnecessary error message

### DIFF
--- a/java/src/jmri/managers/DefaultConditionalManager.java
+++ b/java/src/jmri/managers/DefaultConditionalManager.java
@@ -325,9 +325,7 @@ public class DefaultConditionalManager extends AbstractManager<Conditional>
         for (Logix lgx : logixManager.getNamedBeanSet()) {
             for (int i = 0; i < lgx.getNumConditionals(); i++) {
                 Conditional cdl = getBySystemName(lgx.getConditionalByNumberOrder(i));
-                if (cdl == null) {
-                    log.error("Conditional not found for \"{}\"", lgx.getConditionalByNumberOrder(i));
-                } else {
+                if (cdl != null) {
                     conditionals.add(cdl);
                 }
             }


### PR DESCRIPTION
An error message that only occurs during Logix Conditional XML loading is not relevant and clutters the system console.