### PR TITLE
Root exclude-list at top level

### DIFF
--- a/exclude-list
+++ b/exclude-list
@@ -3,25 +3,25 @@
 # file from delete, e.g. in other repositories
 .git
 .gitignore
-exclude-list
-include-list
+/exclude-list
+/include-list
 
-xml/XSLT/pages
-JavaDoc/doc/*
-xml/XSLT/properties
+/xml/XSLT/pages
+/JavaDoc/doc/*
+/xml/XSLT/properties
 
 .classpath
-.project
-.settings
-build.xml
-default.lcf
-java
-lib
-nbproject
-python.properties
-release.properties
-runtest.csh
-scripts
-serialver.csh
-tests.lcf
+//.project
+/.settings
+/build.xml
+/default.lcf
+/java
+/lib
+/nbproject
+/python.properties
+/release.properties
+/runtest.csh
+/scripts
+/serialver.csh
+/tests.lcf
 


### PR DESCRIPTION
Intended to fix a problem with certain directories in html/en not propogating to the web servers.