### PR TITLE
Add NamedBean.getStateFromName()

### DIFF
--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -359,6 +359,19 @@ public interface NamedBean extends Comparable<NamedBean>, PropertyChangeProvider
     public String describeState(int state);
 
     /**
+     * Get a state from a name
+     * @param name the name
+     * @return the state
+     */
+    public default int getStateFromName(String name) {
+        switch (name) {
+            case "Unknown": return NamedBean.UNKNOWN;
+            case "Inconsistent": return NamedBean.INCONSISTENT;
+            default: throw new IllegalArgumentException("Unknown state name: "+name);
+        }
+    }
+
+    /**
      * Get associated comment text.
      *
      * @return the comment or null

--- a/java/src/jmri/implementation/AbstractLight.java
+++ b/java/src/jmri/implementation/AbstractLight.java
@@ -86,6 +86,16 @@ public abstract class AbstractLight extends AbstractNamedBean
         }
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public int getStateFromName(String name) {
+        switch (name) {
+            case "On": return Light.ON;
+            case "Off": return Light.OFF;
+            default: return super.getStateFromName(name);
+        }
+    }
+
     /**
      * Get enabled status.
      *

--- a/java/src/jmri/implementation/AbstractSensor.java
+++ b/java/src/jmri/implementation/AbstractSensor.java
@@ -3,9 +3,7 @@ package jmri.implementation;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 
-import jmri.Reporter;
-import jmri.Sensor;
-import jmri.Turnout;
+import jmri.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,6 +140,18 @@ public abstract class AbstractSensor extends AbstractNamedBean implements Sensor
                 return Bundle.getMessage("SensorStateInactive");
             default:
                 return super.describeState(state);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getStateFromName(String name) {
+        switch (name) {
+            case "On": return DigitalIO.ON;
+            case "Off": return DigitalIO.OFF;
+            case "Inactive": return Sensor.INACTIVE;
+            case "Active": return Sensor.ACTIVE;
+            default: return super.getStateFromName(name);
         }
     }
 

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -8,19 +8,10 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import javax.annotation.*;
-import jmri.InstanceManager;
-import jmri.JmriException;
-import jmri.NamedBean;
-import jmri.NamedBeanHandle;
-import jmri.NamedBeanUsageReport;
-import jmri.PushbuttonPacket;
-import jmri.Sensor;
-import jmri.SensorManager;
-import jmri.Turnout;
-import jmri.TurnoutOperation;
-import jmri.TurnoutOperationManager;
-import jmri.TurnoutOperator;
+
+import jmri.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -316,6 +307,18 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
             case THROWN: return Bundle.getMessage("TurnoutStateThrown");
             case CLOSED: return Bundle.getMessage("TurnoutStateClosed");
             default: return super.describeState(state);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getStateFromName(String name) {
+        switch (name) {
+            case "On": return DigitalIO.ON;
+            case "Off": return DigitalIO.OFF;
+            case "Closed": return Turnout.CLOSED;
+            case "Thrown": return Turnout.THROWN;
+            default: return super.getStateFromName(name);
         }
     }
 

--- a/java/test/jmri/implementation/AbstractLightTestBase.java
+++ b/java/test/jmri/implementation/AbstractLightTestBase.java
@@ -2,8 +2,7 @@ package jmri.implementation;
 
 import java.beans.PropertyChangeListener;
 
-import jmri.Light;
-import jmri.LightControl;
+import jmri.*;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
@@ -46,6 +45,14 @@ public abstract class AbstractLightTestBase {
     public void testCreate() {
         // initial state when created must be OFF
         Assert.assertEquals("initial commanded state", Light.OFF, t.getState());
+    }
+
+    @Test
+    public void testGetState() {
+        Assert.assertEquals(NamedBean.UNKNOWN, t.getStateFromName("Unknown"));
+        Assert.assertEquals(NamedBean.INCONSISTENT, t.getStateFromName("Inconsistent"));
+        Assert.assertEquals(Light.ON, t.getStateFromName("On"));
+        Assert.assertEquals(Light.OFF, t.getStateFromName("Off"));
     }
 
     @Test

--- a/java/test/jmri/implementation/AbstractSensorTestBase.java
+++ b/java/test/jmri/implementation/AbstractSensorTestBase.java
@@ -2,8 +2,7 @@ package jmri.implementation;
 
 import java.beans.PropertyChangeListener;
 
-import jmri.JmriException;
-import jmri.Sensor;
+import jmri.*;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
@@ -53,6 +52,16 @@ public abstract class AbstractSensorTestBase {
         // initial state when created must be UNKNOWN
         Assert.assertEquals("initial state 1", Sensor.UNKNOWN, t.getState());
         Assert.assertEquals("initial state 2", "Unknown", t.describeState(t.getState()));
+    }
+
+    @Test
+    public void testGetState() {
+        Assert.assertEquals(NamedBean.UNKNOWN, t.getStateFromName("Unknown"));
+        Assert.assertEquals(NamedBean.INCONSISTENT, t.getStateFromName("Inconsistent"));
+        Assert.assertEquals(DigitalIO.ON, t.getStateFromName("On"));
+        Assert.assertEquals(DigitalIO.OFF, t.getStateFromName("Off"));
+        Assert.assertEquals(Sensor.ACTIVE, t.getStateFromName("Active"));
+        Assert.assertEquals(Sensor.INACTIVE, t.getStateFromName("Inactive"));
     }
 
     @Test

--- a/java/test/jmri/implementation/AbstractTurnoutTestBase.java
+++ b/java/test/jmri/implementation/AbstractTurnoutTestBase.java
@@ -4,11 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.beans.PropertyChangeListener;
 
-import jmri.InstanceManager;
-import jmri.JmriException;
-import jmri.Sensor;
+import jmri.*;
 import jmri.util.JUnitUtil;
-import jmri.Turnout;
+
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
@@ -72,6 +70,16 @@ public abstract class AbstractTurnoutTestBase {
         // initial known state when created must be UNKNOWN
         Assert.assertEquals("initial known state", Turnout.UNKNOWN, t.getKnownState());
         Assert.assertEquals("initial commanded state 2", Turnout.UNKNOWN, t.getState());
+    }
+
+    @Test
+    public void testGetState() {
+        Assert.assertEquals(NamedBean.UNKNOWN, t.getStateFromName("Unknown"));
+        Assert.assertEquals(NamedBean.INCONSISTENT, t.getStateFromName("Inconsistent"));
+        Assert.assertEquals(DigitalIO.ON, t.getStateFromName("On"));
+        Assert.assertEquals(DigitalIO.OFF, t.getStateFromName("Off"));
+        Assert.assertEquals(Turnout.CLOSED, t.getStateFromName("Closed"));
+        Assert.assertEquals(Turnout.THROWN, t.getStateFromName("Thrown"));
     }
 
     @Test


### PR DESCRIPTION
Adds a generic mapping from name to state, for example "Thrown" => Turnout.Thrown.

Replaces  #9227