### PR TITLE
DIgitrax FX3: Allow the use of F<n> on each output wire (where <n> is not zero).

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -196,7 +196,7 @@
 
         <h4>Digitrax</h4>
             <ul>
-                <li></li>
+                <li>Allow configuration of more function outputs for FX3 decoders.</li>
             </ul>
 
         <h4>Doehler &amp; Haas</h4>

--- a/xml/decoders/digitrax/fxCVs.xml
+++ b/xml/decoders/digitrax/fxCVs.xml
@@ -26,6 +26,12 @@
   </authorgroup>
   <revhistory xmlns="http://docbook.org/ns/docbook">
     <revision>
+      <revnumber>34</revnumber>
+      <date>2021-01-01</date>
+      <authorinitials>PJSG</authorinitials>
+      <revremark>Reduce the minOut settings to allow use of F* (not F0) on all outputs</revremark>
+    </revision>
+    <revision>
       <revnumber>33</revnumber>
       <date>2014-08-30</date>
       <authorinitials>ALM</authorinitials>
@@ -64,62 +70,62 @@
     <label>Reverse light F0R behavior</label>
     <label xml:lang="it">Luce anteriore funzionamento in marcia indietro</label>
   </variable>
-  <variable item="Function 1 effect generated" CV="51" mask="XXXXVVVV" minOut="3">
+  <variable item="Function 1 effect generated" CV="51" mask="XXXXVVVV" minOut="1">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/effectgen.xml"/>
     <label>Function 1 effect generated</label>
     <label xml:lang="it">Effetti generati Funzione 1</label>
   </variable>
-  <variable item="Function 1 behavior" CV="51" mask="VVVVXXXX" minOut="3">
+  <variable item="Function 1 behavior" CV="51" mask="VVVVXXXX" minOut="1">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/functionbehavior.xml"/>
     <label>Function 1 behavior</label>
     <label xml:lang="it">Funzionamento Funzione 1</label>
   </variable>
-  <variable item="Function 2 effect generated" CV="52" mask="XXXXVVVV" minOut="4">
+  <variable item="Function 2 effect generated" CV="52" mask="XXXXVVVV" minOut="2">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/effectgen.xml"/>
     <label>Function 2 effect generated</label>
     <label xml:lang="it">Effetti generati Funzione 2</label>
   </variable>
-  <variable item="Function 2 behavior" CV="52" mask="VVVVXXXX" minOut="4">
+  <variable item="Function 2 behavior" CV="52" mask="VVVVXXXX" minOut="2">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/functionbehavior.xml"/>
     <label>Function 2 behavior</label>
     <label xml:lang="it">Funzionamento Funzione 2</label>
   </variable>
-  <variable item="Function 3 effect generated" CV="113" mask="XXXXVVVV" minOut="5">
+  <variable item="Function 3 effect generated" CV="113" mask="XXXXVVVV" minOut="3">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/effectgen.xml"/>
     <label>Function 3 effect generated</label>
     <label xml:lang="it">Effetti generati Funzione 3</label>
   </variable>
-  <variable item="Function 3 behavior" CV="113" mask="VVVVXXXX" minOut="5">
+  <variable item="Function 3 behavior" CV="113" mask="VVVVXXXX" minOut="3">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/functionbehavior.xml"/>
     <label>Function 3 behavior</label>
     <label xml:lang="it">Funzionamento Funzione 3</label>
   </variable>
-  <variable item="Function 4 effect generated" CV="114" mask="XXXXVVVV" minOut="6">
+  <variable item="Function 4 effect generated" CV="114" mask="XXXXVVVV" minOut="4">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/effectgen.xml"/>
     <label>Function 4 effect generated</label>
     <label xml:lang="it">Effetti generati Funzione 4</label>
   </variable>
-  <variable item="Function 4 behavior" CV="114" mask="VVVVXXXX" minOut="6">
+  <variable item="Function 4 behavior" CV="114" mask="VVVVXXXX" minOut="4">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/functionbehavior.xml"/>
     <label>Function 4 behavior</label>
     <label xml:lang="it">Funzionamento Funzione 4</label>
   </variable>
-  <variable item="Function 5 effect generated" CV="115" mask="XXXXVVVV" minOut="7">
+  <variable item="Function 5 effect generated" CV="115" mask="XXXXVVVV" minOut="5">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/effectgen.xml"/>
     <label>Function 5 effect generated</label>
     <label xml:lang="it">Effetti generati Funzione 5</label>
   </variable>
-  <variable item="Function 5 behavior" CV="115" mask="VVVVXXXX" minOut="7">
+  <variable item="Function 5 behavior" CV="115" mask="VVVVXXXX" minOut="5">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/functionbehavior.xml"/>
     <label>Function 5 behavior</label>
     <label xml:lang="it">Funzionamento Funzione 5</label>
   </variable>
-  <variable item="Function 6 effect generated" CV="116" mask="XXXXVVVV" minOut="8">
+  <variable item="Function 6 effect generated" CV="116" mask="XXXXVVVV" minOut="6">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/effectgen.xml"/>
     <label>Function 6 effect generated</label>
     <label xml:lang="it">Effetti generati Funzione 6</label>
   </variable>
-  <variable item="Function 6 behavior" CV="116" mask="VVVVXXXX" minOut="8">
+  <variable item="Function 6 behavior" CV="116" mask="VVVVXXXX" minOut="6">
     <xi:include href="http://jmri.org/xml/decoders/digitrax/functionbehavior.xml"/>
     <label>Function 6 behavior</label>
     <label xml:lang="it">Funzionamento Funzione 6</label>


### PR DESCRIPTION
This is a small change to allow the user to customize the behavior of more function outputs. This is to work around problems that the F0F and F0R have hardwired direction built in.

Apparently, all the FX3 decoders have all 8 outputs, but some are no brought out to wires. In some cases they are brought out to pads on the decoder and so could be used. This PR does not solve that problem.

