### PR TITLE
Connection Pref delete

### DIFF
--- a/java/test/jmri/swing/PreferencesPanelTestBase.java
+++ b/java/test/jmri/swing/PreferencesPanelTestBase.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.assertj.core.api.Java6Assertions.catchThrowable;
 
 /**
- *  Base Tests for implementations of the PreferenesPanel interface.
+ *  Base Tests for implementations of the PreferencesPanel interface.
  *
  * @author Paul Bender Colyright (C) 2020
  */


### PR DESCRIPTION
Fix for Connection Pref (Tab) delete IOB.
Also solves the disappearing Connection Type combo contents.
(I left in the old code line 80-84 commented out for now to help a review)