### PR TITLE
New email address

### DIFF
--- a/help/en/html/doc/Technical/index.shtml
+++ b/help/en/html/doc/Technical/index.shtml
@@ -269,7 +269,7 @@
         form, but you must give JMRI credit for their content.</li>
       </ul>
       <p>If you have any questions about this, please <a href=
-      "mailto:jmri@jmri.net">contact us</a> directly.</p>
+      "mailto:jmri@jmri.org">contact us</a> directly.</p>
 
       <h2>Visualizations of JMRI Development Activity</h2>
 

--- a/help/fr/html/doc/Technical/index.shtml
+++ b/help/fr/html/doc/Technical/index.shtml
@@ -254,7 +254,7 @@ pour JMRI leur contenu.
 </ul>
 
 Si vous avez des questions &#224; ce sujet, s'il vous pla&#238;t
-<a href="mailto:jmri@jmri.net">nous contacter</a> directement.
+<a href="mailto:jmri@jmri.org">nous contacter</a> directement.
 
 <h2>D&#233;veloppeur Code Swarm</h2>
 <p>Nous avons cr&#233;&#233; un <a href="/community/visuals/codeswarm.shtml"> Code Swarm of JMRI


### PR DESCRIPTION
jmri@jmri.net has been intermittent for unknown reasons, so switching the contact email to jmri@jmri.org