### PR TITLE
System prefix format

### DIFF
--- a/java/src/jmri/jmrix/AbstractConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractConnectionConfig.java
@@ -31,28 +31,28 @@ abstract public class AbstractConnectionConfig implements ConnectionConfig {
     public AbstractConnectionConfig() {
         try {
             // The next commented-out line replacing the following when Issue #4670 is resolved; see Manager
-            // systemPrefixField = new JFormattedTextField(new jmri.util.swing.RegexFormatter("[A-Za-z]\\d*"));
-            systemPrefixField = new JFormattedTextField(new SystemPrefixFormatter()) {
-                @Override
-                public void setValue(Object value) {
-                    log.debug("setValue {} {}", value, getBackground());
-                    if (getBackground().equals(java.awt.Color.RED)) { // only if might have set before, leaving default otherwise
-                        setBackground(java.awt.Color.WHITE); 
-                        setToolTipText(null);
-                    }
-                    super.setValue(value);
-                }
-                
-                @Override
-                public void setText(String value) {
-                    log.debug("setText {} {}", value, getBackground());
-                    if (getBackground().equals(java.awt.Color.RED)) { // only if might have set before, leaving default otherwise
-                        setBackground(java.awt.Color.WHITE); 
-                        setToolTipText(null);
-                    }
-                    super.setText(value);
-                }
-            };
+            systemPrefixField = new JFormattedTextField(new jmri.util.swing.RegexFormatter("[A-Za-z]\\d*"));
+//            systemPrefixField = new JFormattedTextField(new SystemPrefixFormatter()) {
+//                @Override
+//                public void setValue(Object value) {
+//                    log.debug("setValue {} {}", value, getBackground());
+//                    if (getBackground().equals(java.awt.Color.RED)) { // only if might have set before, leaving default otherwise
+//                        setBackground(java.awt.Color.WHITE);
+//                        setToolTipText(null);
+//                    }
+//                    super.setValue(value);
+//                }
+//
+//                @Override
+//                public void setText(String value) {
+//                    log.debug("setText {} {}", value, getBackground());
+//                    if (getBackground().equals(java.awt.Color.RED)) { // only if might have set before, leaving default otherwise
+//                        setBackground(java.awt.Color.WHITE);
+//                        setToolTipText(null);
+//                    }
+//                    super.setText(value);
+//                }
+//            };
             
             systemPrefixField.setPreferredSize(new JTextField("P123").getPreferredSize());
             systemPrefixField.setFocusLostBehavior(JFormattedTextField.COMMIT_OR_REVERT);

--- a/java/src/jmri/jmrix/dccpp/AbstractDCCppSerialConnectionConfig.java
+++ b/java/src/jmri/jmrix/dccpp/AbstractDCCppSerialConnectionConfig.java
@@ -1,11 +1,10 @@
 package jmri.jmrix.dccpp;
 
 /**
- * Abstract Configuration for a DCC++ Serial Connection
- * <p>
+ * Abstract Configuration for a DCC++ Serial Connection.
  *
  * @author Mark Underwood Copyright (C) 2015
-  *
+ *
  * Based on AbstractXNetSerialConnectionConfig by Paul Bender
  */
 public abstract class AbstractDCCppSerialConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig {
@@ -13,7 +12,7 @@ public abstract class AbstractDCCppSerialConnectionConfig extends jmri.jmrix.Abs
     /**
      * Ctor for an object being created during load process; Swing init is
      * deferred.
-     * @param p serial port adapter.
+     * @param p serial port adapter
      */
     public AbstractDCCppSerialConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Defines the standard/common routines used in multiple classes related to the
- * a DCC++ Command Station, on a DCC++ network.
+ * DCC++ Command Station, on a DCC++ network.
  *
  * @author Bob Jacobsen Copyright (C) 2001
  * @author Portions by Paul Bender Copyright (C) 2003
@@ -48,10 +48,11 @@ public class DCCppCommandStation implements jmri.CommandStation {
     }
     
     /**
-     * Returns the Station Type of the connected Command Station
+     * Get the Station Type of the connected Command Station
      * it is populated by response from the CS, initially "Unknown" 
      * @return StationType
      */
+    @Nonnull
     public String getStationType() {
         return stationType;
     }
@@ -64,10 +65,11 @@ public class DCCppCommandStation implements jmri.CommandStation {
     }
 
     /**
-     * Returns the Build of the connected Command Station
+     * Get the Build of the connected Command Station
      * it is populated by response from the CS, initially "Unknown" 
      * @return Build
      */
+    @Nonnull
     public String getBuild() {
         return build;
     }
@@ -84,16 +86,17 @@ public class DCCppCommandStation implements jmri.CommandStation {
     }
 
     /**
-     * Returns the canonical version of the connected Command Station
+     * Get the canonical version of the connected Command Station
      * it is populated by response from the CS, so initially '0.0.0' 
      * @return Version
      */
+    @Nonnull
     public String getVersion() {
         return version;
     }
 
     /**
-     * Parses the DCC++ CS status response to pull out the base station version
+     * Parse the DCC++ CS status response to pull out the base station version
      * and software version.
      * @param l status response to query.
      */
@@ -222,7 +225,7 @@ public class DCCppCommandStation implements jmri.CommandStation {
      * @param repeats Number of times to repeat the transmission.
      */
     @Override
-    public boolean sendPacket(byte[] packet, int repeats) {
+    public boolean sendPacket(@Nonnull byte [] packet, int repeats) {
 
         if (_tc == null) {
             log.error("Send Packet Called without setting traffic controller");
@@ -233,6 +236,7 @@ public class DCCppCommandStation implements jmri.CommandStation {
         //  DCC++ BaseStation code appends its own error-correction byte.
         // So we have to omit the JMRI-generated one.
         DCCppMessage msg = DCCppMessage.makeWriteDCCPacketMainMsg(reg, packet.length - 1, packet);
+        assert msg != null;
         log.debug("sendPacket:'{}'", msg.toString());
 
         for (int i = 0; i < repeats; i++) {
@@ -276,6 +280,7 @@ public class DCCppCommandStation implements jmri.CommandStation {
     }
 
     @Override
+    @Nonnull
     public String getSystemPrefix() {
         if (adaptermemo == null) {
             return "D";
@@ -311,4 +316,3 @@ public class DCCppCommandStation implements jmri.CommandStation {
     private final static Logger log = LoggerFactory.getLogger(DCCppCommandStation.class);
 
 }
-

--- a/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
@@ -278,7 +278,7 @@ public class DCCppCommandStation implements jmri.CommandStation {
     @Override
     public String getSystemPrefix() {
         if (adaptermemo == null) {
-            return "DCCPP";
+            return "D";
         }
         return adaptermemo.getSystemPrefix();
     }

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnout.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnout.java
@@ -74,7 +74,7 @@ public class DCCppTurnout extends AbstractTurnout implements DCCppListener {
     //@SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC")
     //protected int _mClosed = jmri.Turnout.CLOSED;
 
-    protected String _prefix = "DCCPP"; // default
+    protected String _prefix = "D"; // default
     protected DCCppTrafficController tc = null;
 
     public DCCppTurnout(String prefix, int pNumber, DCCppTrafficController controller) {  // a human-readable turnout number must be specified!

--- a/java/src/jmri/jmrix/dccpp/serial/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/dccpp/serial/configurexml/ConnectionConfigXml.java
@@ -5,7 +5,7 @@ import jmri.jmrix.dccpp.serial.ConnectionConfig;
 import jmri.jmrix.dccpp.serial.DCCppAdapter;
 
 /**
- * Handle XML persistance of layout connections by persistening the DCC++ serial adapter
+ * Handle XML persistence of layout connections by persistening the DCC++ serial adapter
  * (and connections). Note this is named as the XML version of a
  * ConnectionConfig object, but it's actually persisting the DCCppAdapter.
  * <p>


### PR DESCRIPTION
As issue #4670 was closed, activate the formatter.
Prevents users entering non-conforming prefixes in the config Prefix field, was still possible in 4.21.3 although hidden in UI. 