### PR TITLE
Withrottle protocol fast clock documentation

### DIFF
--- a/help/en/package/jmri/jmrit/withrottle/Protocol.shtml
+++ b/help/en/package/jmri/jmrit/withrottle/Protocol.shtml
@@ -505,19 +505,30 @@ PFT1550686525&lt;;&gt;4.0
 PFT1550681224&lt;;&gt;0.0
 </pre>
 
-    <p>The first number is an integer number of seconds since 12:00
-    midnight, January 1st, 1970. This start date is the Unix time epoch,
-    and makes it easy to convert this value using the standard time
-    libraries. Only the hours and minutes are useful. JMRI sends a value
-    based on the system time when the fast clock was started, so will
-    return a value near the calendar date. The Digitrax LnWi returns
-    values within the range 0-86400 (all the values for January 1,
-    1970).<br/>
+    <p>The first number is an integer number of seconds since 12:00 midnight,
+    January 1st, 1970 fast clock time. This zero date is very close to the
+    Unix time epoch, which is 12:00 midnight, January 1st, 1970 UTC, only
+    differing in the time zone offset, where applicable.
+    In fact, this makes it easy to convert this value using the standard time
+    libraries, as long as any time zone conversions are omitted. JMRI sends a
+    value based on the system date when the fast clock was started, so it will
+    return a value near the calendar date. Since the JMRI fast clock does not
+    really support calendar dates, only the hour, minute and second are useful.
+    The Digitrax LNWI returns values within the range 0-86400, which translates
+    to times on January 1st, 1970, when the day, month and year are 
+    calculated.<br/>
+    To give an example: A JMRI instance started on Dec 13, 2020 with a fast clock
+    time set to 10:23:45 am will return 1607855025, which can be converted back
+    to hours, minutes and seconds by "modulo dividing" by 86400
+    (number of seconds in a day) and calculating further as follows:<br/>
+    1607855025 mod 86400 = 37425 seconds since midnight.<br/>
+    37425 seconds since midnight = 10 hours 1425 seconds since midnight = 
+    10 hours 23 minutes 45 seconds since midnight = 10:23:45 am.<br/>
     The second number is the current fast time ratio.  It
     may be an integer value (4) or a floating point value (4.0).  If this
     value is 0 (or 0.0), the clock is stopped.<br/>
     Updates are sent on each change in time or rate, and when clock stopped 
-    or started.</p>
+    or started, so expect one message every fast clock second.</p>
 
     <a name="AlertandInfoMessage" id="AlertandInfoMessage"></a>
     <h3>Alert and Info Message</h3>

--- a/help/en/package/jmri/jmrit/withrottle/Protocol.shtml
+++ b/help/en/package/jmri/jmrit/withrottle/Protocol.shtml
@@ -528,7 +528,7 @@ PFT1550681224&lt;;&gt;0.0
     may be an integer value (4) or a floating point value (4.0).  If this
     value is 0 (or 0.0), the clock is stopped.<br/>
     Updates are sent on each change in time or rate, and when clock stopped 
-    or started, so expect one message every fast clock second.</p>
+    or started, so expect one message every fast clock minute.</p>
 
     <a name="AlertandInfoMessage" id="AlertandInfoMessage"></a>
     <h3>Alert and Info Message</h3>


### PR DESCRIPTION
As discussed on jmri-developers I made an attempt to clarify the fast clock message format of the withrottle protocol in the documentation:

Add time zone information: withrottle fast clock message is independent of system timezone
Add example for calculating hours, minutes and seconds
Clarify the meaning of "time change"