### PR TITLE
Fix invalid syntax in codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,3 @@
-codecov:
-  ci:
-    - !appveyor # ignore CI builds by AppVeyor
 coverage:
   # number of decimal places to display
   precision: 1


### PR DESCRIPTION
Codecov has again started adding annotations to our PRs. It was turned off, but that stopped working some time ago. I asked about it in this thread:
https://community.codecov.io/t/github-checks-api-and-annotation-not-working/2142/13

It turned out to be a problem with our `codecov.yml` file. But since we don't use AppVeyor anymore, that should not be a problem.

The file `codecov.yml` can be syntax checked by this command:

`curl --data-binary @codecov.yml https://codecov.io/validate`