### PR TITLE
Fix the LocoNet simulation default sensor state feature

### DIFF
--- a/java/src/jmri/jmrix/AbstractSimulatorConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractSimulatorConnectionConfig.java
@@ -61,6 +61,17 @@ abstract public class AbstractSimulatorConnectionConfig extends AbstractConnecti
             return;
         }
         addNameEntryCheckers(adapter);
+
+        // Add listeners for advanced options combo boxes.
+        for (Map.Entry<String, Option> entry : options.entrySet()) {
+            final String item = entry.getKey();
+            if (entry.getValue().getComponent() instanceof JComboBox) {
+                ((JComboBox<?>) entry.getValue().getComponent()).addActionListener((ActionEvent e) -> {
+                    adapter.setOptionState(item, options.get(item).getItem());
+                });
+            }
+        }
+
         init = true;
     }
 

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileSystemConnectionMemo.java
@@ -16,16 +16,16 @@ import javax.annotation.OverridingMethodsMustInvokeSuper;
  */
 public class HexFileSystemConnectionMemo extends jmri.jmrix.loconet.LocoNetSystemConnectionMemo {
 
-    /* @Override
-    public jmri.jmrix.loconet.LnSensorManager getSensorManager() {
+    /**
+     * Use the simulation (hexfile) LocoNet sensor manager instead of the standard LocoNet sensor manager.
+     */
+    @Override
+    public LnSensorManager getSensorManager() {
         if (getDisabled()) {
             return null;
         }
-        if (sensorManager == null) {
-            sensorManager = new LnSensorManager(this);
-        }
-        return sensorManager;
-    }*/
+        return (LnSensorManager) classObjectMap.computeIfAbsent(jmri.SensorManager.class, (Class c) -> new LnSensorManager(this));
+    }
 
     /**
      * Substitute the jmri.progdebugger.DebugProgrammerManager when this connection


### PR DESCRIPTION
The default sensor state feature requires the use of the hexfile version of LnSensorManager.  

The second problem is that there were no listeners attached to the advance options combo boxes.