### PR TITLE
WIP Add Manager.getState()

### DIFF
--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -435,6 +435,19 @@ public interface Manager<E extends NamedBean> extends SilenceablePropertyChangeP
     }
 
     /**
+     * Get a state from a name
+     * @param name the name
+     * @return the state
+     */
+    public default int getState(String name) {
+        switch (name) {
+            case "Unknown": return NamedBean.UNKNOWN;
+            case "Inconsistent": return NamedBean.INCONSISTENT;
+            default: throw new IllegalArgumentException("Unknown state name: "+name);
+        }
+    }
+
+    /**
      * Code the validity (including just as a prefix) of a proposed name string.
      *
      * @since 4.9.5

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -29,6 +29,16 @@ public class ProxyLightManager extends AbstractProvidingProxyManager<Light>
         return jmri.InstanceManager.getDefault(jmri.jmrix.internal.InternalSystemConnectionMemo.class).getLightManager();
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public int getState(String name) {
+        switch (name) {
+            case "On": return Light.ON;
+            case "Off": return Light.OFF;
+            default: return super.getState(name);
+        }
+    }
+
     /**
      * Locate via user name, then system name if needed.
      *

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -3,6 +3,7 @@ package jmri.managers;
 import javax.annotation.Nonnull;
 import jmri.Manager;
 
+import jmri.DigitalIO;
 import jmri.Sensor;
 import jmri.SensorManager;
 
@@ -22,6 +23,18 @@ public class ProxySensorManager extends AbstractProvidingProxyManager<Sensor>
     @Override
     protected AbstractManager<Sensor> makeInternalManager() {
         return jmri.InstanceManager.getDefault(jmri.jmrix.internal.InternalSystemConnectionMemo.class).getSensorManager();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getState(String name) {
+        switch (name) {
+            case "On": return DigitalIO.ON;
+            case "Off": return DigitalIO.OFF;
+            case "Inactive": return Sensor.INACTIVE;
+            case "Active": return Sensor.ACTIVE;
+            default: return super.getState(name);
+        }
     }
 
     /**

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -36,6 +36,18 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
         InstanceManager.getDefault(TurnoutOperationManager.class).loadOperationTypes();
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public int getState(String name) {
+        switch (name) {
+            case "On": return DigitalIO.ON;
+            case "Off": return DigitalIO.OFF;
+            case "Closed": return Turnout.CLOSED;
+            case "Thrown": return Turnout.THROWN;
+            default: return super.getState(name);
+        }
+    }
+
     /**
      * Locate via user name, then system name if needed.
      *

--- a/java/test/jmri/managers/ProxyLightManagerTest.java
+++ b/java/test/jmri/managers/ProxyLightManagerTest.java
@@ -5,6 +5,7 @@ import java.beans.PropertyChangeListener;
 import jmri.InstanceManager;
 import jmri.Light;
 import jmri.LightManager;
+import jmri.NamedBean;
 import jmri.jmrix.internal.InternalLightManager;
 import jmri.jmrix.internal.InternalSystemConnectionMemo;
 import jmri.util.JUnitAppender;
@@ -39,6 +40,15 @@ public class ProxyLightManagerTest {
     @Test
     public void testDispose() {
         l.dispose();  // all we're really doing here is making sure the method exists
+    }
+
+    @Test
+    public void testGetState() {
+        LightManager m = InstanceManager.getDefault(LightManager.class);
+        Assert.assertEquals(NamedBean.UNKNOWN, m.getState("Unknown"));
+        Assert.assertEquals(NamedBean.INCONSISTENT, m.getState("Inconsistent"));
+        Assert.assertEquals(Light.ON, m.getState("On"));
+        Assert.assertEquals(Light.OFF, m.getState("Off"));
     }
 
     @Test

--- a/java/test/jmri/managers/ProxySensorManagerTest.java
+++ b/java/test/jmri/managers/ProxySensorManagerTest.java
@@ -27,6 +27,17 @@ public class ProxySensorManagerTest implements Manager.ManagerDataListener<Senso
     }
 
     @Test
+    public void testGetState() {
+        SensorManager m = InstanceManager.getDefault(SensorManager.class);
+        Assert.assertEquals(NamedBean.UNKNOWN, m.getState("Unknown"));
+        Assert.assertEquals(NamedBean.INCONSISTENT, m.getState("Inconsistent"));
+        Assert.assertEquals(DigitalIO.ON, m.getState("On"));
+        Assert.assertEquals(DigitalIO.OFF, m.getState("Off"));
+        Assert.assertEquals(Sensor.ACTIVE, m.getState("Active"));
+        Assert.assertEquals(Sensor.INACTIVE, m.getState("Inactive"));
+    }
+
+    @Test
     public void testPutGetJ() {
         // create
         Sensor tj = l.newSensor("JS1", "mine");

--- a/java/test/jmri/managers/ProxyTurnoutManagerTest.java
+++ b/java/test/jmri/managers/ProxyTurnoutManagerTest.java
@@ -40,6 +40,17 @@ public class ProxyTurnoutManagerTest {
     }
 
     @Test
+    public void testGetState() {
+        TurnoutManager m = InstanceManager.getDefault(TurnoutManager.class);
+        Assert.assertEquals(NamedBean.UNKNOWN, m.getState("Unknown"));
+        Assert.assertEquals(NamedBean.INCONSISTENT, m.getState("Inconsistent"));
+        Assert.assertEquals(DigitalIO.ON, m.getState("On"));
+        Assert.assertEquals(DigitalIO.OFF, m.getState("Off"));
+        Assert.assertEquals(Turnout.CLOSED, m.getState("Closed"));
+        Assert.assertEquals(Turnout.THROWN, m.getState("Thrown"));
+    }
+
+    @Test
     public void testPutGet() {
         // create
         Turnout t = l.newTurnout(getSystemName(getNumToTest1()), "mine");


### PR DESCRIPTION
Adds a generic mapping from name to state, for example "Thrown" => `Turnout.Thrown`.