### PR TITLE
Update getThrottle() in jquery.jmri.js

### DIFF
--- a/web/js/jquery.jmri.js
+++ b/web/js/jquery.jmri.js
@@ -655,7 +655,7 @@
              */
             jmri.getThrottle = function (throttle) {
                 if (jmri.socket) {
-                    jmri.socket.send("throttle", { throttle: throttle, status: true });
+                    jmri.socket.send("throttle", throttle);
                     return true;
                 } else {
                     return false;


### PR DESCRIPTION
A couple of days ago, I asked on the Jmri users mailing list on how to request a throttle from JavaScript. After further investigation, it turned out that the backend code in Java had changed, which resulted in the frontend function getThrottle() doesn't work. This PR fixes this problem.

With this change, you can request a throttle from JavaScript using:
```
throttle = {"name": "Daniel", "address": 21};
result = jmri.getThrottle(throttle);
```
there "Daniel" is a name of the throttle used in the communication between the web client and JMRI.

To set the speed and direction, you can use:

```
throttleData = {"speed": Math.random(), "forward": (Math.random() > 0.5)};
jmri.setThrottle("Daniel", throttleData);
```
To listen on the throttle, you use:
```
jmri = $.JMRI({
    throttle: function(throttle, data) {
        console.log("Speed: ", data.speed);
        console.log("Forward: ", data.forward);
    },
});
```