### PR TITLE
Turnout Table refactor

### DIFF
--- a/java/src/jmri/jmrit/beantable/AbstractTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableAction.java
@@ -171,7 +171,7 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
     
     /**
      * Perform configuration of the JTable as required by a specific TableAction.
-     * @param table 
+     * @param table The table to configure.
      */
     protected void configureTable(JTable table){
     }

--- a/java/src/jmri/jmrit/beantable/AbstractTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableAction.java
@@ -4,6 +4,7 @@ import java.awt.event.ActionEvent;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.HashMap;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.JButton;
@@ -83,6 +84,7 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
         };
         setMenuBar(f); // comes after the Help menu is added by f = new
                        // BeanTableFrame(etc.) in stand alone application
+        configureTable(dataTable);
         setTitle();
         addToFrame(f);
         f.pack();
@@ -144,6 +146,15 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
      */
     protected void setManager(@Nonnull Manager<E> man) {
     }
+    
+    /**
+     * Get the Bean Manager in use by the TableAction.
+     * @return Bean Manager, could be Proxy or normal Manager, may be null.
+     */
+    @CheckForNull
+    protected Manager<E> getManager(){
+        return null;
+    }
 
     /**
      * Allow subclasses to alter the frame's Menubar without having to actually
@@ -156,6 +167,13 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
 
     public JPanel getPanel() {
         return null;
+    }
+    
+    /**
+     * Perform configuration of the JTable as required by a specific TableAction.
+     * @param table 
+     */
+    protected void configureTable(JTable table){
     }
 
     public void dispose() {

--- a/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
@@ -34,11 +34,12 @@ abstract public class AbstractTableTabAction<E extends NamedBean> extends Abstra
         dataPanel = new JPanel();
         dataTabs = new JTabbedPane();
         dataPanel.setLayout(new BorderLayout());
-        if (getManager() instanceof jmri.managers.AbstractProxyManager) {
+        Manager<E> mgr = getManager();
+        if (mgr instanceof jmri.managers.AbstractProxyManager) {
             // build the list, with default at start and internal at end (if present)
-            jmri.managers.AbstractProxyManager<E> proxy = (jmri.managers.AbstractProxyManager<E>) getManager();
+            jmri.managers.AbstractProxyManager<E> proxy = (jmri.managers.AbstractProxyManager<E>) mgr;
 
-            tabbedTableArray.add(new TabbedTableItem<>(Bundle.getMessage("All"), true, getManager(), getNewTableAction("All"))); // NOI18N
+            tabbedTableArray.add(new TabbedTableItem<>(Bundle.getMessage("All"), true, mgr, getNewTableAction("All"))); // NOI18N
 
             proxy.getDisplayOrderManagerList().stream().map(manager -> {
                 String manuName = manager.getMemo().getUserName();
@@ -49,7 +50,8 @@ abstract public class AbstractTableTabAction<E extends NamedBean> extends Abstra
             });
             
         } else {
-            String manuName = getManager().getMemo().getUserName();
+            Manager<E> man = getManager();
+            String manuName = ( man!=null ? man.getMemo().getUserName() : "Unknown Manager");
             tabbedTableArray.add(new TabbedTableItem<>(manuName, true, getManager(), getNewTableAction(manuName)));
         }
         for (int x = 0; x < tabbedTableArray.size(); x++) {

--- a/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
@@ -64,6 +64,7 @@ abstract public class AbstractTableTabAction<E extends NamedBean> extends Abstra
         init = true;
     }
 
+    @Override
     abstract protected Manager<E> getManager();
 
     abstract protected AbstractTableAction<E> getNewTableAction(String choice);
@@ -193,6 +194,7 @@ abstract public class AbstractTableTabAction<E extends NamedBean> extends Abstra
             RowSorterUtil.setSortOrder(sorter, BeanTableDataModel.USERNAMECOL, SortOrder.ASCENDING);
 
             dataModel.configureTable(dataTable);
+            tableAction.configureTable(dataTable);
 
             java.awt.Dimension dataTableSize = dataTable.getPreferredSize();
             // width is right, but if table is empty, it's not high

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -1,8 +1,6 @@
 package jmri.jmrit.beantable;
 
-import java.awt.Component;
-import java.awt.Font;
-import java.awt.Toolkit;
+import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
@@ -19,13 +17,11 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
+
 import javax.annotation.Nonnull;
 import javax.annotation.CheckForNull;
 import javax.swing.*;
-import javax.swing.table.AbstractTableModel;
-import javax.swing.table.TableCellEditor;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableModel;
+import javax.swing.table.*;
 
 import jmri.*;
 import jmri.NamedBean.DisplayOptions;
@@ -110,12 +106,13 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
      * @param column table column number.
      * @return the descriptor if available, else null.
      */
+    @CheckForNull
     protected NamedBeanPropertyDescriptor<?> getPropertyColumnDescriptor(int column) {
         List<NamedBeanPropertyDescriptor<?>> propertyColumns = getManager().getKnownBeanProperties();
         int totalCount = getColumnCount();
         int propertyCount = propertyColumns.size();
         int tgt = column - (totalCount - propertyCount);
-        if (tgt < 0) {
+        if (tgt < 0 || tgt >= propertyCount ) {
             return null;
         }
         return propertyColumns.get(tgt);
@@ -221,7 +218,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
             default:
                 NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
                 if (desc == null) {
-                    return "unknown";
+                    return "btm unknown"; // NOI18N 
                 }
                 return desc.getColumnHeaderText();
         }
@@ -300,15 +297,17 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
             default:
                 NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
                 if (desc == null) {
-                    log.error("internal state inconsistent with table requst for {} {}", row, col);
+                    log.error("internal state inconsistent with table requst for getValueAt {} {}", row, col);
                     return null;
+                }
+                if ( !isCellEditable(row, col) ) {
+                    return null; // do not display if not applicable to hardware type
                 }
                 b = getBySystemName(sysNameList.get(row));
                 Object value = b.getProperty(desc.propertyKey);
                 if (desc instanceof SelectionPropertyDescriptor){
                     JComboBox<String> c = new JComboBox<>(((SelectionPropertyDescriptor) desc).getOptions());
                     c.setSelectedItem(( value!=null ? value.toString() : desc.defaultValue.toString() ));
-                    c.addActionListener(this::comboBoxAction);
                     ComboBoxToolTipRenderer renderer = new ComboBoxToolTipRenderer();
                     c.setRenderer(renderer);
                     renderer.setTooltips(((SelectionPropertyDescriptor) desc).getOptionToolTips());
@@ -318,18 +317,6 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
                     return desc.defaultValue;
                 }
                 return value;
-        }
-    }
-
-    /**
-     * Action for Combo Boxes.
-     * When a selection is made, triggers the setValueAt().
-     * @param e the event from the Combo box.
-     */
-    public void comboBoxAction(ActionEvent e) {
-        log.debug("Combobox change");
-        if (thistable != null && thistable.getCellEditor() != null) {
-            thistable.getCellEditor().stopCellEditing();
         }
     }
 
@@ -346,7 +333,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
             default:
                 NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
                 if (desc == null || desc.getColumnHeaderText() == null) {
-                    log.warn("Unexpected column in getPreferredWidth: {} table {}", col,this);
+                    log.error("Unexpected column in getPreferredWidth: {} table {}", col,this);
                     return new JTextField(8).getPreferredSize().width;
                 }
                 return new JTextField(desc.getColumnHeaderText()).getPreferredSize().width;
@@ -500,8 +487,9 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         // Property columns will be invisible at start.
         setPropertyColumnsVisible(table, false);
 
-        table.setDefaultRenderer(JComboBox.class, new jmri.jmrit.symbolicprog.ValueRenderer());
-        table.setDefaultEditor(JComboBox.class, new jmri.jmrit.symbolicprog.ValueEditor());
+        table.setDefaultRenderer(JComboBox.class, new BtValueRenderer());
+        table.setDefaultEditor(JComboBox.class, new BtComboboxEditor());
+        table.setDefaultRenderer(Boolean.class, new EnablingCheckboxRenderer());
 
         // allow reordering of the columns
         table.getTableHeader().setReorderingAllowed(true);
@@ -509,10 +497,13 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         // have to shut off autoResizeMode to get horizontal scroll to work (JavaSwing p 541)
         table.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
 
-        // resize columns as requested
-        for (int i = 0; i < table.getColumnCount(); i++) {
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+        for (int i = 0; i < columnModel.getColumnCount(false); i++) {
+            
+            // resize columns as requested
             int width = getPreferredWidth(i);
-            table.getColumnModel().getColumn(i).setPreferredWidth(width);
+            columnModel.getColumnByModelIndex(i).setPreferredWidth(width);
+            
         }
         table.sizeColumnsToFit(-1);
 
@@ -522,11 +513,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         MouseListener popupListener = new PopupListener();
         table.addMouseListener(popupListener);
         this.persistTable(table);
-
-        thistable = table;
     }
-
-    private JTable thistable;
 
     protected void configValueColumn(JTable table) {
         // have the value column hold a button
@@ -1017,7 +1004,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
      * @param col The current column.
      * @return a formatted tool tip or null if there is none.
      */
-    String getCellToolTip(JTable table, int row, int col) {
+    public String getCellToolTip(JTable table, int row, int col) {
         String tip = null;
         if (!table.getName().contains("SignalMastLogic")) {
             int column = COMMENTCOL;
@@ -1381,6 +1368,60 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         public void mouseClicked(MouseEvent e) {
             if (e.isPopupTrigger()) {
                 showTableHeaderPopup(e, table);
+            }
+        }
+    }
+
+    private class BtComboboxEditor extends jmri.jmrit.symbolicprog.ValueEditor {
+    
+        public BtComboboxEditor(){
+            super();
+        }
+        
+        @Override
+        public Component getTableCellEditorComponent(JTable table, Object value,
+            boolean isSelected,
+            int row, int column) {
+            if (value instanceof JComboBox) {
+                ((JComboBox) value).addActionListener((ActionEvent e1) -> table.getCellEditor().stopCellEditing());
+            }
+            
+            if (value instanceof JComponent ) {
+            
+                int modelcol =  table.convertColumnIndexToModel(column);
+                int modelrow = table.convertRowIndexToModel(row);
+
+                // if cell is not editable, jcombobox not applicable for hardware type
+                boolean editable = table.getModel().isCellEditable(modelrow, modelcol);
+
+                ((JComponent) value).setEnabled(editable);
+            
+            }
+            
+            return super.getTableCellEditorComponent(table, value, isSelected, row, column);
+        }
+    
+    
+    }
+    
+    private class BtValueRenderer implements TableCellRenderer {
+
+        public BtValueRenderer() {
+            super();
+        }
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value,
+            boolean isSelected, boolean hasFocus, int row, int column) {
+
+            if (value instanceof Component) {
+                return (Component) value;
+            } else if (value instanceof String) {
+                return new JLabel((String) value);
+            } else {
+                JPanel f = new JPanel();
+                f.setBackground(isSelected ? table.getSelectionBackground() : table.getBackground() );
+                return f;
             }
         }
     }

--- a/java/src/jmri/jmrit/beantable/BlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/BlockTableAction.java
@@ -191,7 +191,6 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                     } else if (b.getCurvature() == Block.SEVERE) {
                         c.setSelectedItem(severeText);
                     }
-                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == LENGTHCOL) {
                     double len = 0.0;
@@ -212,7 +211,6 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                     JComboBox<String> c = new JComboBox<>(speedList);
                     c.setEditable(true);
                     c.setSelectedItem(speed);
-                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == STATECOL) {
                     switch (b.getState()) {
@@ -233,7 +231,6 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                         name = sensor.getDisplayName();
                     }
                     c.setSelectedItem(name);
-                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == REPORTERCOL) {
                     Reporter reporter = b.getReporter();
@@ -243,7 +240,6 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                         name = reporter.getDisplayName();
                     }
                     rs.setSelectedItem(name);
-                    rs.addActionListener(super::comboBoxAction);
                     return rs;
                 } else if (col == CURRENTREPCOL) {
                     return Boolean.valueOf(b.isReportingCurrent());

--- a/java/src/jmri/jmrit/beantable/IdTagTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/IdTagTableTabAction.java
@@ -2,6 +2,8 @@ package jmri.jmrit.beantable;
 
 import java.awt.BorderLayout;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.JPanel;
@@ -20,6 +22,7 @@ public class IdTagTableTabAction extends AbstractTableTabAction<IdTag> {
 
     /** {@inheritDoc} */
     @Override
+    @Nonnull
     protected Manager<IdTag> getManager() {
         return InstanceManager.getDefault(IdTagManager.class);
     }

--- a/java/src/jmri/jmrit/beantable/SensorTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SensorTableAction.java
@@ -40,7 +40,7 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
 
         // disable ourself if there is no primary sensor manager available
         if (sensorManager == null) {
-            setEnabled(false);
+            super.setEnabled(false);
         }
     }
 
@@ -425,17 +425,13 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
             menuBar.add(optionsMenu, pos + offset);
         }
     }
-
-    private void showDebounceChanged(ActionEvent e) {
-        ((SensorTableDataModel) m).showDebounce(showDebounceBox.isSelected());
-    }
-
-    private void showPullUpChanged(ActionEvent e) {
-        ((SensorTableDataModel) m).showPullUp(showPullUpBox.isSelected());
-    }
-
-    private void showStateForgetAndQueryChanged(ActionEvent e) {
-        ((SensorTableDataModel) m).showStateForgetAndQuery(showStateForgetAndQueryBox.isSelected());
+    
+    @Override
+    protected void configureTable(JTable table){
+        super.configureTable(table);
+        showDebounceBox.addActionListener((ActionEvent e) -> { ((SensorTableDataModel)m).showDebounce(showDebounceBox.isSelected(), table); });
+        showPullUpBox.addActionListener((ActionEvent e) -> { ((SensorTableDataModel)m).showPullUp(showPullUpBox.isSelected(), table); });
+        showStateForgetAndQueryBox.addActionListener((ActionEvent e) -> { ((SensorTableDataModel)m).showStateForgetAndQuery(showStateForgetAndQueryBox.isSelected(), table); });
     }
 
     private final TriStateJCheckBox showDebounceBox = new TriStateJCheckBox(Bundle.getMessage("SensorDebounceCheckBox"));
@@ -449,14 +445,10 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
     public void addToFrame(BeanTableFrame<Sensor> f) {
         f.addToBottomBox(showDebounceBox, this.getClass().getName());
         showDebounceBox.setToolTipText(Bundle.getMessage("SensorDebounceToolTip"));
-        showDebounceBox.addActionListener(this::showDebounceChanged);
         f.addToBottomBox(showPullUpBox, this.getClass().getName());
         showPullUpBox.setToolTipText(Bundle.getMessage("SensorPullUpToolTip"));
-        showPullUpBox.addActionListener(this::showPullUpChanged);
-        showPullUpBox.setVisible(true);
         f.addToBottomBox(showStateForgetAndQueryBox, this.getClass().getName());
         showStateForgetAndQueryBox.setToolTipText(Bundle.getMessage("StateForgetAndQueryBoxToolTip"));
-        showStateForgetAndQueryBox.addActionListener(this::showStateForgetAndQueryChanged);
     }
     
     /**
@@ -489,13 +481,10 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
         }
         f.addToBottomBox(showDebounceBox, connectionName);
         showDebounceBox.setToolTipText(Bundle.getMessage("SensorDebounceToolTip"));
-        showDebounceBox.addActionListener(this::showDebounceChanged);
         f.addToBottomBox(showPullUpBox, connectionName);
         showPullUpBox.setToolTipText(Bundle.getMessage("SensorPullUpToolTip"));
-        showPullUpBox.addActionListener(this::showPullUpChanged);
         f.addToBottomBox(showStateForgetAndQueryBox, connectionName);
         showStateForgetAndQueryBox.setToolTipText(Bundle.getMessage("StateForgetAndQueryBoxToolTip"));
-        showStateForgetAndQueryBox.addActionListener(this::showStateForgetAndQueryChanged);
     }
 
     /**

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -1,42 +1,22 @@
 package jmri.jmrit.beantable;
 
-import jmri.util.gui.GuiLafPreferencesManager;
-
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.util.Enumeration;
-import java.util.Hashtable;
 import java.util.Objects;
 import java.util.Vector;
 
 import javax.annotation.Nonnull;
-import javax.annotation.CheckForNull;
-import javax.imageio.ImageIO;
 import javax.swing.*;
-import javax.swing.table.TableCellEditor;
-import javax.swing.table.TableCellRenderer;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableModel;
 
 import jmri.*;
-import jmri.NamedBean.DisplayOptions;
-import jmri.implementation.SignalSpeedMap;
-import jmri.jmrit.turnoutoperations.TurnoutOperationConfig;
+import jmri.jmrit.beantable.turnout.TurnoutTableDataModel;
 import jmri.jmrit.turnoutoperations.TurnoutOperationFrame;
 import jmri.swing.ManagerComboBox;
-import jmri.swing.NamedBeanComboBox;
 import jmri.swing.SystemNameValidator;
 import jmri.util.JmriJFrame;
 import jmri.util.swing.TriStateJCheckBox;
-import jmri.util.swing.XTableColumnModel;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,27 +42,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
 
         // disable ourself if there is no primary turnout manager available
         if (turnoutManager == null) {
-            setEnabled(false);
-        }
-
-        //This following must contain the word Global for a correct match in the abstract turnout
-        defaultThrownSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultThrownSpeed());
-        defaultClosedSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultClosedSpeed());
-        //This following must contain the word Block for a correct match in the abstract turnout
-        useBlockSpeed = Bundle.getMessage("UseGlobal", "Block Speed");
-
-        speedListClosed.add(defaultClosedSpeedText);
-        speedListThrown.add(defaultThrownSpeedText);
-        speedListClosed.add(useBlockSpeed);
-        speedListThrown.add(useBlockSpeed);
-        java.util.Vector<String> _speedMap = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getValidSpeedNames();
-        for (String s : _speedMap) {
-            if (!speedListClosed.contains(s)) {
-                speedListClosed.add(s);
-            }
-            if (!speedListThrown.contains(s)) {
-                speedListThrown.add(s);
-            }
+            super.setEnabled(false);
         }
     }
 
@@ -90,23 +50,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         this(Bundle.getMessage("TitleTurnoutTable"));
     }
 
-    String closedText;
-    String thrownText;
-    String defaultThrownSpeedText;
-    String defaultClosedSpeedText;
-    // I18N TODO but note storing in xml independent from Locale
-    String useBlockSpeed;
-    String bothText = "Both";
-    String cabOnlyText = "Cab only";
-    String pushbutText = "Pushbutton only";
-    String noneText = "None";
-
-    private final java.util.Vector<String> speedListClosed = new java.util.Vector<>();
-    private final java.util.Vector<String> speedListThrown = new java.util.Vector<>();
     protected TurnoutManager turnoutManager = InstanceManager.getDefault(TurnoutManager.class);
-    protected JTable table;
-    // for icon state col
-    protected boolean _graphicState = false; // updated from prefs
 
     /**
      * {@inheritDoc}
@@ -116,24 +60,11 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         if (man instanceof TurnoutManager) {
             log.debug("setting manager of TTAction {} to {}",this,man.getClass());
             turnoutManager = (TurnoutManager) man;
+            if (m!=null){ // also update Table Model
+                m.setManager(man);
+            }            
         }
     }
-
-    static public final int INVERTCOL = BeanTableDataModel.NUMCOLUMN;
-    static public final int LOCKCOL = INVERTCOL + 1;
-    static public final int EDITCOL = LOCKCOL + 1;
-    static public final int KNOWNCOL = EDITCOL + 1;
-    static public final int MODECOL = KNOWNCOL + 1;
-    static public final int SENSOR1COL = MODECOL + 1;
-    static public final int SENSOR2COL = SENSOR1COL + 1;
-    static public final int OPSONOFFCOL = SENSOR2COL + 1;
-    static public final int OPSEDITCOL = OPSONOFFCOL + 1;
-    static public final int LOCKOPRCOL = OPSEDITCOL + 1;
-    static public final int LOCKDECCOL = LOCKOPRCOL + 1;
-    static public final int STRAIGHTCOL = LOCKDECCOL + 1;
-    static public final int DIVERGCOL = STRAIGHTCOL + 1;
-    static public final int FORGETCOL = DIVERGCOL + 1;
-    static public final int QUERYCOL = FORGETCOL + 1;
 
     /**
      * Create the JTable DataModel, along with the changes for the specific case
@@ -141,787 +72,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
      */
     @Override
     protected void createModel() {
-        // store the terminology
-        closedText = turnoutManager.getClosedText();
-        thrownText = turnoutManager.getThrownText();
-
-        // load graphic state column display preference
-        // from apps/GuiLafConfigPane.java
-        _graphicState = InstanceManager.getDefault(GuiLafPreferencesManager.class).isGraphicTableState();
-
-        // create the data model object that drives the table
-        // note that this is a class creation, and very long
-        m = new BeanTableDataModel<Turnout>() {
-
-            @Override
-            public int getColumnCount() {
-                return QUERYCOL + getPropertyColumnCount() + 1;
-            }
-
-            @Override
-            public String getColumnName(int col) {
-                switch (col) {
-                    case INVERTCOL:
-                        return Bundle.getMessage("Inverted");
-                    case LOCKCOL:
-                        return Bundle.getMessage("Locked");
-                    case KNOWNCOL:
-                        return Bundle.getMessage("Feedback");
-                    case MODECOL:
-                        return Bundle.getMessage("ModeLabel");
-                    case SENSOR1COL:
-                        return Bundle.getMessage("BlockSensor") + "1";
-                    case SENSOR2COL:
-                        return Bundle.getMessage("BlockSensor") + "2";
-                    case OPSONOFFCOL:
-                        return Bundle.getMessage("TurnoutAutomationMenu");
-                    case OPSEDITCOL:
-                        return "";
-                    case LOCKOPRCOL:
-                        return Bundle.getMessage("LockMode");
-                    case LOCKDECCOL:
-                        return Bundle.getMessage("Decoder");
-                    case DIVERGCOL:
-                        return Bundle.getMessage("ThrownSpeed");
-                    case STRAIGHTCOL:
-                        return Bundle.getMessage("ClosedSpeed");
-                    case FORGETCOL:
-                        return Bundle.getMessage("StateForgetHeader");
-                    case QUERYCOL:
-                        return Bundle.getMessage("StateQueryHeader");
-                    case EDITCOL:
-                        return "";
-                    default:
-                        return super.getColumnName(col);
-                }
-            }
-
-            @Override
-            public Class<?> getColumnClass(int col) {
-                switch (col) {
-                    case INVERTCOL:
-                    case LOCKCOL:
-                        return Boolean.class;
-                    case KNOWNCOL:
-                        return String.class;
-                    case MODECOL:
-                    case SENSOR1COL:
-                    case SENSOR2COL:
-                    case OPSONOFFCOL:
-                    case LOCKOPRCOL:
-                    case LOCKDECCOL:
-                    case DIVERGCOL:
-                    case STRAIGHTCOL:
-                        return JComboBox.class;
-                    case OPSEDITCOL:
-                    case EDITCOL:
-                    case FORGETCOL:
-                    case QUERYCOL:
-                        return JButton.class;
-                    case VALUECOL: // may use an image to show turnout state
-                        return ( _graphicState ? JLabel.class : JButton.class );
-                    default:
-                        return super.getColumnClass(col);
-                }
-            }
-
-            @Override
-            public int getPreferredWidth(int col) {
-                switch (col) {
-                    case INVERTCOL:
-                    case LOCKCOL:
-                        return new JTextField(6).getPreferredSize().width;
-                    case LOCKOPRCOL:
-                    case LOCKDECCOL:
-                    case KNOWNCOL:
-                    case MODECOL:
-                        return new JTextField(10).getPreferredSize().width;
-                    case SENSOR1COL:
-                    case SENSOR2COL:
-                        return new JTextField(5).getPreferredSize().width;
-                    case OPSEDITCOL:
-                        return new JButton(Bundle.getMessage("EditTurnoutOperation")).getPreferredSize().width;
-                    case EDITCOL:
-                        return new JButton(Bundle.getMessage("ButtonEdit")).getPreferredSize().width+4;
-                    case OPSONOFFCOL:
-                        return new JTextField(Bundle.getMessage("TurnoutAutomationMenu")).getPreferredSize().width;
-                    case DIVERGCOL:
-                    case STRAIGHTCOL:
-                        return new JTextField(14).getPreferredSize().width;
-                    case FORGETCOL:
-                        return new JButton(Bundle.getMessage("StateForgetButton")).getPreferredSize().width;
-                    case QUERYCOL:
-                        return new JButton(Bundle.getMessage("StateQueryButton")).getPreferredSize().width;
-                    default:
-                        super.getPreferredWidth(col);
-                }
-                return super.getPreferredWidth(col);
-            }
-
-            @Override
-            public boolean isCellEditable(int row, int col) {
-                Turnout t = turnoutManager.getBySystemName(sysNameList.get(row));
-                if (t == null){
-                    return false;
-                }
-                switch (col) {
-                    case INVERTCOL:
-                        return t.canInvert();
-                    case LOCKCOL:
-                        // checkbox disabled unless current configuration allows locking
-                        return t.canLock(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT);
-                    case OPSEDITCOL:
-                        return t.getTurnoutOperation() != null;
-                    case KNOWNCOL:
-                        return false;
-                    case MODECOL:
-                    case SENSOR1COL:
-                    case SENSOR2COL:
-                    case OPSONOFFCOL:
-                    case LOCKOPRCOL: // editable always so user can configure it, even if current configuration prevents locking now
-                    case LOCKDECCOL: // editable always so user can configure it, even if current configuration prevents locking now
-                    case DIVERGCOL:
-                    case STRAIGHTCOL:
-                    case EDITCOL:
-                    case FORGETCOL:
-                    case QUERYCOL:
-                        return true;
-                    default:
-                        return super.isCellEditable(row, col);
-                }
-            }
-
-            @Override
-            public Object getValueAt(int row, int col) {
-                // some error checking
-                if (row >= sysNameList.size()) {
-                    log.debug("row is greater than name list");
-                    return "error";
-                }
-                String name = sysNameList.get(row);
-                TurnoutManager manager = turnoutManager;
-                Turnout t = manager.getBySystemName(name);
-                if (t == null) {
-                    log.debug("error null turnout!");
-                    return "error";
-                }
-                if (col == INVERTCOL) {
-                    return t.getInverted();
-                } else if (col == LOCKCOL) {
-                    return t.getLocked(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT);
-                } else if (col == KNOWNCOL) {
-                    return t.describeState(t.getKnownState());
-                } else if (col == MODECOL) {
-                    JComboBox<String> c = new JComboBox<>(t.getValidFeedbackNames());
-                    c.setSelectedItem(t.getFeedbackModeName());
-                    c.addActionListener(super::comboBoxAction);
-                    return c;
-                } else if (col == SENSOR1COL) {
-                    return t.getFirstSensor();
-                } else if (col == SENSOR2COL) {
-                    return t.getSecondSensor();
-                } else if (col == OPSONOFFCOL) {
-                    return makeAutomationBox(t);
-                } else if (col == OPSEDITCOL) {
-                    return Bundle.getMessage("EditTurnoutOperation");
-                } else if (col == EDITCOL) {
-                    return Bundle.getMessage("ButtonEdit");
-                } else if (col == LOCKDECCOL) {
-                    JComboBox<String> c;
-                    if ((t.getPossibleLockModes() & Turnout.PUSHBUTTONLOCKOUT) != 0) {
-                        c = new JComboBox<>(t.getValidDecoderNames());
-                    } else {
-                        c = new JComboBox<>(new String[]{t.getDecoderName()});
-                    }
-
-                    c.setSelectedItem(t.getDecoderName());
-                    c.addActionListener(super::comboBoxAction);
-                    return c;
-                } else if (col == LOCKOPRCOL) {
-                    java.util.Vector<String> lockOperations = new java.util.Vector<>();  // Vector is a JComboBox ctor; List is not
-                    int modes = t.getPossibleLockModes();
-                    if ((modes & Turnout.CABLOCKOUT) != 0 && (modes & Turnout.PUSHBUTTONLOCKOUT) != 0) {
-                        lockOperations.add(bothText);
-                    }
-                    if ((modes & Turnout.CABLOCKOUT) != 0) {
-                        lockOperations.add(cabOnlyText);
-                    }
-                    if ((modes & Turnout.PUSHBUTTONLOCKOUT) != 0) {
-                        lockOperations.add(pushbutText);
-                    }
-                    lockOperations.add(noneText);
-                    JComboBox<String> c = new JComboBox<>(lockOperations);
-
-                    if (t.canLock(Turnout.CABLOCKOUT) && t.canLock(Turnout.PUSHBUTTONLOCKOUT)) {
-                        c.setSelectedItem(bothText);
-                    } else if (t.canLock(Turnout.PUSHBUTTONLOCKOUT)) {
-                        c.setSelectedItem(pushbutText);
-                    } else if (t.canLock(Turnout.CABLOCKOUT)) {
-                        c.setSelectedItem(cabOnlyText);
-                    } else {
-                        c.setSelectedItem(noneText);
-                    }
-                    c.addActionListener(super::comboBoxAction);
-                    return c;
-                } else if (col == STRAIGHTCOL) {
-
-                    String speed = t.getStraightSpeed();
-                    if (!speedListClosed.contains(speed)) {
-                        speedListClosed.add(speed);
-                    }
-                    JComboBox<String> c = new JComboBox<>(speedListClosed);
-                    c.setEditable(true);
-                    c.setSelectedItem(speed);
-                    c.addActionListener(super::comboBoxAction);
-                    return c;
-                } else if (col == DIVERGCOL) {
-
-                    String speed = t.getDivergingSpeed();
-                    if (!speedListThrown.contains(speed)) {
-                        speedListThrown.add(speed);
-                    }
-                    JComboBox<String> c = new JComboBox<>(speedListThrown);
-                    c.setEditable(true);
-                    c.setSelectedItem(speed);
-                    c.addActionListener(super::comboBoxAction);
-                    return c;
-                    // } else if (col == VALUECOL && _graphicState) { // not neeeded as the
-                    //  graphic ImageIconRenderer uses the same super.getValueAt(row, col) as
-                    // classic bean state text button
-                } else if (col == FORGETCOL) {
-                    return Bundle.getMessage("StateForgetButton");
-                } else if (col == QUERYCOL) {
-                    return Bundle.getMessage("StateQueryButton");
-                }
-                return super.getValueAt(row, col);
-            }
-
-            @Override
-            public void setValueAt(Object value, int row, int col) {
-                String name = sysNameList.get(row);
-                Turnout t = turnoutManager.getBySystemName(name);
-                if (t == null) {
-                    NullPointerException ex = new NullPointerException("Unexpected null turnout in turnout table");
-                    log.error(ex.getMessage(), ex); // log with stack trace
-                    throw ex;
-                }
-                if (col == INVERTCOL) {
-                    if (t.canInvert()) {
-                        t.setInverted((Boolean) value);
-                        fireTableRowsUpdated(row, row);
-                    }
-                } else if (col == LOCKCOL) {
-                    t.setLocked(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT, (Boolean) value);
-                    fireTableRowsUpdated(row, row);
-                } else if (col == MODECOL) {
-                    @SuppressWarnings("unchecked")
-                    String modeName = (String) ((JComboBox<String>) value).getSelectedItem();
-                    assert modeName != null;
-                    t.setFeedbackMode(modeName);
-                    fireTableRowsUpdated(row, row);
-                } else if (col == SENSOR1COL) {
-                    try {
-                        Sensor sensor = (Sensor) value;
-                        t.provideFirstFeedbackSensor(sensor != null ? sensor.getDisplayName() : null);
-                    } catch (jmri.JmriException e) {
-                        JOptionPane.showMessageDialog(null, e.toString());
-                    }
-                    fireTableRowsUpdated(row, row);
-                } else if (col == SENSOR2COL) {
-                    try {
-                        Sensor sensor = (Sensor) value;
-                        t.provideSecondFeedbackSensor(sensor != null ? sensor.getDisplayName() : null);
-                    } catch (jmri.JmriException e) {
-                        JOptionPane.showMessageDialog(null, e.toString());
-                    }
-                    fireTableRowsUpdated(row, row);
-                //} else if (col == OPSONOFFCOL) {
-                    // do nothing as this is handled by the combo box listener
-                } else if (col == OPSEDITCOL) {
-                    t.setInhibitOperation(false);
-                    @SuppressWarnings("unchecked") // cast to JComboBox<String> required in OPSEDITCOL
-                    JComboBox<String> cb = (JComboBox<String>) getValueAt(row, OPSONOFFCOL);
-                    log.debug("opsSelected = {}", getValueAt(row, OPSONOFFCOL).toString());
-                    editTurnoutOperation(t, cb);
-                    fireTableRowsUpdated(row, row);
-                } else if (col == EDITCOL) {
-                    class WindowMaker implements Runnable {
-
-                        final Turnout t;
-
-                        WindowMaker(Turnout t) {
-                            this.t = t;
-                        }
-
-                        @Override
-                        public void run() {
-                            editButton(t);
-                        }
-                    }
-                    WindowMaker w = new WindowMaker(t);
-                    javax.swing.SwingUtilities.invokeLater(w);
-                } else if (col == LOCKOPRCOL) {
-                    @SuppressWarnings("unchecked")
-                    String lockOpName = (String) ((JComboBox<String>) value)
-                            .getSelectedItem();
-                    assert lockOpName != null;
-                    if (lockOpName.equals(bothText)) {
-                        t.enableLockOperation(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT, true);
-                    }
-                    if (lockOpName.equals(cabOnlyText)) {
-                        t.enableLockOperation(Turnout.CABLOCKOUT, true);
-                        t.enableLockOperation(Turnout.PUSHBUTTONLOCKOUT, false);
-                    }
-                    if (lockOpName.equals(pushbutText)) {
-                        t.enableLockOperation(Turnout.CABLOCKOUT, false);
-                        t.enableLockOperation(Turnout.PUSHBUTTONLOCKOUT, true);
-                    }
-                    fireTableRowsUpdated(row, row);
-                } else if (col == LOCKDECCOL) {
-                    @SuppressWarnings("unchecked")
-                    String decoderName = (String) ((JComboBox<String>) value).getSelectedItem();
-                    t.setDecoderName(decoderName);
-                    fireTableRowsUpdated(row, row);
-                } else if (col == STRAIGHTCOL) {
-                    @SuppressWarnings("unchecked")
-                    String speed = (String) ((JComboBox<String>) value).getSelectedItem();
-                    try {
-                        t.setStraightSpeed(speed);
-                    } catch (jmri.JmriException ex) {
-                        JOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
-                        return;
-                    }
-                    if ((!speedListClosed.contains(speed))) {
-                        assert speed != null;
-                        if (!speed.contains("Global")) {
-                            speedListClosed.add(speed);
-                        }
-                    }
-                    fireTableRowsUpdated(row, row);
-                } else if (col == DIVERGCOL) {
-
-                    @SuppressWarnings("unchecked")
-                    String speed = (String) ((JComboBox<String>) value).getSelectedItem();
-                    try {
-                        t.setDivergingSpeed(speed);
-                    } catch (jmri.JmriException ex) {
-                        JOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
-                        return;
-                    }
-                    if ((!speedListThrown.contains(speed))) {
-                        assert speed != null;
-                        if (!speed.contains("Global")) {
-                            speedListThrown.add(speed);
-                        }
-                    }
-                    fireTableRowsUpdated(row, row);
-                } else if (col == FORGETCOL) {
-                    t.setCommandedState(Turnout.UNKNOWN);
-                } else if (col == QUERYCOL) {
-                    t.setCommandedState(Turnout.UNKNOWN);
-                    t.requestUpdateFromLayout();
-                } else if (col == VALUECOL && _graphicState) { // respond to clicking on ImageIconRenderer CellEditor
-                    clickOn(t);
-                    fireTableRowsUpdated(row, row);
-                } else {
-                    super.setValueAt(value, row, col);
-                    fireTableRowsUpdated(row, row);
-                }
-            }
-
-            @Override
-            public String getValue(@Nonnull String name) {
-                Turnout turn = turnoutManager.getBySystemName(name);
-                if (turn != null) {
-                    return turn.describeState(turn.getCommandedState());
-                }
-                return "Turnout not found";
-            }
-
-            @Override
-            public Manager<Turnout> getManager() {
-                return turnoutManager;
-            }
-
-            @Override
-            public Turnout getBySystemName(@Nonnull String name) {
-                return turnoutManager.getBySystemName(name);
-            }
-
-            @Override
-            public Turnout getByUserName(@Nonnull String name) {
-                return InstanceManager.getDefault(TurnoutManager.class).getByUserName(name);
-            }
-
-            @Override
-            protected String getMasterClassName() {
-                return getClassName();
-            }
-
-            @Override
-            public void clickOn(Turnout t) {
-                t.setCommandedState( t.getCommandedState()== Turnout.CLOSED ? Turnout.THROWN : Turnout.CLOSED);
-            }
-
-            @Override
-            public void configureTable(JTable tbl) {
-                table = tbl;
-
-                table.setDefaultRenderer(Boolean.class, new EnablingCheckboxRenderer());
-                setColumnToHoldButton(table, OPSEDITCOL, editButton());
-                setColumnToHoldButton(table, EDITCOL, editButton());
-                //Hide the following columns by default
-                XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
-                TableColumn column = columnModel.getColumnByModelIndex(STRAIGHTCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(DIVERGCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(KNOWNCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(MODECOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(SENSOR1COL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(SENSOR2COL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(OPSONOFFCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(OPSEDITCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(LOCKOPRCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(LOCKDECCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(FORGETCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(QUERYCOL);
-                columnModel.setColumnVisible(column, false);
-
-                super.configureTable(table);
-            }
-
-            // update table if turnout lock or feedback changes
-            @Override
-            protected boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
-                if (e.getPropertyName().equals("locked")) {
-                    return true;
-                }
-                if (e.getPropertyName().equals("feedbackchange")) {
-                    return true;
-                }
-                if (e.getPropertyName().equals("TurnoutDivergingSpeedChange")) {
-                    return true;
-                }
-                if (e.getPropertyName().equals("TurnoutStraightSpeedChange")) {
-                    return true;
-                } else {
-                    return super.matchPropertyName(e);
-                }
-            }
-
-            @Override
-            public void propertyChange(java.beans.PropertyChangeEvent e) {
-                if (e.getPropertyName().equals("DefaultTurnoutClosedSpeedChange")) {
-                    updateClosedList();
-                } else if (e.getPropertyName().equals("DefaultTurnoutThrownSpeedChange")) {
-                    updateThrownList();
-                } else {
-                    super.propertyChange(e);
-                }
-            }
-
-            /**
-             * Customize the turnout table Value (State) column to show an
-             * appropriate graphic for the turnout state if _graphicState =
-             * true, or (default) just show the localized state text when the
-             * TableDataModel is being called from ListedTableAction.
-             *
-             * @param table a JTable of Turnouts
-             */
-            @Override
-            protected void configValueColumn(JTable table) {
-                // have the value column hold a JPanel (icon)
-                //setColumnToHoldButton(table, VALUECOL, new JLabel("12345678")); // for larger, wide round icon, but cannot be converted to JButton
-                // add extras, override BeanTableDataModel
-                log.debug("Turnout configValueColumn (I am {})", super.toString());
-                if (_graphicState) { // load icons, only once
-                    table.setDefaultEditor(JLabel.class, new ImageIconRenderer()); // editor
-                    table.setDefaultRenderer(JLabel.class, new ImageIconRenderer()); // item class copied from SwitchboardEditor panel
-                } else {
-                    super.configValueColumn(table); // classic text style state indication
-                }
-            }
-
-            @Override
-            public JTable makeJTable(@Nonnull String name, @Nonnull TableModel model, @CheckForNull RowSorter<? extends TableModel> sorter) {
-                return this.configureJTable(name, this.makeJTable(model), sorter);
-            }
-
-            private JTable makeJTable(TableModel model) {
-                return new JTable(model) {
-
-                    @Override
-                    public String getToolTipText(@Nonnull MouseEvent e) {
-                        java.awt.Point p = e.getPoint();
-                        int rowIndex = rowAtPoint(p);
-                        int colIndex = columnAtPoint(p);
-                        int realRowIndex = convertRowIndexToModel(rowIndex);
-                        int realColumnIndex = convertColumnIndexToModel(colIndex);
-                        return getCellToolTip(this, realRowIndex, realColumnIndex);
-                    }
-
-                    @Override
-                    public TableCellRenderer getCellRenderer(int row, int column) {
-                        // Convert the displayed index to the model index, rather than the displayed index
-                        int modelColumn = this.convertColumnIndexToModel(column);
-                        if (modelColumn == SENSOR1COL || modelColumn == SENSOR2COL) {
-                            return getRenderer(row, modelColumn);
-                        } else {
-                            return super.getCellRenderer(row, column);
-                        }
-                    }
-
-                    @Override
-                    public TableCellEditor getCellEditor(int row, int column) {
-                        //Convert the displayed index to the model index, rather than the displayed index
-                        int modelColumn = this.convertColumnIndexToModel(column);
-                        if (modelColumn == SENSOR1COL || modelColumn == SENSOR2COL) {
-                            return getEditor(row, modelColumn);
-                        } else {
-                            return super.getCellEditor(row, column);
-                        }
-                    }
-
-                    TableCellRenderer getRenderer(int row, int column) {
-                        TableCellRenderer retval;
-                        Turnout t = (Turnout) getModel().getValueAt(row, SYSNAMECOL);
-                        java.util.Objects.requireNonNull(t, "SYSNAMECOL column content must be nonnull");
-                        switch (column) {
-                            case SENSOR1COL:
-                                retval = rendererMapSensor1.get(t);
-                                break;
-                            case SENSOR2COL:
-                                retval = rendererMapSensor2.get(t);
-                                break;
-                            default:
-                                return null;
-                        }
-
-                        if (retval == null) {
-                            if (column == SENSOR1COL) {
-                                loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
-                            } else {
-                                loadRenderEditMaps(rendererMapSensor2, editorMapSensor2, t, t.getSecondSensor());
-                            }
-                            retval = rendererMapSensor1.get(t);
-                        }
-                        log.debug("fetched for Turnout \"{}\" renderer {}", t, retval);
-                        return retval;
-                    }
-
-                    TableCellEditor getEditor(int row, int column) {
-                        TableCellEditor retval;
-                        Turnout t = (Turnout) getModel().getValueAt(row, SYSNAMECOL);
-                        java.util.Objects.requireNonNull(t, "SYSNAMECOL column content must be nonnull");
-                        switch (column) {
-                            case SENSOR1COL:
-                                retval = editorMapSensor1.get(t);
-                                break;
-                            case SENSOR2COL:
-                                retval = editorMapSensor2.get(t);
-                                break;
-                            default:
-                                return null;
-                        }
-                        if (retval == null) {
-                            if (column == SENSOR1COL) {
-                                loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
-                                retval = editorMapSensor1.get(t);
-                            } else { //Must be two
-                                loadRenderEditMaps(rendererMapSensor2, editorMapSensor2, t, t.getSecondSensor());
-                                retval = editorMapSensor2.get(t);
-                            }
-                        }
-                        log.debug("fetched for Turnout \"{}\" editor {}", t, retval);
-                        return retval;
-                    }
-
-                    protected void loadRenderEditMaps(Hashtable<Turnout, TableCellRenderer> r, Hashtable<Turnout, TableCellEditor> e,
-                            Turnout t, Sensor s) {
-                        NamedBeanComboBox<Sensor> c = new NamedBeanComboBox<>(InstanceManager.getDefault(SensorManager.class), s, DisplayOptions.DISPLAYNAME);
-                        c.setAllowNull(true);
-
-                        BeanBoxRenderer renderer = new BeanBoxRenderer();
-                        renderer.setSelectedItem(s);
-                        r.put(t, renderer);
-
-                        TableCellEditor editor = new BeanComboBoxEditor(c);
-                        e.put(t, editor);
-                        log.debug("initialize for Turnout \"{}\" Sensor \"{}\"", t, s);
-                    }
-
-                    final Hashtable<Turnout, TableCellRenderer> rendererMapSensor1 = new Hashtable<>();
-                    final Hashtable<Turnout, TableCellEditor> editorMapSensor1 = new Hashtable<>();
-
-                    final Hashtable<Turnout, TableCellRenderer> rendererMapSensor2 = new Hashtable<>();
-                    final Hashtable<Turnout, TableCellEditor> editorMapSensor2 = new Hashtable<>();
-                };
-            }
-
-            @Override
-            protected void setColumnIdentities(JTable table) {
-                super.setColumnIdentities(table);
-                Enumeration<TableColumn> columns;
-                if (table.getColumnModel() instanceof XTableColumnModel) {
-                    columns = ((XTableColumnModel) table.getColumnModel()).getColumns(false);
-                } else {
-                    columns = table.getColumnModel().getColumns();
-                }
-                while (columns.hasMoreElements()) {
-                    TableColumn column = columns.nextElement();
-                    switch (column.getModelIndex()) {
-                        case FORGETCOL:
-                            column.setIdentifier("ForgetState");
-                            break;
-                        case QUERYCOL:
-                            column.setIdentifier("QueryState");
-                            break;
-                        default:
-                        // use existing value
-                    }
-                }
-            }
-
-            /**
-             * Visualize state in table as a graphic, customized for Turnouts (4
-             * states). Renderer and Editor are identical, as the cell contents
-             * are not actually edited, only used to toggle state using
-             * {@link #clickOn(Turnout)}.
-             *
-             * @see jmri.jmrit.beantable.BlockTableAction#createModel()
-             * @see jmri.jmrit.beantable.LightTableAction#createModel()
-             */
-            class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
-
-                protected JLabel label;
-                protected String rootPath = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor
-                protected char beanTypeChar = 'T'; // for Turnout
-                protected String onIconPath = rootPath + beanTypeChar + "-on-s.png";
-                protected String offIconPath = rootPath + beanTypeChar + "-off-s.png";
-                protected BufferedImage onImage;
-                protected BufferedImage offImage;
-                protected ImageIcon onIcon;
-                protected ImageIcon offIcon;
-                protected int iconHeight = -1;
-
-                @Override
-                public Component getTableCellRendererComponent(
-                        JTable table, Object value, boolean isSelected,
-                        boolean hasFocus, int row, int column) {
-                    log.debug("Renderer Item = {}, State = {}", row, value);
-                    if (iconHeight < 0) { // load resources only first time, either for renderer or editor
-                        loadIcons();
-                        log.debug("icons loaded");
-                    }
-                    return updateLabel((String) value, row);
-                }
-
-                @Override
-                public Component getTableCellEditorComponent(
-                        JTable table, Object value, boolean isSelected,
-                        int row, int column) {
-                    log.debug("Renderer Item = {}, State = {}", row, value);
-                    if (iconHeight < 0) { // load resources only first time, either for renderer or editor
-                        loadIcons();
-                        log.debug("icons loaded");
-                    }
-                    return updateLabel((String) value, row);
-                }
-
-                public JLabel updateLabel(String value, int row) {
-                    if (iconHeight > 0) { // if necessary, increase row height;
-                        table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5));
-                    }
-                    if (value.equals(closedText) && onIcon != null) {
-                        label = new JLabel(onIcon);
-                        label.setVerticalAlignment(JLabel.BOTTOM);
-                        log.debug("onIcon set");
-                    } else if (value.equals(thrownText) && offIcon != null) {
-                        label = new JLabel(offIcon);
-                        label.setVerticalAlignment(JLabel.BOTTOM);
-                        log.debug("offIcon set");
-                    } else if (value.equals(Bundle.getMessage("BeanStateInconsistent"))) {
-                        label = new JLabel("X", JLabel.CENTER); // centered text alignment
-                        label.setForeground(Color.red);
-                        log.debug("Turnout state inconsistent");
-                        iconHeight = 0;
-                    } else if (value.equals(Bundle.getMessage("BeanStateUnknown"))) {
-                        label = new JLabel("?", JLabel.CENTER); // centered text alignment
-                        log.debug("Turnout state unknown");
-                        iconHeight = 0;
-                    } else { // failed to load icon
-                        label = new JLabel(value, JLabel.CENTER); // centered text alignment
-                        log.warn("Error reading icons for TurnoutTable");
-                        iconHeight = 0;
-                    }
-                    label.setToolTipText(value);
-                    label.addMouseListener(new MouseAdapter() {
-                        @Override
-                        public final void mousePressed(MouseEvent evt) {
-                            log.debug("Clicked on icon in row {}", row);
-                            stopCellEditing();
-                        }
-                    });
-                    return label;
-                }
-
-                @Override
-                public Object getCellEditorValue() {
-                    log.debug("getCellEditorValue, me = {})", this.toString());
-                    return this.toString();
-                }
-
-                /**
-                 * Read and buffer graphics. Only called once for this table.
-                 *
-                 * @see #getTableCellEditorComponent(JTable, Object, boolean,
-                 * int, int)
-                 */
-                protected void loadIcons() {
-                    try {
-                        onImage = ImageIO.read(new File(onIconPath));
-                        offImage = ImageIO.read(new File(offIconPath));
-                    } catch (IOException ex) {
-                        log.error("error reading image from {} or {}", onIconPath, offIconPath, ex);
-                    }
-                    log.debug("Success reading images");
-                    int imageWidth = onImage.getWidth();
-                    int imageHeight = onImage.getHeight();
-                    // scale icons 50% to fit in table rows
-                    Image smallOnImage = onImage.getScaledInstance(imageWidth / 2, imageHeight / 2, Image.SCALE_DEFAULT);
-                    Image smallOffImage = offImage.getScaledInstance(imageWidth / 2, imageHeight / 2, Image.SCALE_DEFAULT);
-                    onIcon = new ImageIcon(smallOnImage);
-                    offIcon = new ImageIcon(smallOffImage);
-                    iconHeight = onIcon.getIconHeight();
-                }
-
-            } // end of ImageIconRenderer class
-
-        }; // end of custom data model
-    }
-
-    private void updateClosedList() {
-        speedListClosed.remove(defaultClosedSpeedText);
-        defaultClosedSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultClosedSpeed());
-        speedListClosed.add(0, defaultClosedSpeedText);
-        m.fireTableDataChanged();
-    }
-
-    private void updateThrownList() {
-        speedListThrown.remove(defaultThrownSpeedText);
-        defaultThrownSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultThrownSpeed());
-        speedListThrown.add(0, defaultThrownSpeedText);
-        m.fireTableDataChanged();
+        m = new TurnoutTableDataModel(turnoutManager);
     }
 
     /**
@@ -1003,39 +154,6 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
     }
 
     /**
-     * Create a {@literal JComboBox<String>} containing all the options for
-     * turnout automation parameters for this turnout.
-     *
-     * @param t the turnout
-     * @return the JComboBox
-     */
-    protected JComboBox<String> makeAutomationBox(Turnout t) {
-        String[] str = new String[]{"empty"};
-        final JComboBox<String> cb = new JComboBox<>(str);
-        final Turnout myTurnout = t;
-        updateAutomationBox(t, cb);
-        cb.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                setTurnoutOperation(myTurnout, cb);
-                cb.removeActionListener(this);  // avoid recursion
-                updateAutomationBox(myTurnout, cb);
-                cb.addActionListener(this);
-            }
-        });
-        return cb;
-    }
-
-    /**
-     * Create a JButton to edit a turnout's operation.
-     *
-     * @return the JButton
-     */
-    protected JButton editButton() {
-        return new JButton(Bundle.getMessage("EditTurnoutOperation"));
-    }
-
-    /**
      * Add the content and make the appropriate selection to a combo box for a
      * turnout's automation choices.
      *
@@ -1093,163 +211,13 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
     }
 
     /**
-     * Set the turnout's operation info based on the contents of the combo box.
-     *
-     * @param t  turnout being configured
-     * @param cb JComboBox for ops for t in the TurnoutTable
-     */
-    protected void setTurnoutOperation(Turnout t, JComboBox<String> cb) {
-        switch (cb.getSelectedIndex()) {
-            case 0:   // Off
-                t.setInhibitOperation(true);
-                t.setTurnoutOperation(null);
-                break;
-            case 1:   // Default
-                t.setInhibitOperation(false);
-                t.setTurnoutOperation(null);
-                break;
-            default:  // named operation
-                t.setInhibitOperation(false);
-                t.setTurnoutOperation(InstanceManager.getDefault(TurnoutOperationManager.class).
-                        getOperation(((String) Objects.requireNonNull(cb.getSelectedItem()))));
-                break;
-        }
-    }
-
-    /**
-     * Create action to edit a turnout in Edit pane. (also used in windowTest)
-     *
-     * @param t the turnout to be edited
-     */
-    void editButton(Turnout t) {
-        jmri.jmrit.beantable.beanedit.TurnoutEditAction beanEdit = new jmri.jmrit.beantable.beanedit.TurnoutEditAction();
-        beanEdit.setBean(t);
-        beanEdit.actionPerformed(null);
-    }
-
-    private static java.util.concurrent.atomic.AtomicBoolean editingOps = new java.util.concurrent.atomic.AtomicBoolean(false);
-
-    /**
-     * Pop up a TurnoutOperationConfig for the turnout.
-     *
-     * @param t   turnout
-     * @param box JComboBox that triggered the edit
-     */
-    protected void editTurnoutOperation(Turnout t, JComboBox<String> box) {
-        if (!editingOps.getAndSet(true)) { // don't open a second edit ops pane
-            TurnoutOperation op = t.getTurnoutOperation();
-            if (op == null) {
-                TurnoutOperation proto = InstanceManager.getDefault(TurnoutOperationManager.class).getMatchingOperationAlways(t);
-                if (proto != null) {
-                    op = proto.makeNonce(t);
-                    t.setTurnoutOperation(op);
-                }
-            }
-            if (op != null) {
-                if (!op.isNonce()) {
-                    op = op.makeNonce(t);
-                }
-                // make and show edit dialog
-                log.debug("TurnoutOpsEditDialog starting");
-                TurnoutOperationEditor dialog = new TurnoutOperationEditor(this, f, op, t, box);
-                dialog.setVisible(true);
-            } else {
-                JOptionPane.showMessageDialog(f, Bundle.getMessage("TurnoutOperationErrorDialog"),
-                        Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
-            }
-        }
-    }
-
-    protected static class TurnoutOperationEditor extends JDialog {
-
-        TurnoutOperationConfig config;
-        TurnoutOperation myOp;
-        Turnout myTurnout;
-
-        TurnoutOperationEditor(TurnoutTableAction tta, JFrame parent, TurnoutOperation op, Turnout t, JComboBox<String> box) {
-            super(parent);
-            final TurnoutOperationEditor self = this;
-            myOp = op;
-            myOp.addPropertyChangeListener(evt -> {
-                if (evt.getPropertyName().equals("Deleted")) {
-                    setVisible(false);
-                }
-            });
-            myTurnout = t;
-            config = TurnoutOperationConfig.getConfigPanel(op);
-            setTitle();
-            log.debug("TurnoutOpsEditDialog title set");
-            if (config != null) {
-                log.debug("OpsEditDialog opening");
-                Box outerBox = Box.createVerticalBox();
-                outerBox.add(config);
-                Box buttonBox = Box.createHorizontalBox();
-                JButton nameButton = new JButton(Bundle.getMessage("NameSetting"));
-                nameButton.addActionListener(e -> {
-                    String newName = JOptionPane.showInputDialog(Bundle.getMessage("NameParameterSetting"));
-                    if (newName != null && !newName.isEmpty()) {
-                        if (!myOp.rename(newName)) {
-                            JOptionPane.showMessageDialog(self, Bundle.getMessage("TurnoutErrorDuplicate"),
-                                    Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
-                        }
-                        setTitle();
-                        myTurnout.setTurnoutOperation(null);
-                        myTurnout.setTurnoutOperation(myOp); // no-op but updates display - have to <i>change</i> value
-                    }
-                });
-                JButton okButton = new JButton(Bundle.getMessage("ButtonOK"));
-                okButton.addActionListener(e -> {
-                    config.endConfigure();
-                    if (myOp.isNonce() && myOp.equivalentTo(myOp.getDefinitive())) {
-                        myTurnout.setTurnoutOperation(null);
-                        myOp.dispose();
-                        myOp = null;
-                    }
-                    self.setVisible(false);
-                    editingOps.set(false);
-                });
-                JButton cancelButton = new JButton(Bundle.getMessage("ButtonCancel"));
-                cancelButton.addActionListener(e -> {
-                    self.setVisible(false);
-                    editingOps.set(false);
-                });
-                buttonBox.add(Box.createHorizontalGlue());
-                if (!op.isDefinitive()) {
-                    buttonBox.add(nameButton);
-                }
-                buttonBox.add(okButton);
-                buttonBox.add(cancelButton);
-                outerBox.add(buttonBox);
-                getContentPane().add(outerBox);
-                this.addWindowListener(new java.awt.event.WindowAdapter() {
-                    @Override
-                    public void windowClosing(java.awt.event.WindowEvent e) {
-                        editingOps.set(false);
-                    }
-                });
-            } else {
-                log.error("Error opening Turnout automation edit pane");
-            }
-            pack();
-        }
-
-        private void setTitle() {
-            String title = Bundle.getMessage("TurnoutOperationTitle") + " \"" + myOp.getName() + "\"";
-            if (myOp.isNonce()) {
-                title = Bundle.getMessage("TurnoutOperationForTurnout") + " " + myTurnout.getSystemName();
-            }
-            setTitle(title);
-        }
-    }
-
-    /**
      * Show a pane to configure closed and thrown turnout speed defaults.
      *
      * @param _who parent JFrame to center the pane on
      */
     protected void setDefaultSpeeds(JFrame _who) {
-        JComboBox<String> thrownCombo = new JComboBox<>(speedListThrown);
-        JComboBox<String> closedCombo = new JComboBox<>(speedListClosed);
+        JComboBox<String> thrownCombo = new JComboBox<>((( TurnoutTableDataModel)m).speedListThrown);
+        JComboBox<String> closedCombo = new JComboBox<>((( TurnoutTableDataModel)m).speedListClosed);
         thrownCombo.setEditable(true);
         closedCombo.setEditable(true);
 
@@ -1261,8 +229,8 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         closed.add(new JLabel(Bundle.getMessage("MakeLabel", Bundle.getMessage("ClosedSpeed"))));
         closed.add(closedCombo);
 
-        thrownCombo.removeItem(defaultThrownSpeedText);
-        closedCombo.removeItem(defaultClosedSpeedText);
+        thrownCombo.removeItem((( TurnoutTableDataModel)m).defaultThrownSpeedText);
+        closedCombo.removeItem((( TurnoutTableDataModel)m).defaultClosedSpeedText);
 
         thrownCombo.setSelectedItem(turnoutManager.getDefaultThrownSpeed());
         closedCombo.setSelectedItem(turnoutManager.getDefaultClosedSpeed());
@@ -1308,12 +276,36 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         }
     }
 
+    private final JCheckBox doAutomationBox = new JCheckBox(Bundle.getMessage("AutomaticRetry"));
     private final TriStateJCheckBox showFeedbackBox = new TriStateJCheckBox(Bundle.getMessage("ShowFeedbackInfo"));
     private final TriStateJCheckBox showLockBox = new TriStateJCheckBox(Bundle.getMessage("ShowLockInfo"));
     private final TriStateJCheckBox showTurnoutSpeedBox = new TriStateJCheckBox(Bundle.getMessage("ShowTurnoutSpeedDetails"));
-    private final JCheckBox doAutomationBox = new JCheckBox(Bundle.getMessage("AutomaticRetry"));
     private final TriStateJCheckBox showStateForgetAndQueryBox = new TriStateJCheckBox(Bundle.getMessage("ShowStateForgetAndQuery"));
 
+    private void initCheckBoxes(){
+        doAutomationBox.setSelected(InstanceManager.getDefault(TurnoutOperationManager.class).getDoOperations());
+        doAutomationBox.setToolTipText(Bundle.getMessage("TurnoutDoAutomationBoxTooltip"));
+        doAutomationBox.addActionListener(e -> InstanceManager.getDefault(TurnoutOperationManager.class).setDoOperations(doAutomationBox.isSelected()));
+        
+        showFeedbackBox.setToolTipText(Bundle.getMessage("TurnoutFeedbackToolTip"));
+        showLockBox.setToolTipText(Bundle.getMessage("TurnoutLockToolTip"));
+        showTurnoutSpeedBox.setToolTipText(Bundle.getMessage("TurnoutSpeedToolTip"));
+        showStateForgetAndQueryBox.setToolTipText(Bundle.getMessage("StateForgetAndQueryBoxToolTip"));
+    }
+    
+    @Override
+    protected void configureTable(JTable table){
+        super.configureTable(table);
+        showStateForgetAndQueryBox.addActionListener(e ->
+            ((TurnoutTableDataModel) m).showStateForgetAndQueryChanged(showStateForgetAndQueryBox.isSelected(),table));
+        showTurnoutSpeedBox.addActionListener(e ->
+            ((TurnoutTableDataModel) m).showTurnoutSpeedChanged(showTurnoutSpeedBox.isSelected(),table));
+        showFeedbackBox.addActionListener(e ->
+            ((TurnoutTableDataModel) m).showFeedbackChanged(showFeedbackBox.isSelected(), table));
+        showLockBox.addActionListener(e ->
+            ((TurnoutTableDataModel) m).showLockChanged(showLockBox.isSelected(),table));
+    }
+    
     /**
      * Add the check boxes to show/hide extra columns to the Turnout table
      * frame.
@@ -1325,27 +317,12 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
      */
     @Override
     public void addToFrame(BeanTableFrame<Turnout> f) {
+        initCheckBoxes();
         f.addToBottomBox(doAutomationBox, this.getClass().getName());
-        doAutomationBox.setSelected(InstanceManager.getDefault(TurnoutOperationManager.class).getDoOperations());
-        doAutomationBox.setToolTipText(Bundle.getMessage("TurnoutDoAutomationBoxTooltip"));
-        doAutomationBox.addActionListener(e -> InstanceManager.getDefault(TurnoutOperationManager.class).setDoOperations(doAutomationBox.isSelected()));
-        
         f.addToBottomBox(showFeedbackBox, this.getClass().getName());
-        showFeedbackBox.setToolTipText(Bundle.getMessage("TurnoutFeedbackToolTip"));
-        showFeedbackBox.addActionListener(e -> showFeedbackChanged());
-        
         f.addToBottomBox(showLockBox, this.getClass().getName());
-        showLockBox.setToolTipText(Bundle.getMessage("TurnoutLockToolTip"));
-        showLockBox.addActionListener(e -> showLockChanged());
-        
         f.addToBottomBox(showTurnoutSpeedBox, this.getClass().getName());
-        showTurnoutSpeedBox.setToolTipText(Bundle.getMessage("TurnoutSpeedToolTip"));
-        showTurnoutSpeedBox.addActionListener(e -> showTurnoutSpeedChanged());
-        
         f.addToBottomBox(showStateForgetAndQueryBox, this.getClass().getName());
-        showStateForgetAndQueryBox.setToolTipText(Bundle.getMessage("StateForgetAndQueryBoxToolTip"));
-        showStateForgetAndQueryBox.addActionListener(e -> showStateForgetAndQueryChanged());
-
     }
 
     /**
@@ -1362,28 +339,12 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         if (turnoutManager.getClass().getName().contains("ProxyTurnoutManager")) {
             connectionName = "All"; // NOI18N
         }
-
+        initCheckBoxes();
         f.addToBottomBox(doAutomationBox, connectionName);
-        doAutomationBox.setSelected(InstanceManager.getDefault(TurnoutOperationManager.class).getDoOperations());
-        doAutomationBox.setToolTipText(Bundle.getMessage("TurnoutDoAutomationBoxTooltip"));
-        doAutomationBox.addActionListener(e -> InstanceManager.getDefault(TurnoutOperationManager.class).setDoOperations(doAutomationBox.isSelected()));
-        
         f.addToBottomBox(showFeedbackBox, connectionName);
-        showFeedbackBox.setToolTipText(Bundle.getMessage("TurnoutFeedbackToolTip"));
-        showFeedbackBox.addActionListener(e -> showFeedbackChanged());
-        
         f.addToBottomBox(showLockBox, connectionName);
-        showLockBox.setToolTipText(Bundle.getMessage("TurnoutLockToolTip"));
-        showLockBox.addActionListener(e -> showLockChanged());
-        
         f.addToBottomBox(showTurnoutSpeedBox, connectionName);
-        showTurnoutSpeedBox.setToolTipText(Bundle.getMessage("TurnoutSpeedToolTip"));
-        showTurnoutSpeedBox.addActionListener(e -> showTurnoutSpeedChanged());
-        
         f.addToBottomBox(showStateForgetAndQueryBox, connectionName);
-        showStateForgetAndQueryBox.setToolTipText(Bundle.getMessage("StateForgetAndQueryBoxToolTip"));
-        showStateForgetAndQueryBox.addActionListener(e -> showStateForgetAndQueryChanged());
-  
     }
     
     /**
@@ -1394,70 +355,25 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
     protected void columnsVisibleUpdated(boolean[] colsVisible){
         log.debug("columns updated {}",colsVisible);
         showFeedbackBox.setState(new boolean[]{
-            colsVisible[KNOWNCOL],
-            colsVisible[MODECOL],
-            colsVisible[SENSOR1COL],
-            colsVisible[SENSOR2COL],
-            colsVisible[OPSONOFFCOL],
-            colsVisible[OPSEDITCOL]});
+            colsVisible[TurnoutTableDataModel.KNOWNCOL],
+            colsVisible[TurnoutTableDataModel.MODECOL],
+            colsVisible[TurnoutTableDataModel.SENSOR1COL],
+            colsVisible[TurnoutTableDataModel.SENSOR2COL],
+            colsVisible[TurnoutTableDataModel.OPSONOFFCOL],
+            colsVisible[TurnoutTableDataModel.OPSEDITCOL]});
         
         showLockBox.setState(new boolean[]{
-            colsVisible[LOCKDECCOL],
-            colsVisible[LOCKOPRCOL]});
+            colsVisible[TurnoutTableDataModel.LOCKDECCOL],
+            colsVisible[TurnoutTableDataModel.LOCKOPRCOL]});
         
         showTurnoutSpeedBox.setState(new boolean[]{
-            colsVisible[STRAIGHTCOL],
-            colsVisible[DIVERGCOL]});
+            colsVisible[TurnoutTableDataModel.STRAIGHTCOL],
+            colsVisible[TurnoutTableDataModel.DIVERGCOL]});
         
         showStateForgetAndQueryBox.setState(new boolean[]{
-            colsVisible[FORGETCOL],
-            colsVisible[QUERYCOL]});
+            colsVisible[TurnoutTableDataModel.FORGETCOL],
+            colsVisible[TurnoutTableDataModel.QUERYCOL]});
         
-    }
-
-    void showFeedbackChanged() {
-        boolean showFeedback = showFeedbackBox.isSelected();
-        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
-        TableColumn column = columnModel.getColumnByModelIndex(KNOWNCOL);
-        columnModel.setColumnVisible(column, showFeedback);
-        column = columnModel.getColumnByModelIndex(MODECOL);
-        columnModel.setColumnVisible(column, showFeedback);
-        column = columnModel.getColumnByModelIndex(SENSOR1COL);
-        columnModel.setColumnVisible(column, showFeedback);
-        column = columnModel.getColumnByModelIndex(SENSOR2COL);
-        columnModel.setColumnVisible(column, showFeedback);
-        column = columnModel.getColumnByModelIndex(OPSONOFFCOL);
-        columnModel.setColumnVisible(column, showFeedback);
-        column = columnModel.getColumnByModelIndex(OPSEDITCOL);
-        columnModel.setColumnVisible(column, showFeedback);
-    }
-
-    void showLockChanged() {
-        boolean showLock = showLockBox.isSelected();
-        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
-        TableColumn column = ((XTableColumnModel) table.getColumnModel()).getColumnByModelIndex(LOCKDECCOL);
-        columnModel.setColumnVisible(column, showLock);
-        column = columnModel.getColumnByModelIndex(LOCKOPRCOL);
-        columnModel.setColumnVisible(column, showLock);
-    }
-
-    public void showTurnoutSpeedChanged() {
-        boolean showTurnoutSpeed = showTurnoutSpeedBox.isSelected();
-        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
-        TableColumn column = ((XTableColumnModel) table.getColumnModel()).getColumnByModelIndex(STRAIGHTCOL);
-        columnModel.setColumnVisible(column, showTurnoutSpeed);
-        column = columnModel.getColumnByModelIndex(DIVERGCOL);
-        columnModel.setColumnVisible(column, showTurnoutSpeed);
-    }
-
-    public void showStateForgetAndQueryChanged() {
-        boolean showStateForgetAndQuery = showStateForgetAndQueryBox.isSelected();
-        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
-
-        TableColumn column = columnModel.getColumnByModelIndex(FORGETCOL);
-        columnModel.setColumnVisible(column, showStateForgetAndQuery);
-        column = columnModel.getColumnByModelIndex(QUERYCOL);
-        columnModel.setColumnVisible(column, showStateForgetAndQuery);
     }
 
     /**
@@ -1771,39 +687,6 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
     @Override
     public String getClassDescription() {
         return Bundle.getMessage("TitleTurnoutTable");
-    }
-
-    static class BeanBoxRenderer extends NamedBeanComboBox<Sensor> implements TableCellRenderer {
-
-        public BeanBoxRenderer() {
-            super(InstanceManager.getDefault(SensorManager.class));
-            setAllowNull(true);
-        }
-
-        @Override
-        public Component getTableCellRendererComponent(JTable table, Object value,
-                boolean isSelected, boolean hasFocus, int row, int column) {
-            if (isSelected) {
-                setForeground(table.getSelectionForeground());
-                super.setBackground(table.getSelectionBackground());
-            } else {
-                setForeground(table.getForeground());
-                setBackground(table.getBackground());
-            }
-            if (value instanceof Sensor) {
-                setSelectedItem(value);
-            } else {
-                setSelectedItem(null);
-            }
-            return this;
-        }
-    }
-
-    static class BeanComboBoxEditor extends DefaultCellEditor {
-
-        public BeanComboBoxEditor(NamedBeanComboBox<Sensor> beanBox) {
-            super(beanBox);
-        }
     }
 
     private final static Logger log = LoggerFactory.getLogger(TurnoutTableAction.class);

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -48,13 +48,22 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
     private Manager<Sensor> senManager = null;
     protected boolean _graphicState = false; // icon state col updated from prefs
 
+    /**
+     * Create a new Sensor Table Data Model.
+     * The default Manager for the bean type will be a Proxy Manager.
+     */
     public SensorTableDataModel() {
         super();
     }
 
+    /**
+     * Create a new Sensor Table Data Model.
+     * The default Manager for the bean type will be a Proxy Manager unless
+     * one is specified here.
+     * @param manager Bean Manager.
+     */
     public SensorTableDataModel(Manager<Sensor> manager) {
         super(manager);
-        this.setManager(manager);
         updateNameList();
         // load graphic state column display preference
         _graphicState = InstanceManager.getDefault(GuiLafPreferencesManager.class).isGraphicTableState();
@@ -136,12 +145,7 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
     @Override
     protected void clickOn(Sensor t) {
         try {
-            int state = t.getKnownState();
-            if (state == Sensor.INACTIVE) {
-                t.setKnownState(Sensor.ACTIVE);
-            } else {
-                t.setKnownState(Sensor.INACTIVE);
-            }
+            t.setKnownState(t.getKnownState() == Sensor.INACTIVE ? Sensor.ACTIVE : Sensor.INACTIVE );
         } catch (JmriException e) {
             log.warn("Error setting state", e);
         }
@@ -294,7 +298,6 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
             case PULLUPCOL:
                 PullResistanceComboBox c = new PullResistanceComboBox(Sensor.PullResistance.values());
                 c.setSelectedItem(s.getPullResistance());
-                c.addActionListener(super::comboBoxAction);
                 return c;
             case FORGETCOL:
                 return Bundle.getMessage("StateForgetButton");
@@ -461,7 +464,7 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
                 loadIcons();
                 log.debug("icons loaded");
             }
-            return updateLabel((String) value, row);
+            return updateLabel((String) value, row, table);
         }
 
         /**
@@ -476,10 +479,10 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
                 loadIcons();
                 log.debug("icons loaded");
             }
-            return updateLabel((String) value, row);
+            return updateLabel((String) value, row, table);
         }
 
-        public JLabel updateLabel(String value, int row) {
+        public JLabel updateLabel(String value, int row, JTable table) {
             if (iconHeight > 0) { // if necessary, increase row height;
                 table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5)); // adjust table row height for Sensor icon
             }
@@ -555,11 +558,8 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      */
     @Override
     public void configureTable(JTable table) {
-        this.table = table;
         super.configureTable(table);
     }
-
-    protected JTable table;
 
     void editButton(Sensor s) {
         jmri.jmrit.beantable.beanedit.SensorEditAction beanEdit = new jmri.jmrit.beantable.beanedit.SensorEditAction();
@@ -571,8 +571,9 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      * Show or hide the Debounce columns.
      * USEGLOBALDELAY, ACTIVEDELAY, INACTIVEDELAY
      * @param show true to display, false to hide.
+     * @param table the JTable to set column visibility on.
      */
-    public void showDebounce(boolean show) {
+    public void showDebounce(boolean show, JTable table) {
         XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
         TableColumn column = columnModel.getColumnByModelIndex(USEGLOBALDELAY);
         columnModel.setColumnVisible(column, show);
@@ -586,19 +587,20 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      * Show or hide the Pullup column.
      * PULLUPCOL
      * @param show true to display, false to hide.
+     * @param table the JTable to set column visibility on.
      */
-    public void showPullUp(boolean show) {
+    public void showPullUp(boolean show, JTable table) {
         XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
         TableColumn column = columnModel.getColumnByModelIndex(PULLUPCOL);
         columnModel.setColumnVisible(column, show);
     }
 
     /**
-     * Show or hide the State - Forget and Query columns.
-     * FORGETCOL, QUERYCOL
+     * Show or hide the State - Forget and Query columns.FORGETCOL, QUERYCOL
      * @param show true to display, false to hide.
+     * @param table the JTable to set column visibility on.
      */
-    public void showStateForgetAndQuery(boolean show) {
+    public void showStateForgetAndQuery(boolean show, JTable table) {
         XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
         TableColumn column = columnModel.getColumnByModelIndex(FORGETCOL);
         columnModel.setColumnVisible(column, show);
@@ -610,7 +612,6 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
         return jmri.jmrit.beantable.SensorTableAction.class.getName();
     }
 
-//    public static final ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrit.beantable.BeanTableBundle");
     public String getClassDescription() {
         return Bundle.getMessage("TitleSensorTable");
     }

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -439,7 +439,7 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      * Renderer and Editor are identical, as the cell contents are not actually
      * edited, only used to toggle state using {@link #clickOn}.
      */
-    class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
+    static class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
 
         protected JLabel label;
         protected String rootPath = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor

--- a/java/src/jmri/jmrit/beantable/turnout/Bundle.java
+++ b/java/src/jmri/jmrit/beantable/turnout/Bundle.java
@@ -1,0 +1,97 @@
+package jmri.jmrit.beantable.turnout;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Locale;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.jmrit.beantable.Bundle {
+
+    @CheckForNull
+    private static final String name = null; // no local resources
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static public String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    @CheckForNull
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
@@ -29,6 +29,7 @@ public class TurnoutOperationEditorDialog extends JDialog {
     /**
      * Pop up a TurnoutOperationConfig Dialog for the turnout.
      *
+     * @param op TunoutOperation to edit.
      * @param t   turnout
      * @param box JComboBox that triggered the edit, currently unused.
      */

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
@@ -1,0 +1,120 @@
+package jmri.jmrit.beantable.turnout;
+
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.Turnout;
+import jmri.TurnoutOperation;
+import static jmri.jmrit.beantable.turnout.TurnoutTableDataModel.editingOps;
+import jmri.jmrit.turnoutoperations.TurnoutOperationConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Display a TurnoutOperationConfig Dialog for the turnout.
+ * 
+ * Code originally within TurnoutTableAction.
+ * 
+ * @author Bob Jacobsen Copyright (C) 2003, 2004, 2007
+ * @author Egbert Broerse Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class TurnoutOperationEditorDialog extends JDialog {
+
+    private TurnoutOperation myOp;
+    final Turnout myTurnout;
+    final TurnoutOperationEditorDialog self;
+
+    /**
+     * Pop up a TurnoutOperationConfig Dialog for the turnout.
+     *
+     * @param t   turnout
+     * @param box JComboBox that triggered the edit, currently unused.
+     */
+    TurnoutOperationEditorDialog( @Nonnull TurnoutOperation op, Turnout t, JComboBox<String> box) {
+        super();
+        self = this;
+        myOp = op;
+        myTurnout = t;
+        init();
+    }
+        
+    private void init() {
+        
+        myOp.addPropertyChangeListener(evt -> {
+            if (evt.getPropertyName().equals("Deleted")) {
+                setVisible(false);
+            }
+        });
+        
+        TurnoutOperationConfig config = TurnoutOperationConfig.getConfigPanel(myOp);
+        setTitle();
+        log.debug("TurnoutOpsEditDialog title set");
+        if (config != null) {
+            log.debug("OpsEditDialog opening");
+            Box outerBox = Box.createVerticalBox();
+            outerBox.add(config);
+            Box buttonBox = Box.createHorizontalBox();
+            JButton nameButton = new JButton(Bundle.getMessage("NameSetting"));
+            nameButton.addActionListener(e -> {
+                String newName = JOptionPane.showInputDialog(Bundle.getMessage("NameParameterSetting"));
+                if (newName != null && !newName.isEmpty()) {
+                    if (!myOp.rename(newName)) {
+                        JOptionPane.showMessageDialog(self, Bundle.getMessage("TurnoutErrorDuplicate"),
+                                Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
+                    }
+                    setTitle();
+                    myTurnout.setTurnoutOperation(null);
+                    myTurnout.setTurnoutOperation(myOp); // no-op but updates display - have to <i>change</i> value
+                }
+            });
+            JButton okButton = new JButton(Bundle.getMessage("ButtonOK"));
+            okButton.addActionListener(e -> {
+                config.endConfigure();
+                if (myOp.isNonce() && myOp.equivalentTo(myOp.getDefinitive())) {
+                    myTurnout.setTurnoutOperation(null);
+                    myOp.dispose();
+                    myOp = null;
+                }
+                self.setVisible(false);
+                editingOps.set(false);
+            });
+            JButton cancelButton = new JButton(Bundle.getMessage("ButtonCancel"));
+            cancelButton.addActionListener(e -> {
+                self.setVisible(false);
+                editingOps.set(false);
+            });
+            buttonBox.add(Box.createHorizontalGlue());
+            if (!myOp.isDefinitive()) {
+                buttonBox.add(nameButton);
+            }
+            buttonBox.add(okButton);
+            buttonBox.add(cancelButton);
+            outerBox.add(buttonBox);
+            getContentPane().add(outerBox);
+            this.addWindowListener(new java.awt.event.WindowAdapter() {
+                @Override
+                public void windowClosing(java.awt.event.WindowEvent e) {
+                    editingOps.set(false);
+                }
+            });
+            
+        } else {
+            log.error("Error opening Turnout automation edit pane");
+        }
+        pack();
+    }
+
+    private void setTitle() {
+        String title = Bundle.getMessage("TurnoutOperationTitle") + " \"" + myOp.getName() + "\"";
+        if (myOp.isNonce()) {
+            title = Bundle.getMessage("TurnoutOperationForTurnout") + " " + myTurnout.getSystemName();
+        }
+        setTitle(title);
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(TurnoutOperationEditorDialog.class);
+
+}
+

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
@@ -666,6 +666,9 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
 
     @Override
     public JTable makeJTable(@Nonnull String name, @Nonnull TableModel model, @CheckForNull RowSorter<? extends TableModel> sorter) {
+        if (!(model instanceof TurnoutTableDataModel)){
+            throw new IllegalArgumentException("Model is not a TurnoutTableDataModel");
+        }
         return configureJTable(name, new TurnoutTableJTable((TurnoutTableDataModel)model), sorter);
     }
     

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
@@ -1,0 +1,968 @@
+package jmri.jmrit.beantable.turnout;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableModel;
+
+import jmri.*;
+import jmri.implementation.SignalSpeedMap;
+import jmri.jmrit.beantable.*;
+import jmri.util.swing.XTableColumnModel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Data model for a Turnout Table.
+ * Code originally within TurnoutTableAction.
+ * 
+ * @author Bob Jacobsen Copyright (C) 2003, 2004, 2007
+ * @author Egbert Broerse Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
+    
+    static public final int INVERTCOL = BeanTableDataModel.NUMCOLUMN;
+    static public final int LOCKCOL = INVERTCOL + 1;
+    static public final int EDITCOL = LOCKCOL + 1;
+    static public final int KNOWNCOL = EDITCOL + 1;
+    static public final int MODECOL = KNOWNCOL + 1;
+    static public final int SENSOR1COL = MODECOL + 1;
+    static public final int SENSOR2COL = SENSOR1COL + 1;
+    static public final int OPSONOFFCOL = SENSOR2COL + 1;
+    static public final int OPSEDITCOL = OPSONOFFCOL + 1;
+    static public final int LOCKOPRCOL = OPSEDITCOL + 1;
+    static public final int LOCKDECCOL = LOCKOPRCOL + 1;
+    static public final int STRAIGHTCOL = LOCKDECCOL + 1;
+    static public final int DIVERGCOL = STRAIGHTCOL + 1;
+    static public final int FORGETCOL = DIVERGCOL + 1;
+    static public final int QUERYCOL = FORGETCOL + 1;
+    
+    private boolean _graphicState;
+    private TurnoutManager turnoutManager;
+    
+    
+    String closedText;
+    String thrownText;
+    public String defaultThrownSpeedText;
+    public String defaultClosedSpeedText;
+    // I18N TODO but note storing in xml independent from Locale
+    String useBlockSpeed;
+    String bothText = "Both";
+    String cabOnlyText = "Cab only";
+    String pushbutText = "Pushbutton only";
+    String noneText = "None";
+    
+    public final java.util.Vector<String> speedListClosed = new java.util.Vector<>();
+    public final java.util.Vector<String> speedListThrown = new java.util.Vector<>();
+    
+    
+    public TurnoutTableDataModel(){
+        super();
+        initTable();
+    }
+    
+    public TurnoutTableDataModel(Manager<Turnout> mgr){
+        super(mgr);
+        initTable();
+    }
+    
+    private void initTable() {
+        
+        // load graphic state column display preference
+        _graphicState = InstanceManager.getDefault(jmri.util.gui.GuiLafPreferencesManager.class).isGraphicTableState();
+        
+        closedText = turnoutManager.getClosedText();
+        thrownText = turnoutManager.getThrownText();
+
+        //This following must contain the word Global for a correct match in the abstract turnout
+        defaultThrownSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultThrownSpeed());
+        defaultClosedSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultClosedSpeed());
+        
+        //This following must contain the word Block for a correct match in the abstract turnout
+        useBlockSpeed = Bundle.getMessage("UseGlobal", "Block Speed");
+
+        speedListClosed.add(defaultClosedSpeedText);
+        speedListThrown.add(defaultThrownSpeedText);
+        speedListClosed.add(useBlockSpeed);
+        speedListThrown.add(useBlockSpeed);
+        java.util.Vector<String> _speedMap = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getValidSpeedNames();
+        for (String s : _speedMap) {
+            if (!speedListClosed.contains(s)) {
+                speedListClosed.add(s);
+            }
+            if (!speedListThrown.contains(s)) {
+                speedListThrown.add(s);
+            }
+        }
+        
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getColumnCount() {
+        return QUERYCOL + getPropertyColumnCount() + 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getColumnName(int col) {
+        switch (col) {
+            case INVERTCOL:
+                return Bundle.getMessage("Inverted");
+            case LOCKCOL:
+                return Bundle.getMessage("Locked");
+            case KNOWNCOL:
+                return Bundle.getMessage("Feedback");
+            case MODECOL:
+                return Bundle.getMessage("ModeLabel");
+            case SENSOR1COL:
+                return Bundle.getMessage("BlockSensor") + "1";
+            case SENSOR2COL:
+                return Bundle.getMessage("BlockSensor") + "2";
+            case OPSONOFFCOL:
+                return Bundle.getMessage("TurnoutAutomationMenu");
+            case OPSEDITCOL:
+                return "";
+            case LOCKOPRCOL:
+                return Bundle.getMessage("LockMode");
+            case LOCKDECCOL:
+                return Bundle.getMessage("Decoder");
+            case DIVERGCOL:
+                return Bundle.getMessage("ThrownSpeed");
+            case STRAIGHTCOL:
+                return Bundle.getMessage("ClosedSpeed");
+            case FORGETCOL:
+                return Bundle.getMessage("StateForgetHeader");
+            case QUERYCOL:
+                return Bundle.getMessage("StateQueryHeader");
+            case EDITCOL:
+                return "";
+            default:
+                return super.getColumnName(col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<?> getColumnClass(int col) {
+        switch (col) {
+            case INVERTCOL:
+            case LOCKCOL:
+                return Boolean.class;
+            case KNOWNCOL:
+                return String.class;
+            case MODECOL:
+            case SENSOR1COL:
+            case SENSOR2COL:
+            case OPSONOFFCOL:
+            case LOCKOPRCOL:
+            case LOCKDECCOL:
+            case DIVERGCOL:
+            case STRAIGHTCOL:
+                return JComboBox.class;
+            case OPSEDITCOL:
+            case EDITCOL:
+            case FORGETCOL:
+            case QUERYCOL:
+                return JButton.class;
+            case VALUECOL: // may use an image to show turnout state
+                return ( _graphicState ? JLabel.class : JButton.class );
+            default:
+                return super.getColumnClass(col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPreferredWidth(int col) {
+        switch (col) {
+            case INVERTCOL:
+            case LOCKCOL:
+                return new JTextField(6).getPreferredSize().width;
+            case LOCKOPRCOL:
+            case LOCKDECCOL:
+            case KNOWNCOL:
+            case MODECOL:
+                return new JTextField(10).getPreferredSize().width;
+            case SENSOR1COL:
+            case SENSOR2COL:
+                return new JTextField(5).getPreferredSize().width;
+            case OPSEDITCOL:
+                return new JButton(Bundle.getMessage("EditTurnoutOperation")).getPreferredSize().width;
+            case EDITCOL:
+                return new JButton(Bundle.getMessage("ButtonEdit")).getPreferredSize().width+4;
+            case OPSONOFFCOL:
+                return new JTextField(Bundle.getMessage("TurnoutAutomationMenu")).getPreferredSize().width;
+            case DIVERGCOL:
+            case STRAIGHTCOL:
+                return new JTextField(14).getPreferredSize().width;
+            case FORGETCOL:
+                return new JButton(Bundle.getMessage("StateForgetButton")).getPreferredSize().width;
+            case QUERYCOL:
+                return new JButton(Bundle.getMessage("StateQueryButton")).getPreferredSize().width;
+            default:
+                return super.getPreferredWidth(col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCellEditable(int row, int col) {
+        Turnout t = turnoutManager.getBySystemName(sysNameList.get(row));
+        if (t == null){
+            return false;
+        }
+        switch (col) {
+            case INVERTCOL:
+                return t.canInvert();
+            case LOCKCOL:
+                // checkbox disabled unless current configuration allows locking
+                return t.canLock(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT);
+            case OPSEDITCOL:
+                return t.getTurnoutOperation() != null;
+            case KNOWNCOL:
+                return false;
+            case MODECOL:
+            case SENSOR1COL:
+            case SENSOR2COL:
+            case OPSONOFFCOL:
+            case LOCKOPRCOL: // editable always so user can configure it, even if current configuration prevents locking now
+            case LOCKDECCOL: // editable always so user can configure it, even if current configuration prevents locking now
+            case DIVERGCOL:
+            case STRAIGHTCOL:
+            case EDITCOL:
+            case FORGETCOL:
+            case QUERYCOL:
+                return true;
+            default:
+                return super.isCellEditable(row, col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getValueAt(int row, int col) {
+        // some error checking
+        if (row >= sysNameList.size()) {
+            log.warn("row is greater than name list");
+            return "error";
+        }
+        String name = sysNameList.get(row);
+        TurnoutManager manager = turnoutManager;
+        Turnout t = manager.getBySystemName(name);
+        if (t == null) {
+            log.debug("error null turnout!");
+            return "error";
+        }
+        if (col == INVERTCOL) {
+            return t.getInverted();
+        } else if (col == LOCKCOL) {
+            return t.getLocked(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT);
+        } else if (col == KNOWNCOL) {
+            return t.describeState(t.getKnownState());
+        } else if (col == MODECOL) {
+            JComboBox<String> c = new JComboBox<>(t.getValidFeedbackNames());
+            c.setSelectedItem(t.getFeedbackModeName());
+            return c;
+        } else if (col == SENSOR1COL) {
+            return t.getFirstSensor();
+        } else if (col == SENSOR2COL) {
+            return t.getSecondSensor();
+        } else if (col == OPSONOFFCOL) {
+            return makeAutomationBox(t);
+        } else if (col == OPSEDITCOL) {
+            return Bundle.getMessage("EditTurnoutOperation");
+        } else if (col == EDITCOL) {
+            return Bundle.getMessage("ButtonEdit");
+        } else if (col == LOCKDECCOL) {
+            JComboBox<String> c;
+            if ((t.getPossibleLockModes() & Turnout.PUSHBUTTONLOCKOUT) != 0) {
+                c = new JComboBox<>(t.getValidDecoderNames());
+            } else {
+                c = new JComboBox<>(new String[]{t.getDecoderName()});
+            }
+
+            c.setSelectedItem(t.getDecoderName());
+            return c;
+        } else if (col == LOCKOPRCOL) {
+            
+            java.util.Vector<String> lockOperations = new java.util.Vector<>();  // Vector is a JComboBox ctor; List is not
+            int modes = t.getPossibleLockModes();
+            if ((modes & Turnout.CABLOCKOUT) != 0 && (modes & Turnout.PUSHBUTTONLOCKOUT) != 0) {
+                lockOperations.add(bothText);
+            }
+            if ((modes & Turnout.CABLOCKOUT) != 0) {
+                lockOperations.add(cabOnlyText);
+            }
+            if ((modes & Turnout.PUSHBUTTONLOCKOUT) != 0) {
+                lockOperations.add(pushbutText);
+            }
+            lockOperations.add(noneText);
+            JComboBox<String> c = new JComboBox<>(lockOperations);
+
+            if (t.canLock(Turnout.CABLOCKOUT) && t.canLock(Turnout.PUSHBUTTONLOCKOUT)) {
+                c.setSelectedItem(bothText);
+            } else if (t.canLock(Turnout.PUSHBUTTONLOCKOUT)) {
+                c.setSelectedItem(pushbutText);
+            } else if (t.canLock(Turnout.CABLOCKOUT)) {
+                c.setSelectedItem(cabOnlyText);
+            } else {
+                c.setSelectedItem(noneText);
+            }
+            return c;
+        } else if (col == STRAIGHTCOL) {
+
+            String speed = t.getStraightSpeed();
+            if (!speedListClosed.contains(speed)) {
+                speedListClosed.add(speed);
+            }
+            JComboBox<String> c = new JComboBox<>(speedListClosed);
+            c.setEditable(true);
+            c.setSelectedItem(speed);
+            return c;
+        } else if (col == DIVERGCOL) {
+
+            String speed = t.getDivergingSpeed();
+            if (!speedListThrown.contains(speed)) {
+                speedListThrown.add(speed);
+            }
+            JComboBox<String> c = new JComboBox<>(speedListThrown);
+            c.setEditable(true);
+            c.setSelectedItem(speed);
+            return c;
+            // } else if (col == VALUECOL && _graphicState) { // not neeeded as the
+            //  graphic ImageIconRenderer uses the same super.getValueAt(row, col) as
+            // classic bean state text button
+        } else if (col == FORGETCOL) {
+            return Bundle.getMessage("StateForgetButton");
+        } else if (col == QUERYCOL) {
+            return Bundle.getMessage("StateQueryButton");
+        }
+        return super.getValueAt(row, col);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setValueAt(Object value, int row, int col) {
+        String name = sysNameList.get(row);
+        Turnout t = turnoutManager.getBySystemName(name);
+        if (t == null) {
+            NullPointerException ex = new NullPointerException("Unexpected null turnout in turnout table");
+            log.error(ex.getMessage(), ex); // log with stack trace
+            throw ex;
+        }
+        if (col == INVERTCOL) {
+            if (t.canInvert()) {
+                t.setInverted((Boolean) value);
+                fireTableRowsUpdated(row, row);
+            }
+        } else if (col == LOCKCOL) {
+            t.setLocked(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT, (Boolean) value);
+            fireTableRowsUpdated(row, row);
+        } else if (col == MODECOL) {
+            @SuppressWarnings("unchecked")
+            String modeName = (String) ((JComboBox<String>) value).getSelectedItem();
+            assert modeName != null;
+            t.setFeedbackMode(modeName);
+            fireTableRowsUpdated(row, row);
+        } else if (col == SENSOR1COL) {
+            try {
+                Sensor sensor = (Sensor) value;
+                t.provideFirstFeedbackSensor(sensor != null ? sensor.getDisplayName() : null);
+            } catch (jmri.JmriException e) {
+                JOptionPane.showMessageDialog(null, e.toString());
+            }
+            fireTableRowsUpdated(row, row);
+        } else if (col == SENSOR2COL) {
+            try {
+                Sensor sensor = (Sensor) value;
+                t.provideSecondFeedbackSensor(sensor != null ? sensor.getDisplayName() : null);
+            } catch (jmri.JmriException e) {
+                JOptionPane.showMessageDialog(null, e.toString());
+            }
+            fireTableRowsUpdated(row, row);
+        //} else if (col == OPSONOFFCOL) {
+            // do nothing as this is handled by the combo box listener
+        } else if (col == OPSEDITCOL) {
+            t.setInhibitOperation(false);
+            @SuppressWarnings("unchecked") // cast to JComboBox<String> required in OPSEDITCOL
+            JComboBox<String> cb = (JComboBox<String>) getValueAt(row, OPSONOFFCOL);
+            log.debug("opsSelected = {}", getValueAt(row, OPSONOFFCOL).toString());
+            editTurnoutOperation(t, cb);
+            fireTableRowsUpdated(row, row);
+        } else if (col == EDITCOL) {
+            class WindowMaker implements Runnable {
+
+                final Turnout t;
+
+                WindowMaker(Turnout t) {
+                    this.t = t;
+                }
+
+                @Override
+                public void run() {
+                    editButton(t);
+                }
+            }
+            WindowMaker w = new WindowMaker(t);
+            javax.swing.SwingUtilities.invokeLater(w);
+        } else if (col == LOCKOPRCOL) {
+            @SuppressWarnings("unchecked")
+            String lockOpName = (String) ((JComboBox<String>) value)
+                    .getSelectedItem();
+            assert lockOpName != null;
+            if (lockOpName.equals(bothText)) {
+                t.enableLockOperation(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT, true);
+            }
+            if (lockOpName.equals(cabOnlyText)) {
+                t.enableLockOperation(Turnout.CABLOCKOUT, true);
+                t.enableLockOperation(Turnout.PUSHBUTTONLOCKOUT, false);
+            }
+            if (lockOpName.equals(pushbutText)) {
+                t.enableLockOperation(Turnout.CABLOCKOUT, false);
+                t.enableLockOperation(Turnout.PUSHBUTTONLOCKOUT, true);
+            }
+            fireTableRowsUpdated(row, row);
+        } else if (col == LOCKDECCOL) {
+            @SuppressWarnings("unchecked")
+            String decoderName = (String) ((JComboBox<String>) value).getSelectedItem();
+            t.setDecoderName(decoderName);
+            fireTableRowsUpdated(row, row);
+        } else if (col == STRAIGHTCOL) {
+            @SuppressWarnings("unchecked")
+            String speed = (String) ((JComboBox<String>) value).getSelectedItem();
+            try {
+                t.setStraightSpeed(speed);
+            } catch (jmri.JmriException ex) {
+                JOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
+                return;
+            }
+            if ((!speedListClosed.contains(speed))) {
+                assert speed != null;
+                if (!speed.contains("Global")) {
+                    speedListClosed.add(speed);
+                }
+            }
+            fireTableRowsUpdated(row, row);
+        } else if (col == DIVERGCOL) {
+
+            @SuppressWarnings("unchecked")
+            String speed = (String) ((JComboBox<String>) value).getSelectedItem();
+            try {
+                t.setDivergingSpeed(speed);
+            } catch (jmri.JmriException ex) {
+                JOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
+                return;
+            }
+            if ((!speedListThrown.contains(speed))) {
+                assert speed != null;
+                if (!speed.contains("Global")) {
+                    speedListThrown.add(speed);
+                }
+            }
+            fireTableRowsUpdated(row, row);
+        } else if (col == FORGETCOL) {
+            t.setCommandedState(Turnout.UNKNOWN);
+        } else if (col == QUERYCOL) {
+            t.setCommandedState(Turnout.UNKNOWN);
+            t.requestUpdateFromLayout();
+        } else if (col == VALUECOL && _graphicState) { // respond to clicking on ImageIconRenderer CellEditor
+            clickOn(t);
+            fireTableRowsUpdated(row, row);
+        } else {
+            super.setValueAt(value, row, col);
+            fireTableRowsUpdated(row, row);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getValue(@Nonnull String name) {
+        Turnout turn = turnoutManager.getBySystemName(name);
+        if (turn != null) {
+            return turn.describeState(turn.getCommandedState());
+        }
+        return "Turnout not found";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Manager<Turnout> getManager() {
+        if (turnoutManager == null) {
+            turnoutManager = InstanceManager.getDefault(TurnoutManager.class);
+        }
+        return turnoutManager;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected final void setManager(@Nonnull Manager<Turnout> manager) {
+        if (!(manager instanceof TurnoutManager)) {
+            return;
+        }
+        getManager().removePropertyChangeListener(this);
+        if (sysNameList != null) {
+            for (int i = 0; i < sysNameList.size(); i++) {
+                // if object has been deleted, it's not here; ignore it
+                NamedBean b = getBySystemName(sysNameList.get(i));
+                if (b != null) {
+                    b.removePropertyChangeListener(this);
+                }
+            }
+        }
+        turnoutManager = (TurnoutManager) manager;
+        getManager().addPropertyChangeListener(this);
+        updateNameList();
+    }
+
+    @Override
+    public Turnout getBySystemName(@Nonnull String name) {
+        return turnoutManager.getBySystemName(name);
+    }
+
+    @Override
+    public Turnout getByUserName(@Nonnull String name) {
+        return InstanceManager.getDefault(TurnoutManager.class).getByUserName(name);
+    }
+
+    @Override
+    protected String getMasterClassName() {
+        return getClassName();
+    }
+    
+    protected String getClassName() {
+        return jmri.jmrit.beantable.TurnoutTableAction.class.getName();
+    }
+
+    @Override
+    public void clickOn(Turnout t) {
+        t.setCommandedState( t.getCommandedState()== Turnout.CLOSED ? Turnout.THROWN : Turnout.CLOSED);
+    }
+
+    @Override
+    public void configureTable(JTable tbl) {
+        
+        setColumnToHoldButton(tbl, EDITCOL, editButton());
+        setColumnToHoldButton(tbl, OPSEDITCOL, editButton());
+        
+        //Hide the following columns by default
+        XTableColumnModel columnModel = (XTableColumnModel) tbl.getColumnModel();
+        TableColumn column = columnModel.getColumnByModelIndex(STRAIGHTCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(DIVERGCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(KNOWNCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(MODECOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(SENSOR1COL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(SENSOR2COL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(OPSONOFFCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(OPSEDITCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(LOCKOPRCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(LOCKDECCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(FORGETCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(QUERYCOL);
+        columnModel.setColumnVisible(column, false);
+        
+        
+        // and then set user prefs
+        super.configureTable(tbl);
+        
+    }
+
+    // update table if turnout lock or feedback changes
+    @Override
+    protected boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
+        if (e.getPropertyName().equals("locked")) {
+            return true;
+        }
+        if (e.getPropertyName().equals("feedbackchange")) {
+            return true;
+        }
+        if (e.getPropertyName().equals("TurnoutDivergingSpeedChange")) {
+            return true;
+        }
+        if (e.getPropertyName().equals("TurnoutStraightSpeedChange")) {
+            return true;
+        } else {
+            return super.matchPropertyName(e);
+        }
+    }
+
+    @Override
+    public void propertyChange(java.beans.PropertyChangeEvent e) {
+        if (e.getPropertyName().equals("DefaultTurnoutClosedSpeedChange")) {
+            updateClosedList();
+        } else if (e.getPropertyName().equals("DefaultTurnoutThrownSpeedChange")) {
+            updateThrownList();
+        } else {
+            super.propertyChange(e);
+        }
+    }
+
+    /**
+     * Customize the turnout table Value (State) column to show an
+     * appropriate graphic for the turnout state if _graphicState =
+     * true, or (default) just show the localized state text when the
+     * TableDataModel is being called from ListedTableAction.
+     *
+     * @param table a JTable of Turnouts
+     */
+    @Override
+    protected void configValueColumn(JTable table) {
+        // have the value column hold a JPanel (icon)
+        //setColumnToHoldButton(table, VALUECOL, new JLabel("12345678")); // for larger, wide round icon, but cannot be converted to JButton
+        // add extras, override BeanTableDataModel
+        log.debug("Turnout configValueColumn (I am {})", super.toString());
+        if (_graphicState) { // load icons, only once
+            table.setDefaultEditor(JLabel.class, new ImageIconRenderer()); // editor
+            table.setDefaultRenderer(JLabel.class, new ImageIconRenderer()); // item class copied from SwitchboardEditor panel
+        } else {
+            super.configValueColumn(table); // classic text style state indication
+        }
+    }
+
+    @Override
+    public JTable makeJTable(@Nonnull String name, @Nonnull TableModel model, @CheckForNull RowSorter<? extends TableModel> sorter) {
+        return configureJTable(name, new TurnoutTableJTable((TurnoutTableDataModel)model), sorter);
+    }
+    
+    @Override
+    protected void setColumnIdentities(JTable table) {
+        super.setColumnIdentities(table);
+        java.util.Enumeration<TableColumn> columns;
+        if (table.getColumnModel() instanceof XTableColumnModel) {
+            columns = ((XTableColumnModel) table.getColumnModel()).getColumns(false);
+        } else {
+            columns = table.getColumnModel().getColumns();
+        }
+        while (columns.hasMoreElements()) {
+            TableColumn column = columns.nextElement();
+            switch (column.getModelIndex()) {
+                case FORGETCOL:
+                    column.setIdentifier("ForgetState");
+                    break;
+                case QUERYCOL:
+                    column.setIdentifier("QueryState");
+                    break;
+                default:
+                // use existing value
+            }
+        }
+    }
+
+    /**
+     * Pop up a TurnoutOperationConfig for the turnout.
+     *
+     * @param t   turnout
+     * @param box JComboBox that triggered the edit
+     */
+    protected void editTurnoutOperation(Turnout t, JComboBox<String> box) {
+        if (!editingOps.getAndSet(true)) { // don't open a second edit ops pane
+            TurnoutOperation op = t.getTurnoutOperation();
+            if (op == null) {
+                TurnoutOperation proto = InstanceManager.getDefault(TurnoutOperationManager.class).getMatchingOperationAlways(t);
+                if (proto != null) {
+                    op = proto.makeNonce(t);
+                    t.setTurnoutOperation(op);
+                }
+            }
+            if (op != null) {
+                if (!op.isNonce()) {
+                    op = op.makeNonce(t);
+                }
+                // make and show edit dialog
+                log.debug("TurnoutOpsEditDialog starting");
+                TurnoutOperationEditorDialog dialog = new TurnoutOperationEditorDialog(op, t, box);
+                dialog.setVisible(true);
+            } else {
+                JOptionPane.showMessageDialog(box, Bundle.getMessage("TurnoutOperationErrorDialog"),
+                        Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+    
+    /**
+     * Create a {@literal JComboBox<String>} containing all the options for
+     * turnout automation parameters for this turnout.
+     *
+     * @param t the turnout
+     * @return the JComboBox
+     */
+    protected JComboBox<String> makeAutomationBox(Turnout t) {
+        String[] str = new String[]{"empty"};
+        final JComboBox<String> cb = new JComboBox<>(str);
+        final Turnout myTurnout = t;
+        TurnoutTableAction.updateAutomationBox(t, cb);
+        cb.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setTurnoutOperation(myTurnout, cb);
+                cb.removeActionListener(this);  // avoid recursion
+                TurnoutTableAction.updateAutomationBox(myTurnout, cb);
+                cb.addActionListener(this);
+            }
+        });
+        return cb;
+    }
+    
+    /**
+     * Set the turnout's operation info based on the contents of the combo box.
+     *
+     * @param t  turnout being configured
+     * @param cb JComboBox for ops for t in the TurnoutTable
+     */
+    protected void setTurnoutOperation(Turnout t, JComboBox<String> cb) {
+        switch (cb.getSelectedIndex()) {
+            case 0:   // Off
+                t.setInhibitOperation(true);
+                t.setTurnoutOperation(null);
+                break;
+            case 1:   // Default
+                t.setInhibitOperation(false);
+                t.setTurnoutOperation(null);
+                break;
+            default:  // named operation
+                t.setInhibitOperation(false);
+                t.setTurnoutOperation(InstanceManager.getDefault(TurnoutOperationManager.class).
+                        getOperation(((String) java.util.Objects.requireNonNull(cb.getSelectedItem()))));
+                break;
+        }
+    }
+    
+    /**
+     * Create action to edit a turnout in Edit pane. (also used in windowTest)
+     *
+     * @param t the turnout to be edited
+     */
+    void editButton(Turnout t) {
+        jmri.jmrit.beantable.beanedit.TurnoutEditAction beanEdit = new jmri.jmrit.beantable.beanedit.TurnoutEditAction();
+        beanEdit.setBean(t);
+        beanEdit.actionPerformed(null);
+    }
+
+    /**
+     * Create a JButton to edit a turnout's operation.
+     *
+     * @return the JButton
+     */
+    protected JButton editButton() {
+        return new JButton(Bundle.getMessage("EditTurnoutOperation"));
+    }
+    
+    private void updateClosedList() {
+        speedListClosed.remove(defaultClosedSpeedText);
+        defaultClosedSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultClosedSpeed());
+        speedListClosed.add(0, defaultClosedSpeedText);
+        fireTableDataChanged();
+    }
+
+    private void updateThrownList() {
+        speedListThrown.remove(defaultThrownSpeedText);
+        defaultThrownSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultThrownSpeed());
+        speedListThrown.add(0, defaultThrownSpeedText);
+        fireTableDataChanged();
+    }
+    
+    public void showFeedbackChanged(boolean visible, JTable table ) {
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+        TableColumn column = columnModel.getColumnByModelIndex(KNOWNCOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(MODECOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(SENSOR1COL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(SENSOR2COL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(OPSONOFFCOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(OPSEDITCOL);
+        columnModel.setColumnVisible(column, visible);
+    }
+
+    public void showLockChanged(boolean visible, JTable table) {
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+        TableColumn column = ((XTableColumnModel) table.getColumnModel()).getColumnByModelIndex(LOCKDECCOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(LOCKOPRCOL);
+        columnModel.setColumnVisible(column, visible);
+    }
+
+    public void showTurnoutSpeedChanged(boolean visible, JTable table) {
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+        TableColumn column = ((XTableColumnModel) table.getColumnModel()).getColumnByModelIndex(STRAIGHTCOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(DIVERGCOL);
+        columnModel.setColumnVisible(column, visible);
+    }
+
+    public void showStateForgetAndQueryChanged(boolean visible, JTable table) {
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+        TableColumn column = columnModel.getColumnByModelIndex(FORGETCOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(QUERYCOL);
+        columnModel.setColumnVisible(column, visible);
+    }
+
+    
+    /**
+     * Visualize state in table as a graphic, customized for Turnouts (4
+     * states). 
+     * Renderer and Editor are identical, as the cell contents
+     * are not actually edited, only used to toggle state using
+     * {@link #clickOn(Turnout)}.
+     *
+     */
+    class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
+
+        protected JLabel label;
+        protected String rootPath = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor
+        protected char beanTypeChar = 'T'; // for Turnout
+        protected String onIconPath = rootPath + beanTypeChar + "-on-s.png";
+        protected String offIconPath = rootPath + beanTypeChar + "-off-s.png";
+        protected BufferedImage onImage;
+        protected BufferedImage offImage;
+        protected ImageIcon onIcon;
+        protected ImageIcon offIcon;
+        protected int iconHeight = -1;
+
+        @Override
+        public java.awt.Component getTableCellRendererComponent(
+                JTable table, Object value, boolean isSelected,
+                boolean hasFocus, int row, int column) {
+            log.debug("Renderer Item = {}, State = {}", row, value);
+            if (iconHeight < 0) { // load resources only first time, either for renderer or editor
+                loadIcons();
+                log.debug("icons loaded");
+            }
+            return updateLabel((String) value, row, table);
+        }
+
+        @Override
+        public java.awt.Component getTableCellEditorComponent(
+                JTable table, Object value, boolean isSelected,
+                int row, int column) {
+            log.debug("Renderer Item = {}, State = {}", row, value);
+            if (iconHeight < 0) { // load resources only first time, either for renderer or editor
+                loadIcons();
+                log.debug("icons loaded");
+            }
+            return updateLabel((String) value, row, table);
+        }
+
+        public JLabel updateLabel(String value, int row, JTable table) {
+            if (iconHeight > 0) { // if necessary, increase row height;
+                table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5));
+            }
+            if (value.equals(closedText) && onIcon != null) {
+                label = new JLabel(onIcon);
+                label.setVerticalAlignment(JLabel.BOTTOM);
+                log.debug("onIcon set");
+            } else if (value.equals(thrownText) && offIcon != null) {
+                label = new JLabel(offIcon);
+                label.setVerticalAlignment(JLabel.BOTTOM);
+                log.debug("offIcon set");
+            } else if (value.equals(Bundle.getMessage("BeanStateInconsistent"))) {
+                label = new JLabel("X", JLabel.CENTER); // centered text alignment
+                label.setForeground(java.awt.Color.red);
+                log.debug("Turnout state inconsistent");
+                iconHeight = 0;
+            } else if (value.equals(Bundle.getMessage("BeanStateUnknown"))) {
+                label = new JLabel("?", JLabel.CENTER); // centered text alignment
+                log.debug("Turnout state unknown");
+                iconHeight = 0;
+            } else { // failed to load icon
+                label = new JLabel(value, JLabel.CENTER); // centered text alignment
+                log.warn("Error reading icons for TurnoutTable");
+                iconHeight = 0;
+            }
+            label.setToolTipText(value);
+            label.addMouseListener(new MouseAdapter() {
+                @Override
+                public final void mousePressed(MouseEvent evt) {
+                    log.debug("Clicked on icon in row {}", row);
+                    stopCellEditing();
+                }
+            });
+            return label;
+        }
+
+        @Override
+        public Object getCellEditorValue() {
+            log.debug("getCellEditorValue, me = {})", this.toString());
+            return this.toString();
+        }
+
+        /**
+         * Read and buffer graphics. Only called once for this table.
+         *
+         * @see #getTableCellEditorComponent(JTable, Object, boolean,
+         * int, int)
+         */
+        protected void loadIcons() {
+            try {
+                onImage = ImageIO.read(new File(onIconPath));
+                offImage = ImageIO.read(new File(offIconPath));
+            } catch (IOException ex) {
+                log.error("error reading image from {} or {}", onIconPath, offIconPath, ex);
+            }
+            log.debug("Success reading images");
+            int imageWidth = onImage.getWidth();
+            int imageHeight = onImage.getHeight();
+            // scale icons 50% to fit in table rows
+            java.awt.Image smallOnImage = onImage.getScaledInstance(imageWidth / 2, imageHeight / 2, java.awt.Image.SCALE_DEFAULT);
+            java.awt.Image smallOffImage = offImage.getScaledInstance(imageWidth / 2, imageHeight / 2, java.awt.Image.SCALE_DEFAULT);
+            onIcon = new ImageIcon(smallOnImage);
+            offIcon = new ImageIcon(smallOffImage);
+            iconHeight = onIcon.getIconHeight();
+        }
+
+    } // end of ImageIconRenderer class
+
+    protected static java.util.concurrent.atomic.AtomicBoolean editingOps = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+    private final static Logger log = LoggerFactory.getLogger(TurnoutTableDataModel.class);
+    
+}

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableJTable.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableJTable.java
@@ -1,0 +1,183 @@
+package jmri.jmrit.beantable.turnout;
+
+import java.awt.Component;
+import java.awt.event.MouseEvent;
+import java.util.Hashtable;
+
+import javax.annotation.Nonnull;
+import javax.swing.DefaultCellEditor;
+import javax.swing.JTable;
+import javax.swing.table.*;
+
+import jmri.InstanceManager;
+import jmri.NamedBean;
+import jmri.Sensor;
+import jmri.SensorManager;
+import jmri.Turnout;
+
+
+import jmri.swing.NamedBeanComboBox;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JTable to display a TurnoutTableDataModel.
+ * Code originally within TurnoutTableAction.
+ * 
+ * @author Bob Jacobsen Copyright (C) 2003, 2004, 2007
+ * @author Egbert Broerse Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class TurnoutTableJTable extends JTable {
+    
+    final TurnoutTableDataModel model;
+    
+    final Hashtable<Turnout, TableCellRenderer> rendererMapSensor1 = new Hashtable<>();
+    final Hashtable<Turnout, TableCellEditor> editorMapSensor1 = new Hashtable<>();
+
+    final Hashtable<Turnout, TableCellRenderer> rendererMapSensor2 = new Hashtable<>();
+    final Hashtable<Turnout, TableCellEditor> editorMapSensor2 = new Hashtable<>();
+    
+    public TurnoutTableJTable(TurnoutTableDataModel mdl){
+        super(mdl);
+        model = mdl;
+    }
+    
+    @Override
+    public String getToolTipText(@Nonnull MouseEvent e) {
+        java.awt.Point p = e.getPoint();
+        int rowIndex = rowAtPoint(p);
+        int colIndex = columnAtPoint(p);
+        int realRowIndex = convertRowIndexToModel(rowIndex);
+        int realColumnIndex = convertColumnIndexToModel(colIndex);
+        return model.getCellToolTip(this, realRowIndex, realColumnIndex);
+    }
+
+    @Override
+    public TableCellRenderer getCellRenderer(int row, int column) {
+        // Convert the displayed index to the model index, rather than the displayed index
+        int modelColumn = this.convertColumnIndexToModel(column);
+        if (modelColumn == TurnoutTableDataModel.SENSOR1COL || modelColumn == TurnoutTableDataModel.SENSOR2COL) {
+            return getRenderer(row, modelColumn);
+        } else {
+            return super.getCellRenderer(row, column);
+        }
+    }
+
+    @Override
+    public TableCellEditor getCellEditor(int row, int column) {
+        //Convert the displayed index to the model index, rather than the displayed index
+        int modelColumn = this.convertColumnIndexToModel(column);
+        if (modelColumn == TurnoutTableDataModel.SENSOR1COL || modelColumn == TurnoutTableDataModel.SENSOR2COL) {
+            return getEditor(row, modelColumn);
+        } else {
+            return super.getCellEditor(row, column);
+        }
+    }
+
+    TableCellRenderer getRenderer(int row, int column) {
+        TableCellRenderer retval;
+        Turnout t = (Turnout) getModel().getValueAt(row, TurnoutTableDataModel.SYSNAMECOL);
+        java.util.Objects.requireNonNull(t, "SYSNAMECOL column content must be nonnull");
+        switch (column) {
+            case TurnoutTableDataModel.SENSOR1COL:
+                retval = rendererMapSensor1.get(t);
+                break;
+            case TurnoutTableDataModel.SENSOR2COL:
+                retval = rendererMapSensor2.get(t);
+                break;
+            default:
+                return null;
+        }
+
+        if (retval == null) {
+            if (column == TurnoutTableDataModel.SENSOR1COL) {
+                loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
+            } else {
+                loadRenderEditMaps(rendererMapSensor2, editorMapSensor2, t, t.getSecondSensor());
+            }
+            retval = rendererMapSensor1.get(t);
+        }
+        log.debug("fetched for Turnout \"{}\" renderer {}", t, retval);
+        return retval;
+    }
+
+    TableCellEditor getEditor(int row, int column) {
+        TableCellEditor retval;
+        Turnout t = (Turnout) getModel().getValueAt(row, TurnoutTableDataModel.SYSNAMECOL);
+        java.util.Objects.requireNonNull(t, "SYSNAMECOL column content must be nonnull");
+        switch (column) {
+            case TurnoutTableDataModel.SENSOR1COL:
+                retval = editorMapSensor1.get(t);
+                break;
+            case TurnoutTableDataModel.SENSOR2COL:
+                retval = editorMapSensor2.get(t);
+                break;
+            default:
+                return null;
+        }
+        if (retval == null) {
+            if (column == TurnoutTableDataModel.SENSOR1COL) {
+                loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
+                retval = editorMapSensor1.get(t);
+            } else { //Must be two
+                loadRenderEditMaps(rendererMapSensor2, editorMapSensor2, t, t.getSecondSensor());
+                retval = editorMapSensor2.get(t);
+            }
+        }
+        log.debug("fetched for Turnout \"{}\" editor {}", t, retval);
+        return retval;
+    }
+
+    protected void loadRenderEditMaps(Hashtable<Turnout, TableCellRenderer> r, Hashtable<Turnout, TableCellEditor> e,
+            Turnout t, Sensor s) {
+        NamedBeanComboBox<Sensor> c = new NamedBeanComboBox<>(InstanceManager.getDefault(SensorManager.class), s, NamedBean.DisplayOptions.DISPLAYNAME);
+        c.setAllowNull(true);
+
+        BeanBoxRenderer renderer = new BeanBoxRenderer();
+        renderer.setSelectedItem(s);
+        r.put(t, renderer);
+
+        TableCellEditor editor = new BeanComboBoxEditor(c);
+        e.put(t, editor);
+        log.debug("initialize for Turnout \"{}\" Sensor \"{}\"", t, s);
+    }
+    
+    static class BeanBoxRenderer extends NamedBeanComboBox<Sensor> implements TableCellRenderer {
+
+        public BeanBoxRenderer() {
+            super(InstanceManager.getDefault(SensorManager.class));
+            setAllowNull(true);
+        }
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value,
+                boolean isSelected, boolean hasFocus, int row, int column) {
+            if (isSelected) {
+                setForeground(table.getSelectionForeground());
+                super.setBackground(table.getSelectionBackground());
+            } else {
+                setForeground(table.getForeground());
+                setBackground(table.getBackground());
+            }
+            if (value instanceof Sensor) {
+                setSelectedItem(value);
+            } else {
+                setSelectedItem(null);
+            }
+            return this;
+        }
+    }
+    
+    static class BeanComboBoxEditor extends DefaultCellEditor {
+
+        public BeanComboBoxEditor(NamedBeanComboBox<Sensor> beanBox) {
+            super(beanBox);
+        }
+    }
+    
+     
+private final static Logger log = LoggerFactory.getLogger(TurnoutTableJTable.class);
+
+}

--- a/java/test/jmri/jmrit/beantable/AbstractBeanTableDataModelBase.java
+++ b/java/test/jmri/jmrit/beantable/AbstractBeanTableDataModelBase.java
@@ -1,6 +1,9 @@
 package jmri.jmrit.beantable;
 
+import jmri.Manager;
+import jmri.ProvidingManager;
 import jmri.NamedBean;
+import jmri.util.JUnitAppender;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
@@ -29,9 +32,30 @@ public abstract class AbstractBeanTableDataModelBase<B extends jmri.NamedBean> {
      */
     abstract protected int getModelColumnCount();
     
+    /**
+     * Create a NamedBean to use in the Table.
+     */
+    protected void createBean(){
+        Manager<?> mgr = t.getManager(); // Internal Proxy Bean<?> Manager
+        Assert.assertNotNull("Table Bean Manager exists",mgr);
+        if (mgr instanceof ProvidingManager){
+            NamedBean b = ((ProvidingManager<?>) mgr).provide(mgr.getSystemNamePrefix()+"1");
+            Assert.assertNotNull("Bean created",b);
+        } else {
+            Assert.fail("Manager is not a providing manager, this test should be overridden to create a bean");
+        }
+    }
+    
     @Test
     public void testTableNotNull() {
         Assert.assertNotNull("Table exists in tested class",t);
+    }
+    
+    @Test
+    public void testGetRowCount(){
+        assertEquals("0 Rows when model created",0, t.getRowCount());
+        createBean();
+        assertEquals("1 Row when NamedBean created",1, t.getRowCount());
     }
     
     /**
@@ -56,6 +80,55 @@ public abstract class AbstractBeanTableDataModelBase<B extends jmri.NamedBean> {
         assertEquals("Column3 - User Comment",Bundle.getMessage("ColumnComment"), t.getColumnName(3));
         assertEquals("Column4 - Delete button","", t.getColumnName(4));
         
+    }
+    
+    /**
+     * Test of getColumn Name method with no column in model.
+     * Should NOT be overridden by implementing Tests
+     */
+    @Test
+    public void testGetColumnNameNone() {
+        assertEquals("No column, no name via super.","btm unknown",t.getColumnName(t.getColumnCount()) );
+    }
+    
+    /**
+     * Test of isCellEditable Name method with no column in model.
+     * Should NOT be overridden by implementing Tests
+     */
+    @Test
+    public void testCellEditableColumnNone() {
+        createBean(); // ensure there is a row 0
+        assertEquals("No column, not editable",false,t.isCellEditable(0,t.getColumnCount()) );
+    }
+    
+    /**
+     * Test of getValueAt method with no column in model.
+     * Should NOT be overridden by implementing Tests
+     */
+    @Test
+    public void testGetValueAtNoColumn() {
+        createBean(); // ensure there is a row 0
+        assertEquals("No column, no value",null,t.getValueAt(0,t.getColumnCount()) );
+        JUnitAppender.assertErrorMessage("internal state inconsistent with table requst for getValueAt 0 "+t.getColumnCount());
+    }
+    
+    /**
+     * Test of getValueAt method with no column in model.
+     * Should NOT be overridden by implementing Tests
+     */
+    @Test
+    public void testGetWidthNoColumn() {
+        Assert.assertTrue("No column, no value",t.getPreferredWidth(t.getColumnCount())>0);
+        JUnitAppender.assertErrorMessageStartsWith("Unexpected column in getPreferredWidth: "+t.getColumnCount());
+    }
+    
+    /**
+     * Test of getColumnClass method with no column in model.
+     * Should NOT be overridden by implementing Tests
+     */
+    @Test
+    public void testGetColumnClassNone() {
+        assertEquals("No column, no class",null,t.getColumnClass(t.getColumnCount()) );
     }
 
     /**

--- a/java/test/jmri/jmrit/beantable/TurnoutTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/TurnoutTableActionTest.java
@@ -8,6 +8,7 @@ import javax.swing.JTextField;
 import jmri.InstanceManager;
 import jmri.Turnout;
 import jmri.TurnoutManager;
+import jmri.jmrit.beantable.turnout.TurnoutTableDataModel;
 import jmri.jmrix.internal.InternalSystemConnectionMemo;
 import jmri.jmrix.internal.InternalTurnoutManager;
 import jmri.swing.ManagerComboBox;
@@ -189,7 +190,7 @@ public class TurnoutTableActionTest extends AbstractTableActionBase<Turnout> {
 
         JTableOperator tbl = new JTableOperator(jfo, 0);
         // find the "Edit" button and press it.  This is in the table body.
-        tbl.clickOnCell(0, TurnoutTableAction.EDITCOL);
+        tbl.clickOnCell(0, TurnoutTableDataModel.EDITCOL);
         JFrame f2 = JFrameOperator.waitJFrame(getEditFrameName(), true, true);
         jmri.util.swing.JemmyUtil.pressButton(new JFrameOperator(f2), Bundle.getMessage("ButtonCancel"));
         JUnitUtil.dispose(f2);
@@ -201,7 +202,7 @@ public class TurnoutTableActionTest extends AbstractTableActionBase<Turnout> {
     public void testConfigureManagerComboBox() {
         TurnoutManager j = new InternalTurnoutManager(new InternalSystemConnectionMemo("J", "Juliet"));
         InstanceManager.setTurnoutManager(j);
-        ManagerComboBox<Turnout> box = new ManagerComboBox<Turnout>();
+        ManagerComboBox<Turnout> box = new ManagerComboBox<>();
         Assert.assertEquals("empty box", 0, box.getItemCount());
         a.configureManagerComboBox(box, j, TurnoutManager.class);
         Assert.assertEquals("full box", 2, box.getItemCount());

--- a/java/test/jmri/jmrit/beantable/TurnoutTableWindowTest.java
+++ b/java/test/jmri/jmrit/beantable/TurnoutTableWindowTest.java
@@ -3,8 +3,8 @@ package jmri.jmrit.beantable;
 import java.awt.GraphicsEnvironment;
 import javax.swing.JTextField;
 import jmri.InstanceManager;
-import jmri.Turnout;
 import jmri.TurnoutManager;
+import jmri.jmrit.beantable.turnout.TurnoutTableDataModel;
 import jmri.jmrix.cmri.CMRISystemConnectionMemo;
 import jmri.jmrix.cmri.serial.SerialTurnoutManager;
 import jmri.jmrix.internal.InternalSystemConnectionMemo;
@@ -104,17 +104,11 @@ public class TurnoutTableWindowTest {
         jbo.doClick();
         // Ask to close Add pane
         afo.requestClose();
-
-        // Open the Edit Turnout IT1 pane, how to find & click the LT1 Edit col button?
+        
+        // Open the Edit Turnout IT1 pane, 
         // Find the Edit button in EDITCOL of line 0 (for LT1)
-        //AbstractButtonFinder edfinder = new AbstractButtonFinder("Edit");
-        //JButton editbutton = (JButton) edfinder.find(ft, 0);
-        //Assert.assertNotNull(editbutton);
-        // Click button to edit turnout
-        //getHelper().enterClickAndLeave(new MouseEventData(this, editbutton));
-        // open Edit pane by method instead
-        Turnout it1 = InstanceManager.turnoutManagerInstance().getTurnout("IT1");
-        a.editButton(it1); // open edit pane
+        JTableOperator tbl = new JTableOperator(jfo, 0);
+        tbl.clickOnCell(0, TurnoutTableDataModel.EDITCOL);
 
         // Find Edit Turnout pane by name
         JFrameOperator efo = new JFrameOperator("Edit Turnout IT1");

--- a/java/test/jmri/jmrit/beantable/sensor/SensorTableDataModelTest.java
+++ b/java/test/jmri/jmrit/beantable/sensor/SensorTableDataModelTest.java
@@ -5,6 +5,7 @@ import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
 
 /**
  *
@@ -20,6 +21,26 @@ public class SensorTableDataModelTest extends jmri.jmrit.beantable.AbstractBeanT
     @Override
     public int getModelColumnCount(){
         return 13;
+    }
+    
+    @Test
+    public void testGetColumnNames() {
+        assertEquals("Column5 - INVERTCOL",Bundle.getMessage("Inverted"),
+            t.getColumnName(SensorTableDataModel.INVERTCOL));
+        assertEquals("Column6 - EDITCOL","",
+            t.getColumnName(SensorTableDataModel.EDITCOL));
+        assertEquals("Column7 - USEGLOBALDELAY",Bundle.getMessage("SensorUseGlobalDebounce"),
+            t.getColumnName(SensorTableDataModel.USEGLOBALDELAY));
+        assertEquals("Column8 - ACTIVEDELAY",Bundle.getMessage("SensorActiveDebounce"),
+            t.getColumnName(SensorTableDataModel.ACTIVEDELAY));
+        assertEquals("Column9 - INACTIVEDELAY",Bundle.getMessage("SensorInActiveDebounce"),
+            t.getColumnName(SensorTableDataModel.INACTIVEDELAY));
+        assertEquals("Column10 - PULLUPCOL",Bundle.getMessage("SensorPullUp"),
+            t.getColumnName(SensorTableDataModel.PULLUPCOL));
+        assertEquals("Column11 - FORGETCOL",Bundle.getMessage("StateForgetHeader"),
+            t.getColumnName(SensorTableDataModel.FORGETCOL));
+        assertEquals("Column12 - QUERYCOL",Bundle.getMessage("StateQueryHeader"),
+            t.getColumnName(SensorTableDataModel.QUERYCOL));
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/beantable/turnout/BundleTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/BundleTest.java
@@ -1,0 +1,43 @@
+package jmri.jmrit.beantable.turnout;
+
+import java.util.Locale;
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+
+/**
+ * Tests for the Bundle class
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ */
+public class BundleTest  {
+
+    @Test public void testGoodKeyMessage() {
+        Assert.assertEquals("Turnout", Bundle.getMessage("BeanNameTurnout"));
+    }
+
+    @Test
+    public void testBadKeyMessage() {
+        Assert.assertThrows(java.util.MissingResourceException.class, () -> Bundle.getMessage("FFFFFTTTTTTT"));
+    }
+
+    @Test public void testGoodKeyMessageArg() {
+        Assert.assertEquals("Sensor", Bundle.getMessage("BeanNameSensor", new Object[]{}));
+        Assert.assertEquals("About Test", Bundle.getMessage("TitleAbout", "Test"));
+    }
+
+    @Test
+    public void testBadKeyMessageArg() {
+        Assert.assertThrows(java.util.MissingResourceException.class, () -> Bundle.getMessage("FFFFFTTTTTTT", new Object[]{}));
+    }
+
+    @Test public void testLocaleMessage() {
+        Assert.assertEquals("Scambio", Bundle.getMessage(Locale.ITALY, "BeanNameTurnout"));
+    }
+
+    @Test public void testLocaleMessageArg() {
+        Assert.assertEquals("Scambio", Bundle.getMessage(Locale.ITALY, "BeanNameTurnout", new Object[]{}));
+        Assert.assertEquals("Informazioni su Test", Bundle.getMessage(Locale.ITALY, "TitleAbout", "Test"));
+    }
+
+
+}

--- a/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
@@ -1,0 +1,40 @@
+package jmri.jmrit.beantable.turnout;
+
+import jmri.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ *
+ * @author Steve Young Copyright (C) 2021
+ */
+public class TurnoutOperationEditorDialogTest {
+    
+    @Test
+    public void testCTor() {
+        
+        Turnout testedTurnout = InstanceManager.getDefault(TurnoutManager.class).provide("IS1");
+        TurnoutOperation proto = InstanceManager.getDefault(TurnoutOperationManager.class).getMatchingOperationAlways(testedTurnout);
+        Assert.assertNotNull("proto exists",proto);
+        
+        TurnoutOperationEditorDialog t = new TurnoutOperationEditorDialog(proto,testedTurnout,null);
+        Assert.assertNotNull("exists",t);
+        
+        t.dispose();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+    
+}

--- a/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
@@ -15,7 +15,7 @@ public class TurnoutOperationEditorDialogTest {
     
     @Test
     public void testCTor() {
-        
+        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
         Turnout testedTurnout = InstanceManager.getDefault(TurnoutManager.class).provide("IS1");
         TurnoutOperation proto = InstanceManager.getDefault(TurnoutOperationManager.class).getMatchingOperationAlways(testedTurnout);
         Assert.assertNotNull("proto exists",proto);

--- a/java/test/jmri/jmrit/beantable/turnout/TurnoutTableDataModelTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/TurnoutTableDataModelTest.java
@@ -1,0 +1,83 @@
+package jmri.jmrit.beantable.turnout;
+
+import jmri.Turnout;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young (C) 2021
+ */
+public class TurnoutTableDataModelTest extends jmri.jmrit.beantable.AbstractBeanTableDataModelBase<Turnout> {
+
+    @Test
+    public void testCTor() {
+        Assert.assertNotNull("exists",t);
+    }
+    
+    @Override
+    public int getModelColumnCount(){
+        return 20;
+    }
+    
+    @Test
+    public void testGetColumnNames() {
+        assertEquals("Column5 - INVERTCOL",Bundle.getMessage("Inverted"), 
+            t.getColumnName(TurnoutTableDataModel.INVERTCOL));
+        assertEquals("Column6 - LOCKCOL",Bundle.getMessage("Locked"),
+            t.getColumnName(TurnoutTableDataModel.LOCKCOL));
+        assertEquals("Column7 - EDITCOL","",
+            t.getColumnName(TurnoutTableDataModel.EDITCOL));
+        assertEquals("Column8 - KNOWNCOL",Bundle.getMessage("Feedback"),
+            t.getColumnName(TurnoutTableDataModel.KNOWNCOL));
+        assertEquals("Column9 - MODECOL",Bundle.getMessage("ModeLabel"),
+            t.getColumnName(TurnoutTableDataModel.MODECOL));
+        assertEquals("Column10 - SENSOR1COL",Bundle.getMessage("BlockSensor") + "1",
+            t.getColumnName(TurnoutTableDataModel.SENSOR1COL));
+        assertEquals("Column11 - SENSOR2COL",Bundle.getMessage("BlockSensor") + "2",
+            t.getColumnName(TurnoutTableDataModel.SENSOR2COL));
+        assertEquals("Column12 - OPSONOFFCOL",Bundle.getMessage("TurnoutAutomationMenu"),
+            t.getColumnName(TurnoutTableDataModel.OPSONOFFCOL));
+        assertEquals("Column13 - OPSEDITCOL","",
+            t.getColumnName(TurnoutTableDataModel.OPSEDITCOL));
+        assertEquals("Column14 - LOCKOPRCOL",Bundle.getMessage("LockMode"),
+            t.getColumnName(TurnoutTableDataModel.LOCKOPRCOL));
+        assertEquals("Column15 - LOCKDECCOL",Bundle.getMessage("Decoder"),
+            t.getColumnName(TurnoutTableDataModel.LOCKDECCOL));
+        assertEquals("Column16 - STRAIGHTCOL",Bundle.getMessage("ClosedSpeed"),
+            t.getColumnName(TurnoutTableDataModel.STRAIGHTCOL));
+        assertEquals("Column17 - DIVERGCOL",Bundle.getMessage("ThrownSpeed"),
+            t.getColumnName(TurnoutTableDataModel.DIVERGCOL));
+        assertEquals("Column18 - FORGETCOL",Bundle.getMessage("StateForgetHeader"),
+            t.getColumnName(TurnoutTableDataModel.FORGETCOL));
+        assertEquals("Column19 - QUERYCOL",Bundle.getMessage("StateQueryHeader"),
+            t.getColumnName(TurnoutTableDataModel.QUERYCOL));
+
+    }
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initInternalTurnoutManager();
+        t = new TurnoutTableDataModel();
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        if (t!=null){
+            t.dispose();
+        }
+        JUnitUtil.tearDown();
+    }
+
+    // private final static Logger log = LoggerFactory.getLogger(TurnoutTableDataModelTest.class);
+
+}

--- a/java/test/jmri/jmrit/beantable/turnout/TurnoutTableJTableTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/TurnoutTableJTableTest.java
@@ -1,0 +1,31 @@
+package jmri.jmrit.beantable.turnout;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+
+/**
+ *
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class TurnoutTableJTableTest {
+
+    @Test
+    public void testCTor() {
+        TurnoutTableJTable t = new TurnoutTableJTable(null);
+        Assert.assertNotNull("exists",t);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+}


### PR DESCRIPTION
Objectives with this PR :
Improve maintainability of TurnoutTableAction ( more clarity between New Bean UI functions and Table Display )
Stop Bean Table Models keeping a local copy of the last JTable instance passed to them

Default Cell Editor for BeanTable JComboBox now does action for Stop Cell Editing, not Models.
Set default column width loop now includes non-visible columns.

Seperates classes within TurnoutTableAction.java moved to
TurnoutTableDataModel.java
TurnoutTableJTable.java
TurnoutOperationEditorDialog.java