### PR TITLE
Create page and links for Jython Apps that work with JMRI

### DIFF
--- a/help/en/JmriHelp_enIndex.xml
+++ b/help/en/JmriHelp_enIndex.xml
@@ -244,7 +244,7 @@
   <indexitem text="Requirements " target="package.jmri.jmrit.dispatcher.Dispatcher_requirements"/>
 
  </indexitem>
- <indexitem text="Dispatcher System (Python Extension) " target="html.apps.DispatcherSystem.DispatcherSystem"/>
+ <indexitem text="Dispatcher System (Python Extension) " target="html.scripthelp.DispatcherSystem.DispatcherSystem"/>
 
  <indexitem text="Dropbox (Profile Sharing) " target="html.setup.Dropbox"/>
 
@@ -319,6 +319,8 @@
  <indexitem text="Jynstruments " target="html.tools.scripting.Jynstruments"/>
 
  <indexitem text="Jython (in Scripting) " target="html.tools.scripting.Python"/>
+
+ <indexitem text="Jython Apps for JMRI " target="html.tools.scripting.JythonApps"/>
 
  <indexitem text="Layout Editor (Panels) " target="package.jmri.jmrit.display.LayoutEditor"/>
 

--- a/help/en/JmriHelp_enTOC.xml
+++ b/help/en/JmriHelp_enTOC.xml
@@ -223,10 +223,6 @@
    <tocitem text="New Train " target="package.jmri.jmrit.dispatcher.NewTrain"/>
 
   </tocitem>
-  <tocitem text="Dispatcher System (Python Extension) " target="html.apps.DispatcherSystem.DispatcherSystem"/>
-
-  <tocitem text="Manifest Creator " target="html.apps.ManifestCreator.index"/>
-
   <tocitem text="OperationsPro " target="package.jmri.jmrit.operations.Operations">
    <tocitem text="Settings " target="package.jmri.jmrit.operations.Operations_Settings"/>
 
@@ -271,9 +267,16 @@
    <tocitem text="Intro " target="html.apps.SoundPro.SoundPro"/>
 
   </tocitem>
-  <tocitem text="Additional Applications with connections to JMRI " target="html.apps.index_addapp"/>
+  <tocitem text="Additional Applications with connections to JMRI " target="html.apps.index_addapp">
+    <tocitem text="Manifest Creator " target="html.apps.ManifestCreator.index"/>
 
- </tocitem>
+  </tocitem>
+  <tocitem text="Jython Apps for JMRI " target="html.tools.scripting.JythonApps">
+    <tocitem text="YAAT - YetAnotherAutoTrain " target="html.scripthelp.yaat.YAAT"/>
+
+    <tocitem text="Dispatcher System (Python Extension) " target="html.scripthelp.DispatcherSystem.DispatcherSystem"/>
+  </tocitem>
+ </tocitem> 
  <tocitem text="Panels " target="html.apps.PanelPro.index">
   <tocitem text="Panel Editor " target="package.jmri.jmrit.display.PanelEditor"/>
 
@@ -461,6 +464,8 @@
    <tocitem text="Scripting What...Where " target="html.tools.scripting.WhatWhere"/>
 
    <tocitem text="Jynstruments " target="html.tools.scripting.Jynstruments"/>
+
+   <tocitem text="Jython Apps for JMRI " target="html.tools.scripting.JythonApps"/>
 
    <tocitem text="Open Scripting Arch (Apple) " target="html.tools.scripting.AppleScript"/>
 

--- a/help/en/html/apps/index.shtml
+++ b/help/en/html/apps/index.shtml
@@ -72,48 +72,60 @@
       </dl>
 
       <h2><a name="addapp" id="addapp">Additional Applications with JMRI Connections...</a></h2>
-       <p>Hobbyists have created applications that work with JMRI
+       <p>
+       Hobbyists have created applications that work with JMRI
        to provide extra capabilities. In addition, some commercial vendors have
        created applications that work with, add data to, or take data from JMRI</p>
        <p>See the <a href="../../../../community/connections/CommunityConnectionsIndex.shtml">
        community/connections directory</a> for a list and links.  
-       New applications can be added at any time!</p>
+       New applications can be added at any time!
+       </p>
+
+      <h2><a name="jythonapp" id="jythonapp">Jython Applications for JMRI...</a></h2>
+       <p>
+       Some JMRI users have implemented sophiticated capabilities using the <a href="../tools/scripting/index.shtml">JMRI jython scripting facilities.</a>  These are listed 
+       <a href="../tools/scripting/JythonApps.shtml">here</a>.
+      </p>
        
      
       <h2>JMRI Features and Tools</h2>
 
-<p>JMRI software consists of a large library of functions divided into</p>
+        <p>JMRI software consists of a large library of functions divided into</p>
 
-<ul>
-  <li>a system-specific part, with many subparts, each of which communicates with one
-  supported hardware system, like C/MRI, in a system specific way, and</li>
-  <li>a system-independent part where most of the features of JMRI are implemented.</li>
- </ul>
+        <ul>
+          <li>a system-specific part, with many subparts, each of which communicates with one
+          supported hardware system, like C/MRI, in a system specific way, and</li>
+          <li>a system-independent part where most of the features of JMRI are implemented.</li>
+         </ul>
+         
+         
+         <p>So, for example, if the user does something (perhaps setting a route) to
+          cause JMRI to throw a Turnout (track switch), that user action will occur in
+          the system-independent part of the software, and then JMRI will send out the
+          actual command via the system-dependent part appropriate to the hardware
+          system controlling the particular Turnout thrown. JMRI is designed so that
+          features are implemented in the system-independent part as much as possible,
+          with JMRI using system-dependent subparts only when really necessary. Access
+          to system-independent features is via the main JMRI menus, such as the Tools
+          menu.</p>
+
+          <ul>
+            <li>You can
+            find additional information about each of the JMRI "common" tools by clicking through the links in the sidebar or the 
+            <a href="../tools/index.shtml">tools index page.</a></li>
+
+            <li>There are many <a href=
+            "../tools/index.shtml#systemSpecificTools">system-specific
+            tools</a> that are available within the JMRI applications. You can find additional information
+            about each by clicking through the links in the <a href="../tools/index.shtml#systemSpecificTools"> system-specific
+            tools index page</a>.  The tools themselves are invoked from their own menu pulldowns within 
+            the JMRI applications when  you have JMRI configured for each specific System Connection.</li>
+            
+          </ul>
  
  
- <p>So, for example, if the user does something (perhaps setting a route) to
-  cause JMRI to throw a Turnout (track switch), that user action will occur in
-  the system-independent part of the software, and then JMRI will send out the
-  actual command via the system-dependent part appropriate to the hardware
-  system controlling the particular Turnout thrown. JMRI is designed so that
-  features are implemented in the system-independent part as much as possible,
-  with JMRI using system-dependent subparts only when really necessary. Access
-  to system-independent features is via the main JMRI menus, such as the Tools
-  menu.</p>
+          <!--#include virtual="/Footer.shtml" -->
 
-      <ul>
-        <li>You can
-        find additional information about each of the JMRI "common" tools by clicking through the links in the sidebar or the 
-        <a href="../tools/index.shtml">tools index page.</a></li>
-
-        <li>There are many <a href=
-        "../tools/index.shtml#systemSpecificTools">system-specific
-        tools</a> that are available within the JMRI applications. You can find additional information
-        about each by clicking through the links in the <a href="../tools/index.shtml#systemSpecificTools"> system-specific
-        tools index page</a>.  The tools themselves are invoked from their own menu pulldowns within 
-        the JMRI applications when  you have JMRI configured for each specific System Connection.</li>
-        
-      </ul><!--#include virtual="/Footer.shtml" -->
     </div><!-- close #mainContent -->
   </div><!-- close #mBody -->
 </body>

--- a/help/en/html/scripthelp/DispatcherSystem/DispatcherSystem.shtml
+++ b/help/en/html/scripthelp/DispatcherSystem/DispatcherSystem.shtml
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!-- $Id: CATS.shtml,v 1.1 2008-05-23 16:39:46 jacobsen Exp $ -->
+<html lang="en">
+<head><title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- CHANGE FOLLOWING LINE -->
+<META HTTP-EQUIV="Refresh" CONTENT="6; URL=../../apps/DispatcherSystem/DispatcherSystem.shtml ">
+</head>
+<body>
+<p>This page you requested, DispatcherSystem.shtml, is in the process of being moved to scripthelp from its old location:</p>
+<p><a href="../../apps/DispatcherSystem/DispatcherSystem.shtml">/help/en/html/apps/DispatcherSystem/DispatcherSystem.shtml</a>)</p>
+<p>as part of updating and reorganizing our web site.</p>
+<p>You should be redirected to the old location within 6 seconds, or click the link above.</p> 
+</body>
+</html>

--- a/help/en/html/tools/scripting/JythonApps.shtml
+++ b/help/en/html/tools/scripting/JythonApps.shtml
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+
+<html lang="en">
+<head>
+
+  <title>JMRI: Jython Apps for JMRI</title>
+
+  <!--#include virtual="/Style.shtml" -->
+
+</head>
+
+<body>
+  <!--#include virtual="/Header.shtml" -->
+  <div id="mBody">
+    <!--#include virtual="Sidebar.shtml" -->
+    <div id="mainContent">
+      <!-- Page Body -->
+
+      <h1>JMRI: Jython Apps for JMRI</h1>
+
+      <p>Some JMRI users have implemented sophiticated capabilities using the JMRI jython scripting facilities. These are much more than the
+      relatively simple examples presented on <a href="Examples.shtml">the Scripting Examples</a> page.  The developers have provided more 
+      documentation for these "apps" (available in the <a href="../../scripthelp">"scripthelp" directory.</a>  In fact, the distinguishing feature 
+      of apps listed here versus examples listed on the Examples page is that the developers have provided that additional documentation!
+      </p>
+
+      <p><a href=
+      "../../scripthelp/yaat/YAAT.shtml">YAAT (Yet Another Auto Train)</a></p>
+
+      <p>YetAnotherAutoTrain.py (YAAT) provides the ability to define train actions using text files instead of writing Jython code.  
+      The text files contain English like phrases, such as "Set speed to .5" or "Wait for 10 seconds".
+      </p>
+
+      <p><a href=
+      "../../scripthelp/DispatcherSystem/DispatcherSystem.shtml">Dispatcher System</a></p>
+
+      <p>The Dispatcher System extends <a href="../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">JMRI DispatcherPro</a>
+      to make it easier to run trains between locations of your choosing. It uses your panel that has signal logic and sections to generate
+      another panel that you can use to drive trains by pressing the created "Move To" buttons.  Additional features include 
+      stopping and fast mode, and station announcements.
+      </p>
+
+
+      <!--#include virtual="/Footer.shtml" -->
+    </div><!-- closes #mainContent-->
+  </div><!-- closes #mBody-->
+</body>
+</html>

--- a/help/en/html/tools/scripting/SidebarToolLocalPart.shtml
+++ b/help/en/html/tools/scripting/SidebarToolLocalPart.shtml
@@ -5,12 +5,13 @@
 		<dd>Information on writing scripts to control JMRI in more detail:
 		    <ul>
 		    <li><a href="Start.shtml">Getting Started</a>
-		    <li><a href="Python.shtml">The Python/Jython Language</a>
+            <li><a href="Python.shtml">The Python/Jython Language</a>
 		    <li><a href="ex_set_turnouts.shtml">Example: Setting Turnouts</a>
 		    <li><a href="Examples.shtml">Examples (Links)</a>
 		    <li><a href="HowTo.shtml">JMRI Scripting &quot;How To...&quot;</a>
 			<li><a href="WhatWhere.shtml">JMRI Scripting &quot;What...Where&quot;</a>
 			<li><a href="Jynstruments.shtml">Jynstruments to modify the GUI</a>
+			<li><a href="JythonApps.shtml">Jython Apps for JMRI</a>            
             <li><a href="AppleScript.shtml">Open Scripting (for Mac)</a>
 		    </ul>
 		</dd>

--- a/help/en/html/tools/scripting/index.shtml
+++ b/help/en/html/tools/scripting/index.shtml
@@ -9,16 +9,9 @@
   <meta name="keywords" content="custom jmri script, jython, automation, combine java python,
         user scripts, jython examples">
   <title>JMRI: Scripting</title>
-  <!-- Style -->
-  <meta http-equiv="Content-Type" content=
-  "text/html; charset=us-ascii">
-  <link rel="stylesheet" type="text/css" href="/css/default.css"
-  media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css"
-  media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-  <!-- /Style -->
+
+ <!--#include virtual="/Style.shtml" -->
+
 </head>
 
 <body>
@@ -57,6 +50,8 @@
 		
         <li><a href="Jynstruments.shtml">Modifying the GUI with Jynstruments</a></li>
         
+        <li><a href="JythonApps.shtml">Jython Apps: complete apps that use JMRI jython</a></li>
+
         <li><a href="AppleScript.shtml">Open Scripting Architecture (available for Mac)</a></li>
 		    
       </ul>

--- a/help/en/parts/SidebarApplications.shtml
+++ b/help/en/parts/SidebarApplications.shtml
@@ -8,8 +8,10 @@
 	             <li><a href="/help/en/html/apps/DispatcherPro/index.shtml">DispatcherPro&trade;</a></li>
 	             <li><a href="/help/en/package/jmri/jmrit/operations/Operations.shtml">OperationsPro&trade;</a></li>
 	             <li><a href="/help/en/html/apps/SoundPro/SoundPro.shtml">SoundPro&trade;</a></li>
-	             <li><i><a href="/community/connections/CommunityConnectionsIndex.shtml">Apps with JMRI connections...</a></i></li>
-                     <li><a href="/help/en/html/FAQ.shtml">FAQ</a></li>		     
+	             <li><i><a href="/community/connections/CommunityConnectionsIndex.shtml">Apps with JMRI connections...</a></i></li>			
+	             <li><i><a href="/help/en/html/tools/scripting/JythonApps.shtml">Jython Apps for JMRI...</a></i></li>	
+                 <li><a href="/help/en/html/FAQ.shtml">FAQ</a></li>		     
+                 
 		  </ul>
           </dd>
 <!-- /SidebarApplications.shtml -->


### PR DESCRIPTION
New category to handle YAAT and DispatcherSystem and perhaps other full "Jython apps" - that are neither core JMRI apps or just Jython examples or community apps that work with JMRI.  Per suggestion of @dsand47.

[This PR replaces PR #9424 which conflicted with still open PR #9261. This PR should not conflict.]