### PR TITLE
Insert line #84, "import jmri"

### DIFF
--- a/help/en/html/tools/scripting/ex_set_turnouts.shtml
+++ b/help/en/html/tools/scripting/ex_set_turnouts.shtml
@@ -81,6 +81,7 @@
       <div class="section">
         <h2>The Script</h2>
         <pre>
+import jmri
 class setStartup(jmri.jmrit.automat.AbstractAutomaton) :
    def init(self):
      return


### PR DESCRIPTION
The script code as written will not execute without the import to provide critical JMRI definitions.  
   
A direct cut and paste leads beginners to believe that Jython is too difficult to work with.   
   
This problem has most recently been discussed at length in the thread at https://groups.io/g/jmriusers/message/185369