### PR TITLE
NamedBeanPropertyDescriptor - Require parameters not null

### DIFF
--- a/java/src/jmri/NamedBeanPropertyDescriptor.java
+++ b/java/src/jmri/NamedBeanPropertyDescriptor.java
@@ -1,5 +1,9 @@
 package jmri;
 
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
 /**
  * Describes metadata about a given property key for a NamedBean.
  * <p>
@@ -20,9 +24,10 @@ public abstract class NamedBeanPropertyDescriptor<E> {
     /** What should be displayed when a given Bean does not have this property set. */
     public final E defaultValue;
 
-    protected NamedBeanPropertyDescriptor(String propertyKey, E defaultValue) {
-        this.propertyKey = propertyKey;
-        this.defaultValue = defaultValue;
+    protected NamedBeanPropertyDescriptor(
+            @Nonnull String propertyKey, @Nonnull E defaultValue) {
+        this.propertyKey = Objects.requireNonNull(propertyKey);
+        this.defaultValue = Objects.requireNonNull(defaultValue);
     }
 
     /**

--- a/java/src/jmri/SelectionPropertyDescriptor.java
+++ b/java/src/jmri/SelectionPropertyDescriptor.java
@@ -2,6 +2,8 @@ package jmri;
 
 import java.util.Arrays;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 import javax.swing.JComboBox;
 
 /**
@@ -21,7 +23,11 @@ public abstract class SelectionPropertyDescriptor extends NamedBeanPropertyDescr
      * @param optionTips Tool-tips for options of the property in String array.
      * @param defVal Default property value.
      */
-    public SelectionPropertyDescriptor(String key, String[] options, String[] optionTips, String defVal ) {
+    public SelectionPropertyDescriptor(
+            @Nonnull String key,
+            @Nonnull String[] options,
+            @Nonnull String[] optionTips,
+            @Nonnull String defVal ) {
         super(key, defVal );
         values = options;
         valueToolTips = optionTips;


### PR DESCRIPTION
PR #9385 makes `NamedBeanPropertyDescriptor` use `getValueClass()` in the method `hashCode()`. This requires that the field `defaultValue` is not null. This PR adds `@Nonnull` annotation and a non null check in the constructor.