### PR TITLE
Additional Current Meter for SPROG Generation 5 hardware

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -21,7 +21,15 @@
 
         <h4>CBUS</h4>
             <ul>
-                <li></li>
+                <li>
+                    Andrew Crosland added a second current meter instance for SPROG Generation 5 hardware.
+                </li>
+                <li>
+                    Corrected links to images on SPROG Generation 5 hardware help page.
+                </li>
+                <li>
+                    Changed trademark recognition to &reg; for register trademarks, rather than &trade;.
+                </li>
             </ul>
 
         <h4>C/MRI</h4>

--- a/java/src/jmri/jmrix/can/cbus/CbusPredefinedMeters.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusPredefinedMeters.java
@@ -20,16 +20,21 @@ import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
  * Added voltage capability to use with new jmrit.voltmeter class
  * 
  * @author Daniel Bergqvist Copyright (C) 2020
- */
+  * 
+ * @author Andrew Crosland 2021
+ * Added extra current meter for systems with two track outputs
+*/
 public class CbusPredefinedMeters implements CanListener {
 
     private final TrafficController tc;
     private int _nodeToListen;
     private int _eventToListenCurrent;
+    private int _eventToListenCurrentExtra;
     private int _eventToListenVoltage;
     private final CanSystemConnectionMemo _memo;
     final MeterUpdateTask updateTask;
     final Meter currentMeter;
+    final Meter currentMeterExtra;
     final Meter voltageMeter;
     
     public CbusPredefinedMeters(CanSystemConnectionMemo memo) {
@@ -43,11 +48,16 @@ public class CbusPredefinedMeters implements CanListener {
                 memo.getSystemPrefix() + "V" + "CBUSCurrentMeter",
                 Meter.Unit.Milli, 0, 65535.0, 1.0, updateTask);
         
+        currentMeterExtra = new DefaultMeter.DefaultCurrentMeter(
+                memo.getSystemPrefix() + "V2" + "CBUSCurrentMeter",
+                Meter.Unit.Milli, 0, 65535.0, 1.0, updateTask);
+        
         voltageMeter = new DefaultMeter.DefaultVoltageMeter(
                 memo.getSystemPrefix() + "V" + "CBUSVoltageMeter",
                 Meter.Unit.NoPrefix, 0, 6553.5, 0.1, updateTask);
         
         InstanceManager.getDefault(MeterManager.class).register(currentMeter);
+        InstanceManager.getDefault(MeterManager.class).register(currentMeterExtra);
         InstanceManager.getDefault(MeterManager.class).register(voltageMeter);
         
         log.debug("CbusMultiMeter constructor called");
@@ -64,14 +74,18 @@ public class CbusPredefinedMeters implements CanListener {
         if ( r.extendedOrRtr()
             || CbusMessage.getOpcode(r) != CbusConstants.CBUS_ACON2
             || CbusMessage.getNodeNumber(r) != _nodeToListen 
-            || (CbusMessage.getEvent(r) != _eventToListenCurrent 
-                && CbusMessage.getEvent(r) != _eventToListenVoltage )) {
+            || ((CbusMessage.getEvent(r) != _eventToListenCurrent) 
+                && (CbusMessage.getEvent(r) != _eventToListenVoltage)
+                && (CbusMessage.getEvent(r) != _eventToListenCurrentExtra))) {
             return;
         }
         try {
             if (CbusMessage.getEvent(r) == _eventToListenCurrent) {
                 int currentInt = ( r.getElement(5) * 256 ) + r.getElement(6);
                 currentMeter.setCommandedAnalogValue(currentInt * 1.0f );  // mA value, min 0, max 65535, NOT percentage
+            } else if (CbusMessage.getEvent(r) == _eventToListenCurrentExtra) {
+                int currentInt = ( r.getElement(5) * 256 ) + r.getElement(6);
+                currentMeterExtra.setCommandedAnalogValue(currentInt * 1.0f );  // mA value, min 0, max 65535, NOT percentage
             } else {
                 // Voltage from the command station is scaled by a factor of 10 to allow one decimal place
                 int voltageInt = ( r.getElement(5) * 256 ) + r.getElement(6);
@@ -93,10 +107,13 @@ public class CbusPredefinedMeters implements CanListener {
     
     public void dispose() {
         updateTask.disable(currentMeter);
+        updateTask.disable(currentMeterExtra);
         updateTask.disable(voltageMeter);
         InstanceManager.getDefault(MeterManager.class).deregister(currentMeter);
+        InstanceManager.getDefault(MeterManager.class).deregister(currentMeterExtra);
         InstanceManager.getDefault(MeterManager.class).deregister(voltageMeter);
         updateTask.dispose(currentMeter);
+        updateTask.dispose(currentMeterExtra);
         updateTask.dispose(voltageMeter);
     }
     
@@ -117,6 +134,7 @@ public class CbusPredefinedMeters implements CanListener {
             _nodeToListen = 65534;
             _eventToListenCurrent = 1; // hard coded at present
             _eventToListenVoltage = 2; // hard coded at present
+            _eventToListenCurrentExtra = 3; // hard coded at present
             CbusNodeTableDataModel cs =  jmri.InstanceManager.getNullableDefault(CbusNodeTableDataModel.class);
             if (cs != null) {
                 CbusNode csnode = cs.getCsByNum(0);
@@ -129,7 +147,8 @@ public class CbusPredefinedMeters implements CanListener {
             tc.addCanListener(CbusPredefinedMeters.this);
             log.info("Enabled meter Long Ex2Data {} {}", 
                 new CbusNameService(_memo).getEventNodeString(_nodeToListen,_eventToListenCurrent), 
-                new CbusNameService(_memo).getEventNodeString(_nodeToListen,_eventToListenVoltage));
+                new CbusNameService(_memo).getEventNodeString(_nodeToListen,_eventToListenVoltage),
+                new CbusNameService(_memo).getEventNodeString(_nodeToListen,_eventToListenCurrentExtra));
             
             super.enable();
         }

--- a/java/src/jmri/jmrix/can/cbus/CbusPredefinedMeters.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusPredefinedMeters.java
@@ -145,7 +145,7 @@ public class CbusPredefinedMeters implements CanListener {
                 log.info("Unable to fetch Master Command Station from Node Manager");
             }
             tc.addCanListener(CbusPredefinedMeters.this);
-            log.info("Enabled meter Long Ex2Data {} {}", 
+            log.info("Enabled meter Long Ex2Data {} {} {}", 
                 new CbusNameService(_memo).getEventNodeString(_nodeToListen,_eventToListenCurrent), 
                 new CbusNameService(_memo).getEventNodeString(_nodeToListen,_eventToListenVoltage),
                 new CbusNameService(_memo).getEventNodeString(_nodeToListen,_eventToListenCurrentExtra));

--- a/java/src/jmri/jmrix/can/cbus/CbusPredefinedMeters.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusPredefinedMeters.java
@@ -45,15 +45,15 @@ public class CbusPredefinedMeters implements CanListener {
         updateTask = new UpdateTask(-1);
         
         currentMeter = new DefaultMeter.DefaultCurrentMeter(
-                memo.getSystemPrefix() + "V" + "CBUSCurrentMeter",
+                memo.getSystemPrefix() + InstanceManager.getDefault(MeterManager.class).typeLetter() + "CBUSCurrentMeter",
                 Meter.Unit.Milli, 0, 65535.0, 1.0, updateTask);
         
         currentMeterExtra = new DefaultMeter.DefaultCurrentMeter(
-                memo.getSystemPrefix() + "V2" + "CBUSCurrentMeter",
+                memo.getSystemPrefix() + InstanceManager.getDefault(MeterManager.class).typeLetter() + "CBUSCurrentMeter2",
                 Meter.Unit.Milli, 0, 65535.0, 1.0, updateTask);
         
         voltageMeter = new DefaultMeter.DefaultVoltageMeter(
-                memo.getSystemPrefix() + "V" + "CBUSVoltageMeter",
+                memo.getSystemPrefix() + InstanceManager.getDefault(MeterManager.class).typeLetter() + "CBUSVoltageMeter",
                 Meter.Unit.NoPrefix, 0, 6553.5, 0.1, updateTask);
         
         InstanceManager.getDefault(MeterManager.class).register(currentMeter);

--- a/java/test/jmri/jmrix/can/cbus/CbusPredefinedMetersTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusPredefinedMetersTest.java
@@ -61,7 +61,7 @@ public class CbusPredefinedMetersTest {
     }
     
     public double getCurrentExtra() {
-        return InstanceManager.getDefault(MeterManager.class).getBySystemName("MV2CBUSCurrentMeter").getKnownAnalogValue();
+        return InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSCurrentMeter2").getKnownAnalogValue();
     }
     
     public double getVoltage() {

--- a/java/test/jmri/jmrix/can/cbus/CbusPredefinedMetersTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusPredefinedMetersTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.*;
  * @author Paul Bender       Copyright (C) 2017
  * @author Steve Young       Copyright (C) 2019
  * @author Daniel Bergqvist  Copyright (C) 2020
+ * @author Andrew Crosland   Copyright (C) 2021
  */
 public class CbusPredefinedMetersTest {
 
@@ -59,17 +60,23 @@ public class CbusPredefinedMetersTest {
         return InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSCurrentMeter").getKnownAnalogValue();
     }
     
+    public double getCurrentExtra() {
+        return InstanceManager.getDefault(MeterManager.class).getBySystemName("MV2CBUSCurrentMeter").getKnownAnalogValue();
+    }
+    
     public double getVoltage() {
         return InstanceManager.getDefault(MeterManager.class).getBySystemName("MVCBUSVoltageMeter").getKnownAnalogValue();
     }
 
     private void enable() {
         mm.updateTask.enable(mm.currentMeter);
+        mm.updateTask.enable(mm.currentMeterExtra);
         mm.updateTask.enable(mm.voltageMeter);
     }
     
     private void disable() {
         mm.updateTask.disable(mm.currentMeter);
+        mm.updateTask.disable(mm.currentMeterExtra);
         mm.updateTask.disable(mm.voltageMeter);
     }
     
@@ -197,6 +204,106 @@ public class CbusPredefinedMetersTest {
         r.setExtended(false);
         mm.reply(r);
         Assert.assertEquals(4807,getCurrent(),0.001 );
+        
+        disable();
+        
+        nodeModel.dispose();
+        testCs.dispose();
+        
+    }
+    
+    @Test
+    public void testMultiMExtraCanReply(){
+        
+        CbusNodeTableDataModel nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
+        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
+        
+        CbusNode testCs = nodeModel.provideNodeByNodeNum(54321);
+        testCs.setCsNum(0);
+        
+        enable();
+        
+        CanReply r = new CanReply(tcis.getCanid());
+        r.setNumDataElements(7);
+        r.setElement(0, CbusConstants.CBUS_ACOF2);
+        r.setElement(1, 0xd4); // nn 54322
+        r.setElement(2, 0x32); // nn 54322
+        r.setElement(3, 0x00); // en 3
+        r.setElement(4, 0x03); // en 3
+        r.setElement(5, 0x00); // 8mA
+        r.setElement(6, 0x08); // 8mA
+        mm.reply(r);
+        
+        Assert.assertEquals(0,getCurrentExtra(),0.001 ); // wrong opc
+        
+        r.setElement(0, CbusConstants.CBUS_ACON2);
+        mm.reply(r);
+        
+        Assert.assertEquals(0,getCurrentExtra(),0.001 ); // wrong node
+        
+        r.setElement(2, 0x31); // nn 54321
+        mm.reply(r);
+        Assert.assertEquals(8,getCurrentExtra(),0.001 );
+        
+        r.setElement(5, 0x12); // 4807mA
+        r.setElement(6, 0xc7); // 4807mA
+        mm.reply(r);
+        Assert.assertEquals(4807,getCurrentExtra(),0.001 );
+        
+        CanMessage m = new CanMessage(tcis.getCanid());
+        m.setNumDataElements(7);
+        m.setElement(0, CbusConstants.CBUS_ACON2);
+        m.setElement(1, 0xd4); // nn 54321
+        m.setElement(2, 0x31); // nn 54321
+        r.setElement(3, 0x00); // en 3
+        r.setElement(4, 0x03); // en 3
+        m.setElement(5, 0x00); // 0mA
+        m.setElement(6, 0x00); // 0mA
+        
+        mm.message(m);
+        Assert.assertEquals(4807,getCurrentExtra(),0.001 ); // CanMessage Ignored
+        
+        r = new CanReply(tcis.getCanid());
+        r.setNumDataElements(7);
+        r.setElement(0, CbusConstants.CBUS_ACON2);
+        r.setElement(1, 0xd4); // nn 54321
+        r.setElement(2, 0x31); // nn 54321
+        r.setElement(3, 0x00); // en 3
+        r.setElement(4, 0x03); // en 3
+        r.setElement(5, 0x00); // 0mA
+        r.setElement(6, 0x00); // 0mA
+        
+        mm.reply(r);
+        Assert.assertEquals(0,getCurrentExtra(),0.001 );
+        
+        // wrong event num
+        r = new CanReply(tcis.getCanid());
+        r.setNumDataElements(7);
+        r.setElement(0, CbusConstants.CBUS_ACON2);
+        r.setElement(1, 0xd4); // nn 54321
+        r.setElement(2, 0x31); // nn 54321
+        r.setElement(3, 0x00); // en 2
+        r.setElement(4, 0x02); // en 2
+        r.setElement(5, 0x12); // 4807mA
+        r.setElement(6, 0xc7); // 4807mA
+        
+        mm.reply(r);
+        Assert.assertEquals("Wrong event",0,getCurrentExtra(),0.001 );
+        r.setElement(4, 0x03); // en 3
+        r.setRtr(true);
+        
+        mm.reply(r);
+        Assert.assertEquals(0,getCurrentExtra(),0.001 );
+        
+        r.setExtended(true);
+        r.setRtr(false);
+        
+        mm.reply(r);
+        Assert.assertEquals(0,getCurrentExtra(),0.001 );
+        
+        r.setExtended(false);
+        mm.reply(r);
+        Assert.assertEquals(4807,getCurrentExtra(),0.001 );
         
         disable();
         


### PR DESCRIPTION
Hardware has two track outputs with current monitoring capability.
This may not be the best way to do it but I need to get some code in place for hardware beta test users.