### PR TITLE
Added defs for MX605 sound decoder

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -336,7 +336,7 @@
 
         <h4>ZIMO</h4>
             <ul>
-                <li></li>
+                <li>MX605 (Kato type plug N sound decoder for ICE 4)</li>
             </ul>
 
         <h4>Miscellaneous</h4>
@@ -566,4 +566,3 @@
         <ul>
             <li></li>
         </ul>
-

--- a/xml/decoders/Zimo_Unified_software_v37_MX605.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX605.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2002, 2005, 2006, 2007 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Pierre Billon   pierre.bln@me.com" version="1.8" lastUpdated="2021/03/06"/>
+  <!-- This decoder configuration file is based on the Zimo_Unified_software_v37_MX659.xml   -->
+  <!-- V 1 file, dated 20210306.                                                             -->
+  <!--                                                                                       -->
+  <!--                                                                                       -->
+  <!-- This decoder XML is meant to be used with the "Comprehensive" programmer format.      -->
+  <!-- Continued the practice of using unrelated "item" names to place Zimo unique           -->
+  <!-- variables on the proper pane of the Comprehensive programmer.                         -->
+  <!-- V 1 new file,  Pierre Billon, 06 Mar 2021 -->
+  <!-- MX605 is special Zimo sound decoder for Kato N-scale ICE 4 (in theory usable in other Kato vehicules with the Kato in-house connector for EM13 decoder). Due to the combination with MX605FL & MX605SL installed in same engine, Front/rear lights and FO 1 for interior lighting listed as functons of this decoder -->
+  <!-- Known installed firmware version from factory: 38.5 -->
+  <decoder>
+    <family name="Zimo Unified software (version 37+)" mfg="Zimo">
+      <model  model="MX605 version 37+" replacementModel="MX605 version 39+" replacementFamily="query:Zimo Unified software (version 39+)" lowVersionID="37" highVersionID="38" maxInputVolts="30V" maxMotorCurrent="0.7A, peak=1.5A" maxTotalCurrent="0.7A" formFactor="N" connector="DropIn" numOuts="3" numFns="14" productID="189">
+        <output name="1" label="Front Light (MX605SL)">
+          <label xml:lang="de">Lvor (MX605SL)</label>
+        </output>
+        <output name="2" label="Rear Light (MX605SL)">
+          <label xml:lang="de">Lrück (MX605SL)</label>
+        </output>
+        <output name="3" label="FO 1 (MX605FL)">
+          <label xml:lang="de">FA1 (MX605FL)</label>
+        </output>
+      </model>
+    </family>
+    <programming direct="yes" paged="yes" register="yes" ops="yes"/>
+    <variables>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV1-CV99.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV20.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV100-CV152version30.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV153-CV157version28.xml"/>
+      <!-- CV158 has both sound and Railcom information -->
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV158version32.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV161-CV185Servo.xml"/>
+     <!-- CV7 set to default 37 to allow Swiss Mapping Groups 11 to 17 if creating a brand new decoder from scratch -->
+      <variable CV="7" readOnly="yes" default="37">
+        <decVal/>
+        <label>Manufacturer Version No: </label>
+        <label xml:lang="it">Versione Decoder: </label>
+        <label xml:lang="fr">Version décodeur: </label>
+        <label xml:lang="de">Decoder Version: </label>
+      </variable>
+      <variable item="Decoder ID 1" CV="250" default="189" readOnly="yes">
+        <decVal/>
+        <label>Decoder ID 1</label>
+        <label xml:lang="it">ID 1 Decoder: </label>
+        <label xml:lang="cs">Dekodér ID 1:</label>
+      </variable>
+      <variable item="Decoder ID 2" CV="251" readOnly="yes">
+        <decVal/>
+        <label>Decoder ID 2</label>
+        <label xml:lang="it">ID 2 Decoder: </label>
+        <label xml:lang="cs">Dekodér ID 2:</label>
+      </variable>
+      <variable item="Decoder ID 3" CV="252" readOnly="yes">
+        <decVal/>
+        <label>Decoder ID 3</label>
+        <label xml:lang="it">ID 3 Decoder: </label>
+        <label xml:lang="cs">Dekodér ID 3:</label>
+      </variable>
+      <variable item="Decoder ID 4" CV="253" readOnly="yes">
+        <decVal/>
+        <label>Decoder ID 4</label>
+        <label xml:lang="it">ID 4 Decoder: </label>
+        <label xml:lang="cs">Dekodér ID 4:</label>
+      </variable>
+      <!-- Begin sound-only variables -->
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV260-CV355sound_version30.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV356.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV357-CV365sound_version28.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV366-CV371sound.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV372-CV399sound.xml"/>
+      <!-- End sound-only variables -->
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV400-CV428.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CVSwissMapping_v36.xml"/>
+      <!-- more sound variables -->
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV500-CV603.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV604-CV699.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV739-CV744.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV745-CV768.xml"/>
+      <!-- end of more sound variables -->
+      <!-- Begin constant stopping distance variables -->
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV830-CV833.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV835.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CVs_version37.xml"/>
+    </variables>
+    <xi:include href="http://jmri.org/xml/decoders/zimo/factReset-v32.xml"/>
+  </decoder>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneConsist.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneAccelDecel.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneShuntUncouple.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneAltFunctionMap6.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSwissMapping_v36.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneFunctionOutput.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSmoke.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneZimoSpecific.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneRailcom.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneABC.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSpeedRegulation.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneServos2.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneDecoderlock.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneInputMapping.xml"/>
+  <!-- Begin sound-only panes -->
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSoundLevels.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSoundSamples.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSound.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSound-ElectricLoco.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSound-DieselLoco.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneRandomSounds.xml"/>
+  <!-- End sound-only panes -->
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneLoadCode.xml"/>
+</decoder-config>

--- a/xml/decoders/Zimo_Unified_software_v39_MX64x_MX65x.xml
+++ b/xml/decoders/Zimo_Unified_software_v39_MX64x_MX65x.xml
@@ -36,6 +36,8 @@
   <version author="Ronald Kuhn   ronald@wirkuhns.de" version="1.7" lastUpdated="2020/05/02"/>
   <!-- v1.7,  added version 37 firmware capabilities,  Ronald Kuhn, 28 Feb 2018 -->
   <!-- v1.8,  merged MX64x/MX65x-Decoder and added version 39 firmware capabilities,  Ronald Kuhn, 02 May 2020 -->
+  <version author="Pierre Billon   pierre.bln@me.com" version="1.8" lastUpdated="2021/03/06"/>
+  <!-- v1.9,  added sound decoder MX605 (special Kato version for N-scale ICE 4) . Due to the combination with MX605FL & MX605SL installed in same engine, Front/rear lights and FO 1 for interior lighting listed as functons of this decoder,  Pierre Billon, 06 Mar 2021 -->
 
   <decoder>
     <family name="Zimo Unified software (version 39+)" mfg="Zimo">
@@ -523,6 +525,17 @@
         </output>
         <size length="20" width="9.5" height="3.5" units="mm"/>
       </model>
+      <model model="MX605 version 39+" lowVersionID="39" highVersionID="40" maxInputVolts="30V" maxMotorCurrent="0.7A, peak=1.5A" maxTotalCurrent="0.7A" formFactor="N" connector="DropIn" numOuts="3" numFns="14" productID="189">
+        <output name="1" label="Front Light (MX605SL)">
+          <label xml:lang="de">Lvor (MX605SL)</label>
+        </output>
+        <output name="2" label="Rear Light (MX605SL)">
+          <label xml:lang="de">Lrück (MX605SL)</label>
+        </output>
+        <output name="3" label="FO 1 (MX605FL)">
+          <label xml:lang="de">FA1 (MX605FL)</label>
+        </output>
+      </model>
     </family>
     <programming direct="yes" paged="yes" register="yes" ops="yes"/>
     <variables>
@@ -540,7 +553,13 @@
         <label xml:lang="it">Versione Decoder: </label>
         <label xml:lang="fr">Version décodeur: </label>
         <label xml:lang="de">Decoder Version: </label>
-      </variable> 
+      </variable>
+      <variable item="Decoder ID 1" CV="250" default="189" readOnly="yes" include="189">
+        <decVal/>
+        <label>Decoder ID 1</label>
+        <label xml:lang="it">ID 1 Decoder: </label>
+        <label xml:lang="cs">Dekodér ID 1:</label>
+      </variable>
       <variable item="Decoder ID 1" CV="250" default="190" readOnly="yes" include="190">
         <decVal/>
         <label>Decoder ID 1</label>


### PR DESCRIPTION
Fw versions 37+ and 39+. MX605 is special Zimo sound decoder for Kato N-scale ICE 4 (in theory usable in other Kato vehicules with the Kato in-house connector for EM13 decoder). Model nbr 189.

First time contributing on Zimo defs, but should be correct.