### PR TITLE
Add ZIMO model 177 Firmware 37 as per #9183.

### DIFF
--- a/xml/decoders/Zimo_Unified_software_v37_MX617.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX617.xml
@@ -30,7 +30,7 @@
   <!-- V 1 new file -->
   <decoder>
     <family name="Zimo Unified software (version 37+)" mfg="Zimo">
-      <model  model="MX617 version 37+" replacementModel="MX617 version 39+" replacementFamily="query:Zimo Unified software (version 39+)" lowVersionID="37" highVersionID="37" maxInputVolts="35V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="HO" numOuts="6" numFns="14" productID="197">
+      <model  model="MX617 version 37+" replacementModel="MX617 version 39+" replacementFamily="query:Zimo Unified software (version 39+)" lowVersionID="37" highVersionID="37" maxInputVolts="35V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="HO" numOuts="6" numFns="14" productID="177,197">
         <output name="1" label="Front Light">
           <label xml:lang="de">Lvor</label>
         </output>
@@ -51,7 +51,7 @@
         </output>
         <size length="13" width="9" height="2.5" units="mm"/>
       </model>
-      <model  model="MX617F version 37+" replacementModel="MX617F version 39+" replacementFamily="query:Zimo Unified software (version 39+)" lowVersionID="37" highVersionID="37" maxInputVolts="35V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="HO" numOuts="6" numFns="14" productID="197">
+      <model  model="MX617F version 37+" replacementModel="MX617F version 39+" replacementFamily="query:Zimo Unified software (version 39+)" lowVersionID="37" highVersionID="37" maxInputVolts="35V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="HO" numOuts="6" numFns="14" productID="177,197">
         <output name="1" label="Front Light">
           <label xml:lang="de">Lvor</label>
         </output>
@@ -72,7 +72,7 @@
         </output>
         <size length="13" width="9" height="2.5" units="mm"/>
       </model>
-      <model  model="MX617N version 37+" replacementModel="MX617N version 39+" replacementFamily="query:Zimo Unified software (version 39+)" lowVersionID="37" highVersionID="37" maxInputVolts="35V" maxMotorCurrent="0.7A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="HO" numOuts="6" numFns="14" productID="197">
+      <model  model="MX617N version 37+" replacementModel="MX617N version 39+" replacementFamily="query:Zimo Unified software (version 39+)" lowVersionID="37" highVersionID="37" maxInputVolts="35V" maxMotorCurrent="0.7A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="HO" numOuts="6" numFns="14" productID="177,197">
         <output name="1" label="Front Light">
           <label xml:lang="de">Lvor</label>
         </output>
@@ -93,7 +93,7 @@
         </output>
         <size length="13" width="9" height="2.5" units="mm"/>
       </model>
-      <model  model="MX617R version 37+" replacementModel="MX617R version 39+" replacementFamily="query:Zimo Unified software (version 39+)" lowVersionID="37" highVersionID="37" maxInputVolts="35V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="HO" numOuts="6" numFns="14" productID="197">
+      <model  model="MX617R version 37+" replacementModel="MX617R version 39+" replacementFamily="query:Zimo Unified software (version 39+)" lowVersionID="37" highVersionID="37" maxInputVolts="35V" maxMotorCurrent="0.8A, peak=1.5A" maxTotalCurrent="0.8A" formFactor="HO" numOuts="6" numFns="14" productID="177,197">
         <output name="1" label="Front Light">
           <label xml:lang="de">Lvor</label>
         </output>

--- a/xml/decoders/zimo/CV100-CV152version30.xml
+++ b/xml/decoders/zimo/CV100-CV152version30.xml
@@ -968,7 +968,7 @@
     <label xml:lang="cs">Metoda DC zastavení v závislosti na polaritě</label>
     <label xml:lang="de">polaritätsabhängige DC-Bremsabschnitte</label>
   </variable>
-  <variable CV="124" item="SUSI" mask="VXXXXXXX" default="0" minOut="6" exclude="195,197,228,226,232,235,247,MX689_v30">
+  <variable CV="124" item="SUSI" mask="VXXXXXXX" default="0" minOut="6" exclude="177,195,197,228,226,232,235,247,MX689_v30">
     <!-- value 0 => Susi,  value 1 => normal function outputs -->
     <enumVal>
       <enumChoice choice="SUSI Serial interface for sound board">

--- a/xml/decoders/zimo/CV158version32.xml
+++ b/xml/decoders/zimo/CV158version32.xml
@@ -19,7 +19,7 @@
     <label>RailCom speed reporting method</label>
     <label xml:lang="de">RailCom Geschwindigkeits-Rückmeldung</label>
   </variable>
-  <variable CV="158" item="Standing Sound on premature shutdown" mask="XXXXVXXX" default="0" exclude="130,195,197,199,211,218,240">
+  <variable CV="158" item="Standing Sound on premature shutdown" mask="XXXXVXXX" default="0" exclude="130,177,195,197,199,211,218,240">
     <enumVal>
       <enumChoice choice="Present" value="0">
         <choice>Present</choice>
@@ -39,7 +39,7 @@
     <label xml:lang="cs">Zvuk stání při předčasném vypnutí</label>
     <label xml:lang="de">Standgeräusch vorzeitig abbrechen</label>
   </variable>
-  <variable CV="158" item="Chuff rate at higher speed steps" mask="XXXVXXXX" default="0" exclude="130,195,197,199,211,218,240">
+  <variable CV="158" item="Chuff rate at higher speed steps" mask="XXXVXXXX" default="0" exclude="130,177,195,197,199,211,218,240">
     <enumVal>
       <enumChoice choice="Normal" value="0">
         <choice>Normal</choice>
@@ -59,7 +59,7 @@
     <label xml:lang="cs">Frekvence výfuků páry při vyšších rychlostech</label>
     <label xml:lang="de">&lt;html&gt;DAMPFschlag Häufigkeit steigt&lt;br&gt;beim Schnellfahren unterproportional&lt;/html&gt;</label>
   </variable>
-  <variable CV="158" item="Drop one speed step to lower turbocharger" mask="XXVXXXXX" default="0" exclude="130,195,197,199,211,218,240">
+  <variable CV="158" item="Drop one speed step to lower turbocharger" mask="XXVXXXXX" default="0" exclude="130,177,195,197,199,211,218,240">
     <enumVal>
       <enumChoice choice="Off (default)" value="0">
         <choice>Normal</choice>

--- a/xml/decoders/zimo/CV835.xml
+++ b/xml/decoders/zimo/CV835.xml
@@ -22,7 +22,7 @@
       <revremark>Initial for CV835 (FW 37)</revremark>
     </revision>
   </revhistory>
-  <variable CV="835" item="Quick Select Shift key" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="835" item="Quick Select Shift key" exclude="130,177,195,197,199,201,211,218,240">
     <decVal max="32"/>
     <label>Quick Select Shift key</label>
     <label xml:lang="de">Set+1 Taste erweitern</label>

--- a/xml/decoders/zimo/CVSwissMapping_v36.xml
+++ b/xml/decoders/zimo/CVSwissMapping_v36.xml
@@ -827,7 +827,7 @@
     <label xml:lang="cs">Švýcyrské přiřazení skupina 13 A2 vzad</label>
   </variable>
 
- <variable item="Swiss Mapping Group 14 F-key" CV="800" exclude="130,195,197,199,201,211,218,240">
+ <variable item="Swiss Mapping Group 14 F-key" CV="800" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-F0F28.xml"/>
     </enumVal>
@@ -835,7 +835,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 14 Tasto F</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 14 tlačítko F</label>
   </variable>
-  <variable item="Swiss Mapping Group 14 M-key" CV="801" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 14 M-key" CV="801" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-M-key_v34.xml"/>
     </enumVal>
@@ -843,7 +843,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 14 Tasto M</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 14 tlačítko M</label>
   </variable>
-  <variable item="Swiss Mapping Group 14 A1 Fw" CV="802" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 14 A1 Fw" CV="802" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -851,7 +851,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 14 A1 Avanti</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 14 A1 vpřed</label>
   </variable>
-  <variable item="Swiss Mapping Group 14 A2 Fw" CV="803" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 14 A2 Fw" CV="803" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -859,7 +859,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 14 A2 Avanti</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 14 A2 vpřed</label>
   </variable>
-  <variable item="Swiss Mapping Group 14 A1 Rw" CV="804" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 14 A1 Rw" CV="804" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -867,7 +867,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 14 A1 Retro</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 14 A1 vzad</label>
   </variable>
-  <variable item="Swiss Mapping Group 14 A2 Rw" CV="805" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 14 A2 Rw" CV="805" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -876,7 +876,7 @@
     <label xml:lang="cs">Švýcyrské přiřazení skupina 14 A2 vzad</label>
   </variable>
 
- <variable item="Swiss Mapping Group 15 F-key" CV="806" exclude="130,195,197,199,201,211,218,240">
+ <variable item="Swiss Mapping Group 15 F-key" CV="806" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-F0F28.xml"/>
     </enumVal>
@@ -884,7 +884,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 15 Tasto F</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 15 tlačítko F</label>
   </variable>
-  <variable item="Swiss Mapping Group 15 M-key" CV="807" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 15 M-key" CV="807" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-M-key_v34.xml"/>
     </enumVal>
@@ -892,7 +892,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 15 Tasto M</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 15 tlačítko M</label>
   </variable>
-  <variable item="Swiss Mapping Group 15 A1 Fw" CV="808" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 15 A1 Fw" CV="808" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -900,7 +900,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 15 A1 Avanti</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 15 A1 vpřed</label>
   </variable>
-  <variable item="Swiss Mapping Group 15 A2 Fw" CV="809" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 15 A2 Fw" CV="809" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -908,7 +908,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 15 A2 Avanti</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 15 A2 vpřed</label>
   </variable>
-  <variable item="Swiss Mapping Group 15 A1 Rw" CV="810" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 15 A1 Rw" CV="810" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -916,7 +916,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 15 A1 Retro</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 15 A1 vzad</label>
   </variable>
-  <variable item="Swiss Mapping Group 15 A2 Rw" CV="811" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 15 A2 Rw" CV="811" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -925,7 +925,7 @@
     <label xml:lang="cs">Švýcyrské přiřazení skupina 15 A2 vzad</label>
   </variable>
 
- <variable item="Swiss Mapping Group 16 F-key" CV="812" exclude="130,195,197,199,201,211,218,240">
+ <variable item="Swiss Mapping Group 16 F-key" CV="812" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-F0F28.xml"/>
     </enumVal>
@@ -933,7 +933,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 16 Tasto F</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 16 tlačítko F</label>
   </variable>
-  <variable item="Swiss Mapping Group 16 M-key" CV="813" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 16 M-key" CV="813" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-M-key_v34.xml"/>
     </enumVal>
@@ -941,7 +941,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 16 Tasto M</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 16 tlačítko M</label>
   </variable>
-  <variable item="Swiss Mapping Group 16 A1 Fw" CV="814" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 16 A1 Fw" CV="814" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -949,7 +949,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 16 A1 Avanti</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 16 A1 vpřed</label>
   </variable>
-  <variable item="Swiss Mapping Group 16 A2 Fw" CV="815" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 16 A2 Fw" CV="815" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -957,7 +957,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 16 A2 Avanti</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 16 A2 vpřed</label>
   </variable>
-  <variable item="Swiss Mapping Group 16 A1 Rw" CV="816" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 16 A1 Rw" CV="816" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -965,7 +965,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 16 A1 Retro</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 16 A1 vzad</label>
   </variable>
-  <variable item="Swiss Mapping Group 16 A2 Rw" CV="817" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 16 A2 Rw" CV="817" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -974,7 +974,7 @@
     <label xml:lang="cs">Švýcyrské přiřazení skupina 16 A2 vzad</label>
   </variable>
 
- <variable item="Swiss Mapping Group 17 F-key" CV="818" exclude="130,195,197,199,201,211,218,240">
+ <variable item="Swiss Mapping Group 17 F-key" CV="818" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-F0F28.xml"/>
     </enumVal>
@@ -982,7 +982,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 17 Tasto F</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 17 tlačítko F</label>
   </variable>
-  <variable item="Swiss Mapping Group 17 M-key" CV="819" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 17 M-key" CV="819" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-M-key_v34.xml"/>
     </enumVal>
@@ -990,7 +990,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 17 Tasto M</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 17 tlačítko M</label>
   </variable>
-  <variable item="Swiss Mapping Group 17 A1 Fw" CV="820" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 17 A1 Fw" CV="820" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -998,7 +998,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 17 A1 Avanti</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 17 A1 vpřed</label>
   </variable>
-  <variable item="Swiss Mapping Group 17 A2 Fw" CV="821" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 17 A2 Fw" CV="821" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -1006,7 +1006,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 17 A2 Avanti</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 17 A2 vpřed</label>
   </variable>
-  <variable item="Swiss Mapping Group 17 A1 Rw" CV="822" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 17 A1 Rw" CV="822" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>
@@ -1014,7 +1014,7 @@
     <label xml:lang="it">Mappatura Svizzera Gruppo 17 A1 Retro</label>
     <label xml:lang="cs">Švýcyrské přiřazení skupina 17 A1 vzad</label>
   </variable>
-  <variable item="Swiss Mapping Group 17 A2 Rw" CV="823" exclude="130,195,197,199,201,211,218,240">
+  <variable item="Swiss Mapping Group 17 A2 Rw" CV="823" exclude="130,177,195,197,199,201,211,218,240">
     <enumVal>
       <xi:include href="http://jmri.org/xml/decoders/zimo/Choice-FO1FO13.xml"/>
     </enumVal>

--- a/xml/decoders/zimo/CVs_version37.xml
+++ b/xml/decoders/zimo/CVs_version37.xml
@@ -188,35 +188,35 @@
     <label xml:lang="cs">Chování funkčního výstupu 8</label>
     <label xml:lang="de">FA8 Verhalten</label>
   </variable>
-  <variable CV="300" item="CV300-procedures" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="300" item="CV300-procedures" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <decVal/>
     <label>Pseudo programming 1</label>
     <label xml:lang="de">Pseudoprogrammierung 1</label>
       <tooltip>For various sound sample mappings.</tooltip>
       <tooltip xml:lang="de">Diverse Einstellungen um Soundsamples Funktionen zu zuordnen</tooltip>
   </variable>
-  <variable CV="301" item="CV301-procedures" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="301" item="CV301-procedures" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <decVal/>
     <label>Pseudo programming 2</label>
     <label xml:lang="de">Pseudoprogrammierung 2</label>
       <tooltip>For “Incremental Programming” of sound CV’s</tooltip>
       <tooltip xml:lang="de">"Inkrementelles Programmieren“ von Sound-CVs</tooltip>
   </variable>
-  <variable CV="302" item="Load test" default="75" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="302" item="Load test" default="75" exclude="130,177,195,197,199,201,211,218,240">
     <decVal min="75" max="76"/>
     <label>Load test</label>
     <label xml:lang="de">Messfahrt</label>
       <tooltip> </tooltip>
       <tooltip xml:lang="de">Messfahrt zur Bestimmung der Motor-Grundlast</tooltip>
   </variable>
-  <variable CV="307" item="Curve squeal reed" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="307" item="Curve squeal reed" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <decVal/>
     <label>Curve squeal reed input</label>
     <label xml:lang="de">Kurvenquietschen Reed Eingänge</label>
       <tooltip> </tooltip>
       <tooltip xml:lang="de">Welcher Reed-Eingang löst das Kurvenquietschen aus</tooltip>
   </variable>
-  <variable CV="308" item="Curve squeal key" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="308" item="Curve squeal key" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-F1-F28.xml"/>
     <label>Curve squeal key</label>
     <label xml:lang="de">Kurvenquietschen-Taste</label>
@@ -230,90 +230,90 @@
       <tooltip> </tooltip>
       <tooltip xml:lang="de">Die hier zugewiesene Funktionstaste löst einen Bremsvorgang nach der in CV#349 definierten Bremszeit aus</tooltip>
   </variable>
-  <variable CV="348" item="Switch-over" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="348" item="Switch-over" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <decVal max="4"/>
     <label>Switch-over parameters for driving solo</label>
     <label xml:lang="de">Verhaltensdefinition für Lokfahrt</label>
       <tooltip> </tooltip>
       <tooltip xml:lang="de">Auswahl der Maßnahmen, die bei Umschaltung auf Alleinfahrt getroffen werden sollen</tooltip>
   </variable>
-  <variable CV="349" item="Brake time" default="0" exclude="130,195,197,199,201,211,218">
+  <variable CV="349" item="Brake time" default="0" exclude="130,177,195,197,199,201,211,218">
     <decVal/>
     <label>Brake time</label>
     <label xml:lang="de">Bremszeit für Bremstaste</label>
       <tooltip> </tooltip>
       <tooltip xml:lang="de">Bremszeit nach Auslösen der Bremstaste</tooltip>
   </variable>
-  <variable CV="393" item="Ditch Light with Bell" mask="XXXXXXXV" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="393" item="Ditch Light with Bell" mask="XXXXXXXV" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>Ditch Light with Bell</label>
     <label xml:lang="de">Aktiviert Ditch Light wenn Glocke spielt</label>
   </variable>
-  <variable CV="393" item="Ditch Light with Horn" mask="XXXXXXVX" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="393" item="Ditch Light with Horn" mask="XXXXXXVX" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>Ditch Light with Horn</label>
     <label xml:lang="de">Aktiviert Ditch Light wenn Horn spielt</label>
   </variable>
-  <variable CV="393" item="ZIMO Konfig 5-2" mask="XXXXXVXX" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="393" item="ZIMO Konfig 5-2" mask="XXXXXVXX" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>ZIMO Konfig 5-2</label>
     <label xml:lang="de">Hochgeschwindigkeitsschaltwerk 1</label>
       <tooltip>Highspeed switchgear</tooltip>
       <tooltip xml:lang="de">Statt immer mit dem 1.Sample im Hochgeschwindigkeitsschaltwerk zu beginnen, ein Sample nach dem anderen verwenden.</tooltip>
   </variable>
-  <variable CV="393" item="ZIMO Konfig 5-3" mask="XXXXVXXX" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="393" item="ZIMO Konfig 5-3" mask="XXXXVXXX" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>ZIMO Konfig 5-3</label>
     <label xml:lang="de">Hochgeschwindigkeitsschaltwerk 2</label>
       <tooltip>Highspeed switchgear</tooltip>
       <tooltip xml:lang="de">Hochgeschwindigkeitsschaltwerk beim Hochschalten Anfangs- und Endteil des Samples überspringen (falls Loop Zeiger gesetzt sind).</tooltip>
   </variable>
-  <variable CV="393" item="ZIMO Konfig 5-4" mask="XXXVXXXX" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="393" item="ZIMO Konfig 5-4" mask="XXXVXXXX" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>ZIMO Konfig 5-4</label>
     <label xml:lang="de">Thyristor2 Tonhöhe nicht anheben</label>
   </variable>
-  <variable CV="393" item="SUSI as In" mask="XXVXXXXX" default="0" exclude="195,197,199">
+  <variable CV="393" item="SUSI as In" mask="XXVXXXXX" default="0" exclude="177,195,197,199">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>SUSI as In</label>
     <label xml:lang="de">SUSI als Schalteingang</label>
   </variable>
-  <variable CV="828" item="Steam Impact Stroke" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="828" item="Steam Impact Stroke" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <decVal/>
     <label>steam impact stroke for Set+1</label>
     <label xml:lang="de">Dampfschlagtakt für Set+1</label>
     <tooltip> </tooltip>
     <tooltip xml:lang="de">Dampfschlagtakt wie CV # 267 aber für Set+1</tooltip>
   </variable>
-  <variable CV="836" item="Motor Start Sound" mask="XXXXXXXV" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="836" item="Motor Start Sound" mask="XXXXXXXV" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>Motor Start Sound</label>
     <label xml:lang="de">Motor Start Sound</label>
       <tooltip>Don't start if Motor Sound not complete</tooltip>
       <tooltip xml:lang="de">Lok soll nicht Anfahren solange der Motor Start Sound nicht zu Ende gespielt hat.</tooltip>
   </variable>
-  <variable CV="837" item="Script Running 1" mask="XXXXXXXV" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="837" item="Script Running 1" mask="XXXXXXXV" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>Script 1 Running </label>
     <label xml:lang="de">Script Ablauf 1</label>
       <tooltip>Deactivate Script 1</tooltip>
       <tooltip xml:lang="de">Script 1 deaktivieren.</tooltip>
   </variable>
-  <variable CV="837" item="Script Running 2" mask="XXXXXXVX" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="837" item="Script Running 2" mask="XXXXXXVX" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>Script 2 Running</label>
     <label xml:lang="de">Script Ablauf 2</label>
       <tooltip>Deactivate Script 2</tooltip>
       <tooltip xml:lang="de">Script 2 deaktivieren.</tooltip>
   </variable>
-  <variable CV="837" item="Script Running 3" mask="XXXXXVXX" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="837" item="Script Running 3" mask="XXXXXVXX" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>Script 3 Running</label>
     <label xml:lang="de">Script Ablauf 3</label>
       <tooltip>Deactivate Script 3</tooltip>
       <tooltip xml:lang="de">Script 3 deaktivieren.</tooltip>
   </variable>
-  <variable CV="837" item="Script Running 4" mask="XXXXVXXX" default="0" exclude="130,195,197,199,201,211,218,240">
+  <variable CV="837" item="Script Running 4" mask="XXXXVXXX" default="0" exclude="130,177,195,197,199,201,211,218,240">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
     <label>Script 4 Running</label>
     <label xml:lang="de">Script Ablauf 4</label>


### PR DESCRIPTION
@chrisridd This should resolve your problem.

@Klb4ever I'd like your review of this. I've taken a catch-all approach and used a BBEdit grep to add 177 everywhere 197 is mentioned in exclude/include in the ZIMO fragment files. In most cases this will be superfluous and ignored. If you can see any likely problem areas, let me know. I judged that approach least likely to cause incorrect include/exclude.