### PR TITLE
add warn/trip level to meter response from DCC-EX

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppConstants.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppConstants.java
@@ -141,7 +141,7 @@ public final class DCCppConstants {
     public static final String MAXNUMSLOTS_REPLY_REGEX =   "\\s*#\\s*(\\d+).*";
     public static final String CURRENT_REPLY_REGEX =       "\\s*a\\s*(\\d+).*";
     public static final String CURRENT_REPLY_NAMED_REGEX = "\\s*a\\s*(\\w*?[a-zA-Z])\\s*(\\d+).*";
-    public static final String METER_REPLY_REGEX = " *c *(.+) +([\\d\\.]+) +([A-Z]) +(\\w+) +([\\d\\.]+) +([\\d\\.]+) +([\\d\\.]+).*";
+    public static final String METER_REPLY_REGEX = " *c *(.+) +([\\d\\.]+) +([A-Z]) +(\\w+) +([\\d\\.]+) +([\\d\\.]+) +([\\d\\.]+) +([\\d\\.]+).*";
     
     public static final String TRACK_POWER_REPLY_REGEX =       "\\s*p\\s*([0,1])\\s*";
     public static final String TRACK_POWER_REPLY_NAMED_REGEX = "\\s*p\\s*(\\d+)\\s+(\\w+).*";

--- a/java/src/jmri/jmrix/dccpp/DCCppReply.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppReply.java
@@ -186,10 +186,10 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
                 text = "Current: " + getCurrentString() + " / 1024";
                 break;
             case DCCppConstants.METER_REPLY:
-                text = String.format("Meter reply: name %s, value %.2f, type %s, unit %s, min %.2f, max %.2f, resolution %.2f", 
+                text = String.format("Meter reply: name %s, value %.2f, type %s, unit %s, min %.2f, max %.2f, resolution %.2f, warn %.2f", 
                         getMeterName(), getMeterValue(), getMeterType(),  
                         getMeterUnit(), getMeterMinValue(), getMeterMaxValue(), 
-                        getMeterResolution());
+                        getMeterResolution(), getMeterWarnValue());
                 break;
             // case DCCppConstants.LISTPACKET_REPLY:
             //     // TODO: Implement this fully
@@ -947,6 +947,14 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
     public double getMeterResolution() {
         if (this.isMeterReply()) {
             return(this.getValueDouble(7));
+        } else {
+            log.error("MeterReply Parser called on non-MeterReply message type '{}' message '{}'", this.getOpCodeChar(), this.toString());
+            return(0.0);
+        }
+    }
+    public double getMeterWarnValue() {
+        if (this.isMeterReply()) {
+            return(this.getValueDouble(8));
         } else {
             log.error("MeterReply Parser called on non-MeterReply message type '{}' message '{}'", this.getOpCodeChar(), this.toString());
             return(0.0);

--- a/java/src/jmri/jmrix/dccpp/simulator/DCCppSimulatorAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/simulator/DCCppSimulatorAdapter.java
@@ -512,10 +512,10 @@ public class DCCppSimulatorAdapter extends DCCppSimulatorPortController implemen
     private void generateMeterReplies() {
         int currentmA = 1100 + rgen.nextInt(64);
         double voltageV = 14.5 + rgen.nextInt(10)/10.0; 
-        String rs = "c CurrentMAIN " + (trackPowerState ? Double.toString(currentmA) : "0") + " C Milli 0 1997 1";
+        String rs = "c CurrentMAIN " + (trackPowerState ? Double.toString(currentmA) : "0") + " C Milli 0 1997 1 1997";
         DCCppReply r = new DCCppReply(rs);
         writeReply(r);       
-        r = new DCCppReply("c VoltageMAIN " + Double.toString(voltageV) + " V NoPrefix 0 18.0 0.1");
+        r = new DCCppReply("c VoltageMAIN " + Double.toString(voltageV) + " V NoPrefix 0 18.0 0.1 16.0");
         writeReply(r);
         rs = "a " + (trackPowerState ? Integer.toString((1997/currentmA)*100) : "0");
         r = DCCppReply.parseDCCppReply(rs);

--- a/java/test/jmri/jmrix/dccpp/DCCppPredefinedMetersTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppPredefinedMetersTest.java
@@ -22,12 +22,12 @@ public class DCCppPredefinedMetersTest {
     public void testMeterReplies() {
         mm.message(DCCppReply.parseDCCppReply("a10")); // a syntactically valid current reply
         Meter m = InstanceManager.getDefault(MeterManager.class).getBySystemName("DVC_CurrentPct");
-        Assert.assertNotNull(m);
+        Assert.assertNotNull("verify meter was created", m);
         Assert.assertEquals("current level percentage 100.0 - 0.0", (10.0 / DCCppConstants.MAX_CURRENT) * 100, m.getKnownAnalogValue(), 0.05);
 
-        mm.message(DCCppReply.parseDCCppReply("c PROGVolts 18.2 V Milli 9.0 24.0 0.1")); // new meter reply
+        mm.message(DCCppReply.parseDCCppReply("c PROGVolts 18.2 V Milli 9.0 24.0 0.1 18")); // new meter reply
         m = InstanceManager.getDefault(MeterManager.class).getBySystemName("DVV_PROGVolts");       
-        Assert.assertNotNull(m);
+        Assert.assertNotNull("verify meter was created", m);
         Assert.assertEquals("verify value from meter reply", 18.2, m.getKnownAnalogValue(), 0.00001);
         Assert.assertEquals("DVV_PROGVolts", m.getSystemName());
         Assert.assertEquals(jmri.Meter.Unit.Milli, m.getUnit());
@@ -35,14 +35,14 @@ public class DCCppPredefinedMetersTest {
         Assert.assertEquals(24.0,  m.getMax(),   0.00001);
         Assert.assertEquals(0.1,   m.getResolution(), 0.00001);        
 
-        mm.message(DCCppReply.parseDCCppReply("c MAINVolts 25.2 V Milli 9.0 24.0 0.1")); // new meter reply, value exceeds max value
+        mm.message(DCCppReply.parseDCCppReply("c MAINVolts 25.2 V Milli 9.0 24.0 0.1 18")); // new meter reply, value exceeds max value
         m = InstanceManager.getDefault(MeterManager.class).getBySystemName("DVV_MAINVolts");       
-        Assert.assertNotNull(m);
+        Assert.assertNotNull("verify meter was created", m);
         Assert.assertEquals("verify value is capped at maxValue", 24.0, m.getKnownAnalogValue(), 0.00001);
 
-        mm.message(DCCppReply.parseDCCppReply("c My-Current_Meter#1 0.3 C NoPrefix 0.0 5.0 0.01"));
+        mm.message(DCCppReply.parseDCCppReply("c My-Current_Meter#1 0.3 C NoPrefix 0.0 5.0 0.01 4.9"));
         m = InstanceManager.getDefault(MeterManager.class).getBySystemName("DVC_My-Current_Meter#1");       
-        Assert.assertNotNull("use special chars in meter name", m);
+        Assert.assertNotNull("meter created with special chars in name", m);
 }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
@@ -126,7 +126,7 @@ public class DCCppReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     // Test Meter replies
     @Test
     public void testMeterReply() {
-        DCCppReply r = DCCppReply.parseDCCppReply("c MAINCurrent 1.7 C NoPrefix 0.0 100.0 0.1");
+        DCCppReply r = DCCppReply.parseDCCppReply("c MAINCurrent 1.7 C NoPrefix 0.0 100.0 0.1 80");
         Assert.assertTrue(r.isMeterReply());
         Assert.assertFalse(r.isCurrentReply());
         Assert.assertFalse(r.isNamedCurrentReply());
@@ -136,39 +136,39 @@ public class DCCppReplyTest extends jmri.jmrix.AbstractMessageTestBase {
         Assert.assertEquals(0.0,   r.getMeterMinValue(),   0.00001);
         Assert.assertEquals(100.0, r.getMeterMaxValue(),   0.00001);
         Assert.assertEquals(0.1,   r.getMeterResolution(), 0.00001);
+        Assert.assertEquals(80.0,  r.getMeterWarnValue(),  0.00001);
         Assert.assertFalse(r.isMeterTypeVolt());
         Assert.assertTrue(r.isMeterTypeCurrent());
 
-        r = DCCppReply.parseDCCppReply("c PROGVolts 18.2 V Milli 9.0 24.0 0.1");
+        r = DCCppReply.parseDCCppReply("c PROGVolts 18.2 V Milli 9.0 24.0 0.1 22.0");
         Assert.assertEquals("PROGVolts", r.getMeterName());
         Assert.assertEquals(18.2,  r.getMeterValue(), 0.00001);
         Assert.assertEquals(jmri.Meter.Unit.Milli, r.getMeterUnit());
         Assert.assertEquals(9.0,   r.getMeterMinValue(),   0.00001);
         Assert.assertEquals(24.0,  r.getMeterMaxValue(),   0.00001);
         Assert.assertEquals(0.1,   r.getMeterResolution(), 0.00001);
+        Assert.assertEquals(22.0,  r.getMeterWarnValue(),  0.00001);
         Assert.assertTrue(r.isMeterTypeVolt());
         Assert.assertFalse(r.isMeterTypeCurrent());
         
-        r = DCCppReply.parseDCCppReply("c testmeter99.99 12.34 C NoPrefix 0 99.99 0.01");
+        r = DCCppReply.parseDCCppReply("c testmeter99.99 12.34 C NoPrefix 0 99.99 0.01 77.77");
         Assert.assertTrue(r.isMeterReply());
         Assert.assertEquals("testmeter99.99", r.getMeterName());
         Assert.assertEquals(12.34,  r.getMeterValue(), 0.00001);
         Assert.assertEquals(jmri.Meter.Unit.NoPrefix, r.getMeterUnit());
         Assert.assertEquals(0.0,   r.getMeterMinValue(),   0.00001);
         Assert.assertEquals(99.99, r.getMeterMaxValue(),   0.00001);
-        Assert.assertEquals(0.01,   r.getMeterResolution(), 0.00001);
+        Assert.assertEquals(0.01,  r.getMeterResolution(), 0.00001);
+        Assert.assertEquals(77.77, r.getMeterWarnValue(),  0.00001);
         Assert.assertFalse(r.isMeterTypeVolt());
         Assert.assertTrue(r.isMeterTypeCurrent());
 
-        r = DCCppReply.parseDCCppReply("c BadMeterType 0.3 X NoPrefix 0.0 5.0 0.01"); //bad meter type 'X' passed
+        r = DCCppReply.parseDCCppReply("c BadMeterType 0.3 X NoPrefix 0.0 5.0 0.01 5.0"); //bad meter type 'X' passed
         Assert.assertTrue( r.isMeterReply());
         Assert.assertFalse(r.isMeterTypeCurrent());
         Assert.assertFalse(r.isMeterTypeVolt());
         Assert.assertEquals("", r.getMeterType()); //invalid meter types returned as empty string
         Assert.assertEquals(jmri.Meter.Unit.NoPrefix, r.getMeterUnit());
-
-        r = DCCppReply.parseDCCppReply("c BadMeter Name 0.3 C NoPrefix 0.0 5.0 0.01"); //invalid meter name
-        Assert.assertTrue( r.isMeterReply());
 
     }
 
@@ -327,14 +327,14 @@ public class DCCppReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
     @Test
     public void testMonitorStringMeterReply() {
-        DCCppReply l = DCCppReply.parseDCCppReply("c PROGVolts 18.2 V Percent 9.0 24.0 0.1");
-        Assert.assertEquals("Meter reply: name PROGVolts, value 18.20, type V, unit Percent, min 9.00, max 24.00, resolution 0.10", 
+        DCCppReply l = DCCppReply.parseDCCppReply("c PROGVolts 18.2 V Percent 9.0 24.0 0.1 19");
+        Assert.assertEquals("Meter reply: name PROGVolts, value 18.20, type V, unit Percent, min 9.00, max 24.00, resolution 0.10, warn 19.00", 
                 l.toMonitorString());
         Assert.assertTrue( l.isMeterReply());
         Assert.assertTrue( l.isMeterTypeVolt());
         Assert.assertFalse(l.isMeterTypeCurrent());
-        l = DCCppReply.parseDCCppReply("c MAINCurrent 0.3 C Kilo 0.0 5.0 0.01");
-        Assert.assertEquals("Meter reply: name MAINCurrent, value 0.30, type C, unit Kilo, min 0.00, max 5.00, resolution 0.01", 
+        l = DCCppReply.parseDCCppReply("c MAINCurrent 0.3 C Kilo 0.0 5.0 0.01 4");
+        Assert.assertEquals("Meter reply: name MAINCurrent, value 0.30, type C, unit Kilo, min 0.00, max 5.00, resolution 0.01, warn 4.00", 
                 l.toMonitorString());
         Assert.assertTrue( l.isMeterReply());
         Assert.assertTrue( l.isMeterTypeCurrent());


### PR DESCRIPTION
in messaging only, not yet supported in Meter
also restored lookup of beantypeletter 