### PR TITLE
Provide a method for a single audio object cleanup

### DIFF
--- a/java/src/jmri/implementation/AbstractAudio.java
+++ b/java/src/jmri/implementation/AbstractAudio.java
@@ -52,8 +52,8 @@ public abstract class AbstractAudio extends AbstractNamedBean implements Audio {
      * Abstract method that concrete classes will implement to perform necessary
      * cleanup routines.
      * <p>
-     * This method does not call dispose() of this instance.
-     * The caller needs to call dispose() after the call to cleanup().
+     * This method is now included in dispose(). The caller can
+     * call dispose() to cleanup and deregister an audio object.
      */
     abstract protected void cleanup();
 

--- a/java/src/jmri/implementation/AbstractAudio.java
+++ b/java/src/jmri/implementation/AbstractAudio.java
@@ -51,12 +51,16 @@ public abstract class AbstractAudio extends AbstractNamedBean implements Audio {
     /**
      * Abstract method that concrete classes will implement to perform necessary
      * cleanup routines.
+     * <p>
+     * This method does not call dispose() of this instance.
+     * The caller needs to call dispose() after the call to cleanup().
      */
     abstract protected void cleanup();
 
     @Override
     public void dispose() {
         InstanceManager.getDefault(jmri.AudioManager.class).deregister(this);
+        cleanup();
         super.dispose();
     }
 

--- a/java/src/jmri/jmrit/audio/JavaSoundAudioBuffer.java
+++ b/java/src/jmri/jmrit/audio/JavaSoundAudioBuffer.java
@@ -390,7 +390,6 @@ public class JavaSoundAudioBuffer extends AbstractAudioBuffer {
         if (log.isDebugEnabled()) {
             log.debug("Cleanup JavaSoundAudioBuffer ({})", this.getSystemName());
         }
-        this.dispose();
     }
 
     private static final Logger log = LoggerFactory.getLogger(JavaSoundAudioBuffer.class);

--- a/java/src/jmri/jmrit/audio/JavaSoundAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/JavaSoundAudioFactory.java
@@ -109,8 +109,8 @@ public class JavaSoundAudioFactory extends AbstractAudioFactory {
             if (log.isDebugEnabled()) {
                 log.debug("Removing JavaSoundAudioSource: {}", source.getSystemName());
             }
-            // Cast to JavaSoundAudioSource and cleanup
-            ((JavaSoundAudioSource) source).cleanup();
+            // Includes cleanup
+            source.dispose();
         }
 
         // Now, retrieve list of AudioBuffer objects and remove the buffers
@@ -119,8 +119,8 @@ public class JavaSoundAudioFactory extends AbstractAudioFactory {
             if (log.isDebugEnabled()) {
                 log.debug("Removing JavaSoundAudioBuffer: {}", buffer.getSystemName());
             }
-            // Cast to JavaSoundAudioBuffer and cleanup
-            ((JavaSoundAudioBuffer) buffer).cleanup();
+            // Includes cleanup
+            buffer.dispose();
         }
 
         // Lastly, retrieve list of AudioListener objects and remove listener.
@@ -129,8 +129,8 @@ public class JavaSoundAudioFactory extends AbstractAudioFactory {
             if (log.isDebugEnabled()) {
                 log.debug("Removing JavaSoundAudioListener: {}", listener.getSystemName());
             }
-            // Cast to JavaSoundAudioListener and cleanup
-            ((JavaSoundAudioListener) listener).cleanup();
+            // Includes cleanup
+            listener.dispose();
         }
 
         // Finally, shutdown JavaSound and close the output device

--- a/java/src/jmri/jmrit/audio/JavaSoundAudioListener.java
+++ b/java/src/jmri/jmrit/audio/JavaSoundAudioListener.java
@@ -92,7 +92,6 @@ public class JavaSoundAudioListener extends AbstractAudioListener {
         if (log.isDebugEnabled()) {
             log.debug("Cleanup JavaSoundAudioListener ({})", this.getSystemName());
         }
-        this.dispose();
     }
 
     private static final Logger log = LoggerFactory.getLogger(JavaSoundAudioListener.class);

--- a/java/src/jmri/jmrit/audio/JavaSoundAudioSource.java
+++ b/java/src/jmri/jmrit/audio/JavaSoundAudioSource.java
@@ -322,7 +322,6 @@ public class JavaSoundAudioSource extends AbstractAudioSource {
         if (log.isDebugEnabled()) {
             log.debug("Cleanup JavaSoundAudioSource ({})", this.getSystemName());
         }
-        this.dispose();
     }
 
     /**

--- a/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
@@ -377,7 +377,6 @@ public class JoalAudioBuffer extends AbstractAudioBuffer {
         if (log.isDebugEnabled()) {
             log.debug("Cleanup JoalAudioBuffer ({})", this.getSystemName());
         }
-        this.dispose();
     }
 
     private static final Logger log = LoggerFactory.getLogger(JoalAudioBuffer.class);

--- a/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
@@ -370,7 +370,7 @@ public class JoalAudioBuffer extends AbstractAudioBuffer {
     }
 
     @Override
-    protected void cleanup() {
+    public void cleanup() {
         if (initialised) {
             al.alDeleteBuffers(1, dataStorageBuffer, 0);
         }

--- a/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
@@ -377,6 +377,7 @@ public class JoalAudioBuffer extends AbstractAudioBuffer {
         if (log.isDebugEnabled()) {
             log.debug("Cleanup JoalAudioBuffer ({})", this.getSystemName());
         }
+        this.dispose();
     }
 
     private static final Logger log = LoggerFactory.getLogger(JoalAudioBuffer.class);

--- a/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
@@ -370,14 +370,13 @@ public class JoalAudioBuffer extends AbstractAudioBuffer {
     }
 
     @Override
-    public void cleanup() {
+    protected void cleanup() {
         if (initialised) {
             al.alDeleteBuffers(1, dataStorageBuffer, 0);
         }
         if (log.isDebugEnabled()) {
             log.debug("Cleanup JoalAudioBuffer ({})", this.getSystemName());
         }
-        this.dispose();
     }
 
     private static final Logger log = LoggerFactory.getLogger(JoalAudioBuffer.class);

--- a/java/src/jmri/jmrit/audio/JoalAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioFactory.java
@@ -354,8 +354,8 @@ public class JoalAudioFactory extends AbstractAudioFactory {
             if (log.isDebugEnabled()) {
                 log.debug("Removing JoalAudioSource: {}", source.getSystemName());
             }
-            // Cast to JoalAudioSource and cleanup
-            ((JoalAudioSource) source).cleanup();
+            // Includes cleanup
+            source.dispose();
         }
 
         // Now, retrieve list of AudioBuffer objects and remove the buffers
@@ -364,8 +364,8 @@ public class JoalAudioFactory extends AbstractAudioFactory {
             if (log.isDebugEnabled()) {
                 log.debug("Removing JoalAudioBuffer: {}", buffer.getSystemName());
             }
-            // Cast to JoalAudioBuffer and cleanup
-            ((JoalAudioBuffer) buffer).cleanup();
+            // Includes cleanup
+            buffer.dispose();
         }
 
         // Lastly, retrieve list of AudioListener objects and remove listener.
@@ -374,8 +374,8 @@ public class JoalAudioFactory extends AbstractAudioFactory {
             if (log.isDebugEnabled()) {
                 log.debug("Removing JoalAudioListener: {}", listener.getSystemName());
             }
-            // Cast to JoalAudioListener and cleanup
-            ((JoalAudioListener) listener).cleanup();
+            // Includes cleanup
+            listener.dispose();
         }
 
         // Finally, shutdown OpenAL and close the output device

--- a/java/src/jmri/jmrit/audio/JoalAudioListener.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioListener.java
@@ -184,7 +184,6 @@ public class JoalAudioListener extends AbstractAudioListener {
         if (log.isDebugEnabled()) {
             log.debug("Cleanup JoalAudioListener ({})", this.getSystemName());
         }
-        this.dispose();
     }
 
     private static final Logger log = LoggerFactory.getLogger(JoalAudioListener.class);

--- a/java/src/jmri/jmrit/audio/JoalAudioSource.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioSource.java
@@ -539,7 +539,6 @@ public class JoalAudioSource extends AbstractAudioSource {
             this._source = null;
             log.debug("...done cleanup");
         }
-        this.dispose();
     }
 
     @Override

--- a/java/src/jmri/jmrit/audio/JoalAudioSource.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioSource.java
@@ -529,7 +529,7 @@ public class JoalAudioSource extends AbstractAudioSource {
     }
 
     @Override
-    protected void cleanup() {
+    public void cleanup() {
         log.debug("Cleanup JoalAudioSource ({})", this.getSystemName());
         int[] source_type = new int[1];
         al.alGetSourcei(_source[0], AL.AL_SOURCE_TYPE, source_type, 0);

--- a/java/src/jmri/jmrit/audio/JoalAudioSource.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioSource.java
@@ -529,7 +529,7 @@ public class JoalAudioSource extends AbstractAudioSource {
     }
 
     @Override
-    public void cleanup() {
+    protected void cleanup() {
         log.debug("Cleanup JoalAudioSource ({})", this.getSystemName());
         int[] source_type = new int[1];
         al.alGetSourcei(_source[0], AL.AL_SOURCE_TYPE, source_type, 0);

--- a/java/src/jmri/jmrit/audio/NullAudioBuffer.java
+++ b/java/src/jmri/jmrit/audio/NullAudioBuffer.java
@@ -100,7 +100,6 @@ public class NullAudioBuffer extends AbstractAudioBuffer {
         if (log.isDebugEnabled()) {
             log.debug("Cleanup NullAudioBuffer ({})", this.getSystemName());
         }
-        this.dispose();
     }
 
     private static final Logger log = LoggerFactory.getLogger(NullAudioBuffer.class);

--- a/java/src/jmri/jmrit/audio/NullAudioFactory.java
+++ b/java/src/jmri/jmrit/audio/NullAudioFactory.java
@@ -75,8 +75,8 @@ public class NullAudioFactory extends AbstractAudioFactory {
             if (log.isDebugEnabled()) {
                 log.debug("Removing NullAudioSource: {}", source.getSystemName());
             }
-            // Cast to NullAudioSource and cleanup
-            ((NullAudioSource) source).cleanup();
+            // Includes cleanup
+            source.dispose();
         }
 
         // Now, retrieve list of AudioBuffer objects and remove the buffers
@@ -85,8 +85,8 @@ public class NullAudioFactory extends AbstractAudioFactory {
             if (log.isDebugEnabled()) {
                 log.debug("Removing NullAudioBuffer: {}", buffer.getSystemName());
             }
-            // Cast to NullAudioBuffer and cleanup
-            ((NullAudioBuffer) buffer).cleanup();
+            // Includes cleanup
+            buffer.dispose();
         }
 
         // Lastly, retrieve list of AudioListener objects and remove listener.
@@ -95,8 +95,8 @@ public class NullAudioFactory extends AbstractAudioFactory {
             if (log.isDebugEnabled()) {
                 log.debug("Removing NullAudioListener: {}", listener.getSystemName());
             }
-            // Cast to NullAudioListener and cleanup
-            ((NullAudioListener) listener).cleanup();
+            // Includes cleanup
+            listener.dispose();
         }
 
         // Finally, shutdown NullAudio and close the output device

--- a/java/src/jmri/jmrit/audio/NullAudioListener.java
+++ b/java/src/jmri/jmrit/audio/NullAudioListener.java
@@ -60,7 +60,6 @@ public class NullAudioListener extends AbstractAudioListener {
         if (log.isDebugEnabled()) {
             log.debug("Cleanup NullAudioBuffer ({})", this.getSystemName());
         }
-        this.dispose();
     }
 
     private static final Logger log = LoggerFactory.getLogger(NullAudioListener.class);

--- a/java/src/jmri/jmrit/audio/NullAudioSource.java
+++ b/java/src/jmri/jmrit/audio/NullAudioSource.java
@@ -125,7 +125,6 @@ public class NullAudioSource extends AbstractAudioSource {
     @Override
     protected void cleanup() {
         log.debug("Cleanup NullAudioSource ({})", this.getSystemName());
-        this.dispose();
     }
 
     @Override


### PR DESCRIPTION
The ```cleanup()``` method in ```JoalAudioFactory``` handles the removing of the audio objects like sources and buffers. And it handles the audio shutdown inclusive closing the audio device. This ```cleanup()``` method is ```public```. It calls the ```cleanup()``` methods in ```JoalAudioSource``` and ```JoalAudioBuffer```, among others. These methods have protected access.

I am looking for a way to remove Joal audio sources and buffers and to continue the application. The ```cleanup()``` methods in ```JoalAudioSource``` and ```JoalAudioBuffer``` could to this if access were possible. The concrete case is Virtual Sound Decoder (VSD). Within the VSD Manager it is possible to delete a single VSDecoder. So far the sources and buffers of such a single VSDecoder are not deleted. Each delete/add action increases the number of buffers and sources.