### PR TITLE
LE controlpoints store

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -385,7 +385,8 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
-	        <li></li>
+	        <li>A problem storing and reading LE controlpoint values for users with a non-default Locale has been fixed
+            .</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentViewXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentViewXml.java
@@ -2,6 +2,7 @@ package jmri.jmrit.display.layoutEditor.configurexml;
 
 import java.awt.Color;
 import java.awt.geom.Point2D;
+import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,9 +78,11 @@ public class TrackSegmentViewXml extends AbstractXmlAdapter {
                 elementControlpoint.setAttribute("index", "" + i);
 
                 Point2D pt = view.getBezierControlPoint(i);
-                elementControlpoint.setAttribute("x", String.format("%.1f", pt.getX()));
-                elementControlpoint.setAttribute("y", String.format("%.1f", pt.getY()));
-
+                // correctly working code copied from PositionablePointVewXml:
+                DecimalFormat twoDecFormat = new DecimalFormat("#.##");
+                elementControlpoint.setAttribute("x", ""+Float.valueOf(twoDecFormat.format(pt.getX())));
+                elementControlpoint.setAttribute("y", ""+Float.valueOf(twoDecFormat.format(pt.getY())));
+                // String.format follows the Locale of JMRI, resulting in ',' as decimal separator = invalid xml
                 elementControlpoints.addContent(elementControlpoint);
             }
             element.addContent(elementControlpoints);


### PR DESCRIPTION
Store as 2 decimal . decimal separator number format under any Locale. Fix for issue #9386