### PR TITLE
Fix splitVal default issues created by #9157.

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/SplitDateTimeVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitDateTimeVariableValue.java
@@ -133,6 +133,18 @@ public class SplitDateTimeVariableValue extends SplitVariableValue {
         }
     }
 
+    /**
+     * Set value from a String value.
+     * <p>
+     * This does nothing since we can't reliably parse text to date/time value.
+     *
+     * @param value a string representing the date/time value to be set
+     */
+    @Override
+    public void setValue(String value) {
+        log.debug("skipping set of date/time value \"{}\"", value);
+    }
+
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(SplitDateTimeVariableValue.class);
 

--- a/java/src/jmri/jmrit/symbolicprog/SplitHexVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitHexVariableValue.java
@@ -2,6 +2,8 @@ package jmri.jmrit.symbolicprog;
 
 import java.util.HashMap;
 import javax.swing.JLabel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Like {@link SplitVariableValue}, except that the string representation is in
@@ -58,6 +60,21 @@ public class SplitHexVariableValue extends SplitVariableValue {
         return ret;
     }
 
+    /**
+     * Set value from a String value.
+     *
+     * @param value a string representing the unsigned long hex value to be set
+     */
+    @Override
+    public void setValue(String value) {
+        try {
+            long val = Long.parseUnsignedLong(value, 16);
+            setLongValue(val);
+        } catch (NumberFormatException e) {
+            log.warn("skipping set of non-hex value \"{}\"", value);
+        }
+    }
+
     // initialize logging
-//    private final static Logger log = LoggerFactory.getLogger(SplitHexVariableValue.class);
+    private final static Logger log = LoggerFactory.getLogger(SplitHexVariableValue.class);
 }

--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -478,8 +478,12 @@ public class SplitVariableValue extends VariableValue
      */
     @Override
     public void setValue(String value) {
-        long val = Long.parseUnsignedLong(value);
-        setLongValue(val);
+        try {
+            long val = Long.parseUnsignedLong(value);
+            setLongValue(val);
+        } catch (NumberFormatException e) {
+            log.warn("skipping set of non-long value \"{}\"", value);
+        }
     }
 
     @Override

--- a/java/src/jmri/jmrit/symbolicprog/VariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableValue.java
@@ -140,14 +140,18 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
      * need a universally-usable method for setting values, such as default
      * values in decoder definitions.
      * <p>
-     * We don't want to have this method failing silently. Subclasses that need
-     * silent failure will need to override this method.
+     * In the long term we don't want to have this method failing silently.
+     * Subclasses that need silent failure should override this method.
      *
      * @param value the String value to set
      */
     public void setValue(String value) {
-        int val = Integer.parseInt(value);
-        setIntValue(val);
+        try {
+            int val = Integer.parseInt(value);
+            setIntValue(val);
+        } catch (NumberFormatException e) {
+            log.warn("skipping set of non-integer value \"{}\"", value);
+        }
     }
 
     /**


### PR DESCRIPTION
Sorry about that. Broke loading of fully-populated (read from decoder) ESU LokSound/LokPilot etc. roster entries.