### PR TITLE
Turnout Feedback - Improve 1 & 2 Sensor / Support Page

### DIFF
--- a/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
@@ -384,12 +384,12 @@
         
         <tr>
         <td>Unknown</td>
-        <td>Unknown</td>
+        <td>Inconsistent</td>
         </tr>
         
         <tr>
         <td>Inconsistent</td>
-        <td>Unknown</td>
+        <td>Inconsistent</td>
         </tr>
         
         </tbody>

--- a/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
@@ -355,28 +355,62 @@
 
         <dt>ONESENSOR</dt>
 
-        <dd>The Turnout watches the Sensor defined by the "Sensor
-        1" column, which is probably hooked to a microswitch on the
-        turnout or similar. When the Sensor is "Active", the
+        <dd>The Turnout monitors the Sensor defined by the "Sensor
+        1" column, which could be the input from a microswitch on the
+        turnout or similar.
+        <br>When the Sensor is "Active", the
         turnout is known to be in the "Thrown" position. When it's
         "Inactive", the turnout is known to be in the "Closed"
-        position.</dd>
+        position.
+        
+        <table style="border: 1px solid gray;" cellpadding="5" cellspacing="5">
+        <thead>
+        <tr>
+        <th>Sensor 1</th>
+        <th>Feedback (known) State</th>
+        </tr>
+        </thead>
+        
+        <tbody>
+        <tr>
+        <td>Active</td>
+        <td>Thrown</td>
+        </tr>
+        
+        <tr>
+        <td>Inactive</td>
+        <td>Closed</td>
+        </tr>
+        
+        <tr>
+        <td>Unknown</td>
+        <td>Unknown</td>
+        </tr>
+        
+        <tr>
+        <td>Inconsistent</td>
+        <td>Unknown</td>
+        </tr>
+        
+        </tbody>
+        </table>
+        </dd>
 
         <dt>TWOSENSOR</dt>
 
-        <dd>The Turnout watches two Sensors defined by the "Sensor
-        1" and "Sensor 2" columns, which could be from
+        <dd>The Turnout monitors two Sensors defined by the "Sensor
+        1" and "Sensor 2" columns, which could be inputs from
         microswitches at either end of the turnout's throw bar
-        or inputs from servo travel events.<br>
+        or from servo travel events.<br>
         
-        The feedback state is determined by both Sensors:
+        The Turnout feedback state is determined by both Sensors:
         
-        <table>
+        <table style="border: 1px solid gray;" cellpadding="5" cellspacing="5">
         <thead>
         <tr>
         <th>Sensor 1</th>
         <th>Sensor 2</th>
-        <th>Feedback State</th>
+        <th>Feedback (known) State</th>
         </tr>
         </thead>
         
@@ -415,25 +449,25 @@
         <tr>
         <td>Inconsistent</td>
         <td>Inconsistent</td>
-        <td>Inconsistent</td>
+        <td>Unknown</td>
         </tr>
         
         <tr>
         <td>Inconsistent</td>
         <td>Unknown</td>
-        <td>Inconsistent</td>
+        <td>Unknown</td>
         </tr>
         
         <tr>
         <td>Active</td>
         <td>Unknown</td>
-        <td>Inconsistent</td>
+        <td>Unknown</td>
         </tr>
         
         <tr>
         <td>Inactive</td>
         <td>Unknown</td>
-        <td>Inconsistent</td>
+        <td>Unknown</td>
         </tr>
         
         <tr>

--- a/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
@@ -28,7 +28,7 @@
 
       <h2>Turnout Table Columns</h2>
       <p class="im">
-      <img src="images/TurnoutTableColumnList.jpg" alt="Turnout Table Columns (Rel 4.20)" align="right" height="438" width="150">
+      <img src="images/TurnoutTableColumnList.jpg" alt="Turnout Table Columns (Rel 4.20)" style="float:right" height="438" width="150">
       Contents of the Turnout Table are displayed by selecting it under <strong>Tools&rArr;Tables</strong>.
       As with all JMRI tool tables, you can add or remove columns from the display by right-clicking anywhere
       in the column header and selecting or deselecting the desired columns from the menu that appears (see picture at right).
@@ -63,9 +63,9 @@
         in the <a href="../../../apps/TabbedPreferences.shtml#Display">Display
         preferences</a>.<br>
         <img src="images/TurnoutTableText.png" height="140" width="406"
-        align="center" alt="Textual Turnout state column">
+        alt="Textual Turnout state column">
        <img src="images/TurnoutTableGraphic.png" height="96" width="399"
-        align="center" alt="Graphic Turnout state column">
+        alt="Graphic Turnout state column">
         </dd>
  
         <dt><strong>Delete</strong></dt>
@@ -365,11 +365,93 @@
         <dt>TWOSENSOR</dt>
 
         <dd>The Turnout watches two Sensors defined by the "Sensor
-        1" and "Sensor 2" columns, which are probably hooked to
-        microswitches at either end of the turnout's throw bar.
-        When Sensor 1 is "Active", the turnout is known to be
-        "Thrown". When Sensor 2 is "Active", the turnout is known
-        to be "Closed" (normal).</dd>
+        1" and "Sensor 2" columns, which could be from
+        microswitches at either end of the turnout's throw bar
+        or inputs from servo travel events.<br>
+        
+        The feedback state is determined by both Sensors:
+        
+        <table>
+        <thead>
+        <tr>
+        <th>Sensor 1</th>
+        <th>Sensor 2</th>
+        <th>Feedback State</th>
+        </tr>
+        </thead>
+        
+        <tbody>
+        
+        <tr>
+        <td>Active</td>
+        <td>Inactive</td>
+        <td>Thrown</td>
+        </tr>
+        
+        <tr>
+        <td>Inactive</td>
+        <td>Active</td>
+        <td>Closed</td>
+        </tr>
+        
+        <tr>
+        <td>Active</td>
+        <td>Active</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Inactive</td>
+        <td>Inactive</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Unknown</td>
+        <td>Unknown</td>
+        <td>Unknown</td>
+        </tr>
+        
+        <tr>
+        <td>Inconsistent</td>
+        <td>Inconsistent</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Inconsistent</td>
+        <td>Unknown</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Active</td>
+        <td>Unknown</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Inactive</td>
+        <td>Unknown</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Active</td>
+        <td>Inconsistent</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Inactive</td>
+        <td>Inconsistent</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        </tbody>
+        </table>
+        
+        </dd>
 
         <dt>DELAYED</dt>
 

--- a/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
@@ -384,12 +384,12 @@
         
         <tr>
         <td>Unknown</td>
-        <td>Inconsistent</td>
+        <td>Inconsistent <span class="since">since 4.21.5</span></td>
         </tr>
         
         <tr>
         <td>Inconsistent</td>
-        <td>Inconsistent</td>
+        <td>Inconsistent <span class="since">since 4.21.5</span></td>
         </tr>
         
         </tbody>
@@ -404,6 +404,8 @@
         or from servo travel events.<br>
         
         The Turnout feedback state is determined by both Sensors:
+        
+        <-- Table in same order as 2 Sensor Feedback Unit Tests within AbstractTurnoutTestBase -->
         
         <table style="border: 1px solid gray;" cellpadding="5" cellspacing="5">
         <thead>
@@ -429,51 +431,30 @@
         </tr>
         
         <tr>
-        <td>Active</td>
-        <td>Active</td>
-        <td>Inconsistent</td>
-        </tr>
-        
-        <tr>
         <td>Inactive</td>
         <td>Inactive</td>
         <td>Inconsistent</td>
+        <td>Typical condition for a Turnout mid-throw</td>
         </tr>
         
         <tr>
         <td>Unknown</td>
         <td>Unknown</td>
         <td>Unknown</td>
-        </tr>
-        
-        <tr>
-        <td>Inconsistent</td>
-        <td>Inconsistent</td>
-        <td>Unknown</td>
-        </tr>
-        
-        <tr>
-        <td>Inconsistent</td>
-        <td>Unknown</td>
-        <td>Unknown</td>
+        <td>Typical startup condition</td>
         </tr>
         
         <tr>
         <td>Active</td>
-        <td>Unknown</td>
-        <td>Unknown</td>
-        </tr>
-        
-        <tr>
-        <td>Inactive</td>
-        <td>Unknown</td>
-        <td>Unknown</td>
+        <td>Active</td>
+        <td>Inconsistent</td>
         </tr>
         
         <tr>
         <td>Active</td>
         <td>Inconsistent</td>
         <td>Inconsistent</td>
+        <td>Changed from Unknown > Inconsistent 4.21.5</td>
         </tr>
         
         <tr>
@@ -481,6 +462,65 @@
         <td>Inconsistent</td>
         <td>Inconsistent</td>
         </tr>
+        
+        <tr>
+        <td>Inconsistent</td>
+        <td>Active</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Inconsistent</td>
+        <td>Inactive</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Unknown</td>
+        <td>Active</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Unknown</td>
+        <td>Inactive</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Unknown</td>
+        <td>Inconsistent</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Inconsistent</td>
+        <td>Unknown</td>
+        <td>Inconsistent</td>
+        <td>Changed from Unknown > Inconsistent 4.21.5</td>
+        </tr>
+        
+        
+        
+        <tr>
+        <td>Active</td>
+        <td>Unknown</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Inactive</td>
+        <td>Unknown</td>
+        <td>Inconsistent</td>
+        </tr>
+        
+        <tr>
+        <td>Inconsistent</td>
+        <td>Inconsistent</td>
+        <td>Inconsistent</td>
+        <td>Changed from Unknown > Inconsistent 4.21.5</td>
+        </tr>
+        
         
         </tbody>
         </table>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -452,7 +452,8 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li></li>
+            <li>Turnouts with 1 Sensor Feedback update to Unknown state when the Sensor being followed enters an Unknown or Intermittent state.
+            <br>See <a href="https://www.jmri.org/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml#Turnout_Feedback">Turnout Feedback</a></li>
         </ul>
 
     <h3>Scripting</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -452,7 +452,7 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li>Turnouts with 1 Sensor Feedback update to Unknown state when the Sensor being followed enters an Unknown or Intermittent state.
+            <li>Turnouts with 1 Sensor Feedback update to Inconsistent state when the Sensor being followed enters an Unknown or Inconsistent state.
             <br>See <a href="https://www.jmri.org/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml#Turnout_Feedback">Turnout Feedback</a></li>
         </ul>
 

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -902,7 +902,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
                         newKnownState(CLOSED);
                         break;
                     default:
-                        newKnownState(UNKNOWN);
+                        newKnownState(INCONSISTENT);
                         break;
                 }
             } else {

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -894,11 +894,16 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
                     return;
                 }
                 // OK, now handle it
-                int mode = (Integer) evt.getNewValue();
-                if (mode == Sensor.ACTIVE) {
-                    newKnownState(THROWN);
-                } else if (mode == Sensor.INACTIVE) {
-                    newKnownState(CLOSED);
+                switch ((Integer) evt.getNewValue()) {
+                    case Sensor.ACTIVE:
+                        newKnownState(THROWN);
+                        break;
+                    case Sensor.INACTIVE:
+                        newKnownState(CLOSED);
+                        break;
+                    default:
+                        newKnownState(UNKNOWN);
+                        break;
                 }
             } else {
                 // unexpected mismatch

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -922,38 +922,18 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
             }
             // OK, now handle it
             Sensor s2 = getSecondSensor();
-            int mode = (Integer) evt.getNewValue();
-
             if (s2 == null) {
                 log.warn("Turnout feedback sensor 2 configured incorrectly ");
                 return; // can't complete
             }
-            if ((mode == Sensor.ACTIVE) && (src == s2)) {
-                if((s1.getKnownState() == Sensor.INACTIVE)) {
-                   newKnownState(CLOSED);
-                } else {
-                   newKnownState(INCONSISTENT);
-                }
-            } else if ((mode == Sensor.INACTIVE) && (src == s2)) {
-                if((s1.getKnownState() == Sensor.ACTIVE)) {
-                   newKnownState(THROWN);
-                } else {
-                   newKnownState(INCONSISTENT);
-                }
-            } else if ((mode == Sensor.ACTIVE) && (src == s1)) {
-                if((s2.getKnownState() == Sensor.INACTIVE)) {
-                   newKnownState(THROWN);
-                } else {
-                   newKnownState(INCONSISTENT);
-                }
-            } else if ((mode == Sensor.INACTIVE) && (src == s1)) {
-                if((s2.getKnownState() == Sensor.ACTIVE)) {
-                   newKnownState(CLOSED);
-                } else {
-                   newKnownState(INCONSISTENT);
-                }
+            if (s1.getKnownState() == Sensor.INACTIVE && s2.getKnownState() == Sensor.ACTIVE) {
+                newKnownState(CLOSED);
+            } else if (s1.getKnownState() == Sensor.ACTIVE && s2.getKnownState() == Sensor.INACTIVE) {
+                newKnownState(THROWN);
+            } else if (s1.getKnownState() == Sensor.UNKNOWN && s2.getKnownState() == Sensor.UNKNOWN) {
+                newKnownState(UNKNOWN);
             } else {
-                   newKnownState(UNKNOWN);
+                newKnownState(INCONSISTENT);
             }
             // end TWOSENSOR block
         }

--- a/java/test/jmri/implementation/AbstractTurnoutTestBase.java
+++ b/java/test/jmri/implementation/AbstractTurnoutTestBase.java
@@ -236,6 +236,19 @@ public abstract class AbstractTurnoutTestBase {
         s1.setKnownState(Sensor.ACTIVE);
         Assert.assertEquals("listener notified of change for ONESENSOR feedback", Turnout.THROWN,listenStatus);
         Assert.assertEquals("known state for ONESENSOR feedback active", Turnout.THROWN, t.getKnownState());
+        
+        s1.setKnownState(Sensor.UNKNOWN);
+        Assert.assertEquals("unknown state for ONESENSOR feedback ", Turnout.UNKNOWN, t.getKnownState());
+        Assert.assertEquals("listener notified of change for ONESENSOR feedback unknown", Turnout.UNKNOWN,listenStatus);
+        
+        s1.setKnownState(Sensor.INACTIVE);
+        Assert.assertEquals("known state for ONESENSOR feedback Inactive", Turnout.CLOSED, t.getKnownState());
+        Assert.assertEquals("listener notified of change for ONESENSOR feedback reset", Turnout.CLOSED,listenStatus);
+        
+        s1.setKnownState(Sensor.INCONSISTENT);
+        Assert.assertEquals("listener notified of change for ONESENSOR feedback INCONSISTENT", Turnout.UNKNOWN,listenStatus);
+        Assert.assertEquals("INCONSISTENT state for ONESENSOR feedback", Turnout.UNKNOWN, t.getKnownState());
+        
     }
 
     @Test
@@ -269,9 +282,80 @@ public abstract class AbstractTurnoutTestBase {
 
         Assert.assertEquals("listener notified of change for TWOSENSOR feedback ", Turnout.CLOSED,listenStatus);
 
-        s1.setKnownState(Sensor.ACTIVE);
+        s1.setKnownState(Sensor.UNKNOWN);
+        s2.setKnownState(Sensor.UNKNOWN);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (UNKNOWN, UNKNOWN)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
+        
+        
+        // reset TO
+        s1.setKnownState(Sensor.INACTIVE);
         s2.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (Active, Active)", Turnout.INCONSISTENT, t.getKnownState());
+        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
+
+        s1.setKnownState(Sensor.INCONSISTENT);
+        s2.setKnownState(Sensor.INCONSISTENT);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (INCONSISTENT, INCONSISTENT)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
+
+        
+        // reset TO
+        s1.setKnownState(Sensor.INACTIVE);
+        s2.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
+        
+        s1.setKnownState(Sensor.UNKNOWN);
+        s2.setKnownState(Sensor.INCONSISTENT);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (UNKNOWN, INCONSISTENT)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
+        
+        
+        // reset TO
+        s1.setKnownState(Sensor.INACTIVE);
+        s2.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
+        
+        s1.setKnownState(Sensor.INCONSISTENT);
+        s2.setKnownState(Sensor.UNKNOWN);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (INCONSISTENT, UNKNOWN)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
+        
+        
+        // reset TO
+        s1.setKnownState(Sensor.INACTIVE);
+        s2.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
+        
+        s1.setKnownState(Sensor.ACTIVE);
+        s2.setKnownState(Sensor.UNKNOWN);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (ACTIVE, UNKNOWN)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
+        
+        
+        // reset TO
+        s1.setKnownState(Sensor.INACTIVE);
+        s2.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
+
+        s1.setKnownState(Sensor.INACTIVE);
+        s2.setKnownState(Sensor.UNKNOWN);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (INACTIVE, UNKNOWN)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
+        
+        
+        // reset TO
+        s1.setKnownState(Sensor.INACTIVE);
+        s2.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
+
+        s1.setKnownState(Sensor.UNKNOWN);
+        s2.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (UNKNOWN, ACTIVE)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
+        
+        
+        // reset TO
+        s1.setKnownState(Sensor.INACTIVE);
+        s2.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
+
+        s1.setKnownState(Sensor.UNKNOWN);
+        s2.setKnownState(Sensor.INACTIVE);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (UNKNOWN, INACTIVE)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
+        
     }
 
     @Test 

--- a/java/test/jmri/implementation/AbstractTurnoutTestBase.java
+++ b/java/test/jmri/implementation/AbstractTurnoutTestBase.java
@@ -252,6 +252,7 @@ public abstract class AbstractTurnoutTestBase {
         
     }
 
+    // Order of the 2 Sensor Conditions in same order as support page jmrit/beantable/TurnoutTable.shtml
     @Test
     public void testTwoSensorFeedback() throws jmri.JmriException {
         Sensor s1 = InstanceManager.getDefault(jmri.SensorManager.class).provideSensor("IS1");
@@ -270,92 +271,83 @@ public abstract class AbstractTurnoutTestBase {
         JUnitUtil.waitFor( () -> t.getKnownState() != Turnout.UNKNOWN);
 
         Assert.assertEquals("state changed by TWOSENSOR feedback (Active, Inactive)", Turnout.THROWN, t.getKnownState());
-
         Assert.assertEquals("listener notified of change for TWOSENSOR feedback", Turnout.THROWN,listenStatus);
 
-        s1.setKnownState(Sensor.INACTIVE);
-        s2.setKnownState(Sensor.INACTIVE);
-        Assert.assertEquals("known state for TWOSENSOR feedback (Inactive, Inactive)", Turnout.INCONSISTENT, t.getKnownState());
 
         s1.setKnownState(Sensor.INACTIVE);
         s2.setKnownState(Sensor.ACTIVE);
         Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
-
         Assert.assertEquals("listener notified of change for TWOSENSOR feedback ", Turnout.CLOSED,listenStatus);
 
+        
+        s1.setKnownState(Sensor.INACTIVE);
+        s2.setKnownState(Sensor.INACTIVE);
+        Assert.assertEquals("known state for TWOSENSOR feedback (Inactive, Inactive)", Turnout.INCONSISTENT, t.getKnownState());
+
+        
         s1.setKnownState(Sensor.UNKNOWN);
         s2.setKnownState(Sensor.UNKNOWN);
         Assert.assertEquals("state changed by TWOSENSOR feedback (UNKNOWN, UNKNOWN)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
         
         
-        // reset TO
-        s1.setKnownState(Sensor.INACTIVE);
+        s1.setKnownState(Sensor.ACTIVE);
         s2.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
-
-        s1.setKnownState(Sensor.INCONSISTENT);
-        s2.setKnownState(Sensor.INCONSISTENT);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (INCONSISTENT, INCONSISTENT)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
-
+        Assert.assertEquals("state changed by TWOSENSOR feedback (ACTIVE, ACTIVE)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
         
-        // reset TO
-        s1.setKnownState(Sensor.INACTIVE);
-        s2.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
-        
-        s1.setKnownState(Sensor.UNKNOWN);
-        s2.setKnownState(Sensor.INCONSISTENT);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (UNKNOWN, INCONSISTENT)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
-        
-        
-        // reset TO
-        s1.setKnownState(Sensor.INACTIVE);
-        s2.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
-        
-        s1.setKnownState(Sensor.INCONSISTENT);
-        s2.setKnownState(Sensor.UNKNOWN);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (INCONSISTENT, UNKNOWN)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
-        
-        
-        // reset TO
-        s1.setKnownState(Sensor.INACTIVE);
-        s2.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
         
         s1.setKnownState(Sensor.ACTIVE);
-        s2.setKnownState(Sensor.UNKNOWN);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (ACTIVE, UNKNOWN)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
+        s2.setKnownState(Sensor.INCONSISTENT);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (ACTIVE, INCONSISTENT)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
         
         
-        // reset TO
         s1.setKnownState(Sensor.INACTIVE);
-        s2.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
+        s2.setKnownState(Sensor.INCONSISTENT);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (INACTIVE, INCONSISTENT)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
 
-        s1.setKnownState(Sensor.INACTIVE);
-        s2.setKnownState(Sensor.UNKNOWN);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (INACTIVE, UNKNOWN)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
         
-        
-        // reset TO
-        s1.setKnownState(Sensor.INACTIVE);
+        s1.setKnownState(Sensor.INCONSISTENT);
         s2.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
-
+        Assert.assertEquals("state changed by TWOSENSOR feedback (INCONSISTENT, ACTIVE)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
+        
+        
+        s1.setKnownState(Sensor.INCONSISTENT);
+        s2.setKnownState(Sensor.INACTIVE);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (INCONSISTENT, INACTIVE)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
+        
+        
         s1.setKnownState(Sensor.UNKNOWN);
         s2.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (UNKNOWN, ACTIVE)", t.describeState(Turnout.UNKNOWN), t.describeState(t.getKnownState()));
+        Assert.assertEquals("state changed by TWOSENSOR feedback (UNKNOWN, INACTIVE)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
         
         
-        // reset TO
-        s1.setKnownState(Sensor.INACTIVE);
-        s2.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive, Active)", Turnout.CLOSED, t.getKnownState());
-
         s1.setKnownState(Sensor.UNKNOWN);
         s2.setKnownState(Sensor.INACTIVE);
         Assert.assertEquals("state changed by TWOSENSOR feedback (UNKNOWN, INACTIVE)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
+        
+        
+        s1.setKnownState(Sensor.UNKNOWN);
+        s2.setKnownState(Sensor.INCONSISTENT);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (UNKNOWN, INCONSISTENT)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
+        
+        
+        s1.setKnownState(Sensor.INCONSISTENT);
+        s2.setKnownState(Sensor.UNKNOWN);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (INCONSISTENT, UNKNOWN)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
+        
+        
+        s1.setKnownState(Sensor.ACTIVE);
+        s2.setKnownState(Sensor.UNKNOWN);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (ACTIVE, UNKNOWN)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
+        
+        
+        s1.setKnownState(Sensor.INACTIVE);
+        s2.setKnownState(Sensor.UNKNOWN);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (INACTIVE, UNKNOWN)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
+        
+        
+        s1.setKnownState(Sensor.INCONSISTENT);
+        s2.setKnownState(Sensor.INCONSISTENT);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (INCONSISTENT, INCONSISTENT)", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
         
     }
 

--- a/java/test/jmri/implementation/AbstractTurnoutTestBase.java
+++ b/java/test/jmri/implementation/AbstractTurnoutTestBase.java
@@ -238,16 +238,17 @@ public abstract class AbstractTurnoutTestBase {
         Assert.assertEquals("known state for ONESENSOR feedback active", Turnout.THROWN, t.getKnownState());
         
         s1.setKnownState(Sensor.UNKNOWN);
-        Assert.assertEquals("unknown state for ONESENSOR feedback ", Turnout.UNKNOWN, t.getKnownState());
-        Assert.assertEquals("listener notified of change for ONESENSOR feedback unknown", Turnout.UNKNOWN,listenStatus);
+        
+        Assert.assertEquals("unknown state for ONESENSOR feedback ", t.describeState(Turnout.INCONSISTENT), t.describeState(t.getKnownState()));
+        Assert.assertEquals("listener notified of change for ONESENSOR feedback unknown", Turnout.INCONSISTENT,listenStatus);
         
         s1.setKnownState(Sensor.INACTIVE);
         Assert.assertEquals("known state for ONESENSOR feedback Inactive", Turnout.CLOSED, t.getKnownState());
         Assert.assertEquals("listener notified of change for ONESENSOR feedback reset", Turnout.CLOSED,listenStatus);
         
         s1.setKnownState(Sensor.INCONSISTENT);
-        Assert.assertEquals("listener notified of change for ONESENSOR feedback INCONSISTENT", Turnout.UNKNOWN,listenStatus);
-        Assert.assertEquals("INCONSISTENT state for ONESENSOR feedback", Turnout.UNKNOWN, t.getKnownState());
+        Assert.assertEquals("listener notified of change for ONESENSOR feedback INCONSISTENT", Turnout.INCONSISTENT,listenStatus);
+        Assert.assertEquals("INCONSISTENT state for ONESENSOR feedback", Turnout.INCONSISTENT, t.getKnownState());
         
     }
 


### PR DESCRIPTION
Updates 1 & 2 Sensor Turnout Feedback Support Page.

Adds support for 1 Sensor Feedback UNKNOWN and INCONSISTENT states ( fixes #9357  ) .