### PR TITLE
Add 1.5s sleep before first message sent to prevent restart

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -50,7 +50,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     /* According to the specification, DCC++ has a maximum timing
      interval of 500 milliseconds during normal communications */
     protected static final int DCCppProgrammingTimeout = 10000;  // TODO: Appropriate value for DCC++?
-    private static int DCCppMessageTimeout = 2000;  // TODO: Appropriate value for DCC++?
+    private static int DCCppMessageTimeout = 5000;  // TODO: Appropriate value for DCC++?
 
     //private ArrayList<Integer> valueList = new ArrayList<>();
     private StringBuilder myMessage;
@@ -2044,8 +2044,11 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      * <p>
      * reads current being drawn on main operations track
      * <p>
-     * @return {@code <a CURRENT>} where CURRENT = 0-1024, based on
+     * @return (for DCC-EX), 1 or more of  {@code <c MeterName value C/V unit min max res warn>}
+     * where name and settings are used to define arbitrary meters on the DCC-EX side
+     * AND {@code <a CURRENT>} where CURRENT = 0-1024, based on 
      * exponentially-smoothed weighting scheme
+     * 
      */
     public static DCCppMessage makeReadTrackCurrentMsg() {
         return (new DCCppMessage(DCCppConstants.READ_TRACK_CURRENT, DCCppConstants.READ_TRACK_CURRENT_REGEX));

--- a/java/src/jmri/jmrix/dccpp/DCCppPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPacketizer.java
@@ -138,7 +138,7 @@ public class DCCppPacketizer extends DCCppTrafficController {
     @Override
     protected void loadChars(jmri.jmrix.AbstractMRReply msg, java.io.DataInputStream istream) throws java.io.IOException {
         int i;
-        StringBuilder m = new StringBuilder("");
+        StringBuilder m = new StringBuilder();
         log.trace("loading characters from port");
 
         if (!(msg instanceof DCCppReply)) {

--- a/java/src/jmri/jmrix/dccpp/DCCppPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPacketizer.java
@@ -72,7 +72,9 @@ public class DCCppPacketizer extends DCCppTrafficController {
     // DCCppTrafficController class?
     @Override
     protected int addHeaderToOutput(byte[] msg, jmri.jmrix.AbstractMRMessage m) {
-        log.debug("Appending '<' to start of outgoing message. msg length = {}", msg.length);
+        if (log.isTraceEnabled()) {
+            log.trace("Appending '<' to start of outgoing message. msg length = {}", msg.length);
+        }
         msg[0] = (byte) '<';
         return 1;
     }
@@ -93,13 +95,17 @@ public class DCCppPacketizer extends DCCppTrafficController {
     // DCCppTrafficController class?
     @Override
     protected void addTrailerToOutput(byte[] msg, int offset, jmri.jmrix.AbstractMRMessage m) {
-        log.debug("aTTO offset = {} message = {} msg length = {}", offset, m, msg.length);
+        if (log.isTraceEnabled()) {
+            log.trace("aTTO offset = {} message = {} msg length = {}", offset, m, msg.length);
+        }
         if (m.getNumDataElements() == 0) {
             return;
         }
         //msg[offset - 1] = (byte) m.getElement(m.getNumDataElements() - 1);
         msg[offset] = '>';
-        log.debug("finished string = {}", new String(msg, StandardCharsets.UTF_8));
+        if (log.isTraceEnabled()) {
+            log.trace("finished string = {}", new String(msg, StandardCharsets.UTF_8));
+        }
     }
 
     /**
@@ -112,7 +118,7 @@ public class DCCppPacketizer extends DCCppTrafficController {
             ((DCCppPortController) p).setOutputBufferEmpty(false);
             return true;
         } else {
-            log.debug("DCC++ port not ready to receive");
+            log.warn("DCC++ port not ready to send");
             return false;
         }
     }
@@ -132,8 +138,8 @@ public class DCCppPacketizer extends DCCppTrafficController {
     @Override
     protected void loadChars(jmri.jmrix.AbstractMRReply msg, java.io.DataInputStream istream) throws java.io.IOException {
         int i;
-        StringBuilder m = new StringBuilder();
-        log.debug("loading characters from port");
+        StringBuilder m = new StringBuilder("");
+        log.trace("loading characters from port");
 
         if (!(msg instanceof DCCppReply)) {
             log.error("SerialDCCppPacketizer.loadChars called on non-DCCppReply msg!");

--- a/java/src/jmri/jmrix/dccpp/DCCppPredefinedMeters.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppPredefinedMeters.java
@@ -35,7 +35,7 @@ public class DCCppPredefinedMeters implements DCCppListener {
         beanType = InstanceManager.getDefault(MeterManager.class).typeLetter();        
         tc = memo.getDCCppTrafficController();
 
-        updateTask = new MeterUpdateTask(3000, 10000) {
+        updateTask = new MeterUpdateTask(10000, 10000) {
             @Override
             public void requestUpdateFromLayout() {
                 tc.sendDCCppMessage(DCCppMessage.makeReadTrackCurrentMsg(), DCCppPredefinedMeters.this);
@@ -48,7 +48,9 @@ public class DCCppPredefinedMeters implements DCCppListener {
         tc.addDCCppListener(DCCppInterface.CS_INFO, this);
 
         updateTask.initTimer();
-        updateTask.enable(); //enable the send even if no meters exist yet
+        
+        //request one 'c' reply to set up the meters
+        tc.sendDCCppMessage(DCCppMessage.makeReadTrackCurrentMsg(), DCCppPredefinedMeters.this);       
     }
 
     public void setDCCppTrafficController(DCCppTrafficController controller) {
@@ -141,7 +143,7 @@ public class DCCppPredefinedMeters implements DCCppListener {
     // Handle message timeout notification, no retry
     @Override
     public void notifyTimeout(DCCppMessage msg) {
-        log.debug("Notified of timeout on message '{}', not retrying");
+        log.debug("Notified of timeout on message '{}', not retrying", msg);
     }
 
     private final static Logger log = LoggerFactory.getLogger(DCCppPredefinedMeters.class);

--- a/java/src/jmri/jmrix/dccpp/DCCppReply.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppReply.java
@@ -225,10 +225,12 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
     public void parseReply(String s) {
         DCCppReply r = DCCppReply.parseDCCppReply(s);
         log.debug("in parseReply() string: {}", s);
-        this.myRegex = r.myRegex;
-        this.myReply = r.myReply;
-        this._nDataChars = r._nDataChars;
-        log.debug("copied: this: {}", this.toString());
+        if (r != null) {
+            this.myRegex = r.myRegex;
+            this.myReply = r.myReply;
+            this._nDataChars = r._nDataChars;
+            log.trace("copied: this: {}", this);
+        }
     }
 
     ///
@@ -245,7 +247,9 @@ public class DCCppReply extends jmri.jmrix.AbstractMRReply {
      */
     public static DCCppReply parseDCCppReply(String s) {
 
-        log.debug("Parse charAt(0): {}", s.charAt(0));
+        if (log.isTraceEnabled()) {
+            log.trace("Parse charAt(0): {}", s.charAt(0));
+        }
         DCCppReply r = new DCCppReply(s);
         switch (s.charAt(0)) {
             case DCCppConstants.STATUS_REPLY:

--- a/java/src/jmri/jmrix/dccpp/DCCppTrafficController.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTrafficController.java
@@ -23,6 +23,17 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class DCCppTrafficController extends AbstractMRTrafficController implements DCCppInterface {
 
+    @Override
+    protected void transmitLoop() {
+        log.debug("Don't start sending for 1.5 seconds to avoid Arduino restart");
+        try {
+            Thread.sleep(1500);
+        } catch (InterruptedException ignore) {
+            Thread.currentThread().interrupt();
+        }
+        super.transmitLoop();
+    }
+
     /**
      * Create a new DCCppTrafficController instance.
      * Must provide a DCCppCommandStation reference at creation time.

--- a/java/src/jmri/jmrix/dccpp/serial/DCCppAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/serial/DCCppAdapter.java
@@ -85,13 +85,6 @@ public class DCCppAdapter extends DCCppSerialPortController {
 
             opened = true;
 
-            log.info("Sleeping for 1.5 seconds to avoid Arduino restart");
-            try {
-                Thread.sleep(1500);
-            } catch (InterruptedException ignore) {
-            }
-
-
         } catch (NoSuchPortException p) {
 
             return handlePortNotFound(p, portName, log);

--- a/java/src/jmri/jmrix/dccpp/serial/DCCppAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/serial/DCCppAdapter.java
@@ -11,7 +11,6 @@ import jmri.jmrix.dccpp.DCCppCommandStation;
 import jmri.jmrix.dccpp.DCCppInitializationManager;
 import jmri.jmrix.dccpp.DCCppSerialPortController;
 import jmri.jmrix.dccpp.DCCppTrafficController;
-import jmri.jmrix.dccpp.network.DCCppEthernetAdapter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,8 +28,6 @@ import purejavacomm.UnsupportedCommOperationException;
  * Based on jmri.jmirx.lenz.liusb.LIUSBAdapter by Paul Bender
  */
 public class DCCppAdapter extends DCCppSerialPortController {
-    private java.util.TimerTask keepAliveTimer; 
-    private static final long keepAliveTimeoutValue = 30000;     
 
     public DCCppAdapter() {
         super();
@@ -88,8 +85,12 @@ public class DCCppAdapter extends DCCppSerialPortController {
 
             opened = true;
 
-            //start the keepAliveTimer to send periodic 's'tatus messages
-            keepAliveTimer();
+            log.info("Sleeping for 1.5 seconds to avoid Arduino restart");
+            try {
+                Thread.sleep(1500);
+            } catch (InterruptedException ignore) {
+            }
+
 
         } catch (NoSuchPortException p) {
 
@@ -155,28 +156,6 @@ public class DCCppAdapter extends DCCppSerialPortController {
         }
         return null;
     }
-
-    /**
-     * Set up the keepAliveTimer, and start it.
-     */
-    private void keepAliveTimer() {
-        if (keepAliveTimer == null) {
-            keepAliveTimer = new java.util.TimerTask(){
-                    @Override
-                    public void run() {
-                        // If the timer times out, send a request for status
-                        DCCppAdapter.this.getSystemConnectionMemo().getDCCppTrafficController()
-                            .sendDCCppMessage(
-                                              jmri.jmrix.dccpp.DCCppMessage.makeCSStatusMsg(),
-                                              null);
-                    }
-                };
-        } else {
-            keepAliveTimer.cancel();
-        }
-        jmri.util.TimerUtil.schedule(keepAliveTimer, keepAliveTimeoutValue, keepAliveTimeoutValue);
-    }
-    
 
     @Override
     public boolean status() {

--- a/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonPane.java
+++ b/java/src/jmri/jmrix/dccpp/swing/mon/DCCppMonPane.java
@@ -168,7 +168,9 @@ public class DCCppMonPane extends jmri.jmrix.AbstractMonPane implements DCCppLis
     public synchronized void message(final DCCppReply l) {
         // receive a DCC++ message and log it
         // display the raw data if requested
-        log.debug("Message in Monitor: '{}' opcode {}", l, Character.toString(l.getOpCodeChar()));
+        if (log.isDebugEnabled()) {
+            log.debug("Message in Monitor: '{}' opcode {}", l, Character.toString(l.getOpCodeChar()));
+        }
 
         logMessage("", "RX: ", l);
     }


### PR DESCRIPTION
only send meter requests if meter opened
restore previous message timeout of 5s
remove recently added keepalive for USB
more debugging improvements