### PR TITLE
Sensor Tests - Fix abstract Message sent test

### DIFF
--- a/java/test/jmri/implementation/AbstractSensorTest.java
+++ b/java/test/jmri/implementation/AbstractSensorTest.java
@@ -19,10 +19,10 @@ public class AbstractSensorTest extends AbstractSensorTestBase {
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/implementation/AbstractSensorTestBase.java
+++ b/java/test/jmri/implementation/AbstractSensorTestBase.java
@@ -25,9 +25,9 @@ public abstract class AbstractSensorTestBase {
     // return number of listeners registered with the TrafficController
     abstract public int numListeners();
 
-    abstract public void checkOnMsgSent();
+    abstract public void checkActiveMsgSent();
 
-    abstract public void checkOffMsgSent();
+    abstract public void checkInactiveMsgSent();
 
     abstract public void checkStatusRequestMsgSent();
 
@@ -109,6 +109,20 @@ public abstract class AbstractSensorTestBase {
         Assert.assertEquals("state 2", "Active", t.describeState(t.getState()));
     }
 
+    @Test
+    public void testCommandSentActive() throws JmriException {
+        t.setState(Sensor.ACTIVE);
+        Assert.assertEquals("Sensor goes active", Sensor.ACTIVE, t.getState());
+        checkActiveMsgSent();
+    }
+    
+    @Test
+    public void testCommandSentInactive() throws JmriException {
+        t.setState(Sensor.INACTIVE);
+        Assert.assertEquals("sensor goes inactive", Sensor.INACTIVE, t.getState());
+        checkInactiveMsgSent();
+    }
+    
     @Test
     public void testInvertAfterInactive() throws JmriException {
         Assume.assumeTrue(t.canInvert());

--- a/java/test/jmri/jmrix/acela/AcelaSensorTest.java
+++ b/java/test/jmri/jmrix/acela/AcelaSensorTest.java
@@ -15,10 +15,10 @@ public class AcelaSensorTest extends jmri.implementation.AbstractSensorTestBase 
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
@@ -23,12 +23,12 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {
+    public void checkActiveMsgSent() {
         Assert.assertEquals(("[5f8] 98 00 00 00 01"),(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     }
 
     @Override
-    public void checkOffMsgSent() {
+    public void checkInactiveMsgSent() {
         Assert.assertEquals(("[5f8] 99 00 00 00 01"),(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     }
 
@@ -73,12 +73,12 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
         tcis.outbound.clear();
         t.setKnownState(Sensor.ACTIVE);
         Assert.assertTrue(t.getKnownState() == Sensor.ACTIVE);
-        checkOnMsgSent();
+        checkActiveMsgSent();
 
         tcis.outbound.clear();
         t.setKnownState(Sensor.INACTIVE);
         Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
-        checkOffMsgSent();
+        checkInactiveMsgSent();
         
         tcis.outbound.clear();
         t.setKnownState(Sensor.UNKNOWN);
@@ -89,13 +89,13 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
         t.setInverted(true);
         t.setKnownState(Sensor.ACTIVE);
         Assert.assertTrue(t.getKnownState() == Sensor.ACTIVE);
-        checkOffMsgSent();  
+        checkInactiveMsgSent();
 
         tcis.outbound.clear();
         t.setInverted(true);
         t.setKnownState(Sensor.INACTIVE);
         Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
-        checkOnMsgSent();
+        checkActiveMsgSent();
         
         tcis.outbound.clear();
         t.requestUpdateFromLayout();

--- a/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
@@ -23,10 +23,10 @@ public class SerialSensorTest extends jmri.implementation.AbstractSensorTestBase
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/dcc4pc/Dcc4PcSensorTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/Dcc4PcSensorTest.java
@@ -14,10 +14,10 @@ public class Dcc4PcSensorTest extends jmri.implementation.AbstractSensorTestBase
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/dccpp/DCCppSensorTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppSensorTest.java
@@ -22,11 +22,11 @@ public class DCCppSensorTest extends jmri.implementation.AbstractSensorTestBase 
     }
 
     @Override
-    public void checkOnMsgSent() {
+    public void checkActiveMsgSent() {
     }
 
     @Override
-    public void checkOffMsgSent() {
+    public void checkInactiveMsgSent() {
     }
 
     @Override

--- a/java/test/jmri/jmrix/ecos/EcosSensorTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosSensorTest.java
@@ -14,10 +14,10 @@ public class EcosSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/grapevine/SerialSensorTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialSensorTest.java
@@ -18,10 +18,10 @@ public class SerialSensorTest extends jmri.implementation.AbstractSensorTestBase
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/ieee802154/xbee/XBeeSensorTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/XBeeSensorTest.java
@@ -16,10 +16,10 @@ public class XBeeSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientSensorTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientSensorTest.java
@@ -18,10 +18,10 @@ public class JMRIClientSensorTest extends jmri.implementation.AbstractSensorTest
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/lenz/XNetSensorTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetSensorTest.java
@@ -21,11 +21,11 @@ public class XNetSensorTest extends jmri.implementation.AbstractSensorTestBase {
     }
 
     @Override
-    public void checkOnMsgSent() {
+    public void checkActiveMsgSent() {
     }
 
     @Override
-    public void checkOffMsgSent() {
+    public void checkInactiveMsgSent() {
     }
 
     @Override

--- a/java/test/jmri/jmrix/loconet/LnSensorTest.java
+++ b/java/test/jmri/jmrix/loconet/LnSensorTest.java
@@ -20,10 +20,10 @@ public class LnSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public int numListeners() {return lnis.numListeners();}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {

--- a/java/test/jmri/jmrix/maple/SerialSensorTest.java
+++ b/java/test/jmri/jmrix/maple/SerialSensorTest.java
@@ -15,10 +15,10 @@ public class SerialSensorTest extends jmri.implementation.AbstractSensorTestBase
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/marklin/MarklinSensorTest.java
+++ b/java/test/jmri/jmrix/marklin/MarklinSensorTest.java
@@ -14,10 +14,10 @@ public class MarklinSensorTest extends jmri.implementation.AbstractSensorTestBas
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/mqtt/MqttSensorTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttSensorTest.java
@@ -49,15 +49,15 @@ public class MqttSensorTest extends jmri.implementation.AbstractSensorTestBase {
     }
 
     @Override
-    public void checkOnMsgSent() {
-        Assert.assertEquals("topic", "track/turnout/2", saveTopic);
-        Assert.assertEquals("topic", "THROWN", new String(savePayload));
+    public void checkActiveMsgSent() {
+        Assert.assertEquals("topic", "track/sensor/1", saveTopic);
+        Assert.assertEquals("topic", "ACTIVE", new String(savePayload));
     }
 
     @Override
-    public void checkOffMsgSent() {
-        Assert.assertEquals("topic", "track/turnout/2", saveTopic);
-        Assert.assertEquals("topic", "CLOSED", new String(savePayload));
+    public void checkInactiveMsgSent() {
+        Assert.assertEquals("topic", "track/sensor/1", saveTopic);
+        Assert.assertEquals("topic", "INACTIVE", new String(savePayload));
     }
 
     // private final static Logger log = LoggerFactory.getLogger(MqttSensorTest.class);

--- a/java/test/jmri/jmrix/nce/NceSensorTest.java
+++ b/java/test/jmri/jmrix/nce/NceSensorTest.java
@@ -14,10 +14,10 @@ public class NceSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/oaktree/SerialSensorTest.java
+++ b/java/test/jmri/jmrix/oaktree/SerialSensorTest.java
@@ -17,10 +17,10 @@ public class SerialSensorTest extends jmri.implementation.AbstractSensorTestBase
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
@@ -5,6 +5,7 @@ import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.jupiter.api.*;
 import org.openlcb.EventID;
 import org.openlcb.implementations.EventTable;
@@ -38,15 +39,25 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
     }
 
     @Override
-    public void checkOnMsgSent() {
+    public void checkActiveMsgSent() {
         Assert.assertTrue(new OlcbAddress("1.2.3.4.5.6.7.8").match(ti.tc.rcvMessage));
     }
 
     @Override
-    public void checkOffMsgSent() {
+    public void checkInactiveMsgSent() {
         Assert.assertTrue(new OlcbAddress("1.2.3.4.5.6.7.9").match(ti.tc.rcvMessage));
     }
+    
+    @Ignore("Test requires further setup")
+    @Test
+    @Override
+    public void testCommandSentActive() {}
 
+    @Ignore("Test requires further setup")
+    @Test
+    @Override
+    public void testCommandSentInactive() {}
+    
     @Override
     public void checkStatusRequestMsgSent() {
         ti.flush();
@@ -150,19 +161,19 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
         ti.flush();
         Assert.assertNotNull(ti.tc.rcvMessage);
         log.debug("recv msg: {} header {}", ti.tc.rcvMessage, Integer.toHexString(ti.tc.rcvMessage.getHeader()));
-        checkOnMsgSent();
+        checkActiveMsgSent();
         ti.tc.rcvMessage = null;
         t.setKnownState(Sensor.INACTIVE);
         Assert.assertEquals(Sensor.INACTIVE, t.getKnownState());
         ti.flush();
-        checkOffMsgSent();
+        checkInactiveMsgSent();
 
         // Repeat send
         ti.tc.rcvMessage = null;
         t.setKnownState(Sensor.INACTIVE);
         Assert.assertEquals(Sensor.INACTIVE, t.getKnownState());
         ti.flush();
-        checkOffMsgSent();
+        checkInactiveMsgSent();
     }
 
     @Test

--- a/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
@@ -5,7 +5,6 @@ import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.jupiter.api.*;
 import org.openlcb.EventID;
 import org.openlcb.implementations.EventTable;
@@ -48,12 +47,14 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
         Assert.assertTrue(new OlcbAddress("1.2.3.4.5.6.7.9").match(ti.tc.rcvMessage));
     }
     
-    @Ignore("Test requires further setup")
+    @org.junit.jupiter.api.Disabled("Test requires further setup")
+    @jmri.util.junit.annotations.ToDo("Check checkActiveMsgSent() producing correct result")
     @Test
     @Override
     public void testCommandSentActive() {}
 
-    @Ignore("Test requires further setup")
+    @org.junit.jupiter.api.Disabled("Test requires further setup")
+    @jmri.util.junit.annotations.ToDo("Check checkInactiveMsgSent() producing correct result")
     @Test
     @Override
     public void testCommandSentInactive() {}

--- a/java/test/jmri/jmrix/pi/RaspberryPiSensorTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiSensorTest.java
@@ -21,10 +21,10 @@ public class RaspberryPiSensorTest extends jmri.implementation.AbstractSensorTes
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/powerline/SerialSensorTest.java
+++ b/java/test/jmri/jmrix/powerline/SerialSensorTest.java
@@ -14,10 +14,10 @@ public class SerialSensorTest extends jmri.implementation.AbstractSensorTestBase
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/rfid/RfidSensorTest.java
+++ b/java/test/jmri/jmrix/rfid/RfidSensorTest.java
@@ -18,10 +18,10 @@ public class RfidSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/rfid/TimeoutRfidSensorTest.java
+++ b/java/test/jmri/jmrix/rfid/TimeoutRfidSensorTest.java
@@ -18,10 +18,10 @@ public class TimeoutRfidSensorTest extends jmri.implementation.AbstractSensorTes
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/roco/z21/Z21CanSensorTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21CanSensorTest.java
@@ -20,11 +20,11 @@ public class Z21CanSensorTest extends jmri.implementation.AbstractSensorTestBase
     }
 
     @Override
-    public void checkOnMsgSent() {
+    public void checkActiveMsgSent() {
     }
 
     @Override
-    public void checkOffMsgSent() {
+    public void checkInactiveMsgSent() {
     }
 
     @Override

--- a/java/test/jmri/jmrix/roco/z21/Z21RMBusSensorTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21RMBusSensorTest.java
@@ -20,11 +20,11 @@ public class Z21RMBusSensorTest extends jmri.implementation.AbstractSensorTestBa
     }
 
     @Override
-    public void checkOnMsgSent() {
+    public void checkActiveMsgSent() {
     }
 
     @Override
-    public void checkOffMsgSent() {
+    public void checkInactiveMsgSent() {
     }
 
     @Override

--- a/java/test/jmri/jmrix/rps/RpsSensorTest.java
+++ b/java/test/jmri/jmrix/rps/RpsSensorTest.java
@@ -19,10 +19,10 @@ public class RpsSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/secsi/SerialSensorTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialSensorTest.java
@@ -19,11 +19,11 @@ public class SerialSensorTest extends jmri.implementation.AbstractSensorTestBase
     }
 
     @Override
-    public void checkOnMsgSent() {
+    public void checkActiveMsgSent() {
     }
 
     @Override
-    public void checkOffMsgSent() {
+    public void checkInactiveMsgSent() {
     }
 
     @Override

--- a/java/test/jmri/jmrix/srcp/SRCPSensorTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPSensorTest.java
@@ -17,10 +17,10 @@ public class SRCPSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}

--- a/java/test/jmri/jmrix/tams/TamsSensorTest.java
+++ b/java/test/jmri/jmrix/tams/TamsSensorTest.java
@@ -14,10 +14,10 @@ public class TamsSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public int numListeners() {return 0;}
 
     @Override
-    public void checkOnMsgSent() {}
+    public void checkActiveMsgSent() {}
 
     @Override
-    public void checkOffMsgSent() {}
+    public void checkInactiveMsgSent() {}
 
     @Override
     public void checkStatusRequestMsgSent() {}


### PR DESCRIPTION
Fixes #8901 

Renames checkOnMsgSent() > checkActiveMsgSent() and checkOffMsgSent() > checkInactiveMsgSent()
Uses renamed methods in Abstract test.
Fixed MQTT Test.
OpenLCB Test requires further setup.