### PR TITLE
WiThrottle - Fix add duplicate PCL Warning

### DIFF
--- a/java/src/jmri/jmrit/withrottle/ThrottleController.java
+++ b/java/src/jmri/jmrit/withrottle/ThrottleController.java
@@ -169,8 +169,7 @@ public class ThrottleController implements ThrottleListener, PropertyChangeListe
         }
         if (t != null) {
             throttle = t;
-            setFunctionThrottle(throttle);
-            throttle.addPropertyChangeListener(this);
+            setFunctionThrottle(throttle); // adds Property Change Listener
             isAddressSet = true;
             log.debug("DccThrottle found for: {}", throttle.getLocoAddress());
         } else {


### PR DESCRIPTION
#8748 added a warning whenever an attempt was made to add an existing duplicate Property Change Listener to a Throttle.
This affected WiThrottle on notifyThrottleFound() which was attempting to add 2 listeners and causing the warning:

`Preventing jmri.jmrit.withrottle.MultiThrottleController@27f01d44 adding duplicate PCL`

Fixes #8745 which was left open until the warnings were resolved.