### PR TITLE
20210113 dispatcher 2

### DIFF
--- a/java/src/jmri/jmrit/dispatcher/ActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/ActiveTrain.java
@@ -9,6 +9,8 @@ import jmri.NamedBeanHandle;
 import jmri.Path;
 import jmri.Section;
 import jmri.Transit;
+
+import org.python.modules._marshal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -466,7 +468,7 @@ public class ActiveTrain {
                             getDelaySensor().removePropertyChangeListener(delaySensorListener);
                             InstanceManager.getDefault(DispatcherFrame.class).removeDelayedTrain(at);
                             setStarted();
-                            InstanceManager.getDefault(DispatcherFrame.class).forceScanOfAllocation();
+                            InstanceManager.getDefault(DispatcherFrame.class).queueScanOfAllocationRequests();
                             if (resetStartSensor) {
                                 try {
                                     getDelaySensor().setKnownState(jmri.Sensor.INACTIVE);
@@ -499,7 +501,7 @@ public class ActiveTrain {
                             restartSensorListener = null;
                             InstanceManager.getDefault(DispatcherFrame.class).removeDelayedTrain(at);
                             restart();
-                            InstanceManager.getDefault(DispatcherFrame.class).forceScanOfAllocation();
+                            InstanceManager.getDefault(DispatcherFrame.class).queueScanOfAllocationRequests();
                             if (resetRestartSensor) {
                                 try {
                                     getRestartSensor().setKnownState(jmri.Sensor.INACTIVE);
@@ -529,7 +531,7 @@ public class ActiveTrain {
                         if (((Integer) e.getNewValue()).intValue() == jmri.Sensor.INACTIVE) {
                             restartAllocationSensor.getBean().removePropertyChangeListener(restartAllocationSensorListener);
                             restartAllocationSensorListener = null;
-                            InstanceManager.getDefault(DispatcherFrame.class).forceScanOfAllocation();
+                            InstanceManager.getDefault(DispatcherFrame.class).queueScanOfAllocationRequests();
                         }
                     }
                 }
@@ -708,9 +710,6 @@ public class ActiveTrain {
             return;
         }
         mAllocatedSections.remove(index);
-        if (mAutoRun) {
-            mAutoActiveTrain.removeAllocatedSection(as);
-        }
         if (InstanceManager.getDefault(DispatcherFrame.class).getNameInAllocatedBlock()) {
             as.getSection().clearNameInUnoccupiedBlocks();
             as.getSection().suppressNameUpdate(false);
@@ -748,6 +747,8 @@ public class ActiveTrain {
         }
         resetAllAllocatedSections();
         clearAllocations();
+        // wait for autoallocate to do its stuffbefore continuing
+        InstanceManager.getDefault(DispatcherFrame.class).queueWaitForEmpty();
         if (mAutoRun) {
             mAutoActiveTrain.allocateAFresh();
         }
@@ -1095,6 +1096,25 @@ public class ActiveTrain {
         }
         InstanceManager.getDefault(DispatcherFrame.class).addDelayedTrain(this);
     }
+
+    protected boolean isInAllocatedList(AllocatedSection as) {
+        for (int i = 0; i < mAllocatedSections.size(); i++) {
+            if (mAllocatedSections.get(i) == as) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean isInAllocatedList(Section s) {
+        for (int i = 0; i < mAllocatedSections.size(); i++) {
+            if ((mAllocatedSections.get(i)).getSection() == s) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     boolean restartPoint = false;
 

--- a/java/src/jmri/jmrit/dispatcher/AllocationRequest.java
+++ b/java/src/jmri/jmrit/dispatcher/AllocationRequest.java
@@ -134,7 +134,7 @@ public class AllocationRequest {
         //This forces us to rescan the allocation list if the section has gone unoccupied, thus this might get re-allocated
         if (e.getPropertyName().equals("occupancy")) {
             if (((Integer) e.getNewValue()).intValue() == jmri.Section.UNOCCUPIED) {
-                InstanceManager.getDefault(DispatcherFrame.class).forceScanOfAllocation();
+                InstanceManager.getDefault(DispatcherFrame.class).queueScanOfAllocationRequests();
             }
         }
     }
@@ -172,7 +172,7 @@ public class AllocationRequest {
                     if (e.getPropertyName().equals("Held")) {
                         if (!((Boolean) e.getNewValue()).booleanValue()) {
                             mWaitingForSignalMast.removePropertyChangeListener(mSignalMastListener);
-                            InstanceManager.getDefault(DispatcherFrame.class).forceScanOfAllocation();
+                            InstanceManager.getDefault(DispatcherFrame.class).queueScanOfAllocationRequests();
                         }
                     }
                 }
@@ -198,7 +198,7 @@ public class AllocationRequest {
                     if (e.getPropertyName().equals("state")) {
                         if (((Integer) e.getNewValue()).intValue() == jmri.Block.UNOCCUPIED) {
                             mWaitingOnBlock.removePropertyChangeListener(mWaitingOnBlockListener);
-                            InstanceManager.getDefault(DispatcherFrame.class).forceScanOfAllocation();
+                            InstanceManager.getDefault(DispatcherFrame.class).queueScanOfAllocationRequests();
                         }
                     }
                 }

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -540,12 +540,8 @@ public class AutoActiveTrain implements ThrottleListener {
                     }
                 }
             } else if (b != _currentBlock) {
-                String x = "UNKWON";
-                String y = "UNKNOWN";
-                try { x=_currentBlock.getDisplayName(); } catch (Exception ex) {}
-                try { y=_nextBlock.getDisplayName(); } catch (Exception ex) {}
-                log.trace("{}: block going occupied {} is not _nextBlock[{}] or _currentBlock[{}] - ignored.",
-                        _activeTrain.getTrainName(), b.getDisplayName(USERSYS), _currentBlock, _nextBlock);
+                log.trace("{}: block going occupied {} is not _nextBlock or _currentBlock - ignored.",
+                        _activeTrain.getTrainName(), b.getDisplayName(USERSYS));
                 return;
             }
         } else if (b.getState() == Block.UNOCCUPIED) {

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -337,7 +337,11 @@ public class AutoActiveTrain implements ThrottleListener {
                 setSpeedBySignal();
             } else if (InstanceManager.getDefault(DispatcherFrame.class).getAutoAllocate()) {
                 // starting for the first time with automatic allocation of Sections
-                setSpeedBySignal();
+                // the last of 2 threads must call setSpeedBySignal
+                // if the other thread is incomplete _currentAllocated Section will be null
+                if (_currentAllocatedSection != null ) {
+                    setSpeedBySignal();
+                }
             }
         }
     }
@@ -361,17 +365,15 @@ public class AutoActiveTrain implements ThrottleListener {
     }
 
     // more operational variables
-    private final ArrayList<AllocatedSection> _allocatedSectionList = new ArrayList<>();
+    // private final ArrayList<AllocatedSection> _allocatedSectionList = new ArrayList<>();
     private jmri.jmrit.display.layoutEditor.LayoutBlockManager _lbManager = null;
     private AllocatedSection _lastAllocatedSection = null;
 
     protected Section getLastAllocatedSection() {
-        AllocatedSection as = _allocatedSectionList.get(_allocatedSectionList.size() - 1);
-        if (as != null) {
-            return as.getSection();
-        }
-        return null;
+      Section as = _activeTrain.getLastAllocatedSection();
+       return as;
     }
+
     private boolean _initialized = false;
     private Section _nextSection = null;                      // train has not reached this Section yet
     private volatile AllocatedSection _currentAllocatedSection = null;    // head of the train is in this Section
@@ -428,7 +430,7 @@ public class AutoActiveTrain implements ThrottleListener {
      * @param as the allocated that changed
      */
     protected void handleSectionStateChange(AllocatedSection as) {
-        if (!isInAllocatedList(as)) {
+        if (!_activeTrain.isInAllocatedList(as)) {
             addAllocatedSection(as);
         }
     }
@@ -439,7 +441,7 @@ public class AutoActiveTrain implements ThrottleListener {
      * @param as the section that changed
      */
     protected void handleSectionOccupancyChange(AllocatedSection as) {
-        if (!isInAllocatedList(as)) {
+        if (!_activeTrain.isInAllocatedList(as)) {
             log.debug("Unexpected occupancy change notification - Section {}", as.getSection().getDisplayName(USERSYS));
             return;
         }
@@ -484,9 +486,9 @@ public class AutoActiveTrain implements ThrottleListener {
                         _previousBlock = null;
                         _nextBlock = getNextBlock(_currentBlock, _currentAllocatedSection);
                         setEngineDirection();
-                        if ((_nextSection != null) && !isSectionInAllocatedList(_nextSection)) {
+                        if ((_nextSection != null) && !_activeTrain.isInAllocatedList(_nextSection)) {
                             // we need to get a next section
-                            InstanceManager.getDefault(DispatcherFrame.class).forceScanOfAllocation();
+                            InstanceManager.getDefault(DispatcherFrame.class).queueScanOfAllocationRequests();
                             // and then set the signal
                         }
                         // can be mid block
@@ -538,7 +540,12 @@ public class AutoActiveTrain implements ThrottleListener {
                     }
                 }
             } else if (b != _currentBlock) {
-                log.trace("{}: block going occupied {} is not _nextBlock or _currentBlock - ignored.", _activeTrain.getTrainName(), b.getDisplayName(USERSYS));
+                String x = "UNKWON";
+                String y = "UNKNOWN";
+                try { x=_currentBlock.getDisplayName(); } catch (Exception ex) {}
+                try { y=_nextBlock.getDisplayName(); } catch (Exception ex) {}
+                log.trace("{}: block going occupied {} is not _nextBlock[{}] or _currentBlock[{}] - ignored.",
+                        _activeTrain.getTrainName(), b.getDisplayName(USERSYS), _currentBlock, _nextBlock);
                 return;
             }
         } else if (b.getState() == Block.UNOCCUPIED) {
@@ -583,7 +590,6 @@ public class AutoActiveTrain implements ThrottleListener {
     }
 
     private void addAllocatedSection(AllocatedSection as) {
-        _allocatedSectionList.add(as);
         if (!_initialized) {
             // this is first allocated section, get things started
             _initialized = true;
@@ -613,6 +619,10 @@ public class AutoActiveTrain implements ThrottleListener {
                 && isStopping() && (_activeTrain.getStatus() == ActiveTrain.RUNNING)) {
             _needSetSpeed = true;
         }
+        if (InstanceManager.getDefault(DispatcherFrame.class).getSignalType() == DispatcherFrame.SECTIONSALLOCATED) {
+            setSpeedBySignal();
+        }
+        
         // request next allocation if appropriate--Dispatcher must decide whether to allocate it and when
         if ((!InstanceManager.getDefault(DispatcherFrame.class).getAutoAllocate()) && ((_lastAllocatedSection == null)
                 || (_lastAllocatedSection.getNextSection() == as.getSection()))) {
@@ -627,41 +637,9 @@ public class AutoActiveTrain implements ThrottleListener {
         }
     }
 
-    protected void removeAllocatedSection(AllocatedSection as) {
-        int index = -1;
-        for (int i = _allocatedSectionList.size(); i > 0; i--) {
-            if (_allocatedSectionList.get(i - 1) == as) {
-                index = i - 1;
-            }
-        }
-        if (index >= 0) {
-            _allocatedSectionList.remove(index);
-        } else {
-            log.warn("unexpected call to removeAllocatedSection - Section {}", as.getSection().getDisplayName(USERSYS));
-        }
-    }
-
     private boolean isStopping() {
         // here add indicator for new stopping methods, if any are added
         return (_stoppingBySensor || _stoppingByBlockOccupancy || _stoppingUsingSpeedProfile);
-    }
-
-    private boolean isInAllocatedList(AllocatedSection as) {
-        for (int i = 0; i < _allocatedSectionList.size(); i++) {
-            if (_allocatedSectionList.get(i) == as) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isSectionInAllocatedList(Section s) {
-        for (int i = 0; i < _allocatedSectionList.size(); i++) {
-            if ((_allocatedSectionList.get(i)).getSection() == s) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void removeCurrentSignal() {
@@ -729,7 +707,7 @@ public class AutoActiveTrain implements ThrottleListener {
                 // Note: null signal head will result when exiting throat-to-throat blocks.
                 log.debug("new current signal is null - sometimes OK");
             }
-        } else {
+        } else if (InstanceManager.getDefault(DispatcherFrame.class).getSignalType() == DispatcherFrame.SIGNALMAST) {
             //SignalMast
             SignalMast sm = null;
             Block cB = _currentBlock;
@@ -777,6 +755,8 @@ public class AutoActiveTrain implements ThrottleListener {
                 log.debug("{}: new current signalmast is null for section {} - sometimes OK", _activeTrain.getTrainName(),
                         as.getSection().getDisplayName(USERSYS));
             }
+        } else {
+            setSpeedBySignal();
         }
     }
 
@@ -831,7 +811,7 @@ public class AutoActiveTrain implements ThrottleListener {
                 nextSectionExpected = false;
             }
             // check if new next Section exists but is not allocated to this train excepting above circumstances
-            if ( nextSectionExpected &&_nextSection != null && !isSectionInAllocatedList(_nextSection)) {
+            if ( nextSectionExpected &&_nextSection != null && !_activeTrain.isInAllocatedList(_nextSection)) {
                 // next section is not allocated to this train, must not enter it, even if signal is OK.
                 log.warn("Stopping train [{}] in section [{}], as next section [{}] is not allocated",
                         _activeTrain.getActiveTrainName(),_currentAllocatedSection.getSection().getDisplayName(USERSYS),_nextSection.getDisplayName(USERSYS));
@@ -842,7 +822,7 @@ public class AutoActiveTrain implements ThrottleListener {
             if (ts != null &&
                     ts.isSafe() &&
                     _activeTrain.getAllocateMethod() == ActiveTrain.ALLOCATE_BY_SAFE_SECTIONS) {
-                InstanceManager.getDefault(DispatcherFrame.class).forceScanOfAllocation();
+                InstanceManager.getDefault(DispatcherFrame.class).queueScanOfAllocationRequests();
             }
 
         }
@@ -853,7 +833,7 @@ public class AutoActiveTrain implements ThrottleListener {
         log.trace("Set Speed by Signal");
         if (_pausingActive || ((_activeTrain.getStatus() != ActiveTrain.RUNNING)
                 && (_activeTrain.getStatus() != ActiveTrain.WAITING)) || ((_controllingSignal == null)
-                && InstanceManager.getDefault(DispatcherFrame.class).getSignalType() == DispatcherFrame.SIGNALHEAD)
+                && InstanceManager.getDefault(DispatcherFrame.class).getSignalType() == DispatcherFrame.SIGNALHEAD) 
                 || (InstanceManager.getDefault(DispatcherFrame.class).getSignalType() == DispatcherFrame.SIGNALMAST && (_controllingSignalMast == null
                 || (_activeTrain.getStatus() == ActiveTrain.WAITING && !_activeTrain.getStarted())))
                 || (_activeTrain.getMode() != ActiveTrain.AUTOMATIC)) {
@@ -862,224 +842,273 @@ public class AutoActiveTrain implements ThrottleListener {
             return;
         }
         if (InstanceManager.getDefault(DispatcherFrame.class).getSignalType() == DispatcherFrame.SIGNALHEAD) {
-            // a held signal always stop
-            if ( _controllingSignal != null && _controllingSignal.getAppearance() == SignalHead.HELD ) {
-                // Held - Stop
+            setSpeedBySignalHead();
+        } else if (InstanceManager.getDefault(DispatcherFrame.class).getSignalType() == DispatcherFrame.SIGNALMAST) {
+            setSpeedBySignalMast();
+        } else {
+            log.trace("Set Speed by BlocksAllocated");
+            setSpeedBySectionsAllocated();
+        }
+    }
+
+    private void setSpeedBySectionsAllocated() {
+        int sectionsAhead = 0;
+        for (AllocatedSection allocatedSection : _activeTrain.getAllocatedSectionList()) {
+            if (!allocatedSection.getEntered()) {
+                sectionsAhead++;
+            }
+        }
+        float newSpeed = 0.0f;
+        log.info("[{}:SectionsAhead[{}]",_activeTrain.getActiveTrainName() ,sectionsAhead);
+        switch (sectionsAhead) {
+            case 0:
+                newSpeed = 0.0f;
+                break;
+            case 1:
+                newSpeed = jmri.InstanceManager.getDefault(SignalSpeedMap.class)
+                        .getSpeed("Medium");
+                        // .getSpeed(InstanceManager.getDefault(DispatcherFrame.class).getStoppingSpeedName());
+                _activeTrain.setStatus(ActiveTrain.RUNNING);
+                break;
+            default:
+                newSpeed = jmri.InstanceManager.getDefault(SignalSpeedMap.class)
+                        .getSpeed("Normal");
+                // .getSpeed(InstanceManager.getDefault(DispatcherFrame.class).getStoppingSpeedName());
+                _activeTrain.setStatus(ActiveTrain.RUNNING);
+        }
+        for (Block block:_currentAllocatedSection.getSection().getBlockList()) {
+            float speed = -1.0f;
+            speed = getSpeedFromBlock(block);
+          if (speed > 0 && speed < newSpeed) {
+              newSpeed = speed;
+          }
+        }
+        if (newSpeed > 0 ) {
+            log.trace("setSpeedBySectionsAllocated isStopping[{}]",isStopping());
+            cancelStopInCurrentSection();
+            setTargetSpeed(getThrottleSettingFromSpeed(newSpeed));
+        } else {
+            stopInCurrentSection(NO_TASK);
+        }
+    }
+
+    private void setSpeedBySignalMast() {
+        //Set speed using SignalMasts;
+        String displayedAspect = _controllingSignalMast.getAspect();
+        if (log.isTraceEnabled()) {
+            log.trace("{}: Controlling mast {} ({})", _activeTrain.getTrainName(), _controllingSignalMast.getDisplayName(USERSYS), displayedAspect);
+            if (_conSignalProtectedBlock == null) {
+                log.trace("{}: Protected block is null", _activeTrain.getTrainName());
+            } else {
+                log.trace("{}: Protected block: {} state: {} speed: {}", _activeTrain.getTrainName(),
+                        _conSignalProtectedBlock.getSensor().getDisplayName(USERSYS),
+                        (_conSignalProtectedBlock.getSensor().getState() == Block.OCCUPIED ? "OCCUPIED" : "NOT OCCUPIED"),
+                        _conSignalProtectedBlock.getBlockSpeed());
+            }
+        }
+        if ((_controllingSignalMast.getAppearanceMap().getSpecificAppearance(jmri.SignalAppearanceMap.DANGER).equals(displayedAspect))
+                || !_controllingSignalMast.getLit() || _controllingSignalMast.getHeld()) {
+            if ( (_currentAllocatedSection.isInActiveBlockList(_conSignalProtectedBlock) ||
+                    ( _nextSection != null &&  _activeTrain.isInAllocatedList(_nextSection) && _nextSection.containsBlock(_conSignalProtectedBlock)))
+                    && _conSignalProtectedBlock.getSensor().getState() == Block.OCCUPIED) {
+                // Train has just passed this signal - ignore this signal
+                log.debug("{}: _conSignalProtectedBlock is the block just past so ignore {}", _activeTrain.getTrainName(), _conSignalProtectedBlock.getDisplayName(USERSYS));
+            } else {
+                log.debug("{}: Signal {} at Held or Danger so Stop", _activeTrain.getTrainName(), _controllingSignalMast.getDisplayName(USERSYS));
                 stopInCurrentSection(NO_TASK);
                 _stoppingForStopSignal = true;
-                return;
             }
-
-            if (useSpeedProfile) {
-                // find speed from signal.
-                // find speed from block
-                // use least
-                String blockSpeedName = _conSignalProtectedBlock.getBlockSpeed();
-                if (blockSpeedName.contains("Global")) {
-                    blockSpeedName = InstanceManager.getDefault(BlockManager.class).getDefaultSpeed();
-                }
-                float blockSpeed = -1.0f;
-                if (!blockSpeedName.isEmpty()) {
-                    try {
-                        blockSpeed = Float.valueOf(blockSpeedName);
-                    } catch (NumberFormatException nx) {
-                        try {
-                            blockSpeed = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(blockSpeedName);
-                            log.debug("{}: Signal {} speed from map for {} is {}",
-                                    _activeTrain.getTrainName(), _controllingSignal.getDisplayName(USERSYS), blockSpeedName,
-                                    blockSpeed);
-                        } catch (Throwable ex) { // if _anything_ goes wrong, contain it
-                            //Considered Normal if the speed does not appear in the map
-                            log.warn("{}: Block {} Speed {} not found in SignalSpeedMap",
-                                    _activeTrain.getTrainName(), _conSignalProtectedBlock.getDisplayName(USERSYS), blockSpeed);
-                        }
-                    }
-                }
-
-                float signalSpeed = -1.0f;
-                String signalSpeedName = "";
-                String displayedAspect = _controllingSignal.getAppearanceName();
-                try {
-                    signalSpeedName =
-                            jmri.InstanceManager.getDefault(SignalSpeedMap.class).getAppearanceSpeed(displayedAspect);
-                    signalSpeed = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(signalSpeedName);
-                } catch (Throwable ex) { // if _anything_ goes wrong, contain it
-                    signalSpeed = -1.0f;
-                    log.warn("{}: Block {} AppearanceSpeed {} not found in SignalSpeedMap",
-                            _activeTrain.getTrainName(), _conSignalProtectedBlock.getDisplayName(USERSYS), displayedAspect);
-                }
-                float useSpeed = 1.0f;
-                if (blockSpeed < signalSpeed) {
-                    useSpeed = blockSpeed;
-                } else {
-                    useSpeed = signalSpeed;
-                }
-
-                log.trace("BlockSpeed[{}] SignalSpeed[{}]", blockSpeed, signalSpeed);
-                if (useSpeed < 0.01f) {
-                    // check to to see if its allocated to us!!!
-                    //      check Block occupancy sensor if it is in an allocated block, which must change before signal.
-                    if ( (_currentAllocatedSection.isInActiveBlockList(_conSignalProtectedBlock) ||
-                            ( _nextSection != null &&  isSectionInAllocatedList(_nextSection) && _nextSection.containsBlock(_conSignalProtectedBlock)))
-                            && _conSignalProtectedBlock.getSensor().getState() == Block.OCCUPIED) {
-                        // Train has just passed this signal - ignore this signal
-                        log.debug("{}:Ignoring red signal [{}]",_activeTrain.getTrainName(),_controllingSignal.getDisplayName(USERSYS));
-                    } else {
-                        stopInCurrentSection(NO_TASK);
-                        _stoppingForStopSignal = true;
-                    }
-                } else {
-                    setTargetSpeedByProfile(useSpeed);
-                }
-            } else {
-                switch (_controllingSignal.getAppearance()) {
-                    case SignalHead.DARK:
-                    case SignalHead.RED:
-                    case SignalHead.FLASHRED:
-                        // May get here from signal changing before Block knows it is occupied, so must
-                        //      check Block occupancy sensor, which must change before signal.
-                        // check to to see if its allocated to us!!!
-                        //      check Block occupancy sensor if it is in an allocated block, which must change before signal.
-                        if ((_currentAllocatedSection.isInActiveBlockList(_conSignalProtectedBlock) ||
-                                (_nextSection != null && isSectionInAllocatedList(_nextSection) && _nextSection.containsBlock(_conSignalProtectedBlock)))
-                                && _conSignalProtectedBlock.getSensor().getState() == Block.OCCUPIED) {
-                            // Train has just passed this signal - ignore this signal
-                            log.debug("{}:Ignoring red signal [{}]", _activeTrain.getTrainName(),
-                                    _controllingSignal.getDisplayName(USERSYS));
-                        } else {
-                            stopInCurrentSection(NO_TASK);
-                            _stoppingForStopSignal = true;
-                        }
-                        break;
-                    case SignalHead.YELLOW:
-                    case SignalHead.FLASHYELLOW:
-                        setTargetSpeedState(SLOW_SPEED);
-                        _activeTrain.setStatus(ActiveTrain.RUNNING);
-                        break;
-                    case SignalHead.GREEN:
-                    case SignalHead.FLASHGREEN:
-                        setTargetSpeedState(NORMAL_SPEED);
-                        _activeTrain.setStatus(ActiveTrain.RUNNING);
-                        break;
-                    case SignalHead.LUNAR:
-                    case SignalHead.FLASHLUNAR:
-                        setTargetSpeedState(RESTRICTED_SPEED);
-                        _activeTrain.setStatus(ActiveTrain.RUNNING);
-                        break;
-                    default:
-                        log.warn("Signal Head[{}] has invalid Appearence - using stop",_controllingSignal.getAppearance());
-                        stopInCurrentSection(NO_TASK);
-                        _stoppingForStopSignal = true;
-                }
-
-            }
+        } else if (_controllingSignalMast.getAppearanceMap().getSpecificAppearance(jmri.SignalAppearanceMap.PERMISSIVE) != null
+                && _controllingSignalMast.getAppearanceMap().getSpecificAppearance(jmri.SignalAppearanceMap.PERMISSIVE).equals(displayedAspect)) {
+            setTargetSpeedState(RESTRICTED_SPEED);
+            _activeTrain.setStatus(ActiveTrain.RUNNING);
         } else {
-            //Set speed using SignalMasts;
-            String displayedAspect = _controllingSignalMast.getAspect();
-            if (log.isTraceEnabled()) {
-                log.trace("{}: Controlling mast {} ({})", _activeTrain.getTrainName(), _controllingSignalMast.getDisplayName(USERSYS), displayedAspect);
-                if (_conSignalProtectedBlock == null) {
-                    log.trace("{}: Protected block is null", _activeTrain.getTrainName());
-                } else {
-                    log.trace("{}: Protected block: {} state: {} speed: {}", _activeTrain.getTrainName(),
-                            _conSignalProtectedBlock.getSensor().getDisplayName(USERSYS),
-                            (_conSignalProtectedBlock.getSensor().getState() == Block.OCCUPIED ? "OCCUPIED" : "NOT OCCUPIED"),
-                            _conSignalProtectedBlock.getBlockSpeed());
+
+            //if using signalmasts, set speed to lesser of aspect speed and signalmastlogic speed
+            //  (minimum speed on the path to next signal, using turnout and block speeds)
+            String aspectSpeedStr = (String) _controllingSignalMast.getSignalSystem().getProperty(displayedAspect, "speed");
+            log.trace("{}: Signal {} speed {} for aspect {}", _activeTrain.getTrainName(), _controllingSignalMast.getDisplayName(USERSYS), aspectSpeedStr, displayedAspect);
+            float speed = -1.0f;
+            if (aspectSpeedStr != null) {
+                try {
+                    speed = Float.valueOf(aspectSpeedStr);
+                } catch (NumberFormatException nx) {
+                    try {
+                        speed = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(aspectSpeedStr);
+                        log.trace("{}: Signal {} speed from map for {} is {}", _activeTrain.getTrainName(), _controllingSignalMast.getDisplayName(USERSYS), aspectSpeedStr, speed);
+                    } catch (IllegalArgumentException ex) {
+                        //Considered Normal if the speed does not appear in the map
+                        log.trace("{}: Speed not found {}", _activeTrain.getTrainName(), aspectSpeedStr);
+                    }
                 }
             }
-            if ((_controllingSignalMast.getAppearanceMap().getSpecificAppearance(jmri.SignalAppearanceMap.DANGER).equals(displayedAspect))
-                    || !_controllingSignalMast.getLit() || _controllingSignalMast.getHeld()) {
+            int aspectSpeed = (int) speed; //save for debug message
+
+            //get maximum speed for the route between current and next signalmasts
+            float smLogicSpeed = -1.0f;
+            String smDestinationName = "unknown";
+            jmri.SignalMastLogic smLogic = InstanceManager.getDefault(jmri.SignalMastLogicManager.class).getSignalMastLogic(_controllingSignalMast);
+            if (smLogic != null) {
+                SignalMast smDestination = smLogic.getActiveDestination();
+                if (smDestination != null) {
+                    smDestinationName = smDestination.getDisplayName(USERSYS);
+                    smLogicSpeed = (int) smLogic.getMaximumSpeed(smDestination);
+                }
+            }
+
+            //use the smaller of aspect speed or route speed
+            if (smLogicSpeed > -1.0f && smLogicSpeed < speed) {
+                speed = smLogicSpeed;
+            }
+
+            log.debug("{}: {}({}) {}({}), Dest: {}, path max: {}",
+                    _activeTrain.getTrainName(),
+                    _controllingSignalMast.getDisplayName(USERSYS), displayedAspect, aspectSpeedStr, aspectSpeed,
+                    smDestinationName, (int) smLogicSpeed);
+
+            if (speed > -1.0f) {
+                /* We should work on the basis that the speed required in the current block/section is governed by the signalmast
+                 that we have passed and not the one we are approaching when we are accelerating.
+                 However when we are decelerating we should be aiming to meet the speed required by the approaching signalmast
+                 whether that is to slow down or come to a complete stand still.
+                 */
+                if (prevSpeed == -1 || speed < prevSpeed) {
+                    log.debug("{}: Signal {} setting speed to {} for next", _activeTrain.getTrainName(),
+                            _controllingSignalMast.getDisplayName(USERSYS), speed);
+                    setTargetSpeedValue(speed);
+                } else {
+                    log.debug("{}: Signal {} setting speed to {} for previous", _activeTrain.getTrainName(),
+                            _controllingSignalMast.getDisplayName(USERSYS), speed);
+                    setTargetSpeedValue(prevSpeed);
+                }
+                prevSpeed = speed;
+                _activeTrain.setStatus(ActiveTrain.RUNNING);
+
+            } else {
+                log.warn("{}: No specific speeds found so will use the default", _activeTrain.getTrainName());
+                setTargetSpeedState(NORMAL_SPEED);
+                _activeTrain.setStatus(ActiveTrain.RUNNING);
+            }
+        }
+    }
+
+    private void setSpeedBySignalHead() {
+        // a held signal always stop
+        if ( _controllingSignal != null && _controllingSignal.getAppearance() == SignalHead.HELD ) {
+            // Held - Stop
+            stopInCurrentSection(NO_TASK);
+            _stoppingForStopSignal = true;
+            return;
+        }
+
+        if (useSpeedProfile) {
+            // find speed from signal.
+            // find speed from block
+            // use least
+            float blockSpeed = getSpeedFromBlock(_conSignalProtectedBlock);
+
+            float signalSpeed = -1.0f;
+            String signalSpeedName = "";
+            String displayedAspect = _controllingSignal.getAppearanceName();
+            try {
+                signalSpeedName =
+                        jmri.InstanceManager.getDefault(SignalSpeedMap.class).getAppearanceSpeed(displayedAspect);
+                signalSpeed = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(signalSpeedName);
+            } catch (Throwable ex) { // if _anything_ goes wrong, contain it
+                signalSpeed = -1.0f;
+                log.warn("{}: Block {} AppearanceSpeed {} not found in SignalSpeedMap",
+                        _activeTrain.getTrainName(), _conSignalProtectedBlock.getDisplayName(USERSYS), displayedAspect);
+            }
+            float useSpeed = 1.0f;
+            if (blockSpeed < signalSpeed) {
+                useSpeed = blockSpeed;
+            } else {
+                useSpeed = signalSpeed;
+            }
+
+            log.trace("BlockSpeed[{}] SignalSpeed[{}]", blockSpeed, signalSpeed);
+            if (useSpeed < 0.01f) {
+                // check to to see if its allocated to us!!!
+                //      check Block occupancy sensor if it is in an allocated block, which must change before signal.
                 if ( (_currentAllocatedSection.isInActiveBlockList(_conSignalProtectedBlock) ||
-                        ( _nextSection != null &&  isSectionInAllocatedList(_nextSection) && _nextSection.containsBlock(_conSignalProtectedBlock)))
+                        ( _nextSection != null &&  _activeTrain.isInAllocatedList(_nextSection) && _nextSection.containsBlock(_conSignalProtectedBlock)))
                         && _conSignalProtectedBlock.getSensor().getState() == Block.OCCUPIED) {
                     // Train has just passed this signal - ignore this signal
-                    log.debug("{}: _conSignalProtectedBlock is the block just past so ignore {}", _activeTrain.getTrainName(), _conSignalProtectedBlock.getDisplayName(USERSYS));
+                    log.debug("{}:Ignoring red signal [{}]",_activeTrain.getTrainName(),_controllingSignal.getDisplayName(USERSYS));
                 } else {
-                    log.debug("{}: Signal {} at Held or Danger so Stop", _activeTrain.getTrainName(), _controllingSignalMast.getDisplayName(USERSYS));
                     stopInCurrentSection(NO_TASK);
                     _stoppingForStopSignal = true;
                 }
-            } else if (_controllingSignalMast.getAppearanceMap().getSpecificAppearance(jmri.SignalAppearanceMap.PERMISSIVE) != null
-                    && _controllingSignalMast.getAppearanceMap().getSpecificAppearance(jmri.SignalAppearanceMap.PERMISSIVE).equals(displayedAspect)) {
-                setTargetSpeedState(RESTRICTED_SPEED);
-                _activeTrain.setStatus(ActiveTrain.RUNNING);
             } else {
-
-                //if using signalmasts, set speed to lesser of aspect speed and signalmastlogic speed
-                //  (minimum speed on the path to next signal, using turnout and block speeds)
-                String aspectSpeedStr = (String) _controllingSignalMast.getSignalSystem().getProperty(displayedAspect, "speed");
-                log.trace("{}: Signal {} speed {} for aspect {}", _activeTrain.getTrainName(), _controllingSignalMast.getDisplayName(USERSYS), aspectSpeedStr, displayedAspect);
-                float speed = -1.0f;
-                if (aspectSpeedStr != null) {
-                    try {
-                        speed = Float.valueOf(aspectSpeedStr);
-                    } catch (NumberFormatException nx) {
-                        try {
-                            speed = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(aspectSpeedStr);
-                            log.trace("{}: Signal {} speed from map for {} is {}", _activeTrain.getTrainName(), _controllingSignalMast.getDisplayName(USERSYS), aspectSpeedStr, speed);
-                        } catch (IllegalArgumentException ex) {
-                            //Considered Normal if the speed does not appear in the map
-                            log.trace("{}: Speed not found {}", _activeTrain.getTrainName(), aspectSpeedStr);
-                        }
-                    }
-                }
-                int aspectSpeed = (int) speed; //save for debug message
-
-                //get maximum speed for the route between current and next signalmasts
-                float smLogicSpeed = -1.0f;
-                String smDestinationName = "unknown";
-                jmri.SignalMastLogic smLogic = InstanceManager.getDefault(jmri.SignalMastLogicManager.class).getSignalMastLogic(_controllingSignalMast);
-                if (smLogic != null) {
-                    SignalMast smDestination = smLogic.getActiveDestination();
-                    if (smDestination != null) {
-                        smDestinationName = smDestination.getDisplayName(USERSYS);
-                        smLogicSpeed = (int) smLogic.getMaximumSpeed(smDestination);
-                    }
-                }
-
-                //use the smaller of aspect speed or route speed
-                if (smLogicSpeed > -1.0f && smLogicSpeed < speed) {
-                    speed = smLogicSpeed;
-                }
-
-                log.debug("{}: {}({}) {}({}), Dest: {}, path max: {}",
-                        _activeTrain.getTrainName(),
-                        _controllingSignalMast.getDisplayName(USERSYS), displayedAspect, aspectSpeedStr, aspectSpeed,
-                        smDestinationName, (int) smLogicSpeed);
-
-                if (speed > -1.0f) {
-//                    float mls = _controllingSignalMast.getSignalSystem().getMaximumLineSpeed();
-//                    float increment = mls / 7f;
-//                    log.trace("{}: MaximumLineSpeed is {}, speed is {}", _activeTrain.getTrainName(), mls, speed);
-//                    int speedState = (int) Math.ceil(speed / increment);
-//                    if (speedState <= 1) {
-//                        speedState = 2;
-//                    }
-//                    log.trace("{}: SpeedState is {}", _activeTrain.getTrainName(), speedState);
-                    /* We should work on the basis that the speed required in the current block/section is governed by the signalmast
-                     that we have passed and not the one we are approaching when we are accelerating.
-                     However when we are decelerating we should be aiming to meet the speed required by the approaching signalmast
-                     whether that is to slow down or come to a complete stand still.
-                     */
-                    if (prevSpeed == -1 || speed < prevSpeed) {
-                        log.debug("{}: Signal {} setting speed to {} for next", _activeTrain.getTrainName(),
-                                _controllingSignalMast.getDisplayName(USERSYS), speed);
-                        setTargetSpeedValue(speed);
+                setTargetSpeedByProfile(useSpeed);
+            }
+        } else {
+            switch (_controllingSignal.getAppearance()) {
+                case SignalHead.DARK:
+                case SignalHead.RED:
+                case SignalHead.FLASHRED:
+                    // May get here from signal changing before Block knows it is occupied, so must
+                    //      check Block occupancy sensor, which must change before signal.
+                    // check to to see if its allocated to us!!!
+                    //      check Block occupancy sensor if it is in an allocated block, which must change before signal.
+                    if ((_currentAllocatedSection.isInActiveBlockList(_conSignalProtectedBlock) ||
+                            (_nextSection != null && _activeTrain.isInAllocatedList(_nextSection) && _nextSection.containsBlock(_conSignalProtectedBlock)))
+                            && _conSignalProtectedBlock.getSensor().getState() == Block.OCCUPIED) {
+                        // Train has just passed this signal - ignore this signal
+                        log.debug("{}:Ignoring red signal [{}]", _activeTrain.getTrainName(),
+                                _controllingSignal.getDisplayName(USERSYS));
                     } else {
-                        log.debug("{}: Signal {} setting speed to {} for previous", _activeTrain.getTrainName(),
-                                _controllingSignalMast.getDisplayName(USERSYS), speed);
-                        setTargetSpeedValue(prevSpeed);
+                        stopInCurrentSection(NO_TASK);
+                        _stoppingForStopSignal = true;
                     }
-                    prevSpeed = speed;
+                    break;
+                case SignalHead.YELLOW:
+                case SignalHead.FLASHYELLOW:
+                    setTargetSpeedState(SLOW_SPEED);
                     _activeTrain.setStatus(ActiveTrain.RUNNING);
-
-                } else {
-                    log.warn("{}: No specific speeds found so will use the default", _activeTrain.getTrainName());
+                    break;
+                case SignalHead.GREEN:
+                case SignalHead.FLASHGREEN:
                     setTargetSpeedState(NORMAL_SPEED);
                     _activeTrain.setStatus(ActiveTrain.RUNNING);
+                    break;
+                case SignalHead.LUNAR:
+                case SignalHead.FLASHLUNAR:
+                    setTargetSpeedState(RESTRICTED_SPEED);
+                    _activeTrain.setStatus(ActiveTrain.RUNNING);
+                    break;
+                default:
+                    log.warn("Signal Head[{}] has invalid Appearence - using stop",_controllingSignal.getAppearance());
+                    stopInCurrentSection(NO_TASK);
+                    _stoppingForStopSignal = true;
+            }
+
+        }
+    }
+
+    protected float getSpeedFromBlock(Block block) {
+        String blockSpeedName = block.getBlockSpeed();
+        if (blockSpeedName.contains("Global")) {
+            blockSpeedName = InstanceManager.getDefault(BlockManager.class).getDefaultSpeed();
+        }
+        float blockSpeed = -1.0f;
+        if (!blockSpeedName.isEmpty()) {
+            try {
+                blockSpeed = Float.valueOf(blockSpeedName);
+            } catch (NumberFormatException nx) {
+                try {
+                    blockSpeed = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(blockSpeedName);
+                    log.debug("{}: block speed from map for {} is {}",
+                            _activeTrain.getTrainName(), block.getDisplayName(USERSYS), blockSpeedName,
+                            blockSpeed);
+                } catch (Throwable ex) { // if _anything_ goes wrong, contain it
+                    //Considered Normal if the speed does not appear in the map
+                    log.warn("{}: Block {} Speed {} not found in SignalSpeedMap",
+                            _activeTrain.getTrainName(), block.getDisplayName(USERSYS), blockSpeed);
                 }
             }
         }
+        return blockSpeed;
     }
 
     float prevSpeed = -1.0f;
@@ -1267,8 +1296,8 @@ public class AutoActiveTrain implements ThrottleListener {
                 _previousBlock = null;
                 _nextBlock = getNextBlock(_currentBlock,_currentAllocatedSection);
                 if (_activeTrain.getDelayedRestart() == ActiveTrain.NODELAY) {
-                    if ((_nextSection != null) && !isSectionInAllocatedList(_nextSection)) {
-                        InstanceManager.getDefault(DispatcherFrame.class).forceScanOfAllocation();
+                    if ((_nextSection != null) && !_activeTrain.isInAllocatedList(_nextSection)) {
+                        InstanceManager.getDefault(DispatcherFrame.class).queueScanOfAllocationRequests();
                         break;
                     }
                     // a reversal can happen in mid section
@@ -1289,8 +1318,8 @@ public class AutoActiveTrain implements ThrottleListener {
                         _nextBlock = getNextBlock(_currentBlock,_currentAllocatedSection);
                         setEngineDirection();
                         _activeTrain.setRestart();
-                        if ((_nextSection != null) && !isSectionInAllocatedList(_nextSection)) {
-                            InstanceManager.getDefault(DispatcherFrame.class).forceScanOfAllocation();
+                        if ((_nextSection != null) && !_activeTrain.isInAllocatedList(_nextSection)) {
+                            InstanceManager.getDefault(DispatcherFrame.class).queueScanOfAllocationRequests();
                         }
                         // can be mid block
                         setupNewCurrentSignal(null, true);
@@ -1796,13 +1825,13 @@ public class AutoActiveTrain implements ThrottleListener {
                     _halted = true;
                 } else if (_slowToStop) {
                     // this only sets to speed zero, stop
-                    if (useSpeedProfile) {
+                    if (useSpeedProfile && !_speedProfileStoppingIsRunning) {
                         re.getSpeedProfile().setExtraInitialDelay(1500f);
                         re.getSpeedProfile().changeLocoSpeed(_throttle, _currentBlock, 0,
                                 _stopBySpeedProfileAdjust);
                         _speedProfileStoppingIsRunning = true;
                         _targetSpeed = 0.0f;
-                    } else {
+                    } else if (!_speedProfileStoppingIsRunning) {
                         _throttle.setSpeedSetting(0.0f);
                         _currentSpeed = 0.0f;
                         _targetSpeed = 0.0f;

--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -1627,7 +1627,7 @@ public class AutoAllocate implements Runnable {
             return false;
         }
 
-        if (sec.equals(mActiveTrain.getNextSectionToAllocate())) {
+        if (!sec.equals(mActiveTrain.getNextSectionToAllocate())) {
             log.error("[{}]Allocation request section does not match active train next section to allocate",mActiveTrain.getActiveTrainName());
             log.error("[{}]Section requested {}",mActiveTrain.getActiveTrainName(), sec.getDisplayName(USERSYS));
             if (mActiveTrain.getNextSectionToAllocate() != null) {

--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -1,15 +1,23 @@
 package jmri.jmrit.dispatcher;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import jmri.Block;
 import jmri.InstanceManager;
 import jmri.Section;
 import jmri.Sensor;
 import jmri.Transit;
 import jmri.TransitSection;
+import jmri.jmrit.dispatcher.TaskAllocateRelease.TaskAction;
 import jmri.jmrit.display.layoutEditor.ConnectivityUtil;
 import jmri.jmrit.display.layoutEditor.LevelXing;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +59,9 @@ import org.slf4j.LoggerFactory;
  * DispatcherFrame. When AutoAllocate is switched off, all existing
  * AllocationPlan objects are discarded.
  * <p>
+ * All work done within the class is queued using a blocking queue. This is
+ * to ensure the integrity of arrays, both in Dispatcher and ActiveTrain,
+ * and to prevent calls within calls to modify those arrays, including autorelease.
  * <br>
  * <hr>
  * This file is part of JMRI.
@@ -65,10 +76,13 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dave Duchamp Copyright (C) 2011
  */
-public class AutoAllocate {
+public class AutoAllocate implements Runnable {
 
-    public AutoAllocate(DispatcherFrame d) {
+    LinkedBlockingQueue<TaskAllocateRelease> taskList;
+
+    public AutoAllocate(DispatcherFrame d, List<AllocationRequest> inAllocationRequests) {
         _dispatcher = d;
+        allocationRequests = inAllocationRequests;
         if (_dispatcher == null) {
             log.error("null DispatcherFrame when constructing AutoAllocate");
             return;
@@ -78,6 +92,7 @@ public class AutoAllocate {
             return;
         }
         _conUtil = _dispatcher.getLayoutEditor().getConnectivityUtil();
+        taskList = new LinkedBlockingQueue<>();
     }
 
     // operational variables
@@ -87,13 +102,75 @@ public class AutoAllocate {
     private final List<AllocationPlan> _planList = new ArrayList<>();
     private int nextPlanNum = 1;
     private final List<AllocationRequest> orderedRequests = new ArrayList<>();
+    private List<AllocationRequest> allocationRequests = null;
+    private final Map<String, String> reservedSections = new HashMap<String, String>();
+
+    private boolean abort = false;
+
+    /**
+     * Stops the autoAllocate nicely
+     */
+    protected void setAbort() {
+        abort = true;
+        scanAllocationRequests(new TaskAllocateRelease(TaskAction.ABORT)); //force queue flush
+    }
+
+    /*
+     * return true when the taskList queue is Empty
+     */
+    protected boolean allRequestsDone() {
+        return taskList.isEmpty();
+    }
+
+    protected void scanAllocationRequests(TaskAllocateRelease task) {
+        taskList.add(task);
+    }
+
+    /*
+     * Main loop processing queue
+     */
+    @Override
+    public void run() {
+        while (!abort) {
+            try {
+                TaskAllocateRelease task = taskList.take();
+                try {
+                    switch (task.getAction()) {
+                        case AUTO_RELEASE:
+                            _dispatcher.checkAutoRelease();
+                            break;
+                        case RELEASE_ONE:
+                            _dispatcher.doReleaseAllocatedSection(task.getAllocatedSection(),
+                                    task.getTerminatingTrain());
+                            break;
+                        case RELEASE_RESERVED:
+                            removeAllReservesForTrain(task.getTrainName());
+                            break;
+                        case SCAN_REQUESTS:
+                            scanAllocationRequestList(allocationRequests);
+                            break;
+                        case ABORT:
+                            abort = true; //belt an braces
+                            break;
+                        default:
+                            log.error("Unknown action in TaskAllocateRelease - ignoring");
+                    }
+                } catch (Exception ex) {
+                    log.error("Unexpected Exeption, likely bad task request.", ex);
+                }
+            } catch (InterruptedException ex) {
+                log.error("Blocklist killed, taking this as terminate", ex);
+                abort = true;
+            }
+        }
+    }
 
     /**
      * This is the entry point to AutoAllocate when it is triggered.
      *
      * @param list list to scan
      */
-    protected synchronized void scanAllocationRequestList(List<AllocationRequest> list) {
+    private synchronized void scanAllocationRequestList(List<AllocationRequest> list) {
         boolean okToAllocate = false;
         if (list.size() <= 0) {
             return;
@@ -109,25 +186,47 @@ public class AutoAllocate {
                     log.error("error in allocation request list - AllocationRequest is null");
                     continue;
                 }
-                // Check to see if there is a sensor temporarily block allocation blocking allocation
+                // Check to see if there is a sensor temporarily block
+                // allocation blocking allocation
                 ActiveTrain activeTrain = ar.getActiveTrain();
                 String trainName = activeTrain.getTrainName();
                 log.trace("{}: try to allocate [{}]", trainName, ar.getSection().getDisplayName(USERSYS));
                 if (activeTrain.getLastAllocatedSection() != null) {
-                    //do stuff associated with the last allocated section
+                    // do stuff associated with the last allocated section
                     Transit arTransit = activeTrain.getTransit();
                     TransitSection arCurrentTransitSection =
                             arTransit.getTransitSectionFromSectionAndSeq(activeTrain.getLastAllocatedSection(),
                                     activeTrain.getLastAllocatedSectionSeqNumber());
-                    if (stopAllocateSensorSet(activeTrain,arCurrentTransitSection)) {
-                        log.debug("stopAllocateSensor active");
+                    // stop allocating sensor active?
+                    if (stopAllocateSensorSet(activeTrain, arCurrentTransitSection)) {
+                        log.debug("[{}]:StopAllocateSensor active", trainName);
                         continue;
                     }
+                    // is the train held
+                    if (activeTrain.holdAllocation) {
+                        log.debug("[{}]:Allocation is Holding", trainName);
+                        continue;
+                    }
+
+                    // this already reserved for the train, allocate.
+                    String reservedTrainName = reservedSections.get(ar.getSection().getSystemName());
+                    if (reservedTrainName != null) {
+                        if (reservedTrainName.equals(trainName)) {
+                            String sectionName = ar.getSection().getSystemName();
+                            if (allocateMore(ar)) {
+                                reservedSections.remove(sectionName);
+                            }
+                            continue;
+                        }
+                    }
+
                     if (activeTrain.getAllocateMethod() == ActiveTrain.ALLOCATE_BY_SAFE_SECTIONS) {
-                        log.trace("{}: Allocating using Safe Sections", trainName);
-                        // if the last allocated section is safe but not occupied short cut out of here
+                        log.trace("{}: Allocating [{}] using Safe Sections", trainName,
+                                ar.getSection().getDisplayName());
+                        // if the last allocated section is safe but not
+                        // occupied short cut out of here
                         if (arCurrentTransitSection.isSafe() &&
-                                activeTrain.getLastAllocatedSection().getState() == Section.FREE) {
+                                activeTrain.getLastAllocatedSection().getOccupancy() != Section.OCCUPIED) {
                             log.debug("Allocating Train [{}] has not arrived at Passing Point",
                                     trainName);
                             continue;
@@ -142,7 +241,10 @@ public class AutoAllocate {
                         if (activeTrain.isTransitReversed()) {
                             iIncrement = -1;
                             iLimit = 0;
-                            iStart = itSequ; //reverse transits start allocating from the next one, they allocate the one there in already
+                            iStart = itSequ; // reverse transits start
+                                             // allocating from the next
+                                             // one, they allocate the one
+                                             // there in already
                         } else {
                             if (activeTrain.getStartBlockSectionSequenceNumber() == ar.getSectionSeqNumber()) {
                                 skip = true;
@@ -158,31 +260,56 @@ public class AutoAllocate {
                             for (ix = iStart; ix != iLimit; ix += iIncrement) {
                                 log.trace("index [{}] Limit [{}] transitsize [{}]", ix, iLimit,
                                         arTransit.getTransitSectionList().size());
-                                // ensure all blocks section and blocks free till next Passing Point, check alternates if they exist.
+                                // ensure all blocks section and blocks free
+                                // till next Passing Point, check alternates
+                                // if they exist.
                                 Section sS;
                                 ArrayList<TransitSection> sectionsInSeq = arTransit.getTransitSectionListBySeq(ix);
-                                areForwardsFree = false; //Posit will be bad
+                                areForwardsFree = false; // Posit will be
+                                                         // bad
                                 log.trace("Search ALternates Size[{}]", sectionsInSeq.size());
                                 int seqNumberfound = 0;
                                 for (int iSectionsInSeq = 0; iSectionsInSeq < sectionsInSeq.size() &&
                                         !areForwardsFree; iSectionsInSeq++) {
                                     log.trace("iSectionInSeq[{}]", iSectionsInSeq);
                                     sS = sectionsInSeq.get(iSectionsInSeq).getSection();
-                                    seqNumberfound = iSectionsInSeq; // save for later
-                                    //debug code
-                                    log.trace("SectionName[{}] getState[{}] occupancy[{}] ", sS.getDisplayName(USERSYS),
+                                    seqNumberfound = iSectionsInSeq; // save
+                                                                     // for
+                                                                     // later
+                                    // debug code
+                                    log.trace("SectionName[{}] getState[{}] occupancy[{}] ",
+                                            sS.getDisplayName(USERSYS),
                                             sS.getState(), sS.getOccupancy());
-                                    if (sS.getState() != Section.FREE) {
-                                        log.debug("{}: Forward section [{}] unavailable", trainName, sS.getDisplayName(USERSYS));
+                                    if (!checkUnallocatedCleanly(activeTrain, sS)) {
+                                        areForwardsFree = false;
+                                    } else if (sS.getState() != Section.FREE) {
+                                        log.debug("{}: Forward section [{}] unavailable", trainName,
+                                                sS.getDisplayName(USERSYS));
                                         areForwardsFree = false;
                                     } else if (sS.getOccupancy() != Section.UNOCCUPIED) {
-                                        log.debug("{}: Forward section [{}] is not unoccupied", trainName, sS.getDisplayName(USERSYS));
+                                        log.debug("{}: Forward section [{}] is not unoccupied", trainName,
+                                                sS.getDisplayName(USERSYS));
+                                        areForwardsFree = false;
+                                    } else if (_dispatcher.checkBlocksNotInAllocatedSection(sS, ar) != null) {
+                                        log.debug("{}: Forward section [{}] is in conflict with [{}]",
+                                                trainName, sS.getUserName(),
+                                                _dispatcher.checkBlocksNotInAllocatedSection(sS, ar));
+                                        areForwardsFree = false;
+                                    } else if (reservedSections.get(sS.getSystemName()) != null &&
+                                            !reservedSections.get(sS.getSystemName()).equals(trainName)) {
+                                        log.debug("{}: Forward section [{}] is reserved for [{}]",
+                                                trainName, sS.getDisplayName(USERSYS),
+                                                reservedSections.get(sS.getSystemName()));
                                         areForwardsFree = false;
                                     } else {
+                                        log.debug("Adding [{}],[{}]", sS.getDisplayName(USERSYS), trainName);
+                                        reservedSections.put(sS.getSystemName(), trainName);
                                         areForwardsFree = true;
                                     }
                                 }
                                 if (!areForwardsFree) {
+                                    // delete all reserves for this train
+                                    removeAllReservesForTrain(trainName);
                                     break;
                                 }
                                 if (sectionsInSeq.get(seqNumberfound).isSafe()) {
@@ -190,39 +317,62 @@ public class AutoAllocate {
                                     break;
                                 }
                             }
+
                             log.trace("ForwardsFree[{}]", areForwardsFree);
                             if (!areForwardsFree) {
                                 continue;
                             }
                         }
-//                        if (allocateIfLessThanThreeAhead(ar)) {
-//                            continue;
-//                        }
-                        allocateMore(ar);
+                        String sectionSystemName;
+                        try {
+                            sectionSystemName = ar.getSection().getSystemName();
+                        } catch (Exception ex) {
+                            log.error("Error", ex);
+                            sectionSystemName = "Unknown";
+                        }
+                        if (allocateMore(ar)) {
+                            // First Time thru this will in the list
+                            if (!sectionSystemName.equals("Unknown")) {
+                                log.debug("removing : [{}]", sectionSystemName);
+                                reservedSections.remove(sectionSystemName);
+                            } else {
+                                log.error("{};Cannot allocate allocatable section[{}]", trainName,
+                                        sectionSystemName);
+                            }
+                        }
                         continue;
-                    }
+                    } // end of allocating by safe sections
                 }
                 log.trace("Using Regular");
-                if (InstanceManager.getDefault(DispatcherFrame.class).getSignalType() == DispatcherFrame.SIGNALMAST &&
+                if (InstanceManager.getDefault(DispatcherFrame.class)
+                        .getSignalType() == DispatcherFrame.SIGNALMAST &&
                         isSignalHeldAtStartOfSection(ar)) {
                     continue;
                 }
+                if (!checkUnallocatedCleanly(activeTrain, ar.getSection())) {
+                    okToAllocate = false;
+                    continue;
+                }
                 if (getPlanThisTrain(activeTrain) != null) {
-                    // this train is in an active Allocation Plan, anything to do now?
+                    // this train is in an active Allocation Plan, anything
+                    // to do now?
                     if (willAllocatingFollowPlan(ar, getPlanThisTrain(activeTrain))) {
                         if (allocateMore(ar)) {
                             continue;
                         }
                     }
                 } else if (!waitingForStartTime(ar)) {
-                    // train isn't waiting, continue only if requested Section is currently free and not occupied
+                    // train isn't waiting, continue only if requested
+                    // Section is currently free and not occupied
                     if ((ar.getSection().getState() == Section.FREE) &&
                             (ar.getSection().getOccupancy() != Section.OCCUPIED) &&
                             (_dispatcher.getSignalType() == DispatcherFrame.SIGNALHEAD ||
+                                    _dispatcher.getSignalType() == DispatcherFrame.SECTIONSALLOCATED ||
                                     (_dispatcher.getSignalType() == DispatcherFrame.SIGNALMAST &&
                                             _dispatcher.checkBlocksNotInAllocatedSection(ar.getSection(),
                                                     ar) == null))) {
-                        // requested Section is currently free and not occupied
+                        // requested Section is currently free and not
+                        // occupied
                         List<ActiveTrain> activeTrainsList = _dispatcher.getActiveTrainsList();
                         if (activeTrainsList.size() == 1) {
                             // this is the only ActiveTrain
@@ -230,7 +380,8 @@ public class AutoAllocate {
                                 continue;
                             }
                         } else {
-                            //check if any other ActiveTrain will need this Section or its alternates, if any
+                            // check if any other ActiveTrain will need this
+                            // Section or its alternates, if any
                             okToAllocate = true;
                             List<ActiveTrain> neededByTrainList = new ArrayList<>();
                             for (int j = 0; j < activeTrainsList.size(); j++) {
@@ -242,9 +393,11 @@ public class AutoAllocate {
                                 }
                             }
                             if (neededByTrainList.size() <= 0) {
-                                // no other ActiveTrain needs this Section, any LevelXings?
+                                // no other ActiveTrain needs this Section,
+                                // any LevelXings?
                                 if (containsLevelXing(ar.getSection())) {
-                                    // check if allocating this Section might block a higher priority train
+                                    // check if allocating this Section
+                                    // might block a higher priority train
                                     for (int j = 0; j < activeTrainsList.size(); j++) {
                                         ActiveTrain at = activeTrainsList.get(j);
                                         if ((at != activeTrain) &&
@@ -256,16 +409,22 @@ public class AutoAllocate {
                                     }
                                 }
                             } else {
-                                // requested Section (or alternate) is needed by other active Active Train(s)
+                                // requested Section (or alternate) is
+                                // needed by other active Active Train(s)
                                 for (int k = 0; k < neededByTrainList.size(); k++) {
-                                    // section is also needed by this active train
+                                    // section is also needed by this active
+                                    // train
                                     ActiveTrain nt = neededByTrainList.get(k);
-                                    // are trains moving in same direction through the requested Section?
+                                    // are trains moving in same direction
+                                    // through the requested Section?
                                     if (sameDirection(ar, nt)) {
-                                        // trains will move in the same direction thru requested section
+                                        // trains will move in the same
+                                        // direction thru requested section
                                         if (firstTrainLeadsSecond(activeTrain, nt) &&
                                                 (nt.getPriority() > activeTrain.getPriority())) {
-                                            // a higher priority train is trailing this train, can we let it pass?
+                                            // a higher priority train is
+                                            // trailing this train, can we
+                                            // let it pass?
                                             if (checkForPassingPlan(ar, nt, neededByTrainList)) {
                                                 // PASSING_MEET plan created
                                                 if (!willAllocatingFollowPlan(ar,
@@ -275,8 +434,10 @@ public class AutoAllocate {
                                             }
                                         }
                                     } else {
-                                        // trains will move in opposite directions thru requested section
-                                        //   explore possibility of an XING_MEET to avoid gridlock
+                                        // trains will move in opposite
+                                        // directions thru requested section
+                                        // explore possibility of an
+                                        // XING_MEET to avoid gridlock
                                         if (willTrainsCross(activeTrain, nt)) {
                                             if (checkForXingPlan(ar, nt, neededByTrainList)) {
                                                 // XING_MEET plan created
@@ -298,10 +459,56 @@ public class AutoAllocate {
                     }
                 }
             } catch (RuntimeException e) {
-                log.warn("scanAllocationRequestList - maybe the allocationrequest was removed due to a terminating train??{}", e.toString());
+                log.warn(
+                        "scanAllocationRequestList - maybe the allocationrequest was removed due to a terminating train??{}",
+                        e.toString());
                 continue;
             }
         }
+    }
+
+    /**
+     * Remove all reserved sections for a train name
+     *
+     * @param trainName remove reserved spaces for this train
+     */
+    protected void removeAllReservesForTrain(String trainName) {
+        Iterator<Entry<String, String>> iterRS = reservedSections.entrySet().iterator();
+        while (iterRS.hasNext()) {
+            Map.Entry<String, String> pair = iterRS.next();
+            if (pair.getValue().equals(trainName)) {
+                iterRS.remove();
+            }
+        }
+    }
+
+    /**
+     * Remove a specific section reservation for a train.
+     *
+     * @param trainName         Name of the train
+     * @param sectionSystemName Systemname
+     */
+    protected void releaseReservation(String trainName, String sectionSystemName) {
+        String reservedTrainName = reservedSections.get(sectionSystemName);
+        if (reservedTrainName.equals(trainName)) {
+            reservedSections.remove(sectionSystemName);
+        }
+    }
+
+    /*
+     * Check each ActiveTrains sections for a given section. We need to do this
+     * as Section is flagged as free before it is fully released, then when it
+     * is released it updates , incorrectly, the section status and allocations.
+     */
+    private boolean checkUnallocatedCleanly(ActiveTrain at, Section section) {
+        for (ActiveTrain atx : InstanceManager.getDefault(DispatcherFrame.class).getActiveTrainsList()) {
+            for (AllocatedSection asx : atx.getAllocatedSectionList()) {
+                if (asx.getSection() == section) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     /**
@@ -309,7 +516,7 @@ public class AutoAllocate {
      * allocated and there are alternate Section choices for the next Section.
      *
      * @param sList the possible next Sections
-     * @param ar the section being allocated when a choice is needed
+     * @param ar    the section being allocated when a choice is needed
      * @return the allocated section
      */
     protected Section autoNextSectionChoice(List<Section> sList, AllocationRequest ar) {
@@ -323,7 +530,8 @@ public class AutoAllocate {
             log.warn("Failure of prepared choice of next Section in AutoAllocate");
         }
         // Jay Janzen
-        // If there is an AP check to see if the AP's target is on the list of choices
+        // If there is an AP check to see if the AP's target is on the list of
+        // choices
         // and if so, return that.
         ActiveTrain at = ar.getActiveTrain();
         AllocationPlan ap = getPlanThisTrain(at);
@@ -343,7 +551,8 @@ public class AutoAllocate {
             }
         }
         // If our end block section is on the list of choices
-        // return that occupied or not. In the list of choices the primary occurs
+        // return that occupied or not. In the list of choices the primary
+        // occurs
         // ahead any alternates, so if our end block is an alternate and its
         // primary is unoccupied, the search will select the primary and
         // we wind up skipping right over our end section.
@@ -352,17 +561,20 @@ public class AutoAllocate {
                 return sList.get(i);
             }
         }
-        // no prepared choice, or prepared choice failed, is there an unoccupied Section available
+        // no prepared choice, or prepared choice failed, is there an unoccupied
+        // Section available
         for (int i = 0; i < sList.size(); i++) {
             if ((sList.get(i).getOccupancy() == Section.UNOCCUPIED) &&
                     (sList.get(i).getState() == Section.FREE) &&
                     (_dispatcher.getSignalType() == DispatcherFrame.SIGNALHEAD ||
+                            _dispatcher.getSignalType() == DispatcherFrame.SECTIONSALLOCATED ||
                             (_dispatcher.getSignalType() == DispatcherFrame.SIGNALMAST &&
                                     _dispatcher.checkBlocksNotInAllocatedSection(sList.get(i), ar) == null))) {
                 return sList.get(i);
             }
         }
-        // no unoccupied Section available, check for Section allocated in same direction as this request
+        // no unoccupied Section available, check for Section allocated in same
+        // direction as this request
         int dir = ar.getSectionDirection();
         List<AllocatedSection> allocatedSections = _dispatcher.getAllocatedSectionsList();
         for (int m = 0; m < sList.size(); m++) {
@@ -376,7 +588,8 @@ public class AutoAllocate {
                 }
             }
         }
-        // if all else fails, return null so Dispatcher will ask the dispatcher to choose
+        // if all else fails, return null so Dispatcher will ask the dispatcher
+        // to choose
         return null;
     }
 
@@ -417,7 +630,8 @@ public class AutoAllocate {
                 sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
                 if (sensor.getKnownState() == Sensor.ACTIVE) {
                     log.trace("Sensor[{}] InActive", sensor.getDisplayName(USERSYS));
-                    at.initializeRestartAllocationSensor(jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor));
+                    at.initializeRestartAllocationSensor(jmri.InstanceManager
+                            .getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor));
                     return true;
                 }
             } catch (NumberFormatException ex) {
@@ -442,8 +656,9 @@ public class AutoAllocate {
     }
 
     private boolean willAllocatingFollowPlan(AllocationRequest ar, AllocationPlan ap) {
-        // return 'true' if this AllocationRequest is consistent with specified plan,
-        //     returns 'false' otherwise
+        // return 'true' if this AllocationRequest is consistent with specified
+        // plan,
+        // returns 'false' otherwise
         ActiveTrain at = ar.getActiveTrain();
         int cTrainNum = 0;
         if (ap.getActiveTrain(1) == at) {
@@ -502,7 +717,9 @@ public class AutoAllocate {
         log.trace("in allocateMore, ar.Section={}", ar.getSection().getDisplayName(USERSYS));
         int allocateSectionsAhead = ar.getActiveTrain().getAllocateMethod();
         if (allocateSectionsAhead == ActiveTrain.ALLOCATE_AS_FAR_AS_IT_CAN) {
-            _dispatcher.allocateSection(ar, null);
+            if (_dispatcher.allocateSection(ar, null) == null) {
+                return false;
+            }
             return true;
         }
         // test how far ahead of occupied track this requested section is
@@ -533,16 +750,20 @@ public class AutoAllocate {
                     (curAS != null) &&
                     ((curAS.getSection().getOccupancy() != jmri.Section.OCCUPIED) &&
                             ar.getActiveTrain().getTransit()
-                                .getTransitSectionFromSectionAndSeq(curAS.getSection(),curSeq).isSafe())) {
-                // last allocated section exists and is not occupied but is a Passing point
+                                    .getTransitSectionFromSectionAndSeq(curAS.getSection(), curSeq).isSafe())) {
+                // last allocated section exists and is not occupied but is a
+                // Passing point
                 // block further allocations till occupied.
                 log.trace("{}: not at end of safe allocations, [{}] not allocated", ar.getActiveTrain().getTrainName(),
                         ar.getSection().getDisplayName(USERSYS));
                 return false;
             } else if (allocateBySafeSections) {
                 log.trace("auto allocating Section keep going");
-                _dispatcher.allocateSection(ar, null);
-                return true;
+                if (_dispatcher.allocateSection(ar, null) != null) {
+                    return true;
+                } else {
+                    return false;
+                }
             }
             log.trace("Auto allocating by count");
             int numberAllocatedButUnoccupied = 0;
@@ -554,7 +775,9 @@ public class AutoAllocate {
             }
             log.trace("FinalCounter[{}]", numberAllocatedButUnoccupied);
             if (numberAllocatedButUnoccupied < allocateSectionsAhead) {
-                _dispatcher.allocateSection(ar, null);
+                if (_dispatcher.allocateSection(ar, null) == null) {
+                    return false;
+                }
                 return true;
             }
             return false;
@@ -562,13 +785,16 @@ public class AutoAllocate {
         }
         log.debug("{}: auto allocating Section {}", ar.getActiveTrain().getTrainName(),
                 ar.getSection().getDisplayName(USERSYS));
-        _dispatcher.allocateSection(ar, null);
+        if (_dispatcher.allocateSection(ar, null) == null) {
+            return false;
+        }
         return true;
     }
 
     private boolean checkForXingPlan(AllocationRequest ar, ActiveTrain nt,
             List<ActiveTrain> neededByTrainList) {
-        // returns 'true' if an AllocationPlan has been set up, returns 'false' otherwise
+        // returns 'true' if an AllocationPlan has been set up, returns 'false'
+        // otherwise
         Section nSec = null;
         Section aSec = null;
         int nSecSeq = 0;
@@ -579,7 +805,8 @@ public class AutoAllocate {
             if (apx.getPlanType() != AllocationPlan.XING_MEET) {
                 return false;
             }
-            // already in a XING_MEET Allocation Plan - find target Section and sequence
+            // already in a XING_MEET Allocation Plan - find target Section and
+            // sequence
             if (apx.getActiveTrain(1) == nt) {
                 nSecSeq = apx.getTargetSectionSequenceNum(1);
                 nSec = apx.getTargetSection(1);
@@ -601,7 +828,8 @@ public class AutoAllocate {
                 return false;
             }
         } else {
-            // neither train is in an AllocationPlan currently, check for suitable passing siding
+            // neither train is in an AllocationPlan currently, check for
+            // suitable passing siding
             int aSeq = ar.getSectionSeqNumber();
             // is an alternate Section available here or ahead
             aSecSeq = findPassingSection(at, aSeq);
@@ -610,7 +838,8 @@ public class AutoAllocate {
                 int nCurrentSeq = getCurrentSequenceNumber(nt);
                 nSecSeq = findPassingSection(nt, nCurrentSeq);
                 if (nSecSeq > 0) {
-                    // has passing section ahead, will this train traverse a Section in it
+                    // has passing section ahead, will this train traverse a
+                    // Section in it
                     List<Section> nSections = nt.getTransit().getSectionListBySeq(nSecSeq);
                     for (int i = 0; (i < nSections.size()) && (aSec == null); i++) {
                         aSecSeq = willTraverse(nSections.get(i), at, aSeq);
@@ -640,7 +869,8 @@ public class AutoAllocate {
                 return false;
             }
         }
-        // check for conflicting train or conflicting plan that could cause gridlock
+        // check for conflicting train or conflicting plan that could cause
+        // gridlock
         if (neededByTrainList.size() > 2) {
             // is there another train between these two
             if (!areTrainsAdjacent(at, nt)) {
@@ -665,7 +895,8 @@ public class AutoAllocate {
 
     private boolean checkForPassingPlan(AllocationRequest ar, ActiveTrain nt,
             List<ActiveTrain> neededByTrainList) {
-        // returns 'true' if an AllocationPlan has been set up, returns 'false' otherwise
+        // returns 'true' if an AllocationPlan has been set up, returns 'false'
+        // otherwise
         Section nSec = null;
         Section aSec = null;
         int nSecSeq = 0;
@@ -676,39 +907,24 @@ public class AutoAllocate {
             if (apx.getPlanType() != AllocationPlan.PASSING_MEET) {
                 return false;
             }
-            // already in a PASSING_MEET Allocation Plan - find target Section and sequence
+            // already in a PASSING_MEET Allocation Plan - find target Section
+            // and sequence
             Section oSection = null;
-            //            ActiveTrain oTrain = null;
+            // ActiveTrain oTrain = null;
             if (apx.getActiveTrain(1) == nt) {
                 nSecSeq = apx.getTargetSectionSequenceNum(1);
                 nSec = apx.getTargetSection(1);
                 oSection = apx.getTargetSection(2);
-                //                oTrain = apx.getActiveTrain(2);
             } else {
                 nSecSeq = apx.getTargetSectionSequenceNum(2);
                 nSec = apx.getTargetSection(2);
                 oSection = apx.getTargetSection(1);
-                //                oTrain = apx.getActiveTrain(1);
             }
             int aCurrentSeq = getCurrentSequenceNumber(at);
             aSecSeq = willTraverse(nSec, at, aCurrentSeq);
             if (aSecSeq == 0) {
                 return false;
             }
-            //            int tnSecSeq = nSecSeq;
-            //            if (nt.getPriority() > oTrain.getPriority()) {
-            //                if (!nt.isAllocationReversed()) {
-            //                    tnSecSeq--;
-            //                    if (tnSecSeq <= 0) {
-            //                        tnSecSeq = nSecSeq;
-            //                    }
-            //                } else {
-            //                    tnSecSeq++;
-            //                    if (tnSecSeq > nt.getTransit().getMaxSequence()) {
-            //                        tnSecSeq = nSecSeq;
-            //                    }
-            //                }
-            //            }
             List<Section> nSections = nt.getTransit().getSectionListBySeq(nSecSeq);
             if (nSections.size() <= 1) {
                 return false;
@@ -745,7 +961,8 @@ public class AutoAllocate {
                 int nCurrentSeq = getCurrentSequenceNumber(nt);
                 nSecSeq = findPassingSection(nt, nCurrentSeq);
                 if (nSecSeq > 0) {
-                    // has passing section ahead, will this train traverse a Section in it
+                    // has passing section ahead, will this train traverse a
+                    // Section in it
                     List<Section> nSections = nt.getTransit().getSectionListBySeq(nSecSeq);
                     for (int i = 0; (i < nSections.size()) && (aSec == null); i++) {
                         aSecSeq = willTraverse(nSections.get(i), at, aSeq);
@@ -759,7 +976,8 @@ public class AutoAllocate {
                     }
                 }
             } else {
-                // will the higher priority train go through any of these alternate sections
+                // will the higher priority train go through any of these
+                // alternate sections
                 List<Section> aSections = at.getTransit().getSectionListBySeq(aSecSeq);
                 int nCurrentSeq = getCurrentSequenceNumber(nt);
                 for (int i = 0; (i < aSections.size()) && (aSec == null); i++) {
@@ -774,7 +992,7 @@ public class AutoAllocate {
             if ((aSec == null) || (nSec == null)) {
                 return false;
             }
-            //     push higher priority train one section further, if possible
+            // push higher priority train one section further, if possible
             if (!nt.isAllocationReversed()) {
                 if (nSecSeq < nt.getTransit().getMaxSequence()) {
                     nSecSeq++;
@@ -789,8 +1007,10 @@ public class AutoAllocate {
         }
         // is there another train trying to let this high priority train pass
         if (neededByTrainList.size() > 2) {
-            // Note: e.g. Two lower priority trains ahead of a high priority train could cause gridlock
-            //    if both try to set up a PASSING_PLAN meet at the same place, so we exclude that case.
+            // Note: e.g. Two lower priority trains ahead of a high priority
+            // train could cause gridlock
+            // if both try to set up a PASSING_PLAN meet at the same place, so
+            // we exclude that case.
             // is there another train between these two
             if (!areTrainsAdjacent(at, nt)) {
                 return false;
@@ -814,16 +1034,19 @@ public class AutoAllocate {
 
     private boolean isThereConflictingPlan(ActiveTrain at, Section aSec, int aSecSeq,
             ActiveTrain nt, Section nSec, int nSecSeq, int type) {
-        // returns 'true' if there is a conflicting plan that may result in gridlock
-        //    if this plan is set up, return 'false' if not.
-        // Note: may have to add other tests to this method in the future to prevent gridlock
-        //   situations not currently tested for.
+        // returns 'true' if there is a conflicting plan that may result in
+        // gridlock
+        // if this plan is set up, return 'false' if not.
+        // Note: may have to add other tests to this method in the future to
+        // prevent gridlock
+        // situations not currently tested for.
         if (_planList.size() == 0) {
             return false;
         }
         for (int i = 0; i < _planList.size(); i++) {
             AllocationPlan ap = _planList.get(i);
-            // check if this plan involves the second train (it'll never involve the first)
+            // check if this plan involves the second train (it'll never involve
+            // the first)
             int trainNum = 0;
             if (ap.getActiveTrain(1) == nt) {
                 trainNum = 1;
@@ -838,7 +1061,8 @@ public class AutoAllocate {
                     return true;
                 }
             } else {
-                // different trains, does this plan use the same Passing Section?
+                // different trains, does this plan use the same Passing
+                // Section?
                 List<Section> aSections = at.getTransit().getSectionListBySeq(aSecSeq);
                 for (int j = 0; j < aSections.size(); j++) {
                     if ((aSections.get(j) == ap.getTargetSection(1)) || (aSections.get(j) == ap.getTargetSection(2))) {
@@ -852,7 +1076,8 @@ public class AutoAllocate {
     }
 
     private Section getBestOtherSection(List<Section> sList, Section aSec) {
-        // returns the best Section from the list that is not aSec, or else return null
+        // returns the best Section from the list that is not aSec, or else
+        // return null
         for (int i = 0; i < sList.size(); i++) {
             if ((sList.get(i) != aSec) &&
                     (sList.get(i).getState() == Section.FREE) &&
@@ -915,7 +1140,8 @@ public class AutoAllocate {
     }
 
     private boolean sectionNeeded(AllocationRequest ar, ActiveTrain at) {
-        // returns 'true' if request section, or its alternates, will be needed by specified train
+        // returns 'true' if request section, or its alternates, will be needed
+        // by specified train
         if ((ar == null) || (at == null)) {
             log.error("null argument on entry to 'sectionNeeded'");
             return false;
@@ -984,7 +1210,8 @@ public class AutoAllocate {
     }
 
     private boolean sameDirection(AllocationRequest ar, ActiveTrain at) {
-        // returns 'true' if both trains will move thru the requested section in the same direction
+        // returns 'true' if both trains will move thru the requested section in
+        // the same direction
         if ((ar == null) || (at == null)) {
             log.error("null argument on entry to 'sameDirection'");
             return false;
@@ -1049,7 +1276,8 @@ public class AutoAllocate {
             for (int i = 0; i < ntsList.size(); i++) {
                 if (ntsList.get(i).getSequenceNumber() > nSeq) {
                     if (ntsList.get(i).getSection() == aSec) {
-                        // second train has found first train in its on coming Sections
+                        // second train has found first train in its on coming
+                        // Sections
                         return true;
                     }
                 }
@@ -1058,7 +1286,8 @@ public class AutoAllocate {
             for (int i = ntsList.size() - 1; i <= 0; i--) {
                 if (ntsList.get(i).getSequenceNumber() < nSeq) {
                     if (ntsList.get(i).getSection() == aSec) {
-                        // second train has found first train in its on coming Sections
+                        // second train has found first train in its on coming
+                        // Sections
                         return true;
                     }
                 }
@@ -1102,7 +1331,8 @@ public class AutoAllocate {
             for (int i = 0; i < ntsList.size(); i++) {
                 if (ntsList.get(i).getSequenceNumber() > nSeq) {
                     if (ntsList.get(i).getSection() == aSec) {
-                        // second train has found first train in its on coming Sections
+                        // second train has found first train in its on coming
+                        // Sections
                         return true;
                     }
                 }
@@ -1111,7 +1341,8 @@ public class AutoAllocate {
             for (int i = ntsList.size() - 1; i <= 0; i--) {
                 if (ntsList.get(i).getSequenceNumber() < nSeq) {
                     if (ntsList.get(i).getSection() == aSec) {
-                        // second train has found first train in its on coming Sections
+                        // second train has found first train in its on coming
+                        // Sections
                         return true;
                     }
                 }
@@ -1121,8 +1352,9 @@ public class AutoAllocate {
     }
 
     private boolean areTrainsAdjacent(ActiveTrain at, ActiveTrain nt) {
-        // returns 'false' if a different ActiveTrain has allocated track between the
-        //      two trains, returns 'true' otherwise
+        // returns 'false' if a different ActiveTrain has allocated track
+        // between the
+        // two trains, returns 'true' otherwise
         List<AllocatedSection> allocatedSections = _dispatcher.getAllocatedSectionsList();
         List<TransitSection> atsList = at.getTransit().getTransitSectionList();
         int aSeq = getCurrentSequenceNumber(at);
@@ -1134,14 +1366,16 @@ public class AutoAllocate {
                     if (atsList.get(i).getSequenceNumber() > aSeq) {
                         Section tSec = atsList.get(i).getSection();
                         if (tSec == nSec) {
-                            // reached second train position, no train in between
+                            // reached second train position, no train in
+                            // between
                             return true;
                         } else {
                             for (int j = 0; j < allocatedSections.size(); j++) {
                                 if (allocatedSections.get(j).getSection() == tSec) {
                                     if ((allocatedSections.get(j).getActiveTrain() != at) &&
                                             (allocatedSections.get(j).getActiveTrain() != nt)) {
-                                        // allocated to a third train, trains not adjacent
+                                        // allocated to a third train, trains
+                                        // not adjacent
                                         return false;
                                     }
                                 }
@@ -1154,14 +1388,16 @@ public class AutoAllocate {
                     if (atsList.get(i).getSequenceNumber() < aSeq) {
                         Section tSec = atsList.get(i).getSection();
                         if (tSec == nSec) {
-                            // reached second train position, no train in between
+                            // reached second train position, no train in
+                            // between
                             return true;
                         } else {
                             for (int j = 0; j < allocatedSections.size(); j++) {
                                 if (allocatedSections.get(j).getSection() == tSec) {
                                     if ((allocatedSections.get(j).getActiveTrain() != at) &&
                                             (allocatedSections.get(j).getActiveTrain() != nt)) {
-                                        // allocated to a third train, trains not adjacent
+                                        // allocated to a third train, trains
+                                        // not adjacent
                                         return false;
                                     }
                                 }
@@ -1177,14 +1413,16 @@ public class AutoAllocate {
                     if (atsList.get(i).getSequenceNumber() > aSeq) {
                         Section tSec = atsList.get(i).getSection();
                         if (tSec == nSec) {
-                            // reached second train position, no train in between
+                            // reached second train position, no train in
+                            // between
                             return true;
                         } else {
                             for (int j = 0; j < allocatedSections.size(); j++) {
                                 if (allocatedSections.get(j).getSection() == tSec) {
                                     if ((allocatedSections.get(j).getActiveTrain() != at) &&
                                             (allocatedSections.get(j).getActiveTrain() != nt)) {
-                                        // allocated to a third train, trains not adjacent
+                                        // allocated to a third train, trains
+                                        // not adjacent
                                         return false;
                                     }
                                 }
@@ -1197,14 +1435,16 @@ public class AutoAllocate {
                     if (atsList.get(i).getSequenceNumber() < aSeq) {
                         Section tSec = atsList.get(i).getSection();
                         if (tSec == nSec) {
-                            // reached second train position, no train in between
+                            // reached second train position, no train in
+                            // between
                             return true;
                         } else {
                             for (int j = 0; j < allocatedSections.size(); j++) {
                                 if (allocatedSections.get(j).getSection() == tSec) {
                                     if ((allocatedSections.get(j).getActiveTrain() != at) &&
                                             (allocatedSections.get(j).getActiveTrain() != nt)) {
-                                        // allocated to a third train, trains not adjacent
+                                        // allocated to a third train, trains
+                                        // not adjacent
                                         return false;
                                     }
                                 }
@@ -1218,8 +1458,10 @@ public class AutoAllocate {
     }
 
     private int getCurrentSequenceNumber(ActiveTrain at) {
-        // finds the current position of the head of the ActiveTrain in its Transit
-        // returns sequence number of current position. getCurSection() returns Section.
+        // finds the current position of the head of the ActiveTrain in its
+        // Transit
+        // returns sequence number of current position. getCurSection() returns
+        // Section.
         int seq = 0;
         curSection = null;
         if (at == null) {
@@ -1240,7 +1482,8 @@ public class AutoAllocate {
             }
             if (seq == at.getTransit().getMaxSequence()) {
                 if (at.getResetWhenDone()) {
-                    // train may have passed the last Section during continuous running
+                    // train may have passed the last Section during continuous
+                    // running
                     boolean further = true;
                     for (int j = 0; (j < tsList.size()) && further; j++) {
                         if ((tsList.get(j).getSection().getOccupancy() == Section.OCCUPIED) &&
@@ -1281,7 +1524,8 @@ public class AutoAllocate {
 
     Section curSection = null;
 
-    // Returns the Section with the sequence number returned by last call to getCurrentSequenceNumber
+    // Returns the Section with the sequence number returned by last call to
+    // getCurrentSequenceNumber
     private Section getCurSection() {
         return curSection;
     }
@@ -1314,7 +1558,8 @@ public class AutoAllocate {
     }
 
     private boolean willLevelXingsBlockTrain(ActiveTrain at) {
-        // returns true if any LevelXings in _levelXingList will block the specified train
+        // returns true if any LevelXings in _levelXingList will block the
+        // specified train
         if (at == null) {
             log.error("null argument on entry to 'willLevelXingsBlockTrain'");
             return true; // returns true to be safe
@@ -1330,7 +1575,8 @@ public class AutoAllocate {
                 if (InstanceManager.getDefault(DispatcherFrame.class).getSignalType() == DispatcherFrame.SIGNALMAST) {
                     return true;
                 } else {
-                    // temp - return false - continious trains always meet for ever and no one moves...
+                    // temp - return false - continious trains always meet for
+                    // ever and no one moves...
                     return false;
                 }
                 // return true;
@@ -1385,7 +1631,7 @@ public class AutoAllocate {
             log.error("Allocation request section does not match active train next section to allocate");
             log.error("Section to allocate {}", sec.getDisplayName(USERSYS));
             if (mActiveTrain.getNextSectionToAllocate() != null) {
-                log.error("Active Train expected {}", mActiveTrain.getNextSectionToAllocate().getDisplayName(USERSYS));
+                log.error("Active Train expected {}", mActiveTrain.getNextSectionToAllocate().getDisplayName(USERSYS), Thread.currentThread().getStackTrace());
             }
             return false;
         }
@@ -1396,7 +1642,7 @@ public class AutoAllocate {
             protectingBlock = sec.getBlockBySequenceNumber(0);
             facingBlock = lastSec.getBlockBySequenceNumber(lastSec.getNumBlocks() - 1);
         } else {
-            //Reverse
+            // Reverse
             protectingBlock = sec.getBlockBySequenceNumber(sec.getNumBlocks() - 1);
             facingBlock = lastSec.getBlockBySequenceNumber(0);
         }

--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -460,8 +460,7 @@ public class AutoAllocate implements Runnable {
                 }
             } catch (RuntimeException e) {
                 log.warn(
-                        "scanAllocationRequestList - maybe the allocationrequest was removed due to a terminating train??{}",
-                        e.toString());
+                        "scanAllocationRequestList - maybe the allocationrequest was removed due to a terminating train??",e);
                 continue;
             }
         }

--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -1627,11 +1627,16 @@ public class AutoAllocate implements Runnable {
             return false;
         }
 
-        if (!sec.equals(mActiveTrain.getNextSectionToAllocate())) {
-            log.error("Allocation request section does not match active train next section to allocate");
-            log.error("Section to allocate {}", sec.getDisplayName(USERSYS));
+        if (sec.equals(mActiveTrain.getNextSectionToAllocate())) {
+            log.error("[{}]Allocation request section does not match active train next section to allocate",mActiveTrain.getActiveTrainName());
+            log.error("[{}]Section requested {}",mActiveTrain.getActiveTrainName(), sec.getDisplayName(USERSYS));
             if (mActiveTrain.getNextSectionToAllocate() != null) {
-                log.error("Active Train expected {}", mActiveTrain.getNextSectionToAllocate().getDisplayName(USERSYS), Thread.currentThread().getStackTrace());
+                log.error("[{}]Section expected {}",
+                        mActiveTrain.getActiveTrainName(), mActiveTrain.getNextSectionToAllocate().getDisplayName(USERSYS));
+            }
+            if (mActiveTrain.getLastAllocatedSection() != null) {
+                log.error("[{}]Last Section Allocated {}",
+                        mActiveTrain.getActiveTrainName(), mActiveTrain.getLastAllocatedSection().getDisplayName(USERSYS));
             }
             return false;
         }

--- a/java/src/jmri/jmrit/dispatcher/DispatcherBundle.properties
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherBundle.properties
@@ -68,6 +68,7 @@ UseConnectivity = Use connectivity from Layout Editor panel:
 UseConnectivityHint = Select to use the connectivity from the selected Layout Editor panel.
 SignalType1 = Signal Heads/SSL
 SignalType2 = Signal Masts/SML
+SignalType3 = No Signals
 SignalTypeHint = Select the type of signaling used on the panel and which Dispatcher will follow.
 LayoutEditorHint = Select Layout Editor panel with best connectivity, if there are more than one.
 TrainsFromRoster = Trains from Roster

--- a/java/src/jmri/jmrit/dispatcher/OptionsFile.java
+++ b/java/src/jmri/jmrit/dispatcher/OptionsFile.java
@@ -44,8 +44,6 @@ public class OptionsFile extends jmri.jmrit.XmlFile implements InstanceManagerAu
     // operational variables
     protected DispatcherFrame dispatcher = null;
     private static String defaultFileName = FileUtil.getUserFilesPath() + "dispatcheroptions.xml";
-    public static final int SIGNALHEAD = 0x00;
-    public static final int SIGNALMAST = 0x01;
 
     public static void setDefaultFileName(String testLocation) {
         defaultFileName = testLocation;
@@ -93,9 +91,15 @@ public class OptionsFile extends jmri.jmrit.XmlFile implements InstanceManagerAu
                         }
                     }
                     if (options.getAttribute("usesignaltype") != null) {
-                        dispatcher.setSignalType(SIGNALHEAD);
-                        if (options.getAttribute("usesignaltype").getValue().equals("signalmast")) {
-                            dispatcher.setSignalType(SIGNALMAST);
+                        switch (options.getAttribute("usesignaltype").getValue()) {
+                            case "signalmast":
+                                dispatcher.setSignalType(DispatcherFrame.SIGNALMAST);
+                                break;
+                            case "sectionsallocated":
+                                dispatcher.setSignalType(DispatcherFrame.SECTIONSALLOCATED);
+                                break;
+                            default:
+                                dispatcher.setSignalType(DispatcherFrame.SIGNALHEAD);
                         }
                     }
                     if (options.getAttribute("useconnectivity") != null) {
@@ -126,6 +130,12 @@ public class OptionsFile extends jmri.jmrit.XmlFile implements InstanceManagerAu
                         dispatcher.setAutoAllocate(false);
                         if (options.getAttribute("autoallocate").getValue().equals("yes")) {
                             dispatcher.setAutoAllocate(true);
+                        }
+                    }
+                    if (options.getAttribute("autorelease") != null) {
+                        dispatcher.setAutoRelease(false);
+                        if (options.getAttribute("autorelease").getValue().equals("yes")) {
+                            dispatcher.setAutoRelease(true);
                         }
                     }
                     if (options.getAttribute("autoturnouts") != null) {
@@ -209,9 +219,9 @@ public class OptionsFile extends jmri.jmrit.XmlFile implements InstanceManagerAu
                     if (options.getAttribute("stoppingspeedname") != null) {
                         dispatcher.setStoppingSpeedName((options.getAttribute("stoppingspeedname")).getValue());
                     }
+                    
                     log.debug("  Options: {}, Detection={}, AutoAllocate={}, AutoTurnouts={}, SetSSLDirectionSensors={}", 
-                            (dispatcher.getSignalType()==SIGNALHEAD?"SignalHeads/SSL":"SignalMasts"),
-                            (dispatcher.getHasOccupancyDetection()?"yes":"no"),
+                            (dispatcher.getSignalTypeString()),
                             (dispatcher.getAutoAllocate()?"yes":"no"),
                             (dispatcher.getAutoTurnouts()?"yes":"no"),
                             (dispatcher.getSetSSLDirectionalSensors()?"yes":"no"));
@@ -251,6 +261,7 @@ public class OptionsFile extends jmri.jmrit.XmlFile implements InstanceManagerAu
         options.setAttribute("trainsfromtrains", "" + (dispatcher.getTrainsFromTrains() ? "yes" : "no"));
         options.setAttribute("trainsfromuser", "" + (dispatcher.getTrainsFromUser() ? "yes" : "no"));
         options.setAttribute("autoallocate", "" + (dispatcher.getAutoAllocate() ? "yes" : "no"));
+        options.setAttribute("autorelease", "" + (dispatcher.getAutoRelease() ? "yes" : "no"));
         options.setAttribute("autoturnouts", "" + (dispatcher.getAutoTurnouts() ? "yes" : "no"));
         options.setAttribute("trustknownturnouts", "" + (dispatcher.getTrustKnownTurnouts() ? "yes" : "no"));
         options.setAttribute("minthrottleinterval", "" + (dispatcher.getMinThrottleInterval()));
@@ -266,10 +277,15 @@ public class OptionsFile extends jmri.jmrit.XmlFile implements InstanceManagerAu
         options.setAttribute("usescalemeters", "" + (dispatcher.getUseScaleMeters() ? "yes" : "no"));
         options.setAttribute("userosterentryinblock", "" + (dispatcher.getRosterEntryInBlock() ? "yes" : "no"));
         options.setAttribute("stoppingspeedname", dispatcher.getStoppingSpeedName());
-        if (dispatcher.getSignalType() == SIGNALHEAD) {
-            options.setAttribute("usesignaltype", "signalhead");
-        } else {
-            options.setAttribute("usesignaltype", "signalmast");
+        switch (dispatcher.getSignalType()) {
+            case DispatcherFrame.SIGNALMAST:
+                options.setAttribute("usesignaltype", "signalmast");
+                break;
+            case DispatcherFrame.SECTIONSALLOCATED:
+                options.setAttribute("usesignaltype", "sectionsallocated");
+                break;
+            default:
+                options.setAttribute("usesignaltype", "signalhead");
         }
         root.addContent(options);
 

--- a/java/src/jmri/jmrit/dispatcher/OptionsMenu.java
+++ b/java/src/jmri/jmrit/dispatcher/OptionsMenu.java
@@ -127,7 +127,7 @@ public class OptionsMenu extends JMenu {
     JCheckBox trustKnownTurnoutsCheckBox = new JCheckBox(Bundle.getMessage("trustKnownTurnouts"));
     JComboBox<String> stoppingSpeedBox = new JComboBox<>();
 
-    String[] signalTypes = {Bundle.getMessage("SignalType1"), Bundle.getMessage("SignalType2")};
+    String[] signalTypes = {Bundle.getMessage("SignalType1"), Bundle.getMessage("SignalType2"), Bundle.getMessage("SignalType3")};
 
     private void optionWindowRequested(ActionEvent e) {
         if (optionsFrame == null) {

--- a/java/src/jmri/jmrit/dispatcher/TaskAllocateRelease.java
+++ b/java/src/jmri/jmrit/dispatcher/TaskAllocateRelease.java
@@ -1,0 +1,48 @@
+package jmri.jmrit.dispatcher;
+
+public class TaskAllocateRelease {
+
+    TaskAllocateRelease(TaskAction action) {
+        act = action;
+    }
+
+    TaskAllocateRelease(TaskAction action, String trainName) {
+        act = action;
+        this.trainName = trainName;
+    }
+
+    TaskAllocateRelease(TaskAction action, AllocatedSection aSection, boolean termTrain) {
+        act = action;
+        allocatedSection = aSection;
+        terminateingTrain = termTrain;
+    }
+
+    private TaskAction act;
+    private String trainName = null;
+    private AllocatedSection allocatedSection = null;
+    private boolean terminateingTrain = false;
+
+    public enum TaskAction {
+        SCAN_REQUESTS,
+        RELEASE_RESERVED,
+        RELEASE_ONE,
+        AUTO_RELEASE,
+        ABORT;
+    }
+
+    public TaskAction getAction() {
+        return act;
+    }
+
+    public String getTrainName() {
+        return trainName;
+    }
+
+    public AllocatedSection getAllocatedSection() {
+        return allocatedSection;
+    }
+
+    public boolean getTerminatingTrain() {
+        return terminateingTrain;
+    }
+}

--- a/java/test/jmri/jmrit/dispatcher/AllocationPlanTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AllocationPlanTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrit.dispatcher;
 
 import java.awt.GraphicsEnvironment;
+import java.util.ArrayList;
+import java.util.List;
 
 import jmri.InstanceManager;
 import jmri.util.JUnitUtil;
@@ -21,7 +23,7 @@ public class AllocationPlanTest {
         OptionsFile.setDefaultFileName("java/test/jmri/jmrit/dispatcher/dispatcheroptions.xml");  // exist?
 
         DispatcherFrame d = InstanceManager.getDefault(DispatcherFrame.class);
-        AutoAllocate aa = new AutoAllocate(d);
+        AutoAllocate aa = new AutoAllocate(d, new ArrayList<>() );
         jmri.util.JUnitAppender.assertErrorMessage("null LayoutEditor when constructing AutoAllocate");
         AllocationPlan t = new AllocationPlan(aa,1);
         Assert.assertNotNull("exists",t);

--- a/java/test/jmri/jmrit/dispatcher/AutoActiveTrainsSMLStoppingTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AutoActiveTrainsSMLStoppingTest.java
@@ -99,7 +99,9 @@ public class AutoActiveTrainsSMLStoppingTest {
         aat = at.getAutoActiveTrain();
 
         // trains loads and runs, 4 allocated sections, the one we are in and 3 ahead.
-        assertThat(d.getAllocatedSectionsList()).withFailMessage("Section South 1").hasSize(4);
+        JUnitUtil.waitFor(() -> {
+            return(d.getAllocatedSectionsList().size()==4);
+        },"Allocated sections should be 4");
 
         JUnitUtil.waitFor(() -> {
             return smm.getSignalMast("Sw-West-Cont").getAspect().equals("Clear");
@@ -154,6 +156,9 @@ public class AutoActiveTrainsSMLStoppingTest {
         JButtonOperator bo = new JButtonOperator(dw, Bundle.getMessage("TerminateTrain"));
         bo.push();
 
+        assertThat((d.getActiveTrainsList().isEmpty())).withFailMessage("All trains terminated").isTrue();
+
+
         // *******************************************************************************
         //  Here start South - West - North - Stop -East South - Stop - using stopping sensors
         // *******************************************************************************
@@ -163,7 +168,10 @@ public class AutoActiveTrainsSMLStoppingTest {
 
         d.loadTrainFromTrainInfo("SSL3TestTrain.xml");
 
-        assertThat(d.getActiveTrainsList().size()).withFailMessage("Train Loaded").isEqualTo(1);
+        // trains loads and runs, 3 (east blocked) allocated sections, the one we are in and 2 ahead.
+        JUnitUtil.waitFor(() -> {
+            return(d.getAllocatedSectionsList().size()==3);
+        },"Allocated sections should be 3");
 
         at = d.getActiveTrainsList().get(0);
         aat = at.getAutoActiveTrain();
@@ -219,7 +227,8 @@ public class AutoActiveTrainsSMLStoppingTest {
         JUnitUtil.setBeanStateAndWait(bm.getBlock("Block South 1"), Block.OCCUPIED);
         JUnitUtil.setBeanStateAndWait(bm.getBlock("Block East Switch"), Block.UNOCCUPIED);
         assertEquals(bm.getBlock("Block South 1").getState(),Block.OCCUPIED);
-        assertEquals(aat.getThrottle().getSpeedSetting() , speedStopping);
+        assertEquals(bm.getBlock("Block East Switch").getState(),Block.UNOCCUPIED);
+        
         JUnitUtil.waitFor(() -> {
             return aat.getThrottle().getSpeedSetting() == speedStopping;
         }, "Failed to slow entering south. begin - end - no stop - stopping sensors.");
@@ -243,20 +252,29 @@ public class AutoActiveTrainsSMLStoppingTest {
         // block track at East.
         JUnitUtil.setBeanStateAndWait(bm.getBlock("Block East"), Block.OCCUPIED);
 
-        d.loadTrainFromTrainInfo("SSL3TestTrain.xml");
+        JUnitUtil.waitFor(() -> {
+            return smm.getSignalMast("Sw-West-Cont").getAspect().equals("Stop");
+        }, "Signal West End Div now Clear");
 
-        assertThat(d.getActiveTrainsList().size()).withFailMessage("Train Loaded").isEqualTo(1);
+        d.loadTrainFromTrainInfo("SSL3TestTrain.xml");
 
         at = d.getActiveTrainsList().get(0);
         aat = at.getAutoActiveTrain();
 
+        // trains loads and runs, 3 (East Blocked) allocated sections, the one we are in and 2 ahead.
+        JUnitUtil.waitFor(() -> {
+            return(d.getAllocatedSectionsList().size()==3);
+        },"Allocated sections should be 3");
+
         JUnitUtil.waitFor(() -> {
             return smm.getSignalMast("Sw-West-Cont").getAspect().equals("Clear");
         }, "Signal West End Div now Clear");
+        assertEquals(sm.getSensor("Dir West Fwd").getState(),Sensor.ACTIVE);
+        assertEquals(sm.getSensor("Dir West Rev").getState(),Sensor.INACTIVE);
 
         JUnitUtil.waitFor(() -> {
-            return aat.getThrottle().getSpeedSetting() == speedMedium;
-        }, "Failed to Start begin - stop north - go - end - stop");
+            return aat.getThrottle().getSpeedSetting() == speedNormal;
+            }, "Failed to Start begin - stop north - go - end - stop");
 
         JUnitUtil.setBeanStateAndWait(bm.getBlock("Block West Switch"), Block.OCCUPIED);
         JUnitUtil.setBeanStateAndWait(bm.getBlock("Block South 1"), Block.UNOCCUPIED);
@@ -333,7 +351,10 @@ public class AutoActiveTrainsSMLStoppingTest {
         aat = at.getAutoActiveTrain();
 
         // trains loads and runs, 4 allocated sections, the one we are in and 3 ahead.
-        assertThat(d.getAllocatedSectionsList()).withFailMessage("Section South 1").hasSize(4);
+        JUnitUtil.waitFor(() -> {
+            return(d.getAllocatedSectionsList().size()==4);
+        },"Allocated sections should be 4");
+
         // set up loco address
         JUnitUtil.waitFor(() -> {
             return smm.getSignalMast("Sw-West-Cont").getAspect().equals("Clear");
@@ -393,6 +414,11 @@ public class AutoActiveTrainsSMLStoppingTest {
 
         at = d.getActiveTrainsList().get(0);
         aat = at.getAutoActiveTrain();
+
+        // trains loads and runs, 3 (east Blocked) allocated sections, the one we are in and 2 ahead.
+        JUnitUtil.waitFor(() -> {
+            return(d.getAllocatedSectionsList().size()==3);
+        },"Allocated sections should be 3");
 
         JUnitUtil.waitFor(() -> {
             return smm.getSignalMast("Sw-West-Cont").getAspect().equals("Clear");
@@ -477,6 +503,11 @@ public class AutoActiveTrainsSMLStoppingTest {
         at = d.getActiveTrainsList().get(0);
         aat = at.getAutoActiveTrain();
 
+        // trains loads and runs, 3 (east Blocked) allocated sections, the one we are in and 2 ahead.
+        JUnitUtil.waitFor(() -> {
+            return(d.getAllocatedSectionsList().size()==3);
+        },"Allocated sections should be 3");
+
         JUnitUtil.waitFor(() -> {
             return smm.getSignalMast("Sw-West-Cont").getAspect().equals("Clear");
         }, "Signal West End Div now Clear begin - start stop north - go - end - stop on previous block");
@@ -559,7 +590,10 @@ public class AutoActiveTrainsSMLStoppingTest {
         aat = at.getAutoActiveTrain();
 
         // trains loads and runs, 4 allocated sections, the one we are in and 3 ahead.
-        assertThat(d.getAllocatedSectionsList()).withFailMessage("Section South 1").hasSize(4);
+        JUnitUtil.waitFor(() -> {
+            return(d.getAllocatedSectionsList().size()==4);
+        },"Allocated sections should be 4");
+
         // set up loco address
         JUnitUtil.waitFor(() -> {
             return smm.getSignalMast("Sw-West-Cont").getAspect().equals("Clear");
@@ -618,6 +652,11 @@ public class AutoActiveTrainsSMLStoppingTest {
 
         at = d.getActiveTrainsList().get(0);
         aat = at.getAutoActiveTrain();
+
+        // trains loads and runs, 3 (East Blocked) allocated sections, the one we are in and 2 ahead.
+        JUnitUtil.waitFor(() -> {
+            return(d.getAllocatedSectionsList().size()==3);
+        },"Allocated sections should be 3");
 
         JUnitUtil.waitFor(() -> {
             return smm.getSignalMast("Sw-West-Cont").getAspect().equals("Clear");
@@ -690,6 +729,15 @@ public class AutoActiveTrainsSMLStoppingTest {
         at = d.getActiveTrainsList().get(0);
         aat = at.getAutoActiveTrain();
 
+        // trains loads and runs, 3 (east Blocked) allocated sections, the one we are in and 2 ahead.
+        JUnitUtil.waitFor(() -> {
+            return(d.getAllocatedSectionsList().size()==3);
+        },"Allocated sections should be 3");
+
+        JUnitUtil.waitFor(() -> {
+            return smm.getSignalMast("Sw-West-Cont").getAspect().equals("Clear");
+        }, "Signal West End Div now Clear");
+
         JUnitUtil.waitFor(() -> {
             return smm.getSignalMast("Sw-West-Cont").getAspect().equals("Clear");
         }, "Signal West End Div now Clear begin - start stop north - go - end - stop on previous block");
@@ -751,7 +799,9 @@ public class AutoActiveTrainsSMLStoppingTest {
         // as we don't see the throttle go to zero if we do that.
 
         bo.push();
-
+        // wait for cleanup to finish
+        JUnitUtil.waitFor(200);
+        
         assertThat((d.getActiveTrainsList().isEmpty())).withFailMessage("All trains terminated").isTrue();
         JFrameOperator aw = new JFrameOperator("AutoTrains");
 

--- a/java/test/jmri/jmrit/dispatcher/AutoAllocateTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AutoAllocateTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.dispatcher;
 
 import java.awt.GraphicsEnvironment;
+import java.util.ArrayList;
 
 import jmri.InstanceManager;
 import jmri.util.JUnitUtil;
@@ -23,7 +24,7 @@ public class AutoAllocateTest {
         OptionsFile.setDefaultFileName("java/test/jmri/jmrit/dispatcher/dispatcheroptions.xml");  // exist?
 
         DispatcherFrame d = InstanceManager.getDefault(DispatcherFrame.class);
-        AutoAllocate t = new AutoAllocate(d);
+        AutoAllocate t = new AutoAllocate(d, new ArrayList<>());
         Assert.assertNotNull("exists",t);
         jmri.util.JUnitAppender.assertErrorMessage("null LayoutEditor when constructing AutoAllocate");
         JUnitUtil.dispose(d);
@@ -32,7 +33,7 @@ public class AutoAllocateTest {
     @Test
     public void testErrorCase() {
         // present so there's some class test coverage when skipping intermittent
-        new AutoAllocate(null);
+        new AutoAllocate(null,null);
         JUnitAppender.assertErrorMessage("null DispatcherFrame when constructing AutoAllocate");
         
     }

--- a/java/test/jmri/jmrit/dispatcher/AutoTrainsFrameStopManualTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AutoTrainsFrameStopManualTest.java
@@ -252,6 +252,8 @@ import java.nio.file.StandardCopyOption;
 
             JButtonOperator bo = new JButtonOperator(dw, Bundle.getMessage("TerminateTrain"));
             bo.push();
+            // wait for cleanup to finish
+            JUnitUtil.waitFor(200);
 
             assertThat((d.getActiveTrainsList().isEmpty())).withFailMessage("All trains terminated").isTrue();
             JFrameOperator aw = new JFrameOperator("AutoTrains");

--- a/java/test/jmri/jmrit/dispatcher/LoadAtStartUpTest.java
+++ b/java/test/jmri/jmrit/dispatcher/LoadAtStartUpTest.java
@@ -73,6 +73,9 @@ public class LoadAtStartUpTest {
         assertThat(d.getActiveTrainsList().size()).withFailMessage("Train Loaded").isEqualTo(1);
 
         // trains loads and runs, 4 allocated sections, the one we are in and 3 ahead.
+        JUnitUtil.waitFor(() -> {
+            return d.getAllocatedSectionsList().size() == 4;
+        }, "Allocate Sections ahead");
         assertThat(d.getAllocatedSectionsList()).withFailMessage("Allocated sections 4").hasSize(4);
         // set up loco address
         DccLocoAddress addr = new DccLocoAddress(1000, true);
@@ -183,6 +186,8 @@ public class LoadAtStartUpTest {
         // cancel (terminate) the train.
         JButtonOperator bo = new JButtonOperator(dw, Bundle.getMessage("TerminateTrain"));
         bo.push();
+        // wait for cleanup to finish
+        JUnitUtil.waitFor(200);
 
         assertThat((d.getActiveTrainsList().isEmpty())).withFailMessage("All trains terminated").isTrue();
 

--- a/java/test/jmri/jmrit/dispatcher/LoadAtStartUpTest.java
+++ b/java/test/jmri/jmrit/dispatcher/LoadAtStartUpTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.dispatcher;
 
+import org.junit.Assume;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.JButtonOperator;
@@ -42,6 +43,7 @@ public class LoadAtStartUpTest {
     @SuppressWarnings("null")  // spec says cannot happen, everything defined in test data.
     @Test
     public void testShowAndClose() throws Exception {
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         jmri.configurexml.ConfigXmlManager cm = new jmri.configurexml.ConfigXmlManager() {
         };
         WarrantPreferences.getDefault().setShutdown(WarrantPreferences.Shutdown.NO_MERGE);

--- a/java/test/jmri/jmrit/dispatcher/LoadAtStartUpTest.java
+++ b/java/test/jmri/jmrit/dispatcher/LoadAtStartUpTest.java
@@ -14,7 +14,6 @@ import jmri.Throttle;
 import jmri.ThrottleManager;
 import jmri.implementation.SignalSpeedMap;
 import jmri.jmrit.logix.WarrantPreferences;
-import jmri.profile.ProfileManager;
 import jmri.util.FileUtil;
 import jmri.util.JUnitUtil;
 
@@ -37,6 +36,9 @@ import java.nio.file.StandardCopyOption;
 @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LoadAtStartUpTest {
 
+    // Only one aat at a time
+    private AutoActiveTrain aat = null;
+
     @SuppressWarnings("null")  // spec says cannot happen, everything defined in test data.
     @Test
     public void testShowAndClose() throws Exception {
@@ -52,8 +54,6 @@ public class LoadAtStartUpTest {
         DispatcherFrame d = InstanceManager.getDefault(DispatcherFrame.class);
         JFrameOperator dw = new JFrameOperator(Bundle.getMessage("TitleDispatcher"));
         
-        // we need a throttle manager
-        ThrottleManager m = InstanceManager.getDefault(ThrottleManager.class);
         // signal mast manager
         SignalMastManager smm = InstanceManager.getDefault(SignalMastManager.class);
 
@@ -66,19 +66,23 @@ public class LoadAtStartUpTest {
         }
         // place train on layout
         sm.getSensor("Occ South Platform").setState(Sensor.ACTIVE);
-
+        JUnitUtil.waitFor(100);
+        sm.getSensor("Occ West Platform Switch").setState(Sensor.ACTIVE); // set blocker
+        
         // and load. only one of 2 trains will load
         d.loadAtStartup();
-
         assertThat(d.getActiveTrainsList().size()).withFailMessage("Train Loaded").isEqualTo(1);
+        
+        sm.getSensor("Occ West Platform Switch").setState(Sensor.INACTIVE); // release blocker
 
         // trains loads and runs, 4 allocated sections, the one we are in and 3 ahead.
         JUnitUtil.waitFor(() -> {
             return d.getAllocatedSectionsList().size() == 4;
         }, "Allocate Sections ahead");
         assertThat(d.getAllocatedSectionsList()).withFailMessage("Allocated sections 4").hasSize(4);
-        // set up loco address
-        DccLocoAddress addr = new DccLocoAddress(1000, true);
+        // get autoactivetrain object
+        ActiveTrain at = d.getActiveTrainsList().get(0);
+        aat = at.getAutoActiveTrain();
         JUnitUtil.waitFor(() -> {
             return smm.getSignalMast("West End Div").getAspect().equals("Clear");
         }, "Signal West End Div now green");
@@ -87,7 +91,7 @@ public class LoadAtStartUpTest {
         assertThat(smm.getSignalMast("West To South").getAspect()).withFailMessage("1 West To South  Green").isEqualTo("Clear");
         assertThat(smm.getSignalMast("South To East").getAspect()).withFailMessage("1 South To East Signal Green").isEqualTo("Approach");
         assertThat(smm.getSignalMast("East End Throat").getAspect()).withFailMessage("1 East End Throat Signal Green").isEqualTo("Stop");
-        float speed = (float) m.getThrottleInfo(addr, Throttle.SPEEDSETTING);
+        float speed = aat.getThrottle().getSpeedSetting();
         assertThat(speed).isEqualTo(speedRestricted);
 
         sm.getSensor("Occ West Platform Switch").setState(Sensor.ACTIVE);
@@ -99,7 +103,7 @@ public class LoadAtStartUpTest {
         assertThat(smm.getSignalMast("West To South").getAspect()).withFailMessage("2 West To South  Green").isEqualTo("Clear");
         assertThat(smm.getSignalMast("South To East").getAspect()).withFailMessage("2 South To East Signal Green").isEqualTo("Approach");
         assertThat(smm.getSignalMast("East End Throat").getAspect()).withFailMessage("2 East End Throat Signal Green").isEqualTo("Stop");
-        speed = (float) m.getThrottleInfo(addr, Throttle.SPEEDSETTING);
+        speed = aat.getThrottle().getSpeedSetting();
         assertThat(speed).isEqualTo(speedRestricted);
 
         sm.getSensor("Occ West Block").setState(Sensor.ACTIVE);
@@ -111,7 +115,7 @@ public class LoadAtStartUpTest {
         assertThat(smm.getSignalMast("West To South").getAspect()).withFailMessage("3 West To South  Green").isEqualTo("Clear");
         assertThat(smm.getSignalMast("South To East").getAspect()).withFailMessage("3 South To East Signal Green").isEqualTo("Clear");
         assertThat(smm.getSignalMast("East End Throat").getAspect()).withFailMessage("3 East End Throat Signal Approach").isEqualTo("Approach");
-        speed = (float) m.getThrottleInfo(addr, Throttle.SPEEDSETTING);
+        speed = aat.getThrottle().getSpeedSetting();
         assertThat(speed).isEqualTo(speedRestricted);
 
         sm.getSensor("Occ South Block").setState(Sensor.ACTIVE);
@@ -124,7 +128,7 @@ public class LoadAtStartUpTest {
         assertThat(smm.getSignalMast("East End Throat").getAspect()).withFailMessage("4 East End Throat Signal Green").isEqualTo("Approach");
         String strSigSpeed  = (String) smm.getSignalMast("South To East").getSignalSystem().getProperty(smm.getSignalMast("South To East").getAspect(), "speed");
         assertThat(jmri.InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(strSigSpeed)/100).isEqualTo(speedNormal);
-        speed = (float) m.getThrottleInfo(addr, Throttle.SPEEDSETTING);
+        speed = aat.getThrottle().getSpeedSetting();
         assertThat(speed).isEqualTo(0.6f); //The signal head indicates 1.0f but train is limited to a max of 0.6f
 
         sm.getSensor("Occ West Block").setState(Sensor.INACTIVE);
@@ -137,7 +141,7 @@ public class LoadAtStartUpTest {
         assertThat(smm.getSignalMast("West To South").getAspect()).withFailMessage("5 West To South  Red").isEqualTo("Stop");
         assertThat(smm.getSignalMast("South To East").getAspect()).withFailMessage("5 South To East Signal Red").isEqualTo("Stop");
         assertThat(smm.getSignalMast("East End Throat").getAspect()).withFailMessage("5 East End Throat Signal yellow").isEqualTo("Approach");
-        speed = (float) m.getThrottleInfo(addr, Throttle.SPEEDSETTING);
+        speed = aat.getThrottle().getSpeedSetting();
         assertThat(speed).isEqualTo(speedRestricted);
 
         sm.getSensor("Occ South Block").setState(Sensor.INACTIVE);
@@ -149,7 +153,7 @@ public class LoadAtStartUpTest {
         assertThat(smm.getSignalMast("West To South").getAspect()).withFailMessage("6 West To South  Red").isEqualTo("Stop");
         assertThat(smm.getSignalMast("South To East").getAspect()).withFailMessage("6 South To East Signal Red").isEqualTo("Stop");
         assertThat(smm.getSignalMast("East End Throat").getAspect()).withFailMessage("6 East End Throat Signal Red").isEqualTo("Stop");
-        speed = (float) m.getThrottleInfo(addr, Throttle.SPEEDSETTING);
+        speed = aat.getThrottle().getSpeedSetting();
         assertThat(speed).isEqualTo(speedRestricted);
 
         sm.getSensor("Occ East Platform Switch").setState(Sensor.ACTIVE);
@@ -158,7 +162,7 @@ public class LoadAtStartUpTest {
         assertThat(smm.getSignalMast("West To South").getAspect()).withFailMessage("7 West To South  Red").isEqualTo("Stop");
         assertThat(smm.getSignalMast("South To East").getAspect()).withFailMessage("7 South To East Signal Red").isEqualTo("Stop");
         assertThat(smm.getSignalMast("East End Throat").getAspect()).withFailMessage("7 East End Throat Signal Red").isEqualTo("Stop");
-        speed = (float) m.getThrottleInfo(addr, Throttle.SPEEDSETTING);
+        speed = aat.getThrottle().getSpeedSetting();
         assertThat(speed).isEqualTo(speedRestricted);
 
         sm.getSensor("Occ South Platform").setState(Sensor.ACTIVE);
@@ -167,7 +171,7 @@ public class LoadAtStartUpTest {
         assertThat(smm.getSignalMast("West To South").getAspect()).withFailMessage("8 West To South  Red").isEqualTo("Stop");
         assertThat(smm.getSignalMast("South To East").getAspect()).withFailMessage("8 South To East Signal Red").isEqualTo("Stop");
         assertThat(smm.getSignalMast("East End Throat").getAspect()).withFailMessage("8 East End Throat Signal Red").isEqualTo("Stop");
-        speed = (float) m.getThrottleInfo(addr, Throttle.SPEEDSETTING);
+        speed = aat.getThrottle().getSpeedSetting();
         assertThat(speed).isEqualTo(speedRestricted);
 
         sm.getSensor("Occ East Block").setState(Sensor.INACTIVE);
@@ -180,7 +184,7 @@ public class LoadAtStartUpTest {
 
         // train slows to stop
         JUnitUtil.waitFor(() -> {
-            return (float) m.getThrottleInfo(addr, Throttle.SPEEDSETTING) == 0.0;
+            return aat.getThrottle().getSpeedSetting() == 0.0;
         }, "Signal Just passed east end throat now stop");
 
         // cancel (terminate) the train.


### PR DESCRIPTION
Dispatcher
    Cut number of arrays from 3 to 2 by removing the allocated section array from AutoActiveTrain.
    When running in autoallocate and or autorelease feed all request thru a blocking queue to ensure one at a time updates to the allocated section arrays.
    When allocating safesection transits put a reserve on the sections.
    When getting informed of a throttle aquire check for currentsection null, which happens on fast machines when first starting trains.
    In adition to running by SML or SSL add the option to run without signals.
    Start breaking up the code for autoActiveTrain.
