### PR TITLE
Update meter LoadStoreTest

### DIFF
--- a/java/test/jmri/jmrit/swing/meter/LoadAndStoreTest.java
+++ b/java/test/jmri/jmrit/swing/meter/LoadAndStoreTest.java
@@ -7,8 +7,11 @@ import jmri.InstanceManager;
 import jmri.jmrix.roco.z21.*;
 import jmri.util.*;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -27,6 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @author Bob Jacobsen      Copyright 2009, 2014
  * @author Daniel Bergqvist  Copyright 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
 
     private Z21InterfaceScaffold tc;
@@ -44,11 +48,20 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
     public LoadAndStoreTest() {
         super(SaveType.User, true);
     }
+    
+    @TempDir 
+    protected java.nio.file.Path tempDir;
 
     @BeforeEach
     @Override
     public void setUp() {
         super.setUp();
+        try {
+            JUnitUtil.resetProfileManager( new jmri.profile.NullProfile( tempDir.toFile()));
+        }
+        catch (java.io.IOException e){
+            Assert.fail("Unable to create temp directory");
+        }
         
         // This test requires a registred connection config since ProxyMeterManager
         // auto creates system meter managers using the connection configs.


### PR DESCRIPTION
adds headless check
adds temp directory

Attempt to resolve AllTest failures, see #9030