### PR TITLE
Add automation for "Needs I18N" label

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -51,7 +51,7 @@ mergeable: # see https://github.com/mergeability/mergeable
     validate:
       - do: changeset
         must_exclude:
-          regex: "\.properties$"
+          regex: '\.properties$'
     pass:
       - do: checks
         status: 'success'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -47,11 +47,11 @@ mergeable: # see https://github.com/mergeability/mergeable
       - do: checks
         status: 'success'
   - when: pull_request.opened
-    name: 'Add label if *.properties modified'
+    name: 'Add label if any .properties file modified'
     validate:
       - do: changeset
         must_exclude:
-          regex: "*.properties"
+          regex: "\.properties$"
     pass:
       - do: checks
         status: 'success'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -46,6 +46,25 @@ mergeable: # see https://github.com/mergeability/mergeable
             Thanks for the PR. Please consider adding a release note in the help/en/releasenotes/current-draft-note.shtml file.
       - do: checks
         status: 'success'
+  - when: pull_request.opened
+    name: 'Add label if *.properties modified'
+    validate:
+      - do: changeset
+        must_exclude:
+          regex: "*.properties"
+    pass:
+      - do: checks
+        status: 'success'
+    fail:
+      - do: comment
+        payload:
+          body: > 
+            Thanks for the PR. It includes changes to properties files, so the 'Needs I18N' label has been added"
+      - do: labels
+        labels: [ 'Needs I18N' ]
+        mode: 'add'
+      - do: checks
+        status: 'success'
   - when: schedule.repository
     name: 'Allow merge after one day'
     validate:


### PR DESCRIPTION
This adds a clause to the Mergeability bot that will add the "Needs I18N" label if any .properties files have been changed.

As this is start-of-run infrastructure, it's hard to test it completely without merging it.  This PR as such won't do anything until it's been merged.  Once that happens, a close and open on PR #9310 should result in the label being added.