### PR TITLE
LocoNet Do for LINK and UNLINK what we did for MOVE and set COMMON

### DIFF
--- a/java/src/jmri/jmrix/loconet/LocoNetSlot.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSlot.java
@@ -836,7 +836,9 @@ public class LocoNetSlot {
                 lastUpdateTime = System.currentTimeMillis();
                 return;
             }
-            case LnConstants.OPC_MOVE_SLOTS: {
+            case LnConstants.OPC_MOVE_SLOTS:
+            case LnConstants.OPC_LINK_SLOTS:
+            case LnConstants.OPC_UNLINK_SLOTS: {
                 // change in slot status, if any, will be reported by the reply,
                 // so don't need to do anything here (but could)
                 lastUpdateTime = System.currentTimeMillis();

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -577,6 +577,8 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
             case LnConstants.OPC_LOCO_SND:
             case LnConstants.OPC_LOCO_SPD:
             case LnConstants.OPC_SLOT_STAT1:
+            case LnConstants.OPC_LINK_SLOTS:
+            case LnConstants.OPC_UNLINK_SLOTS:
                 i = m.getElement(1);
                 break;
 
@@ -801,11 +803,21 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
             sendReadSlotDelayed(i,100);
         } else if (m.getOpCode() == LnConstants.OPC_MOVE_SLOTS) {
             // if a true move get the new from slot status
+            // the to slot status is sent in the reply, but not if dispatch or null
+            // as those return slot info.
+            int slotTwo;
+            slotTwo = m.getElement(2);
+            if (i != 0 && slotTwo != 0 && i != slotTwo) {
+                sendReadSlotDelayed(i,100);
+            }
+        } else if (m.getOpCode() == LnConstants.OPC_LINK_SLOTS ||
+                m.getOpCode() == LnConstants.OPC_UNLINK_SLOTS ) {
+            // unlink and link return first slot by not second (to or from)
             // the to slot status is sent in the reply
             int slotTwo;
             slotTwo = m.getElement(2);
             if (i != 0 && slotTwo != 0) {
-                sendReadSlotDelayed(i,100);
+                sendReadSlotDelayed(slotTwo,100);
             }
        }
     }

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -1252,6 +1252,62 @@ public class SlotManagerTest {
 
         }
     }
+    
+    @Test
+    public void testSetCommon() {
+        // Set slot 5 common, request slot 5
+        slotmanager.message(new LocoNetMessage(new int[]{0xB5, 0x05, 0x17, 0x00}));
+        JUnitUtil.waitFor(() -> {
+            return lnis.outbound.size() > 0;
+        }, "Requests slot read 5 after delay");
+        Assert.assertEquals("Request read slot 5",
+                "BB 05 00 00",
+                lnis.outbound.elementAt(0).toString());
+    }
+
+    @Test
+    public void testMove_NullMove() {
+        // slot move 4 > 4 read nothing after delay.
+        slotmanager.message(new LocoNetMessage(new int[]{0xba, 0x01, 0x01, 0x00}));
+        JUnitUtil.waitFor(200);
+        Assert.assertEquals("No Outbound Data", 0, lnis.outbound.size());
+    }
+
+   @Test
+    public void testMove_TrueMove() {
+        // slot move 1 > 2 read 1 after delay.
+        slotmanager.message(new LocoNetMessage(new int[]{0xba, 0x01, 0x02, 0x00}));
+        JUnitUtil.waitFor(() -> {
+            return lnis.outbound.size() > 0;
+        }, "Requests slot read 1 after delay");
+        Assert.assertEquals("Request read slot 1",
+                "BB 01 00 00",
+                lnis.outbound.elementAt(0).toString());
+    }
+
+    @Test
+    public void testLink() {
+        // slot Link 3 > 4 read 4 after delay.
+        slotmanager.message(new LocoNetMessage(new int[]{0xb8, 0x03, 0x04, 0x00}));
+        JUnitUtil.waitFor(() -> {
+            return lnis.outbound.size() > 0;
+        }, "Requests slot read 4 after delay");
+        Assert.assertEquals("Request read slot 4",
+                "BB 04 00 00",
+                lnis.outbound.elementAt(0).toString());
+    }
+
+    @Test
+    public void testUnLink() {
+        // slot unLink 6 from 7 read 7 after delay.
+        slotmanager.message(new LocoNetMessage(new int[]{0xb9, 0x06, 0x07, 0x00}));
+        JUnitUtil.waitFor(() -> {
+            return lnis.outbound.size() > 0;
+        }, "Requests slot read 7 after delay");
+        Assert.assertEquals("Request read slot 7",
+                "BB 07 00 00",
+                lnis.outbound.elementAt(0).toString());
+    }
 
     LocoNetInterfaceScaffold lnis;
     SlotManager slotmanager;


### PR DESCRIPTION
Request a slot read for the "other slot".
Suppress the Slot Read for null moves
Add tests.

@devel-bobm  This adds the same stuff as we added for the slots going common and moved for the "other" slot involved in a LINK or UNLINK.