### PR TITLE
Fix typo in `current-draft-note.shtml`.

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -106,7 +106,7 @@
                     </ul>
                 </li>
                 <li>Allow selection of "Stand-alone LocoNet (with external LocoNet Data
-                    Termination!)" for Digitrax PR4.
+                    Termination!)" for Digitrax PR4.</li>
             </ul>
 
         <h4>Maple</h4>


### PR DESCRIPTION
Fix typo.
