### PR TITLE
WIP & TEST: I18 n check test  

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -46,6 +46,25 @@ mergeable: # see https://github.com/mergeability/mergeable
             Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
       - do: checks
         status: 'success'
+  - when: pull_request.opened
+    name: 'Add label if *.properties modified'
+    validate:
+      - do: changeset
+        must_exclude:
+          regex: "*.properties"
+    pass:
+      - do: checks
+        status: 'success'
+    fail:
+      - do: comment
+        payload:
+          body: > 
+            Thanks for the PR. It includes changes to properties files, so the 'Needs I18N' label has been added"
+      - do: labels
+        labels: [ 'Needs I18N' ]
+        mode: 'add'
+      - do: checks
+        status: 'success'
   - when: schedule.repository
     name: 'Allow merge after one day'
     validate:

--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -1,5 +1,7 @@
 # NamedBeanBundle.properties
 #
+# Add a test line
+#
 # Default properties for the jmri package of JMRI
 #
 # This resource bundle should only be referenced via the Bundle class tree,

--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -1,6 +1,6 @@
 # NamedBeanBundle.properties
 #
-# Add a test line
+# Add a test line  
 #
 # Default properties for the jmri package of JMRI
 #


### PR DESCRIPTION
Meant as a test of the infrastructure change in #9311

Before PR #9311 is merged, this shouldn't have any interesting CI behavior.

If closed and opened after #9311 is merged, it should have the "Needs I18N" label added automatically.

Not intended to ever be merged, though it's not a disaster if it is; it just adds a dummy comment to a properties file.