### PR TITLE
Fix new bean validation

### DIFF
--- a/java/src/jmri/jmrit/beantable/AbstractTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableAction.java
@@ -292,6 +292,7 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
      * @param ex the exception that occurred
      */
     protected void displayHwError(String curAddress, Exception ex) {
+        log.warn("Invalid Entry: {}",ex.getMessage());
         jmri.InstanceManager.getDefault(jmri.UserPreferencesManager .class).
                 showErrorMessage(Bundle.getMessage("ErrorTitle"),
                         Bundle.getMessage("ErrorConvertHW", curAddress),"" + ex,"",

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -588,6 +588,13 @@ public class LightTableAction extends AbstractTableAction<Light> {
             hardwareAddressTextField.setText(""); // reset from possible previous use
             hardwareAddressTextField.setToolTipText(Bundle.getMessage("LightHardwareAddressHint"));
             hardwareAddressTextField.setName("hwAddressTextField"); // for GUI test NOI18N
+            
+            if (hardwareAddressValidator==null){
+                hardwareAddressValidator = new SystemNameValidator(hardwareAddressTextField, Objects.requireNonNull(prefixBox.getSelectedItem()), true);
+            } else {
+                hardwareAddressValidator.setManager(prefixBox.getSelectedItem());
+            }
+            
             hardwareAddressValidator = new SystemNameValidator(hardwareAddressTextField, Objects.requireNonNull(prefixBox.getSelectedItem()), true);
             hardwareAddressTextField.setInputVerifier(hardwareAddressValidator);
             prefixBox.addActionListener((evt) -> hardwareAddressValidator.setManager(prefixBox.getSelectedItem()));

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -595,7 +595,7 @@ public class LightTableAction extends AbstractTableAction<Light> {
                 hardwareAddressValidator.setManager(prefixBox.getSelectedItem());
             }
             
-            hardwareAddressValidator = new SystemNameValidator(hardwareAddressTextField, Objects.requireNonNull(prefixBox.getSelectedItem()), true);
+            
             hardwareAddressTextField.setInputVerifier(hardwareAddressValidator);
             prefixBox.addActionListener((evt) -> hardwareAddressValidator.setManager(prefixBox.getSelectedItem()));
             hardwareAddressValidator.addPropertyChangeListener("validation", (evt) -> { // NOI18N

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -303,7 +303,13 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
             prefixBox.setName("prefixBox"); // NOI18N
             addButton = new JButton(Bundle.getMessage("ButtonCreate"));
             addButton.addActionListener(createListener);
-            hardwareAddressValidator = new SystemNameValidator(hardwareAddressTextField, prefixBox.getSelectedItem(), true);
+            
+            if (hardwareAddressValidator==null){
+                hardwareAddressValidator = new SystemNameValidator(hardwareAddressTextField, java.util.Objects.requireNonNull(prefixBox.getSelectedItem()), true);
+            } else {
+                hardwareAddressValidator.setManager(prefixBox.getSelectedItem());
+            }
+
             // create panel
             addFrame.add(new AddNewHardwareDevicePanel(hardwareAddressTextField, hardwareAddressValidator, userNameTextField, prefixBox,
                     numberToAddSpinner, rangeCheckBox, addButton, cancelListener, rangeListener, statusBarLabel));

--- a/java/src/jmri/jmrit/beantable/SensorTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SensorTableAction.java
@@ -196,7 +196,7 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
         String statusMessage = Bundle.getMessage("ItemCreateFeedback", Bundle.getMessage("BeanNameSensor"));
         String errorMessage;
         for (int x = 0; x < numberOfSensors; x++) {
-            log.debug("b4 next valid addr for prefix {} conn choice mgr {}",sensorPrefix,((SensorManager)connectionChoice));
+            log.debug("b4 next valid addr for prefix {} conn choice mgr {}",sensorPrefix,connectionChoice);
             try {
                 curAddress = InstanceManager.getDefault(SensorManager.class).getNextValidAddress(curAddress, sensorPrefix, false);
             } catch (jmri.JmriException ex) {

--- a/java/src/jmri/jmrit/beantable/SensorTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SensorTableAction.java
@@ -127,7 +127,14 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
             prefixBox.setName("prefixBox"); // NOI18N
             addButton = new JButton(Bundle.getMessage("ButtonCreate"));
             addButton.addActionListener(createListener);
-            hardwareAddressValidator = new SystemNameValidator(hardwareAddressTextField, prefixBox.getSelectedItem(), true);
+            
+            log.debug("add frame hwAddValidator is {} prefix box is {}",hardwareAddressValidator, prefixBox.getSelectedItem());
+            if (hardwareAddressValidator==null){
+                hardwareAddressValidator = new SystemNameValidator(hardwareAddressTextField, prefixBox.getSelectedItem(), true);
+            } else {
+                hardwareAddressValidator.setManager(prefixBox.getSelectedItem());
+            }
+
             // create panel
             addFrame.add(new AddNewHardwareDevicePanel(hardwareAddressTextField, hardwareAddressValidator, userNameField, prefixBox,
                     numberToAddSpinner, rangeBox, addButton, cancelListener, rangeListener, statusBarLabel));
@@ -189,6 +196,7 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
         String statusMessage = Bundle.getMessage("ItemCreateFeedback", Bundle.getMessage("BeanNameSensor"));
         String errorMessage;
         for (int x = 0; x < numberOfSensors; x++) {
+            log.debug("b4 next valid addr for prefix {} conn choice mgr {}",sensorPrefix,((SensorManager)connectionChoice));
             try {
                 curAddress = InstanceManager.getDefault(SensorManager.class).getNextValidAddress(curAddress, sensorPrefix, false);
             } catch (jmri.JmriException ex) {

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -980,7 +980,13 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
             addButton = new JButton(Bundle.getMessage("ButtonCreate"));
             addButton.addActionListener(this::createPressed);
             // create panel
-            hardwareAddressValidator = new SystemNameValidator(hardwareAddressTextField, Objects.requireNonNull(prefixBox.getSelectedItem()), true);
+            
+            if (hardwareAddressValidator==null){
+                hardwareAddressValidator = new SystemNameValidator(hardwareAddressTextField, Objects.requireNonNull(prefixBox.getSelectedItem()), true);
+            } else {
+                hardwareAddressValidator.setManager(prefixBox.getSelectedItem());
+            }
+            
             addFrame.add(new AddNewHardwareDevicePanel(hardwareAddressTextField, hardwareAddressValidator, userNameTextField, prefixBox,
                     numberToAddSpinner, rangeBox, addButton, cancelListener, rangeListener, statusBarLabel));
             // tooltip for hardwareAddressTextField will be assigned next by canAddRange()

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -667,7 +667,7 @@ public abstract class AbstractManager<E extends NamedBean> extends VetoableChang
      */
     @Nonnull
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws JmriException {
-        log.debug("getNextValid for address {}", curAddress);
+        log.debug("getNextValid for address {} ignoring {}", curAddress, ignoreInitialExisting);
         String testAddr;
         NamedBean bean;
         int increment;
@@ -679,7 +679,9 @@ public abstract class AbstractManager<E extends NamedBean> extends VetoableChang
             bean = getBySystemName(testAddr);
             increment = ( bean instanceof Turnout ? ((Turnout)bean).getNumberOutputBits() : 1);
             testAddr = testAddr.substring(getSystemNamePrefix().length());
-            getIncrement(testAddr, increment);
+            
+            // do not check for incrementability here as could be String only
+            // getIncrement(testAddr, increment);
         }
         catch ( NamedBean.BadSystemNameException | JmriException ex ){
             throw new JmriException(ex.getMessage());

--- a/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
@@ -67,6 +67,11 @@ public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTest
     @Test
     @Override
     public void testMakeSystemNameWithPrefixNotASystemName() {}
+    
+    // No manager-specific system name validation at present
+    @Test
+    @Override
+    public void testIncorrectGetNextValidAddress() {}
 
     @BeforeEach
     @Override

--- a/java/test/jmri/jmrix/internal/InternalReporterManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalReporterManagerTest.java
@@ -32,6 +32,12 @@ public class InternalReporterManagerTest extends jmri.managers.AbstractReporterM
     @Test
     @Override
     public void testMakeSystemNameWithPrefixNotASystemName() {}
+    
+    // No manager-specific system name validation at present
+    @Test
+    @Override
+    public void testIncorrectGetNextValidAddress() {}
+    
 
     @BeforeEach
     @Override

--- a/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
@@ -299,6 +299,11 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
     @Override
     public void testMakeSystemNameWithPrefixNotASystemName() {}
     
+    // No manager-specific system name validation at present
+    @Test
+    @Override
+    public void testIncorrectGetNextValidAddress() {}
+    
     @SuppressWarnings("deprecation")
     @Test
     public void testDeprecatedGetNextValidAddress() throws JmriException {

--- a/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
@@ -179,6 +179,11 @@ public class InternalTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgr
     @Test
     @Override
     public void testMakeSystemNameWithPrefixNotASystemName() {}
+    
+    // No manager-specific system name validation at present
+    @Test
+    @Override
+    public void testIncorrectGetNextValidAddress() {}
 
     // from here down is testing infrastructure
     @Override

--- a/java/test/jmri/managers/ProxyReporterManagerTest.java
+++ b/java/test/jmri/managers/ProxyReporterManagerTest.java
@@ -88,16 +88,20 @@ public class ProxyReporterManagerTest extends AbstractReporterMgrTestBase {
         Assert.assertNotNull(InstanceManager.getDefault(ReporterManager.class).provideReporter("IR2"));
     }
     
-    // No manager-specific system name validation at present
+    // No manager-specific system name validation
     @Test
     @Override
     public void testMakeSystemNameWithNoPrefixNotASystemName() {}
     
-    // No manager-specific system name validation at present
+    // No manager-specific system name validation
     @Test
     @Override
     public void testMakeSystemNameWithPrefixNotASystemName() {}
-
+    
+    // No manager-specific system name validation
+    @Test
+    @Override
+    public void testIncorrectGetNextValidAddress() {}
 
     @BeforeEach
     @Override


### PR DESCRIPTION
See #9431

Adds warn so actual error is known if not created.
Stops multiple hardwareAddressValidator Instances.

getNextValidAddress() should return String not containing number

Further code improvements planned in this area however should resolve immediate issue.