### PR TITLE
messaging enhancements and cleanup, retry some timed-out messages

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -31,7 +31,7 @@
 
         <h4>DCC-EX</h4>
             <ul>
-                <li>prepare for future message syntax enhancements</li>
+                <li>messaging enhancements and cleanup, retry some failed messages</li>
             </ul>
 
         <h4>DCC4pc</h4>

--- a/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
@@ -237,7 +237,7 @@ public class DCCppCommandStation implements jmri.CommandStation {
         // So we have to omit the JMRI-generated one.
         DCCppMessage msg = DCCppMessage.makeWriteDCCPacketMainMsg(reg, packet.length - 1, packet);
         assert msg != null;
-        log.debug("sendPacket:'{}'", msg.toString());
+        log.debug("sendPacket:'{}'", msg);
 
         for (int i = 0; i < repeats; i++) {
             _tc.sendDCCppMessage(msg, null);

--- a/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
@@ -120,20 +120,17 @@ public class DCCppCommandStation implements jmri.CommandStation {
 
     protected void setCommandStationMaxNumSlots(DCCppReply l) {
         int newNumSlots = l.getValueInt(1);
-        if (newNumSlots < maxNumSlots) {
-            log.warn("Command Station maxNumSlots cannot be reduced from {} to {}", maxNumSlots, newNumSlots);
-            return;
-        }
-        log.info("changing maxNumSlots from {} to {}", maxNumSlots, newNumSlots);
-        maxNumSlots = newNumSlots;
+        setCommandStationMaxNumSlots(newNumSlots);
     }
     protected void setCommandStationMaxNumSlots(int newNumSlots) {
         if (newNumSlots < maxNumSlots) {
             log.warn("Command Station maxNumSlots cannot be reduced from {} to {}", maxNumSlots, newNumSlots);
             return;
         }
-        log.info("changing maxNumSlots from {} to {}", maxNumSlots, newNumSlots);
-        maxNumSlots = newNumSlots;
+        if (newNumSlots != maxNumSlots) {
+            log.info("changing maxNumSlots from {} to {}", maxNumSlots, newNumSlots);
+            maxNumSlots = newNumSlots;
+        }
     }
     protected int getCommandStationMaxNumSlots() {
         return maxNumSlots;

--- a/java/src/jmri/jmrix/dccpp/DCCppConstants.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppConstants.java
@@ -71,7 +71,7 @@ public final class DCCppConstants {
     // Special Commands not for normal use.  Diagnostic and Test Use Only
     public static final char WRITE_DCC_PACKET_MAIN  = 'M';
     public static final char WRITE_DCC_PACKET_PROG  = 'P';
-    public static final char GET_FREE_MEMORY        = 'F';
+//    public static final char GET_FREE_MEMORY        = 'F';
     public static final char LIST_REGISTER_CONTENTS = 'L';
     public static final char ENTER_DIAG_MODE_CMD    = 'D'; // Enter Diagnostics mode -- NEW V1.2?
  
@@ -127,7 +127,7 @@ public final class DCCppConstants {
     public static final String QUERY_SENSOR_REGEX = "\\s*[Q,q]\\s*(\\d+)\\s*";
     public static final String WRITE_DCC_PACKET_MAIN_REGEX = "M\\s+(\\d+)((\\s+[0-9a-fA-F]{1,2}){2,5})\\s*"; // M REG pktbyte1 pktbyte2 pktbyte3 ?pktbyte4 ?pktbyte5
     public static final String WRITE_DCC_PACKET_PROG_REGEX = "P\\s+(\\d+)((\\s+[0-9a-fA-F]{1,2}){2,5})\\s*"; // P REG pktbyte1 pktbyte2 pktbyte3 ?pktbyte4 ?pktbyte5
-    public static final String GET_FREE_MEMORY_REGEX = "\\s*f\\s*";
+//    public static final String GET_FREE_MEMORY_REGEX = "\\s*f\\s*";
     public static final String LIST_REGISTER_CONTENTS_REGEX = "\\s*L\\s*";
     public static final String ENTER_DIAG_MODE_REGEX = "\\s*D\\s*";
     public static final String READ_MAXNUMSLOTS_REGEX = "\\s*#\\s*";
@@ -161,7 +161,7 @@ public final class DCCppConstants {
     public static final String STATUS_REPLY_ESP32_REGEX = "iDCC\\+\\+.*ESP32.*: V-([\\d\\.]+)\\s+/\\s+(.*)"; // V1.0
     public static final String STATUS_REPLY_DCCEX_REGEX = "i(DCC-EX) V-([\\d\\.]*).*G-(.*)"; 
     //public static final String STATUS_REPLY_REGEX = "i(DCC\\+\\+\\s?.*):\\s?(?:BUILD)? (.*)"; // V1.0 / V1.1 / V1.2
-    public static final String FREE_MEMORY_REPLY_REGEX =  "\\s*f\\s*(\\d+).*";
+//    public static final String FREE_MEMORY_REPLY_REGEX =  "\\s*f\\s*(\\d+).*";
     public static final String WRITE_EEPROM_REPLY_REGEX = "\\s*e\\s*(\\d+)\\s+(\\d+)\\s+(\\d+).*";
     public static final String COMM_TYPE_REPLY_REGEX =    "\\s*N\\s*(\\d+):\\s+((SERIAL)|(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})).*";
 

--- a/java/src/jmri/jmrix/dccpp/DCCppLight.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppLight.java
@@ -102,7 +102,7 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
     @Override
     synchronized public void setState(int newState) {
         if (newState != ON && newState != OFF) {
-            // Unsuported state
+            // Unsupported state
             log.warn("Unsupported state {} requested for light {}", newState, getSystemName());
             return;
         }
@@ -151,7 +151,7 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
     @Override
     public void notifyTimeout(DCCppMessage msg) {
         if (log.isDebugEnabled()) {
-            log.debug("Notified of timeout on message {}", msg.toString());
+            log.debug("Notified of timeout on message '{}'", msg.toString());
         }
     }
 

--- a/java/src/jmri/jmrix/dccpp/DCCppLight.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppLight.java
@@ -150,9 +150,7 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        if (log.isDebugEnabled()) {
-            log.debug("Notified of timeout on message '{}'", msg.toString());
-        }
+        log.debug("Notified of timeout on message '{}'", msg);
     }
 
     private final static Logger log = LoggerFactory.getLogger(DCCppLight.class);

--- a/java/src/jmri/jmrix/dccpp/DCCppLightManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppLightManager.java
@@ -79,8 +79,8 @@ public class DCCppLightManager extends AbstractLightManager {
 
     /**
      * Get the bit address from the system name.
-     * @param systemName a valid LocoNet-based Turnout System Name
-     * @return the turnout number extracted from the system name
+     * @param systemName a valid Light System Name
+     * @return the light number extracted from the system name
      */
     public int getBitFromSystemName(String systemName) {
         try {

--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -42,14 +42,12 @@ import org.slf4j.LoggerFactory;
  */
 public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delayed {
 
-    private static int _nRetries = 5;
+    private static int _nRetries = 3;
 
     /* According to the specification, DCC++ has a maximum timing
      interval of 500 milliseconds during normal communications */
-    // TODO: Note this timing interval is actually an XpressNet thing...
-    // Need to find out what DCC++'s equivalent is.
     protected static final int DCCppProgrammingTimeout = 10000;  // TODO: Appropriate value for DCC++?
-    private static int DCCppMessageTimeout = 5000;  // TODO: Appropriate value for DCC++?
+    private static int DCCppMessageTimeout = 2000;  // TODO: Appropriate value for DCC++?
 
     //private ArrayList<Integer> valueList = new ArrayList<>();
     private StringBuilder myMessage;
@@ -173,8 +171,8 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
                 return (new DCCppMessage(DCCppConstants.CLEAR_EEPROM_CMD, DCCppConstants.CLEAR_EEPROM_REGEX));
             case DCCppConstants.FUNCTION_CMD:
                 break;
-            case DCCppConstants.GET_FREE_MEMORY:
-                return (new DCCppMessage(DCCppConstants.GET_FREE_MEMORY, DCCppConstants.GET_FREE_MEMORY_REGEX));
+//            case DCCppConstants.GET_FREE_MEMORY:
+//                return (new DCCppMessage(DCCppConstants.GET_FREE_MEMORY, DCCppConstants.GET_FREE_MEMORY_REGEX));
             case DCCppConstants.LIST_REGISTER_CONTENTS:
                 return (new DCCppMessage(DCCppConstants.LIST_REGISTER_CONTENTS, DCCppConstants.LIST_REGISTER_CONTENTS_REGEX));
             case DCCppConstants.OPS_WRITE_CV_BIT:
@@ -401,9 +399,9 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
             case DCCppConstants.WRITE_DCC_PACKET_PROG:
                 myRegex = DCCppConstants.WRITE_DCC_PACKET_PROG_REGEX;
                 break;
-            case DCCppConstants.GET_FREE_MEMORY:
-                myRegex = DCCppConstants.GET_FREE_MEMORY_REGEX;
-                break;
+//            case DCCppConstants.GET_FREE_MEMORY:
+//                myRegex = DCCppConstants.GET_FREE_MEMORY_REGEX;
+//                break;
             case DCCppConstants.LIST_REGISTER_CONTENTS:
                 myRegex = DCCppConstants.LIST_REGISTER_CONTENTS_REGEX;
                 break;
@@ -473,33 +471,33 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
             case DCCppConstants.TURNOUT_CMD:
                 if (isTurnoutAddMessage()) {
                     text = "Add Turnout: ";
-                    text += "T/O ID: " + getTOIDString();
+                    text += "ID: " + getTOIDString();
                     text += ", Address: " + getTOAddressString();
                     text += ", Subaddr: " + getTOSubAddressString();
                 } else if (isTurnoutDeleteMessage()) {
                     text = "Delete Turnout: ";
-                    text += "T/O ID: " + getTOIDString();
+                    text += "ID: " + getTOIDString();
                 } else if (isListTurnoutsMessage()) {
                     text = "List Turnouts...";
                 } else {
                     text = "Turnout Cmd: ";
-                    text += "T/O ID: " + getTOIDString();
+                    text += "ID: " + getTOIDString();
                     text += ", State: " + getTOStateString();
                 }
                 break;
             case DCCppConstants.OUTPUT_CMD:
                 if (isOutputCmdMessage()) {
                     text = "Output Cmd: ";
-                    text += "Output ID: " + getOutputIDString();
+                    text += "ID: " + getOutputIDString();
                     text += ", State: " + getOutputStateString();
                 } else if (isOutputAddMessage()) {
                     text = "Add Output: ";
-                    text += "Output ID: " + getOutputIDString();
+                    text += "ID: " + getOutputIDString();
                     text += ", Pin: " + getOutputPinString();
                     text += ", IFlag: " + getOutputIFlagString();
                 } else if (isOutputDeleteMessage()) {
                     text = "Delete Output: ";
-                    text += "Output ID: " + getOutputIDString();
+                    text += "ID: " + getOutputIDString();
                 } else if (isListOutputsMessage()) {
                     text = "List Outputs...";
                 } else {
@@ -509,12 +507,12 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
             case DCCppConstants.SENSOR_CMD:
                 if (isSensorAddMessage()) {
                     text = "Add Sensor: ";
-                    text += "Sensor ID: " + getSensorIDString();
+                    text += "ID: " + getSensorIDString();
                     text += ", Pin: " + getSensorPinString();
                     text += ", Pullup: " + getSensorPullupString();
                 } else if (isSensorDeleteMessage()) {
                     text = "Delete Sensor: ";
-                    text += "Sensor ID: " + getSensorIDString();
+                    text += "ID: " + getSensorIDString();
                 } else if (isListSensorsMessage()) {
                     text = "List Sensors...";
                 } else {
@@ -581,16 +579,24 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
                 text += "Register: " + getRegisterString();
                 text += ", Packet:" + getPacketString();
                 break;
-            case DCCppConstants.GET_FREE_MEMORY:
-                text = "Get Free Memory Cmd: ";
-                text += toString();
-                break;
+//            case DCCppConstants.GET_FREE_MEMORY:
+//                text = "Get Free Memory Cmd: ";
+//                text += toString();
+//                break;
             case DCCppConstants.LIST_REGISTER_CONTENTS:
                 text = "List Register Contents Cmd: ";
                 text += toString();
                 break;
+            case DCCppConstants.WRITE_TO_EEPROM_CMD:
+                text = "Write to EEPROM Cmd: ";
+                text += toString();
+                break;
+            case DCCppConstants.CLEAR_EEPROM_CMD:
+                text = "Clear EEPROM Cmd: ";
+                text += toString();
+                break;
             default:
-                text = "Unknown Message: " + toString();
+                text = "Unknown Message: '" + toString() + "'";
         }
 
         return text;
@@ -658,7 +664,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     public String getValueString(int idx) {
         Matcher m = match(toString(), myRegex, "gvs");
         if (m == null) {
-            log.error("No match!");
+            log.error("DCCppMessage '{}' not matched by '{}'", this.toString(), myRegex);
             return ("");
         } else if (idx <= m.groupCount()) {
             return (m.group(idx));
@@ -671,7 +677,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     public int getValueInt(int idx) {
         Matcher m = match(toString(), myRegex, "gvi");
         if (m == null) {
-            log.error("No match!");
+            log.error("DCCppMessage '{}' not matched by '{}'", this.toString(), myRegex);
             return (0);
         } else if (idx <= m.groupCount()) {
             return (Integer.parseInt(m.group(idx)));
@@ -683,10 +689,10 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
 
     public boolean getValueBool(int idx) {
         log.debug("msg = {}, regex = {}", this, myRegex);
-        Matcher m = match(toString(), myRegex, "gvi");
+        Matcher m = match(toString(), myRegex, "gvb");
 
         if (m == null) {
-            log.error("No Match!");
+            log.error("DCCppMessage '{}' not matched by '{}'", this.toString(), myRegex);
             return (false);
         } else if (idx <= m.groupCount()) {
             return (!m.group(idx).equals("0"));
@@ -761,7 +767,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
             Pattern p = Pattern.compile(pat);
             Matcher m = p.matcher(s);
             if (!m.matches()) {
-                log.debug("No Match {} Command: {} Pattern: {}", name, s, pat);
+                log.debug("No Match {} Command: '{}' Pattern: '{}'", name, s, pat);
                 return (null);
             }
             return (m);
@@ -1507,7 +1513,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
             case DCCppConstants.READ_TRACK_CURRENT:
             case DCCppConstants.READ_CS_STATUS:
             case DCCppConstants.READ_MAXNUMSLOTS:
-            case DCCppConstants.GET_FREE_MEMORY:
+//            case DCCppConstants.GET_FREE_MEMORY:
             case DCCppConstants.OUTPUT_CMD:
             case DCCppConstants.LIST_REGISTER_CONTENTS:
                 retv = true;
@@ -1655,12 +1661,15 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     public static DCCppMessage makeTurnoutAddMsg(int id, int addr, int subaddr) {
         // Sanity check inputs
         if (id < 0 || id > DCCppConstants.MAX_TURNOUT_ADDRESS) {
+            log.error("turnout Id {} must be between {} and {}", id, 0, DCCppConstants.MAX_TURNOUT_ADDRESS);
             return (null);
         }
         if (addr < 0 || addr > DCCppConstants.MAX_ACC_DECODER_ADDRESS) {
+            log.error("turnout address {} must be between {} and {}", id, 0, DCCppConstants.MAX_ACC_DECODER_ADDRESS);
             return (null);
         }
         if (subaddr < 0 || subaddr > DCCppConstants.MAX_ACC_DECODER_SUBADDR) {
+            log.error("turnout subaddress {} must be between {} and {}", id, 0, DCCppConstants.MAX_ACC_DECODER_SUBADDR);
             return (null);
         }
 
@@ -2660,10 +2669,10 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
 
     }
 
-    public static DCCppMessage makeCheckFreeMemMsg() {
-        return (new DCCppMessage(DCCppConstants.GET_FREE_MEMORY, DCCppConstants.GET_FREE_MEMORY_REGEX));
-    }
-
+//    public static DCCppMessage makeCheckFreeMemMsg() {
+//        return (new DCCppMessage(DCCppConstants.GET_FREE_MEMORY, DCCppConstants.GET_FREE_MEMORY_REGEX));
+//    }
+//
     public static DCCppMessage makeListRegisterContentsMsg() {
         return (new DCCppMessage(DCCppConstants.LIST_REGISTER_CONTENTS,
                 DCCppConstants.LIST_REGISTER_CONTENTS_REGEX));

--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -770,7 +770,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
             Pattern p = Pattern.compile(pat);
             Matcher m = p.matcher(s);
             if (!m.matches()) {
-                log.debug("No Match {} Command: '{}' Pattern: '{}'", name, s, pat);
+                log.trace("No Match {} Command: '{}' Pattern: '{}'", name, s, pat);
                 return (null);
             }
             return (m);

--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -595,6 +595,9 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
                 text = "Clear EEPROM Cmd: ";
                 text += toString();
                 break;
+            case DCCppConstants.QUERY_SENSOR_STATES_CMD:
+                text = "Query Sensor States Cmd: '" + toString() + "'";
+                break;               
             default:
                 text = "Unknown Message: '" + toString() + "'";
         }

--- a/java/src/jmri/jmrix/dccpp/DCCppNetworkPortController.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppNetworkPortController.java
@@ -4,7 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Base for classes representing a LocoNet communications port
+ * Base for classes representing a DCCpp communications port
  *
  * @author Kevin Dickerson Copyright (C) 2011
  * @author Mark Underwoodn Copyright (C) 2015
@@ -47,8 +47,6 @@ public abstract class DCCppNetworkPortController extends jmri.jmrix.AbstractNetw
         }
     }
     
-    // There are also "PR3 standalone programmer" and "Stand-alone LocoNet"
-    // in pr3/PR3Adapter
     /**
      * Set config info from a name, which needs to be one of the valid ones.
      * @param name exact name of command station type.

--- a/java/src/jmri/jmrix/dccpp/DCCppNetworkPortController.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppNetworkPortController.java
@@ -67,7 +67,7 @@ public abstract class DCCppNetworkPortController extends jmri.jmrix.AbstractNetw
      * @param value command station type.
      */
     public void setCommandStationType(int value) {
-        log.debug("setCommandStationType: {}{}", Integer.toString(value));
+        log.debug("setCommandStationType: {}", Integer.toString(value));
         commandStationType = value;
     }
     

--- a/java/src/jmri/jmrix/dccpp/DCCppPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPacketizer.java
@@ -52,6 +52,7 @@ public class DCCppPacketizer extends DCCppTrafficController {
     @Override
     public void sendDCCppMessage(DCCppMessage m, DCCppListener reply) {
         if (m.length() != 0) {
+            log.debug("Sending: '{}'", m);            
             sendMessage(m, reply);
             // why the next line?
             // https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#yield--
@@ -149,19 +150,19 @@ public class DCCppPacketizer extends DCCppTrafficController {
             // Spin waiting for '<'
             char1 = readByteProtected(istream);
         }
-        log.debug("Serial: Message started...");
+        log.trace("Serial: Message started...");
         // Pick up the rest of the command
         for (i = 0; i < msg.maxSize(); i++) {
             char1 = readByteProtected(istream);
             if (char1 == '>') {
-                log.debug("Received: {}", m);
+                log.debug("Received: '{}'", m);
                 // NOTE: Cast is OK because we checked runtime type of msg above.
                 ((DCCppReply) msg).parseReply(m.toString());
                 break;
             } else {
                 m.append(Character.toString((char) char1));
                 //char1 = readByteProtected(istream);
-                log.debug("msg char[{}]: {} ({})", i, char1, Character.toString((char) char1));
+                log.trace("msg char[{}]: {} ({})", i, char1, Character.toString((char) char1));
                 //msg.setElement(i, char1 & 0xFF);
             }
         }

--- a/java/src/jmri/jmrix/dccpp/DCCppPowerManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPowerManager.java
@@ -86,7 +86,7 @@ public class DCCppPowerManager extends AbstractPowerManager<DCCppSystemConnectio
     // If the message still has retries available, reduce retries and send it back to the traffic controller.
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message '{}' , {} retries available.", msg.toString(), msg.getRetries());
+        log.debug("Notified of timeout on message '{}' , {} retries available.", msg, msg.getRetries());
         if (msg.getRetries() > 0) {
             msg.setRetries(msg.getRetries() - 1);
             tc.sendDCCppMessage(msg, this);

--- a/java/src/jmri/jmrix/dccpp/DCCppPowerManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPowerManager.java
@@ -61,8 +61,8 @@ public class DCCppPowerManager extends AbstractPowerManager<DCCppSystemConnectio
     // listen for power and status messages
     @Override
     public void message(DCCppReply m) {
-        log.debug("Message received: {}", m);
         if (m.isPowerReply()) {
+            log.debug("Power Reply message received: {}", m);
             int old = power;
             if (m.getPowerBool()) {
                 power = ON;
@@ -82,10 +82,15 @@ public class DCCppPowerManager extends AbstractPowerManager<DCCppSystemConnectio
     public void message(DCCppMessage l) {
     }
 
-    // Handle a timeout notification
+    // Handle message timeout notification
+    // If the message still has retries available, reduce retries and send it back to the traffic controller.
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message '{}'", msg);
+        log.debug("Notified of timeout on message '{}' , {} retries available.", msg.toString(), msg.getRetries());
+        if (msg.getRetries() > 0) {
+            msg.setRetries(msg.getRetries() - 1);
+            tc.sendDCCppMessage(msg, this);
+        }        
     }
 
     // Initialize logging information

--- a/java/src/jmri/jmrix/dccpp/DCCppPredefinedMeters.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPredefinedMeters.java
@@ -44,7 +44,7 @@ public class DCCppPredefinedMeters implements DCCppListener {
         //is_enabled = false;
         updateTask.initTimer();
 
-        log.debug("DCCppMultiMeter constructor called");
+        log.debug("DCCppPredefinedMeters constructor called");
     }
 
     public void setDCCppTrafficController(DCCppTrafficController controller) {
@@ -53,8 +53,8 @@ public class DCCppPredefinedMeters implements DCCppListener {
 
     @Override
     public void message(DCCppReply r) {
-        log.debug("DCCppMultiMeter received reply: {}", r.toString());
         if (r.isCurrentReply()) {
+            log.debug("DCCppPredefinedMeters received reply: {}", r.toString());
             try {
                 currentMeter.setCommandedAnalogValue(((r.getCurrentInt() * 1.0f) / (DCCppConstants.MAX_CURRENT * 1.0f)) * 100.0f );  // return as percentage.
             } catch (JmriException e) {
@@ -77,7 +77,7 @@ public class DCCppPredefinedMeters implements DCCppListener {
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message {}, {} retries available.", msg.toString(), msg.getRetries());
+        log.debug("Notified of timeout on message '{}', {} retries available.", msg.toString(), msg.getRetries());
     }
 
     private final static Logger log = LoggerFactory.getLogger(DCCppPredefinedMeters.class);

--- a/java/src/jmri/jmrix/dccpp/DCCppPredefinedMeters.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPredefinedMeters.java
@@ -54,7 +54,7 @@ public class DCCppPredefinedMeters implements DCCppListener {
     @Override
     public void message(DCCppReply r) {
         if (r.isCurrentReply()) {
-            log.debug("DCCppPredefinedMeters received reply: {}", r.toString());
+            log.debug("DCCppPredefinedMeters received reply: '{}'", r);
             try {
                 currentMeter.setCommandedAnalogValue(((r.getCurrentInt() * 1.0f) / (DCCppConstants.MAX_CURRENT * 1.0f)) * 100.0f );  // return as percentage.
             } catch (JmriException e) {

--- a/java/src/jmri/jmrix/dccpp/DCCppPredefinedMeters.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPredefinedMeters.java
@@ -77,7 +77,7 @@ public class DCCppPredefinedMeters implements DCCppListener {
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message '{}', {} retries available.", msg.toString(), msg.getRetries());
+        log.debug("Notified of timeout on message '{}', {} retries available.", msg, msg.getRetries());
     }
 
     private final static Logger log = LoggerFactory.getLogger(DCCppPredefinedMeters.class);

--- a/java/src/jmri/jmrix/dccpp/DCCppProgrammer.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppProgrammer.java
@@ -264,7 +264,7 @@ public class DCCppProgrammer extends AbstractProgrammer implements DCCppListener
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message '{}'", msg.toString());
+        log.debug("Notified of timeout on message '{}'", msg);
     }
 
 

--- a/java/src/jmri/jmrix/dccpp/DCCppProgrammer.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppProgrammer.java
@@ -264,9 +264,7 @@ public class DCCppProgrammer extends AbstractProgrammer implements DCCppListener
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        if (log.isDebugEnabled()) {
-            log.debug("Notified of timeout on message{}", msg.toString());
-        }
+        log.debug("Notified of timeout on message '{}'", msg.toString());
     }
 
 

--- a/java/src/jmri/jmrix/dccpp/DCCppReply.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppReply.java
@@ -96,53 +96,53 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
             case DCCppConstants.TURNOUT_REPLY:
                 if (isTurnoutDefReply()) {
                     text = "Turnout Reply: ";
-                    text += "T/O Number: " + getTOIDString() + ", ";
-                    text += "T/O Address: " + getTOAddressString() + ", ";
-                    text += "T/O Index: " + getTOAddressIndexString() + ", ";
+                    text += "Number: " + getTOIDString() + ", ";
+                    text += "Address: " + getTOAddressString() + ", ";
+                    text += "Index: " + getTOAddressIndexString() + ", ";
                     // if we are able to parse the address and index we can convert it
                     // to a standard DCC address for display.
                     if (getTOAddressInt() != -1 && getTOAddressIndexInt() != -1) {
                         int boardAddr = getTOAddressInt();
                         int boardIndex = getTOAddressIndexInt();
                         int dccAddress = (((boardAddr - 1) * 4) + boardIndex) + 1;
-                        text += "T/O DCC Address: " + Integer.toString(dccAddress) + ", ";
+                        text += "DCC Address: " + Integer.toString(dccAddress) + ", ";
                     }
                     text += "Direction: " + getTOStateString();
                 } else {
                     text = "Turnout Reply: ";
-                    text += "T/O Number: " + getTOIDString() + ", ";
+                    text += "Number: " + getTOIDString() + ", ";
                     text += "Direction: " + getTOStateString();
                 }
                 break;
             case DCCppConstants.SENSOR_REPLY_H:
                 text = "Sensor Reply (Inactive): ";
-                text += "Sensor Number: " + getSensorNumString() + ", ";
+                text += "Number: " + getSensorNumString() + ", ";
                 text += "State: INACTIVE";
                 break;
             case DCCppConstants.SENSOR_REPLY_L:
                 // Also covers the V1.0 version SENSOR_REPLY
                 if (isSensorDefReply()) {
                     text = "Sensor Def Reply: ";
-                    text += "Sensor Number: " + getSensorDefNumString() + ", ";
-                    text += "Sensor Pin: " + getSensorDefPinString() + ", ";
-                    text += "Sensor Pullup: " + getSensorDefPullupString();
+                    text += "Number: " + getSensorDefNumString() + ", ";
+                    text += "Pin: " + getSensorDefPinString() + ", ";
+                    text += "Pullup: " + getSensorDefPullupString();
                 } else {
                     text = "Sensor Reply (Active): ";
-                    text += "Sensor Number: " + getSensorNumString() + ", ";
+                    text += "Number: " + getSensorNumString() + ", ";
                     text += "State: ACTIVE";
                 }
                 break;
             case DCCppConstants.OUTPUT_REPLY:
                 if (isOutputCmdReply()) {
                     text = "Output Command Reply: ";
-                    text += "Output Number: " + getOutputNumString() + ", ";
-                    text += "OutputState: " + getOutputCmdStateString();
+                    text += "Number: " + getOutputNumString() + ", ";
+                    text += "State: " + getOutputCmdStateString();
                 } else if (isOutputListReply()) {
                     text = "Output Command Reply: ";
-                    text += "Output Number: " + getOutputNumString() + ", ";
-                    text += "Output Pin: " + getOutputListPinString() + ", ";
-                    text += "Output Flags: " + getOutputListIFlagString() + ", ";
-                    text += "Output State: " + getOutputListStateString();
+                    text += "Number: " + getOutputNumString() + ", ";
+                    text += "Pin: " + getOutputListPinString() + ", ";
+                    text += "Flags: " + getOutputListIFlagString() + ", ";
+                    text += "State: " + getOutputListStateString();
                 } else {
                     text = "Invalid Output Reply Format: ";
                     text += toString();
@@ -194,11 +194,11 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
                 text += "Sensors: " + getValueString(2) + ", ";
                 text += "Outputs: " + getValueString(3);
                 break;
-            case DCCppConstants.MEMORY_REPLY:
-                // TODO: Implement this fully
-                text = "Memory Reply... ";
-                text += "Free Memory: " + getFreeMemoryString();
-                break;
+//            case DCCppConstants.MEMORY_REPLY:
+//                // TODO: Implement this fully
+//                text = "Memory Reply... ";
+//                text += "Free Memory: " + getFreeMemoryString();
+//                break;
             case DCCppConstants.COMM_TYPE_REPLY:
                 text = "Comm Type Reply ";
                 text += "Type: " + Integer.toString(getCommTypeInt());
@@ -214,9 +214,7 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
                 text = "Number of slots reply: " + getValueString(1);
                 break;
             default:
-                text = "Unrecognized reply: ";
-                text += toString() + "vals: ";
-                text += toString().replace("", " ").trim(); // inserts a space for every character
+                text = "Unrecognized reply: '" + toString() + "'";
         }
 
         return text;
@@ -255,8 +253,8 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
                     log.debug("BSC Status Reply: {}", r.toString());
                     r.myRegex = DCCppConstants.STATUS_REPLY_BSC_REGEX;
                 } else if (s.matches(DCCppConstants.STATUS_REPLY_ESP32_REGEX)) {
-                        log.debug("ESP32 Status Reply: {}", r.toString());
-                        r.myRegex = DCCppConstants.STATUS_REPLY_ESP32_REGEX;
+                    log.debug("ESP32 Status Reply: {}", r.toString());
+                    r.myRegex = DCCppConstants.STATUS_REPLY_ESP32_REGEX;
                 } else if (s.matches(DCCppConstants.STATUS_REPLY_REGEX)) {
                     log.debug("Original Status Reply: {}", r.toString());
                     r.myRegex = DCCppConstants.STATUS_REPLY_REGEX;
@@ -327,11 +325,11 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
                     r.myRegex = DCCppConstants.WRITE_EEPROM_REPLY_REGEX;
                 }
                 return(r);
-            case DCCppConstants.MEMORY_REPLY:
-                if (s.matches(DCCppConstants.FREE_MEMORY_REPLY_REGEX)) {
-                    r.myRegex = DCCppConstants.FREE_MEMORY_REPLY_REGEX;
-                }
-                return(r);
+//            case DCCppConstants.MEMORY_REPLY:
+//                if (s.matches(DCCppConstants.FREE_MEMORY_REPLY_REGEX)) {
+//                    r.myRegex = DCCppConstants.FREE_MEMORY_REPLY_REGEX;
+//                }
+//                return(r);
             case DCCppConstants.SENSOR_REPLY_H:
                 if (s.matches(DCCppConstants.SENSOR_INACTIVE_REPLY_REGEX)) {
                     r.myRegex = DCCppConstants.SENSOR_INACTIVE_REPLY_REGEX;
@@ -1095,19 +1093,19 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
         return(this.myRegex.equals(DCCppConstants.SENSOR_INACTIVE_REPLY_REGEX));
     }
 
-    public String getFreeMemoryString() {
-        if (this.isFreeMemoryReply()) {
-            return(this.getValueString(1));
-        } else {
-            log.error("FreeMemoryReply Parser called on non-FreeMemoryReply message type {}", this.getOpCodeChar());
-            return("0");
-        }
-    }
-
-    public int getFreeMemoryInt() {
-        return(Integer.parseInt(this.getFreeMemoryString()));
-    }
-    
+//    public String getFreeMemoryString() {
+//        if (this.isFreeMemoryReply()) {
+//            return(this.getValueString(1));
+//        } else {
+//            log.error("FreeMemoryReply Parser called on non-FreeMemoryReply message type {}", this.getOpCodeChar());
+//            return("0");
+//        }
+//    }
+//
+//    public int getFreeMemoryInt() {
+//        return(Integer.parseInt(this.getFreeMemoryString()));
+//    }
+//    
     public int getCommTypeInt() {
         if (this.isCommTypeReply()) {
             return(this.getValueInt(1));
@@ -1152,7 +1150,7 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
     public boolean isMADCSuccessReply() { return(this.getOpCodeChar() == DCCppConstants.MADC_SUCCESS_REPLY); }
     public boolean isStatusReply() { return(this.getOpCodeChar() == DCCppConstants.STATUS_REPLY); }
 //    public boolean isESPStatusReply() { return(this.matches(DCCppConstants.STATUS_REPLY_ESP32_REGEX)); }
-    public boolean isFreeMemoryReply() { return(this.matches(DCCppConstants.FREE_MEMORY_REPLY_REGEX)); }
+//    public boolean isFreeMemoryReply() { return(this.matches(DCCppConstants.FREE_MEMORY_REPLY_REGEX)); }
     public boolean isOutputListReply() { return(this.matches(DCCppConstants.OUTPUT_LIST_REPLY_REGEX)); }
     public boolean isOutputCmdReply() { return(this.matches(DCCppConstants.OUTPUT_REPLY_REGEX)); }
     public boolean isCommTypeReply() { return(this.matches(DCCppConstants.COMM_TYPE_REPLY_REGEX)); }

--- a/java/src/jmri/jmrix/dccpp/DCCppReply.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppReply.java
@@ -72,7 +72,7 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
 
     @Override
     public String toString() {
-        log.trace("DCCppReply.toString(): msg {}", myReply.toString());
+        log.trace("DCCppReply.toString(): msg '{}'", myReply);
         return myReply.toString();
     }
 
@@ -250,22 +250,22 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
         switch(s.charAt(0)) {
             case DCCppConstants.STATUS_REPLY:
                 if (s.matches(DCCppConstants.STATUS_REPLY_BSC_REGEX)) {
-                    log.debug("BSC Status Reply: {}", r.toString());
+                    log.debug("BSC Status Reply: '{}'", r);
                     r.myRegex = DCCppConstants.STATUS_REPLY_BSC_REGEX;
                 } else if (s.matches(DCCppConstants.STATUS_REPLY_ESP32_REGEX)) {
-                    log.debug("ESP32 Status Reply: {}", r.toString());
+                    log.debug("ESP32 Status Reply: '{}'", r);
                     r.myRegex = DCCppConstants.STATUS_REPLY_ESP32_REGEX;
                 } else if (s.matches(DCCppConstants.STATUS_REPLY_REGEX)) {
-                    log.debug("Original Status Reply: {}", r.toString());
+                    log.debug("Original Status Reply: '{}'", r);
                     r.myRegex = DCCppConstants.STATUS_REPLY_REGEX;
                 } else if (s.matches(DCCppConstants.STATUS_REPLY_DCCEX_REGEX)) {
-                    log.debug("DCC-EX Status Reply: {}", r.toString());
+                    log.debug("DCC-EX Status Reply: '{}'", r);
                     r.myRegex = DCCppConstants.STATUS_REPLY_DCCEX_REGEX;
                 } 
                 return(r);
             case DCCppConstants.THROTTLE_REPLY:
                 if (s.matches(DCCppConstants.THROTTLE_REPLY_REGEX)) {
-                   log.debug("Throttle Reply: {}", r.toString());
+                   log.debug("Throttle Reply: '{}'", r);
                    r.myRegex = DCCppConstants.THROTTLE_REPLY_REGEX;
                 }
                 return(r);
@@ -280,7 +280,7 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
                 } else if (s.matches(DCCppConstants.MADC_FAIL_REPLY_REGEX)) {
                     r.myRegex = DCCppConstants.MADC_FAIL_REPLY_REGEX;
                 }
-                log.debug("Parsed Reply: {} length {}", r.toString(), r._nDataChars);
+                log.debug("Parsed Reply: '{}' length {}", r.toString(), r._nDataChars);
                 return(r);
             case DCCppConstants.OUTPUT_REPLY:
                 if (s.matches(DCCppConstants.OUTPUT_LIST_REPLY_REGEX)) {
@@ -288,7 +288,7 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
                 } else if (s.matches(DCCppConstants.OUTPUT_REPLY_REGEX)) {
                     r.myRegex = DCCppConstants.OUTPUT_REPLY_REGEX;
                 }
-                log.debug("Parsed Reply: {} length {}", r.toString(), r._nDataChars);
+                log.debug("Parsed Reply: '{}' length {}", r, r._nDataChars);
                 return(r);
             case DCCppConstants.PROGRAM_REPLY:
                 if (s.matches(DCCppConstants.PROGRAM_BIT_REPLY_REGEX)) {
@@ -533,7 +533,7 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
             Pattern p = Pattern.compile(pat);
             Matcher m = p.matcher(s);
             if (!m.matches()) {
-                //log.debug("No Match {} Command: {} pattern {}",name, s, pat);
+                log.trace("No Match {} Command: {} pattern {}",name, s, pat);
                 return(null);
             }
             return(m);

--- a/java/src/jmri/jmrix/dccpp/DCCppSensor.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppSensor.java
@@ -151,9 +151,7 @@ public class DCCppSensor extends AbstractSensor implements DCCppListener {
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        if (log.isDebugEnabled()) {
-            log.debug("Notified of timeout on message '{}'", msg.toString());
-        }
+        log.debug("Notified of timeout on message '{}'", msg);
     }
 
     @Override

--- a/java/src/jmri/jmrix/dccpp/DCCppSensor.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppSensor.java
@@ -114,15 +114,10 @@ public class DCCppSensor extends AbstractSensor implements DCCppListener {
      */
     @Override
     public synchronized void message(DCCppReply l) {
-        if (log.isDebugEnabled()) {
-            log.debug("received message: {}", l);
-        }
-
-        if (l.isSensorDefReply()) {
+         if (l.isSensorDefReply()) {
+            log.debug("Sensor Def Reply received: '{}'", l);
             if (l.getSensorDefNumInt() == address) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Def Message for sensor {} (Pin {})", systemName, address);
-                }
+                log.debug("Def Message for sensor {} (Pin {})", systemName, address);
                 pin = l.getSensorDefPinInt();
                 pullup = l.getSensorDefPullupBool();
                 setOwnState(Sensor.UNKNOWN);
@@ -157,7 +152,7 @@ public class DCCppSensor extends AbstractSensor implements DCCppListener {
     @Override
     public void notifyTimeout(DCCppMessage msg) {
         if (log.isDebugEnabled()) {
-            log.debug("Notified of timeout on message{}", msg.toString());
+            log.debug("Notified of timeout on message '{}'", msg.toString());
         }
     }
 

--- a/java/src/jmri/jmrix/dccpp/DCCppSensorManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppSensorManager.java
@@ -116,7 +116,7 @@ public class DCCppSensorManager extends jmri.managers.AbstractSensorManager impl
     }
 
     /**
-     * Listen for the messages to the LI100/LI101.
+     * Listen for the outgoing messages (to the command station)
      * 
      * @param l the message to parse
      */
@@ -217,8 +217,8 @@ public class DCCppSensorManager extends jmri.managers.AbstractSensorManager impl
 
     /**
      * Get the bit address from the system name.
-     * @param systemName a valid LocoNet-based Turnout System Name
-     * @return the turnout number extracted from the system name
+     * @param systemName a valid Sensor System Name
+     * @return the sensor number extracted from the system name
      */
     public int getBitFromSystemName(String systemName) {
         try {

--- a/java/src/jmri/jmrix/dccpp/DCCppSensorManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppSensorManager.java
@@ -128,7 +128,7 @@ public class DCCppSensorManager extends jmri.managers.AbstractSensorManager impl
     // If the message still has retries available, reduce retries and send it back to the traffic controller.
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message '{}' , {} retries available.", msg.toString(), msg.getRetries());
+        log.debug("Notified of timeout on message '{}' , {} retries available.", msg, msg.getRetries());
         if (msg.getRetries() > 0) {
             msg.setRetries(msg.getRetries() - 1);
             tc.sendDCCppMessage(msg, this);

--- a/java/src/jmri/jmrix/dccpp/DCCppSensorManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppSensorManager.java
@@ -84,7 +84,6 @@ public class DCCppSensorManager extends jmri.managers.AbstractSensorManager impl
     @Override
     public void message(DCCppReply l) {
         int addr = -1;  // -1 flags that no sensor address was found in reply
-        log.debug("received message: {}", l);
         if (l.isSensorDefReply()) {
             addr = l.getSensorDefNumInt();
             if (log.isDebugEnabled()) {
@@ -125,14 +124,15 @@ public class DCCppSensorManager extends jmri.managers.AbstractSensorManager impl
     public void message(DCCppMessage l) {
     }
 
-    /**
-     * Handle a timeout notification.
-     * 
-     * @param msg the message to parse
-     */
+    // Handle message timeout notification
+    // If the message still has retries available, reduce retries and send it back to the traffic controller.
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message {}", msg);
+        log.debug("Notified of timeout on message '{}' , {} retries available.", msg.toString(), msg.getRetries());
+        if (msg.getRetries() > 0) {
+            msg.setRetries(msg.getRetries() - 1);
+            tc.sendDCCppMessage(msg, this);
+        }        
     }
 
     @Override

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
@@ -91,7 +91,7 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
             getFunction(0), getFunction(1), getFunction(2), getFunction(3), getFunction(4));
         DCCppMessage msg = DCCppMessage.makeFunctionGroup1OpsMsg(this.getDccAddress(),
             getFunction(0), getFunction(1), getFunction(2), getFunction(3), getFunction(4));
-        log.debug("sendFunctionGroup1(): Message: {}", msg.toString());
+        log.debug("sendFunctionGroup1(): Message: {}", msg);
         // now, queue the message for sending to the command station
         //queueMessage(msg, THROTTLEFUNCSENT);
         queueMessage(msg, THROTTLEIDLE);
@@ -148,7 +148,7 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
         DCCppMessage msg = DCCppMessage.makeFunctionGroup5OpsMsg(this.getDccAddress(),
             getFunction(21), getFunction(22), getFunction(23), getFunction(24),
             getFunction(25), getFunction(26), getFunction(27), getFunction(28));
-        log.debug("sendFunctionGroup5(): Message: {}", msg.toString());
+        log.debug("sendFunctionGroup5(): Message: '{}'", msg);
         // now, queue the message for sending to the command station
         //queueMessage(msg, THROTTLEFUNCSENT);
         queueMessage(msg, THROTTLEIDLE);
@@ -324,7 +324,7 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message '{}' , {} retries available.", msg.toString(), msg.getRetries());
+        log.debug("Notified of timeout on message '{}' , {} retries available.", msg, msg.getRetries());
         if (msg.getRetries() > 0) {
             // If the message still has retries available, send it back to 
             // the traffic controller.

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
@@ -324,9 +324,7 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        if (log.isDebugEnabled()) {
-            log.debug("Notified of timeout on message{} , {} retries available.", msg.toString(), msg.getRetries());
-        }
+        log.debug("Notified of timeout on message '{}' , {} retries available.", msg.toString(), msg.getRetries());
         if (msg.getRetries() > 0) {
             // If the message still has retries available, send it back to 
             // the traffic controller.

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
@@ -316,7 +316,7 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
     }
 
  
-    // listen for the messages to the LI100/LI101
+    // Listen for the outgoing messages (to the command station)
     @Override
     public void message(DCCppMessage l) {
     }

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
@@ -255,7 +255,7 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
         // First, we want to see if this throttle is waiting for a message 
         //or not.
         if (log.isDebugEnabled()) {
-            log.debug("Throttle {} - received message \"{}\"", getDccAddress(), l.toString());
+            log.debug("Throttle {} - received message '{}'", getDccAddress(), l);
         }
         if (requestState == THROTTLEIDLE) {
             log.debug("Current throttle status is THROTTLEIDLE");
@@ -278,7 +278,7 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
   
         }
         if ((requestState & THROTTLEFUNCSENT) == THROTTLEFUNCSENT) {
-            log.debug("Current throttle status is THROTTLEFUNCSENT. Ignoring Reply: {}",l.toString());
+            log.debug("Current throttle status is THROTTLEFUNCSENT. Ignoring Reply: '{}'", l);
         }
         requestState=THROTTLEIDLE;
         sendQueuedMessage();

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
@@ -141,9 +141,15 @@ public class DCCppThrottleManager extends AbstractThrottleManager implements DCC
     public void message(DCCppMessage l) {
     }
 
-    // Handle a timeout notification
+    // Handle message timeout notification
+    // If the message still has retries available, reduce retries and send it back to the traffic controller.
     @Override
     public void notifyTimeout(DCCppMessage msg) {
+        log.debug("Notified of timeout on message '{}' , {} retries available.", msg.toString(), msg.getRetries());
+        if (msg.getRetries() > 0) {
+            msg.setRetries(msg.getRetries() - 1);
+            tc.sendDCCppMessage(msg, this);
+        }        
     }
 
     @Override

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
@@ -145,7 +145,7 @@ public class DCCppThrottleManager extends AbstractThrottleManager implements DCC
     // If the message still has retries available, reduce retries and send it back to the traffic controller.
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message '{}' , {} retries available.", msg.toString(), msg.getRetries());
+        log.debug("Notified of timeout on message '{}' , {} retries available.", msg, msg.getRetries());
         if (msg.getRetries() > 0) {
             msg.setRetries(msg.getRetries() - 1);
             tc.sendDCCppMessage(msg, this);

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnout.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnout.java
@@ -273,7 +273,7 @@ public class DCCppTurnout extends AbstractTurnout implements DCCppListener {
         }
     }
 
-    // listen for the messages to the LI100/LI101
+    // Listen for the outgoing messages (to the command station)
     @Override
     public void message(DCCppMessage l) {
     }

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnout.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnout.java
@@ -207,7 +207,7 @@ public class DCCppTurnout extends AbstractTurnout implements DCCppListener {
             internalState = IDLE;
                 break;
         }
-        log.debug("Sending Message: {}", msg.toString());
+        log.debug("Sending Message: '{}'", msg);
         tc.sendDCCppMessage(msg, null);  // status returned via manager
     }
     
@@ -281,7 +281,7 @@ public class DCCppTurnout extends AbstractTurnout implements DCCppListener {
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message '{}'", msg.toString());
+        log.debug("Notified of timeout on message '{}'", msg);
     }
 
     /*

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnout.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnout.java
@@ -260,8 +260,6 @@ public class DCCppTurnout extends AbstractTurnout implements DCCppListener {
      */
     @Override
     synchronized public void message(DCCppReply l) {
-        log.debug("received message: {}", l);
-
         switch (getFeedbackMode()) {
         case EXACT:
             handleExactModeFeedback(l);
@@ -283,9 +281,7 @@ public class DCCppTurnout extends AbstractTurnout implements DCCppListener {
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        if (log.isDebugEnabled()) {
-            log.debug("Notified of timeout on message {}", msg.toString());
-        }
+        log.debug("Notified of timeout on message '{}'", msg.toString());
     }
 
     /*

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
@@ -33,8 +33,9 @@ public class DCCppTurnoutManager extends jmri.managers.AbstractTurnoutManager im
         // set up listener
         tc.addDCCppListener(DCCppInterface.FEEDBACK, this);
         // request list of turnouts
-        DCCppMessage msg = DCCppMessage.makeTurnoutListMsg();
-        tc.sendDCCppMessage(msg, this);
+        tc.sendDCCppMessage(DCCppMessage.makeTurnoutListMsg(), this);
+        // request list of outputs
+        tc.sendDCCppMessage(DCCppMessage.makeOutputListMsg(), this);
     }
 
     /**

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
@@ -71,10 +71,8 @@ public class DCCppTurnoutManager extends jmri.managers.AbstractTurnoutManager im
      */
     @Override
     public void message(DCCppReply l) {
-        if (log.isDebugEnabled()) {
-            log.debug("received message: {}", l.toString());
-        }
         if (l.isTurnoutReply()) {
+            log.debug("received Turnout Reply message: {}", l.toString());
             // parse message type
             int addr = l.getTOIDInt();
             if (addr >= 0) {
@@ -97,6 +95,7 @@ public class DCCppTurnoutManager extends jmri.managers.AbstractTurnoutManager im
                 }
             }
         } else if (l.isOutputCmdReply()) {
+            log.debug("received Output Cmd Reply message: {}", l.toString());
             // parse message type
             int addr = l.getOutputNumInt();
             if (addr >= 0) {
@@ -150,14 +149,15 @@ public class DCCppTurnoutManager extends jmri.managers.AbstractTurnoutManager im
     public void message(DCCppMessage l) {
     }
 
-    /**
-     * Handle a timeout notification.
-     */
+    // Handle message timeout notification
+    // If the message still has retries available, reduce retries and send it back to the traffic controller.
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        if (log.isDebugEnabled()) {
-            log.debug("Notified of timeout on message{}", msg.toString());
-        }
+        log.debug("Notified of timeout on message '{}' , {} retries available.", msg.toString(), msg.getRetries());
+        if (msg.getRetries() > 0) {
+            msg.setRetries(msg.getRetries() - 1);
+            tc.sendDCCppMessage(msg, this);
+        }        
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
@@ -73,7 +73,7 @@ public class DCCppTurnoutManager extends jmri.managers.AbstractTurnoutManager im
     @Override
     public void message(DCCppReply l) {
         if (l.isTurnoutReply()) {
-            log.debug("received Turnout Reply message: {}", l.toString());
+            log.debug("received Turnout Reply message: '{}'", l);
             // parse message type
             int addr = l.getTOIDInt();
             if (addr >= 0) {
@@ -96,7 +96,7 @@ public class DCCppTurnoutManager extends jmri.managers.AbstractTurnoutManager im
                 }
             }
         } else if (l.isOutputCmdReply()) {
-            log.debug("received Output Cmd Reply message: {}", l.toString());
+            log.debug("received Output Cmd Reply message: '{}'", l);
             // parse message type
             int addr = l.getOutputNumInt();
             if (addr >= 0) {

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
@@ -154,7 +154,7 @@ public class DCCppTurnoutManager extends jmri.managers.AbstractTurnoutManager im
     // If the message still has retries available, reduce retries and send it back to the traffic controller.
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message '{}' , {} retries available.", msg.toString(), msg.getRetries());
+        log.debug("Notified of timeout on message '{}' , {} retries available.", msg, msg.getRetries());
         if (msg.getRetries() > 0) {
             msg.setRetries(msg.getRetries() - 1);
             tc.sendDCCppMessage(msg, this);

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
@@ -144,7 +144,7 @@ public class DCCppTurnoutManager extends jmri.managers.AbstractTurnoutManager im
     }
 
     /**
-     * Listen for the messages to the LI100/LI101
+     * Listen for the outgoing messages (to the command station)
      */
     @Override
     public void message(DCCppMessage l) {
@@ -187,7 +187,7 @@ public class DCCppTurnoutManager extends jmri.managers.AbstractTurnoutManager im
     /**
      * Get the bit address from the system name.
      *
-     * @param systemName a valid LocoNet-based Turnout System Name
+     * @param systemName a valid Turnout System Name
      * @return the turnout number extracted from the system name
      */
     public int getBitFromSystemName(String systemName) {

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnoutReplyCache.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnoutReplyCache.java
@@ -115,7 +115,7 @@ public class DCCppTurnoutReplyCache implements DCCppListener {
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message '{}'", msg.toString());
+        log.debug("Notified of timeout on message '{}'", msg);
     }
 
     private final static Logger log = LoggerFactory.getLogger(DCCppTurnoutReplyCache.class);

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnoutReplyCache.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnoutReplyCache.java
@@ -115,9 +115,7 @@ public class DCCppTurnoutReplyCache implements DCCppListener {
     // Handle a timeout notification
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        if (log.isDebugEnabled()) {
-            log.debug("Notified of timeout on message{}", msg.toString());
-        }
+        log.debug("Notified of timeout on message '{}'", msg.toString());
     }
 
     private final static Logger log = LoggerFactory.getLogger(DCCppTurnoutReplyCache.class);

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnoutReplyCache.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnoutReplyCache.java
@@ -107,7 +107,7 @@ public class DCCppTurnoutReplyCache implements DCCppListener {
         }
     }
 
-    // listen for the messages to the LI100/LI101
+    // Listen for the outgoing messages (to the command station)
     @Override
     public void message(DCCppMessage l) {
     }

--- a/java/src/jmri/jmrix/dccpp/dccppovertcp/DCCppOverTcpPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/dccppovertcp/DCCppOverTcpPacketizer.java
@@ -142,7 +142,7 @@ public class DCCppOverTcpPacketizer extends DCCppPacketizer {
         // update statistics
         //transmittedMsgCount++;
 
-        log.debug("queue DCCpp packet: {}", m.toString());
+        log.debug("queue DCCpp packet: {}", m);
         // in an atomic operation, queue the request and wake the xmit thread
         try {
             synchronized (xmtHandler) {

--- a/java/src/jmri/jmrix/dccpp/network/DCCppEthernetPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/network/DCCppEthernetPacketizer.java
@@ -76,7 +76,7 @@ public class DCCppEthernetPacketizer extends jmri.jmrix.dccpp.serial.SerialDCCpp
                         break;
                     } else if (m.getRetries() >= 0) {
                         if (log.isDebugEnabled()) {
-                            log.debug("Retry message: {} attempts remaining: {}", m.toString(), m.getRetries());
+                            log.debug("Retry message: '{}' attempts remaining: {}", m, m.getRetries());
                         }
                         m.setRetries(m.getRetries() - 1);
                         try {

--- a/java/src/jmri/jmrix/dccpp/simulator/DCCppSimulatorAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/simulator/DCCppSimulatorAdapter.java
@@ -247,7 +247,7 @@ public class DCCppSimulatorAdapter extends DCCppSimulatorPortController implemen
         Matcher m;
         DCCppReply reply = null;
 
-        log.debug("Generate Reply to message type {} string = {}", msg.getElement(0), msg.toString());
+        log.debug("Generate Reply to message type '{}' string = '{}'", msg.getElement(0), msg);
 
         switch (msg.getElement(0)) {
 
@@ -296,7 +296,7 @@ public class DCCppSimulatorAdapter extends DCCppSimulatorPortController implemen
 
             case DCCppConstants.OUTPUT_CMD:
                 if (msg.isOutputCmdMessage()) {
-                    log.debug("Output Command Message: {}", msg.toString());
+                    log.debug("Output Command Message: '{}'", msg);
                     r = "Y" + msg.getOutputIDString() + " " + (msg.getOutputStateBool() ? "1" : "0");
                     log.debug("Reply String: {}", r);
                     reply = DCCppReply.parseDCCppReply(r);

--- a/java/src/jmri/jmrix/dccpp/swing/ConfigBaseStationAction.java
+++ b/java/src/jmri/jmrix/dccpp/swing/ConfigBaseStationAction.java
@@ -43,18 +43,17 @@ public class ConfigBaseStationAction extends AbstractAction {
     public void actionPerformed(ActionEvent e) {
         if (f == null || !f.isVisible()) {
             
-            // Get info on Sensors
             DCCppSystemConnectionMemo systemMemo = jmri.InstanceManager.getDefault(DCCppSystemConnectionMemo.class);
             DCCppSensorManager smgr = (DCCppSensorManager)systemMemo.getSensorManager();
             DCCppTurnoutManager tmgr = (DCCppTurnoutManager)systemMemo.getTurnoutManager();
-            // Send query for sensor values
             DCCppTrafficController tc = systemMemo.getDCCppTrafficController();
-    
             f = new ConfigBaseStationFrame(smgr, tmgr, tc);
             tc.addDCCppListener(DCCppInterface.CS_INFO, f);
-            tc.sendDCCppMessage(DCCppMessage.makeSensorListMsg(), f); // TODO: Put this in Constants?
-            tc.sendDCCppMessage(DCCppMessage.makeTurnoutListMsg(), f); // TODO: Put this in Constants?
-            tc.sendDCCppMessage(DCCppMessage.makeOutputListMsg(), f); // TODO: Put this in Constants?
+            
+            // Request definitions for Turnouts, Sensors and Outputs
+            tc.sendDCCppMessage(DCCppMessage.makeSensorListMsg(), f); 
+            tc.sendDCCppMessage(DCCppMessage.makeTurnoutListMsg(), f);
+            tc.sendDCCppMessage(DCCppMessage.makeOutputListMsg(), f); 
         }
         f.setExtendedState(Frame.NORMAL);
     }

--- a/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonPane.java
+++ b/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonPane.java
@@ -168,7 +168,7 @@ public class DCCppMonPane extends jmri.jmrix.AbstractMonPane implements DCCppLis
     public synchronized void message(final DCCppReply l) {
         // receive a DCC++ message and log it
         // display the raw data if requested
-        log.debug("Message in Monitor: {} opcode {}", l.toString(), Character.toString(l.getOpCodeChar()));
+        log.debug("Message in Monitor: '{}' opcode {}", l, Character.toString(l.getOpCodeChar()));
 
         logMessage("", "RX: ", l);
     }

--- a/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonPane.java
+++ b/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonPane.java
@@ -185,9 +185,7 @@ public class DCCppMonPane extends jmri.jmrix.AbstractMonPane implements DCCppLis
     // Handle a timeout notification
     @Override
     public void notifyTimeout(final DCCppMessage msg) {
-        if (log.isDebugEnabled()) {
-            log.debug("Notified of timeout on message{}", msg.toString());
-        }
+        log.debug("Notified of timeout on message '{}'", msg);
     }
 
     /**

--- a/java/src/jmri/jmrix/dccpp/swing/packetgen/PacketGenFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/packetgen/PacketGenFrame.java
@@ -54,7 +54,7 @@ public class PacketGenFrame extends jmri.jmrix.swing.AbstractPacketGenFrame {
             s = s.substring(0, s.lastIndexOf('>'));
         }
         DCCppMessage m = new DCCppMessage(s);
-        log.debug("Sending: {}", m);
+        log.debug("Sending: '{}'", m);
         return(m);
     }
 

--- a/java/test/jmri/jmrix/dccpp/DCCppMessageTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppMessageTest.java
@@ -42,7 +42,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr1ActivateTrue() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(1, true);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 7, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -56,7 +56,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr1ActivateFalse() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(1, false);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 7, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -70,7 +70,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr4ActivateTrue() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(4, true);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 7, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -84,7 +84,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr4ActivateFalse() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(4, false);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 7, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -98,7 +98,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr5ActivateTrue() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(5, true);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 7, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -112,7 +112,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr5ActivateFalse() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(5, false);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 7, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -126,7 +126,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr40ActivateTrue() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(40, true);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 8, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -141,7 +141,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr40ActivateFalse() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(40, false);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 8, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -156,7 +156,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr41ActivateTrue() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(41, true);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 8, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -171,7 +171,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr41ActivateFalse() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(41, false);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 8, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -186,7 +186,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr2040ActivateTrue() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(2040, true);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 9, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -202,7 +202,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr2040ActivateFalse() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(2040, false);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 9, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -218,7 +218,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr2041ActivateTrue() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(2041, true);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 9, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -234,7 +234,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr2041ActivateFalse() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(2041, false);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 9, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -250,7 +250,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr2044ActivateTrue() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(2044, true);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 9, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -266,7 +266,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMakeAccessoryDecoderMsgAddr2044ActivateFalse() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(2044, false);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 9, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -283,7 +283,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetAccessoryDecoderMsgActivateTrue() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(23, 2, true);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 8, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -298,7 +298,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetAccessoryDecoderMsgActivateFalse() {
         msg = DCCppMessage.makeAccessoryDecoderMsg(23, 2, false);
-        log.debug("accessory decoder message = {}", msg.toString());
+        log.debug("accessory decoder message = '{}'", msg);
         Assert.assertEquals("length", 8, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -325,7 +325,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetTurnoutCommandMsgThrown() {
         msg = DCCppMessage.makeTurnoutCommandMsg(23, true);
-        log.debug("turnout message = {}", msg.toString());
+        log.debug("turnout message = '{}'", msg);
         Assert.assertEquals("length", 6, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'T', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -338,7 +338,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetTurnoutCommandMsgClosed() {
         msg = DCCppMessage.makeTurnoutCommandMsg(23, false);
-        log.debug("turnout message = {}", msg.toString());
+        log.debug("turnout message = '{}'", msg);
         Assert.assertEquals("length", 6, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'T', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -363,7 +363,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetWriteDirectCVMsg() {
         msg = DCCppMessage.makeWriteDirectCVMsg(29, 12, 1, 2);
-        log.debug("write cv message = {}", msg.toString());
+        log.debug("write cv message = '{}'", msg);
         Assert.assertEquals("length", 11, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'W', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -387,7 +387,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetBitWriteDirectCVMsg() {
         msg = DCCppMessage.makeBitWriteDirectCVMsg(17, 4, 1, 3, 4);
-        log.debug("write cv bit message = {}", msg.toString());
+        log.debug("write cv bit message = '{}'", msg);
         Assert.assertEquals("length", 12, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'B', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -412,7 +412,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetReadDirectCVMsg() {
         msg = DCCppMessage.makeReadDirectCVMsg(17, 4, 3);
-        log.debug("read cv message = {}", msg.toString());
+        log.debug("read cv message = '{}'", msg);
         Assert.assertEquals("length", 8, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'R', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -433,7 +433,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetWriteOpsModeCVMsg() {
         msg = DCCppMessage.makeWriteOpsModeCVMsg(17, 4, 3);
-        log.debug("write ops cv message = {}", msg.toString());
+        log.debug("write ops cv message = '{}'", msg);
         Assert.assertEquals("length", 8, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'w', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -454,7 +454,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetBitWriteOpsModeCVMsg() {
         msg = DCCppMessage.makeBitWriteOpsModeCVMsg(17, 4, 3, 1);
-        log.debug("write ops bit cv message = {}", msg.toString());
+        log.debug("write ops bit cv message = '{}'", msg);
         Assert.assertEquals("length", 10, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'b', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -477,12 +477,12 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testSetTrackPowerMsg() {
         msg = DCCppMessage.makeSetTrackPowerMsg(true);
-        log.debug("track power on message = {}", msg.toString());
+        log.debug("track power on message = '{}'", msg);
         Assert.assertEquals("length", 1, msg.getNumDataElements());
         Assert.assertEquals("0th byte", '1', msg.getElement(0) & 0xFF);
 
         msg = DCCppMessage.makeSetTrackPowerMsg(false);
-        log.debug("track power off message = {}", msg.toString());
+        log.debug("track power off message = '{}'", msg);
         Assert.assertEquals("length", 1, msg.getNumDataElements());
         Assert.assertEquals("0th byte", '0', msg.getElement(0) & 0xFF);
     }
@@ -496,7 +496,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testReadTrackCurrentMsg() {
         msg = DCCppMessage.makeReadTrackCurrentMsg();
-        log.debug("read track current message = {}", msg.toString());
+        log.debug("read track current message = '{}'", msg);
         Assert.assertEquals("length", 1, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'c', msg.getElement(0) & 0xFF);
     }
@@ -510,7 +510,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetCSStatusMsg() {
         msg = DCCppMessage.makeCSStatusMsg();
-        log.debug("get status message = {}", msg.toString());
+        log.debug("get status message = '{}'", msg);
         Assert.assertEquals("length", 1, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 's', msg.getElement(0) & 0xFF);
     }
@@ -524,7 +524,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetAddressedEmergencyStopMsg() {
         msg = DCCppMessage.makeAddressedEmergencyStop(5, 24);
-        log.debug("emergency stop message = {}", msg.toString());
+        log.debug("emergency stop message = '{}'", msg);
         Assert.assertEquals("length", 11, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 't', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -548,7 +548,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetSpeedAndDirectionMsg() {
         msg = DCCppMessage.makeSpeedAndDirectionMsg(5, 24, 0.5f, false);
-        log.debug("Speed message 1 = {}", msg.toString());
+        log.debug("Speed message 1 = '{}'", msg);
         Assert.assertEquals("length", 11, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 't', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -563,7 +563,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
         Assert.assertEquals("10th byte", '0', msg.getElement(10) & 0xFF);
 
         msg = DCCppMessage.makeSpeedAndDirectionMsg(5, 24, 1.0f, true);
-        log.debug("Speed message 2 = {}", msg.toString());
+        log.debug("Speed message 2 = '{}'", msg);
         Assert.assertEquals("length", 12, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 't', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -579,7 +579,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
         Assert.assertEquals("11th byte", '1', msg.getElement(11) & 0xFF);
 
         msg = DCCppMessage.makeSpeedAndDirectionMsg(5, 24, -1, true);
-        log.debug("Speed message 3 = {}", msg.toString());
+        log.debug("Speed message 3 = '{}'", msg);
         Assert.assertEquals("length", 11, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 't', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -604,7 +604,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     public void testgetWriteDCCPacketMainMsg() {
         byte packet[] = {(byte) 0xC4, (byte) 0xD2, (byte) 0x12, (byte) 0x0C, (byte) 0x08};
         msg = DCCppMessage.makeWriteDCCPacketMainMsg(0, 5, packet);
-        log.debug("DCC packet main message = {}", msg.toString());
+        log.debug("DCC packet main message = '{}'", msg);
         Assert.assertEquals("length", 18, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'M', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -637,7 +637,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     public void testgetWriteDCCPacketProgMsg() {
         byte packet[] = {(byte) 0xC4, (byte) 0xD2, (byte) 0x12, (byte) 0x0C, (byte) 0x08};
         msg = DCCppMessage.makeWriteDCCPacketProgMsg(0, 5, packet);
-        log.debug("DCC packet main message = {}", msg.toString());
+        log.debug("DCC packet main message = '{}'", msg);
         Assert.assertEquals("length", 18, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'P', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -669,7 +669,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetOutputCmdMsgOn() {
         msg = DCCppMessage.makeOutputCmdMsg(23, true);
-        log.debug("turnout message = {}", msg.toString());
+        log.debug("turnout message = '{}'", msg);
         Assert.assertEquals("length", 6, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'Z', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
@@ -682,7 +682,7 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetOutputCmdMsgOff() {
         msg = DCCppMessage.makeOutputCmdMsg(23, false);
-        log.debug("turnout message = {}", msg.toString());
+        log.debug("turnout message = '{}'", msg);
         Assert.assertEquals("length", 6, msg.getNumDataElements());
         Assert.assertEquals("0th byte", 'Z', msg.getElement(0) & 0xFF);
         Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);

--- a/java/test/jmri/jmrix/dccpp/DCCppMessageTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppMessageTest.java
@@ -351,13 +351,13 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMonitorStringTurnoutCommandMsgThrown() {
         msg = DCCppMessage.makeTurnoutCommandMsg(23, true);
-        Assert.assertEquals("Monitor string", "Turnout Cmd: T/O ID: 23, State: THROWN", msg.toMonitorString());
+        Assert.assertEquals("Monitor string", "Turnout Cmd: ID: 23, State: THROWN", msg.toMonitorString());
     }
 
     @Test
     public void testMonitorStringTurnoutCommandMsgClosed() {
         msg = DCCppMessage.makeTurnoutCommandMsg(23, false);
-        Assert.assertEquals("Monitor string", "Turnout Cmd: T/O ID: 23, State: CLOSED", msg.toMonitorString());
+        Assert.assertEquals("Monitor string", "Turnout Cmd: ID: 23, State: CLOSED", msg.toMonitorString());
     }
 
     @Test
@@ -695,13 +695,13 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMonitorStringOutputCmdMsgOn() {
         msg = DCCppMessage.makeOutputCmdMsg(23, true);
-        Assert.assertEquals("Monitor string", "Output Cmd: Output ID: 23, State: HIGH", msg.toMonitorString());
+        Assert.assertEquals("Monitor string", "Output Cmd: ID: 23, State: HIGH", msg.toMonitorString());
     }
 
     @Test
     public void testMonitorStringOutputCmdMsgOff() {
         msg = DCCppMessage.makeOutputCmdMsg(23, false);
-        Assert.assertEquals("Monitor string", "Output Cmd: Output ID: 23, State: LOW", msg.toMonitorString());
+        Assert.assertEquals("Monitor string", "Output Cmd: ID: 23, State: LOW", msg.toMonitorString());
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
@@ -286,21 +286,21 @@ public class DCCppReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testMonitorStringTurnoutReply() {
         DCCppReply l = DCCppReply.parseDCCppReply("H 1234 0");
-        Assert.assertEquals("Monitor string", "Turnout Reply: T/O Number: 1234, Direction: CLOSED", l.toMonitorString());
+        Assert.assertEquals("Monitor string", "Turnout Reply: Number: 1234, Direction: CLOSED", l.toMonitorString());
     }
 
     @Test
     public void testMonitorStringOutputPinReply() {
         DCCppReply l = DCCppReply.parseDCCppReply("Y 1234 0");
-        Assert.assertEquals("Monitor string", "Output Command Reply: Output Number: 1234, OutputState: LOW", l.toMonitorString());
+        Assert.assertEquals("Monitor string", "Output Command Reply: Number: 1234, State: LOW", l.toMonitorString());
     }
 
     @Test
     public void testMonitorStringSensorStatusReply() {
         DCCppReply l = DCCppReply.parseDCCppReply("Q 1234");
-        Assert.assertEquals("Monitor string", "Sensor Reply (Active): Sensor Number: 1234, State: ACTIVE", l.toMonitorString());
+        Assert.assertEquals("Monitor string", "Sensor Reply (Active): Number: 1234, State: ACTIVE", l.toMonitorString());
         l = DCCppReply.parseDCCppReply("q 1234");
-        Assert.assertEquals("Monitor string", "Sensor Reply (Inactive): Sensor Number: 1234, State: INACTIVE", l.toMonitorString());
+        Assert.assertEquals("Monitor string", "Sensor Reply (Inactive): Number: 1234, State: INACTIVE", l.toMonitorString());
     }
 
     @Test


### PR DESCRIPTION
remove 'F' and 'f' free-memory messages, these are now being used by DCC-EX for another command
logging additions and improvements
also request 'Z' at startup for Output definition list