### PR TITLE
commandStationTypes missing COMMAND_STATION_STANDALONE

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnNetworkPortController.java
+++ b/java/src/jmri/jmrix/loconet/LnNetworkPortController.java
@@ -29,6 +29,7 @@ public abstract class LnNetworkPortController extends jmri.jmrix.AbstractNetwork
     protected boolean mTranspondingAvailable = false;
 
     protected LnCommandStationType[] commandStationTypes = {
+        LnCommandStationType.COMMAND_STATION_STANDALONE,
         LnCommandStationType.COMMAND_STATION_DCS100,
         LnCommandStationType.COMMAND_STATION_DCS240,
         LnCommandStationType.COMMAND_STATION_DCS210,


### PR DESCRIPTION
According to [this](https://www.jmri.org/help/en/html/hardware/loconet/PR4.shtml) when connecting JMRI to a Digitrax PR4 that doesn't have a command station you should select the "Standalone LocoNet"… which isn't given as a option in the connection profile for Digitrax/LocoNet.
The fix was to add the COMMAND_STATION_STANDALONE emum to the commandStationTypes variable in <LnNetworkPortController.java>.