### PR TITLE
Beantable State column

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -537,9 +537,10 @@ FromPortal      = From Portal
 PathName        = Path Name
 Path            = Path
 ToPortal        = To Portal
-ColumnState     = Turnout State
+TurnoutState    = Turnout State
+ColumnState     = State
 
-OBlocksMenu        = Tables
+OBlocksMenu     = Tables
 
 #These are used with the pop-up menu
 Move                                 = Move

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_ca.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_ca.properties
@@ -683,4 +683,5 @@ SignalName      = Nom del senyal
 FromPortal      = Des del Portal
 PathName        = Nom del Portal
 ToPortal        = a un Portal
-ColumnState     = Ajust d'Agulla
+TurnoutState    = Ajust d'Agulla
+ColumnState     = Ajust

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_cs.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_cs.properties
@@ -535,7 +535,8 @@ FromPortal      = Z Port\u00e1lu
 PathName        = N\u00e1zev Cesty
 Path            = Cesta
 ToPortal        = Do Port\u00e1lu
-ColumnState     = Nastaven\u00ed V\u00fdhybky
+TurnoutState    = Nastaven\u00ed V\u00fdhybky
+ColumnState     = Nastaven\u00ed
 
 OBlocksMenu     = Tabulky
 

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_da.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_da.properties
@@ -648,7 +648,8 @@ SignalName      = Signal Name
 FromPortal      = From Portal
 PathName        = Path Name
 ToPortal        = To Portal
-ColumnState     = Turnout Setting
+TurnoutState    = Turnout Setting
+ColumnState     = State
 
 # Messages prefs pane item
 DeleteLogix                          = When Deleting the Logix

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_de.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_de.properties
@@ -635,7 +635,8 @@ SignalName=Signalname
 FromPortal=Von Portal
 PathName=Pfadname
 ToPortal=Nach Portal
-ColumnState=Weichenzustand
+TurnoutState = Weichenzustand
+ColumnState = Zustand
 
 # Messages prefs pane item
 DeleteLogix = Beim L\u00f6schen von Logix

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_fr.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_fr.properties
@@ -552,7 +552,8 @@ SignalName = Nom du Feu
 FromPortal = Depuis le Portail
 PathName = Nom du Chemin
 ToPortal = Pour Portail
-ColumnState = R\u00e9glages Aiguillage
+TurnoutState = R\u00e9glages Aiguillage
+ColumnState = Position
 
 # Messages prefs pane item
 DeleteLogix = lors de la suppression du Logix

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_it.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_it.properties
@@ -484,7 +484,8 @@ SignalName = Nome Segnale
 FromPortal = Dal Portale
 PathName = Nome Percorso
 ToPortal = Al Portale
-ColumnState = Impostazione Scambio
+TurnoutState = Impostazione Scambio
+ColumnState = Impostazione
 
 # Messages prefs pane item
 DeleteLogix = Quando si elimina la Logix

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_nl.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_nl.properties
@@ -531,9 +531,10 @@ SignalName      = Naam Sein
 FromPortal      = Van Portal
 PathName        = Naam Pad
 ToPortal        = Naar Portal
-ColumnState     = Wisselstand
+TurnoutState    = Wisselstand
+ColumnState     = Stand
 
-OBlocksMenu        = Tabellen
+OBlocksMenu     = Tabellen
 
 #These are used with the pop-up menu
 Move = Verplaats

--- a/java/src/jmri/jmrit/beantable/SignalHeadTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalHeadTableAction.java
@@ -572,7 +572,7 @@ public class SignalHeadTableAction extends AbstractTableAction<SignalHead> {
     private JComboBox<String> prefixBox = new JComboBox<String>();
     private JLabel prefixBoxLabel = new JLabel(Bundle.getMessage("MakeLabel", Bundle.getMessage("DCCSystem")));
 
-    private JLabel stateLabel1 = new JLabel(Bundle.getMessage("MakeLabel", Bundle.getMessage("ColumnState")));
+    private JLabel stateLabel1 = new JLabel(Bundle.getMessage("MakeLabel", Bundle.getMessage("TurnoutState")));
     private JLabel stateLabel2 = new JLabel(stateLabel1.getText()); // faster than Bundle?
     private JLabel stateLabel3 = new JLabel(stateLabel1.getText());
     private JLabel stateLabel4 = new JLabel(stateLabel1.getText());

--- a/java/src/jmri/jmrit/beantable/oblock/PathTurnoutTableModel.java
+++ b/java/src/jmri/jmrit/beantable/oblock/PathTurnoutTableModel.java
@@ -107,7 +107,7 @@ public class PathTurnoutTableModel extends AbstractTableModel implements Propert
             case TURNOUT_NAME_COL:
                 return Bundle.getMessage("LabelItemName");
             case STATE_COL:
-                return Bundle.getMessage("ColumnState"); // state
+                return Bundle.getMessage("TurnoutState"); // state
             default:
                 // fall through
                 break;


### PR DESCRIPTION
Anyone noticed Sensor and Light tables had a column named Turnout State?
Reverted to simply "State", added extra key for "Turnout State" used in OPath table and Signal Head config pane.
Check l10n (only 2 keys)