### PR TITLE
Modify the StartJMRI template to support macOS 11 Big Sur

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -323,13 +323,16 @@ if [ -z "${JAVA_HOME}" ] ; then
             JAVA_HOME=""
         fi
         # Find an installed JRE/JDK location
-        if [[ -z "${JAVA_HOME}" && -x /usr/libexec/java_home ]] ; then
-            # Test for any JDKs of version 1.8 or newer
-            JAVA_HOME=$( /usr/libexec/java_home --version 1.8+ --failfast 2>/dev/null )
-            if [ -n "${JAVA_HOME}" ] ; then
-                JAVACMD="${JAVA_HOME}/bin/java"
+        for jversion in 1.8 9 10 11 12 13 14 15 16 17 ; do
+            if [[ -z "${JAVA_HOME}" && -x /usr/libexec/java_home ]] ; then
+                # Test for any JDKs
+                JAVA_HOME=$( /usr/libexec/java_home --version ${jversion} --failfast 2>/dev/null )
+                if [ -n "${JAVA_HOME}" ] ; then
+                    JAVACMD="${JAVA_HOME}/bin/java"
+                    break
+                fi
             fi
-        fi
+        done
         if [ -z "${JAVA_HOME}" ] ; then
             # JAVA_HOME is still not defined, so prompt to install Java for OS X
             /usr/bin/osascript << EOT


### PR DESCRIPTION
The script change was manually applied to the existing scripts on macOS 10.15.7 and macOS 11.1 to test the code change.