### PR TITLE
MQTT update

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -118,6 +118,12 @@
                 <li>Added support for creating ranges of Turnouts and Lights.<br>
                 Sensor, Turnout and Light Address ranges do not have to be fully numeric,
                 and will be incremented using the final number in an address.</li>
+                <li>Added support for changing the default quality of service and 
+                retention policy for transmissions.  See the 
+                <a href="http://jmri.org/jython/SetMqttOptions.py">jython/SetMqttOptions.py</a>
+                script for an example.</li>
+                <li>Fix a nasty threading bug in the MQTT Light support that can 
+                cause a JMRI lockup on the first access after adding a Light.</li>
             </ul>
 
         <h4>MRC</h4>

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -29,6 +29,9 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
     private final static String PROTOCOL = "tcp://";
     private final static String DEFAULT_BASETOPIC = Bundle.getMessage("TopicBase");
     
+    public boolean retained = true;  // public for script access
+    public int      qosflag = 2;     // public for script access
+    
     /**
      * Otherwise known as "Channel", this is prepended to the 
      * topic for all JMRI inward and outward communications.

--- a/java/src/jmri/jmrix/mqtt/MqttLight.java
+++ b/java/src/jmri/jmrix/mqtt/MqttLight.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
 /**
  * MQTT implementation of the Light interface.
  *
- * @author Bob Jacobsen Copyright (C) 2001, 2008
+ * @author Bob Jacobsen Copyright (C) 2001, 2008, 2020
  * @author Paul Bender Copyright (C) 2010
  * @author Fredrik Elestedt  Copyright (C) 2020
  */
@@ -78,7 +78,8 @@ public class MqttLight extends AbstractLight implements MqttEventListener {
     // Handle a request to change state by sending a formatted packet
     // to the server.
     @Override
-    protected synchronized void doNewState(int oldState, int newState) {
+    protected void doNewState(int oldState, int newState) {
+        log.debug("doNewState with old state {} new state {}", oldState, newState);
         if (oldState == newState) {
             return; //no change, just quit.
         }  // sort out states
@@ -103,7 +104,9 @@ public class MqttLight extends AbstractLight implements MqttEventListener {
     }
 
     private void sendMessage(String c) {
-        mqttAdapter.publish(this.sendTopic, c.getBytes());
+        jmri.util.ThreadingUtil.runOnLayoutEventually(() -> {
+            mqttAdapter.publish(this.sendTopic, c.getBytes());
+        });
     }
 
     @Override

--- a/java/test/jmri/jmrix/mqtt/MqttLightTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttLightTest.java
@@ -50,12 +50,19 @@ public class MqttLightTest extends AbstractLightTestBase {
        
         t.setCommandedState(Light.ON);
         
-        Assert.assertEquals("topic", "track/light/2", saveTopic);
+        JUnitUtil.waitFor( ()->{
+            return "track/light/2".equals(saveTopic);
+        }, "topic check");
         Assert.assertEquals("topic", "ON", new String(savePayload));
         
+        saveTopic = null;
+        savePayload = null;
+
         t.setCommandedState(Light.OFF);
         
-        Assert.assertEquals("topic", "track/light/2", saveTopic);
+        JUnitUtil.waitFor( ()->{
+            return "track/light/2".equals(saveTopic);
+        }, "topic check");
         Assert.assertEquals("topic", "OFF", new String(savePayload));
         
     }
@@ -72,6 +79,9 @@ public class MqttLightTest extends AbstractLightTestBase {
     
     @Override
     public void checkOnMsgSent() {
+        JUnitUtil.waitFor( ()->{
+            return "track/light/2".equals(saveTopic);
+        }, "topic check");
         Assert.assertEquals("topic", "track/light/2", saveTopic);
         Assert.assertEquals("topic", "ON", new String(savePayload));
     }

--- a/jython/ReceiveMqttMessage.py
+++ b/jython/ReceiveMqttMessage.py
@@ -10,7 +10,7 @@ import jmri
 import java
 
 # Find the MqttAdapter
-mqqtAdapter = jmri.InstanceManager.getDefault( jmri.jmrix.mqtt.MqttSystemConnectionMemo ).getMqttAdapter()
+mqttAdapter = jmri.InstanceManager.getDefault( jmri.jmrix.mqtt.MqttSystemConnectionMemo ).getMqttAdapter()
 
 # listener class
 class myMqttListener(jmri.jmrix.mqtt.MqttEventListener) :
@@ -20,5 +20,5 @@ class myMqttListener(jmri.jmrix.mqtt.MqttEventListener) :
     
 # register a topic
 topic = "jmri/test/topic"  # note this will be prefixed by configured channel, i.e. "/trains/"
-mqqtAdapter.subscribe(topic, myMqttListener())
+mqttAdapter.subscribe(topic, myMqttListener())
 

--- a/jython/SendMqttMessage.py
+++ b/jython/SendMqttMessage.py
@@ -10,12 +10,12 @@ import java
 from org.python.core.util import StringUtil
 
 # Find the MqttAdapter
-mqqtAdapter = jmri.InstanceManager.getDefault( jmri.jmrix.mqtt.MqttSystemConnectionMemo ).getMqttAdapter()
+mqttAdapter = jmri.InstanceManager.getDefault( jmri.jmrix.mqtt.MqttSystemConnectionMemo ).getMqttAdapter()
 
 # create content to send "/trains/jmri/test/topic message content"
 topic = "jmri/test/topic"  # note this will be prefixed by configured channel, i.e. "/trains/"
 payload = "message content"
 
 # send  
-mqqtAdapter.publish(topic, payload)
+mqttAdapter.publish(topic, payload)
 

--- a/jython/SetMqttOptions.py
+++ b/jython/SetMqttOptions.py
@@ -1,0 +1,17 @@
+# Example of how to set options in an MqttAdapter
+#
+# Author: Bob Jacobsen, copyright 2020
+
+import jmri
+import java
+from org.python.core.util import StringUtil
+
+# Find the MqttAdapter
+mqttAdapter = jmri.InstanceManager.getDefault( jmri.jmrix.mqtt.MqttSystemConnectionMemo ).getMqttAdapter()
+
+# set the retain option for transmissions (true is the JMRI default value)
+mqttAdapter.retain = true
+
+# set the Quality Of Service for transmissions (2 is the JMRI default value, 0-2 valid)
+mqttAdapter.qosflag = 2
+


### PR DESCRIPTION
 - Fix a threading issue that could lock up JMRI on the first access to a Light
 - Add ability to set QoS and retain option on transmissions from a script, along with sample script

plus fixed some script typos.