### PR TITLE
20210218 dispatcher check turnouts

### DIFF
--- a/java/src/jmri/jmrit/dispatcher/ActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/ActiveTrain.java
@@ -739,6 +739,7 @@ public class ActiveTrain {
         }
         for (AllocatedSection as : sectionsToRelease) {
             InstanceManager.getDefault(DispatcherFrame.class).releaseAllocatedSection(as, true); // need to find Allocated Section
+            InstanceManager.getDefault(DispatcherFrame.class).queueWaitForEmpty(); //ensure release processed before proceding.
             as.getSection().setState(jmri.Section.FREE);
         }
         if (mLastAllocatedSection != null) {

--- a/java/src/jmri/jmrit/dispatcher/AllocatedSection.java
+++ b/java/src/jmri/jmrit/dispatcher/AllocatedSection.java
@@ -12,6 +12,9 @@ import jmri.InstanceManager;
 import jmri.Section;
 import jmri.Sensor;
 import jmri.TransitSection;
+import jmri.jmrit.display.layoutEditor.LayoutTrackExpectedState;
+import jmri.jmrit.display.layoutEditor.LayoutTurnout;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,10 +101,21 @@ public class AllocatedSection {
     private int mAllocationNumber = 0;     // used to keep track of allocation order
     private Sensor mForwardStoppingSensor = null;
     private Sensor mReverseStoppingSensor = null;
+    // list of expected states of turnouts in allocated section
+    // used for delayed checking
+    private List<LayoutTrackExpectedState<LayoutTurnout>> autoTurnoutsResponse = null;
 
     //
     // Access methods
     //
+    public void setAutoTurnoutsResponse(List<LayoutTrackExpectedState<LayoutTurnout>> atr) {
+        autoTurnoutsResponse = atr;
+    }
+
+    public List<LayoutTrackExpectedState<LayoutTurnout>> getAutoTurnoutsResponse() {
+        return autoTurnoutsResponse;
+    }
+
     public Section getSection() {
         return mSection;
     }

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -933,7 +933,7 @@ public class AutoActiveTrain implements ThrottleListener {
      */
     private boolean checkTurn(AllocatedSection as) {
         if (as != null && as.getAutoTurnoutsResponse() != null) {
-            Turnout to = InstanceManager.getDefault(DispatcherFrame.class).getAutoTurnoutsHelper().CheckStateAgainstList(as.getAutoTurnoutsResponse());
+            Turnout to = InstanceManager.getDefault(DispatcherFrame.class).getAutoTurnoutsHelper().checkStateAgainstList(as.getAutoTurnoutsResponse());
             if (to != null) {
                 // at least one turnout isnt correctly set
                 to.addPropertyChangeListener(_turnoutStateListener = (PropertyChangeEvent e) -> {

--- a/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.dispatcher;
 
+import java.beans.PropertyChangeEvent;
 import java.util.ArrayList;
 import java.util.List;
 import jmri.Block;
@@ -58,9 +59,9 @@ public class AutoTurnouts {
      * @param at          the associated train
      * @param le          the associated layout panel
      * @param prevSection the prior section
-     * @return true if affected turnouts are correctly set; false otherwise.
+     * @return list of turnouts and their expected states if affected turnouts are correctly set; null otherwise.
      */
-    protected boolean checkTurnoutsInSection(Section s, int seqNum, Section nextSection,
+    protected List<LayoutTrackExpectedState<LayoutTurnout>> checkTurnoutsInSection(Section s, int seqNum, Section nextSection,
             ActiveTrain at, LayoutEditor le, Section prevSection) {
         return turnoutUtil(s, seqNum, nextSection, at, le, false, false, prevSection);
     }
@@ -88,34 +89,59 @@ public class AutoTurnouts {
      * @param trustKnownTurnouts true to trust known turnouts
      * @param prevSection        the prior section
      *
-     * @return true if affected turnouts are correctly set or commands have been
-     *         issued to set any that aren't set correctly; false if a needed
+     * @return list of turnouts and their expected states if affected turnouts are correctly set or commands have been
+     *         issued to set any that aren't set correctly; null if a needed
      *         command could not be issued because the turnout's Block is
      *         occupied
      */
-    protected boolean setTurnoutsInSection(Section s, int seqNum, Section nextSection,
+    protected List<LayoutTrackExpectedState<LayoutTurnout>> setTurnoutsInSection(Section s, int seqNum, Section nextSection,
             ActiveTrain at, LayoutEditor le, boolean trustKnownTurnouts, Section prevSection) {
         return turnoutUtil(s, seqNum, nextSection, at, le, trustKnownTurnouts, true, prevSection);
     }
 
+    protected Turnout CheckStateAgainstList(List<LayoutTrackExpectedState<LayoutTurnout>> turnoutList) {
+        if (turnoutList != null) {
+            for (LayoutTrackExpectedState<LayoutTurnout> tes : turnoutList) {
+                Turnout to = tes.getObject().getTurnout();
+                int setting = tes.getExpectedState();
+                if (tes.getObject() instanceof LayoutSlip) {
+                    setting = ((LayoutSlip) tes.getObject()).getTurnoutState(tes.getExpectedState());
+                }
+                if (to.getKnownState() != setting) {
+                    return to;
+                }
+                if (tes.getObject() instanceof LayoutSlip) {
+                    //Look at the state of the second turnout in the slip
+                    setting = ((LayoutSlip) tes.getObject()).getTurnoutBState(tes.getExpectedState());
+                    to = ((LayoutSlip) tes.getObject()).getTurnoutB();
+                    if (to.getKnownState() != setting) {
+                        return to;
+                    }
+                }
+             }
+        }
+        return null;
+    }
     /**
      * Internal method implementing the above two methods Returns 'true' if
      * turnouts are set correctly, 'false' otherwise If 'set' is 'true' this
      * routine will attempt to set the turnouts, if 'false' it reports what it
      * finds.
      */
-    private boolean turnoutUtil(Section s, int seqNum, Section nextSection,
+    private List<LayoutTrackExpectedState<LayoutTurnout>> turnoutUtil(Section s, int seqNum, Section nextSection,
             ActiveTrain at, LayoutEditor le, boolean trustKnownTurnouts, boolean set, Section prevSection) {
+        // initialize response structure
+        List<LayoutTrackExpectedState<LayoutTurnout>> turnoutListForAllocatedSection = new ArrayList<>();
         // validate input and initialize
         Transit tran = at.getTransit();
         if ((s == null) || (seqNum > tran.getMaxSequence()) || (!tran.containsSection(s)) || (le == null)) {
             log.error("Invalid argument when checking or setting turnouts in Section.");
-            return false;
+            return null;
         }
         int direction = at.getAllocationDirectionFromSectionAndSeq(s, seqNum);
         if (direction == 0) {
             log.error("Invalid Section/sequence arguments when checking or setting turnouts");
-            return false;
+            return null;
         }
         // Did have this set to include SignalMasts as part of the && statement
         //Sections created using Signal masts will generally only have a single entry/exit point.
@@ -123,7 +149,7 @@ public class AutoTurnouts {
         if (_dispatcher.getSignalType() == DispatcherFrame.SIGNALHEAD && (s.getForwardEntryPointList().size() <= 1) && (s.getReverseEntryPointList().size() <= 1)) {
             log.debug("No entry points lists");
             // no possibility of turnouts
-            return true;
+            return turnoutListForAllocatedSection;
         }
         // initialize connectivity utilities and beginning block pointers
         ConnectivityUtil ct = le.getConnectivityUtil();
@@ -177,7 +203,7 @@ public class AutoTurnouts {
             } catch (Exception ex ) {
                 log.warn(ex.getLocalizedMessage());
             }
-            return true;
+            return turnoutListForAllocatedSection;
         }
 
         Block nextBlock = null;
@@ -200,7 +226,7 @@ public class AutoTurnouts {
                             (at.isAllocationReversed() && curBlock != at.getStartBlock())))) {
                 log.error("[{}]Error in block sequence numbers when setting/checking turnouts.",
                         curBlock.getDisplayName(USERSYS));
-                return false;
+                return null;
             }
         }
 
@@ -223,6 +249,8 @@ public class AutoTurnouts {
                     log.error("Found null Turnout reference at {}: {}", i, turnoutList.get(i).getObject());
                     continue; // move to next loop, what else can we do?
                 }
+                // save for return
+                turnoutListForAllocatedSection.add(turnoutList.get(i));
                 int setting = turnoutList.get(i).getExpectedState();
                 if (turnoutList.get(i).getObject() instanceof LayoutSlip) {
                     setting = ((LayoutSlip) turnoutList.get(i).getObject()).getTurnoutState(turnoutList.get(i).getExpectedState());
@@ -311,7 +339,10 @@ public class AutoTurnouts {
                 curBlock = null;
             }
         }
-        return turnoutsOK;
+        if (turnoutsOK) {
+            return turnoutListForAllocatedSection;
+        }
+        return null;
     }
 
     private final static Logger log = LoggerFactory.getLogger(AutoTurnouts.class);

--- a/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
@@ -99,7 +99,7 @@ public class AutoTurnouts {
         return turnoutUtil(s, seqNum, nextSection, at, le, trustKnownTurnouts, true, prevSection);
     }
 
-    protected Turnout CheckStateAgainstList(List<LayoutTrackExpectedState<LayoutTurnout>> turnoutList) {
+    protected Turnout checkStateAgainstList(List<LayoutTrackExpectedState<LayoutTurnout>> turnoutList) {
         if (turnoutList != null) {
             for (LayoutTrackExpectedState<LayoutTurnout> tes : turnoutList) {
                 Turnout to = tes.getObject().getTurnout();

--- a/java/src/jmri/jmrix/AbstractMonFrame.java
+++ b/java/src/jmri/jmrix/AbstractMonFrame.java
@@ -83,7 +83,7 @@ public abstract class AbstractMonFrame extends JmriJFrame {
     AbstractMonFrame self;
 
     // to find and remember the log file
-    final javax.swing.JFileChooser logFileChooser = new JFileChooser(FileUtil.getUserFilesPath());
+    public final javax.swing.JFileChooser logFileChooser = new JFileChooser(FileUtil.getUserFilesPath());
 
     public AbstractMonFrame() {
         super();


### PR DESCRIPTION
When setting turnouts return a list with the correct settings 
so that they may be checked as having happend before allowing train to enter
line ahead when line ahead not protected by signal.
Fix restart train by waiting for releases to complete before updating section status