### PR TITLE
Remove LocoIO menu

### DIFF
--- a/java/src/jmri/jmrix/loconet/locoio/LocoIO.java
+++ b/java/src/jmri/jmrix/loconet/locoio/LocoIO.java
@@ -127,8 +127,7 @@ public class LocoIO {
      * Compose and send a message out onto LocoNet changing the LocoIO hardware board
      * address of all connected LocoIO boards.
      * <p>
-     * User is warned beforehand that this is a broadcast type operation in
-     * {@link jmri.jmrix.loconet.locoio.LocoIOPanel#cautionAddrSet()}
+     * User is warned that this is a broadcast type operation.
      *
      * @param address the new base address of the LocoIO board to change
      * @param subAddress the new subAddress of the board

--- a/java/src/jmri/jmrix/loconet/locoio/LocoIOPanel.java
+++ b/java/src/jmri/jmrix/loconet/locoio/LocoIOPanel.java
@@ -33,7 +33,10 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2002
  * @author Egbert Broerse 2018
+ * @deprecated since 4.2.23 (10-2020) replaced by Roster based LocoIO definition
+ * xml/decoders/Public_Domain_HDL_LocoIO.xml using SV1MODE
  */
+@Deprecated
 public class LocoIOPanel extends jmri.jmrix.loconet.swing.LnPanel
         implements java.beans.PropertyChangeListener {
 

--- a/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
+++ b/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
@@ -57,7 +57,7 @@ public class LocoNetMenu extends JMenu {
                     lastWasSeparator = true;
                 }
             } else {
-                if ((item.interfaceOnly == false) ||
+                if ((!item.interfaceOnly) ||
                         isLocoNetInterface) {
                     add(new LnNamedPaneAction(Bundle.getMessage(item.name), wi, item.load, memo));
                     lastWasSeparator = false;
@@ -79,7 +79,6 @@ public class LocoNetMenu extends JMenu {
         new Item("MenuItemLocoStats", "jmri.jmrix.loconet.locostats.swing.LocoStatsPanel", false), // NOI18N
         null,
         new Item("MenuItemBDL16Programmer", "jmri.jmrix.loconet.bdl16.BDL16Panel", true), // NOI18N
-        new Item("MenuItemLocoIOProgrammer", "jmri.jmrix.loconet.locoio.LocoIOPanel", true), // NOI18N
         new Item("MenuItemPM4Programmer", "jmri.jmrix.loconet.pm4.PM4Panel", true), // NOI18N
         new Item("MenuItemSE8cProgrammer", "jmri.jmrix.loconet.se8.SE8Panel", true), // NOI18N
         new Item("MenuItemDS64Programmer", "jmri.jmrix.loconet.ds64.Ds64TabbedPanel", true), // NOI18N


### PR DESCRIPTION
Remove access to LocoIO (legacy) via Ln menu.
Mark LocoIOPanel class deprecated, citing replacement method