### PR TITLE
Fix NPE new-format splitVal with default value.

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -22,8 +22,9 @@ import org.slf4j.LoggerFactory;
  * <br>
  * The {@code mask} attribute represents the part of the value that's present in
  * each CV; higher-order bits are loaded to subsequent CVs.<br>
- * It is possible to assign a specific mask for each CV by provising a space separated list of masks,
- * starting with the lowest, and matching the order of CV's
+ * It is possible to assign a specific mask for each CV by providing a space
+ * separated list of masks, starting with the lowest, and matching the order of
+ * CVs
  * <br><br>
  * The original use was for addresses of stationary (accessory) decoders.
  * <br>
@@ -230,7 +231,8 @@ public class SplitVariableValue extends VariableValue
      * Access a specific mask, used in tests
      *
      * @param i index of CV in variable
-     * @return a single mask as string in the form XXXXVVVV, or empty string if index out of bounds
+     * @return a single mask as string in the form XXXXVVVV, or empty string if
+     *         index out of bounds
      */
     protected String getMask(int i) {
         if (i < cvCount) {
@@ -471,15 +473,13 @@ public class SplitVariableValue extends VariableValue
 
     /**
      * Set value from a String value.
+     *
+     * @param value a string representing the Long value to be set
      */
     @Override
     public void setValue(String value) {
-        try {
-            long val = Long.parseUnsignedLong(value);
-            setLongValue(val);
-        } catch (NumberFormatException e) {
-            log.debug("skipping set of non-long value \"{}\"", value);
-        }
+        long val = Long.parseUnsignedLong(value);
+        setLongValue(val);
     }
 
     @Override

--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -376,7 +376,15 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
 
         // set to default value if specified (CV load may later override this)
         if (setDefaultValue(e, v)) {
-            _cvModel.getCvByNumber(CV).setState(VariableValue.FROMFILE); // correct for transition to "edited"
+            // need to correct state of associated CV(s) & handle a possible CV List
+            List<String> cvList = CvUtil.expandCvList(CV);  // see if CV is in list format
+            if (cvList.isEmpty()) {
+                cvList.add(CV);  // it's an ordinary CV so add it as such
+            }
+            for (String theCV : cvList) {
+                log.debug("Setting CV={} of '{}'to {}", theCV, CV, VariableValue.stateNameFromValue(VariableValue.FROMFILE));
+                _cvModel.getCvByNumber(theCV).setState(VariableValue.FROMFILE); // correct for transition to "edited"
+            }
         }
     }
 
@@ -415,7 +423,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         boolean set = false;
         if ((a = e.getAttribute("default")) != null) {
             String val = a.getValue();
-            variable.setIntValue(Integer.parseInt(val));
+            variable.setValue(val);
             set = true;
         }
         // check for matching child
@@ -423,7 +431,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         for (Element defaultItem : elements) {
             if (_df != null && DecoderFile.isIncluded(defaultItem, _df.getProductID(), _df.getModel(), _df.getFamily(), "", "")) {
                 log.debug("element included by productID={} model={} family={}", _df.getProductID(), _df.getModel(), _df.getFamily());
-                variable.setIntValue(Integer.parseInt(defaultItem.getAttribute("default").getValue()));
+                variable.setValue(defaultItem.getAttribute("default").getValue());
                 return true;
             }
         }

--- a/java/src/jmri/jmrit/symbolicprog/VariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableValue.java
@@ -133,18 +133,21 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
      * Set value from a String value.
      * <p>
      * The current implementation is a stand-in. Note that e.g. Speed Tables
-     * don't use a single Int, so will just be skipped. The solution to that is
-     * to overload this in complicated variable types.
+     * don't use a single Int. The solution to that is to override this in
+     * complicated variable types.
+     * <p>
+     * Since variable values can now be non-integer (text, long, hex etc.) we
+     * need a universally-usable method for setting values, such as default
+     * values in decoder definitions.
+     * <p>
+     * We don't want to have this method failing silently. Subclasses that need
+     * silent failure will need to override this method.
      *
      * @param value the String value to set
      */
     public void setValue(String value) {
-        try {
-            int val = Integer.parseInt(value);
-            setIntValue(val);
-        } catch (NumberFormatException e) {
-            log.debug("skipping set of non-integer value \"{}\"", value);
-        }
+        int val = Integer.parseInt(value);
+        setIntValue(val);
     }
 
     /**
@@ -420,8 +423,8 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
     }
 
     /**
-     * Extending classes should override to return a single mask in case
-     * a list of masks was provided and the class only uses one.
+     * Extending classes should override to return a single mask in case a list
+     * of masks was provided and the class only uses one.
      *
      * @return the CV bitmask in the form XXXVVVXX
      */
@@ -520,7 +523,7 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
     public boolean isToRead() {
         if (_cvMap.get(getCvNum()) != null) { // skip displayed variables without a CV
             return _cvMap.get(getCvNum()).isToRead();
-            }
+        }
         return false;
     }
 
@@ -608,8 +611,9 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
     private boolean _busy = false;
 
     /**
-     * In case a set of masks was provided, at end of Ctor pick the first mask for
-     * implementing classes that use just one. Call not required if mask is ignored.
+     * In case a set of masks was provided, at end of Ctor pick the first mask
+     * for implementing classes that use just one. Call not required if mask is
+     * ignored.
      */
     protected void simplifyMask() {
         if (_mask != null && _mask.contains(" ")) {

--- a/java/test/jmri/jmrit/symbolicprog/VariableTableModelTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/VariableTableModelTest.java
@@ -204,6 +204,119 @@ public class VariableTableModelTest {
 
     }
 
+    // Check creating a splitVal variable with no default value
+    @Test
+    public void testVarSplitValnoDefault() {
+        String[] args = {"CV", "Name"};
+        VariableTableModel t = new VariableTableModel(null, args, new CvTableModel(null, p));
+
+        // create a JDOM tree with just some elements
+        Element root = new Element("decoder-config");
+        Document doc = new Document(root);
+        doc.setDocType(new DocType("decoder-config", "decoder-config.dtd"));
+
+        // add some elements
+        Element el0;
+        root.addContent(new Element("decoder") // the sites information here lists all relevant
+                .addContent(new Element("variables")
+                        .addContent(el0 = new Element("variable")
+                                .setAttribute("CV", "1,9")
+                                .setAttribute("label", "SplitVal no default")
+                                .addContent(new Element("splitVal")
+                                )
+                        )
+                ) // variables element
+        ) // decoder element
+                ; // end of adding contents
+
+        // and test reading this
+        t.setRow(0, el0);
+
+        // check finding
+        Assert.assertEquals("length of variable list ", 1, t.getRowCount());
+        Assert.assertEquals("name of 1st variable ", "SplitVal no default", t.getLabel(0));
+        Assert.assertEquals("find variable by name ", 0, t.findVarIndex("SplitVal no default"));
+        Assert.assertEquals("find nonexistant variable ", -1, t.findVarIndex("not there, eh?"));
+
+    }
+
+    // Check creating a splitVal variable with default value
+    @Test
+    public void testVarSplitValwithDefault() {
+        String[] args = {"CV", "Name"};
+        VariableTableModel t = new VariableTableModel(null, args, new CvTableModel(null, p));
+
+        // create a JDOM tree with just some elements
+        Element root = new Element("decoder-config");
+        Document doc = new Document(root);
+        doc.setDocType(new DocType("decoder-config", "decoder-config.dtd"));
+
+        // add some elements
+        Element el0;
+        root.addContent(new Element("decoder") // the sites information here lists all relevant
+                .addContent(new Element("variables")
+                        .addContent(el0 = new Element("variable")
+                                .setAttribute("CV", "1,9")
+                                .setAttribute("label", "SplitVal with default")
+                                .setAttribute("default", "32700")
+                                .addContent(new Element("splitVal")
+                                )
+                        )
+                ) // variables element
+        ) // decoder element
+                ; // end of adding contents
+
+        // and test reading this
+        t.setRow(0, el0);
+
+        // check finding
+        Assert.assertEquals("length of variable list ", 1, t.getRowCount());
+        Assert.assertEquals("name of 1st variable ", "SplitVal with default", t.getLabel(0));
+        Assert.assertEquals("find variable by name ", 0, t.findVarIndex("SplitVal with default"));
+        SplitVariableValue sv = (SplitVariableValue) t.getVariable(t.findVarIndex("SplitVal with default"));
+        Assert.assertEquals("find value of variable ", 32700, sv.getLongValue());
+        
+
+    }
+
+    // Check creating a splitVal variable with big default value
+    @Test
+    public void testVarSplitValwithBigDefault() {
+        String[] args = {"CV", "Name"};
+        VariableTableModel t = new VariableTableModel(null, args, new CvTableModel(null, p));
+
+        // create a JDOM tree with just some elements
+        Element root = new Element("decoder-config");
+        Document doc = new Document(root);
+        doc.setDocType(new DocType("decoder-config", "decoder-config.dtd"));
+
+        // add some elements
+        Element el0;
+        root.addContent(new Element("decoder") // the sites information here lists all relevant
+                .addContent(new Element("variables")
+                        .addContent(el0 = new Element("variable")
+                                .setAttribute("CV", "1:8")
+                                .setAttribute("label", "SplitVal with big default")
+                                .setAttribute("default", "35184372088832")
+                                .addContent(new Element("splitVal")
+                                )
+                        )
+                ) // variables element
+        ) // decoder element
+                ; // end of adding contents
+
+        // and test reading this
+        t.setRow(0, el0);
+
+        // check finding
+        Assert.assertEquals("length of variable list ", 1, t.getRowCount());
+        Assert.assertEquals("name of 1st variable ", "SplitVal with big default", t.getLabel(0));
+        Assert.assertEquals("find variable by name ", 0, t.findVarIndex("SplitVal with big default"));
+        SplitVariableValue sv = (SplitVariableValue) t.getVariable(t.findVarIndex("SplitVal with big default"));
+        Assert.assertEquals("find value of variable ", 35184372088832L, sv.getLongValue());
+
+    }
+
     // Check creating an enumvar with various groupings
     @Test
     public void testVarEnumVar() {


### PR DESCRIPTION
Fixes an NPE when trying to load any decoder definition containing the combination of a new-format splitVal with a specified default value.

Also fixes loading of a default value for variables that can have non-integer values (e.g. text, Long).

As an example, the attached updated definition file displayed the problem with current master:
[ESU_SwitchPilot.xml.zip](https://github.com/JMRI/JMRI/files/5557468/ESU_SwitchPilot.xml.zip)