### PR TITLE
Add label list accessor

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -218,6 +218,11 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     }
 
     @Nonnull
+    public List<PositionableLabel> getLabelImageList()  {
+        return labelImage;
+    }
+
+    @Nonnull
     public List<BlockContentsIcon> getBlockContentsLabelList() {
         return blockContentsLabelList;
     }


### PR DESCRIPTION
LayoutEditor.labelImage (which is actually a list) used to be accessible by scripts.  Now, it's private.  This PR adds an accessor as [requested on JMRIusers](https://groups.io/g/jmriusers/message/181723).