### PR TITLE
CBUS Sensor enable Inconsistent state

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusSensor.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensor.java
@@ -82,40 +82,32 @@ public class CbusSensor extends AbstractSensor implements CanListener, CbusEvent
     }
 
     /**
-     * User request to set the state, which means that we broadcast that to all
-     * listeners by putting it out on CBUS. In turn, the code in this class
+     * User request to set the state.
+     * We broadcast that to all listeners by putting it out on CBUS. 
+     * In turn, the code in this class
      * should use setOwnState to handle internal sets and bean notifies.
-     * Unknown state does not send a message to CBUS but updates 
-     * internal sensor state, enabling user test of Start of Day / Logix.
+     * Unknown / intermittent states do not send a message to CBUS,
+     * but do update sensor state.
      * {@inheritDoc}
      */
     @Override
     public void setKnownState(int s) throws jmri.JmriException {
+        setOwnState(s);
         CanMessage m;
-        if (s == Sensor.ACTIVE) {
-            if (getInverted()){
-                m = addrInactive.makeMessage(tc.getCanid());
-                setOwnState(Sensor.ACTIVE);
-            } else {
-                m = addrActive.makeMessage(tc.getCanid());
-                setOwnState(Sensor.ACTIVE);
-            }
-            CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
-            tc.sendCanMessage(m, this);
-        } else if (s == Sensor.INACTIVE) {
-            if (getInverted()){
-                m = addrActive.makeMessage(tc.getCanid());
-                setOwnState(Sensor.INACTIVE);                
-            } else {
-                m = addrInactive.makeMessage(tc.getCanid());
-                setOwnState(Sensor.INACTIVE);
-            }
-            CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
-            tc.sendCanMessage(m, this);
+        switch (s) {
+            case Sensor.ACTIVE:
+                m = ( getInverted() ? addrInactive.makeMessage(tc.getCanid()) : 
+                    addrActive.makeMessage(tc.getCanid()));
+                break;
+            case Sensor.INACTIVE:
+                m = ( !getInverted() ? addrInactive.makeMessage(tc.getCanid()) : 
+                    addrActive.makeMessage(tc.getCanid()));
+                break;
+            default:
+                return;
         }
-        if (s == Sensor.UNKNOWN){
-            setOwnState(Sensor.UNKNOWN);
-        }
+        CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
+        tc.sendCanMessage(m, this);
     }
     
     /**

--- a/java/src/jmri/jmrix/can/cbus/CbusSensor.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensor.java
@@ -86,7 +86,7 @@ public class CbusSensor extends AbstractSensor implements CanListener, CbusEvent
      * We broadcast that to all listeners by putting it out on CBUS. 
      * In turn, the code in this class
      * should use setOwnState to handle internal sets and bean notifies.
-     * Unknown / intermittent states do not send a message to CBUS,
+     * Unknown / Inconsistent states do not send a message to CBUS,
      * but do update sensor state.
      * {@inheritDoc}
      */

--- a/java/test/jmri/implementation/AbstractSensorTestBase.java
+++ b/java/test/jmri/implementation/AbstractSensorTestBase.java
@@ -217,6 +217,27 @@ public abstract class AbstractSensorTestBase {
         jmri.util.JUnitUtil.waitFor(()->{return t.getCommandedState() == Sensor.OFF;}, "commanded state = OFF");
         Assert.assertTrue("Sensor is ON", t.getCommandedState() == Sensor.OFF);
     }
+    
+    @Test
+    public void testSensorSetKnownState() throws JmriException {
+
+        t.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("ACTIVE", t.describeState(Sensor.ACTIVE), t.describeState(t.getState()));
+
+        t.setKnownState(Sensor.INACTIVE);
+        Assert.assertEquals("INACTIVE", t.describeState(Sensor.INACTIVE), t.describeState(t.getState()));
+
+        t.setKnownState(Sensor.UNKNOWN);
+        Assert.assertEquals("UNKNOWN", t.describeState(Sensor.UNKNOWN), t.describeState(t.getState()));
+
+        // Reset known state to something normal
+        t.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("ACTIVE", t.describeState(Sensor.ACTIVE), t.describeState(t.getState()));
+
+        t.setKnownState(Sensor.INCONSISTENT);
+        Assert.assertEquals("INCONSISTENT", t.describeState(Sensor.INCONSISTENT), t.describeState(t.getState()));
+
+    }
 
     //dispose of t.
     @AfterEach

--- a/java/test/jmri/implementation/AbstractSensorTestBase.java
+++ b/java/test/jmri/implementation/AbstractSensorTestBase.java
@@ -221,21 +221,23 @@ public abstract class AbstractSensorTestBase {
     @Test
     public void testSensorSetKnownState() throws JmriException {
 
+        // Assert.assertEquals("ACTIVE", t.describeState(Sensor.ACTIVE), t.describeState(t.getState()));
+        
         t.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals("ACTIVE", t.describeState(Sensor.ACTIVE), t.describeState(t.getState()));
+        Assert.assertEquals("ACTIVE", Sensor.ACTIVE, t.getState());
 
         t.setKnownState(Sensor.INACTIVE);
-        Assert.assertEquals("INACTIVE", t.describeState(Sensor.INACTIVE), t.describeState(t.getState()));
+        Assert.assertEquals("INACTIVE", Sensor.INACTIVE, t.getState());
 
         t.setKnownState(Sensor.UNKNOWN);
-        Assert.assertEquals("UNKNOWN", t.describeState(Sensor.UNKNOWN), t.describeState(t.getState()));
+        Assert.assertEquals("UNKNOWN", Sensor.UNKNOWN, t.getState());
 
         // Reset known state to something normal
         t.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals("ACTIVE", t.describeState(Sensor.ACTIVE), t.describeState(t.getState()));
+        Assert.assertEquals("ACTIVE", Sensor.ACTIVE, t.getState());
 
         t.setKnownState(Sensor.INCONSISTENT);
-        Assert.assertEquals("INCONSISTENT", t.describeState(Sensor.INCONSISTENT), t.describeState(t.getState()));
+        Assert.assertEquals("INCONSISTENT", Sensor.INCONSISTENT, t.getState());
 
     }
 

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
@@ -439,6 +439,34 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
     
     }
     
+    @Test
+    public void checkNoMsgSentOnSetStateUnknownInconsistent() throws jmri.JmriException {
+        
+        Assert.assertTrue(t.getKnownState() == Sensor.UNKNOWN);
+        Assert.assertEquals(("tcis 0"),0,(tcis.outbound.size()));
+        
+        t.setKnownState(Sensor.ACTIVE);
+        Assert.assertTrue(t.getKnownState() == Sensor.ACTIVE);
+        Assert.assertEquals(("tcis 1"),1,(tcis.outbound.size()));
+
+        t.setKnownState(Sensor.UNKNOWN);
+        Assert.assertTrue(t.getKnownState() == Sensor.UNKNOWN);
+        Assert.assertEquals(("tcis still 1"),1,(tcis.outbound.size()));
+        
+        t.setKnownState(Sensor.INACTIVE);
+        Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
+        Assert.assertEquals(("tcis 2"),2,(tcis.outbound.size()));
+        
+        t.setKnownState(Sensor.INCONSISTENT);
+        Assert.assertTrue(t.getKnownState() == Sensor.INCONSISTENT);
+        Assert.assertEquals(("tcis still 2"),2,(tcis.outbound.size()));
+        
+        t.setKnownState(Sensor.ACTIVE);
+        Assert.assertTrue(t.getKnownState() == Sensor.ACTIVE);
+        Assert.assertEquals(("tcis 3"),3,(tcis.outbound.size()));
+
+    }
+    
     private TrafficControllerScaffold tcis;
     
     @Override

--- a/java/test/jmri/jmrix/dcc4pc/Dcc4PcSensorTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/Dcc4PcSensorTest.java
@@ -21,6 +21,11 @@ public class Dcc4PcSensorTest extends jmri.implementation.AbstractSensorTestBase
 
     @Override
     public void checkStatusRequestMsgSent() {}
+    
+    @Override
+    public void testSensorSetKnownState() {
+        // status not currently updated for INCONSISTENT
+    }
 
     @Override
     @BeforeEach

--- a/java/test/jmri/jmrix/loconet/LnSensorTest.java
+++ b/java/test/jmri/jmrix/loconet/LnSensorTest.java
@@ -31,6 +31,11 @@ public class LnSensorTest extends jmri.implementation.AbstractSensorTestBase {
         // to send.
     }
     
+    @Override
+    public void testSensorSetKnownState() {
+        // status not currently updated when set UNKNOWN / INCONSISTENT
+    }
+    
     // LnSensor test for incoming status message
     @Test
     public void testLnSensorStatusMsg() {


### PR DESCRIPTION
Enables Inconsistent state to be set on CbusSensor.
Unit tests for state setting.
To replace #9359 