### PR TITLE
LayoutEditor:Add menu to change toolbar coordinates format

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -32,6 +32,7 @@ import jmri.jmrit.dispatcher.DispatcherAction;
 import jmri.jmrit.dispatcher.DispatcherFrame;
 import jmri.jmrit.display.*;
 import jmri.jmrit.display.layoutEditor.LayoutEditorDialogs.*;
+import jmri.jmrit.display.layoutEditor.LayoutEditorToolBarPanel.LocationFormat;
 import jmri.jmrit.display.panelEditor.PanelEditor;
 import jmri.jmrit.entryexit.AddEntryExitPairAction;
 import jmri.swing.NamedBeanComboBox;
@@ -144,6 +145,10 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     private JRadioButtonMenuItem tooltipNoneMenuItem = null;
     private JRadioButtonMenuItem tooltipInEditMenuItem = null;
     private JRadioButtonMenuItem tooltipNotInEditMenuItem = null;
+
+    private JCheckBoxMenuItem pixelsCheckBoxMenuItem = new JCheckBoxMenuItem(Bundle.getMessage("Pixels"));
+    private JCheckBoxMenuItem metricCMCheckBoxMenuItem = new JCheckBoxMenuItem(Bundle.getMessage("MetricCM"));
+    private JCheckBoxMenuItem englishFeetInchesCheckBoxMenuItem = new JCheckBoxMenuItem(Bundle.getMessage("EnglishFeetInches"));
 
     private JCheckBoxMenuItem snapToGridOnAddCheckBoxMenuItem = null;
     private JCheckBoxMenuItem snapToGridOnMoveCheckBoxMenuItem = null;
@@ -303,6 +308,9 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     // A hash to store string -> KeyEvent constants, used to set keyboard shortcuts per locale
     private HashMap<String, Integer> stringsToVTCodes = new HashMap<>();
 
+    /*==============*\
+    |* Toolbar side *|
+    \*==============*/
     private enum ToolBarSide {
         eTOP("top"),
         eLEFT("left"),
@@ -418,8 +426,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
                 Object prefsProp = prefsMgr.getProperty(windowFrameRef, "toolBarSide");
                 // log.debug("{}.toolBarSide is {}", windowFrameRef, prefsProp);
-                if (prefsProp
-                        != null) {
+                if (prefsProp != null) {
                     ToolBarSide newToolBarSide = ToolBarSide.getName((String) prefsProp);
                     setToolBarSide(newToolBarSide);
                 }
@@ -1136,6 +1143,46 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         });
 
         //
+        // location coordinates format menu
+        //
+        JMenu locationMenu = new JMenu(Bundle.getMessage("LocationMenuTitle")); // used for location format SubMenu
+        optionMenu.add(locationMenu);
+
+        InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent((prefsMgr) -> {
+            String windowFrameRef = getWindowFrameRef();
+            Object prefsProp = prefsMgr.getProperty(windowFrameRef, "LocationFormat");
+            // log.debug("{}.LocationFormat is {}", windowFrameRef, prefsProp);
+            if (prefsProp != null) {
+                getLayoutEditorToolBarPanel().setLocationFormat(LocationFormat.valueOf((String) prefsProp));
+            }
+        });
+
+        // pixels (jmri classic)
+        locationMenu.add(pixelsCheckBoxMenuItem);
+        pixelsCheckBoxMenuItem.addActionListener((ActionEvent event) -> {
+            getLayoutEditorToolBarPanel().setLocationFormat(LocationFormat.ePIXELS);
+            selectLocationFormatCheckBoxMenuItem();
+            redrawPanel();
+        });
+
+        // metric cm's
+        locationMenu.add(metricCMCheckBoxMenuItem);
+        metricCMCheckBoxMenuItem.addActionListener((ActionEvent event) -> {
+            getLayoutEditorToolBarPanel().setLocationFormat(LocationFormat.eMETRIC_CM);
+            selectLocationFormatCheckBoxMenuItem();
+            redrawPanel();
+        });
+
+        // english feet/inches/16th's
+        locationMenu.add(englishFeetInchesCheckBoxMenuItem);
+        englishFeetInchesCheckBoxMenuItem.addActionListener((ActionEvent event) -> {
+            getLayoutEditorToolBarPanel().setLocationFormat(LocationFormat.eENGLISH_FEET_INCHES);
+            selectLocationFormatCheckBoxMenuItem();
+            redrawPanel();
+        });
+        selectLocationFormatCheckBoxMenuItem();
+
+        //
         // grid menu
         //
         JMenu gridMenu = new JMenu(Bundle.getMessage("GridMenuTitle")); // used for Grid SubMenu
@@ -1362,6 +1409,12 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         turnoutDrawUnselectedLegCheckBoxMenuItem.setSelected(turnoutDrawUnselectedLeg);
 
         return optionMenu;
+    }
+
+    private void selectLocationFormatCheckBoxMenuItem() {
+        pixelsCheckBoxMenuItem.setSelected(getLayoutEditorToolBarPanel().getLocationFormat() == LocationFormat.ePIXELS);
+        metricCMCheckBoxMenuItem.setSelected(getLayoutEditorToolBarPanel().getLocationFormat() == LocationFormat.eMETRIC_CM);
+        englishFeetInchesCheckBoxMenuItem.setSelected(getLayoutEditorToolBarPanel().getLocationFormat() == LocationFormat.eENGLISH_FEET_INCHES);
     }
 
     /*============================================*\

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -1073,7 +1073,10 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             optionMenu.add(locationItem);
             locationItem.addActionListener((ActionEvent event) -> {
                 setCurrentPositionAndSize();
-                log.debug("Bounds:{}, {}, {}, {}, {}, {}", gContext.getUpperLeftX(), gContext.getUpperLeftY(), gContext.getWindowWidth(), gContext.getWindowHeight(), gContext.getLayoutWidth(), gContext.getLayoutHeight());
+                log.debug("Bounds:{}, {}, {}, {}, {}, {}",
+                        gContext.getUpperLeftX(), gContext.getUpperLeftY(),
+                        gContext.getWindowWidth(), gContext.getWindowHeight(),
+                        gContext.getLayoutWidth(), gContext.getLayoutHeight());
             });
         }
 
@@ -1831,8 +1834,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             yLoc = (int) (mouseLoc.getY() / theZoom);
             dLoc = new Point2D.Double(xLoc, yLoc);
 
-            leToolBarPanel.xLabel.setText(Integer.toString(xLoc));
-            leToolBarPanel.yLabel.setText(Integer.toString(yLoc));
+            leToolBarPanel.setLocationText(dLoc);
         }
         adjustClip();
     }
@@ -2780,8 +2782,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         if (isEditable()) {
             boolean prevSelectionActive = selectionActive;
             selectionActive = false;
-            leToolBarPanel.xLabel.setText(Integer.toString(xLoc));
-            leToolBarPanel.yLabel.setText(Integer.toString(yLoc));
+            leToolBarPanel.setLocationText(dLoc);
 
             if (event.isPopupTrigger()) {
                 if (isMetaDown(event) || event.isAltDown()) {
@@ -3304,8 +3305,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         snapToGridInvert = event.isAltDown();
 
         if (isEditable()) {
-            leToolBarPanel.xLabel.setText(Integer.toString(xLoc));
-            leToolBarPanel.yLabel.setText(Integer.toString(yLoc));
+            leToolBarPanel.setLocationText(dLoc);
 
             // released the mouse with shift down... see what we're adding
             if (!event.isPopupTrigger() && !isMetaDown(event) && event.isShiftDown()) {
@@ -3317,8 +3317,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                     currentPoint = MathUtil.granulize(currentPoint, gContext.getGridSize());
                     xLoc = (int) currentPoint.getX();
                     yLoc = (int) currentPoint.getY();
-                    leToolBarPanel.xLabel.setText(Integer.toString(xLoc));
-                    leToolBarPanel.yLabel.setText(Integer.toString(yLoc));
+                    leToolBarPanel.setLocationText(currentPoint);
                 }
 
                 if (leToolBarPanel.turnoutRHButton.isSelected()) {
@@ -4502,8 +4501,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         snapToGridInvert = event.isAltDown();
 
         if (isEditable()) {
-            leToolBarPanel.xLabel.setText(Integer.toString(xLoc));
-            leToolBarPanel.yLabel.setText(Integer.toString(yLoc));
+            leToolBarPanel.setLocationText(dLoc);
         }
         List<Positionable> selections = getSelectedItems(event);
         Positionable selection = null;
@@ -4555,8 +4553,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
 
         // process this mouse dragged event
         if (isEditable()) {
-            leToolBarPanel.xLabel.setText(Integer.toString(xLoc));
-            leToolBarPanel.yLabel.setText(Integer.toString(yLoc));
+            leToolBarPanel.setLocationText(dLoc);
         }
         currentPoint = MathUtil.add(dLoc, startDelta);
         // don't allow negative placement, objects could become unreachable
@@ -4579,8 +4576,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                     currentPoint = MathUtil.granulize(currentPoint, gContext.getGridSize());
                     xLoc = (int) currentPoint.getX();
                     yLoc = (int) currentPoint.getY();
-                    leToolBarPanel.xLabel.setText(Integer.toString(xLoc));
-                    leToolBarPanel.yLabel.setText(Integer.toString(yLoc));
+                    leToolBarPanel.setLocationText(currentPoint);
                 }
 
                 if ((_positionableSelection.size() > 0)

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -156,6 +156,10 @@ OccupancySensorToolTip = Enter name of occupancy sensor for this block; no entry
 BlockContentsLabel = Block Contents
 Track = Track
 Location = Location
+Pixels = Pixels (220)
+MetricCM = Metric (13.75 cm)
+EnglishFeetInches = English (1'' 1 3/4\")
+
 Nodes = Track Nodes
 EditIcon = Change Icon
 EditSensorIcons = Change Sensor Icons

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -155,10 +155,11 @@ BlockSensorName = Block Sensor Name
 OccupancySensorToolTip = Enter name of occupancy sensor for this block; no entry means don't change.
 BlockContentsLabel = Block Contents
 Track = Track
+LocationMenuTitle = ToolBar Location Format
 Location = Location
-Pixels = Pixels (220)
-MetricCM = Metric (13.75 cm)
-EnglishFeetInches = English (1'' 1 3/4\")
+Pixels = Pixels
+MetricCM = Metric CM's
+EnglishFeetInches = English ft/in/16th's
 
 Nodes = Track Nodes
 EditIcon = Change Icon

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorToolBarPanel.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorToolBarPanel.java
@@ -579,6 +579,7 @@ public class LayoutEditorToolBarPanel extends JPanel {
     public void setLocationFormat(LocationFormat locationFormat) {
         if (this.locationFormat != locationFormat) {
             switch (locationFormat) {
+                default:
                 case ePIXELS: {
                     Dimension coordSize = new JLabel("10000").getPreferredSize();
                     xLabel.setPreferredSize(coordSize);

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorToolBarPanel.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorToolBarPanel.java
@@ -411,6 +411,18 @@ public class LayoutEditorToolBarPanel extends JPanel {
                     locationPopupMenu.show(locationPanel, me.getX(), me.getY());
                 }
             }
+            @Override
+            public void mouseReleased(MouseEvent me) {
+                if (me.isPopupTrigger()) {
+                    locationPopupMenu.show(locationPanel, me.getX(), me.getY());
+                }
+            }
+            @Override
+            public void mouseClicked(MouseEvent me) {
+                if (me.isPopupTrigger()) {
+                    locationPopupMenu.show(locationPanel, me.getX(), me.getY());
+                }
+            }
         });
 
         // second row of edit tool bar items

--- a/java/src/jmri/util/MathUtil.java
+++ b/java/src/jmri/util/MathUtil.java
@@ -44,6 +44,19 @@ public final class MathUtil {
     }
 
     /**
+     * @param a the first number
+     * @param b the second number
+     * @return the greatest common divisor of a and b
+     */
+    public static int gcd(int a, int b) {
+        int result = b;
+        if (a != 0) {
+            result = gcd(b % a, a);
+        }
+        return result;
+    }
+
+    /**
      * Convert Point to Point2D.
      *
      * @param p the Point

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -895,7 +895,7 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         JMenuOperator jmo = new JMenuOperator(jfo, Bundle.getMessage("MenuOptions"));
         Assert.assertNotNull("Options Menu Exists", jmo);
-        Assert.assertEquals("Menu Item Count", 17, jmo.getItemCount());
+        Assert.assertEquals("Menu Item Count", 18, jmo.getItemCount());
     }
 
     @Test


### PR DESCRIPTION
Contextual-(right- or control-)click on the coordinates in the toolbar to popup a menu that allows you to change between pixel (default), metric (cm) or English (feet, inches) formats.
Note: Current also changes grid intervals (metric: 10/10, english 12/16)… but doesn't have to.
TODO: add code to save/load format preferences.