### PR TITLE
WIP LnSensor CbusSensor Dcc4pcSensor not respecting setKnownState()

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusSensor.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensor.java
@@ -92,29 +92,32 @@ public class CbusSensor extends AbstractSensor implements CanListener, CbusEvent
     @Override
     public void setKnownState(int s) throws jmri.JmriException {
         CanMessage m;
-        if (s == Sensor.ACTIVE) {
-            if (getInverted()){
-                m = addrInactive.makeMessage(tc.getCanid());
-                setOwnState(Sensor.ACTIVE);
-            } else {
-                m = addrActive.makeMessage(tc.getCanid());
-                setOwnState(Sensor.ACTIVE);
-            }
-            CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
-            tc.sendCanMessage(m, this);
-        } else if (s == Sensor.INACTIVE) {
-            if (getInverted()){
-                m = addrActive.makeMessage(tc.getCanid());
-                setOwnState(Sensor.INACTIVE);                
-            } else {
-                m = addrInactive.makeMessage(tc.getCanid());
-                setOwnState(Sensor.INACTIVE);
-            }
-            CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
-            tc.sendCanMessage(m, this);
-        }
-        if (s == Sensor.UNKNOWN){
-            setOwnState(Sensor.UNKNOWN);
+        switch (s) {
+            case Sensor.ACTIVE:
+                if (getInverted()){
+                    m = addrInactive.makeMessage(tc.getCanid());
+                    setOwnState(Sensor.ACTIVE);
+                } else {
+                    m = addrActive.makeMessage(tc.getCanid());
+                    setOwnState(Sensor.ACTIVE);
+                }
+                CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
+                tc.sendCanMessage(m, this);
+                break;
+            case Sensor.INACTIVE:
+                if (getInverted()){
+                    m = addrActive.makeMessage(tc.getCanid());
+                    setOwnState(Sensor.INACTIVE);
+                } else {
+                    m = addrInactive.makeMessage(tc.getCanid());
+                    setOwnState(Sensor.INACTIVE);
+                }
+                CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
+                tc.sendCanMessage(m, this);
+                break;
+            default:
+                setOwnState(s);
+                break;
         }
     }
     

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcSensor.java
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcSensor.java
@@ -51,6 +51,9 @@ public class Dcc4PcSensor extends AbstractSensor {
             case ORIENTB:
                 stateConvert = ACTIVE;
                 break; //"Occupied RailComm Orientation B"
+            case INCONSISTENT:
+                stateConvert = INCONSISTENT;
+                break;
             default:
                 stateConvert = UNKNOWN;
                 break;

--- a/java/src/jmri/jmrix/loconet/LnSensor.java
+++ b/java/src/jmri/jmrix/loconet/LnSensor.java
@@ -75,6 +75,9 @@ public class LnSensor extends AbstractSensor  {
         l.setElement(2, l.getElement(2) | 0x40);
         // send
         tc.sendLocoNetMessage(l);
+        
+        // and do internal operations
+        setOwnState(s);
     }
 
     /**

--- a/java/test/jmri/implementation/AbstractSensorTestBase.java
+++ b/java/test/jmri/implementation/AbstractSensorTestBase.java
@@ -203,6 +203,27 @@ public abstract class AbstractSensorTestBase {
         jmri.util.JUnitUtil.waitFor(()->{return t.getCommandedState() == Sensor.OFF;}, "commanded state = OFF");
         Assert.assertTrue("Sensor is ON", t.getCommandedState() == Sensor.OFF);
     }
+    
+    @Test
+    public void testSensorSetKnownState() throws JmriException {
+    
+        t.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("ACTIVE", t.describeState(Sensor.ACTIVE), t.describeState(t.getState()));
+    
+        t.setKnownState(Sensor.INACTIVE);
+        Assert.assertEquals("INACTIVE", t.describeState(Sensor.INACTIVE), t.describeState(t.getState()));
+    
+        t.setKnownState(Sensor.UNKNOWN);
+        Assert.assertEquals("UNKNOWN", t.describeState(Sensor.UNKNOWN), t.describeState(t.getState()));
+        
+        // Reset known state to something normal
+        t.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("ACTIVE", t.describeState(Sensor.ACTIVE), t.describeState(t.getState()));
+        
+        t.setKnownState(Sensor.INCONSISTENT);
+        Assert.assertEquals("INCONSISTENT", t.describeState(Sensor.INCONSISTENT), t.describeState(t.getState()));
+        
+    }
 
     //dispose of t.
     @AfterEach


### PR DESCRIPTION
NEEDS CHECK FROM LN CONTRIBUTORS BEFORE MERGING

While running Jython to set all Sensors to INCONSISTENT, MERG CBUS Sensors were not respecting setKnownState(INCONSISTENT) but Internal were.

Adds Sensor Unit Tests to check setKnownState() is set for ACTIVE, INACTIVE, UNKNOWN, INCONSISTENT
Requested back from Sensors via getKnownState()

LnSensor - Added call to setOwnState from setKnownState to match all other Sensors overriding super.  ( May be relevant to #8848 ? )
CBUS Sensor  - INCONSISTENT Condition missing, added as default in switch.
DCC4PC Sensor  - Condition missing - Added INCONSISTENT to setKnownState