### PR TITLE
Loconet Sim as Default programmer

### DIFF
--- a/java/src/apps/AppsBundle.properties
+++ b/java/src/apps/AppsBundle.properties
@@ -113,5 +113,5 @@ TooltipDefaultnotValid = {0} is not a valid choice for{1}
 TooltipDefaultSelected = {0} is selected for{1}
 TooltipDefaultNotSelected = {0} is not selected for{1}
 TooltipDefaultSelectedRestart = {0} is selected for{1}(applied after restart)
-StartupCheckForUpdateAction=Check for Updates
-StartupSystemConsoleAction=Open JMRI System Console
+StartupCheckForUpdateAction = Check for Updates
+StartupSystemConsoleAction = Open JMRI System Console

--- a/java/src/jmri/jmrit/progsupport/ProgModePane.java
+++ b/java/src/jmri/jmrit/progsupport/ProgModePane.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Provide a JPanel to configure the programming mode.
  * <p>
- * The using code should get a configured programmer with getProgrammer.
+ * The using code should get a configured programmer with getProgrammer().
  * <p>
  * This pane will only display ops mode options if ops mode is available, as
  * evidenced by an attempt to get an ops mode programmer at startup time.

--- a/java/src/jmri/jmrit/progsupport/ProgModeSelector.java
+++ b/java/src/jmri/jmrit/progsupport/ProgModeSelector.java
@@ -5,7 +5,7 @@ import jmri.Programmer;
 /**
  * Provide a JPanel to configure the programming mode.
  * <p>
- * The using code should get a configured programmer with getProgrammer.
+ * The using code should get a configured programmer with getProgrammer().
  * <p>
  * This pane will only display ops mode options if ops mode is available, as
  * evidenced by an attempt to get an ops mode programmer at startup time.

--- a/java/src/jmri/jmrit/progsupport/ProgOpsModePane.java
+++ b/java/src/jmri/jmrit/progsupport/ProgOpsModePane.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Provide a JPanel to configure the ops programming mode.
+ * Provide a JPanel to configure the ops programming (Adressed) mode.
  * <p>
  * Note that you should call the dispose() method when you're really done, so
  * that a ProgModePane object can disconnect its listeners.

--- a/java/src/jmri/jmrit/progsupport/ProgServiceModeComboBox.java
+++ b/java/src/jmri/jmrit/progsupport/ProgServiceModeComboBox.java
@@ -105,7 +105,8 @@ public class ProgServiceModeComboBox extends ProgModeSelector implements Propert
             }
             if (globProg != null) {
                 v.add(pm);
-                log.debug("ProgSMCombo added programmer {} as item {}", pm.getClass(), v.size());
+                log.debug("ProgSMCombo added programmer {} as item {}",
+                        (pm.getClass() != null ? pm.getClass() : "null"), v.size());
                 // listen for changes
                 globProg.addPropertyChangeListener(this);
             }

--- a/java/src/jmri/jmrit/progsupport/ProgServiceModeComboBox.java
+++ b/java/src/jmri/jmrit/progsupport/ProgServiceModeComboBox.java
@@ -106,7 +106,7 @@ public class ProgServiceModeComboBox extends ProgModeSelector implements Propert
             if (globProg != null) {
                 v.add(pm);
                 log.debug("ProgSMCombo added programmer {} as item {}",
-                        (pm.getClass() != null ? pm.getClass() : "null"), v.size());
+                        (pm != null ? pm.getClass() : "null"), v.size());
                 // listen for changes
                 globProg.addPropertyChangeListener(this);
             }
@@ -114,11 +114,7 @@ public class ProgServiceModeComboBox extends ProgModeSelector implements Propert
 
         add(progLabel);
         add(progBox = new JComboBox<>(v));
-        // if only one, don't show (might be confusing to user, better show combo with just 1 choice)
-        //if (progBox.getItemCount() < 2) {
-        //    progLabel.setVisible(false);
-        //    progBox.setVisible(false);
-        //} else {
+        // if only one, don't show is confusing to user, so show combo with just 1 choice)
         progBox.setSelectedItem(InstanceManager.getDefault(jmri.GlobalProgrammerManager.class)); // set default
         progBox.addActionListener(new ActionListener() {
             @Override
@@ -127,7 +123,6 @@ public class ProgServiceModeComboBox extends ProgModeSelector implements Propert
                 programmerSelected();
             }
         });
-        // }
 
         // install items in GUI
         add(new JLabel(Bundle.getMessage("ProgrammingModeLabel")));

--- a/java/src/jmri/jmrit/progsupport/ProgServiceModeComboBox.java
+++ b/java/src/jmri/jmrit/progsupport/ProgServiceModeComboBox.java
@@ -10,17 +10,15 @@ import javax.swing.BoxLayout;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
-import jmri.GlobalProgrammerManager;
-import jmri.InstanceManager;
-import jmri.Programmer;
-import jmri.ProgrammingMode;
+
+import jmri.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Provide a JPanel with a JComboBox to configure the service mode programmer.
+ * Provide a JPanel with a JComboBox to configure the service mode (Global) programmer.
  * <p>
- * The using code should get a configured programmer with getProgrammer.
+ * The using code should get a configured programmer with {@link #getProgrammer()}.
  * <p>
  * A ProgModePane may "share" between one of these and a ProgOpsModePane, which
  * means that there might be _none_ of these buttons selected. When that
@@ -80,7 +78,8 @@ public class ProgServiceModeComboBox extends ProgModeSelector implements Propert
     }
 
     /**
-     * Get the list of global managers
+     * Get the list of Global ProgrammingManagers.
+     *
      * @return empty list if none
      */
     protected List<GlobalProgrammerManager> getMgrList() {
@@ -96,50 +95,51 @@ public class ProgServiceModeComboBox extends ProgModeSelector implements Propert
         setLayout(new BoxLayout(this, direction));
 
         // create the programmer display combo box
-        progBox = new JComboBox<GlobalProgrammerManager>();
+        progBox = new JComboBox<>();
         Vector<GlobalProgrammerManager> v = new Vector<>();
         for (GlobalProgrammerManager pm : getMgrList()) {
-            Programmer globProg=null;
-            if (pm != null ) {
+            Programmer globProg = null;
+            if (pm != null) {
                 globProg = pm.getGlobalProgrammer();
             }
-            if ( globProg != null) {
+            if (globProg != null) {
                 v.add(pm);
+                log.debug("ProgSMCombo added programmer {} as item {}", pm.getClass(), v.size());
                 // listen for changes
                 globProg.addPropertyChangeListener(this);
             }
         }
 
-        add(progBox = new JComboBox<GlobalProgrammerManager>(v));
-        // if only one, don't show
-        if (progBox.getItemCount() < 2) {
-            progBox.setVisible(false);
-        } else {
-            progBox.setSelectedItem(InstanceManager.getDefault(jmri.GlobalProgrammerManager.class)); // set default
-            progBox.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    // new programmer selection
-                    programmerSelected();
-                }
-            });
-        }
+        add(progBox = new JComboBox<>(v));
+        // if only one, don't show (might be confusing to user, better show combo with just 1 choice)
+        //if (progBox.getItemCount() < 2) {
+        //    progLabel.setVisible(false);
+        //    progBox.setVisible(false);
+        //} else {
+        progBox.setSelectedItem(InstanceManager.getDefault(jmri.GlobalProgrammerManager.class)); // set default
+        progBox.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                // new programmer selection
+                programmerSelected();
+            }
+        });
+        // }
 
         // install items in GUI
-        add(new JLabel(Bundle.getMessage("ProgrammingMode")));
+        add(new JLabel(Bundle.getMessage("ProgrammingModeLabel")));
 
         add(modeBox);
 
         // and execute the setup for 1st time
         programmerSelected();
-
     }
 
     /**
-     * reload the interface with the new programmers
+     * Reload the interface with the new programming modes
      */
     void programmerSelected() {
-        DefaultComboBoxModel<ProgrammingMode> model = new DefaultComboBoxModel<ProgrammingMode>();
+        DefaultComboBoxModel<ProgrammingMode> model = new DefaultComboBoxModel<>();
         Programmer p = getProgrammer();
         if (p != null) {
             for (ProgrammingMode mode : getProgrammer().getSupportedModes()) {
@@ -151,11 +151,10 @@ public class ProgServiceModeComboBox extends ProgModeSelector implements Propert
         ProgrammingMode mode = (getProgrammer() != null) ? getProgrammer().getMode() : null;
         log.trace("programmerSelected sets mode {}", mode);
         modeBox.setSelectedItem(mode);
-
     }
 
     /**
-     * Listen to box for mode changes
+     * Listen to modeBox for mode changes
      */
     @Override
     public void actionPerformed(java.awt.event.ActionEvent e) {

--- a/java/src/jmri/jmrit/progsupport/ProgServiceModeComboBox.java
+++ b/java/src/jmri/jmrit/progsupport/ProgServiceModeComboBox.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 public class ProgServiceModeComboBox extends ProgModeSelector implements PropertyChangeListener, ActionListener {
 
     // GUI member declarations
+    JLabel progLabel = new JLabel(Bundle.getMessage("ProgrammerLabel"));
     JComboBox<GlobalProgrammerManager> progBox;
     JComboBox<ProgrammingMode> modeBox;
     ArrayList<Integer> modes = new ArrayList<Integer>();
@@ -110,6 +111,7 @@ public class ProgServiceModeComboBox extends ProgModeSelector implements Propert
             }
         }
 
+        add(progLabel);
         add(progBox = new JComboBox<>(v));
         // if only one, don't show (might be confusing to user, better show combo with just 1 choice)
         //if (progBox.getItemCount() < 2) {

--- a/java/src/jmri/jmrit/progsupport/ProgServiceModePane.java
+++ b/java/src/jmri/jmrit/progsupport/ProgServiceModePane.java
@@ -18,7 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Provide a JPanel to configure the service mode programmer.
+ * Provide a JPanel to configure the service mode (Global) programmer.
  * <p>
  * The using code should get a configured programmer with getProgrammer. Since
  * there's only one service mode programmer, maybe this isn't critical, but it's

--- a/java/src/jmri/jmrit/progsupport/ProgSupportBundle.properties
+++ b/java/src/jmri/jmrit/progsupport/ProgSupportBundle.properties
@@ -13,7 +13,6 @@ UnknownMode = Unknown Programming Mode
 ProgrammingMode = Programming Mode:
 ProgrammingModeLabel = Mode:
 ProgrammerLabel = Program on:
-ProgGlobalMark = G
 
 NotAvailable = Not Available
 

--- a/java/src/jmri/jmrit/progsupport/ProgSupportBundle.properties
+++ b/java/src/jmri/jmrit/progsupport/ProgSupportBundle.properties
@@ -10,7 +10,10 @@ AddressMode = Address Mode
 OpsByteMode = Ops Byte Mode
 UnknownMode = Unknown Programming Mode
 
-ProgrammingMode = Programming Mode
+ProgrammingMode = Programming Mode:
+ProgrammingModeLabel = Mode:
+ProgrammerLabel = Program on:
+ProgGlobalMark = G
 
 NotAvailable = Not Available
 
@@ -32,6 +35,6 @@ SignalAddress = Signal address
 DccAccessoryAddressOffSet = Offset Address
 
 AddressLabel = Address:
-OpsModeLabel = Mode:
+OpsModeLabel = Addressed Programming Mode:
 SignalAddressLabel = Signal address:
 NodeLabel = Node address:

--- a/java/src/jmri/jmrit/progsupport/ProgSupportBundle_de.properties
+++ b/java/src/jmri/jmrit/progsupport/ProgSupportBundle_de.properties
@@ -23,4 +23,4 @@ LongAddress = Erweiterte Adresse
 DecoderAddress=Dekoderadresse
 AccessoryAddress=Accessory-Adresse
 AddressLabel=Adresse:
-OpsModeLabel=Modus:
+OpsModeLabel = Gleis Programmiermodus:

--- a/java/src/jmri/jmrit/progsupport/ProgSupportBundle_nl.properties
+++ b/java/src/jmri/jmrit/progsupport/ProgSupportBundle_nl.properties
@@ -12,8 +12,7 @@ UnknownMode=Onbekende programmeermodus
 
 ProgrammingMode = Programmeermodus
 ProgrammingModeLabel = Modus:
-ProgrammerLabel = Program via:
-ProgGlobalMark = G
+ProgrammerLabel = Programmeer via:
 
 NotAvailable = Niet beschikbaar
 

--- a/java/src/jmri/jmrit/progsupport/ProgSupportBundle_nl.properties
+++ b/java/src/jmri/jmrit/progsupport/ProgSupportBundle_nl.properties
@@ -11,20 +11,23 @@ OpsByteMode = Ops Byte
 UnknownMode=Onbekende programmeermodus
 
 ProgrammingMode = Programmeermodus
+ProgrammingModeLabel = Modus:
+ProgrammerLabel = Program via:
+ProgGlobalMark = G
 
 NotAvailable = Niet beschikbaar
 
 ToolTipEnterDecoderAddress = Vul het adres (getal) van de decoder in
-ToolTipShortAddress=Het korte (1 byte) adres (bereik 1-127)
-ToolTipLongAddress=Het lange (1 byte) adres (bereik 0-10239)
-ToolTipDecoderAddress=Het 9-bit decoder- of module-adres (bereik 1-511)
-ToolTipAccessoryAddress=Het 11-bit accessory of uitgang-adres (bereik 1-2044)
+ToolTipShortAddress = Het korte (1 byte) adres (bereik 1-127)
+ToolTipLongAddress = Het lange (1 byte) adres (bereik 0-10239)
+ToolTipDecoderAddress = Het 9-bit decoder- of module-adres (bereik 1-511)
+ToolTipAccessoryAddress = Het 11-bit accessory of uitgang-adres (bereik 1-2044)
 #ToolTipCheckedLongAddress = Indien geselecteerd wordt een lang (extended) adres gebruikt,\nanders een kort adres
 
 TitleSetProgrammingMode = Stel programmeermodus in
-ShortAddress=Kort adres
+ShortAddress = Kort adres
 LongAddress = Lang adres
-DecoderAddress=Decoderadres
-AccessoryAddress=Accessoire-adres
+DecoderAddress = Decoderadres
+AccessoryAddress = Accessoire-adres
 AddressLabel = Adres:
-OpsModeLabel=Modus:
+OpsModeLabel = Globale (POM) Programmermodus:

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -29,30 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.imageio.ImageIO;
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComponent;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JMenu;
-import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JRadioButton;
-import javax.swing.JRadioButtonMenuItem;
-import javax.swing.JSplitPane;
-import javax.swing.JTable;
-import javax.swing.JTextPane;
-import javax.swing.ListSelectionModel;
-import javax.swing.Timer;
-import javax.swing.TransferHandler;
-import javax.swing.UIManager;
+import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
 import jmri.AddressedProgrammerManager;
 import jmri.GlobalProgrammerManager;
@@ -195,7 +172,11 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
 
     protected void additionsToToolBar() {
         getToolBar().add(new LargePowerManagerButton(true));
-        getToolBar().add(modePanel);
+        getToolBar().add(Box.createHorizontalGlue());
+        JPanel p = new JPanel();
+        p.setAlignmentX(JPanel.RIGHT_ALIGNMENT);
+        p.add(modePanel);
+        getToolBar().add(p);
     }
 
     /**

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneServiceProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneServiceProgFrame.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Extend the PaneProgFrame to handle service mode operations.
+ * Extend the PaneProgFrame to handle service (Global) mode operations.
  * <p>
  * If no programmer is provided, the programmer parts of the GUI are suppressed.
  *

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle.properties
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle.properties
@@ -5,7 +5,7 @@
 DefaultSensorState = Default State of Sensors
 MaxSlots = Maximum Number of Slots
 
-TitleLocoNetSimulator = LocoNet Simulator
+TitleLocoNetSimulator = {0} Simulator
 OpenFile = Open File...
 OpenFileTooltip = run from hex file
 ButtonPause = Pause

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_cs.properties
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_cs.properties
@@ -6,7 +6,7 @@
 DefaultSensorState = V\u00fdchoz\u00ed stav sn\u00edma\u010d\u016f
 MaxSlots = Maxim\u00e1ln\u00ed po\u010det Slot\u016f
 
-TitleLocoNetSimulator = LocoNet Simul\u00e1tor
+TitleLocoNetSimulator = {0} Simul\u00e1tor
 OpenFile = Otev\u0159\u00edt soubor...
 OpenFileTooltip = spustit z hex souboru
 ButtonPause = Pozastavit

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_de.properties
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_de.properties
@@ -1,5 +1,5 @@
 DefaultSensorState=Standardzustand von Detektoren
-TitleLocoNetSimulator=LocoNet Simulator
+TitleLocoNetSimulator = {0} Simulator
 OpenFile=\u00d6ffne Datei...
 OpenFileTooltip=Ablauf einer hexadezimale Datei
 ButtonPause=Warte

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_fr.properties
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_fr.properties
@@ -4,7 +4,7 @@
 
 DefaultSensorState = &#201;tat par D&#233;faut des Capteurs
 
-TitleLocoNetSimulator = Simulateur LocoNet
+TitleLocoNetSimulator = Simulateur {0}
 OpenFile = Ouvrir Fichier...
 OpenFileTooltip = lancer depuis ficher hex
 ButtonPause = Pause

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_nl.properties
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_nl.properties
@@ -4,7 +4,7 @@
 
 DefaultSensorState = Standaardinstelling Terugmelders
 
-TitleLocoNetSimulator = LocoNet Simulator
+TitleLocoNetSimulator = {0} Simulator
 OpenFile = Open bestand...
 OpenFileTooltip = laad vanaf een hexadecimaal bestand
 ButtonPause = Wacht

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileFrame.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileFrame.java
@@ -78,7 +78,7 @@ public class HexFileFrame extends JmriJFrame {
         jLabel1.setText(Bundle.getMessage("FieldDelay"));
         jLabel1.setVisible(true);
 
-        setTitle(Bundle.getMessage("TitleLocoNetSimulator"));
+        setTitle(Bundle.getMessage("TitleLocoNetSimulator", getAdapter().getUserName()));
         getContentPane().setLayout(new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
 
         JPanel pane1 = new JPanel();
@@ -192,13 +192,18 @@ public class HexFileFrame extends JmriJFrame {
         }
 
         // Install a debug programmer, replacing the existing LocoNet one
+        // Note that this needs to be repeated for the DefaultManagers, if one is set to HexFile (Ln Sim)
+        // see jmri.jmrix.loconet.hexfile.HexFileSystemConnectionMemo
+        log.debug("HexFileFrame called");
         DefaultProgrammerManager ep = port.getSystemConnectionMemo().getProgrammerManager();
         port.getSystemConnectionMemo().setProgrammerManager(
                 new jmri.progdebugger.DebugProgrammerManager(port.getSystemConnectionMemo()));
         if (port.getSystemConnectionMemo().getProgrammerManager().isAddressedModePossible()) {
+            log.debug("replacing AddressedProgrammer in Hex");
             jmri.InstanceManager.store(port.getSystemConnectionMemo().getProgrammerManager(), jmri.AddressedProgrammerManager.class);
         }
         if (port.getSystemConnectionMemo().getProgrammerManager().isGlobalProgrammerAvailable()) {
+            log.debug("replacing GlobalProgrammer in Hex");
             jmri.InstanceManager.store(port.getSystemConnectionMemo().getProgrammerManager(), GlobalProgrammerManager.class);
         }
         jmri.InstanceManager.deregister(ep, jmri.AddressedProgrammerManager.class);

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileSystemConnectionMemo.java
@@ -1,5 +1,10 @@
 package jmri.jmrix.loconet.hexfile;
 
+import jmri.GlobalProgrammerManager;
+import jmri.managers.ManagerDefaultSelector;
+
+import javax.annotation.OverridingMethodsMustInvokeSuper;
+
 /**
  * Lightweight class to denote that a system is "active" via a LocoNet hexfile emulator.
  * <p>
@@ -7,10 +12,11 @@ package jmri.jmrix.loconet.hexfile;
  * activate their particular system.
  *
  * @author Kevin Dickerson Copyright (C) 2010
+ * @author Egbert Broerse (C) 2020
  */
 public class HexFileSystemConnectionMemo extends jmri.jmrix.loconet.LocoNetSystemConnectionMemo {
 
-/*    @Override
+    /* @Override
     public jmri.jmrix.loconet.LnSensorManager getSensorManager() {
         if (getDisabled()) {
             return null;
@@ -20,5 +26,36 @@ public class HexFileSystemConnectionMemo extends jmri.jmrix.loconet.LocoNetSyste
         }
         return sensorManager;
     }*/
+
+    /**
+     * Substitute the jmri.progdebugger.DebugProgrammerManager when this connection
+     * is set to provide the default (Service Mode) GlobalProgrammerManager, replacing
+     * the LocoNet LnProgrammerManager that the super class would return.
+     * For setting up this connection the substitution was already done in
+     * {@link HexFileFrame#configure()} to allow for debugging and mocking replies
+     * from the layout connection.
+     * Since the {@link ManagerDefaultSelector} directly calls this memo, and not
+     * the InstanceManager, we prevent to return the default class which does not match
+     * the active instance, creating an extra programmer that shows up as an extra
+     * line in the Program over combo.
+     *
+     * @param <T>  Type of manager to get
+     * @param type Type of manager to get
+     * @return The manager or null if provides() is false for T
+     * @see #provides(java.lang.Class)
+     */
+    @OverridingMethodsMustInvokeSuper
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(Class<?> type) {
+        if (type.equals(GlobalProgrammerManager.class)) {
+            log.debug("Hex memo returned Global(Ops)ModeProgrammer");
+            return (T) getProgrammerManager();
+        } else {
+            return super.get(type);
+        }
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(HexFileSystemConnectionMemo.class);
 
 }

--- a/java/src/jmri/managers/ManagerDefaultSelector.java
+++ b/java/src/jmri/managers/ManagerDefaultSelector.java
@@ -119,7 +119,7 @@ public class ManagerDefaultSelector extends AbstractPreferencesManager {
                         if (log.isDebugEnabled()) {
                             log.debug("Start CONNECTION_ADDED processing with {} existing", list.size());
                             for (int i = 0; i < list.size(); i++) {
-                                log.debug("    System {}: {}", i, list.get(i));
+                                log.debug("    System {}: {} (\"{}\")", i, list.get(i), list.get(i).getUserName());
                             }
                         }
 


### PR DESCRIPTION
Fix for a second programmer showing in the Roster programing (connection) combo (by the same name) when hex is set as Default service mode (aka global) programmer.
Handled as a bug as the DefaultManager hides a programmer that was created earlier on startup.
As an aside, while trying to spot the cause, I realized Hexfile frames for multiple connections all have the same title. Adds connection name to help pick the one you want.