### PR TITLE
Add 'Standalone LocoNet' option for PR4

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -94,7 +94,7 @@
                     interrogation mechanism now implements a minimum delay from
                     the last Sensor Report, Turnout Report or Interrogate Query
                     message before sending the next Interrogate Query message.</li>
-                <li>The "DS64 Configuration Tool" was updated:</li>
+                <li>The "DS64 Configuration Tool" was updated:
                     <ul>
                         <li>to correctly perform the "Factory Reset" operation
                             without encountering a "Java Exception";</li>
@@ -104,6 +104,9 @@
                             tab and maintain value coherency between the "OpSw Values" tab
                             and the "Basic Settings" tab.</li>
                     </ul>
+                </li>
+                <li>Allow selection of "Stand-alone LocoNet (with external LocoNet Data
+                    Termination!)" for Digitrax PR4.
             </ul>
 
         <h4>Maple</h4>

--- a/java/src/jmri/jmrix/loconet/pr4/PR4Adapter.java
+++ b/java/src/jmri/jmrix/loconet/pr4/PR4Adapter.java
@@ -58,7 +58,7 @@ public class PR4Adapter extends LocoBufferAdapter {
      * port. This overrides the version in loconet.locobuffer, but it has to
      * duplicate much of the functionality there, so the code is basically
      * copied.
-     * 
+     *
      * Note that the PR4 does not support "LocoNet Data Signal termination" when
      * in LocoNet interface mode (i.e. MS100 mode).
      */
@@ -163,11 +163,15 @@ public class PR4Adapter extends LocoBufferAdapter {
      *      name(s) of modes without command stations
      */
     public String[] commandStationOptions() {
-        String[] retval = new String[commandStationNames.length + 1];
+        String[] retval = new String[commandStationNames.length + 2];
         retval[0] = LnCommandStationType.COMMAND_STATION_PR4_ALONE.getName();
         for (int i = 0; i < commandStationNames.length; i++) {
             retval[i + 1] = commandStationNames[i];
         }
+        // Add "Standalone LocoNet" option
+        // Note: PR4 does not provide "LocoNet Data Termination" and _requires_
+        // some external source of that feature.
+        retval[retval.length - 1] = LnCommandStationType.COMMAND_STATION_STANDALONE.getName() + " (using external LocoNet Data Termination!)"; // NOI18N
         return retval;
     }
 

--- a/java/test/jmri/jmrix/loconet/pr4/PR4AdapterTest.java
+++ b/java/test/jmri/jmrix/loconet/pr4/PR4AdapterTest.java
@@ -23,15 +23,19 @@ public class PR4AdapterTest {
         PR4Adapter t = new PR4Adapter();
         String[] cmdStns = t.commandStationOptions();
         boolean foundPR4StandaloneProgrammer = false;
+        boolean foundPR4StandaloneLocoNet = false;
         for (int i=0; i < cmdStns.length; i++) {
-            Assert.assertNotEquals("should not find 'Stand-alone LocoNet", 
-                    LnCommandStationType.COMMAND_STATION_STANDALONE.getName(), cmdStns[i]);
             if (cmdStns[i].equals(LnCommandStationType.COMMAND_STATION_PR4_ALONE.getName())) {
                 foundPR4StandaloneProgrammer = true;
             }
+            if (cmdStns[i].compareTo(
+                    LnCommandStationType.COMMAND_STATION_STANDALONE.getName().toString() +
+                    " (using external LocoNet Data Termination!)") == 0) {
+                foundPR4StandaloneLocoNet = true;
+            }
         }
         Assert.assertTrue("Found PR4 in standalone programmer mode", foundPR4StandaloneProgrammer);
-            
+        Assert.assertTrue("Should have found 'Stand-alone LocoNet but did not!", foundPR4StandaloneLocoNet);            
     }
 
     @BeforeEach


### PR DESCRIPTION
Adds "Stand-alone LocoNet" option for PR4, with a comment in the GUI option to note that an external source of LocoNet Data Termination is required.

Replaces P/R #9186.
