### PR TITLE
Fix URL references for screenshots

### DIFF
--- a/help/en/html/hardware/loconet/LocoIO.shtml
+++ b/help/en/html/hardware/loconet/LocoIO.shtml
@@ -100,35 +100,35 @@
         <li>Looking at your hardware, select the correct PIC programmer firmware version from the list. It often is
           labeled on the biggest IC chip. If your version is not in the list, select the first higher one. In this
           example we pick "LocoIO v1.53":<br>
-          <a href="images/LocoIODefinition/Create1_New.png"><img
-          src="images/LocoIODefinition/Create1_New.png"
+          <a href="images/LocoIoDefinition/Create1_New.png"><img
+          src="images/LocoIoDefinition/Create1_New.png"
           width="370" height="235" alt="Screenshot LocoIO Config step 1"></a>
         </li>
         <li>On the right of the Create New Loco pane, enter a name for this module, eg. "LocoIO 81/1 rev 1.53", and
         fix the ultra-long decoder DCC address suggested. We chose 81, the factory default board address:<br>
-        <a href="images/LocoIODefinition/Create2_Correct.png"><img
-        src="images/LocoIODefinition/Create2_Correct.png"
+        <a href="images/LocoIoDefinition/Create2_Correct.png"><img
+        src="images/LocoIoDefinition/Create2_Correct.png"
         width="370" height="235" alt="Screenshot LocoIO Config step 2"></a><br>
         Click [Save] and close the Create New Loco pane.</li>
 
         <li>You will see the new entry appear in the Roster.<br>
         Select it, make sure to select Programming on Main, and click [Program]:<br>
-        <a href="images/LocoIODefinition/Create3_POM.png"><img
-        src="images/LocoIODefinition/Create3_POM.png"
+        <a href="images/LocoIoDefinition/Create3_POM.png"><img
+        src="images/LocoIoDefinition/Create3_POM.png"
         width="294" height="230" alt="Screenshot LocoIO Config step 3"></a>
         </li>
 
         <li>On the Basic tab, enter the actual LocoIO Main Address and Sub-address, "81" and "1" respectively in our
         example:<br>
-        <a href="images/LocoIODefinition/Create4_CheckAddress.png"><img
-        src="images/LocoIODefinition/Create4_CheckAddress.png"
+        <a href="images/LocoIoDefinition/Create4_CheckAddress.png"><img
+        src="images/LocoIoDefinition/Create4_CheckAddress.png"
         width="343" height="261" alt="Screenshot LocoIO Config step 4"></a>
         </li>
 
         <li>Next, go to the Roster Entry pane, click [Save to Roster] and close &amp; reopen the LocoIO
           definition from the Roster to update the actual decoder address:<br>
-          <a href="images/LocoIODefinition/Create5_SaveClose.png"><img
-          src="images/LocoIODefinition/Create5_SaveClose.png"
+          <a href="images/LocoIoDefinition/Create5_SaveClose.png"><img
+          src="images/LocoIoDefinition/Create5_SaveClose.png"
           width="343" height="261" alt="Screenshot LocoIO Config step 5"></a>
         </li>
 
@@ -143,26 +143,26 @@
         </li>
 
         <li><br>
-          <a href="images/LocoIODefinition/Create6_Locotab.png"><img
-                  src="images/LocoIODefinition/Create6_Locotab.png"
+          <a href="images/LocoIoDefinition/Create6_Locotab.png"><img
+                  src="images/LocoIoDefinition/Create6_Locotab.png"
                   width="343" height="262" alt="Screenshot LocoIO Config step 6"></a>
         </li>
 
         <li><br>
-          <a href="images/LocoIODefinition/Create7_LocotabRead.png"><img
-                  src="images/LocoIODefinition/Create7_LocotabRead.png"
+          <a href="images/LocoIoDefinition/Create7_LocotabRead.png"><img
+                  src="images/LocoIoDefinition/Create7_LocotabRead.png"
                   width="343" height="262" alt="Screenshot LocoIO Config step 7"></a>
         </li>
 
         <li><br>
-          <a href="images/LocoIODefinition/Create8a_InitialPortstab.png"><img
-                  src="images/LocoIODefinition/Create8a_InitialPortstab.png"
+          <a href="images/LocoIoDefinition/Create8a_InitialPortstab.png"><img
+                  src="images/LocoIoDefinition/Create8a_InitialPortstab.png"
                   width="579" height="199" alt="Screenshot LocoIO Config step 8a"></a>
         </li>
 
         <li><br>
-          <a href="images/LocoIODefinition/Create8b_After1stReadAll.png"><img
-                  src="images/LocoIODefinition/Create8b_After1stReadAll.png"
+          <a href="images/LocoIoDefinition/Create8b_After1stReadAll.png"><img
+                  src="images/LocoIoDefinition/Create8b_After1stReadAll.png"
                   width="592" height="442" alt="Screenshot LocoIO Config step 8b"></a>
         </li>
 
@@ -170,49 +170,49 @@
           DecoderPro can't figure out some choices, so you will have to assist at this point for those ports that still
           show "Port not in Use". At least you will notice the numbers already changed.
           For example on Port 4 the number in the Config field reads "95":<br>
-          <a href="images/LocoIODefinition/Create9a_Port4Combo.png"><img
-          src="images/LocoIODefinition/Create9a_Port4Combo.png"
+          <a href="images/LocoIoDefinition/Create9a_Port4Combo.png"><img
+          src="images/LocoIoDefinition/Create9a_Port4Combo.png"
           width="405" height="130" alt="Screenshot LocoIO Config step 9a"></a>
         </li>
 
         <li>Turn to the Cheat Sheet tab reference, in the Config column look up "95". It's is a Block Detector -
           Active High:<br>
-          <a href="images/LocoIODefinition/Create9b_CheatSheet.png"><img
-          src="images/LocoIODefinition/Create9b_CheatSheet.png"
+          <a href="images/LocoIoDefinition/Create9b_CheatSheet.png"><img
+          src="images/LocoIoDefinition/Create9b_CheatSheet.png"
           width="274" height="195" alt="Screenshot LocoIO Config step 9b"></a>
         </li>
 
         <li>Return to the Ports tab and in the Port 4 Mode combo, pick "Block Detector - Active High" (either odd or even
           address, will correct automatically later on):<br>
-          <a href="images/LocoIODefinition/Create9c_Port4ComboOpen.png"><img
-          src="images/LocoIODefinition/Create9c_Port4ComboOpen.png"
+          <a href="images/LocoIoDefinition/Create9c_Port4ComboOpen.png"><img
+          src="images/LocoIoDefinition/Create9c_Port4ComboOpen.png"
           width="425" height="130" alt="Screenshot LocoIO Config step 9c"></a>
         </li>
 
         <li>After clicking [Read changes on sheet]:<br>
-          <a href="images/LocoIODefinition/Create9d_Port4ModeSet.png"><img
-          src="images/LocoIODefinition/Create9d_Port4ModeSet.png"
+          <a href="images/LocoIoDefinition/Create9d_Port4ModeSet.png"><img
+          src="images/LocoIoDefinition/Create9d_Port4ModeSet.png"
           width="427" height="126" alt="Screenshot LocoIO Config step 9d"></a>
         </li>
 
         <li>After fixing all mode combo's that are not "0", once again click [Read full sheet] to update all fields
           and inspect the LocoIO configuration. Scroll down to see more ports:<br>
-          <a href="images/LocoIODefinition/Create10_Ready.png"><img
-          src="images/LocoIODefinition/Create10_Ready.png"
+          <a href="images/LocoIoDefinition/Create10_Ready.png"><img
+          src="images/LocoIoDefinition/Create10_Ready.png"
           width="564" height="442" alt="Screenshot LocoIO Config step 10"></a>
         </li>
 
         <li>Inputs allow setting up to two more actions carried out when the pin goes to ON. You can set the action
           type and the address on the right hand side of the LocoIO programmer pane as shown here. See the HDL
           documentation for examples and further information:<br>
-          <a href="images/LocoIODefinition/Create11_Opcode.png"><img
-          src="images/LocoIODefinition/Create11_Opcode.png"
+          <a href="images/LocoIoDefinition/Create11_Opcode.png"><img
+          src="images/LocoIoDefinition/Create11_Opcode.png"
           width="275" height="116" alt="Screenshot LocoIO Opcode Config"></a>
         </li>
 
         <li>A LocoBooster module will show several special options:<br>
-          <a href="images/LocoIODefinition/Create12_Lbooster.png"><img
-          src="images/LocoIODefinition/Create12_Lbooster.png"
+          <a href="images/LocoIoDefinition/Create12_Lbooster.png"><img
+          src="images/LocoIoDefinition/Create12_Lbooster.png"
           width="400" height="541" alt="Screenshot LocoBooster Config pane"></a>
         </li>
 
@@ -228,7 +228,7 @@
 
       <a name="second" id="second"></a>
       <h2>LocoIO Programmer 2 <strong>(no longer supported)</strong></h2>
-      <a href="images/LocoIo_v2.png"><img src="images/LocoIo_v2.png"
+      <a href="images/LocoIO_v2.png"><img src="images/LocoIO_v2.png"
       width="397" height="305" alt="Screenshot of LocoIO Configuration Tool
       v2 (deprecated)"></a>
       <p><em>The following entry is only shown as reference for JMRI


### PR DESCRIPTION
Fixes capitalization errors in screenshot URL references - this just matches the reference capitalization to the file path, it doesn't change file names to follow the 'all lowercase' rule for file names.