### PR TITLE
Doehler & Haass fw 3.12.050 update (+implemented product ID detection)

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -201,7 +201,19 @@
 
         <h4>Doehler &amp; Haas</h4>
             <ul>
-                <li></li>
+                <li>New - for all new D&amp;H definitions: decoder model (product ID) is now detected automatically thanks to the introduction of CV 261 in updated firmware.</li>
+                <li>DH05C (fw 3.12.050 - including update path from older fw versions definitions)</li>
+                <li>DH10C (fw 3.12.050 - including update path from older fw versions definitions)</li>
+                <li>DH12A (fw 3.12.050 - including update path from older fw versions definitions)</li>
+                <li>DH16A (fw 3.12.050 - including update path from older fw versions definitions)</li>
+                <li>DH18A (fw 3.12.050 - including update path from older fw versions definitions)</li>
+                <li>DH21A (fw 3.12.050 - including update path from older fw versions definitions)</li>
+                <li>DH22A (fw 3.12.050 - including update path from older fw versions definitions)</li>
+                <li>PD05A (fw 3.12.050 - including update path from older fw versions definitions)</li>
+                <li>PD12A (fw 3.12.050 - including update path from older fw versions definitions)</li>
+                <li>FH05B (fw 3.12.050 - including update path from older fw versions definitions)</li>
+                <li>FH18A (fw 3.12.050 - including update path from older fw versions definitions)</li>
+                <li>FH22A (fw 3.12.050 - including update path from older fw versions definitions)</li>
             </ul>
 
         <h4>ESU</h4>
@@ -581,4 +593,3 @@
         <ul>
             <li></li>
         </ul>
-

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -348,7 +348,7 @@
 
         <h4>ZIMO</h4>
             <ul>
-                <li></li>
+                <li>MX605 (Kato type plug N sound decoder for ICE 4)</li>
             </ul>
 
         <h4>Miscellaneous</h4>

--- a/java/src/jmri/jmrit/beantable/AbstractTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableAction.java
@@ -171,7 +171,7 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
     
     /**
      * Perform configuration of the JTable as required by a specific TableAction.
-     * @param table 
+     * @param table The table to configure.
      */
     protected void configureTable(JTable table){
     }

--- a/java/src/jmri/jmrit/beantable/AbstractTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableAction.java
@@ -4,6 +4,7 @@ import java.awt.event.ActionEvent;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.HashMap;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.JButton;
@@ -83,6 +84,7 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
         };
         setMenuBar(f); // comes after the Help menu is added by f = new
                        // BeanTableFrame(etc.) in stand alone application
+        configureTable(dataTable);
         setTitle();
         addToFrame(f);
         f.pack();
@@ -144,6 +146,15 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
      */
     protected void setManager(@Nonnull Manager<E> man) {
     }
+    
+    /**
+     * Get the Bean Manager in use by the TableAction.
+     * @return Bean Manager, could be Proxy or normal Manager, may be null.
+     */
+    @CheckForNull
+    protected Manager<E> getManager(){
+        return null;
+    }
 
     /**
      * Allow subclasses to alter the frame's Menubar without having to actually
@@ -156,6 +167,13 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
 
     public JPanel getPanel() {
         return null;
+    }
+    
+    /**
+     * Perform configuration of the JTable as required by a specific TableAction.
+     * @param table 
+     */
+    protected void configureTable(JTable table){
     }
 
     public void dispose() {

--- a/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
@@ -34,11 +34,12 @@ abstract public class AbstractTableTabAction<E extends NamedBean> extends Abstra
         dataPanel = new JPanel();
         dataTabs = new JTabbedPane();
         dataPanel.setLayout(new BorderLayout());
-        if (getManager() instanceof jmri.managers.AbstractProxyManager) {
+        Manager<E> mgr = getManager();
+        if (mgr instanceof jmri.managers.AbstractProxyManager) {
             // build the list, with default at start and internal at end (if present)
-            jmri.managers.AbstractProxyManager<E> proxy = (jmri.managers.AbstractProxyManager<E>) getManager();
+            jmri.managers.AbstractProxyManager<E> proxy = (jmri.managers.AbstractProxyManager<E>) mgr;
 
-            tabbedTableArray.add(new TabbedTableItem<>(Bundle.getMessage("All"), true, getManager(), getNewTableAction("All"))); // NOI18N
+            tabbedTableArray.add(new TabbedTableItem<>(Bundle.getMessage("All"), true, mgr, getNewTableAction("All"))); // NOI18N
 
             proxy.getDisplayOrderManagerList().stream().map(manager -> {
                 String manuName = manager.getMemo().getUserName();
@@ -49,7 +50,8 @@ abstract public class AbstractTableTabAction<E extends NamedBean> extends Abstra
             });
             
         } else {
-            String manuName = getManager().getMemo().getUserName();
+            Manager<E> man = getManager();
+            String manuName = ( man!=null ? man.getMemo().getUserName() : "Unknown Manager");
             tabbedTableArray.add(new TabbedTableItem<>(manuName, true, getManager(), getNewTableAction(manuName)));
         }
         for (int x = 0; x < tabbedTableArray.size(); x++) {

--- a/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
@@ -64,6 +64,7 @@ abstract public class AbstractTableTabAction<E extends NamedBean> extends Abstra
         init = true;
     }
 
+    @Override
     abstract protected Manager<E> getManager();
 
     abstract protected AbstractTableAction<E> getNewTableAction(String choice);
@@ -193,6 +194,7 @@ abstract public class AbstractTableTabAction<E extends NamedBean> extends Abstra
             RowSorterUtil.setSortOrder(sorter, BeanTableDataModel.USERNAMECOL, SortOrder.ASCENDING);
 
             dataModel.configureTable(dataTable);
+            tableAction.configureTable(dataTable);
 
             java.awt.Dimension dataTableSize = dataTable.getPreferredSize();
             // width is right, but if table is empty, it's not high

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -1,8 +1,6 @@
 package jmri.jmrit.beantable;
 
-import java.awt.Component;
-import java.awt.Font;
-import java.awt.Toolkit;
+import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
@@ -19,13 +17,11 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
+
 import javax.annotation.Nonnull;
 import javax.annotation.CheckForNull;
 import javax.swing.*;
-import javax.swing.table.AbstractTableModel;
-import javax.swing.table.TableCellEditor;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableModel;
+import javax.swing.table.*;
 
 import jmri.*;
 import jmri.NamedBean.DisplayOptions;
@@ -110,12 +106,13 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
      * @param column table column number.
      * @return the descriptor if available, else null.
      */
+    @CheckForNull
     protected NamedBeanPropertyDescriptor<?> getPropertyColumnDescriptor(int column) {
         List<NamedBeanPropertyDescriptor<?>> propertyColumns = getManager().getKnownBeanProperties();
         int totalCount = getColumnCount();
         int propertyCount = propertyColumns.size();
         int tgt = column - (totalCount - propertyCount);
-        if (tgt < 0) {
+        if (tgt < 0 || tgt >= propertyCount ) {
             return null;
         }
         return propertyColumns.get(tgt);
@@ -221,7 +218,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
             default:
                 NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
                 if (desc == null) {
-                    return "unknown";
+                    return "btm unknown"; // NOI18N 
                 }
                 return desc.getColumnHeaderText();
         }
@@ -300,15 +297,17 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
             default:
                 NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
                 if (desc == null) {
-                    log.error("internal state inconsistent with table requst for {} {}", row, col);
+                    log.error("internal state inconsistent with table requst for getValueAt {} {}", row, col);
                     return null;
+                }
+                if ( !isCellEditable(row, col) ) {
+                    return null; // do not display if not applicable to hardware type
                 }
                 b = getBySystemName(sysNameList.get(row));
                 Object value = b.getProperty(desc.propertyKey);
                 if (desc instanceof SelectionPropertyDescriptor){
                     JComboBox<String> c = new JComboBox<>(((SelectionPropertyDescriptor) desc).getOptions());
                     c.setSelectedItem(( value!=null ? value.toString() : desc.defaultValue.toString() ));
-                    c.addActionListener(this::comboBoxAction);
                     ComboBoxToolTipRenderer renderer = new ComboBoxToolTipRenderer();
                     c.setRenderer(renderer);
                     renderer.setTooltips(((SelectionPropertyDescriptor) desc).getOptionToolTips());
@@ -318,18 +317,6 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
                     return desc.defaultValue;
                 }
                 return value;
-        }
-    }
-
-    /**
-     * Action for Combo Boxes.
-     * When a selection is made, triggers the setValueAt().
-     * @param e the event from the Combo box.
-     */
-    public void comboBoxAction(ActionEvent e) {
-        log.debug("Combobox change");
-        if (thistable != null && thistable.getCellEditor() != null) {
-            thistable.getCellEditor().stopCellEditing();
         }
     }
 
@@ -346,7 +333,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
             default:
                 NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
                 if (desc == null || desc.getColumnHeaderText() == null) {
-                    log.warn("Unexpected column in getPreferredWidth: {} table {}", col,this);
+                    log.error("Unexpected column in getPreferredWidth: {} table {}", col,this);
                     return new JTextField(8).getPreferredSize().width;
                 }
                 return new JTextField(desc.getColumnHeaderText()).getPreferredSize().width;
@@ -500,8 +487,9 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         // Property columns will be invisible at start.
         setPropertyColumnsVisible(table, false);
 
-        table.setDefaultRenderer(JComboBox.class, new jmri.jmrit.symbolicprog.ValueRenderer());
-        table.setDefaultEditor(JComboBox.class, new jmri.jmrit.symbolicprog.ValueEditor());
+        table.setDefaultRenderer(JComboBox.class, new BtValueRenderer());
+        table.setDefaultEditor(JComboBox.class, new BtComboboxEditor());
+        table.setDefaultRenderer(Boolean.class, new EnablingCheckboxRenderer());
 
         // allow reordering of the columns
         table.getTableHeader().setReorderingAllowed(true);
@@ -509,10 +497,13 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         // have to shut off autoResizeMode to get horizontal scroll to work (JavaSwing p 541)
         table.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
 
-        // resize columns as requested
-        for (int i = 0; i < table.getColumnCount(); i++) {
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+        for (int i = 0; i < columnModel.getColumnCount(false); i++) {
+            
+            // resize columns as requested
             int width = getPreferredWidth(i);
-            table.getColumnModel().getColumn(i).setPreferredWidth(width);
+            columnModel.getColumnByModelIndex(i).setPreferredWidth(width);
+            
         }
         table.sizeColumnsToFit(-1);
 
@@ -522,11 +513,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         MouseListener popupListener = new PopupListener();
         table.addMouseListener(popupListener);
         this.persistTable(table);
-
-        thistable = table;
     }
-
-    private JTable thistable;
 
     protected void configValueColumn(JTable table) {
         // have the value column hold a button
@@ -1017,7 +1004,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
      * @param col The current column.
      * @return a formatted tool tip or null if there is none.
      */
-    String getCellToolTip(JTable table, int row, int col) {
+    public String getCellToolTip(JTable table, int row, int col) {
         String tip = null;
         if (!table.getName().contains("SignalMastLogic")) {
             int column = COMMENTCOL;
@@ -1381,6 +1368,60 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         public void mouseClicked(MouseEvent e) {
             if (e.isPopupTrigger()) {
                 showTableHeaderPopup(e, table);
+            }
+        }
+    }
+
+    private class BtComboboxEditor extends jmri.jmrit.symbolicprog.ValueEditor {
+    
+        public BtComboboxEditor(){
+            super();
+        }
+        
+        @Override
+        public Component getTableCellEditorComponent(JTable table, Object value,
+            boolean isSelected,
+            int row, int column) {
+            if (value instanceof JComboBox) {
+                ((JComboBox) value).addActionListener((ActionEvent e1) -> table.getCellEditor().stopCellEditing());
+            }
+            
+            if (value instanceof JComponent ) {
+            
+                int modelcol =  table.convertColumnIndexToModel(column);
+                int modelrow = table.convertRowIndexToModel(row);
+
+                // if cell is not editable, jcombobox not applicable for hardware type
+                boolean editable = table.getModel().isCellEditable(modelrow, modelcol);
+
+                ((JComponent) value).setEnabled(editable);
+            
+            }
+            
+            return super.getTableCellEditorComponent(table, value, isSelected, row, column);
+        }
+    
+    
+    }
+    
+    private class BtValueRenderer implements TableCellRenderer {
+
+        public BtValueRenderer() {
+            super();
+        }
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value,
+            boolean isSelected, boolean hasFocus, int row, int column) {
+
+            if (value instanceof Component) {
+                return (Component) value;
+            } else if (value instanceof String) {
+                return new JLabel((String) value);
+            } else {
+                JPanel f = new JPanel();
+                f.setBackground(isSelected ? table.getSelectionBackground() : table.getBackground() );
+                return f;
             }
         }
     }

--- a/java/src/jmri/jmrit/beantable/BlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/BlockTableAction.java
@@ -191,7 +191,6 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                     } else if (b.getCurvature() == Block.SEVERE) {
                         c.setSelectedItem(severeText);
                     }
-                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == LENGTHCOL) {
                     double len = 0.0;
@@ -212,7 +211,6 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                     JComboBox<String> c = new JComboBox<>(speedList);
                     c.setEditable(true);
                     c.setSelectedItem(speed);
-                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == STATECOL) {
                     switch (b.getState()) {
@@ -233,7 +231,6 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                         name = sensor.getDisplayName();
                     }
                     c.setSelectedItem(name);
-                    c.addActionListener(super::comboBoxAction);
                     return c;
                 } else if (col == REPORTERCOL) {
                     Reporter reporter = b.getReporter();
@@ -243,7 +240,6 @@ public class BlockTableAction extends AbstractTableAction<Block> {
                         name = reporter.getDisplayName();
                     }
                     rs.setSelectedItem(name);
-                    rs.addActionListener(super::comboBoxAction);
                     return rs;
                 } else if (col == CURRENTREPCOL) {
                     return Boolean.valueOf(b.isReportingCurrent());

--- a/java/src/jmri/jmrit/beantable/IdTagTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/IdTagTableTabAction.java
@@ -2,6 +2,8 @@ package jmri.jmrit.beantable;
 
 import java.awt.BorderLayout;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.JPanel;
@@ -20,6 +22,7 @@ public class IdTagTableTabAction extends AbstractTableTabAction<IdTag> {
 
     /** {@inheritDoc} */
     @Override
+    @Nonnull
     protected Manager<IdTag> getManager() {
         return InstanceManager.getDefault(IdTagManager.class);
     }

--- a/java/src/jmri/jmrit/beantable/SensorTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SensorTableAction.java
@@ -40,7 +40,7 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
 
         // disable ourself if there is no primary sensor manager available
         if (sensorManager == null) {
-            setEnabled(false);
+            super.setEnabled(false);
         }
     }
 
@@ -425,17 +425,13 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
             menuBar.add(optionsMenu, pos + offset);
         }
     }
-
-    private void showDebounceChanged(ActionEvent e) {
-        ((SensorTableDataModel) m).showDebounce(showDebounceBox.isSelected());
-    }
-
-    private void showPullUpChanged(ActionEvent e) {
-        ((SensorTableDataModel) m).showPullUp(showPullUpBox.isSelected());
-    }
-
-    private void showStateForgetAndQueryChanged(ActionEvent e) {
-        ((SensorTableDataModel) m).showStateForgetAndQuery(showStateForgetAndQueryBox.isSelected());
+    
+    @Override
+    protected void configureTable(JTable table){
+        super.configureTable(table);
+        showDebounceBox.addActionListener((ActionEvent e) -> { ((SensorTableDataModel)m).showDebounce(showDebounceBox.isSelected(), table); });
+        showPullUpBox.addActionListener((ActionEvent e) -> { ((SensorTableDataModel)m).showPullUp(showPullUpBox.isSelected(), table); });
+        showStateForgetAndQueryBox.addActionListener((ActionEvent e) -> { ((SensorTableDataModel)m).showStateForgetAndQuery(showStateForgetAndQueryBox.isSelected(), table); });
     }
 
     private final TriStateJCheckBox showDebounceBox = new TriStateJCheckBox(Bundle.getMessage("SensorDebounceCheckBox"));
@@ -449,14 +445,10 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
     public void addToFrame(BeanTableFrame<Sensor> f) {
         f.addToBottomBox(showDebounceBox, this.getClass().getName());
         showDebounceBox.setToolTipText(Bundle.getMessage("SensorDebounceToolTip"));
-        showDebounceBox.addActionListener(this::showDebounceChanged);
         f.addToBottomBox(showPullUpBox, this.getClass().getName());
         showPullUpBox.setToolTipText(Bundle.getMessage("SensorPullUpToolTip"));
-        showPullUpBox.addActionListener(this::showPullUpChanged);
-        showPullUpBox.setVisible(true);
         f.addToBottomBox(showStateForgetAndQueryBox, this.getClass().getName());
         showStateForgetAndQueryBox.setToolTipText(Bundle.getMessage("StateForgetAndQueryBoxToolTip"));
-        showStateForgetAndQueryBox.addActionListener(this::showStateForgetAndQueryChanged);
     }
     
     /**
@@ -489,13 +481,10 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
         }
         f.addToBottomBox(showDebounceBox, connectionName);
         showDebounceBox.setToolTipText(Bundle.getMessage("SensorDebounceToolTip"));
-        showDebounceBox.addActionListener(this::showDebounceChanged);
         f.addToBottomBox(showPullUpBox, connectionName);
         showPullUpBox.setToolTipText(Bundle.getMessage("SensorPullUpToolTip"));
-        showPullUpBox.addActionListener(this::showPullUpChanged);
         f.addToBottomBox(showStateForgetAndQueryBox, connectionName);
         showStateForgetAndQueryBox.setToolTipText(Bundle.getMessage("StateForgetAndQueryBoxToolTip"));
-        showStateForgetAndQueryBox.addActionListener(this::showStateForgetAndQueryChanged);
     }
 
     /**

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -1,42 +1,22 @@
 package jmri.jmrit.beantable;
 
-import jmri.util.gui.GuiLafPreferencesManager;
-
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.util.Enumeration;
-import java.util.Hashtable;
 import java.util.Objects;
 import java.util.Vector;
 
 import javax.annotation.Nonnull;
-import javax.annotation.CheckForNull;
-import javax.imageio.ImageIO;
 import javax.swing.*;
-import javax.swing.table.TableCellEditor;
-import javax.swing.table.TableCellRenderer;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableModel;
 
 import jmri.*;
-import jmri.NamedBean.DisplayOptions;
-import jmri.implementation.SignalSpeedMap;
-import jmri.jmrit.turnoutoperations.TurnoutOperationConfig;
+import jmri.jmrit.beantable.turnout.TurnoutTableDataModel;
 import jmri.jmrit.turnoutoperations.TurnoutOperationFrame;
 import jmri.swing.ManagerComboBox;
-import jmri.swing.NamedBeanComboBox;
 import jmri.swing.SystemNameValidator;
 import jmri.util.JmriJFrame;
 import jmri.util.swing.TriStateJCheckBox;
-import jmri.util.swing.XTableColumnModel;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,27 +42,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
 
         // disable ourself if there is no primary turnout manager available
         if (turnoutManager == null) {
-            setEnabled(false);
-        }
-
-        //This following must contain the word Global for a correct match in the abstract turnout
-        defaultThrownSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultThrownSpeed());
-        defaultClosedSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultClosedSpeed());
-        //This following must contain the word Block for a correct match in the abstract turnout
-        useBlockSpeed = Bundle.getMessage("UseGlobal", "Block Speed");
-
-        speedListClosed.add(defaultClosedSpeedText);
-        speedListThrown.add(defaultThrownSpeedText);
-        speedListClosed.add(useBlockSpeed);
-        speedListThrown.add(useBlockSpeed);
-        java.util.Vector<String> _speedMap = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getValidSpeedNames();
-        for (String s : _speedMap) {
-            if (!speedListClosed.contains(s)) {
-                speedListClosed.add(s);
-            }
-            if (!speedListThrown.contains(s)) {
-                speedListThrown.add(s);
-            }
+            super.setEnabled(false);
         }
     }
 
@@ -90,23 +50,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         this(Bundle.getMessage("TitleTurnoutTable"));
     }
 
-    String closedText;
-    String thrownText;
-    String defaultThrownSpeedText;
-    String defaultClosedSpeedText;
-    // I18N TODO but note storing in xml independent from Locale
-    String useBlockSpeed;
-    String bothText = "Both";
-    String cabOnlyText = "Cab only";
-    String pushbutText = "Pushbutton only";
-    String noneText = "None";
-
-    private final java.util.Vector<String> speedListClosed = new java.util.Vector<>();
-    private final java.util.Vector<String> speedListThrown = new java.util.Vector<>();
     protected TurnoutManager turnoutManager = InstanceManager.getDefault(TurnoutManager.class);
-    protected JTable table;
-    // for icon state col
-    protected boolean _graphicState = false; // updated from prefs
 
     /**
      * {@inheritDoc}
@@ -116,24 +60,11 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         if (man instanceof TurnoutManager) {
             log.debug("setting manager of TTAction {} to {}",this,man.getClass());
             turnoutManager = (TurnoutManager) man;
+            if (m!=null){ // also update Table Model
+                m.setManager(man);
+            }            
         }
     }
-
-    static public final int INVERTCOL = BeanTableDataModel.NUMCOLUMN;
-    static public final int LOCKCOL = INVERTCOL + 1;
-    static public final int EDITCOL = LOCKCOL + 1;
-    static public final int KNOWNCOL = EDITCOL + 1;
-    static public final int MODECOL = KNOWNCOL + 1;
-    static public final int SENSOR1COL = MODECOL + 1;
-    static public final int SENSOR2COL = SENSOR1COL + 1;
-    static public final int OPSONOFFCOL = SENSOR2COL + 1;
-    static public final int OPSEDITCOL = OPSONOFFCOL + 1;
-    static public final int LOCKOPRCOL = OPSEDITCOL + 1;
-    static public final int LOCKDECCOL = LOCKOPRCOL + 1;
-    static public final int STRAIGHTCOL = LOCKDECCOL + 1;
-    static public final int DIVERGCOL = STRAIGHTCOL + 1;
-    static public final int FORGETCOL = DIVERGCOL + 1;
-    static public final int QUERYCOL = FORGETCOL + 1;
 
     /**
      * Create the JTable DataModel, along with the changes for the specific case
@@ -141,787 +72,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
      */
     @Override
     protected void createModel() {
-        // store the terminology
-        closedText = turnoutManager.getClosedText();
-        thrownText = turnoutManager.getThrownText();
-
-        // load graphic state column display preference
-        // from apps/GuiLafConfigPane.java
-        _graphicState = InstanceManager.getDefault(GuiLafPreferencesManager.class).isGraphicTableState();
-
-        // create the data model object that drives the table
-        // note that this is a class creation, and very long
-        m = new BeanTableDataModel<Turnout>() {
-
-            @Override
-            public int getColumnCount() {
-                return QUERYCOL + getPropertyColumnCount() + 1;
-            }
-
-            @Override
-            public String getColumnName(int col) {
-                switch (col) {
-                    case INVERTCOL:
-                        return Bundle.getMessage("Inverted");
-                    case LOCKCOL:
-                        return Bundle.getMessage("Locked");
-                    case KNOWNCOL:
-                        return Bundle.getMessage("Feedback");
-                    case MODECOL:
-                        return Bundle.getMessage("ModeLabel");
-                    case SENSOR1COL:
-                        return Bundle.getMessage("BlockSensor") + "1";
-                    case SENSOR2COL:
-                        return Bundle.getMessage("BlockSensor") + "2";
-                    case OPSONOFFCOL:
-                        return Bundle.getMessage("TurnoutAutomationMenu");
-                    case OPSEDITCOL:
-                        return "";
-                    case LOCKOPRCOL:
-                        return Bundle.getMessage("LockMode");
-                    case LOCKDECCOL:
-                        return Bundle.getMessage("Decoder");
-                    case DIVERGCOL:
-                        return Bundle.getMessage("ThrownSpeed");
-                    case STRAIGHTCOL:
-                        return Bundle.getMessage("ClosedSpeed");
-                    case FORGETCOL:
-                        return Bundle.getMessage("StateForgetHeader");
-                    case QUERYCOL:
-                        return Bundle.getMessage("StateQueryHeader");
-                    case EDITCOL:
-                        return "";
-                    default:
-                        return super.getColumnName(col);
-                }
-            }
-
-            @Override
-            public Class<?> getColumnClass(int col) {
-                switch (col) {
-                    case INVERTCOL:
-                    case LOCKCOL:
-                        return Boolean.class;
-                    case KNOWNCOL:
-                        return String.class;
-                    case MODECOL:
-                    case SENSOR1COL:
-                    case SENSOR2COL:
-                    case OPSONOFFCOL:
-                    case LOCKOPRCOL:
-                    case LOCKDECCOL:
-                    case DIVERGCOL:
-                    case STRAIGHTCOL:
-                        return JComboBox.class;
-                    case OPSEDITCOL:
-                    case EDITCOL:
-                    case FORGETCOL:
-                    case QUERYCOL:
-                        return JButton.class;
-                    case VALUECOL: // may use an image to show turnout state
-                        return ( _graphicState ? JLabel.class : JButton.class );
-                    default:
-                        return super.getColumnClass(col);
-                }
-            }
-
-            @Override
-            public int getPreferredWidth(int col) {
-                switch (col) {
-                    case INVERTCOL:
-                    case LOCKCOL:
-                        return new JTextField(6).getPreferredSize().width;
-                    case LOCKOPRCOL:
-                    case LOCKDECCOL:
-                    case KNOWNCOL:
-                    case MODECOL:
-                        return new JTextField(10).getPreferredSize().width;
-                    case SENSOR1COL:
-                    case SENSOR2COL:
-                        return new JTextField(5).getPreferredSize().width;
-                    case OPSEDITCOL:
-                        return new JButton(Bundle.getMessage("EditTurnoutOperation")).getPreferredSize().width;
-                    case EDITCOL:
-                        return new JButton(Bundle.getMessage("ButtonEdit")).getPreferredSize().width+4;
-                    case OPSONOFFCOL:
-                        return new JTextField(Bundle.getMessage("TurnoutAutomationMenu")).getPreferredSize().width;
-                    case DIVERGCOL:
-                    case STRAIGHTCOL:
-                        return new JTextField(14).getPreferredSize().width;
-                    case FORGETCOL:
-                        return new JButton(Bundle.getMessage("StateForgetButton")).getPreferredSize().width;
-                    case QUERYCOL:
-                        return new JButton(Bundle.getMessage("StateQueryButton")).getPreferredSize().width;
-                    default:
-                        super.getPreferredWidth(col);
-                }
-                return super.getPreferredWidth(col);
-            }
-
-            @Override
-            public boolean isCellEditable(int row, int col) {
-                Turnout t = turnoutManager.getBySystemName(sysNameList.get(row));
-                if (t == null){
-                    return false;
-                }
-                switch (col) {
-                    case INVERTCOL:
-                        return t.canInvert();
-                    case LOCKCOL:
-                        // checkbox disabled unless current configuration allows locking
-                        return t.canLock(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT);
-                    case OPSEDITCOL:
-                        return t.getTurnoutOperation() != null;
-                    case KNOWNCOL:
-                        return false;
-                    case MODECOL:
-                    case SENSOR1COL:
-                    case SENSOR2COL:
-                    case OPSONOFFCOL:
-                    case LOCKOPRCOL: // editable always so user can configure it, even if current configuration prevents locking now
-                    case LOCKDECCOL: // editable always so user can configure it, even if current configuration prevents locking now
-                    case DIVERGCOL:
-                    case STRAIGHTCOL:
-                    case EDITCOL:
-                    case FORGETCOL:
-                    case QUERYCOL:
-                        return true;
-                    default:
-                        return super.isCellEditable(row, col);
-                }
-            }
-
-            @Override
-            public Object getValueAt(int row, int col) {
-                // some error checking
-                if (row >= sysNameList.size()) {
-                    log.debug("row is greater than name list");
-                    return "error";
-                }
-                String name = sysNameList.get(row);
-                TurnoutManager manager = turnoutManager;
-                Turnout t = manager.getBySystemName(name);
-                if (t == null) {
-                    log.debug("error null turnout!");
-                    return "error";
-                }
-                if (col == INVERTCOL) {
-                    return t.getInverted();
-                } else if (col == LOCKCOL) {
-                    return t.getLocked(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT);
-                } else if (col == KNOWNCOL) {
-                    return t.describeState(t.getKnownState());
-                } else if (col == MODECOL) {
-                    JComboBox<String> c = new JComboBox<>(t.getValidFeedbackNames());
-                    c.setSelectedItem(t.getFeedbackModeName());
-                    c.addActionListener(super::comboBoxAction);
-                    return c;
-                } else if (col == SENSOR1COL) {
-                    return t.getFirstSensor();
-                } else if (col == SENSOR2COL) {
-                    return t.getSecondSensor();
-                } else if (col == OPSONOFFCOL) {
-                    return makeAutomationBox(t);
-                } else if (col == OPSEDITCOL) {
-                    return Bundle.getMessage("EditTurnoutOperation");
-                } else if (col == EDITCOL) {
-                    return Bundle.getMessage("ButtonEdit");
-                } else if (col == LOCKDECCOL) {
-                    JComboBox<String> c;
-                    if ((t.getPossibleLockModes() & Turnout.PUSHBUTTONLOCKOUT) != 0) {
-                        c = new JComboBox<>(t.getValidDecoderNames());
-                    } else {
-                        c = new JComboBox<>(new String[]{t.getDecoderName()});
-                    }
-
-                    c.setSelectedItem(t.getDecoderName());
-                    c.addActionListener(super::comboBoxAction);
-                    return c;
-                } else if (col == LOCKOPRCOL) {
-                    java.util.Vector<String> lockOperations = new java.util.Vector<>();  // Vector is a JComboBox ctor; List is not
-                    int modes = t.getPossibleLockModes();
-                    if ((modes & Turnout.CABLOCKOUT) != 0 && (modes & Turnout.PUSHBUTTONLOCKOUT) != 0) {
-                        lockOperations.add(bothText);
-                    }
-                    if ((modes & Turnout.CABLOCKOUT) != 0) {
-                        lockOperations.add(cabOnlyText);
-                    }
-                    if ((modes & Turnout.PUSHBUTTONLOCKOUT) != 0) {
-                        lockOperations.add(pushbutText);
-                    }
-                    lockOperations.add(noneText);
-                    JComboBox<String> c = new JComboBox<>(lockOperations);
-
-                    if (t.canLock(Turnout.CABLOCKOUT) && t.canLock(Turnout.PUSHBUTTONLOCKOUT)) {
-                        c.setSelectedItem(bothText);
-                    } else if (t.canLock(Turnout.PUSHBUTTONLOCKOUT)) {
-                        c.setSelectedItem(pushbutText);
-                    } else if (t.canLock(Turnout.CABLOCKOUT)) {
-                        c.setSelectedItem(cabOnlyText);
-                    } else {
-                        c.setSelectedItem(noneText);
-                    }
-                    c.addActionListener(super::comboBoxAction);
-                    return c;
-                } else if (col == STRAIGHTCOL) {
-
-                    String speed = t.getStraightSpeed();
-                    if (!speedListClosed.contains(speed)) {
-                        speedListClosed.add(speed);
-                    }
-                    JComboBox<String> c = new JComboBox<>(speedListClosed);
-                    c.setEditable(true);
-                    c.setSelectedItem(speed);
-                    c.addActionListener(super::comboBoxAction);
-                    return c;
-                } else if (col == DIVERGCOL) {
-
-                    String speed = t.getDivergingSpeed();
-                    if (!speedListThrown.contains(speed)) {
-                        speedListThrown.add(speed);
-                    }
-                    JComboBox<String> c = new JComboBox<>(speedListThrown);
-                    c.setEditable(true);
-                    c.setSelectedItem(speed);
-                    c.addActionListener(super::comboBoxAction);
-                    return c;
-                    // } else if (col == VALUECOL && _graphicState) { // not neeeded as the
-                    //  graphic ImageIconRenderer uses the same super.getValueAt(row, col) as
-                    // classic bean state text button
-                } else if (col == FORGETCOL) {
-                    return Bundle.getMessage("StateForgetButton");
-                } else if (col == QUERYCOL) {
-                    return Bundle.getMessage("StateQueryButton");
-                }
-                return super.getValueAt(row, col);
-            }
-
-            @Override
-            public void setValueAt(Object value, int row, int col) {
-                String name = sysNameList.get(row);
-                Turnout t = turnoutManager.getBySystemName(name);
-                if (t == null) {
-                    NullPointerException ex = new NullPointerException("Unexpected null turnout in turnout table");
-                    log.error(ex.getMessage(), ex); // log with stack trace
-                    throw ex;
-                }
-                if (col == INVERTCOL) {
-                    if (t.canInvert()) {
-                        t.setInverted((Boolean) value);
-                        fireTableRowsUpdated(row, row);
-                    }
-                } else if (col == LOCKCOL) {
-                    t.setLocked(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT, (Boolean) value);
-                    fireTableRowsUpdated(row, row);
-                } else if (col == MODECOL) {
-                    @SuppressWarnings("unchecked")
-                    String modeName = (String) ((JComboBox<String>) value).getSelectedItem();
-                    assert modeName != null;
-                    t.setFeedbackMode(modeName);
-                    fireTableRowsUpdated(row, row);
-                } else if (col == SENSOR1COL) {
-                    try {
-                        Sensor sensor = (Sensor) value;
-                        t.provideFirstFeedbackSensor(sensor != null ? sensor.getDisplayName() : null);
-                    } catch (jmri.JmriException e) {
-                        JOptionPane.showMessageDialog(null, e.toString());
-                    }
-                    fireTableRowsUpdated(row, row);
-                } else if (col == SENSOR2COL) {
-                    try {
-                        Sensor sensor = (Sensor) value;
-                        t.provideSecondFeedbackSensor(sensor != null ? sensor.getDisplayName() : null);
-                    } catch (jmri.JmriException e) {
-                        JOptionPane.showMessageDialog(null, e.toString());
-                    }
-                    fireTableRowsUpdated(row, row);
-                //} else if (col == OPSONOFFCOL) {
-                    // do nothing as this is handled by the combo box listener
-                } else if (col == OPSEDITCOL) {
-                    t.setInhibitOperation(false);
-                    @SuppressWarnings("unchecked") // cast to JComboBox<String> required in OPSEDITCOL
-                    JComboBox<String> cb = (JComboBox<String>) getValueAt(row, OPSONOFFCOL);
-                    log.debug("opsSelected = {}", getValueAt(row, OPSONOFFCOL).toString());
-                    editTurnoutOperation(t, cb);
-                    fireTableRowsUpdated(row, row);
-                } else if (col == EDITCOL) {
-                    class WindowMaker implements Runnable {
-
-                        final Turnout t;
-
-                        WindowMaker(Turnout t) {
-                            this.t = t;
-                        }
-
-                        @Override
-                        public void run() {
-                            editButton(t);
-                        }
-                    }
-                    WindowMaker w = new WindowMaker(t);
-                    javax.swing.SwingUtilities.invokeLater(w);
-                } else if (col == LOCKOPRCOL) {
-                    @SuppressWarnings("unchecked")
-                    String lockOpName = (String) ((JComboBox<String>) value)
-                            .getSelectedItem();
-                    assert lockOpName != null;
-                    if (lockOpName.equals(bothText)) {
-                        t.enableLockOperation(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT, true);
-                    }
-                    if (lockOpName.equals(cabOnlyText)) {
-                        t.enableLockOperation(Turnout.CABLOCKOUT, true);
-                        t.enableLockOperation(Turnout.PUSHBUTTONLOCKOUT, false);
-                    }
-                    if (lockOpName.equals(pushbutText)) {
-                        t.enableLockOperation(Turnout.CABLOCKOUT, false);
-                        t.enableLockOperation(Turnout.PUSHBUTTONLOCKOUT, true);
-                    }
-                    fireTableRowsUpdated(row, row);
-                } else if (col == LOCKDECCOL) {
-                    @SuppressWarnings("unchecked")
-                    String decoderName = (String) ((JComboBox<String>) value).getSelectedItem();
-                    t.setDecoderName(decoderName);
-                    fireTableRowsUpdated(row, row);
-                } else if (col == STRAIGHTCOL) {
-                    @SuppressWarnings("unchecked")
-                    String speed = (String) ((JComboBox<String>) value).getSelectedItem();
-                    try {
-                        t.setStraightSpeed(speed);
-                    } catch (jmri.JmriException ex) {
-                        JOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
-                        return;
-                    }
-                    if ((!speedListClosed.contains(speed))) {
-                        assert speed != null;
-                        if (!speed.contains("Global")) {
-                            speedListClosed.add(speed);
-                        }
-                    }
-                    fireTableRowsUpdated(row, row);
-                } else if (col == DIVERGCOL) {
-
-                    @SuppressWarnings("unchecked")
-                    String speed = (String) ((JComboBox<String>) value).getSelectedItem();
-                    try {
-                        t.setDivergingSpeed(speed);
-                    } catch (jmri.JmriException ex) {
-                        JOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
-                        return;
-                    }
-                    if ((!speedListThrown.contains(speed))) {
-                        assert speed != null;
-                        if (!speed.contains("Global")) {
-                            speedListThrown.add(speed);
-                        }
-                    }
-                    fireTableRowsUpdated(row, row);
-                } else if (col == FORGETCOL) {
-                    t.setCommandedState(Turnout.UNKNOWN);
-                } else if (col == QUERYCOL) {
-                    t.setCommandedState(Turnout.UNKNOWN);
-                    t.requestUpdateFromLayout();
-                } else if (col == VALUECOL && _graphicState) { // respond to clicking on ImageIconRenderer CellEditor
-                    clickOn(t);
-                    fireTableRowsUpdated(row, row);
-                } else {
-                    super.setValueAt(value, row, col);
-                    fireTableRowsUpdated(row, row);
-                }
-            }
-
-            @Override
-            public String getValue(@Nonnull String name) {
-                Turnout turn = turnoutManager.getBySystemName(name);
-                if (turn != null) {
-                    return turn.describeState(turn.getCommandedState());
-                }
-                return "Turnout not found";
-            }
-
-            @Override
-            public Manager<Turnout> getManager() {
-                return turnoutManager;
-            }
-
-            @Override
-            public Turnout getBySystemName(@Nonnull String name) {
-                return turnoutManager.getBySystemName(name);
-            }
-
-            @Override
-            public Turnout getByUserName(@Nonnull String name) {
-                return InstanceManager.getDefault(TurnoutManager.class).getByUserName(name);
-            }
-
-            @Override
-            protected String getMasterClassName() {
-                return getClassName();
-            }
-
-            @Override
-            public void clickOn(Turnout t) {
-                t.setCommandedState( t.getCommandedState()== Turnout.CLOSED ? Turnout.THROWN : Turnout.CLOSED);
-            }
-
-            @Override
-            public void configureTable(JTable tbl) {
-                table = tbl;
-
-                table.setDefaultRenderer(Boolean.class, new EnablingCheckboxRenderer());
-                setColumnToHoldButton(table, OPSEDITCOL, editButton());
-                setColumnToHoldButton(table, EDITCOL, editButton());
-                //Hide the following columns by default
-                XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
-                TableColumn column = columnModel.getColumnByModelIndex(STRAIGHTCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(DIVERGCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(KNOWNCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(MODECOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(SENSOR1COL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(SENSOR2COL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(OPSONOFFCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(OPSEDITCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(LOCKOPRCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(LOCKDECCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(FORGETCOL);
-                columnModel.setColumnVisible(column, false);
-                column = columnModel.getColumnByModelIndex(QUERYCOL);
-                columnModel.setColumnVisible(column, false);
-
-                super.configureTable(table);
-            }
-
-            // update table if turnout lock or feedback changes
-            @Override
-            protected boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
-                if (e.getPropertyName().equals("locked")) {
-                    return true;
-                }
-                if (e.getPropertyName().equals("feedbackchange")) {
-                    return true;
-                }
-                if (e.getPropertyName().equals("TurnoutDivergingSpeedChange")) {
-                    return true;
-                }
-                if (e.getPropertyName().equals("TurnoutStraightSpeedChange")) {
-                    return true;
-                } else {
-                    return super.matchPropertyName(e);
-                }
-            }
-
-            @Override
-            public void propertyChange(java.beans.PropertyChangeEvent e) {
-                if (e.getPropertyName().equals("DefaultTurnoutClosedSpeedChange")) {
-                    updateClosedList();
-                } else if (e.getPropertyName().equals("DefaultTurnoutThrownSpeedChange")) {
-                    updateThrownList();
-                } else {
-                    super.propertyChange(e);
-                }
-            }
-
-            /**
-             * Customize the turnout table Value (State) column to show an
-             * appropriate graphic for the turnout state if _graphicState =
-             * true, or (default) just show the localized state text when the
-             * TableDataModel is being called from ListedTableAction.
-             *
-             * @param table a JTable of Turnouts
-             */
-            @Override
-            protected void configValueColumn(JTable table) {
-                // have the value column hold a JPanel (icon)
-                //setColumnToHoldButton(table, VALUECOL, new JLabel("12345678")); // for larger, wide round icon, but cannot be converted to JButton
-                // add extras, override BeanTableDataModel
-                log.debug("Turnout configValueColumn (I am {})", super.toString());
-                if (_graphicState) { // load icons, only once
-                    table.setDefaultEditor(JLabel.class, new ImageIconRenderer()); // editor
-                    table.setDefaultRenderer(JLabel.class, new ImageIconRenderer()); // item class copied from SwitchboardEditor panel
-                } else {
-                    super.configValueColumn(table); // classic text style state indication
-                }
-            }
-
-            @Override
-            public JTable makeJTable(@Nonnull String name, @Nonnull TableModel model, @CheckForNull RowSorter<? extends TableModel> sorter) {
-                return this.configureJTable(name, this.makeJTable(model), sorter);
-            }
-
-            private JTable makeJTable(TableModel model) {
-                return new JTable(model) {
-
-                    @Override
-                    public String getToolTipText(@Nonnull MouseEvent e) {
-                        java.awt.Point p = e.getPoint();
-                        int rowIndex = rowAtPoint(p);
-                        int colIndex = columnAtPoint(p);
-                        int realRowIndex = convertRowIndexToModel(rowIndex);
-                        int realColumnIndex = convertColumnIndexToModel(colIndex);
-                        return getCellToolTip(this, realRowIndex, realColumnIndex);
-                    }
-
-                    @Override
-                    public TableCellRenderer getCellRenderer(int row, int column) {
-                        // Convert the displayed index to the model index, rather than the displayed index
-                        int modelColumn = this.convertColumnIndexToModel(column);
-                        if (modelColumn == SENSOR1COL || modelColumn == SENSOR2COL) {
-                            return getRenderer(row, modelColumn);
-                        } else {
-                            return super.getCellRenderer(row, column);
-                        }
-                    }
-
-                    @Override
-                    public TableCellEditor getCellEditor(int row, int column) {
-                        //Convert the displayed index to the model index, rather than the displayed index
-                        int modelColumn = this.convertColumnIndexToModel(column);
-                        if (modelColumn == SENSOR1COL || modelColumn == SENSOR2COL) {
-                            return getEditor(row, modelColumn);
-                        } else {
-                            return super.getCellEditor(row, column);
-                        }
-                    }
-
-                    TableCellRenderer getRenderer(int row, int column) {
-                        TableCellRenderer retval;
-                        Turnout t = (Turnout) getModel().getValueAt(row, SYSNAMECOL);
-                        java.util.Objects.requireNonNull(t, "SYSNAMECOL column content must be nonnull");
-                        switch (column) {
-                            case SENSOR1COL:
-                                retval = rendererMapSensor1.get(t);
-                                break;
-                            case SENSOR2COL:
-                                retval = rendererMapSensor2.get(t);
-                                break;
-                            default:
-                                return null;
-                        }
-
-                        if (retval == null) {
-                            if (column == SENSOR1COL) {
-                                loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
-                            } else {
-                                loadRenderEditMaps(rendererMapSensor2, editorMapSensor2, t, t.getSecondSensor());
-                            }
-                            retval = rendererMapSensor1.get(t);
-                        }
-                        log.debug("fetched for Turnout \"{}\" renderer {}", t, retval);
-                        return retval;
-                    }
-
-                    TableCellEditor getEditor(int row, int column) {
-                        TableCellEditor retval;
-                        Turnout t = (Turnout) getModel().getValueAt(row, SYSNAMECOL);
-                        java.util.Objects.requireNonNull(t, "SYSNAMECOL column content must be nonnull");
-                        switch (column) {
-                            case SENSOR1COL:
-                                retval = editorMapSensor1.get(t);
-                                break;
-                            case SENSOR2COL:
-                                retval = editorMapSensor2.get(t);
-                                break;
-                            default:
-                                return null;
-                        }
-                        if (retval == null) {
-                            if (column == SENSOR1COL) {
-                                loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
-                                retval = editorMapSensor1.get(t);
-                            } else { //Must be two
-                                loadRenderEditMaps(rendererMapSensor2, editorMapSensor2, t, t.getSecondSensor());
-                                retval = editorMapSensor2.get(t);
-                            }
-                        }
-                        log.debug("fetched for Turnout \"{}\" editor {}", t, retval);
-                        return retval;
-                    }
-
-                    protected void loadRenderEditMaps(Hashtable<Turnout, TableCellRenderer> r, Hashtable<Turnout, TableCellEditor> e,
-                            Turnout t, Sensor s) {
-                        NamedBeanComboBox<Sensor> c = new NamedBeanComboBox<>(InstanceManager.getDefault(SensorManager.class), s, DisplayOptions.DISPLAYNAME);
-                        c.setAllowNull(true);
-
-                        BeanBoxRenderer renderer = new BeanBoxRenderer();
-                        renderer.setSelectedItem(s);
-                        r.put(t, renderer);
-
-                        TableCellEditor editor = new BeanComboBoxEditor(c);
-                        e.put(t, editor);
-                        log.debug("initialize for Turnout \"{}\" Sensor \"{}\"", t, s);
-                    }
-
-                    final Hashtable<Turnout, TableCellRenderer> rendererMapSensor1 = new Hashtable<>();
-                    final Hashtable<Turnout, TableCellEditor> editorMapSensor1 = new Hashtable<>();
-
-                    final Hashtable<Turnout, TableCellRenderer> rendererMapSensor2 = new Hashtable<>();
-                    final Hashtable<Turnout, TableCellEditor> editorMapSensor2 = new Hashtable<>();
-                };
-            }
-
-            @Override
-            protected void setColumnIdentities(JTable table) {
-                super.setColumnIdentities(table);
-                Enumeration<TableColumn> columns;
-                if (table.getColumnModel() instanceof XTableColumnModel) {
-                    columns = ((XTableColumnModel) table.getColumnModel()).getColumns(false);
-                } else {
-                    columns = table.getColumnModel().getColumns();
-                }
-                while (columns.hasMoreElements()) {
-                    TableColumn column = columns.nextElement();
-                    switch (column.getModelIndex()) {
-                        case FORGETCOL:
-                            column.setIdentifier("ForgetState");
-                            break;
-                        case QUERYCOL:
-                            column.setIdentifier("QueryState");
-                            break;
-                        default:
-                        // use existing value
-                    }
-                }
-            }
-
-            /**
-             * Visualize state in table as a graphic, customized for Turnouts (4
-             * states). Renderer and Editor are identical, as the cell contents
-             * are not actually edited, only used to toggle state using
-             * {@link #clickOn(Turnout)}.
-             *
-             * @see jmri.jmrit.beantable.BlockTableAction#createModel()
-             * @see jmri.jmrit.beantable.LightTableAction#createModel()
-             */
-            class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
-
-                protected JLabel label;
-                protected String rootPath = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor
-                protected char beanTypeChar = 'T'; // for Turnout
-                protected String onIconPath = rootPath + beanTypeChar + "-on-s.png";
-                protected String offIconPath = rootPath + beanTypeChar + "-off-s.png";
-                protected BufferedImage onImage;
-                protected BufferedImage offImage;
-                protected ImageIcon onIcon;
-                protected ImageIcon offIcon;
-                protected int iconHeight = -1;
-
-                @Override
-                public Component getTableCellRendererComponent(
-                        JTable table, Object value, boolean isSelected,
-                        boolean hasFocus, int row, int column) {
-                    log.debug("Renderer Item = {}, State = {}", row, value);
-                    if (iconHeight < 0) { // load resources only first time, either for renderer or editor
-                        loadIcons();
-                        log.debug("icons loaded");
-                    }
-                    return updateLabel((String) value, row);
-                }
-
-                @Override
-                public Component getTableCellEditorComponent(
-                        JTable table, Object value, boolean isSelected,
-                        int row, int column) {
-                    log.debug("Renderer Item = {}, State = {}", row, value);
-                    if (iconHeight < 0) { // load resources only first time, either for renderer or editor
-                        loadIcons();
-                        log.debug("icons loaded");
-                    }
-                    return updateLabel((String) value, row);
-                }
-
-                public JLabel updateLabel(String value, int row) {
-                    if (iconHeight > 0) { // if necessary, increase row height;
-                        table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5));
-                    }
-                    if (value.equals(closedText) && onIcon != null) {
-                        label = new JLabel(onIcon);
-                        label.setVerticalAlignment(JLabel.BOTTOM);
-                        log.debug("onIcon set");
-                    } else if (value.equals(thrownText) && offIcon != null) {
-                        label = new JLabel(offIcon);
-                        label.setVerticalAlignment(JLabel.BOTTOM);
-                        log.debug("offIcon set");
-                    } else if (value.equals(Bundle.getMessage("BeanStateInconsistent"))) {
-                        label = new JLabel("X", JLabel.CENTER); // centered text alignment
-                        label.setForeground(Color.red);
-                        log.debug("Turnout state inconsistent");
-                        iconHeight = 0;
-                    } else if (value.equals(Bundle.getMessage("BeanStateUnknown"))) {
-                        label = new JLabel("?", JLabel.CENTER); // centered text alignment
-                        log.debug("Turnout state unknown");
-                        iconHeight = 0;
-                    } else { // failed to load icon
-                        label = new JLabel(value, JLabel.CENTER); // centered text alignment
-                        log.warn("Error reading icons for TurnoutTable");
-                        iconHeight = 0;
-                    }
-                    label.setToolTipText(value);
-                    label.addMouseListener(new MouseAdapter() {
-                        @Override
-                        public final void mousePressed(MouseEvent evt) {
-                            log.debug("Clicked on icon in row {}", row);
-                            stopCellEditing();
-                        }
-                    });
-                    return label;
-                }
-
-                @Override
-                public Object getCellEditorValue() {
-                    log.debug("getCellEditorValue, me = {})", this.toString());
-                    return this.toString();
-                }
-
-                /**
-                 * Read and buffer graphics. Only called once for this table.
-                 *
-                 * @see #getTableCellEditorComponent(JTable, Object, boolean,
-                 * int, int)
-                 */
-                protected void loadIcons() {
-                    try {
-                        onImage = ImageIO.read(new File(onIconPath));
-                        offImage = ImageIO.read(new File(offIconPath));
-                    } catch (IOException ex) {
-                        log.error("error reading image from {} or {}", onIconPath, offIconPath, ex);
-                    }
-                    log.debug("Success reading images");
-                    int imageWidth = onImage.getWidth();
-                    int imageHeight = onImage.getHeight();
-                    // scale icons 50% to fit in table rows
-                    Image smallOnImage = onImage.getScaledInstance(imageWidth / 2, imageHeight / 2, Image.SCALE_DEFAULT);
-                    Image smallOffImage = offImage.getScaledInstance(imageWidth / 2, imageHeight / 2, Image.SCALE_DEFAULT);
-                    onIcon = new ImageIcon(smallOnImage);
-                    offIcon = new ImageIcon(smallOffImage);
-                    iconHeight = onIcon.getIconHeight();
-                }
-
-            } // end of ImageIconRenderer class
-
-        }; // end of custom data model
-    }
-
-    private void updateClosedList() {
-        speedListClosed.remove(defaultClosedSpeedText);
-        defaultClosedSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultClosedSpeed());
-        speedListClosed.add(0, defaultClosedSpeedText);
-        m.fireTableDataChanged();
-    }
-
-    private void updateThrownList() {
-        speedListThrown.remove(defaultThrownSpeedText);
-        defaultThrownSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultThrownSpeed());
-        speedListThrown.add(0, defaultThrownSpeedText);
-        m.fireTableDataChanged();
+        m = new TurnoutTableDataModel(turnoutManager);
     }
 
     /**
@@ -1003,39 +154,6 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
     }
 
     /**
-     * Create a {@literal JComboBox<String>} containing all the options for
-     * turnout automation parameters for this turnout.
-     *
-     * @param t the turnout
-     * @return the JComboBox
-     */
-    protected JComboBox<String> makeAutomationBox(Turnout t) {
-        String[] str = new String[]{"empty"};
-        final JComboBox<String> cb = new JComboBox<>(str);
-        final Turnout myTurnout = t;
-        updateAutomationBox(t, cb);
-        cb.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                setTurnoutOperation(myTurnout, cb);
-                cb.removeActionListener(this);  // avoid recursion
-                updateAutomationBox(myTurnout, cb);
-                cb.addActionListener(this);
-            }
-        });
-        return cb;
-    }
-
-    /**
-     * Create a JButton to edit a turnout's operation.
-     *
-     * @return the JButton
-     */
-    protected JButton editButton() {
-        return new JButton(Bundle.getMessage("EditTurnoutOperation"));
-    }
-
-    /**
      * Add the content and make the appropriate selection to a combo box for a
      * turnout's automation choices.
      *
@@ -1093,163 +211,13 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
     }
 
     /**
-     * Set the turnout's operation info based on the contents of the combo box.
-     *
-     * @param t  turnout being configured
-     * @param cb JComboBox for ops for t in the TurnoutTable
-     */
-    protected void setTurnoutOperation(Turnout t, JComboBox<String> cb) {
-        switch (cb.getSelectedIndex()) {
-            case 0:   // Off
-                t.setInhibitOperation(true);
-                t.setTurnoutOperation(null);
-                break;
-            case 1:   // Default
-                t.setInhibitOperation(false);
-                t.setTurnoutOperation(null);
-                break;
-            default:  // named operation
-                t.setInhibitOperation(false);
-                t.setTurnoutOperation(InstanceManager.getDefault(TurnoutOperationManager.class).
-                        getOperation(((String) Objects.requireNonNull(cb.getSelectedItem()))));
-                break;
-        }
-    }
-
-    /**
-     * Create action to edit a turnout in Edit pane. (also used in windowTest)
-     *
-     * @param t the turnout to be edited
-     */
-    void editButton(Turnout t) {
-        jmri.jmrit.beantable.beanedit.TurnoutEditAction beanEdit = new jmri.jmrit.beantable.beanedit.TurnoutEditAction();
-        beanEdit.setBean(t);
-        beanEdit.actionPerformed(null);
-    }
-
-    private static java.util.concurrent.atomic.AtomicBoolean editingOps = new java.util.concurrent.atomic.AtomicBoolean(false);
-
-    /**
-     * Pop up a TurnoutOperationConfig for the turnout.
-     *
-     * @param t   turnout
-     * @param box JComboBox that triggered the edit
-     */
-    protected void editTurnoutOperation(Turnout t, JComboBox<String> box) {
-        if (!editingOps.getAndSet(true)) { // don't open a second edit ops pane
-            TurnoutOperation op = t.getTurnoutOperation();
-            if (op == null) {
-                TurnoutOperation proto = InstanceManager.getDefault(TurnoutOperationManager.class).getMatchingOperationAlways(t);
-                if (proto != null) {
-                    op = proto.makeNonce(t);
-                    t.setTurnoutOperation(op);
-                }
-            }
-            if (op != null) {
-                if (!op.isNonce()) {
-                    op = op.makeNonce(t);
-                }
-                // make and show edit dialog
-                log.debug("TurnoutOpsEditDialog starting");
-                TurnoutOperationEditor dialog = new TurnoutOperationEditor(this, f, op, t, box);
-                dialog.setVisible(true);
-            } else {
-                JOptionPane.showMessageDialog(f, Bundle.getMessage("TurnoutOperationErrorDialog"),
-                        Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
-            }
-        }
-    }
-
-    protected static class TurnoutOperationEditor extends JDialog {
-
-        TurnoutOperationConfig config;
-        TurnoutOperation myOp;
-        Turnout myTurnout;
-
-        TurnoutOperationEditor(TurnoutTableAction tta, JFrame parent, TurnoutOperation op, Turnout t, JComboBox<String> box) {
-            super(parent);
-            final TurnoutOperationEditor self = this;
-            myOp = op;
-            myOp.addPropertyChangeListener(evt -> {
-                if (evt.getPropertyName().equals("Deleted")) {
-                    setVisible(false);
-                }
-            });
-            myTurnout = t;
-            config = TurnoutOperationConfig.getConfigPanel(op);
-            setTitle();
-            log.debug("TurnoutOpsEditDialog title set");
-            if (config != null) {
-                log.debug("OpsEditDialog opening");
-                Box outerBox = Box.createVerticalBox();
-                outerBox.add(config);
-                Box buttonBox = Box.createHorizontalBox();
-                JButton nameButton = new JButton(Bundle.getMessage("NameSetting"));
-                nameButton.addActionListener(e -> {
-                    String newName = JOptionPane.showInputDialog(Bundle.getMessage("NameParameterSetting"));
-                    if (newName != null && !newName.isEmpty()) {
-                        if (!myOp.rename(newName)) {
-                            JOptionPane.showMessageDialog(self, Bundle.getMessage("TurnoutErrorDuplicate"),
-                                    Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
-                        }
-                        setTitle();
-                        myTurnout.setTurnoutOperation(null);
-                        myTurnout.setTurnoutOperation(myOp); // no-op but updates display - have to <i>change</i> value
-                    }
-                });
-                JButton okButton = new JButton(Bundle.getMessage("ButtonOK"));
-                okButton.addActionListener(e -> {
-                    config.endConfigure();
-                    if (myOp.isNonce() && myOp.equivalentTo(myOp.getDefinitive())) {
-                        myTurnout.setTurnoutOperation(null);
-                        myOp.dispose();
-                        myOp = null;
-                    }
-                    self.setVisible(false);
-                    editingOps.set(false);
-                });
-                JButton cancelButton = new JButton(Bundle.getMessage("ButtonCancel"));
-                cancelButton.addActionListener(e -> {
-                    self.setVisible(false);
-                    editingOps.set(false);
-                });
-                buttonBox.add(Box.createHorizontalGlue());
-                if (!op.isDefinitive()) {
-                    buttonBox.add(nameButton);
-                }
-                buttonBox.add(okButton);
-                buttonBox.add(cancelButton);
-                outerBox.add(buttonBox);
-                getContentPane().add(outerBox);
-                this.addWindowListener(new java.awt.event.WindowAdapter() {
-                    @Override
-                    public void windowClosing(java.awt.event.WindowEvent e) {
-                        editingOps.set(false);
-                    }
-                });
-            } else {
-                log.error("Error opening Turnout automation edit pane");
-            }
-            pack();
-        }
-
-        private void setTitle() {
-            String title = Bundle.getMessage("TurnoutOperationTitle") + " \"" + myOp.getName() + "\"";
-            if (myOp.isNonce()) {
-                title = Bundle.getMessage("TurnoutOperationForTurnout") + " " + myTurnout.getSystemName();
-            }
-            setTitle(title);
-        }
-    }
-
-    /**
      * Show a pane to configure closed and thrown turnout speed defaults.
      *
      * @param _who parent JFrame to center the pane on
      */
     protected void setDefaultSpeeds(JFrame _who) {
-        JComboBox<String> thrownCombo = new JComboBox<>(speedListThrown);
-        JComboBox<String> closedCombo = new JComboBox<>(speedListClosed);
+        JComboBox<String> thrownCombo = new JComboBox<>((( TurnoutTableDataModel)m).speedListThrown);
+        JComboBox<String> closedCombo = new JComboBox<>((( TurnoutTableDataModel)m).speedListClosed);
         thrownCombo.setEditable(true);
         closedCombo.setEditable(true);
 
@@ -1261,8 +229,8 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         closed.add(new JLabel(Bundle.getMessage("MakeLabel", Bundle.getMessage("ClosedSpeed"))));
         closed.add(closedCombo);
 
-        thrownCombo.removeItem(defaultThrownSpeedText);
-        closedCombo.removeItem(defaultClosedSpeedText);
+        thrownCombo.removeItem((( TurnoutTableDataModel)m).defaultThrownSpeedText);
+        closedCombo.removeItem((( TurnoutTableDataModel)m).defaultClosedSpeedText);
 
         thrownCombo.setSelectedItem(turnoutManager.getDefaultThrownSpeed());
         closedCombo.setSelectedItem(turnoutManager.getDefaultClosedSpeed());
@@ -1308,12 +276,36 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         }
     }
 
+    private final JCheckBox doAutomationBox = new JCheckBox(Bundle.getMessage("AutomaticRetry"));
     private final TriStateJCheckBox showFeedbackBox = new TriStateJCheckBox(Bundle.getMessage("ShowFeedbackInfo"));
     private final TriStateJCheckBox showLockBox = new TriStateJCheckBox(Bundle.getMessage("ShowLockInfo"));
     private final TriStateJCheckBox showTurnoutSpeedBox = new TriStateJCheckBox(Bundle.getMessage("ShowTurnoutSpeedDetails"));
-    private final JCheckBox doAutomationBox = new JCheckBox(Bundle.getMessage("AutomaticRetry"));
     private final TriStateJCheckBox showStateForgetAndQueryBox = new TriStateJCheckBox(Bundle.getMessage("ShowStateForgetAndQuery"));
 
+    private void initCheckBoxes(){
+        doAutomationBox.setSelected(InstanceManager.getDefault(TurnoutOperationManager.class).getDoOperations());
+        doAutomationBox.setToolTipText(Bundle.getMessage("TurnoutDoAutomationBoxTooltip"));
+        doAutomationBox.addActionListener(e -> InstanceManager.getDefault(TurnoutOperationManager.class).setDoOperations(doAutomationBox.isSelected()));
+        
+        showFeedbackBox.setToolTipText(Bundle.getMessage("TurnoutFeedbackToolTip"));
+        showLockBox.setToolTipText(Bundle.getMessage("TurnoutLockToolTip"));
+        showTurnoutSpeedBox.setToolTipText(Bundle.getMessage("TurnoutSpeedToolTip"));
+        showStateForgetAndQueryBox.setToolTipText(Bundle.getMessage("StateForgetAndQueryBoxToolTip"));
+    }
+    
+    @Override
+    protected void configureTable(JTable table){
+        super.configureTable(table);
+        showStateForgetAndQueryBox.addActionListener(e ->
+            ((TurnoutTableDataModel) m).showStateForgetAndQueryChanged(showStateForgetAndQueryBox.isSelected(),table));
+        showTurnoutSpeedBox.addActionListener(e ->
+            ((TurnoutTableDataModel) m).showTurnoutSpeedChanged(showTurnoutSpeedBox.isSelected(),table));
+        showFeedbackBox.addActionListener(e ->
+            ((TurnoutTableDataModel) m).showFeedbackChanged(showFeedbackBox.isSelected(), table));
+        showLockBox.addActionListener(e ->
+            ((TurnoutTableDataModel) m).showLockChanged(showLockBox.isSelected(),table));
+    }
+    
     /**
      * Add the check boxes to show/hide extra columns to the Turnout table
      * frame.
@@ -1325,27 +317,12 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
      */
     @Override
     public void addToFrame(BeanTableFrame<Turnout> f) {
+        initCheckBoxes();
         f.addToBottomBox(doAutomationBox, this.getClass().getName());
-        doAutomationBox.setSelected(InstanceManager.getDefault(TurnoutOperationManager.class).getDoOperations());
-        doAutomationBox.setToolTipText(Bundle.getMessage("TurnoutDoAutomationBoxTooltip"));
-        doAutomationBox.addActionListener(e -> InstanceManager.getDefault(TurnoutOperationManager.class).setDoOperations(doAutomationBox.isSelected()));
-        
         f.addToBottomBox(showFeedbackBox, this.getClass().getName());
-        showFeedbackBox.setToolTipText(Bundle.getMessage("TurnoutFeedbackToolTip"));
-        showFeedbackBox.addActionListener(e -> showFeedbackChanged());
-        
         f.addToBottomBox(showLockBox, this.getClass().getName());
-        showLockBox.setToolTipText(Bundle.getMessage("TurnoutLockToolTip"));
-        showLockBox.addActionListener(e -> showLockChanged());
-        
         f.addToBottomBox(showTurnoutSpeedBox, this.getClass().getName());
-        showTurnoutSpeedBox.setToolTipText(Bundle.getMessage("TurnoutSpeedToolTip"));
-        showTurnoutSpeedBox.addActionListener(e -> showTurnoutSpeedChanged());
-        
         f.addToBottomBox(showStateForgetAndQueryBox, this.getClass().getName());
-        showStateForgetAndQueryBox.setToolTipText(Bundle.getMessage("StateForgetAndQueryBoxToolTip"));
-        showStateForgetAndQueryBox.addActionListener(e -> showStateForgetAndQueryChanged());
-
     }
 
     /**
@@ -1362,28 +339,12 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         if (turnoutManager.getClass().getName().contains("ProxyTurnoutManager")) {
             connectionName = "All"; // NOI18N
         }
-
+        initCheckBoxes();
         f.addToBottomBox(doAutomationBox, connectionName);
-        doAutomationBox.setSelected(InstanceManager.getDefault(TurnoutOperationManager.class).getDoOperations());
-        doAutomationBox.setToolTipText(Bundle.getMessage("TurnoutDoAutomationBoxTooltip"));
-        doAutomationBox.addActionListener(e -> InstanceManager.getDefault(TurnoutOperationManager.class).setDoOperations(doAutomationBox.isSelected()));
-        
         f.addToBottomBox(showFeedbackBox, connectionName);
-        showFeedbackBox.setToolTipText(Bundle.getMessage("TurnoutFeedbackToolTip"));
-        showFeedbackBox.addActionListener(e -> showFeedbackChanged());
-        
         f.addToBottomBox(showLockBox, connectionName);
-        showLockBox.setToolTipText(Bundle.getMessage("TurnoutLockToolTip"));
-        showLockBox.addActionListener(e -> showLockChanged());
-        
         f.addToBottomBox(showTurnoutSpeedBox, connectionName);
-        showTurnoutSpeedBox.setToolTipText(Bundle.getMessage("TurnoutSpeedToolTip"));
-        showTurnoutSpeedBox.addActionListener(e -> showTurnoutSpeedChanged());
-        
         f.addToBottomBox(showStateForgetAndQueryBox, connectionName);
-        showStateForgetAndQueryBox.setToolTipText(Bundle.getMessage("StateForgetAndQueryBoxToolTip"));
-        showStateForgetAndQueryBox.addActionListener(e -> showStateForgetAndQueryChanged());
-  
     }
     
     /**
@@ -1394,70 +355,25 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
     protected void columnsVisibleUpdated(boolean[] colsVisible){
         log.debug("columns updated {}",colsVisible);
         showFeedbackBox.setState(new boolean[]{
-            colsVisible[KNOWNCOL],
-            colsVisible[MODECOL],
-            colsVisible[SENSOR1COL],
-            colsVisible[SENSOR2COL],
-            colsVisible[OPSONOFFCOL],
-            colsVisible[OPSEDITCOL]});
+            colsVisible[TurnoutTableDataModel.KNOWNCOL],
+            colsVisible[TurnoutTableDataModel.MODECOL],
+            colsVisible[TurnoutTableDataModel.SENSOR1COL],
+            colsVisible[TurnoutTableDataModel.SENSOR2COL],
+            colsVisible[TurnoutTableDataModel.OPSONOFFCOL],
+            colsVisible[TurnoutTableDataModel.OPSEDITCOL]});
         
         showLockBox.setState(new boolean[]{
-            colsVisible[LOCKDECCOL],
-            colsVisible[LOCKOPRCOL]});
+            colsVisible[TurnoutTableDataModel.LOCKDECCOL],
+            colsVisible[TurnoutTableDataModel.LOCKOPRCOL]});
         
         showTurnoutSpeedBox.setState(new boolean[]{
-            colsVisible[STRAIGHTCOL],
-            colsVisible[DIVERGCOL]});
+            colsVisible[TurnoutTableDataModel.STRAIGHTCOL],
+            colsVisible[TurnoutTableDataModel.DIVERGCOL]});
         
         showStateForgetAndQueryBox.setState(new boolean[]{
-            colsVisible[FORGETCOL],
-            colsVisible[QUERYCOL]});
+            colsVisible[TurnoutTableDataModel.FORGETCOL],
+            colsVisible[TurnoutTableDataModel.QUERYCOL]});
         
-    }
-
-    void showFeedbackChanged() {
-        boolean showFeedback = showFeedbackBox.isSelected();
-        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
-        TableColumn column = columnModel.getColumnByModelIndex(KNOWNCOL);
-        columnModel.setColumnVisible(column, showFeedback);
-        column = columnModel.getColumnByModelIndex(MODECOL);
-        columnModel.setColumnVisible(column, showFeedback);
-        column = columnModel.getColumnByModelIndex(SENSOR1COL);
-        columnModel.setColumnVisible(column, showFeedback);
-        column = columnModel.getColumnByModelIndex(SENSOR2COL);
-        columnModel.setColumnVisible(column, showFeedback);
-        column = columnModel.getColumnByModelIndex(OPSONOFFCOL);
-        columnModel.setColumnVisible(column, showFeedback);
-        column = columnModel.getColumnByModelIndex(OPSEDITCOL);
-        columnModel.setColumnVisible(column, showFeedback);
-    }
-
-    void showLockChanged() {
-        boolean showLock = showLockBox.isSelected();
-        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
-        TableColumn column = ((XTableColumnModel) table.getColumnModel()).getColumnByModelIndex(LOCKDECCOL);
-        columnModel.setColumnVisible(column, showLock);
-        column = columnModel.getColumnByModelIndex(LOCKOPRCOL);
-        columnModel.setColumnVisible(column, showLock);
-    }
-
-    public void showTurnoutSpeedChanged() {
-        boolean showTurnoutSpeed = showTurnoutSpeedBox.isSelected();
-        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
-        TableColumn column = ((XTableColumnModel) table.getColumnModel()).getColumnByModelIndex(STRAIGHTCOL);
-        columnModel.setColumnVisible(column, showTurnoutSpeed);
-        column = columnModel.getColumnByModelIndex(DIVERGCOL);
-        columnModel.setColumnVisible(column, showTurnoutSpeed);
-    }
-
-    public void showStateForgetAndQueryChanged() {
-        boolean showStateForgetAndQuery = showStateForgetAndQueryBox.isSelected();
-        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
-
-        TableColumn column = columnModel.getColumnByModelIndex(FORGETCOL);
-        columnModel.setColumnVisible(column, showStateForgetAndQuery);
-        column = columnModel.getColumnByModelIndex(QUERYCOL);
-        columnModel.setColumnVisible(column, showStateForgetAndQuery);
     }
 
     /**
@@ -1771,39 +687,6 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
     @Override
     public String getClassDescription() {
         return Bundle.getMessage("TitleTurnoutTable");
-    }
-
-    static class BeanBoxRenderer extends NamedBeanComboBox<Sensor> implements TableCellRenderer {
-
-        public BeanBoxRenderer() {
-            super(InstanceManager.getDefault(SensorManager.class));
-            setAllowNull(true);
-        }
-
-        @Override
-        public Component getTableCellRendererComponent(JTable table, Object value,
-                boolean isSelected, boolean hasFocus, int row, int column) {
-            if (isSelected) {
-                setForeground(table.getSelectionForeground());
-                super.setBackground(table.getSelectionBackground());
-            } else {
-                setForeground(table.getForeground());
-                setBackground(table.getBackground());
-            }
-            if (value instanceof Sensor) {
-                setSelectedItem(value);
-            } else {
-                setSelectedItem(null);
-            }
-            return this;
-        }
-    }
-
-    static class BeanComboBoxEditor extends DefaultCellEditor {
-
-        public BeanComboBoxEditor(NamedBeanComboBox<Sensor> beanBox) {
-            super(beanBox);
-        }
     }
 
     private final static Logger log = LoggerFactory.getLogger(TurnoutTableAction.class);

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -48,13 +48,22 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
     private Manager<Sensor> senManager = null;
     protected boolean _graphicState = false; // icon state col updated from prefs
 
+    /**
+     * Create a new Sensor Table Data Model.
+     * The default Manager for the bean type will be a Proxy Manager.
+     */
     public SensorTableDataModel() {
         super();
     }
 
+    /**
+     * Create a new Sensor Table Data Model.
+     * The default Manager for the bean type will be a Proxy Manager unless
+     * one is specified here.
+     * @param manager Bean Manager.
+     */
     public SensorTableDataModel(Manager<Sensor> manager) {
         super(manager);
-        this.setManager(manager);
         updateNameList();
         // load graphic state column display preference
         _graphicState = InstanceManager.getDefault(GuiLafPreferencesManager.class).isGraphicTableState();
@@ -136,12 +145,7 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
     @Override
     protected void clickOn(Sensor t) {
         try {
-            int state = t.getKnownState();
-            if (state == Sensor.INACTIVE) {
-                t.setKnownState(Sensor.ACTIVE);
-            } else {
-                t.setKnownState(Sensor.INACTIVE);
-            }
+            t.setKnownState(t.getKnownState() == Sensor.INACTIVE ? Sensor.ACTIVE : Sensor.INACTIVE );
         } catch (JmriException e) {
             log.warn("Error setting state", e);
         }
@@ -294,7 +298,6 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
             case PULLUPCOL:
                 PullResistanceComboBox c = new PullResistanceComboBox(Sensor.PullResistance.values());
                 c.setSelectedItem(s.getPullResistance());
-                c.addActionListener(super::comboBoxAction);
                 return c;
             case FORGETCOL:
                 return Bundle.getMessage("StateForgetButton");
@@ -461,7 +464,7 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
                 loadIcons();
                 log.debug("icons loaded");
             }
-            return updateLabel((String) value, row);
+            return updateLabel((String) value, row, table);
         }
 
         /**
@@ -476,10 +479,10 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
                 loadIcons();
                 log.debug("icons loaded");
             }
-            return updateLabel((String) value, row);
+            return updateLabel((String) value, row, table);
         }
 
-        public JLabel updateLabel(String value, int row) {
+        public JLabel updateLabel(String value, int row, JTable table) {
             if (iconHeight > 0) { // if necessary, increase row height;
                 table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5)); // adjust table row height for Sensor icon
             }
@@ -555,11 +558,8 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      */
     @Override
     public void configureTable(JTable table) {
-        this.table = table;
         super.configureTable(table);
     }
-
-    protected JTable table;
 
     void editButton(Sensor s) {
         jmri.jmrit.beantable.beanedit.SensorEditAction beanEdit = new jmri.jmrit.beantable.beanedit.SensorEditAction();
@@ -571,8 +571,9 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      * Show or hide the Debounce columns.
      * USEGLOBALDELAY, ACTIVEDELAY, INACTIVEDELAY
      * @param show true to display, false to hide.
+     * @param table the JTable to set column visibility on.
      */
-    public void showDebounce(boolean show) {
+    public void showDebounce(boolean show, JTable table) {
         XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
         TableColumn column = columnModel.getColumnByModelIndex(USEGLOBALDELAY);
         columnModel.setColumnVisible(column, show);
@@ -586,19 +587,20 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      * Show or hide the Pullup column.
      * PULLUPCOL
      * @param show true to display, false to hide.
+     * @param table the JTable to set column visibility on.
      */
-    public void showPullUp(boolean show) {
+    public void showPullUp(boolean show, JTable table) {
         XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
         TableColumn column = columnModel.getColumnByModelIndex(PULLUPCOL);
         columnModel.setColumnVisible(column, show);
     }
 
     /**
-     * Show or hide the State - Forget and Query columns.
-     * FORGETCOL, QUERYCOL
+     * Show or hide the State - Forget and Query columns.FORGETCOL, QUERYCOL
      * @param show true to display, false to hide.
+     * @param table the JTable to set column visibility on.
      */
-    public void showStateForgetAndQuery(boolean show) {
+    public void showStateForgetAndQuery(boolean show, JTable table) {
         XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
         TableColumn column = columnModel.getColumnByModelIndex(FORGETCOL);
         columnModel.setColumnVisible(column, show);
@@ -610,7 +612,6 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
         return jmri.jmrit.beantable.SensorTableAction.class.getName();
     }
 
-//    public static final ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrit.beantable.BeanTableBundle");
     public String getClassDescription() {
         return Bundle.getMessage("TitleSensorTable");
     }

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -439,7 +439,7 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      * Renderer and Editor are identical, as the cell contents are not actually
      * edited, only used to toggle state using {@link #clickOn}.
      */
-    class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
+    static class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
 
         protected JLabel label;
         protected String rootPath = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor

--- a/java/src/jmri/jmrit/beantable/turnout/Bundle.java
+++ b/java/src/jmri/jmrit/beantable/turnout/Bundle.java
@@ -1,0 +1,97 @@
+package jmri.jmrit.beantable.turnout;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Locale;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.jmrit.beantable.Bundle {
+
+    @CheckForNull
+    private static final String name = null; // no local resources
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static public String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    @CheckForNull
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
@@ -29,6 +29,7 @@ public class TurnoutOperationEditorDialog extends JDialog {
     /**
      * Pop up a TurnoutOperationConfig Dialog for the turnout.
      *
+     * @param op TunoutOperation to edit.
      * @param t   turnout
      * @param box JComboBox that triggered the edit, currently unused.
      */

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialog.java
@@ -1,0 +1,120 @@
+package jmri.jmrit.beantable.turnout;
+
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.Turnout;
+import jmri.TurnoutOperation;
+import static jmri.jmrit.beantable.turnout.TurnoutTableDataModel.editingOps;
+import jmri.jmrit.turnoutoperations.TurnoutOperationConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Display a TurnoutOperationConfig Dialog for the turnout.
+ * 
+ * Code originally within TurnoutTableAction.
+ * 
+ * @author Bob Jacobsen Copyright (C) 2003, 2004, 2007
+ * @author Egbert Broerse Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class TurnoutOperationEditorDialog extends JDialog {
+
+    private TurnoutOperation myOp;
+    final Turnout myTurnout;
+    final TurnoutOperationEditorDialog self;
+
+    /**
+     * Pop up a TurnoutOperationConfig Dialog for the turnout.
+     *
+     * @param t   turnout
+     * @param box JComboBox that triggered the edit, currently unused.
+     */
+    TurnoutOperationEditorDialog( @Nonnull TurnoutOperation op, Turnout t, JComboBox<String> box) {
+        super();
+        self = this;
+        myOp = op;
+        myTurnout = t;
+        init();
+    }
+        
+    private void init() {
+        
+        myOp.addPropertyChangeListener(evt -> {
+            if (evt.getPropertyName().equals("Deleted")) {
+                setVisible(false);
+            }
+        });
+        
+        TurnoutOperationConfig config = TurnoutOperationConfig.getConfigPanel(myOp);
+        setTitle();
+        log.debug("TurnoutOpsEditDialog title set");
+        if (config != null) {
+            log.debug("OpsEditDialog opening");
+            Box outerBox = Box.createVerticalBox();
+            outerBox.add(config);
+            Box buttonBox = Box.createHorizontalBox();
+            JButton nameButton = new JButton(Bundle.getMessage("NameSetting"));
+            nameButton.addActionListener(e -> {
+                String newName = JOptionPane.showInputDialog(Bundle.getMessage("NameParameterSetting"));
+                if (newName != null && !newName.isEmpty()) {
+                    if (!myOp.rename(newName)) {
+                        JOptionPane.showMessageDialog(self, Bundle.getMessage("TurnoutErrorDuplicate"),
+                                Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
+                    }
+                    setTitle();
+                    myTurnout.setTurnoutOperation(null);
+                    myTurnout.setTurnoutOperation(myOp); // no-op but updates display - have to <i>change</i> value
+                }
+            });
+            JButton okButton = new JButton(Bundle.getMessage("ButtonOK"));
+            okButton.addActionListener(e -> {
+                config.endConfigure();
+                if (myOp.isNonce() && myOp.equivalentTo(myOp.getDefinitive())) {
+                    myTurnout.setTurnoutOperation(null);
+                    myOp.dispose();
+                    myOp = null;
+                }
+                self.setVisible(false);
+                editingOps.set(false);
+            });
+            JButton cancelButton = new JButton(Bundle.getMessage("ButtonCancel"));
+            cancelButton.addActionListener(e -> {
+                self.setVisible(false);
+                editingOps.set(false);
+            });
+            buttonBox.add(Box.createHorizontalGlue());
+            if (!myOp.isDefinitive()) {
+                buttonBox.add(nameButton);
+            }
+            buttonBox.add(okButton);
+            buttonBox.add(cancelButton);
+            outerBox.add(buttonBox);
+            getContentPane().add(outerBox);
+            this.addWindowListener(new java.awt.event.WindowAdapter() {
+                @Override
+                public void windowClosing(java.awt.event.WindowEvent e) {
+                    editingOps.set(false);
+                }
+            });
+            
+        } else {
+            log.error("Error opening Turnout automation edit pane");
+        }
+        pack();
+    }
+
+    private void setTitle() {
+        String title = Bundle.getMessage("TurnoutOperationTitle") + " \"" + myOp.getName() + "\"";
+        if (myOp.isNonce()) {
+            title = Bundle.getMessage("TurnoutOperationForTurnout") + " " + myTurnout.getSystemName();
+        }
+        setTitle(title);
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(TurnoutOperationEditorDialog.class);
+
+}
+

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
@@ -666,6 +666,9 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
 
     @Override
     public JTable makeJTable(@Nonnull String name, @Nonnull TableModel model, @CheckForNull RowSorter<? extends TableModel> sorter) {
+        if (!(model instanceof TurnoutTableDataModel)){
+            throw new IllegalArgumentException("Model is not a TurnoutTableDataModel");
+        }
         return configureJTable(name, new TurnoutTableJTable((TurnoutTableDataModel)model), sorter);
     }
     

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
@@ -1,0 +1,968 @@
+package jmri.jmrit.beantable.turnout;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableModel;
+
+import jmri.*;
+import jmri.implementation.SignalSpeedMap;
+import jmri.jmrit.beantable.*;
+import jmri.util.swing.XTableColumnModel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Data model for a Turnout Table.
+ * Code originally within TurnoutTableAction.
+ * 
+ * @author Bob Jacobsen Copyright (C) 2003, 2004, 2007
+ * @author Egbert Broerse Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
+    
+    static public final int INVERTCOL = BeanTableDataModel.NUMCOLUMN;
+    static public final int LOCKCOL = INVERTCOL + 1;
+    static public final int EDITCOL = LOCKCOL + 1;
+    static public final int KNOWNCOL = EDITCOL + 1;
+    static public final int MODECOL = KNOWNCOL + 1;
+    static public final int SENSOR1COL = MODECOL + 1;
+    static public final int SENSOR2COL = SENSOR1COL + 1;
+    static public final int OPSONOFFCOL = SENSOR2COL + 1;
+    static public final int OPSEDITCOL = OPSONOFFCOL + 1;
+    static public final int LOCKOPRCOL = OPSEDITCOL + 1;
+    static public final int LOCKDECCOL = LOCKOPRCOL + 1;
+    static public final int STRAIGHTCOL = LOCKDECCOL + 1;
+    static public final int DIVERGCOL = STRAIGHTCOL + 1;
+    static public final int FORGETCOL = DIVERGCOL + 1;
+    static public final int QUERYCOL = FORGETCOL + 1;
+    
+    private boolean _graphicState;
+    private TurnoutManager turnoutManager;
+    
+    
+    String closedText;
+    String thrownText;
+    public String defaultThrownSpeedText;
+    public String defaultClosedSpeedText;
+    // I18N TODO but note storing in xml independent from Locale
+    String useBlockSpeed;
+    String bothText = "Both";
+    String cabOnlyText = "Cab only";
+    String pushbutText = "Pushbutton only";
+    String noneText = "None";
+    
+    public final java.util.Vector<String> speedListClosed = new java.util.Vector<>();
+    public final java.util.Vector<String> speedListThrown = new java.util.Vector<>();
+    
+    
+    public TurnoutTableDataModel(){
+        super();
+        initTable();
+    }
+    
+    public TurnoutTableDataModel(Manager<Turnout> mgr){
+        super(mgr);
+        initTable();
+    }
+    
+    private void initTable() {
+        
+        // load graphic state column display preference
+        _graphicState = InstanceManager.getDefault(jmri.util.gui.GuiLafPreferencesManager.class).isGraphicTableState();
+        
+        closedText = turnoutManager.getClosedText();
+        thrownText = turnoutManager.getThrownText();
+
+        //This following must contain the word Global for a correct match in the abstract turnout
+        defaultThrownSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultThrownSpeed());
+        defaultClosedSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultClosedSpeed());
+        
+        //This following must contain the word Block for a correct match in the abstract turnout
+        useBlockSpeed = Bundle.getMessage("UseGlobal", "Block Speed");
+
+        speedListClosed.add(defaultClosedSpeedText);
+        speedListThrown.add(defaultThrownSpeedText);
+        speedListClosed.add(useBlockSpeed);
+        speedListThrown.add(useBlockSpeed);
+        java.util.Vector<String> _speedMap = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getValidSpeedNames();
+        for (String s : _speedMap) {
+            if (!speedListClosed.contains(s)) {
+                speedListClosed.add(s);
+            }
+            if (!speedListThrown.contains(s)) {
+                speedListThrown.add(s);
+            }
+        }
+        
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getColumnCount() {
+        return QUERYCOL + getPropertyColumnCount() + 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getColumnName(int col) {
+        switch (col) {
+            case INVERTCOL:
+                return Bundle.getMessage("Inverted");
+            case LOCKCOL:
+                return Bundle.getMessage("Locked");
+            case KNOWNCOL:
+                return Bundle.getMessage("Feedback");
+            case MODECOL:
+                return Bundle.getMessage("ModeLabel");
+            case SENSOR1COL:
+                return Bundle.getMessage("BlockSensor") + "1";
+            case SENSOR2COL:
+                return Bundle.getMessage("BlockSensor") + "2";
+            case OPSONOFFCOL:
+                return Bundle.getMessage("TurnoutAutomationMenu");
+            case OPSEDITCOL:
+                return "";
+            case LOCKOPRCOL:
+                return Bundle.getMessage("LockMode");
+            case LOCKDECCOL:
+                return Bundle.getMessage("Decoder");
+            case DIVERGCOL:
+                return Bundle.getMessage("ThrownSpeed");
+            case STRAIGHTCOL:
+                return Bundle.getMessage("ClosedSpeed");
+            case FORGETCOL:
+                return Bundle.getMessage("StateForgetHeader");
+            case QUERYCOL:
+                return Bundle.getMessage("StateQueryHeader");
+            case EDITCOL:
+                return "";
+            default:
+                return super.getColumnName(col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<?> getColumnClass(int col) {
+        switch (col) {
+            case INVERTCOL:
+            case LOCKCOL:
+                return Boolean.class;
+            case KNOWNCOL:
+                return String.class;
+            case MODECOL:
+            case SENSOR1COL:
+            case SENSOR2COL:
+            case OPSONOFFCOL:
+            case LOCKOPRCOL:
+            case LOCKDECCOL:
+            case DIVERGCOL:
+            case STRAIGHTCOL:
+                return JComboBox.class;
+            case OPSEDITCOL:
+            case EDITCOL:
+            case FORGETCOL:
+            case QUERYCOL:
+                return JButton.class;
+            case VALUECOL: // may use an image to show turnout state
+                return ( _graphicState ? JLabel.class : JButton.class );
+            default:
+                return super.getColumnClass(col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPreferredWidth(int col) {
+        switch (col) {
+            case INVERTCOL:
+            case LOCKCOL:
+                return new JTextField(6).getPreferredSize().width;
+            case LOCKOPRCOL:
+            case LOCKDECCOL:
+            case KNOWNCOL:
+            case MODECOL:
+                return new JTextField(10).getPreferredSize().width;
+            case SENSOR1COL:
+            case SENSOR2COL:
+                return new JTextField(5).getPreferredSize().width;
+            case OPSEDITCOL:
+                return new JButton(Bundle.getMessage("EditTurnoutOperation")).getPreferredSize().width;
+            case EDITCOL:
+                return new JButton(Bundle.getMessage("ButtonEdit")).getPreferredSize().width+4;
+            case OPSONOFFCOL:
+                return new JTextField(Bundle.getMessage("TurnoutAutomationMenu")).getPreferredSize().width;
+            case DIVERGCOL:
+            case STRAIGHTCOL:
+                return new JTextField(14).getPreferredSize().width;
+            case FORGETCOL:
+                return new JButton(Bundle.getMessage("StateForgetButton")).getPreferredSize().width;
+            case QUERYCOL:
+                return new JButton(Bundle.getMessage("StateQueryButton")).getPreferredSize().width;
+            default:
+                return super.getPreferredWidth(col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCellEditable(int row, int col) {
+        Turnout t = turnoutManager.getBySystemName(sysNameList.get(row));
+        if (t == null){
+            return false;
+        }
+        switch (col) {
+            case INVERTCOL:
+                return t.canInvert();
+            case LOCKCOL:
+                // checkbox disabled unless current configuration allows locking
+                return t.canLock(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT);
+            case OPSEDITCOL:
+                return t.getTurnoutOperation() != null;
+            case KNOWNCOL:
+                return false;
+            case MODECOL:
+            case SENSOR1COL:
+            case SENSOR2COL:
+            case OPSONOFFCOL:
+            case LOCKOPRCOL: // editable always so user can configure it, even if current configuration prevents locking now
+            case LOCKDECCOL: // editable always so user can configure it, even if current configuration prevents locking now
+            case DIVERGCOL:
+            case STRAIGHTCOL:
+            case EDITCOL:
+            case FORGETCOL:
+            case QUERYCOL:
+                return true;
+            default:
+                return super.isCellEditable(row, col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getValueAt(int row, int col) {
+        // some error checking
+        if (row >= sysNameList.size()) {
+            log.warn("row is greater than name list");
+            return "error";
+        }
+        String name = sysNameList.get(row);
+        TurnoutManager manager = turnoutManager;
+        Turnout t = manager.getBySystemName(name);
+        if (t == null) {
+            log.debug("error null turnout!");
+            return "error";
+        }
+        if (col == INVERTCOL) {
+            return t.getInverted();
+        } else if (col == LOCKCOL) {
+            return t.getLocked(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT);
+        } else if (col == KNOWNCOL) {
+            return t.describeState(t.getKnownState());
+        } else if (col == MODECOL) {
+            JComboBox<String> c = new JComboBox<>(t.getValidFeedbackNames());
+            c.setSelectedItem(t.getFeedbackModeName());
+            return c;
+        } else if (col == SENSOR1COL) {
+            return t.getFirstSensor();
+        } else if (col == SENSOR2COL) {
+            return t.getSecondSensor();
+        } else if (col == OPSONOFFCOL) {
+            return makeAutomationBox(t);
+        } else if (col == OPSEDITCOL) {
+            return Bundle.getMessage("EditTurnoutOperation");
+        } else if (col == EDITCOL) {
+            return Bundle.getMessage("ButtonEdit");
+        } else if (col == LOCKDECCOL) {
+            JComboBox<String> c;
+            if ((t.getPossibleLockModes() & Turnout.PUSHBUTTONLOCKOUT) != 0) {
+                c = new JComboBox<>(t.getValidDecoderNames());
+            } else {
+                c = new JComboBox<>(new String[]{t.getDecoderName()});
+            }
+
+            c.setSelectedItem(t.getDecoderName());
+            return c;
+        } else if (col == LOCKOPRCOL) {
+            
+            java.util.Vector<String> lockOperations = new java.util.Vector<>();  // Vector is a JComboBox ctor; List is not
+            int modes = t.getPossibleLockModes();
+            if ((modes & Turnout.CABLOCKOUT) != 0 && (modes & Turnout.PUSHBUTTONLOCKOUT) != 0) {
+                lockOperations.add(bothText);
+            }
+            if ((modes & Turnout.CABLOCKOUT) != 0) {
+                lockOperations.add(cabOnlyText);
+            }
+            if ((modes & Turnout.PUSHBUTTONLOCKOUT) != 0) {
+                lockOperations.add(pushbutText);
+            }
+            lockOperations.add(noneText);
+            JComboBox<String> c = new JComboBox<>(lockOperations);
+
+            if (t.canLock(Turnout.CABLOCKOUT) && t.canLock(Turnout.PUSHBUTTONLOCKOUT)) {
+                c.setSelectedItem(bothText);
+            } else if (t.canLock(Turnout.PUSHBUTTONLOCKOUT)) {
+                c.setSelectedItem(pushbutText);
+            } else if (t.canLock(Turnout.CABLOCKOUT)) {
+                c.setSelectedItem(cabOnlyText);
+            } else {
+                c.setSelectedItem(noneText);
+            }
+            return c;
+        } else if (col == STRAIGHTCOL) {
+
+            String speed = t.getStraightSpeed();
+            if (!speedListClosed.contains(speed)) {
+                speedListClosed.add(speed);
+            }
+            JComboBox<String> c = new JComboBox<>(speedListClosed);
+            c.setEditable(true);
+            c.setSelectedItem(speed);
+            return c;
+        } else if (col == DIVERGCOL) {
+
+            String speed = t.getDivergingSpeed();
+            if (!speedListThrown.contains(speed)) {
+                speedListThrown.add(speed);
+            }
+            JComboBox<String> c = new JComboBox<>(speedListThrown);
+            c.setEditable(true);
+            c.setSelectedItem(speed);
+            return c;
+            // } else if (col == VALUECOL && _graphicState) { // not neeeded as the
+            //  graphic ImageIconRenderer uses the same super.getValueAt(row, col) as
+            // classic bean state text button
+        } else if (col == FORGETCOL) {
+            return Bundle.getMessage("StateForgetButton");
+        } else if (col == QUERYCOL) {
+            return Bundle.getMessage("StateQueryButton");
+        }
+        return super.getValueAt(row, col);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setValueAt(Object value, int row, int col) {
+        String name = sysNameList.get(row);
+        Turnout t = turnoutManager.getBySystemName(name);
+        if (t == null) {
+            NullPointerException ex = new NullPointerException("Unexpected null turnout in turnout table");
+            log.error(ex.getMessage(), ex); // log with stack trace
+            throw ex;
+        }
+        if (col == INVERTCOL) {
+            if (t.canInvert()) {
+                t.setInverted((Boolean) value);
+                fireTableRowsUpdated(row, row);
+            }
+        } else if (col == LOCKCOL) {
+            t.setLocked(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT, (Boolean) value);
+            fireTableRowsUpdated(row, row);
+        } else if (col == MODECOL) {
+            @SuppressWarnings("unchecked")
+            String modeName = (String) ((JComboBox<String>) value).getSelectedItem();
+            assert modeName != null;
+            t.setFeedbackMode(modeName);
+            fireTableRowsUpdated(row, row);
+        } else if (col == SENSOR1COL) {
+            try {
+                Sensor sensor = (Sensor) value;
+                t.provideFirstFeedbackSensor(sensor != null ? sensor.getDisplayName() : null);
+            } catch (jmri.JmriException e) {
+                JOptionPane.showMessageDialog(null, e.toString());
+            }
+            fireTableRowsUpdated(row, row);
+        } else if (col == SENSOR2COL) {
+            try {
+                Sensor sensor = (Sensor) value;
+                t.provideSecondFeedbackSensor(sensor != null ? sensor.getDisplayName() : null);
+            } catch (jmri.JmriException e) {
+                JOptionPane.showMessageDialog(null, e.toString());
+            }
+            fireTableRowsUpdated(row, row);
+        //} else if (col == OPSONOFFCOL) {
+            // do nothing as this is handled by the combo box listener
+        } else if (col == OPSEDITCOL) {
+            t.setInhibitOperation(false);
+            @SuppressWarnings("unchecked") // cast to JComboBox<String> required in OPSEDITCOL
+            JComboBox<String> cb = (JComboBox<String>) getValueAt(row, OPSONOFFCOL);
+            log.debug("opsSelected = {}", getValueAt(row, OPSONOFFCOL).toString());
+            editTurnoutOperation(t, cb);
+            fireTableRowsUpdated(row, row);
+        } else if (col == EDITCOL) {
+            class WindowMaker implements Runnable {
+
+                final Turnout t;
+
+                WindowMaker(Turnout t) {
+                    this.t = t;
+                }
+
+                @Override
+                public void run() {
+                    editButton(t);
+                }
+            }
+            WindowMaker w = new WindowMaker(t);
+            javax.swing.SwingUtilities.invokeLater(w);
+        } else if (col == LOCKOPRCOL) {
+            @SuppressWarnings("unchecked")
+            String lockOpName = (String) ((JComboBox<String>) value)
+                    .getSelectedItem();
+            assert lockOpName != null;
+            if (lockOpName.equals(bothText)) {
+                t.enableLockOperation(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT, true);
+            }
+            if (lockOpName.equals(cabOnlyText)) {
+                t.enableLockOperation(Turnout.CABLOCKOUT, true);
+                t.enableLockOperation(Turnout.PUSHBUTTONLOCKOUT, false);
+            }
+            if (lockOpName.equals(pushbutText)) {
+                t.enableLockOperation(Turnout.CABLOCKOUT, false);
+                t.enableLockOperation(Turnout.PUSHBUTTONLOCKOUT, true);
+            }
+            fireTableRowsUpdated(row, row);
+        } else if (col == LOCKDECCOL) {
+            @SuppressWarnings("unchecked")
+            String decoderName = (String) ((JComboBox<String>) value).getSelectedItem();
+            t.setDecoderName(decoderName);
+            fireTableRowsUpdated(row, row);
+        } else if (col == STRAIGHTCOL) {
+            @SuppressWarnings("unchecked")
+            String speed = (String) ((JComboBox<String>) value).getSelectedItem();
+            try {
+                t.setStraightSpeed(speed);
+            } catch (jmri.JmriException ex) {
+                JOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
+                return;
+            }
+            if ((!speedListClosed.contains(speed))) {
+                assert speed != null;
+                if (!speed.contains("Global")) {
+                    speedListClosed.add(speed);
+                }
+            }
+            fireTableRowsUpdated(row, row);
+        } else if (col == DIVERGCOL) {
+
+            @SuppressWarnings("unchecked")
+            String speed = (String) ((JComboBox<String>) value).getSelectedItem();
+            try {
+                t.setDivergingSpeed(speed);
+            } catch (jmri.JmriException ex) {
+                JOptionPane.showMessageDialog(null, ex.getMessage() + "\n" + speed);
+                return;
+            }
+            if ((!speedListThrown.contains(speed))) {
+                assert speed != null;
+                if (!speed.contains("Global")) {
+                    speedListThrown.add(speed);
+                }
+            }
+            fireTableRowsUpdated(row, row);
+        } else if (col == FORGETCOL) {
+            t.setCommandedState(Turnout.UNKNOWN);
+        } else if (col == QUERYCOL) {
+            t.setCommandedState(Turnout.UNKNOWN);
+            t.requestUpdateFromLayout();
+        } else if (col == VALUECOL && _graphicState) { // respond to clicking on ImageIconRenderer CellEditor
+            clickOn(t);
+            fireTableRowsUpdated(row, row);
+        } else {
+            super.setValueAt(value, row, col);
+            fireTableRowsUpdated(row, row);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getValue(@Nonnull String name) {
+        Turnout turn = turnoutManager.getBySystemName(name);
+        if (turn != null) {
+            return turn.describeState(turn.getCommandedState());
+        }
+        return "Turnout not found";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Manager<Turnout> getManager() {
+        if (turnoutManager == null) {
+            turnoutManager = InstanceManager.getDefault(TurnoutManager.class);
+        }
+        return turnoutManager;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected final void setManager(@Nonnull Manager<Turnout> manager) {
+        if (!(manager instanceof TurnoutManager)) {
+            return;
+        }
+        getManager().removePropertyChangeListener(this);
+        if (sysNameList != null) {
+            for (int i = 0; i < sysNameList.size(); i++) {
+                // if object has been deleted, it's not here; ignore it
+                NamedBean b = getBySystemName(sysNameList.get(i));
+                if (b != null) {
+                    b.removePropertyChangeListener(this);
+                }
+            }
+        }
+        turnoutManager = (TurnoutManager) manager;
+        getManager().addPropertyChangeListener(this);
+        updateNameList();
+    }
+
+    @Override
+    public Turnout getBySystemName(@Nonnull String name) {
+        return turnoutManager.getBySystemName(name);
+    }
+
+    @Override
+    public Turnout getByUserName(@Nonnull String name) {
+        return InstanceManager.getDefault(TurnoutManager.class).getByUserName(name);
+    }
+
+    @Override
+    protected String getMasterClassName() {
+        return getClassName();
+    }
+    
+    protected String getClassName() {
+        return jmri.jmrit.beantable.TurnoutTableAction.class.getName();
+    }
+
+    @Override
+    public void clickOn(Turnout t) {
+        t.setCommandedState( t.getCommandedState()== Turnout.CLOSED ? Turnout.THROWN : Turnout.CLOSED);
+    }
+
+    @Override
+    public void configureTable(JTable tbl) {
+        
+        setColumnToHoldButton(tbl, EDITCOL, editButton());
+        setColumnToHoldButton(tbl, OPSEDITCOL, editButton());
+        
+        //Hide the following columns by default
+        XTableColumnModel columnModel = (XTableColumnModel) tbl.getColumnModel();
+        TableColumn column = columnModel.getColumnByModelIndex(STRAIGHTCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(DIVERGCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(KNOWNCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(MODECOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(SENSOR1COL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(SENSOR2COL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(OPSONOFFCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(OPSEDITCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(LOCKOPRCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(LOCKDECCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(FORGETCOL);
+        columnModel.setColumnVisible(column, false);
+        column = columnModel.getColumnByModelIndex(QUERYCOL);
+        columnModel.setColumnVisible(column, false);
+        
+        
+        // and then set user prefs
+        super.configureTable(tbl);
+        
+    }
+
+    // update table if turnout lock or feedback changes
+    @Override
+    protected boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
+        if (e.getPropertyName().equals("locked")) {
+            return true;
+        }
+        if (e.getPropertyName().equals("feedbackchange")) {
+            return true;
+        }
+        if (e.getPropertyName().equals("TurnoutDivergingSpeedChange")) {
+            return true;
+        }
+        if (e.getPropertyName().equals("TurnoutStraightSpeedChange")) {
+            return true;
+        } else {
+            return super.matchPropertyName(e);
+        }
+    }
+
+    @Override
+    public void propertyChange(java.beans.PropertyChangeEvent e) {
+        if (e.getPropertyName().equals("DefaultTurnoutClosedSpeedChange")) {
+            updateClosedList();
+        } else if (e.getPropertyName().equals("DefaultTurnoutThrownSpeedChange")) {
+            updateThrownList();
+        } else {
+            super.propertyChange(e);
+        }
+    }
+
+    /**
+     * Customize the turnout table Value (State) column to show an
+     * appropriate graphic for the turnout state if _graphicState =
+     * true, or (default) just show the localized state text when the
+     * TableDataModel is being called from ListedTableAction.
+     *
+     * @param table a JTable of Turnouts
+     */
+    @Override
+    protected void configValueColumn(JTable table) {
+        // have the value column hold a JPanel (icon)
+        //setColumnToHoldButton(table, VALUECOL, new JLabel("12345678")); // for larger, wide round icon, but cannot be converted to JButton
+        // add extras, override BeanTableDataModel
+        log.debug("Turnout configValueColumn (I am {})", super.toString());
+        if (_graphicState) { // load icons, only once
+            table.setDefaultEditor(JLabel.class, new ImageIconRenderer()); // editor
+            table.setDefaultRenderer(JLabel.class, new ImageIconRenderer()); // item class copied from SwitchboardEditor panel
+        } else {
+            super.configValueColumn(table); // classic text style state indication
+        }
+    }
+
+    @Override
+    public JTable makeJTable(@Nonnull String name, @Nonnull TableModel model, @CheckForNull RowSorter<? extends TableModel> sorter) {
+        return configureJTable(name, new TurnoutTableJTable((TurnoutTableDataModel)model), sorter);
+    }
+    
+    @Override
+    protected void setColumnIdentities(JTable table) {
+        super.setColumnIdentities(table);
+        java.util.Enumeration<TableColumn> columns;
+        if (table.getColumnModel() instanceof XTableColumnModel) {
+            columns = ((XTableColumnModel) table.getColumnModel()).getColumns(false);
+        } else {
+            columns = table.getColumnModel().getColumns();
+        }
+        while (columns.hasMoreElements()) {
+            TableColumn column = columns.nextElement();
+            switch (column.getModelIndex()) {
+                case FORGETCOL:
+                    column.setIdentifier("ForgetState");
+                    break;
+                case QUERYCOL:
+                    column.setIdentifier("QueryState");
+                    break;
+                default:
+                // use existing value
+            }
+        }
+    }
+
+    /**
+     * Pop up a TurnoutOperationConfig for the turnout.
+     *
+     * @param t   turnout
+     * @param box JComboBox that triggered the edit
+     */
+    protected void editTurnoutOperation(Turnout t, JComboBox<String> box) {
+        if (!editingOps.getAndSet(true)) { // don't open a second edit ops pane
+            TurnoutOperation op = t.getTurnoutOperation();
+            if (op == null) {
+                TurnoutOperation proto = InstanceManager.getDefault(TurnoutOperationManager.class).getMatchingOperationAlways(t);
+                if (proto != null) {
+                    op = proto.makeNonce(t);
+                    t.setTurnoutOperation(op);
+                }
+            }
+            if (op != null) {
+                if (!op.isNonce()) {
+                    op = op.makeNonce(t);
+                }
+                // make and show edit dialog
+                log.debug("TurnoutOpsEditDialog starting");
+                TurnoutOperationEditorDialog dialog = new TurnoutOperationEditorDialog(op, t, box);
+                dialog.setVisible(true);
+            } else {
+                JOptionPane.showMessageDialog(box, Bundle.getMessage("TurnoutOperationErrorDialog"),
+                        Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+    
+    /**
+     * Create a {@literal JComboBox<String>} containing all the options for
+     * turnout automation parameters for this turnout.
+     *
+     * @param t the turnout
+     * @return the JComboBox
+     */
+    protected JComboBox<String> makeAutomationBox(Turnout t) {
+        String[] str = new String[]{"empty"};
+        final JComboBox<String> cb = new JComboBox<>(str);
+        final Turnout myTurnout = t;
+        TurnoutTableAction.updateAutomationBox(t, cb);
+        cb.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setTurnoutOperation(myTurnout, cb);
+                cb.removeActionListener(this);  // avoid recursion
+                TurnoutTableAction.updateAutomationBox(myTurnout, cb);
+                cb.addActionListener(this);
+            }
+        });
+        return cb;
+    }
+    
+    /**
+     * Set the turnout's operation info based on the contents of the combo box.
+     *
+     * @param t  turnout being configured
+     * @param cb JComboBox for ops for t in the TurnoutTable
+     */
+    protected void setTurnoutOperation(Turnout t, JComboBox<String> cb) {
+        switch (cb.getSelectedIndex()) {
+            case 0:   // Off
+                t.setInhibitOperation(true);
+                t.setTurnoutOperation(null);
+                break;
+            case 1:   // Default
+                t.setInhibitOperation(false);
+                t.setTurnoutOperation(null);
+                break;
+            default:  // named operation
+                t.setInhibitOperation(false);
+                t.setTurnoutOperation(InstanceManager.getDefault(TurnoutOperationManager.class).
+                        getOperation(((String) java.util.Objects.requireNonNull(cb.getSelectedItem()))));
+                break;
+        }
+    }
+    
+    /**
+     * Create action to edit a turnout in Edit pane. (also used in windowTest)
+     *
+     * @param t the turnout to be edited
+     */
+    void editButton(Turnout t) {
+        jmri.jmrit.beantable.beanedit.TurnoutEditAction beanEdit = new jmri.jmrit.beantable.beanedit.TurnoutEditAction();
+        beanEdit.setBean(t);
+        beanEdit.actionPerformed(null);
+    }
+
+    /**
+     * Create a JButton to edit a turnout's operation.
+     *
+     * @return the JButton
+     */
+    protected JButton editButton() {
+        return new JButton(Bundle.getMessage("EditTurnoutOperation"));
+    }
+    
+    private void updateClosedList() {
+        speedListClosed.remove(defaultClosedSpeedText);
+        defaultClosedSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultClosedSpeed());
+        speedListClosed.add(0, defaultClosedSpeedText);
+        fireTableDataChanged();
+    }
+
+    private void updateThrownList() {
+        speedListThrown.remove(defaultThrownSpeedText);
+        defaultThrownSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + turnoutManager.getDefaultThrownSpeed());
+        speedListThrown.add(0, defaultThrownSpeedText);
+        fireTableDataChanged();
+    }
+    
+    public void showFeedbackChanged(boolean visible, JTable table ) {
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+        TableColumn column = columnModel.getColumnByModelIndex(KNOWNCOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(MODECOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(SENSOR1COL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(SENSOR2COL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(OPSONOFFCOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(OPSEDITCOL);
+        columnModel.setColumnVisible(column, visible);
+    }
+
+    public void showLockChanged(boolean visible, JTable table) {
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+        TableColumn column = ((XTableColumnModel) table.getColumnModel()).getColumnByModelIndex(LOCKDECCOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(LOCKOPRCOL);
+        columnModel.setColumnVisible(column, visible);
+    }
+
+    public void showTurnoutSpeedChanged(boolean visible, JTable table) {
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+        TableColumn column = ((XTableColumnModel) table.getColumnModel()).getColumnByModelIndex(STRAIGHTCOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(DIVERGCOL);
+        columnModel.setColumnVisible(column, visible);
+    }
+
+    public void showStateForgetAndQueryChanged(boolean visible, JTable table) {
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+        TableColumn column = columnModel.getColumnByModelIndex(FORGETCOL);
+        columnModel.setColumnVisible(column, visible);
+        column = columnModel.getColumnByModelIndex(QUERYCOL);
+        columnModel.setColumnVisible(column, visible);
+    }
+
+    
+    /**
+     * Visualize state in table as a graphic, customized for Turnouts (4
+     * states). 
+     * Renderer and Editor are identical, as the cell contents
+     * are not actually edited, only used to toggle state using
+     * {@link #clickOn(Turnout)}.
+     *
+     */
+    class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
+
+        protected JLabel label;
+        protected String rootPath = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor
+        protected char beanTypeChar = 'T'; // for Turnout
+        protected String onIconPath = rootPath + beanTypeChar + "-on-s.png";
+        protected String offIconPath = rootPath + beanTypeChar + "-off-s.png";
+        protected BufferedImage onImage;
+        protected BufferedImage offImage;
+        protected ImageIcon onIcon;
+        protected ImageIcon offIcon;
+        protected int iconHeight = -1;
+
+        @Override
+        public java.awt.Component getTableCellRendererComponent(
+                JTable table, Object value, boolean isSelected,
+                boolean hasFocus, int row, int column) {
+            log.debug("Renderer Item = {}, State = {}", row, value);
+            if (iconHeight < 0) { // load resources only first time, either for renderer or editor
+                loadIcons();
+                log.debug("icons loaded");
+            }
+            return updateLabel((String) value, row, table);
+        }
+
+        @Override
+        public java.awt.Component getTableCellEditorComponent(
+                JTable table, Object value, boolean isSelected,
+                int row, int column) {
+            log.debug("Renderer Item = {}, State = {}", row, value);
+            if (iconHeight < 0) { // load resources only first time, either for renderer or editor
+                loadIcons();
+                log.debug("icons loaded");
+            }
+            return updateLabel((String) value, row, table);
+        }
+
+        public JLabel updateLabel(String value, int row, JTable table) {
+            if (iconHeight > 0) { // if necessary, increase row height;
+                table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5));
+            }
+            if (value.equals(closedText) && onIcon != null) {
+                label = new JLabel(onIcon);
+                label.setVerticalAlignment(JLabel.BOTTOM);
+                log.debug("onIcon set");
+            } else if (value.equals(thrownText) && offIcon != null) {
+                label = new JLabel(offIcon);
+                label.setVerticalAlignment(JLabel.BOTTOM);
+                log.debug("offIcon set");
+            } else if (value.equals(Bundle.getMessage("BeanStateInconsistent"))) {
+                label = new JLabel("X", JLabel.CENTER); // centered text alignment
+                label.setForeground(java.awt.Color.red);
+                log.debug("Turnout state inconsistent");
+                iconHeight = 0;
+            } else if (value.equals(Bundle.getMessage("BeanStateUnknown"))) {
+                label = new JLabel("?", JLabel.CENTER); // centered text alignment
+                log.debug("Turnout state unknown");
+                iconHeight = 0;
+            } else { // failed to load icon
+                label = new JLabel(value, JLabel.CENTER); // centered text alignment
+                log.warn("Error reading icons for TurnoutTable");
+                iconHeight = 0;
+            }
+            label.setToolTipText(value);
+            label.addMouseListener(new MouseAdapter() {
+                @Override
+                public final void mousePressed(MouseEvent evt) {
+                    log.debug("Clicked on icon in row {}", row);
+                    stopCellEditing();
+                }
+            });
+            return label;
+        }
+
+        @Override
+        public Object getCellEditorValue() {
+            log.debug("getCellEditorValue, me = {})", this.toString());
+            return this.toString();
+        }
+
+        /**
+         * Read and buffer graphics. Only called once for this table.
+         *
+         * @see #getTableCellEditorComponent(JTable, Object, boolean,
+         * int, int)
+         */
+        protected void loadIcons() {
+            try {
+                onImage = ImageIO.read(new File(onIconPath));
+                offImage = ImageIO.read(new File(offIconPath));
+            } catch (IOException ex) {
+                log.error("error reading image from {} or {}", onIconPath, offIconPath, ex);
+            }
+            log.debug("Success reading images");
+            int imageWidth = onImage.getWidth();
+            int imageHeight = onImage.getHeight();
+            // scale icons 50% to fit in table rows
+            java.awt.Image smallOnImage = onImage.getScaledInstance(imageWidth / 2, imageHeight / 2, java.awt.Image.SCALE_DEFAULT);
+            java.awt.Image smallOffImage = offImage.getScaledInstance(imageWidth / 2, imageHeight / 2, java.awt.Image.SCALE_DEFAULT);
+            onIcon = new ImageIcon(smallOnImage);
+            offIcon = new ImageIcon(smallOffImage);
+            iconHeight = onIcon.getIconHeight();
+        }
+
+    } // end of ImageIconRenderer class
+
+    protected static java.util.concurrent.atomic.AtomicBoolean editingOps = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+    private final static Logger log = LoggerFactory.getLogger(TurnoutTableDataModel.class);
+    
+}

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableJTable.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableJTable.java
@@ -1,0 +1,183 @@
+package jmri.jmrit.beantable.turnout;
+
+import java.awt.Component;
+import java.awt.event.MouseEvent;
+import java.util.Hashtable;
+
+import javax.annotation.Nonnull;
+import javax.swing.DefaultCellEditor;
+import javax.swing.JTable;
+import javax.swing.table.*;
+
+import jmri.InstanceManager;
+import jmri.NamedBean;
+import jmri.Sensor;
+import jmri.SensorManager;
+import jmri.Turnout;
+
+
+import jmri.swing.NamedBeanComboBox;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JTable to display a TurnoutTableDataModel.
+ * Code originally within TurnoutTableAction.
+ * 
+ * @author Bob Jacobsen Copyright (C) 2003, 2004, 2007
+ * @author Egbert Broerse Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class TurnoutTableJTable extends JTable {
+    
+    final TurnoutTableDataModel model;
+    
+    final Hashtable<Turnout, TableCellRenderer> rendererMapSensor1 = new Hashtable<>();
+    final Hashtable<Turnout, TableCellEditor> editorMapSensor1 = new Hashtable<>();
+
+    final Hashtable<Turnout, TableCellRenderer> rendererMapSensor2 = new Hashtable<>();
+    final Hashtable<Turnout, TableCellEditor> editorMapSensor2 = new Hashtable<>();
+    
+    public TurnoutTableJTable(TurnoutTableDataModel mdl){
+        super(mdl);
+        model = mdl;
+    }
+    
+    @Override
+    public String getToolTipText(@Nonnull MouseEvent e) {
+        java.awt.Point p = e.getPoint();
+        int rowIndex = rowAtPoint(p);
+        int colIndex = columnAtPoint(p);
+        int realRowIndex = convertRowIndexToModel(rowIndex);
+        int realColumnIndex = convertColumnIndexToModel(colIndex);
+        return model.getCellToolTip(this, realRowIndex, realColumnIndex);
+    }
+
+    @Override
+    public TableCellRenderer getCellRenderer(int row, int column) {
+        // Convert the displayed index to the model index, rather than the displayed index
+        int modelColumn = this.convertColumnIndexToModel(column);
+        if (modelColumn == TurnoutTableDataModel.SENSOR1COL || modelColumn == TurnoutTableDataModel.SENSOR2COL) {
+            return getRenderer(row, modelColumn);
+        } else {
+            return super.getCellRenderer(row, column);
+        }
+    }
+
+    @Override
+    public TableCellEditor getCellEditor(int row, int column) {
+        //Convert the displayed index to the model index, rather than the displayed index
+        int modelColumn = this.convertColumnIndexToModel(column);
+        if (modelColumn == TurnoutTableDataModel.SENSOR1COL || modelColumn == TurnoutTableDataModel.SENSOR2COL) {
+            return getEditor(row, modelColumn);
+        } else {
+            return super.getCellEditor(row, column);
+        }
+    }
+
+    TableCellRenderer getRenderer(int row, int column) {
+        TableCellRenderer retval;
+        Turnout t = (Turnout) getModel().getValueAt(row, TurnoutTableDataModel.SYSNAMECOL);
+        java.util.Objects.requireNonNull(t, "SYSNAMECOL column content must be nonnull");
+        switch (column) {
+            case TurnoutTableDataModel.SENSOR1COL:
+                retval = rendererMapSensor1.get(t);
+                break;
+            case TurnoutTableDataModel.SENSOR2COL:
+                retval = rendererMapSensor2.get(t);
+                break;
+            default:
+                return null;
+        }
+
+        if (retval == null) {
+            if (column == TurnoutTableDataModel.SENSOR1COL) {
+                loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
+            } else {
+                loadRenderEditMaps(rendererMapSensor2, editorMapSensor2, t, t.getSecondSensor());
+            }
+            retval = rendererMapSensor1.get(t);
+        }
+        log.debug("fetched for Turnout \"{}\" renderer {}", t, retval);
+        return retval;
+    }
+
+    TableCellEditor getEditor(int row, int column) {
+        TableCellEditor retval;
+        Turnout t = (Turnout) getModel().getValueAt(row, TurnoutTableDataModel.SYSNAMECOL);
+        java.util.Objects.requireNonNull(t, "SYSNAMECOL column content must be nonnull");
+        switch (column) {
+            case TurnoutTableDataModel.SENSOR1COL:
+                retval = editorMapSensor1.get(t);
+                break;
+            case TurnoutTableDataModel.SENSOR2COL:
+                retval = editorMapSensor2.get(t);
+                break;
+            default:
+                return null;
+        }
+        if (retval == null) {
+            if (column == TurnoutTableDataModel.SENSOR1COL) {
+                loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
+                retval = editorMapSensor1.get(t);
+            } else { //Must be two
+                loadRenderEditMaps(rendererMapSensor2, editorMapSensor2, t, t.getSecondSensor());
+                retval = editorMapSensor2.get(t);
+            }
+        }
+        log.debug("fetched for Turnout \"{}\" editor {}", t, retval);
+        return retval;
+    }
+
+    protected void loadRenderEditMaps(Hashtable<Turnout, TableCellRenderer> r, Hashtable<Turnout, TableCellEditor> e,
+            Turnout t, Sensor s) {
+        NamedBeanComboBox<Sensor> c = new NamedBeanComboBox<>(InstanceManager.getDefault(SensorManager.class), s, NamedBean.DisplayOptions.DISPLAYNAME);
+        c.setAllowNull(true);
+
+        BeanBoxRenderer renderer = new BeanBoxRenderer();
+        renderer.setSelectedItem(s);
+        r.put(t, renderer);
+
+        TableCellEditor editor = new BeanComboBoxEditor(c);
+        e.put(t, editor);
+        log.debug("initialize for Turnout \"{}\" Sensor \"{}\"", t, s);
+    }
+    
+    static class BeanBoxRenderer extends NamedBeanComboBox<Sensor> implements TableCellRenderer {
+
+        public BeanBoxRenderer() {
+            super(InstanceManager.getDefault(SensorManager.class));
+            setAllowNull(true);
+        }
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value,
+                boolean isSelected, boolean hasFocus, int row, int column) {
+            if (isSelected) {
+                setForeground(table.getSelectionForeground());
+                super.setBackground(table.getSelectionBackground());
+            } else {
+                setForeground(table.getForeground());
+                setBackground(table.getBackground());
+            }
+            if (value instanceof Sensor) {
+                setSelectedItem(value);
+            } else {
+                setSelectedItem(null);
+            }
+            return this;
+        }
+    }
+    
+    static class BeanComboBoxEditor extends DefaultCellEditor {
+
+        public BeanComboBoxEditor(NamedBeanComboBox<Sensor> beanBox) {
+            super(beanBox);
+        }
+    }
+    
+     
+private final static Logger log = LoggerFactory.getLogger(TurnoutTableJTable.class);
+
+}

--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
  * <li>DIY: (mfgID == 13) CV47 is the highest byte, CV48 is high byte, CV49 is
  * low byte, CV50 is the lowest byte; (CV47 == 1) is reserved for the Czech
  * Republic</li>
+ * <li>Doehler & Haass: (mfgID == 97) CV261 is ID from 2020 firmwares</li>
  * </ul>
  * <dl>
  * <dt>Optional CVs:</dt>
@@ -135,6 +136,11 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             statusUpdate("Read decoder product ID #1 CV 47");
             readCV("47");
             return false;
+        } else if (mfgID == 97) {  // Doehler & Haass
+            statusUpdate("Read optional decoder ID CV 261");
+            setOptionalCv(true);
+            readCV("261");
+            return false;
         }
         return true;
     }
@@ -183,6 +189,12 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             statusUpdate("Read decoder product ID #2 CV 48");
             readCV("48");
             return false;
+        } else if (mfgID == 97) {  // Doehler & Haass
+            if (isOptionalCv()) {
+                return true;
+            }
+            productID = value;
+            return true;
         }
         log.error("unexpected step 4 reached with value: {}", value);
         return true;

--- a/java/test/jmri/jmrit/beantable/AbstractBeanTableDataModelBase.java
+++ b/java/test/jmri/jmrit/beantable/AbstractBeanTableDataModelBase.java
@@ -1,6 +1,9 @@
 package jmri.jmrit.beantable;
 
+import jmri.Manager;
+import jmri.ProvidingManager;
 import jmri.NamedBean;
+import jmri.util.JUnitAppender;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
@@ -29,9 +32,30 @@ public abstract class AbstractBeanTableDataModelBase<B extends jmri.NamedBean> {
      */
     abstract protected int getModelColumnCount();
     
+    /**
+     * Create a NamedBean to use in the Table.
+     */
+    protected void createBean(){
+        Manager<?> mgr = t.getManager(); // Internal Proxy Bean<?> Manager
+        Assert.assertNotNull("Table Bean Manager exists",mgr);
+        if (mgr instanceof ProvidingManager){
+            NamedBean b = ((ProvidingManager<?>) mgr).provide(mgr.getSystemNamePrefix()+"1");
+            Assert.assertNotNull("Bean created",b);
+        } else {
+            Assert.fail("Manager is not a providing manager, this test should be overridden to create a bean");
+        }
+    }
+    
     @Test
     public void testTableNotNull() {
         Assert.assertNotNull("Table exists in tested class",t);
+    }
+    
+    @Test
+    public void testGetRowCount(){
+        assertEquals("0 Rows when model created",0, t.getRowCount());
+        createBean();
+        assertEquals("1 Row when NamedBean created",1, t.getRowCount());
     }
     
     /**
@@ -56,6 +80,55 @@ public abstract class AbstractBeanTableDataModelBase<B extends jmri.NamedBean> {
         assertEquals("Column3 - User Comment",Bundle.getMessage("ColumnComment"), t.getColumnName(3));
         assertEquals("Column4 - Delete button","", t.getColumnName(4));
         
+    }
+    
+    /**
+     * Test of getColumn Name method with no column in model.
+     * Should NOT be overridden by implementing Tests
+     */
+    @Test
+    public void testGetColumnNameNone() {
+        assertEquals("No column, no name via super.","btm unknown",t.getColumnName(t.getColumnCount()) );
+    }
+    
+    /**
+     * Test of isCellEditable Name method with no column in model.
+     * Should NOT be overridden by implementing Tests
+     */
+    @Test
+    public void testCellEditableColumnNone() {
+        createBean(); // ensure there is a row 0
+        assertEquals("No column, not editable",false,t.isCellEditable(0,t.getColumnCount()) );
+    }
+    
+    /**
+     * Test of getValueAt method with no column in model.
+     * Should NOT be overridden by implementing Tests
+     */
+    @Test
+    public void testGetValueAtNoColumn() {
+        createBean(); // ensure there is a row 0
+        assertEquals("No column, no value",null,t.getValueAt(0,t.getColumnCount()) );
+        JUnitAppender.assertErrorMessage("internal state inconsistent with table requst for getValueAt 0 "+t.getColumnCount());
+    }
+    
+    /**
+     * Test of getValueAt method with no column in model.
+     * Should NOT be overridden by implementing Tests
+     */
+    @Test
+    public void testGetWidthNoColumn() {
+        Assert.assertTrue("No column, no value",t.getPreferredWidth(t.getColumnCount())>0);
+        JUnitAppender.assertErrorMessageStartsWith("Unexpected column in getPreferredWidth: "+t.getColumnCount());
+    }
+    
+    /**
+     * Test of getColumnClass method with no column in model.
+     * Should NOT be overridden by implementing Tests
+     */
+    @Test
+    public void testGetColumnClassNone() {
+        assertEquals("No column, no class",null,t.getColumnClass(t.getColumnCount()) );
     }
 
     /**

--- a/java/test/jmri/jmrit/beantable/TurnoutTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/TurnoutTableActionTest.java
@@ -8,6 +8,7 @@ import javax.swing.JTextField;
 import jmri.InstanceManager;
 import jmri.Turnout;
 import jmri.TurnoutManager;
+import jmri.jmrit.beantable.turnout.TurnoutTableDataModel;
 import jmri.jmrix.internal.InternalSystemConnectionMemo;
 import jmri.jmrix.internal.InternalTurnoutManager;
 import jmri.swing.ManagerComboBox;
@@ -189,7 +190,7 @@ public class TurnoutTableActionTest extends AbstractTableActionBase<Turnout> {
 
         JTableOperator tbl = new JTableOperator(jfo, 0);
         // find the "Edit" button and press it.  This is in the table body.
-        tbl.clickOnCell(0, TurnoutTableAction.EDITCOL);
+        tbl.clickOnCell(0, TurnoutTableDataModel.EDITCOL);
         JFrame f2 = JFrameOperator.waitJFrame(getEditFrameName(), true, true);
         jmri.util.swing.JemmyUtil.pressButton(new JFrameOperator(f2), Bundle.getMessage("ButtonCancel"));
         JUnitUtil.dispose(f2);
@@ -201,7 +202,7 @@ public class TurnoutTableActionTest extends AbstractTableActionBase<Turnout> {
     public void testConfigureManagerComboBox() {
         TurnoutManager j = new InternalTurnoutManager(new InternalSystemConnectionMemo("J", "Juliet"));
         InstanceManager.setTurnoutManager(j);
-        ManagerComboBox<Turnout> box = new ManagerComboBox<Turnout>();
+        ManagerComboBox<Turnout> box = new ManagerComboBox<>();
         Assert.assertEquals("empty box", 0, box.getItemCount());
         a.configureManagerComboBox(box, j, TurnoutManager.class);
         Assert.assertEquals("full box", 2, box.getItemCount());

--- a/java/test/jmri/jmrit/beantable/TurnoutTableWindowTest.java
+++ b/java/test/jmri/jmrit/beantable/TurnoutTableWindowTest.java
@@ -3,8 +3,8 @@ package jmri.jmrit.beantable;
 import java.awt.GraphicsEnvironment;
 import javax.swing.JTextField;
 import jmri.InstanceManager;
-import jmri.Turnout;
 import jmri.TurnoutManager;
+import jmri.jmrit.beantable.turnout.TurnoutTableDataModel;
 import jmri.jmrix.cmri.CMRISystemConnectionMemo;
 import jmri.jmrix.cmri.serial.SerialTurnoutManager;
 import jmri.jmrix.internal.InternalSystemConnectionMemo;
@@ -104,17 +104,11 @@ public class TurnoutTableWindowTest {
         jbo.doClick();
         // Ask to close Add pane
         afo.requestClose();
-
-        // Open the Edit Turnout IT1 pane, how to find & click the LT1 Edit col button?
+        
+        // Open the Edit Turnout IT1 pane, 
         // Find the Edit button in EDITCOL of line 0 (for LT1)
-        //AbstractButtonFinder edfinder = new AbstractButtonFinder("Edit");
-        //JButton editbutton = (JButton) edfinder.find(ft, 0);
-        //Assert.assertNotNull(editbutton);
-        // Click button to edit turnout
-        //getHelper().enterClickAndLeave(new MouseEventData(this, editbutton));
-        // open Edit pane by method instead
-        Turnout it1 = InstanceManager.turnoutManagerInstance().getTurnout("IT1");
-        a.editButton(it1); // open edit pane
+        JTableOperator tbl = new JTableOperator(jfo, 0);
+        tbl.clickOnCell(0, TurnoutTableDataModel.EDITCOL);
 
         // Find Edit Turnout pane by name
         JFrameOperator efo = new JFrameOperator("Edit Turnout IT1");

--- a/java/test/jmri/jmrit/beantable/sensor/SensorTableDataModelTest.java
+++ b/java/test/jmri/jmrit/beantable/sensor/SensorTableDataModelTest.java
@@ -5,6 +5,7 @@ import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
 
 /**
  *
@@ -20,6 +21,26 @@ public class SensorTableDataModelTest extends jmri.jmrit.beantable.AbstractBeanT
     @Override
     public int getModelColumnCount(){
         return 13;
+    }
+    
+    @Test
+    public void testGetColumnNames() {
+        assertEquals("Column5 - INVERTCOL",Bundle.getMessage("Inverted"),
+            t.getColumnName(SensorTableDataModel.INVERTCOL));
+        assertEquals("Column6 - EDITCOL","",
+            t.getColumnName(SensorTableDataModel.EDITCOL));
+        assertEquals("Column7 - USEGLOBALDELAY",Bundle.getMessage("SensorUseGlobalDebounce"),
+            t.getColumnName(SensorTableDataModel.USEGLOBALDELAY));
+        assertEquals("Column8 - ACTIVEDELAY",Bundle.getMessage("SensorActiveDebounce"),
+            t.getColumnName(SensorTableDataModel.ACTIVEDELAY));
+        assertEquals("Column9 - INACTIVEDELAY",Bundle.getMessage("SensorInActiveDebounce"),
+            t.getColumnName(SensorTableDataModel.INACTIVEDELAY));
+        assertEquals("Column10 - PULLUPCOL",Bundle.getMessage("SensorPullUp"),
+            t.getColumnName(SensorTableDataModel.PULLUPCOL));
+        assertEquals("Column11 - FORGETCOL",Bundle.getMessage("StateForgetHeader"),
+            t.getColumnName(SensorTableDataModel.FORGETCOL));
+        assertEquals("Column12 - QUERYCOL",Bundle.getMessage("StateQueryHeader"),
+            t.getColumnName(SensorTableDataModel.QUERYCOL));
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/beantable/turnout/BundleTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/BundleTest.java
@@ -1,0 +1,43 @@
+package jmri.jmrit.beantable.turnout;
+
+import java.util.Locale;
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+
+/**
+ * Tests for the Bundle class
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ */
+public class BundleTest  {
+
+    @Test public void testGoodKeyMessage() {
+        Assert.assertEquals("Turnout", Bundle.getMessage("BeanNameTurnout"));
+    }
+
+    @Test
+    public void testBadKeyMessage() {
+        Assert.assertThrows(java.util.MissingResourceException.class, () -> Bundle.getMessage("FFFFFTTTTTTT"));
+    }
+
+    @Test public void testGoodKeyMessageArg() {
+        Assert.assertEquals("Sensor", Bundle.getMessage("BeanNameSensor", new Object[]{}));
+        Assert.assertEquals("About Test", Bundle.getMessage("TitleAbout", "Test"));
+    }
+
+    @Test
+    public void testBadKeyMessageArg() {
+        Assert.assertThrows(java.util.MissingResourceException.class, () -> Bundle.getMessage("FFFFFTTTTTTT", new Object[]{}));
+    }
+
+    @Test public void testLocaleMessage() {
+        Assert.assertEquals("Scambio", Bundle.getMessage(Locale.ITALY, "BeanNameTurnout"));
+    }
+
+    @Test public void testLocaleMessageArg() {
+        Assert.assertEquals("Scambio", Bundle.getMessage(Locale.ITALY, "BeanNameTurnout", new Object[]{}));
+        Assert.assertEquals("Informazioni su Test", Bundle.getMessage(Locale.ITALY, "TitleAbout", "Test"));
+    }
+
+
+}

--- a/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
@@ -1,0 +1,40 @@
+package jmri.jmrit.beantable.turnout;
+
+import jmri.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ *
+ * @author Steve Young Copyright (C) 2021
+ */
+public class TurnoutOperationEditorDialogTest {
+    
+    @Test
+    public void testCTor() {
+        
+        Turnout testedTurnout = InstanceManager.getDefault(TurnoutManager.class).provide("IS1");
+        TurnoutOperation proto = InstanceManager.getDefault(TurnoutOperationManager.class).getMatchingOperationAlways(testedTurnout);
+        Assert.assertNotNull("proto exists",proto);
+        
+        TurnoutOperationEditorDialog t = new TurnoutOperationEditorDialog(proto,testedTurnout,null);
+        Assert.assertNotNull("exists",t);
+        
+        t.dispose();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+    
+}

--- a/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/TurnoutOperationEditorDialogTest.java
@@ -15,7 +15,7 @@ public class TurnoutOperationEditorDialogTest {
     
     @Test
     public void testCTor() {
-        
+        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
         Turnout testedTurnout = InstanceManager.getDefault(TurnoutManager.class).provide("IS1");
         TurnoutOperation proto = InstanceManager.getDefault(TurnoutOperationManager.class).getMatchingOperationAlways(testedTurnout);
         Assert.assertNotNull("proto exists",proto);

--- a/java/test/jmri/jmrit/beantable/turnout/TurnoutTableDataModelTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/TurnoutTableDataModelTest.java
@@ -1,0 +1,83 @@
+package jmri.jmrit.beantable.turnout;
+
+import jmri.Turnout;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young (C) 2021
+ */
+public class TurnoutTableDataModelTest extends jmri.jmrit.beantable.AbstractBeanTableDataModelBase<Turnout> {
+
+    @Test
+    public void testCTor() {
+        Assert.assertNotNull("exists",t);
+    }
+    
+    @Override
+    public int getModelColumnCount(){
+        return 20;
+    }
+    
+    @Test
+    public void testGetColumnNames() {
+        assertEquals("Column5 - INVERTCOL",Bundle.getMessage("Inverted"), 
+            t.getColumnName(TurnoutTableDataModel.INVERTCOL));
+        assertEquals("Column6 - LOCKCOL",Bundle.getMessage("Locked"),
+            t.getColumnName(TurnoutTableDataModel.LOCKCOL));
+        assertEquals("Column7 - EDITCOL","",
+            t.getColumnName(TurnoutTableDataModel.EDITCOL));
+        assertEquals("Column8 - KNOWNCOL",Bundle.getMessage("Feedback"),
+            t.getColumnName(TurnoutTableDataModel.KNOWNCOL));
+        assertEquals("Column9 - MODECOL",Bundle.getMessage("ModeLabel"),
+            t.getColumnName(TurnoutTableDataModel.MODECOL));
+        assertEquals("Column10 - SENSOR1COL",Bundle.getMessage("BlockSensor") + "1",
+            t.getColumnName(TurnoutTableDataModel.SENSOR1COL));
+        assertEquals("Column11 - SENSOR2COL",Bundle.getMessage("BlockSensor") + "2",
+            t.getColumnName(TurnoutTableDataModel.SENSOR2COL));
+        assertEquals("Column12 - OPSONOFFCOL",Bundle.getMessage("TurnoutAutomationMenu"),
+            t.getColumnName(TurnoutTableDataModel.OPSONOFFCOL));
+        assertEquals("Column13 - OPSEDITCOL","",
+            t.getColumnName(TurnoutTableDataModel.OPSEDITCOL));
+        assertEquals("Column14 - LOCKOPRCOL",Bundle.getMessage("LockMode"),
+            t.getColumnName(TurnoutTableDataModel.LOCKOPRCOL));
+        assertEquals("Column15 - LOCKDECCOL",Bundle.getMessage("Decoder"),
+            t.getColumnName(TurnoutTableDataModel.LOCKDECCOL));
+        assertEquals("Column16 - STRAIGHTCOL",Bundle.getMessage("ClosedSpeed"),
+            t.getColumnName(TurnoutTableDataModel.STRAIGHTCOL));
+        assertEquals("Column17 - DIVERGCOL",Bundle.getMessage("ThrownSpeed"),
+            t.getColumnName(TurnoutTableDataModel.DIVERGCOL));
+        assertEquals("Column18 - FORGETCOL",Bundle.getMessage("StateForgetHeader"),
+            t.getColumnName(TurnoutTableDataModel.FORGETCOL));
+        assertEquals("Column19 - QUERYCOL",Bundle.getMessage("StateQueryHeader"),
+            t.getColumnName(TurnoutTableDataModel.QUERYCOL));
+
+    }
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initInternalTurnoutManager();
+        t = new TurnoutTableDataModel();
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        if (t!=null){
+            t.dispose();
+        }
+        JUnitUtil.tearDown();
+    }
+
+    // private final static Logger log = LoggerFactory.getLogger(TurnoutTableDataModelTest.class);
+
+}

--- a/java/test/jmri/jmrit/beantable/turnout/TurnoutTableJTableTest.java
+++ b/java/test/jmri/jmrit/beantable/turnout/TurnoutTableJTableTest.java
@@ -1,0 +1,31 @@
+package jmri.jmrit.beantable.turnout;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+
+/**
+ *
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class TurnoutTableJTableTest {
+
+    @Test
+    public void testCTor() {
+        TurnoutTableJTable t = new TurnoutTableJTable(null);
+        Assert.assertNotNull("exists",t);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+}

--- a/xml/ESU_LokPilotBasic1.0.xml
+++ b/xml/ESU_LokPilotBasic1.0.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!--Copyright (C) JMRI 2003, 2004, 2008, 2021 All rights reserved           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version author="Jeff Schmaltz escopetas@comcast.net" version="1.0" lastUpdated="20080131"/>
+  <version author="Jeff Schmaltz escopetas@comcast.net" version="1.1" lastUpdated="20090218"/>
+  <version author="W.D.Kok" version="2.00" lastUpdated="20210307"/>
+  <!--   - This decoder configuration file is based on ESU_LokPilotDCC.xml                  -->
+  <!--     V 4, dated 20050619, by Walter Thompson. Which also acknowledged                 -->
+  <!--     "the contribution of many others" including 'jake'.                              -->
+  <!--   - Based on the "LokPilot Basic - BEMF for all your engines" 2-page                 -->
+  <!--     instructions, P/N 04507-05795.                                                   -->
+  <!--   - This decoder XML is meant to be used with the "Comprehensive" programmer format. -->
+  <!--     Continued the practice of using unrelated "item" names to place ESU unique       -->
+  <!--     variables on the proper pane of the Comprehensive programmer.                    -->
+  <!--   - Any and all feedback on this file would be appreciated.                          -->
+  <!--                                                                                      -->
+  <!-- 1.0 - Initial release                                                                -->
+  <!-- 1.1 - Added family lowVersionID & highVersionID, range 0-255 because CV 7 doesn't    -->
+  <!--       seem to match software version number                                          -->
+  <!-- 2.0 - German and Dutch translating inserted                                          -->
+  <!--     - CV7 and 8 switched to mfgVersionId.xml                                         -->
+  <!--     - CV 49 and 51 switched to enum-disabledEnabled.xml                              -->
+  <!--     - Define the fixed Function-Output mapping                                       -->
+  <!--     - Impute tooltip                                                                 -->
+  <!--     - CV3 and 4 switched to v1AccelDecel_1-63.xml                                    -->
+  <!--     - CV2, 5 and 6 switched to v1VstartHighMid_1-63.xml                              -->
+  <decoder>
+    <family name="ESU LokPilot Basic 1.0" mfg="Electronic Solutions Ulm GmbH" lowVersionID="0" highVersionID="255">
+      <model model="LokPilot Basic 1.0" maxInputVolts="25 V" maxMotorCurrent="0.7 A" maxTotalCurrent="1.05 A" numOuts="5" numFns="5" formFactor="HO" connector="NMRAmedium" productID="52690">
+        <output name="1" label="Front|light" maxcurrent="180 mA" connection="wire">
+          <label xml:lang="de">Vorder-|Licht</label>
+          <label xml:lang="nl">Kop-|Lampen</label>
+        </output>
+        <output name="2" label="Rear|light" maxcurrent="180 mA" connection="wire">
+          <label xml:lang="de">Hinter-|Licht</label>
+          <label xml:lang="nl">Achter-|Licht</label>
+        </output>
+        <output name="3" label="AUX1" maxcurrent="180 mA" connection="wire"/>
+        <output name="4" label="Shunting|gear">
+          <label xml:lang="de">Rangier|gang</label>
+          <label xml:lang="nl">Rangeer|snelheid</label>
+        </output>
+        <output name="5" label="Acceleration|brake delay">
+          <label xml:lang="de">Anfahr/Brems|Verzögerung</label>
+          <label xml:lang="nl">Optrek/rem|vertraging </label>
+        </output>
+        <size length="25.5" width="15.5" height="4.5" units="mm"/>
+      </model>
+    </family>
+    <programming direct="yes" paged="yes" register="yes" ops="yes"/>
+    <variables>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/esu/v1AccelDecel_1-63.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/esu/v1VstartHighMid_1-63.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
+      <!-- CV=29 -->
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29direction.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29speedSteps.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
+      <variable CV="49" mask="XXXXXXXV" default="1" item="EMF Static Config">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+        <label>BEMF control</label>
+        <label xml:lang="de">Lastregelung</label>
+        <label xml:lang="nl">Lastregeling</label>
+      </variable>
+      <variable CV="51" mask="XXXXXXXV" default="1" item="Dither option">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-disabledEnabled.xml"/>
+        <label>Brake mode control</label>
+        <label xml:lang="de">Bremsmodus</label>
+        <label xml:lang="nl">Remmodus</label>
+        <tooltip>&lt;html&gt;Defines what happens if the decoders detects DC with reverse polarity.&lt;br&gt;
+        Disabled: locomotive enters in DC mode&lt;br&gt;
+        Enabled: locomotive will stop&lt;br&gt;&lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Verhalten, wenn Gleichstrom umgekehrter Polarität gefunden wird.&lt;br&gt;
+        Deaktiviert: Lok wechselt in Analogmodus&lt;br&gt;
+        Aktiviert: Lok bremst ab&lt;br&gt;&lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Gedrag wanneer gelijkstroom van omgekeerde polariteit wordt gevonden.&lt;br&gt;
+        Uitgeschakeld: Locomotief schakelt over naar analoge modus&lt;br&gt;
+        Ingeschakeld: Loc remt af&lt;br&gt;&lt;/html&gt;</tooltip>
+      </variable>
+      <variable CV="54" default="32" item="EMF Dynamic Config" tooltip="Determines how strongly load control effects, range 0-63">
+        <decVal min="0" max="63"/>
+        <label>Load control parameter K</label>
+        <label xml:lang="de">Laststeuerungsparameter K</label>
+        <label xml:lang="nl">Parameter K voor belastingsregeling</label>
+        <tooltip>&lt;html&gt;Defines the effect of BEMF.&lt;br&gt;
+                             The higher the value, the stronger the effect of BEMF control.&lt;br&gt;
+                             (Range: 0-63, Default: 32) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt die Härte der Regelung.&lt;br&gt;
+                                           Je grösser der Wert, desto stärker regelt der LokPilot Basic den Motor.&lt;br&gt;
+                                           (Bereich: 0-63, voreingestellt: 32) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Definieert het effect van BEMF.&lt;br&gt;
+                                           Hoe hoger de waarde, hoe sterker het effect van BEMF-controle.&lt;br&gt;
+                                           (Bereik: 0-63, standaardinstelling: 32) &lt;/html&gt;</tooltip>
+      </variable>
+      <variable CV="55" default="24" item="EMF Droop Config" tooltip="Determines the momentum of the motor, range 0-63">
+        <decVal min="0" max="63"/>
+        <label>Load control parameter I</label>
+        <label xml:lang="de">Laststeuerungsparameter I</label>
+        <label xml:lang="nl">Parameter I voor belastingsregeling</label>
+        <tooltip>&lt;html&gt;Defines momentum (inertia) of motor.&lt;br&gt;
+                             The higher the momentum of the motor (large flywheel or bigger diameter),&lt;br&gt;
+                             the lower this value has to be set.&lt;br&gt;
+                             (Range: 0-63, Default: 24) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt durch die Trägheit des Motors.&lt;br&gt;
+                                           Je träger der Motor ist (wenn also viel Schwungmasse&lt;br&gt;
+                                           vorhanden ist oder der Motor einen grossen Durchmesser hat),&lt;br&gt;
+                                           desto kleiner muss der Wert sein.&lt;br&gt;
+                                           (Bereich: 0-63, voreingestellt: 24) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Bepaald door de traagheid van de motor.&lt;br&gt;
+                                           Je trager de motor is (d.w.z. als er veel vliegwielmassa&lt;br&gt;
+                                           is of de motor heeft een grote diameter),&lt;br&gt;
+                                           hoe kleiner de waarde moet zijn.&lt;br&gt;
+                                           (Bereik: 0-63, standaardinstelling: 24) &lt;/html&gt;</tooltip>
+      </variable>
+      <variable CV="63" default="7" item="Global lighting option 1" tooltip="Defines the brightness of the function outputs, range 0-7">
+        <decVal min="0" max="7"/>
+        <label>Lamp brightness</label>
+        <label xml:lang="de">Lichthelligkeit </label>
+        <label xml:lang="nl">Helderheid van het licht</label>
+        <tooltip>&lt;html&gt;Defines the brightness of the function outputs.&lt;br&gt;
+                             The lower the value of this CV, the darker are&lt;br&gt;
+                             the bulbs connected.&lt;br&gt;
+                             (Range: 1-63, Default: 63) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt die Helligkeit der Funktionsausgänge.&lt;br&gt;
+                                           Je grösser der Wert, desto heller sind die Lampen&lt;br&gt;
+                                           (Bereich: 1-63, voreingestellt: 63) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Hiermee bepaalt u de helderheid van de functie-uitgangen.&lt;br&gt;
+                                           Hoe groter de waarde, hoe helderder de lampen&lt;br&gt;
+                                           (Bereik: 1-63, standaardinstelling: 63) &lt;/html&gt;</tooltip>
+      </variable>
+      <!-- Define the fixed Function-Output mapping -->
+      <constant item="FL(f) controls output 1" minOut="1" default="1"/>
+      <constant item="FL(r) controls output 2" minOut="2" default="1"/>
+      <constant item="F1 controls output 3" minOut="3" default="1"/>
+      <constant item="F3 controls output 4" minOut="4" default="1"/>
+      <constant item="F4 controls output 5" minOut="5" default="1"/>
+    </variables>
+    <resets>
+      <factReset label="HARD RESET" CV="8" default="8">
+        <label>HARD RESET, All CVs reset to default values</label>
+        <label xml:lang="de">Decoder-Reset, Alle CVs auf Standardwerte zurückgesetzt</label>
+        <label xml:lang="nl">Decoder-reset, Alle cv's worden teruggezet naar standaardwaarden</label>
+      </factReset> 
+    </resets>
+  </decoder>
+</decoder-config>

--- a/xml/decoders/Doehler_Haass_fw3.02_DH05-10C_12-16-18A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.02_DH05-10C_12-16-18A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version version="5" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
+  <!--  Added update paths to newest fw 3.12.050 -->
   <version version="4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20151018"/>
   <!--  Merged DH05C, DH10C, DH12A, DH16A, DH18A def files (same CV characteristics) -->
   <version version="3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20150223"/>
@@ -21,7 +23,7 @@
   <version version="2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20140220"/>
   <!-- 2 2014/02/20 Update: future proofing
 		This is a complete rewrite of my original submission for many D&H decoders.
-		This updates ensure a cleaner, more future proof organisation (despite more files). 
+		This updates ensure a cleaner, more future proof organisation (despite more files).
 		FIRMWARE INFORMATION: from http://doehler-haass.de/cms/pages/haeufige-fragen/decoder-cv-tabelle.php
 		DECODER VERSION INFORMATION: from the changelog files, downloaded through the D&H Update program.
 		Please note that the "firmware" and "decoder" versions differ in their numbering, despite a common
@@ -30,15 +32,15 @@
 		These definitions include both numbers (Firmware version & Decoder version).
 		-->
   <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20130731"/>
-  <!-- 1 2013/07/31 Creation 
+  <!-- 1 2013/07/31 Creation
 		First decoder template for the Doehler & Haass decoder range.
-		This LOCOMOTIVE decoder file creates the corresponding family, and 
-		includes all decoders defs & specs. 
+		This LOCOMOTIVE decoder file creates the corresponding family, and
+		includes all decoders defs & specs.
 		It requires variables and panes as defined in the doehler_hass/ folder.
   -->
   <decoder>
     <family name="Train Decoders (firmware 3.02+)" mfg="Doehler und Haass">
-      <model model="DH05C" lowVersionID="3" highVersionID="3" numOuts="4" numFns="16" productID="DH05C" comment="DH05C-0 / DH05C-1 / DH05C-3" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="3" highVersionID="3" numOuts="4" numFns="16" productID="DH05C" comment="DH05C-0 / DH05C-1 / DH05C-3" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -53,7 +55,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-	  <model model="DH10C" lowVersionID="3" highVersionID="3" numOuts="4" numFns="16" productID="DH10C" comment="DH10C-0 / DH10C-1 / DH10C-3" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+	  <model model="DH10C" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="3" highVersionID="3" numOuts="4" numFns="16" productID="DH10C" comment="DH10C-0 / DH10C-1 / DH10C-3" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -68,7 +70,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-	  <model model="DH12A" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH12A" comment="DH12A" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+	  <model model="DH12A" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH12A" comment="DH12A" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -83,7 +85,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-	  <model model="DH16A" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH16A" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+	  <model model="DH16A" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH16A" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -98,7 +100,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-	  <model model="DH18A" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH18A" comment="DH18A" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+	  <model model="DH18A" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH18A" comment="DH18A" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>

--- a/xml/decoders/Doehler_Haass_fw3.03_DH05-10C_12-16-18-21A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.03_DH05-10C_12-16-18-21A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version version="6" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
+  <!--  Added update paths to newest fw 3.12.050 -->
   <version version="5" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20151018"/>
   <!--  Merged DH05C, DH10C, DH12A, DH16A, DH18A, DH21A def files (same CV characteristics) -->
   <version version="4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20150223"/>
@@ -41,7 +43,7 @@
   -->
   <decoder>
     <family name="Train Decoders (firmware 3.03+)" mfg="Doehler und Haass">
-      <model model="DH05C v3.03 (firmware 3.03+)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH05C_3_03" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from 15 Jan 2014" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C v3.03 (firmware 3.03+)" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH05C_3_03" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from 15 Jan 2014" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -58,7 +60,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-	  <model model="DH10C v3.03 (firmware 3.03+)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH10C_3_03" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from 15 Jan 2014" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+	  <model model="DH10C v3.03 (firmware 3.03+)" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH10C_3_03" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from 15 Jan 2014" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -75,7 +77,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-	  <model model="DH12A v3.03 (firmware 3.03+)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH12A_3_03" comment="DH12A with update from 15 Jan 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+	  <model model="DH12A v3.03 (firmware 3.03+)" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH12A_3_03" comment="DH12A with update from 15 Jan 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -90,7 +92,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-	  <model model="DH16A v3.03 (firmware 3.03+)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH16A_3_03" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from 15 Jan 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+	  <model model="DH16A v3.03 (firmware 3.03+)" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH16A_3_03" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from 15 Jan 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -105,7 +107,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-	  <model model="DH18A v3.03 (firmware 3.03+)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH18A_3_03" comment="DH18A with update from 15 Jan 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+	  <model model="DH18A v3.03 (firmware 3.03+)" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="3" highVersionID="3" numOuts="6" numFns="16" productID="DH18A_3_03" comment="DH18A with update from 15 Jan 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
 		<output name="2" label="Rear|Light" maxcurrent="150mA"/>
 		<output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -120,7 +122,7 @@
             <protocol>selectrix</protocol>
         </protocols>
       </model>
-	  <model model="DH21A v3.03 (firmware 3.03+)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH21A_3_03" comment="DH21A with release firmware" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+	  <model model="DH21A v3.03 (firmware 3.03+)" replacementModel="DH21A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH21A_3_03" comment="DH21A with release firmware" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>

--- a/xml/decoders/Doehler_Haass_fw3.04_DH05-10C_12-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.04_DH05-10C_12-16-18-21-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version version="7" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
+  <!--  Added update paths to newest fw 3.12.050 -->
   <version version="6" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20151018"/>
   <!--  Merged DH05C, DH10C, DH12A, DH16A, DH18A, DH21A, DH22A def files (same CV characteristics) -->
   <version version="5" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20150223"/>
@@ -49,7 +51,7 @@
   -->
   <decoder>
     <family name="Train Decoders (firmware 3.04 - May 2014)" mfg="Doehler und Haass">
-      <model model="DH05C v3.04 (firmware 3.04+)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH05C_3_04" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from 31 May 2014" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C v3.04 (firmware 3.04+)" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH05C_3_04" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from 31 May 2014" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -67,7 +69,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH10C v3.04 (firmware 3.04+)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH10C_3_04" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+	  <model model="DH10C v3.04 (firmware 3.04+)" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH10C_3_04" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -85,7 +87,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH12A v3.04 (firmware 3.04+)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH12A_3_04" comment="DH12A with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+	  <model model="DH12A v3.04 (firmware 3.04+)" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH12A_3_04" comment="DH12A with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -101,7 +103,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH16A v3.04 (firmware 3.04+)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH16A_3_04" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+	  <model model="DH16A v3.04 (firmware 3.04+)" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH16A_3_04" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -117,23 +119,23 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH18A v3.04 (firmware 3.04+)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH18A_3_04" comment="DH18A with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+	  <model model="DH18A v3.04 (firmware 3.04+)" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH18A_3_04" comment="DH18A with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
-		<output name="2" label="Rear|Light" maxcurrent="150mA"/>
-		<output name="3" label="AUX|1" maxcurrent="300mA"/>
-		<output name="4" label="AUX|2" maxcurrent="300mA"/>
-		<output name="5" label="AUX|3" maxcurrent="NC - Logic Level"/>
-		<output name="6" label="AUX|4" maxcurrent="NC - Logic Level"/>
+		    <output name="2" label="Rear|Light" maxcurrent="150mA"/>
+		    <output name="3" label="AUX|1" maxcurrent="300mA"/>
+		    <output name="4" label="AUX|2" maxcurrent="300mA"/>
+	      <output name="5" label="AUX|3" maxcurrent="NC - Logic Level"/>
+	      <output name="6" label="AUX|4" maxcurrent="NC - Logic Level"/>
         <output name="7" label="Dimmed|Lights"/>
         <output name="8" label="Shunting|Speed"/>
         <size length="13.5" width="9.0" height="2.8" units="mm"/>
-		<protocols>
+		    <protocols>
             <protocol>dcc</protocol>
             <protocol>selectrix</protocol>
             <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH21A v3.04 (firmware 3.04+)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH21A_3_04" comment="DH21A with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+	  <model model="DH21A v3.04 (firmware 3.04+)" replacementModel="DH21A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH21A_3_04" comment="DH21A with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -149,7 +151,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH22A v3.04 (firmware 3.04+)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH22A_3_04" comment="DH22A with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+	  <model model="DH22A v3.04 (firmware 3.04+)" replacementModel="DH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="54" highVersionID="54" numOuts="6" numFns="16" productID="DH22A_3_04" comment="DH22A with update from 31 May 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>

--- a/xml/decoders/Doehler_Haass_fw3.05_DH05-10C_12-16-18-21-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.05_DH05-10C_12-16-18-21-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version version="3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
+  <!--  Added update paths to newest fw 3.12.050 -->
   <version version="2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20151018"/>
   <!--  Merged DH05C, DH10C, DH12A, DH16A, DH18A, DH21A, DH22A def files (same CV characteristics) -->
   <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20150306"/>
@@ -21,7 +23,7 @@
 		-->
   <decoder>
     <family name="Train Decoders (firmware 3.05 - Oct 2014)" mfg="Doehler und Haass">
-      <model model="DH05C v3.05.104 (firmware 3.05+)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH05C_2014_10" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from October 2014" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C v3.05.104 (firmware 3.05+)" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH05C_2014_10" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from October 2014" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -39,7 +41,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH05C v3.05.114 (firmware 3.05+)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH05C_2014_11" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from November 2014" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C v3.05.114 (firmware 3.05+)" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH05C_2014_11" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from November 2014" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -57,7 +59,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH05C v3.05.15 (firmware 3.05+)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH05C_2015_01" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from January 2015" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C v3.05.15 (firmware 3.05+)" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH05C_2015_01" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from January 2015" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -75,7 +77,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH10C v3.05.104 (firmware 3.05+)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH10C_2014_10" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from October 2014" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+	  <model model="DH10C v3.05.104 (firmware 3.05+)" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH10C_2014_10" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from October 2014" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -93,7 +95,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH10C v3.05.114 (firmware 3.05+)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH10C_2014_11" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from November 2014" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="DH10C v3.05.114 (firmware 3.05+)" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH10C_2014_11" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from November 2014" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -111,7 +113,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH10C v3.05.15 (firmware 3.05+)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH10C_2015_01" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from January 2015" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="DH10C v3.05.15 (firmware 3.05+)" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH10C_2015_01" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from January 2015" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -129,7 +131,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH12A v3.05.104 (firmware 3.05+)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH12A_2014_10" comment="DH12A with update from October 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+	  <model model="DH12A v3.05.104 (firmware 3.05+)" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH12A_2014_10" comment="DH12A with update from October 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -145,7 +147,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH12A v3.05.114 (firmware 3.05+)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH12A_2014_11" comment="DH12A with update from November 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+      <model model="DH12A v3.05.114 (firmware 3.05+)" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH12A_2014_11" comment="DH12A with update from November 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -161,7 +163,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH12A v3.05.15 (firmware 3.05+)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH12A_2015_01" comment="DH12A with update from January 2015" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+      <model model="DH12A v3.05.15 (firmware 3.05+)" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH12A_2015_01" comment="DH12A with update from January 2015" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -177,7 +179,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH16A v3.05.104 (firmware 3.05+)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH16A_2014_10" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from October 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+	  <model model="DH16A v3.05.104 (firmware 3.05+)" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH16A_2014_10" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from October 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -193,7 +195,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A v3.05.114 (firmware 3.05+)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH16A_2014_11" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from November 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A v3.05.114 (firmware 3.05+)" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH16A_2014_11" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from November 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -209,7 +211,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A v3.05.15 (firmware 3.05+)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH16A_2015_01" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from January 2015" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A v3.05.15 (firmware 3.05+)" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH16A_2015_01" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from January 2015" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -225,7 +227,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH18A v3.05.104 (firmware 3.05+)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH18A_2014_10" comment="DH18A with update from October 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+	  <model model="DH18A v3.05.104 (firmware 3.05+)" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH18A_2014_10" comment="DH18A with update from October 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
 		<output name="2" label="Rear|Light" maxcurrent="150mA"/>
 		<output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -241,7 +243,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A v3.05.114 (firmware 3.05+)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH18A_2014_11" comment="DH18A with update from November 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A v3.05.114 (firmware 3.05+)" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH18A_2014_11" comment="DH18A with update from November 2014" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
 		<output name="2" label="Rear|Light" maxcurrent="150mA"/>
 		<output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -257,7 +259,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A v3.05.15 (firmware 3.05+)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH18A_2015_01" comment="DH18A with update from January 2015" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A v3.05.15 (firmware 3.05+)" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH18A_2015_01" comment="DH18A with update from January 2015" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
 		<output name="2" label="Rear|Light" maxcurrent="150mA"/>
 		<output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -273,7 +275,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH21A v3.05.104 (firmware 3.05+)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH21A_2014_10" comment="DH21A with update from October 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+	  <model model="DH21A v3.05.104 (firmware 3.05+)" replacementModel="DH21A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH21A_2014_10" comment="DH21A with update from October 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -289,7 +291,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A v3.05.114 (firmware 3.05+)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH21A_2014_11" comment="DH21A with update from November 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A v3.05.114 (firmware 3.05+)" replacementModel="DH21A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH21A_2014_11" comment="DH21A with update from November 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -305,7 +307,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A v3.05.15 (firmware 3.05+)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH21A_2015_01" comment="DH21A with update from January 2015" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A v3.05.15 (firmware 3.05+)" replacementModel="DH21A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH21A_2015_01" comment="DH21A with update from January 2015" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -321,7 +323,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-	  <model model="DH22A v3.05.104 (firmware 3.05+)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH22A_2014_10" comment="DH22A with update from October 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+	  <model model="DH22A v3.05.104 (firmware 3.05+)" replacementModel="DH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="104" highVersionID="104" numOuts="6" numFns="16" productID="DH22A_2014_10" comment="DH22A with update from October 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -337,7 +339,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A v3.05.114 (firmware 3.05+)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH22A_2014_11" comment="DH22A with update from November 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A v3.05.114 (firmware 3.05+)" replacementModel="DH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="114" highVersionID="114" numOuts="6" numFns="16" productID="DH22A_2014_11" comment="DH22A with update from November 2014" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>
@@ -353,7 +355,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A v3.05.15 (firmware 3.05+)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH22A_2015_01" comment="DH22A with update from January 2015" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A v3.05.15 (firmware 3.05+)" replacementModel="DH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="DH22A_2015_01" comment="DH22A with update from January 2015" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>

--- a/xml/decoders/Doehler_Haass_fw3.05_FH05B.xml
+++ b/xml/decoders/Doehler_Haass_fw3.05_FH05B.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version version="2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
+<!--  Added update paths to newest fw 3.12.050 -->
   <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="2016-12-14"/>
   <!--  Creation (new firmware).
         3 firmware versions are defined here (3.05 = 3.05.104, 3.05.114, 3.05.15).
@@ -19,7 +21,7 @@
         -->
   <decoder>
     <family name="Function Decoders (firmware 3.05 - Oct 2014)" mfg="Doehler und Haass">
-      <model model="FH05B v3.05.15 (firmware 3.05+)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="FH05B_2014.10" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from October 2014" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="FH05B v3.05.15 (firmware 3.05+)" replacementModel="FH05B v3.12.050 (firmware 3.12+)" replacementFamily="query:Function Decoders (2020)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="FH05B_2014.10" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from October 2014" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA"/>
         <output name="2" label="Rear|Light" maxcurrent="150mA"/>
         <output name="3" label="AUX|1" maxcurrent="300mA"/>

--- a/xml/decoders/Doehler_Haass_fw3.06-07_DH05-10C_12-16-18-21-22A_PD12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.06-07_DH05-10C_12-16-18-21-22A_PD12A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="5" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
+  <!--  Added update paths to newest fw 3.12.050 -->
   <version version="4" author="Alain Le Marchand" lastUpdated="2019-07-28"/>
   <!--  Simplified productID for PD05 and PD12: no more version indicated -->
     <version version="3" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>
@@ -25,7 +27,7 @@
         -->
   <decoder>
     <family name="Train Decoders (2016)" mfg="Doehler und Haass">
-      <model model="DH05C v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="4" numFns="16" productID="DH05C_2016_03" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from March 2016" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C v3.06.26 (firmware 3.06+)" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="26" highVersionID="26" numOuts="4" numFns="16" productID="DH05C_2016_03" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from March 2016" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -67,7 +69,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH10C v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="4" numFns="16" productID="DH10C_2016_03" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="DH10C v3.06.26 (firmware 3.06+)" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="26" highVersionID="26" numOuts="4" numFns="16" productID="DH10C_2016_03" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -109,7 +111,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH12A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="6" numFns="16" productID="DH12A_2016_03" comment="DH12A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+      <model model="DH12A v3.06.26 (firmware 3.06+)" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="26" highVersionID="26" numOuts="6" numFns="16" productID="DH12A_2016_03" comment="DH12A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -149,7 +151,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="6" numFns="16" productID="DH16A_2016_03" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A v3.06.26 (firmware 3.06+)" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="26" highVersionID="26" numOuts="6" numFns="16" productID="DH16A_2016_03" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -189,7 +191,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="8" numFns="16" productID="DH18A_2016_03" comment="DH18A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A v3.06.26 (firmware 3.06+)" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="26" highVersionID="26" numOuts="8" numFns="16" productID="DH18A_2016_03" comment="DH18A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -237,7 +239,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="8" numFns="16" productID="DH21A_2016_03" comment="DH21A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A v3.06.26 (firmware 3.06+)" replacementModel="DH21A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="26" highVersionID="26" numOuts="8" numFns="16" productID="DH21A_2016_03" comment="DH21A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -285,7 +287,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="6" numFns="16" productID="DH22A_2016_03" comment="DH22A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A v3.06.26 (firmware 3.06+)" replacementModel="DH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="26" highVersionID="26" numOuts="6" numFns="16" productID="DH22A_2016_03" comment="DH22A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -325,7 +327,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="PD12A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="4" numFns="16" productID="PD12A" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+      <model model="PD12A v3.06.26 (firmware 3.06+)" replacementModel="PD12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="26" highVersionID="26" numOuts="4" numFns="16" productID="PD12A" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -355,7 +357,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="DH05C v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="4" numFns="16" productID="DH05C_2016_06" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from June 2016" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C v3.07.66 (firmware 3.07+)" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="66" highVersionID="66" numOuts="4" numFns="16" productID="DH05C_2016_06" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from June 2016" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -397,7 +399,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH10C v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="4" numFns="16" productID="DH10C_2016_06" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="DH10C v3.07.66 (firmware 3.07+)" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="66" highVersionID="66" numOuts="4" numFns="16" productID="DH10C_2016_06" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -440,7 +442,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH12A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="6" numFns="16" productID="DH12A_2016_06" comment="DH12A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+      <model model="DH12A v3.07.66 (firmware 3.07+)" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="66" highVersionID="66" numOuts="6" numFns="16" productID="DH12A_2016_06" comment="DH12A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -480,7 +482,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="6" numFns="16" productID="DH16A_2016_06" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A v3.07.66 (firmware 3.07+)" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="66" highVersionID="66" numOuts="6" numFns="16" productID="DH16A_2016_06" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -520,7 +522,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="8" numFns="16" productID="DH18A_2016_06" comment="DH18A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A v3.07.66 (firmware 3.07+)" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="66" highVersionID="66" numOuts="8" numFns="16" productID="DH18A_2016_06" comment="DH18A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -568,7 +570,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="8" numFns="16" productID="DH21A_2016_06" comment="DH21A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A v3.07.66 (firmware 3.07+)" replacementModel="DH21A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="66" highVersionID="66" numOuts="8" numFns="16" productID="DH21A_2016_06" comment="DH21A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -616,7 +618,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="6" numFns="16" productID="DH22A_2016_06" comment="DH22A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A v3.07.66 (firmware 3.07+)" replacementModel="DH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="66" highVersionID="66" numOuts="6" numFns="16" productID="DH22A_2016_06" comment="DH22A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -656,7 +658,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="PD12A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="4" numFns="16" productID="PD12A" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+      <model model="PD12A v3.07.66 (firmware 3.07+)" replacementModel="PD12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="66" highVersionID="66" numOuts="4" numFns="16" productID="PD12A" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.08-09_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.08-09_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+    <version version="6" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
+  <!--  Added update paths to newest fw 3.12.050 -->
     <version version="5.1" author="Alain Le Marchand" lastUpdated="2019-07-28"/>
   <!--  Simplified productID for PD05 and PD12: no more version indicated -->
     <version version="5" author="Alain Le Marchand" lastUpdated="2019-07-21"/>
@@ -29,7 +31,7 @@
         -->
   <decoder>
     <family name="Train Decoders (2017)" mfg="Doehler und Haass">
-      <model model="DH05C v3.08.27 (firmware 3.08+)" lowVersionID="27" highVersionID="27" numOuts="4" numFns="16" productID="DH05C_2017_02" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from February 2017" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C v3.08.27 (firmware 3.08+)" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="27" highVersionID="27" numOuts="4" numFns="16" productID="DH05C_2017_02" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from February 2017" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -71,7 +73,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH10C v3.08.27 (firmware 3.08+)" lowVersionID="27" highVersionID="27" numOuts="4" numFns="16" productID="DH10C_2017_02" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from February 2017" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="DH10C v3.08.27 (firmware 3.08+)" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="27" highVersionID="27" numOuts="4" numFns="16" productID="DH10C_2017_02" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from February 2017" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -113,7 +115,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH12A v3.08.27 (firmware 3.08+)" lowVersionID="27" highVersionID="27" numOuts="6" numFns="16" productID="DH12A_2017_02" comment="DH12A with update from February 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+      <model model="DH12A v3.08.27 (firmware 3.08+)" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="27" highVersionID="27" numOuts="6" numFns="16" productID="DH12A_2017_02" comment="DH12A with update from February 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -153,7 +155,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A v3.08.27 (firmware 3.08+)" lowVersionID="27" highVersionID="27" numOuts="6" numFns="16" productID="DH16A_2017_02" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from February 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A v3.08.27 (firmware 3.08+)" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="27" highVersionID="27" numOuts="6" numFns="16" productID="DH16A_2017_02" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from February 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -193,7 +195,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A v3.08.27 (firmware 3.08+)" lowVersionID="27" highVersionID="27" numOuts="8" numFns="16" productID="DH18A_2017_02" comment="DH18A with update from February 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A v3.08.27 (firmware 3.08+)" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="27" highVersionID="27" numOuts="8" numFns="16" productID="DH18A_2017_02" comment="DH18A with update from February 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -241,7 +243,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A v3.08.27 (firmware 3.08+)" lowVersionID="27" highVersionID="27" numOuts="8" numFns="16" productID="DH21A_2017_02" comment="DH21A with update from February 2017" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A v3.08.27 (firmware 3.08+)" replacementModel="DH21A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="27" highVersionID="27" numOuts="8" numFns="16" productID="DH21A_2017_02" comment="DH21A with update from February 2017" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -289,7 +291,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A v3.08.27 (firmware 3.08+)" lowVersionID="27" highVersionID="27" numOuts="6" numFns="16" productID="DH22A_2017_02" comment="DH22A with update from February 2017" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A v3.08.27 (firmware 3.08+)" replacementModel="DH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="27" highVersionID="27" numOuts="6" numFns="16" productID="DH22A_2017_02" comment="DH22A with update from February 2017" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -329,7 +331,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="PD12A v3.08.27 (firmware 3.08+)" lowVersionID="27" highVersionID="27" numOuts="4" numFns="16" productID="PD12A" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from February 2017" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+      <model model="PD12A v3.08.27 (firmware 3.08+)" replacementModel="PD12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="27" highVersionID="27" numOuts="4" numFns="16" productID="PD12A" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from February 2017" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -359,7 +361,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="DH05C v3.09.117 (firmware 3.09+)" lowVersionID="117" highVersionID="117" numOuts="4" numFns="16" productID="DH05C_2017_11" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from November 2017" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C v3.09.117 (firmware 3.09+)" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="117" highVersionID="117" numOuts="4" numFns="16" productID="DH05C_2017_11" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from November 2017" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -401,7 +403,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH10C v3.09.117 (firmware 3.09+)" lowVersionID="117" highVersionID="117" numOuts="4" numFns="16" productID="DH10C_2017_11" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from November 2017" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="DH10C v3.09.117 (firmware 3.09+)" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="117" highVersionID="117" numOuts="4" numFns="16" productID="DH10C_2017_11" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from November 2017" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -444,7 +446,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH12A v3.09.117 (firmware 3.09+)" lowVersionID="117" highVersionID="117" numOuts="6" numFns="16" productID="DH12A_2017_11" comment="DH12A with update from November 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+      <model model="DH12A v3.09.117 (firmware 3.09+)" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="117" highVersionID="117" numOuts="6" numFns="16" productID="DH12A_2017_11" comment="DH12A with update from November 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -484,7 +486,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A v3.09.117 (firmware 3.09+)" lowVersionID="117" highVersionID="117" numOuts="6" numFns="16" productID="DH16A_2017_11" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from November 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A v3.09.117 (firmware 3.09+)" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="117" highVersionID="117" numOuts="6" numFns="16" productID="DH16A_2017_11" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from November 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -524,7 +526,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A v3.09.117 (firmware 3.09+)" lowVersionID="117" highVersionID="117" numOuts="8" numFns="16" productID="DH18A_2017_11" comment="DH18A with update from November 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A v3.09.117 (firmware 3.09+)" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="117" highVersionID="117" numOuts="8" numFns="16" productID="DH18A_2017_11" comment="DH18A with update from November 2017" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -572,7 +574,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A v3.09.117 (firmware 3.09+)" lowVersionID="117" highVersionID="117" numOuts="8" numFns="16" productID="DH21A_2017_11" comment="DH21A with update from November 2017" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A v3.09.117 (firmware 3.09+)" replacementModel="DH21A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="117" highVersionID="117" numOuts="8" numFns="16" productID="DH21A_2017_11" comment="DH21A with update from November 2017" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -620,7 +622,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A v3.09.117 (firmware 3.09+)" lowVersionID="117" highVersionID="117" numOuts="6" numFns="16" productID="DH22A_2017_11" comment="DH22A with update from November 2017" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A v3.09.117 (firmware 3.09+)" replacementModel="DH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="117" highVersionID="117" numOuts="6" numFns="16" productID="DH22A_2017_11" comment="DH22A with update from November 2017" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -660,7 +662,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="PD05A v3.09.117 (firmware 3.09+)" lowVersionID="117" highVersionID="117" numOuts="2" numFns="16" productID="PD05A" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from November 2017" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="PD05A v3.09.117 (firmware 3.09+)" replacementModel="PD05A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="117" highVersionID="117" numOuts="2" numFns="16" productID="PD05A" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from November 2017" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -682,7 +684,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD12A v3.09.117 (firmware 3.09+)" lowVersionID="117" highVersionID="117" numOuts="4" numFns="16" productID="PD12A" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from November 2017" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+      <model model="PD12A v3.09.117 (firmware 3.09+)" replacementModel="PD12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="117" highVersionID="117" numOuts="4" numFns="16" productID="PD12A" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from November 2017" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.10-11_FH05B-18-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.10-11_FH05B-18-22A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <version version="4" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
+<!--  Added update paths to newest fw 3.12.050 -->
   <version version="3" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2020-05-05"/>
   <!--  (new firmware 3.10 and 3.11 and including of FH18A)
         -->
@@ -25,7 +27,7 @@
         -->
   <decoder>
     <family name="Function Decoders (2018)" mfg="Doehler und Haass">
-      <model model="FH05B v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="6" numFns="16" productID="FH05B_2018.04" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from April 2018" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="FH05B v3.10.48 (firmware 3.10+)" replacementModel="FH05B v3.12.050 (firmware 3.12+)" replacementFamily="query:Function Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="6" numFns="16" productID="FH05B_2018.04" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from April 2018" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -66,7 +68,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="FH18A v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="8" numFns="18" productID="FH18A_2018.04" comment="FH18A with update from April 2018" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
+      <model model="FH18A v3.10.48 (firmware 3.10+)" replacementModel="FH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Function Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="8" numFns="18" productID="FH18A_2018.04" comment="FH18A with update from April 2018" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -113,7 +115,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="FH22A v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="8" numFns="18" productID="FH22A_2018.04" comment="FH22A with update from April 2018" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
+      <model model="FH22A v3.10.48 (firmware 3.10+)" replacementModel="FH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Function Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="8" numFns="18" productID="FH22A_2018.04" comment="FH22A with update from April 2018" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -162,7 +164,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="FH05B v3.11.98 (firmware 3.11+)" lowVersionID="98" highVersionID="98" numOuts="6" numFns="16" productID="FH05B_2018.10" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from October 2018" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="FH05B v3.11.98 (firmware 3.11+)" replacementModel="FH05B v3.12.050 (firmware 3.12+)" replacementFamily="query:Function Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="6" numFns="16" productID="FH05B_2018.10" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from October 2018" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -177,7 +179,7 @@
         </output>
         <output name="4" label="AUX|2" maxcurrent="300mA">
           <label xml:lang="de">AUX 2</label>
-          <label xml:lang="ca">AUX 2</label>       
+          <label xml:lang="ca">AUX 2</label>
         </output>
         <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
         <!-- New from fw3.03  -->
@@ -203,7 +205,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="FH18A v3.11.98 (firmware 3.11+)" lowVersionID="98" highVersionID="98" numOuts="8" numFns="18" productID="FH18A_2018.10" comment="FH18A with update from October 2018" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
+      <model model="FH18A v3.11.98 (firmware 3.11+)" replacementModel="FH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Function Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="8" numFns="18" productID="FH18A_2018.10" comment="FH18A with update from October 2018" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -250,7 +252,7 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="FH22A v3.11.98 (firmware 3.11+)" lowVersionID="98" highVersionID="98" numOuts="8" numFns="18" productID="FH22A_2018.10" comment="FH22A with update from October 2018" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
+      <model model="FH22A v3.11.98 (firmware 3.11+)" replacementModel="FH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Function Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="8" numFns="18" productID="FH22A_2018.10" comment="FH22A with update from October 2018" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.10_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.10_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -12,6 +12,8 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+    <version version="6" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
+  <!--  Added update paths to newest fw 3.12.050 -->
     <version version="5.1" author="Alain Le Marchand" lastUpdated="2019-07-28"/>
   <!--  Only for fw version 3.10
         Add the new CVs
@@ -34,7 +36,7 @@
         -->
   <decoder>
     <family name="Train Decoders (2018)" mfg="Doehler und Haass">
-      <model model="DH05C v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="4" numFns="16" productID="DH05C_2018_04" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from April 2018" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="DH05C v3.10.48 (firmware 3.10+)" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="4" numFns="16" productID="DH05C_2018_04" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from April 2018" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -76,7 +78,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH10C v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="4" numFns="16" productID="DH10C_2018_04" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from April 2018" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="DH10C v3.10.48 (firmware 3.10+)" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="4" numFns="16" productID="DH10C_2018_04" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from April 2018" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -118,7 +120,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH12A v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="6" numFns="16" productID="DH12A_2018_04" comment="DH12A with update from April 2018" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+      <model model="DH12A v3.10.48 (firmware 3.10+)" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="6" numFns="16" productID="DH12A_2018_04" comment="DH12A with update from April 2018" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -158,7 +160,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="6" numFns="16" productID="DH16A_2018_04" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from April 2018" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A v3.10.48 (firmware 3.10+)" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="6" numFns="16" productID="DH16A_2018_04" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from April 2018" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -198,7 +200,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="8" numFns="16" productID="DH18A_2018_04" comment="DH18A with update from April 2018" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A v3.10.48 (firmware 3.10+)" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="8" numFns="16" productID="DH18A_2018_04" comment="DH18A with update from April 2018" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -246,7 +248,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="8" numFns="16" productID="DH21A_2018_04" comment="DH21A with update from April 2018" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A v3.10.48 (firmware 3.10+)" replacementModel="DH21A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="8" numFns="16" productID="DH21A_2018_04" comment="DH21A with update from April 2018" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -294,7 +296,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="6" numFns="16" productID="DH22A_2018_04" comment="DH22A with update from April 2018" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A v3.10.48 (firmware 3.10+)" replacementModel="DH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="6" numFns="16" productID="DH22A_2018_04" comment="DH22A with update from April 2018" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -334,7 +336,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="PD05A v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="2" numFns="16" productID="PD05A" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from April 2018" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="PD05A v3.10.48 (firmware 3.10+)" replacementModel="PD05A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="2" numFns="16" productID="PD05A" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from April 2018" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -356,7 +358,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD12A v3.10.48 (firmware 3.10+)" lowVersionID="48" highVersionID="48" numOuts="4" numFns="16" productID="PD12A" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from April 2018" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+      <model model="PD12A v3.10.48 (firmware 3.10+)" replacementModel="PD12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="48" highVersionID="48" numOuts="4" numFns="16" productID="PD12A" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from April 2018" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.12_DH05-10C_12-16-18-21-22A_PD05-12A.xml
@@ -12,33 +12,13 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-    <version version="6" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
-  <!--  Added update paths to newest fw 3.12.050 -->
-    <version version="5.1.1" author="Ronald Kuhn" lastUpdated="2020-05-02"/>
-  <!--  delete unused entry -->
-    <version version="5.1" author="Alain Le Marchand" lastUpdated="2019-07-28"/>
-  <!--  Only for fw version 3.11
-         Add the new CVs
-        Simplified productID for PD05 and PD12: no more version indicated -->
-    <version version="5" author="Alain Le Marchand" lastUpdated="2019-07-21"/>
-  <!--  New Firmware 3.10 and 3.11 with new CV156 and CV157
-        and changes to CV09, CV134, CV144
-        Add PD05A
-        -->
-  <version version="4" author="Alain Le Marchand" lastUpdated="2018-02-04"/>
-  <!--  New Firmware 3.08 and 3.09 with new CV65 -->
-  <version version="3" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>
-  <!--  New Firmware 3.06 and 3.07 with new CV's and added translation to german -->
-  <version version="2" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20151018"/>
-  <!--  Merged DH05C, DH10C, DH12A, DH16A, DH18A, DH21A, DH22A def files (same CV characteristics) -->
-  <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20150306"/>
-  <!--  Creation (new firmware).
-        3 firmware versions are defined here (3.05 = 3.05.104, 3.05.114, 3.05.15).
-        Those are maintenance release and do no bring any new CV or function.
+  <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
+  <!--  Creation (new firmware 3.12.050).
+        Based on Doehler_Haass_fw3.11_DH05-10C_12-16-18-21-22A_PD05-12A.xml
         -->
   <decoder>
-    <family name="Train Decoders (2018)" mfg="Doehler und Haass">
-      <model model="DH05C v3.11.98 (firmware 3.11+)" replacementModel="DH05C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="4" numFns="16" productID="DH05C_2018_09" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from September 2018" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+    <family name="Train Decoders (2020)" mfg="Doehler und Haass">
+      <model model="DH05C v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="4" numFns="16" productID="52" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from May 2020" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -80,7 +60,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH10C v3.11.98 (firmware 3.11+)" replacementModel="DH10C v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="4" numFns="16" productID="DH10C_2018_09" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from September 2018" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+      <model model="DH10C v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="4" numFns="16" productID="102" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -123,7 +103,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH12A v3.11.98 (firmware 3.11+)" replacementModel="DH12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="6" numFns="16" productID="DH12A_2018_09" comment="DH12A with update from September 2018" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+      <model model="DH12A v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="6" numFns="16" productID="120" comment="DH12A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -163,7 +143,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH16A v3.11.98 (firmware 3.11+)" replacementModel="DH16A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="6" numFns="16" productID="DH16A_2018_09" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from September 2018" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+      <model model="DH16A v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="6" numFns="16" productID="160" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -203,7 +183,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH18A v3.11.98 (firmware 3.11+)" replacementModel="DH18A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="8" numFns="16" productID="DH18A_2018_09" comment="DH18A with update from September 2018" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+      <model model="DH18A v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="8" numFns="16" productID="180" comment="DH18A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -251,7 +231,7 @@
             <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH21A v3.11.98 (firmware 3.11+)" replacementModel="DH21A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="8" numFns="16" productID="DH21A_2018_09" comment="DH21A with update from September 2018" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+      <model model="DH21A v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="8" numFns="16" productID="200" comment="DH21A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum frontal</label>
@@ -299,7 +279,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="DH22A v3.11.98 (firmware 3.11+)" replacementModel="DH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="6" numFns="16" productID="DH22A_2018_09" comment="DH22A with update from September 2018" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+      <model model="DH22A v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="6" numFns="16" productID="202" comment="DH22A with update from May 2020" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -339,7 +319,7 @@
           <protocol>motorola</protocol>
         </protocols>
       </model>
-      <model model="PD05A v3.11.98 (firmware 3.11+)" replacementModel="PD05A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="2" numFns="16" productID="PD05A" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from September 2018" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+      <model model="PD05A v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="2" numFns="16" productID="131" comment="PD05A-0 / PD05A-2 / PD05A-3 with update from May 2020" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -361,7 +341,7 @@
           <protocol>dcc</protocol>
         </protocols>
       </model>
-      <model model="PD12A v3.11.98 (firmware 3.11+)" replacementModel="PD12A v3.12.050 (firmware 3.12+)" replacementFamily="query:Train Decoders (2020)" lowVersionID="98" highVersionID="98" numOuts="4" numFns="16" productID="PD12A" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from September 2018" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+      <model model="PD12A v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="4" numFns="16" productID="130" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from May 2020" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>

--- a/xml/decoders/Doehler_Haass_fw3.12_FH05B-18-22A.xml
+++ b/xml/decoders/Doehler_Haass_fw3.12_FH05B-18-22A.xml
@@ -12,19 +12,13 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <version version="3" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
-<!--  Added update paths to newest fw 3.12.050 -->
-  <version version="2" author="Ronald Kuhn, ronald@wirkuhns.de" lastUpdated="2016-12-14"/>
-  <!--  (new firmware 3.06 and 3.07).
-        -->
-  <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20150306"/>
-  <!--  Creation (new firmware).
-        3 firmware versions are defined here (3.05 = 3.05.104, 3.05.114, 3.05.15).
-          Those are maintenance release and do no bring any new CV or function.
+  <version version="1" author="Pierre Billon, pierre.bln@me.com" lastUpdated="20210308"/>
+  <!--  Creation (new firmware 3.12.050).
+        Based on Doehler_Haass_fw3.10-11_FH05B-18-22A.xml
         -->
   <decoder>
-    <family name="Function Decoders (2016)" mfg="Doehler und Haass">
-      <model model="FH05B v3.06.26 (firmware 3.06+)" replacementModel="FH05B v3.12.050 (firmware 3.12+)" replacementFamily="query:Function Decoders (2020)" lowVersionID="26" highVersionID="26" numOuts="6" numFns="16" productID="FH05B_2016.03" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from March 2016" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+    <family name="Function Decoders (2020)" mfg="Doehler und Haass">
+      <model model="FH05B v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="6" numFns="16" productID="41" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from May 2020" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
@@ -43,102 +37,12 @@
         </output>
         <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
         <!-- New from fw3.03  -->
-          <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
-          <label xml:lang="ca">AUX 3|o SUSI ZCLK</label>
-        </output>
-        <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
-        <!-- New from fw3.03  -->
-          <label xml:lang="de">AUX 4|(o. SUSI ZDAT)</label>
-          <label xml:lang="ca">AUX 4|(o SUSI ZDAT)</label>
-        </output>
-        <output name="7" label="Dimmed|Lights">
-          <label xml:lang="de">Abblend-|licht</label>
-          <label xml:lang="ca">Intensitat de llums</label>
-        </output>
-        <output name="8" label="Shunting|Speed">
-          <label xml:lang="de">Rangiergang</label>
-          <label xml:lang="ca">Marxa de maniobres</label>
-        </output>
-        <size length="13.7" width="7.8" height="1.5" units="mm"/>
-        <protocols>
-          <protocol>dcc</protocol>
-          <protocol>selectrix</protocol>
-        </protocols>
-      </model>
-      <model model="FH22A v3.06.26 (firmware 3.06+)" replacementModel="FH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Function Decoders (2020)" lowVersionID="26" highVersionID="26" numOuts="8" numFns="16" productID="FH22A_2016.03" comment="FH22A with update from March 2016" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
-        <output name="1" label="Front|Light" maxcurrent="150mA">
-          <label xml:lang="de">LV</label>
-          <label xml:lang="ca">Llum Frontal</label>
-        </output>
-        <output name="2" label="Rear|Light" maxcurrent="150mA">
-          <label xml:lang="de">LR</label>
-          <label xml:lang="ca">Llum Posterior</label>
-        </output>
-        <output name="3" label="AUX|1" maxcurrent="300mA">
-          <label xml:lang="de">AUX 1</label>
-          <label xml:lang="ca">AUX 1</label>
-        </output>
-        <output name="4" label="AUX|2" maxcurrent="300mA">
-          <label xml:lang="de">AUX 2</label>
-          <label xml:lang="ca">AUX 2</label>
-        </output>
-        <output name="5" label="AUX|3" maxcurrent="1A">
-          <label xml:lang="de">AUX 3</label>
-          <label xml:lang="ca">AUX 3</label>
-        </output>
-        <output name="6" label="AUX|4" maxcurrent="1A">
-          <label xml:lang="de">AUX 4</label>
-          <label xml:lang="ca">AUX 4</label>
-        </output>
-        <output name="7" label="AUX 5|(or SUSI ZCLK)" maxcurrent="20mA">
-        <!-- New from fw3.03  -->
-          <label xml:lang="de">AUX 5|(o. SUSI ZCLK)</label>
-		  <label xml:lang="ca">AUX 5| SUSI ZCLK</label>
-        </output>
-        <output name="8" label="AUX 6|(or SUSI ZDAT)" maxcurrent="20mA">
-        <!-- New from fw3.03  -->
-          <label xml:lang="de">AUX 6|(o. SUSI ZDAT)</label>
-          <label xml:lang="ca">AUX 6| SUSI ZDAT</label>
-        </output>
-        <output name="9" label="Dimmed|Lights">
-          <label xml:lang="de">Abblend-|licht</label>
-          <label xml:lang="ca">Intensitat Llums</label>
-        </output>
-        <output name="10" label="Shunting|Speed">
-          <label xml:lang="de">Rangiergang</label>
-          <label xml:lang="ca">Marxa de Maniobres</label>
-        </output>
-        <size length="16.1" width="15.8" height="3.3" units="mm"/>
-        <protocols>
-          <protocol>dcc</protocol>
-          <protocol>selectrix</protocol>
-        </protocols>
-      </model>
-      <model model="FH05B v3.07.66 (firmware 3.07+)" replacementModel="FH05B v3.12.050 (firmware 3.12+)" replacementFamily="query:Function Decoders (2020)" lowVersionID="66" highVersionID="66" numOuts="6" numFns="16" productID="FH05B_2016.06" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from June 2016" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
-        <output name="1" label="Front|Light" maxcurrent="150mA">
-          <label xml:lang="de">LV</label>
-          <label xml:lang="ca">Llum Frontal</label>
-        </output>
-        <output name="2" label="Rear|Light" maxcurrent="150mA">
-          <label xml:lang="de">LR</label>
-          <label xml:lang="ca">Llum Posterior</label>
-        </output>
-        <output name="3" label="AUX|1" maxcurrent="300mA">
-          <label xml:lang="de">AUX 1</label>
-          <label xml:lang="ca">AUX 1</label>
-        </output>
-        <output name="4" label="AUX|2" maxcurrent="300mA">
-          <label xml:lang="de">AUX 2</label>
-          <label xml:lang="ca">AUX 2</label>
-        </output>
-        <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
-        <!-- New from fw3.03  -->
-          <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          <label xml:lang="de">AUX 3|SUSI ZCLK</label>
           <label xml:lang="ca">AUX 3| SUSI ZCLK</label>
         </output>
         <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
         <!-- New from fw3.03  -->
-          <label xml:lang="de">AUX 4|(o. SUSI ZDAT)</label>
+          <label xml:lang="de">AUX 4|SUSI ZDAT</label>
           <label xml:lang="ca">AUX 4\SUSI ZDAT</label>
         </output>
         <output name="7" label="Dimmed|Lights">
@@ -146,7 +50,7 @@
           <label xml:lang="ca">Intensitat de llums</label>
         </output>
         <output name="8" label="Shunting|Speed">
-          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="de">Rangier-|gang</label>
           <label xml:lang="ca">Marxa de maniobres</label>
         </output>
         <size length="13.7" width="7.8" height="1.5" units="mm"/>
@@ -155,13 +59,61 @@
           <protocol>selectrix</protocol>
         </protocols>
       </model>
-      <model model="FH22A v3.07.66 (firmware 3.07+)" replacementModel="FH22A v3.12.050 (firmware 3.12+)" replacementFamily="query:Function Decoders (2020)" lowVersionID="66" highVersionID="66" numOuts="8" numFns="16" productID="FH22A_2016.06" comment="FH22A with update from June 2016" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
+      <model model="FH18A v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="8" numFns="18" productID="170" comment="FH18A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="1.0A" connector="Next18">
         <output name="1" label="Front|Light" maxcurrent="150mA">
           <label xml:lang="de">LV</label>
           <label xml:lang="ca">Llum Frontal</label>
         </output>
         <output name="2" label="Rear|Light" maxcurrent="150mA">
-          <label xml:lang="de">Llum Posterior</label>
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
+        </output>
+        <output name="3" label="AUX|1" maxcurrent="300mA">
+          <label xml:lang="de">AUX 1</label>
+          <label xml:lang="ca">AUX 1</label>
+        </output>
+        <output name="4" label="AUX|2" maxcurrent="300mA">
+          <label xml:lang="de">AUX 2</label>
+          <label xml:lang="ca">AUX 2</label>
+        </output>
+        <output name="5" label="AUX|3" maxcurrent="20mA">
+          <label xml:lang="de">AUX 3</label>
+          <label xml:lang="ca">AUX 3</label>
+        </output>
+        <output name="6" label="AUX|4" maxcurrent="20mA">
+          <label xml:lang="de">AUX 4</label>
+          <label xml:lang="ca">AUX 4</label>
+        </output>
+        <output name="7" label="AUX 5|(or SUSI ZCLK)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 5|SUSI ZCLK</label>
+          <label xml:lang="ca">AUX 5| SUSI ZCLK</label>
+        </output>
+        <output name="8" label="AUX 6|(or SUSI ZDAT)" maxcurrent="20mA">
+          <label xml:lang="de">AUX 6|SUSI ZDAT</label>
+          <label xml:lang="ca">AUX 6| SUSI ZDAT</label>
+        </output>
+        <output name="9" label="Dimmed|Lights">
+          <label xml:lang="de">Abblend-|licht</label>
+          <label xml:lang="ca">Intensitat Llums</label>
+        </output>
+        <output name="10" label="Shunting|Speed">
+          <label xml:lang="de">Rangier-|gang</label>
+          <label xml:lang="ca">Marxa de Maniobres</label>
+        </output>
+        <size length="10.7" width="9.7" height="3.2" units="mm"/>
+        <protocols>
+          <protocol>dcc</protocol>
+          <protocol>selectrix</protocol>
+        </protocols>
+      </model>
+      <model model="FH22A v3.12.050 (firmware 3.12+)" lowVersionID="50" highVersionID="50" numOuts="8" numFns="18" productID="192" comment="FH22A with update from May 2020" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
+        <output name="1" label="Front|Light" maxcurrent="150mA">
+          <label xml:lang="de">LV</label>
+          <label xml:lang="ca">Llum Frontal</label>
+        </output>
+        <output name="2" label="Rear|Light" maxcurrent="150mA">
+          <label xml:lang="de">LR</label>
+          <label xml:lang="ca">Llum Posterior</label>
         </output>
         <output name="3" label="AUX|1" maxcurrent="300mA">
           <label xml:lang="de">AUX 1</label>
@@ -181,12 +133,12 @@
         </output>
         <output name="7" label="AUX 5|(or SUSI ZCLK)" maxcurrent="20mA">
         <!-- New from fw3.03  -->
-          <label xml:lang="de">AUX 5|(o. SUSI ZCLK)</label>
+          <label xml:lang="de">AUX 5|SUSI ZCLK</label>
           <label xml:lang="ca">AUX 5| SUSI ZCLK</label>
         </output>
         <output name="8" label="AUX 6|(or SUSI ZDAT)" maxcurrent="20mA">
         <!-- New from fw3.03  -->
-          <label xml:lang="de">AUX 6|(o. SUSI ZDAT)</label>
+          <label xml:lang="de">AUX 6|SUSI ZDAT</label>
           <label xml:lang="ca">AUX 6| SUSI ZDAT</label>
         </output>
         <output name="9" label="Dimmed|Lights">
@@ -194,7 +146,7 @@
           <label xml:lang="ca">Intensitat Llums</label>
         </output>
         <output name="10" label="Shunting|Speed">
-          <label xml:lang="de">Rangiergang</label>
+          <label xml:lang="de">Rangier-|gang</label>
           <label xml:lang="ca">Marxa Maniobres</label>
         </output>
         <size length="16.1" width="15.8" height="3.3" units="mm"/>
@@ -216,7 +168,12 @@
       <!-- SECTION 2 - Standard variables for decoders released after around 2012  -->
       <!--  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Vars_post2012_base.xml"/> -->
       <!--  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Vars_post2012_dc.xml"/> -->
-      <!-- SECTION 3    - Analog functions  -->
+<!-- relevant für FH ??? Start-->
+     <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv65_95.xml"/>
+      <!-- New CV65 from Fw 3.08 and above -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv65_fw3.08.xml"/>
+<!-- relevant für FH ??? Ende-->
+       <!-- SECTION 3    - Analog functions  -->
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv29_analog.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/analogModeFunction.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv14_analogModeFunction.xml"/>
@@ -226,6 +183,10 @@
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv135-136_144_railcom_fw3.06.xml"/>
       <!-- SECTION 6    - Extra general options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_energysaving_fw3.03.xml"/-->
+<!-- relevant für FH ??? Start-->
+      <!--              - Extra general options as of fw3.10 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv144_fw3.10.xml"/>
+<!-- relevant für FH ??? Ende-->
       <!-- SECTION 7    - Extra SUSI options as of fw3.03 -->
       <!-- RK xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv137_susi_fw3.03.xml"/-->
       <!-- SECTION 8    - Motorola format as of fw3.04 -->
@@ -236,6 +197,10 @@
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv260-265_fw3.06.xml"/>
       <!-- SECTION 11    - New effects as of fw3.06 -->
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv145-152_fw3.06.xml"/>
+<!-- relevant für FH ??? Start-->
+      <!--               - New effects as of fw3.10 -->
+      <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv156-157_fw3.10.xml"/>
+<!-- relevant für FH ??? Ende-->
       <!-- SECTION 12    - disable effects as of fw3.06 -->
       <xi:include href="http://jmri.org/xml/decoders/doehler_haass/cv125-133_fw3.06.xml"/>
       <!-- SECTION 13    - shunt options as of fw3.06 -->
@@ -262,7 +227,10 @@
   <!-- Common pane(s) for all Doehler und Haass decoders  -->
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_StartBrakeShunt.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_function_fw3.06.xml"/>
-  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_common.xml"/>
+  <!-- xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_common.xml"/ -->
+<!-- relevant für FH ??? Start-->
+  <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_common_fw3.10.xml"/>
+<!-- relevant für FH ??? Ende-->
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_info.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/doehler_haass/Pane_firmware.xml"/>
   <!-- Pane(s) valid for some decoders only  -->

--- a/xml/decoders/ESU_LokPilot1.0.xml
+++ b/xml/decoders/ESU_LokPilot1.0.xml
@@ -11,173 +11,501 @@
 <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
-<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-    <!--                                                                                                                                             -->
-    <!-- Old Multiprotocol decoder without function mapping 4 outputs, Slowspeed and BEMF-->
-    <!-- Version 1 based on an old ESU manual for Lokpilot delivered in January 2002-->
-    <version author="Alain CARASSO" version="1" lastUpdated="20171110"/>
-    <decoder>
-        <family name="ESU LokPilot 1.0" mfg="Electronic Solutions Ulm GmbH" lowVersionID="21">
-            <model model="LokPilot V1.0" numOuts="4" numFns="6" nmraWarrant="yes">
-                <output name="1" label="Front Lights"/>
-                <output name="2" label="Back Lights"/>
-                <output name="3" label="Aux1"/>
-                <output name="4" label="Aux2"/>
-                <output name="5" label="Shunting"/>
-                <output name="6" label="Acc/Dec off"/>
-            </model>
-        </family>
-        <programming direct="yes" paged="yes" register="yes" ops="yes"/>
-        <variables>
-            <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
-            <variable item="Vstart" CV="2" default="3" comment="A value of 63 corresponds to 100%">
-                <decVal max="63"/>
-                <label>Vstart</label>
-                <label xml:lang="it">Volt Partenza</label>
-                <label xml:lang="fr">V demarrage</label>
-                <label xml:lang="de">Startspannung</label>
-                <comment>A value of 63 corresponds to 100%</comment>
-            </variable>
-            <variable CV="3" default="4" item="Accel">
-                <decVal max="63"/>
-                <label>Acceleration</label>
-                <label xml:lang="it">Accellerazione (0-63)</label>
-                <label xml:lang="fr">Acceleration (0-63)</label>
-                <label xml:lang="de">Anfahrverzögerung (0-63)</label>
-            </variable>
-            <variable CV="4" default="3" item="Decel">
-                <decVal max="63"/>
-                <label>Deceleration</label>
-                <label xml:lang="it">Decellerazione (1-63)</label>
-                <label xml:lang="fr">Deceleration (1-63)</label>
-                <label xml:lang="de">Bremszeit (1-63)</label>
-            </variable>
-            <variable item="Vhigh" CV="5" default="63" comment="Range 1-63">
-                <decVal max="63"/>
-                <label>Vhigh</label>
-                <comment>Range 1-63</comment>
-            </variable>
-            <variable item="Vmid" CV="6" default="25" comment="Range 1-63">
-                <decVal max="63"/>
-                <label>Vmid</label>
-                <comment>Range 1-63</comment>
-            </variable>
-            <!--readOnly="yes" -->
-            <!-- CV 7-8 -->
-            <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
-            <variable item="Manufacturer ID - Reset" CV="8" default="151">
-                <decVal/>
-                <label>Manufacturer ID - Reset</label>
-            </variable>
-            <!-- CV=29 -->
-            <xi:include href="http://jmri.org/xml/decoders/nmra/cv29direction.xml"/>
-            <xi:include href="http://jmri.org/xml/decoders/nmra/cv29speedSteps.xml"/>
-            <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
-
-            <variable item="EMF Static Config" CV="49" default="1" comment="Range 01-02">
-                <decVal min="1" max="2"/>
-                <label>BEMF Active</label>
-                <comment>Range 01-02</comment>
-            </variable>
-            <variable item="Marklin Delta Config" CV="50" default="02" comment="Range 01-02">
-                <decVal min="1" max="2"/>
-                <label>Marklin Delta Config</label>
-                <comment>Range 01-02</comment>
-            </variable>
-            <variable item="EMF Dynamic Config" CV="51" default="56" comment="Range 0-79">
-                <decVal min="0" max="79"/>
-                <label>Adjust EMK Voltage</label>
-                <comment>Range 0-79</comment>
-            </variable>
-            <variable item="EMF Droop Config" CV="52" default="32" comment="Range 0-79">
-                <decVal min="0" max="79"/>
-                <label>K Adjustment</label>
-                <comment>Range 0-79</comment>
-            </variable>
-            <variable item="EMF Feedback Cutout" CV="53" default="24" comment="Range 0-79">
-                <decVal min="0" max="79"/>
-                <label>I Adjustment</label>
-                <comment>Range 0-79</comment>
-            </variable>
-            <variable CV="54" default="16" item="Global lighting option" tooltip="Defines the brightness of the function outputs, range 0-16">
-                <decVal min="0" max="16"/>
-                <label>Global lighting option</label>
-            </variable>
-            <variable item="Analog Mode" CV="55" default="3" mask="XXXXXXVV">
-                <enumVal>
-                    <enumChoice choice="Off">
-                        <choice>Off</choice>
-                    </enumChoice>
-                    <enumChoice choice="AC Analog Mode">
-                        <choice>AC Analog Mode</choice>
-                    </enumChoice>
-                    <enumChoice choice="DC Analog Mode">
-                        <choice>DC Analog Mode</choice>
-                    </enumChoice>
-                    <enumChoice choice="AC+DC Analog Mode">
-                        <choice>AC+DC Analog Mode</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>Analog Mode</label>
-            </variable>
-            <variable CV="56" default="3" item="Braking Mode" tooltip="MARKLIN: 1, ZIMO: 2, MARKLIN+ZIMO: 3, No braking: 4">
-                <decVal min="1" max="4"/>
-                <label>Braking Mode</label>
-            </variable>
-            <variable item="ESU Braking Mode" CV="57" default="0" comment="Range 0-63">
-                <decVal min="0" max="63"/>
-                <label>ESU Braking Mode</label>
-                <comment>Range 0-63</comment>
-            </variable>
-
-            <variable item="DCC Speedstep Detection" CV="64" default="1" mask="XXXXXXXV">
-                <enumVal>
-                    <enumChoice choice="Off">
-                        <choice>Off</choice>
-                    </enumChoice>
-                    <enumChoice choice="On">
-                        <choice>On</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>DCC Speedstep Detection</label>
-            </variable>
-            <variable item="ZIMO Manual Function" CV="64" default="1" mask="XXXXXXVX">
-                <enumVal>
-                    <enumChoice choice="New (MX2000)">
-                        <choice>New (MX2000)</choice>
-                    </enumChoice>
-                    <enumChoice choice="Old (MX1)">
-                        <choice>Old (MX1)</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>ZIMO Manual Function</label>
-            </variable>
-            <variable item="Emergency Stop" CV="64" default="0" mask="XXXXXVXX">
-                <enumVal>
-                    <enumChoice choice="On">
-                        <choice>On</choice>
-                    </enumChoice>
-                    <enumChoice choice="Off">
-                        <choice>Off</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>Emergency Stop</label>
-            </variable>
-        </variables>
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <!--                                                                                 -->
+  <!-- Old Multiprotocol decoder without function mapping 4 outputs, Slowspeed and BEMF-->
+  <!-- Version 1 based on an old ESU manual for Lokpilot delivered in January 2002-->
+  <version author="Alain CARASSO" version="1.00" lastUpdated="20171110"/>
+  <version author="W.D.Kok" version="2.00" lastUpdated="20210307"/>
+  <!-- 1.00 - Initial release                                                                -->
+  <!-- 2.00 - German and Dutch translating inserted                                          -->
+  <!--      - Define the fixed Function-Output mapping                                       -->
+  <!--      - CV3 and 4 switched to v1AccelDecel_1-63.xml                                    -->
+  <!--      - CV2, 5 and 6 switched to v1VstartHighMid_1-63.xml                              -->
+  <!--      - Input Reset                                                                    -->
+  <!--      - Impute tooltip                                                                 -->
+  <decoder>
+    <family name="ESU LokPilot 1.0" mfg="Electronic Solutions Ulm GmbH" lowVersionID="21">
+      <model model="LokPilot V1.0" numOuts="6" numFns="6" maxMotorCurrent="1.1A" maxTotalCurrent="1.2A" formFactor="HO" connector="NEM652" nmraWarrant="yes" productID="50600">
+        <output name="1" label="Front|light" maxcurrent="140 mA">
+          <label xml:lang="de">Vorder-|Licht</label>
+          <label xml:lang="nl">Kop-|Lampen</label>
+        </output>
+        <output name="2" label="Rear|light" maxcurrent="140 mA">
+          <label xml:lang="de">Hinter-|Licht</label>
+          <label xml:lang="nl">Achter-|Licht</label>
+        </output>
+        <output name="3" label="AUX1" maxcurrent="140 mA"/>
+        <output name="4" label="AUX2" maxcurrent="140 mA"/>
+        <output name="5" label="Shunting|gear">
+          <label xml:lang="de">Rangier|gang</label>
+          <label xml:lang="nl">Rangeer|snelheid</label>
+        </output>
+        <output name="6" label="Acceleration|brake delay off">
+          <label xml:lang="de">Anfahr/Brems|Verzögerung aus</label>
+          <label xml:lang="nl">Optrek/rem|vertraging uit</label>
+        </output>
+        <size length="26.5" width="15.5" height="6.5" units="mm"/>
+      </model>
+    </family>
+    <programming direct="yes" paged="yes" register="yes" ops="yes"/>
+    <variables>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/esu/v1AccelDecel_1-63.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/esu/v1VstartHighMid_1-63.xml"/>
+      <!--readOnly="yes" -->
+      <!-- CV 7-8 -->
+      <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
+      <!-- CV=29 -->
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29direction.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29speedSteps.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
+      <variable CV="49" default="1" item="EMF Static Config">
+        <enumVal>
+          <enumChoice choice="Active" value="1">
+            <choice>BEMF Active</choice>
+            <choice xml:lang="de">Lastregelung ein</choice>
+            <choice xml:lang="nl">Lastregeling aan</choice>
+          </enumChoice>
+          <enumChoice choice="Inactive" value="2">
+            <choice>BEMF Inactive</choice>
+            <choice xml:lang="de">Lastregelung aus</choice>
+            <choice xml:lang="nl">Lastregeling uit</choice>
+          </enumChoice>
+        </enumVal>
+        <label>BEMF control</label>
+        <label xml:lang="de">Lastregelung</label>
+        <label xml:lang="nl">Lastregeling</label>
+      </variable>
+      <variable CV="50" item="Märklin Delta Mode" default="2">
+         <enumVal>
+          <enumChoice choice="Active" value="1">
+            <choice>Headlights are always on (Delta mode)</choice>
+            <choice xml:lang="de">Lichter stets einschalten (Deltamodus)</choice>
+            <choice xml:lang="nl">Schakelt altijd het licht in (Deltamodus</choice>
+          </enumChoice>
+          <enumChoice choice="Inactive" value="2">
+            <choice>Headlights switched with function (normal)</choice>
+            <choice xml:lang="de">Lichter mit Lichttaste schalten (normal)</choice>
+            <choice xml:lang="nl">Schakelt het lichten met de lichtknop (normaal)</choice>
+          </enumChoice>
+        </enumVal>
+        <label>Märklin Delta mode</label>
+        <label xml:lang="de">Märklin Deltamodus</label>
+        <label xml:lang="nl">Märklin Deltamodus</label>
+      </variable>
+      <variable CV="51" item="EMF Dynamic Config" default="56">
+        <decVal min="0" max="79"/>
+        <label>Load Control param. 1 (Voltage)</label>
+        <label xml:lang="de">Lastregelung Param. 1 (Spannung)</label>
+        <label xml:lang="nl">Lastregelings param. 1 (Spanning)</label>
+        <tooltip>&lt;html&gt;Defines the Back EMF voltage, which the motor should generate at maximum speed.&lt;br&gt;
+                             The higher the efficiency, the higher this value may be set. If the locomotive&lt;br&gt;
+                             does not reach maximum speed, reduce this parameter.&lt;br&gt;
+                             (Range: 0-79, Default: 56)&lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt die Höhe der Spannung, die vom Motor zurückkommen muss.&lt;br&gt;
+                                           Je besser der Wirkungsgrad des Motors, desto höher kann dieser&lt;br&gt;
+                                           Wert sein. Wenn die Lok nicht die Höchstgeschwindigkeit erreicht,&lt;br&gt;
+                                           diesen Parameter reduzieren.&lt;br&gt;
+                                           (Bereich: 0-79, voreingestellt: 56) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Definieert de Back EMF-spanning, die de motor bij maximale snelheid&lt;br&gt;
+                                           moet genereren. Hoe hoger de efficiëntie, hoe hoger deze waarde kan&lt;br&gt;
+                                           worden ingesteld. Als de locomotief de maximumsnelheid niet bereikt,&lt;br&gt;
+                                           verlaagt u deze parameter.&lt;br&gt;
+                                           (Bereik: 0-79, standaardinstelling: 56) &lt;/html&gt;</tooltip>
+        <comment>Range 0-79</comment>
+      </variable>
+      <variable CV="52" item="EMF Droop Config" default="32">
+        <decVal min="0" max="79"/>
+        <label>Load Control param. 2 (K Adjustment)</label>
+        <label xml:lang="de">Lastregelung Param. 2 (K-segment)</label>
+        <label xml:lang="nl">Lastregelings param. 2 (K-segment)</label>
+        <tooltip>&lt;html&gt;Defines the effect of load control. The higher the value,&lt;br&gt;
+                             the stronger the effect of Back EMF control.&lt;br&gt;
+                             (Range: 0-79, Default: 32)&lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt die Härte der Regelung. Je grösser der Wert,&lt;br&gt;
+                                           desto stärker regelt der LokPilot den Motor.&lt;br&gt;
+                                           (Bereich: 0-79, voreingestellt: 32) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Bepaalt de hardheid van de regeling. Hoe groter de waarde,&lt;br&gt;
+                                           hoe meer de LokPilot de motor regelt.&lt;br&gt;
+                                           (Bereik: 0-79, standaardinstelling: 32) &lt;/html&gt;</tooltip>
+        <comment>Range 0-79</comment>
+      </variable>
+      <variable CV="53" item="EMF Feedback Cutout" default="24">
+        <decVal min="0" max="79"/>
+        <label>Load Control param. 3 (I Adjustment)</label>
+        <label xml:lang="de">Lastregelung Param. 3 (I-segment)</label>
+        <label xml:lang="nl">Lastregelings param. 3 (I-segment)</label>
+        <tooltip>&lt;html&gt;Defines momentum of motor. The higher the momenum of the motor (large flywheel&lt;br&gt;
+                             or bigger diameter motor) the lower this value has to be set.&lt;br&gt;
+                             (Range: 0-79, Default: 24)&lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt durch die Trägheit des Motors. Je träger der Motor ist&lt;br&gt;
+                                           (wenn also viel Schwungmasse vorhanden ist oder der Motor einen&lt;br&gt;
+                                           grossen Durchmesser hat), desto kleiner muss der Wert sein.&lt;br&gt;
+                                           (Bereich: 0-79, voreingestellt: 24) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Bepaald door de traagheid van de motor. Hoe trager de motor is&lt;br&gt;
+                                           (d.w.z. als er veel vliegwielmassa is of de motor heeft een&lt;br&gt;
+                                           grote diameter), hoe kleiner de waarde moet zijn.&lt;br&gt;
+                                           (Bereik: 0-79, standaardinstelling: 24) &lt;/html&gt;</tooltip>
+        <comment>Range 0-79</comment>
+      </variable>
+      <variable CV="54" item="Global lighting option 8" default="16">
+        <decVal min="0" max="16"/>
+        <label>Lights brightness</label>
+        <label xml:lang="de">Lichthelligkeit </label>
+        <label xml:lang="nl">Helderheid van het licht</label>
+        <tooltip>&lt;html&gt;Defines the brightness of the function outputs.&lt;br&gt;
+                             The lower the value of this CV, the darker are&lt;br&gt;
+                             the bulbs connected.&lt;br&gt;
+                             (Range: 1-16, Default: 16) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt die Helligkeit der Funktionsausgänge.&lt;br&gt;
+                                           Je grösser der Wert, desto heller sind die Lampen&lt;br&gt;
+                                           (Bereich: 1-16, voreingestellt: 16) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Hiermee bepaalt u de helderheid van de functie-uitgangen.&lt;br&gt;
+                                           Hoe groter de waarde, hoe helderder de lampen&lt;br&gt;
+                                           (Bereik: 1-16, standaardinstelling: 16) &lt;/html&gt;</tooltip>
+      </variable>
+      <variable CV="55" mask="XXXXXXVV" item="Analog Mode" default="3">
+        <enumVal>
+          <enumChoice choice="Off">
+            <choice>Off</choice>
+            <choice xml:lang="de">Aus</choice>
+            <choice xml:lang="nl">Uit</choice>
+          </enumChoice>
+          <enumChoice choice="AC Analog Mode">
+            <choice>AC Analog Mode</choice>
+            <choice xml:lang="de">AC Analoge Modus</choice>
+            <choice xml:lang="nl">AC analoge modus</choice>
+          </enumChoice>
+          <enumChoice choice="DC Analog Mode">
+            <choice>DC Analog Mode</choice>
+            <choice xml:lang="de">DC Analoge Modus</choice>
+            <choice xml:lang="nl">DC analoge modus</choice>
+          </enumChoice>
+          <enumChoice choice="AC+DC Analog Mode">
+            <choice>AC+DC Analog Mode</choice>
+            <choice xml:lang="de">AC+DC Analoge Modus</choice>
+            <choice xml:lang="nl">AC+DC analoge modus</choice>
+          </enumChoice>
+        </enumVal>
+        <label>Analog Mode</label>
+        <label xml:lang="de">Analog Modus</label>
+        <label xml:lang="nl">Analog modus</label>
+      </variable>
+      <variable CV="56" item="Braking Mode" default="3">
+        <enumVal>
+          <enumChoice choice="Märklin" value="1">
+            <choice>Märklin</choice>
+          </enumChoice>
+          <enumChoice choice="Zimo" value="2">
+            <choice>Zimo</choice>
+          </enumChoice>
+          <enumChoice choice="Mär+Zimo" value="3">
+            <choice>Märklin and Zimo</choice>
+            <choice xml:lang="de">Märklin und Zimo</choice>
+            <choice xml:lang="nl">Märklin en Zimo</choice>
+          </enumChoice>
+          <enumChoice choice="AC+DC Analog Mode" value="4">
+            <choice>No braking Mode</choice>
+            <choice xml:lang="de">Kein Bremsmodus</choice>
+            <choice xml:lang="nl">geen remmodus</choice>
+          </enumChoice>
+        </enumVal>
+        <label>Braking Mode</label>
+        <label xml:lang="de">Bremsmodus</label>
+        <label xml:lang="nl">Rem modus</label>
+      </variable>
+      <variable CV="57" item="ESU Braking Mode" default="0">
+        <decVal min="0" max="63"/>
+        <label>Signal Dependent Deceleration</label>
+        <label xml:lang="de">Signalabhängige Verzögerung</label>
+        <label xml:lang="nl">Signaalafhankelijke vertraging</label>
+        <tooltip>&lt;html&gt;This allows you to set a path that the locomotive travels from the beginning&lt;br&gt;
+                             of the brake section to the stop. This makes it possible to stop right in front&lt;br&gt;
+                             of the red signal, regardless of the speed of the locomotive. The LokPilot&lt;br&gt;
+                             then calculates how hard the locomotive should brake.&lt;br&gt;
+                             (Range: 0-63, Default: 0)&lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Hiermit kann ein Weg eingestellt werden, den die Lok vom Anfang des Bremsabschnitts&lt;br&gt;
+                                           bis Zum Halt zurücklegt. Damit ist es möglich, unabhängig von der Geschwindigkeit&lt;br&gt;
+                                           der Lok immer genau vor dem roten Signal zum Stehen zu kommen. Der LokPilot&lt;br&gt;
+                                           berechnet dann, wie stark die Lok bremsen soll.&lt;br&gt;
+                                           (Bereich: 0-63, voreingestellt: 0) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Hiermee kan u een weg instellen die de locomotief van het begin van de remweg tot de&lt;br&gt;
+                                           halte aflegt. Dit maakt het mogelijk om altijd voor het rode signaal te stoppen,&lt;br&gt;
+                                           ongeacht de snelheid van de locomotief. De LokPilot berekent vervolgens hoe hard&lt;br&gt;
+                                           de locomotief moet remmen.&lt;br&gt;
+                                           (Bereik: 0-63, standaardinstelling: 0) &lt;/html&gt;</tooltip>
+        <comment>Range 0-63</comment>
+      </variable>
+      <variable CV="64" mask="XXXXXXXV" item="DCC Speedstep Detection" default="1">
+        <enumVal>
+          <enumChoice choice="Off">
+            <choice>Disable DCC speed step detection</choice>
+            <choice xml:lang="de">Fahrstufenerkennung DCC aus</choice>
+            <choice xml:lang="nl">Rijstappenerkenning DCC uit</choice>
+          </enumChoice>
+          <enumChoice choice="On">
+            <choice>Enable DCC speed step detection (recomm.)</choice>
+            <choice xml:lang="de">Fahrstufenerkennung DCC ein (empfohlen)</choice>
+            <choice xml:lang="nl">Rijstappenerkenning DCC aan (aanbevolen)</choice>
+          </enumChoice>
+        </enumVal>
+        <label>DCC Speedstep Detection</label>
+        <label xml:lang="de">DCC Fahrstufenerkennung</label>
+        <label xml:lang="nl">DCC rijstappenerkenning</label>
+      </variable>
+      <variable CV="64" mask="XXXXXXVX" item="ZIMO Manual Function" default="1">
+        <enumVal>
+          <enumChoice choice="New (MX2000)">
+            <choice>New ZIMO Manual function (MX2000)</choice>
+            <choice xml:lang="de">Neue ZIMO-Manual Funktion (MX2000)</choice>
+            <choice xml:lang="nl">Nieuwe ZIMO-manual Functie (MX2000)</choice>
+          </enumChoice>
+          <enumChoice choice="Old (MX1)">
+            <choice>Old ZIMO Manual function (MX1)</choice>
+            <choice xml:lang="de">Alte ZIMO-Manual Funktion (MX1)</choice>
+            <choice xml:lang="nl">Oude ZIMO-manual Functie (MX1)</choice>
+          </enumChoice>
+        </enumVal>
+        <label>ZIMO</label>
+      </variable>
+      <variable CV="64" mask="XXXXXVXX" item="Emergency Stop" default="0">
+        <enumVal>
+          <enumChoice choice="On">
+            <choice>Motor brake (emergency stop) on</choice>
+            <choice xml:lang="de">Motorbremse (Nothalt Stop) ein</choice>
+            <choice xml:lang="nl">Motorrem (nootstop) aan</choice>
+          </enumChoice>
+          <enumChoice choice="Off">
+            <choice>Motor brake (emergency stop) off</choice>
+            <choice xml:lang="de">Motorbremse (Nothalt Stop) aus</choice>
+            <choice xml:lang="nl">Motorrem (nootstop) uit</choice>
+          </enumChoice>
+        </enumVal>
+        <label>Emergency stop</label>
+        <label xml:lang="de">Nothalt</label>
+        <label xml:lang="nl">Nootstop</label>
+      </variable>
+      <constant item="FL(f) controls output 1" minOut="1" default="1"/>
+      <constant item="FL(r) controls output 2" minOut="2" default="1"/>
+      <constant item="F1 controls output 3" minOut="3" default="1"/>
+      <constant item="F2 controls output 4" minOut="4" default="1"/>
+      <constant item="F3 controls output 5" minOut="5" default="1"/>
+      <constant item="F4 controls output 6" minOut="6" default="1"/>
+    </variables>
+    <resets>
+      <factReset label="HARD RESET" CV="8" default="8">
+        <label>HARD RESET, All CVs reset to default values</label>
+        <label xml:lang="de">Decoder-Reset, Alle CVs auf Standardwerte zurückgesetzt</label>
+        <label xml:lang="nl">Decoder-reset, Alle cv's worden teruggezet naar standaardwaarden</label>
+      </factReset> 
+    </resets>
     </decoder>
-    <pane>
-        <column>
-            <display item="ZIMO Manual Function"/>
-        </column>
-        <column>
-            <display item="Emergency Stop"/>
-        </column>
-        <column>
-            <display item="ESU Braking Mode"/>
-        </column>
-        <column>
-            <display item="Analog Mode"/>
-        </column>
-        <name>ESU</name>
+    <pane> <!-- Analog Controls -->
+      <column>
+        <grid gridy="1" weightx="1" ipadx="10">
+          <griditem gridx="0" gridy="0" gridwidth="1">
+            <display item="Analog (DC) Operation"/>
+          </griditem>
+          <griditem gridx="0" gridy="NEXT" gridwidth="1">
+            <label>
+              <text>  </text>
+            </label>
+          </griditem>
+          <group>
+            <qualifier>
+              <variableref>Analog (DC) Operation</variableref>
+              <relation>eq</relation>
+              <value>1</value>
+            </qualifier>
+            <griditem gridx="0" gridy="NEXT" gridwidth="1">
+              <display item="Analog Mode" label="" format="radiobuttons"/>
+            </griditem>
+          </group>
+        </grid>
+      </column>
+      <name>Analog Controls</name>
+      <name xml:lang="ca">Control Analògic</name>
+      <name xml:lang="cs">Analogové řízení</name>
+      <name xml:lang="da">Analog Kontrol</name>
+      <name xml:lang="de">Analogeinstellungen</name>
+      <name xml:lang="fr">Contrôles en Analogique</name>
+      <name xml:lang="it">Controlli Analogici</name>
+      <name xml:lang="nl">Analoge instellingen</name>
+    </pane>
+    <pane> <!-- ESU -->
+      <name>ESU</name>
+      <column>
+        <row>
+          <column>
+            <grid gridy="1" weightx="1" ipadx="10">
+              <griditem gridx="0" gridy="0" gridwidth="4">
+                <label>
+                  <text>&lt;html&gt;&lt;h2&gt;&lt;u&gt;Braking&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                  <text xml:lang="de">&lt;html&gt;&lt;h2&gt;&lt;u&gt;Bremsen&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                  <text xml:lang="nl">&lt;html&gt;&lt;h2&gt;&lt;u&gt;Remmen&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="1" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+                <label>
+                  <text>Braking Mode</text>
+                  <text xml:lang="de">Bremsmodus</text>
+                  <text xml:lang="nl">Rem modus</text>
+                </label>
+              </griditem>
+              <griditem gridx="2" gridy="CURRENT" gridwidth="1" anchor="LINE_START">
+                <display item="Braking Mode" label=""/>
+              </griditem>
+              <griditem gridx="3" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="1" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+                <label>
+                  <text>Signal Dependent Deceleration</text>
+                  <text xml:lang="de">Signalabhängige Verzögerung</text>
+                  <text xml:lang="nl">Signaalafhankelijke vertraging</text>
+                </label>
+              </griditem>
+              <griditem gridx="2" gridy="CURRENT" gridwidth="1" anchor="LINE_START">
+                <row>
+                  <display item="ESU Braking Mode" label=""/>
+                  <display item="ESU Braking Mode" format="hslider" label=""/>
+                </row>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem><griditem gridx="1" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+                <label>
+                  <text>Emergency stop</text>
+                  <text xml:lang="de">Nothalt</text>
+                  <text xml:lang="nl">Nootstop</text>
+                </label>
+              </griditem>
+              <griditem gridx="2" gridy="CURRENT" gridwidth="1" anchor="LINE_START">
+                <display item="Emergency Stop" label=""/>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+            </grid>
+          </column>
+        </row>
+        <separator/>
+        <separator/>
+        <row>
+          <column>
+            <grid gridy="1" weightx="1" ipadx="10">
+              <griditem gridx="0" gridy="0" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="3">
+                <label>
+                  <text>&lt;html&gt;&lt;h2&gt;&lt;u&gt;ZIMO&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="NEXT" gridy="NEXT" gridwidth="1">
+                <display item="ZIMO Manual Function" label=""/>
+              </griditem>
+              <griditem gridx="NEXT" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+            </grid>
+          </column>
+          <separator/>
+          <separator/>
+          <column>
+            <grid gridy="1" weightx="1" ipadx="10">
+              <griditem gridx="0" gridy="0" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="3">
+                <label>
+                  <text>&lt;html&gt;&lt;h2&gt;&lt;u&gt;MÄRKLIN DELTA&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="NEXT" gridy="NEXT" gridwidth="1">
+                <display item="Märklin Delta Mode" label=""/>
+              </griditem>
+              <griditem gridx="NEXT" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="3">
+                <label>
+                  <text>Only needed for Märklin Delta operation.</text>
+                  <text xml:lang="de">Alleen für Märklin Delta Betrieb benötigt.</text>
+                  <text xml:lang="nl">Alleen voor Märklin Delta Bedrijf nodig</text>
+                </label>
+              </griditem>
+              <griditem gridx="NEXT" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+            </grid>
+          </column>
+        </row>
+        <separator/>
+        <separator/>
+        <row>
+          <column>
+            <grid gridy="1" weightx="1" ipadx="10">
+              <griditem gridx="0" gridy="0" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="3">
+                <label>
+                  <text>&lt;html&gt;&lt;h2&gt;&lt;u&gt;DCC Speedstep Detection&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                  <text xml:lang="de">&lt;html&gt;&lt;h2&gt;&lt;u&gt;DCC Fahrstufenerkennung&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                  <text xml:lang="nl">&lt;html&gt;&lt;h2&gt;&lt;u&gt;DCC rijstappenerkenning&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="NEXT" gridy="NEXT" gridwidth="1">
+                <display item="DCC Speedstep Detection" label=""/>
+              </griditem>
+              <griditem gridx="NEXT" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+            </grid>
+          </column>
+        </row>
+      </column>
     </pane>
 </decoder-config>

--- a/xml/decoders/ESU_LokPilotDCC_1.0.xml
+++ b/xml/decoders/ESU_LokPilotDCC_1.0.xml
@@ -11,7 +11,7 @@
 <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
-<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
     <version author="Walter Thompson wsthompson#earthlink.net" version="4" lastUpdated="20050619"/>
     <!--Based on the contribution of many others -->
     <!--version 2 - add consist direction - jake -->

--- a/xml/decoders/ESU_LokPilotDCC_1.0.xml
+++ b/xml/decoders/ESU_LokPilotDCC_1.0.xml
@@ -24,731 +24,831 @@
     <version author="Dave Heap" version="6" lastUpdated="20130127"/>
   <!-- ver7 new model/family nomenclature -->
   <version author="Dave Heap" version="7" lastUpdated="20171112"/>
-     <decoder>
-        <family name="ESU LokPilot 1.0" mfg="Electronic Solutions Ulm GmbH" lowVersionID="21">
-            <model model="LokPilotDCC V1.0" numOuts="6" numFns="8" nmraWarrant="yes">
-                <output name="1" label="Front Lights"/>
-                <output name="2" label="Back Lights"/>
-                <output name="3" label="Aux1"/>
-                <output name="4" label="Aux2"/>
-                <output name="5" label="Shunting"/>
-                <output name="6" label="Acc/Dec off"/>
-            </model>
-        </family>
-        <programming direct="yes" paged="yes" register="yes" ops="yes"/>
-        <variables>
-            <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
-            <variable item="Vstart" CV="2" default="3" comment="A value of 63 corresponds to 100%">
-                <decVal max="63"/>
-                <label>Vstart</label>
-                <label xml:lang="it">Volt Partenza</label>
-                <label xml:lang="fr">V démarr.</label>
-                <label xml:lang="de">Startspannung</label>
-                <comment>A value of 63 corresponds to 100%</comment>
-            </variable>
-            <variable CV="3" default="4" item="Accel">
-                <decVal max="63"/>
-                <label>Acceleration</label>
-                <label xml:lang="it">Accellerazione (0-63)</label>
-                <label xml:lang="fr">Accelération (0-63)</label>
-                <label xml:lang="de">Anfahrverzögerung (0-63)</label>
-            </variable>
-            <variable CV="4" default="3" item="Decel">
-                <decVal max="63"/>
-                <label>Deceleration</label>
-                <label xml:lang="it">Decellerazione (1-63)</label>
-                <label xml:lang="fr">Décélération (1-63)</label>
-                <label xml:lang="de">Bremszeit (1-63)</label>
-            </variable>
-            <variable item="Vhigh" CV="5" default="63" comment="Range 1-63">
-                <decVal max="63"/>
-                <label>Vhigh</label>
-                <comment>Range 1-63</comment>
-            </variable>
-            <variable item="Vmid" CV="6" default="25" comment="Range 1-63">
-                <decVal max="63"/>
-                <label>Vmid</label>
-                <comment>Range 1-63</comment>
-            </variable>
-            <!--readOnly="yes" -->
-            <!-- CV 7-8 -->
-            <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
-            <variable item="Manufacturer ID - Reset" CV="8">
-                <decVal/>
-                <label>Manufacturer ID - Reset</label>
-            </variable>
-            <!-- CV=19 -->
-            <xi:include href="http://jmri.org/xml/decoders/nmra/consistAddrDirection.xml"/>
-            <!-- CV=29 -->
-            <xi:include href="http://jmri.org/xml/decoders/nmra/cv29direction.xml"/>
-            <xi:include href="http://jmri.org/xml/decoders/nmra/cv29speedSteps.xml"/>
-            <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
-            <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table3-28.xml"/>
-            <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1" default="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(f) controls output 1</label>
-            </variable>
-            <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(f) controls output 2</label>
-            </variable>
-            <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="3">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(f) controls output 3</label>
-            </variable>
-            <variable item="FL(f) controls output 4" CV="33" mask="XXXXVXXX" minOut="4">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(f) controls output 4</label>
-            </variable>
-            <variable item="FL(f) controls output 5" CV="33" mask="XXXVXXXX" minOut="5">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(f) controls output 5</label>
-            </variable>
-            <variable item="FL(f) controls output 6" CV="33" mask="XXVXXXXX" minOut="6">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(f) controls output 6</label>
-            </variable>
-            <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(r) controls output 1</label>
-            </variable>
-            <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2" default="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(r) controls output 2</label>
-            </variable>
-            <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="3">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(r) controls output 3</label>
-            </variable>
-            <variable item="FL(r) controls output 4" CV="34" mask="XXXXVXXX" minOut="4">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(r) controls output 4</label>
-            </variable>
-            <variable item="FL(r) controls output 5" CV="34" mask="XXXVXXXX" minOut="5">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(r) controls output 5</label>
-            </variable>
-            <variable item="FL(r) controls output 6" CV="34" mask="XXVXXXXX" minOut="6">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>FL(r) controls output 6</label>
-            </variable>
-            <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F1 controls output 1</label>
-            </variable>
-            <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F1 controls output 2</label>
-            </variable>
-            <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" minFn="1" default="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F1 controls output 3</label>
-            </variable>
-            <variable item="F1 controls output 4" CV="35" mask="XXXXVXXX" minOut="4" minFn="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F1 controls output 4</label>
-            </variable>
-            <variable item="F1 controls output 5" CV="35" mask="XXXVXXXX" minOut="5" minFn="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F1 controls output 5</label>
-            </variable>
-            <variable item="F1 controls output 6" CV="35" mask="XXVXXXXX" minOut="6" minFn="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F1 controls output 6</label>
-            </variable>
-            <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F2 controls output 1</label>
-            </variable>
-            <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F2 controls output 2</label>
-            </variable>
-            <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="3" minFn="2">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F2 controls output 3</label>
-            </variable>
-            <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="4" minFn="2" default="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F2 controls output 4</label>
-            </variable>
-            <variable item="F2 controls output 5" CV="36" mask="XXXVXXXX" minOut="5" minFn="2">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F2 controls output 5</label>
-            </variable>
-            <variable item="F2 controls output 6" CV="36" mask="XXVXXXXX" minOut="6" minFn="2">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F2 controls output 6</label>
-            </variable>
-            <variable item="F3 controls output 3" CV="37" mask="XXXXXXXV" minOut="3" minFn="3">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F3 controls output 3</label>
-            </variable>
-            <variable item="F3 controls output 4" CV="37" mask="XXXXXXVX" minOut="4" minFn="3">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F3 controls output 4</label>
-            </variable>
-            <variable item="F3 controls output 5" CV="37" mask="XXXXXVXX" minOut="5" minFn="3" default="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F3 controls output 5</label>
-            </variable>
-            <variable item="F3 controls output 6" CV="37" mask="XXXXVXXX" minOut="6" minFn="3">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F3 controls output 6</label>
-            </variable>
-            <variable item="F4 controls output 3" CV="38" mask="XXXXXXXV" minOut="3" minFn="4">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F4 controls output 3</label>
-            </variable>
-            <variable item="F4 controls output 4" CV="38" mask="XXXXXXVX" minOut="4" minFn="4">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F4 controls output 4</label>
-            </variable>
-            <variable item="F4 controls output 5" CV="38" mask="XXXXXVXX" minOut="5" minFn="4">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F4 controls output 5</label>
-            </variable>
-            <variable item="F4 controls output 6" CV="38" mask="XXXXVXXX" minOut="6" minFn="4" default="1">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F4 controls output 6</label>
-            </variable>
-            <variable item="F5 controls output 3" CV="39" mask="XXXXXXXV" minOut="3" minFn="5">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F5 controls output 3</label>
-            </variable>
-            <variable item="F5 controls output 4" CV="39" mask="XXXXXXVX" minOut="4" minFn="5">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F5 controls output 4</label>
-            </variable>
-            <variable item="F5 controls output 5" CV="39" mask="XXXXXVXX" minOut="5" minFn="5">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F5 controls output 5</label>
-            </variable>
-            <variable item="F5 controls output 6" CV="39" mask="XXXXVXXX" minOut="6" minFn="5">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F5 controls output 6</label>
-            </variable>
-            <variable item="F6 controls output 3" CV="40" mask="XXXXXXXV" minOut="3" minFn="6">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F6 controls output 3</label>
-            </variable>
-            <variable item="F6 controls output 4" CV="40" mask="XXXXXXVX" minOut="4" minFn="6">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F6 controls output 4</label>
-            </variable>
-            <variable item="F6 controls output 5" CV="40" mask="XXXXXVXX" minOut="5" minFn="6">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F6 controls output 5</label>
-            </variable>
-            <variable item="F6 controls output 6" CV="40" mask="XXXXVXXX" minOut="6" minFn="6">
-                <enumVal>
-                    <enumChoice choice="No">
-                        <choice>No</choice>
-                    </enumChoice>
-                    <enumChoice choice="Yes">
-                        <choice>Yes</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>F6 controls output 6</label>
-            </variable>
-            <variable item="EMF Static Config" CV="49" mask="XXXXXXXV" default="1">
-                <enumVal>
-                    <enumChoice choice="Off">
-                        <choice>Off</choice>
-                    </enumChoice>
-                    <enumChoice choice="On">
-                        <choice>On</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>BEMF Active</label>
-            </variable>
-            <variable item="EMF Dynamic Config" CV="51" default="56" comment="Range 0-79">
-                <decVal min="0" max="79"/>
-                <label>Adjust EMK Voltage</label>
-                <comment>Range 0-79</comment>
-            </variable>
-            <variable item="EMF Droop Config" CV="52" default="32" comment="Range 0-79">
-                <decVal min="0" max="79"/>
-                <label>K Adjustment</label>
-                <comment>Range 0-79</comment>
-            </variable>
-            <variable item="EMF Feedback Cutout" CV="53" default="24" comment="Range 0-79">
-                <decVal min="0" max="79"/>
-                <label>I Adjustment</label>
-                <comment>Range 0-79</comment>
-            </variable>
-            <variable item="Analog Mode" CV="55" mask="XXXXXXVV">
-                <enumVal>
-                    <enumChoice choice="Off">
-                        <choice>Off</choice>
-                    </enumChoice>
-                    <enumChoice choice="AC Analog Mode">
-                        <choice>AC Analog Mode</choice>
-                    </enumChoice>
-                    <enumChoice choice="DC Analog Mode">
-                        <choice>DC Analog Mode</choice>
-                    </enumChoice>
-                    <enumChoice choice="AC+DC Analog Mode">
-                        <choice>AC+DC Analog Mode</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>Analog Mode</label>
-            </variable>
-            <variable item="Signal Dependent Deceleration" CV="57" default="0" comment="Range 0-63">
-                <decVal min="0" max="63"/>
-                <label>Signal Dependent Deceleration</label>
-                <comment>Range 0-63</comment>
-            </variable>
-            <variable item="Global lighting option 1" CV="59" default="33" comment="Range 10-63, value is multiplied by 32.768 ms">
-                <decVal min="10" max="63"/>
-                <label>Blink Rate</label>
-                <comment>Range 10-63, value is multiplied by 32.768 ms</comment>
-            </variable>
-            <variable item="Output 1 effect generated" CV="60" default="15" mask="XXXXVVVV">
-                <decVal/>
-                <label>Brightness Head Lights</label>
-            </variable>
-            <variable item="Output 1 behavior" CV="60" default="0" mask="XVVVXXXX">
-                <enumVal>
-                    <enumChoice choice="Off">
-                        <choice>Off</choice>
-                    </enumChoice>
-                    <enumChoice choice="Blink (Phase 1)">
-                        <choice>Blink (Phase 1)</choice>
-                    </enumChoice>
-                    <enumChoice choice="Blink (Phase 2)">
-                        <choice>Blink (Phase 2)</choice>
-                    </enumChoice>
-                    <enumChoice choice="Strobe">
-                        <choice>Strobe</choice>
-                    </enumChoice>
-                    <enumChoice choice="Double Strobe">
-                        <choice>Double Strobe</choice>
-                    </enumChoice>
-                    <enumChoice choice="Marslight">
-                        <choice>Marslight</choice>
-                    </enumChoice>
-                    <enumChoice choice="Gyrolight">
-                        <choice>Gyrolight</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>Output Configuration Head Lights</label>
-            </variable>
-            <variable item="Output 2 effect generated" CV="61" default="15" mask="XXXXVVVV">
-                <decVal/>
-                <label>Brightness Back Lights</label>
-            </variable>
-            <variable item="Output 2 behavior" CV="61" default="0" mask="XVVVXXXX">
-                <enumVal>
-                    <enumChoice choice="Off">
-                        <choice>Off</choice>
-                    </enumChoice>
-                    <enumChoice choice="Blink (Phase 1)">
-                        <choice>Blink (Phase 1)</choice>
-                    </enumChoice>
-                    <enumChoice choice="Blink (Phase 2)">
-                        <choice>Blink (Phase 2)</choice>
-                    </enumChoice>
-                    <enumChoice choice="Strobe">
-                        <choice>Strobe</choice>
-                    </enumChoice>
-                    <enumChoice choice="Double Strobe">
-                        <choice>Double Strobe</choice>
-                    </enumChoice>
-                    <enumChoice choice="Marslight">
-                        <choice>Marslight</choice>
-                    </enumChoice>
-                    <enumChoice choice="Gyrolight">
-                        <choice>Gyrolight</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>Output Configuration Back Lights</label>
-            </variable>
-            <variable item="Output 3 effect generated" CV="62" default="15" mask="XXXXVVVV">
-                <decVal/>
-                <label>Brightness AUX1</label>
-            </variable>
-            <variable item="Output 3 behavior" CV="62" default="0" mask="XVVVXXXX">
-                <enumVal>
-                    <enumChoice choice="Off">
-                        <choice>Off</choice>
-                    </enumChoice>
-                    <enumChoice choice="Blink (Phase 1)">
-                        <choice>Blink (Phase 1)</choice>
-                    </enumChoice>
-                    <enumChoice choice="Blink (Phase 2)">
-                        <choice>Blink (Phase 2)</choice>
-                    </enumChoice>
-                    <enumChoice choice="Strobe">
-                        <choice>Strobe</choice>
-                    </enumChoice>
-                    <enumChoice choice="Double Strobe">
-                        <choice>Double Strobe</choice>
-                    </enumChoice>
-                    <enumChoice choice="Marslight">
-                        <choice>Marslight</choice>
-                    </enumChoice>
-                    <enumChoice choice="Gyrolight">
-                        <choice>Gyrolight</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>Output Configuration AUX1</label>
-            </variable>
-            <variable item="Output 4 effect generated" CV="63" default="15" mask="XXXXVVVV">
-                <decVal/>
-                <label>Brightness AUX2</label>
-            </variable>
-            <variable item="Output 4 behavior" CV="63" default="0" mask="XVVVXXXX">
-                <enumVal>
-                    <enumChoice choice="Off">
-                        <choice>Off</choice>
-                    </enumChoice>
-                    <enumChoice choice="Blink (Phase 1)">
-                        <choice>Blink (Phase 1)</choice>
-                    </enumChoice>
-                    <enumChoice choice="Blink (Phase 2)">
-                        <choice>Blink (Phase 2)</choice>
-                    </enumChoice>
-                    <enumChoice choice="Strobe">
-                        <choice>Strobe</choice>
-                    </enumChoice>
-                    <enumChoice choice="Double Strobe">
-                        <choice>Double Strobe</choice>
-                    </enumChoice>
-                    <enumChoice choice="Marslight">
-                        <choice>Marslight</choice>
-                    </enumChoice>
-                    <enumChoice choice="Gyrolight">
-                        <choice>Gyrolight</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>Output Configuration AUX2</label>
-            </variable>
-            <variable item="DCC Speedstep Detection" CV="64" default="1" mask="XXXXXXXV">
-                <enumVal>
-                    <enumChoice choice="Off">
-                        <choice>Off</choice>
-                    </enumChoice>
-                    <enumChoice choice="On">
-                        <choice>On</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>DCC Speedstep Detection</label>
-            </variable>
-            <variable item="ZIMO Manual Function" CV="64" default="1" mask="XXXXXXVX">
-                <enumVal>
-                    <enumChoice choice="New (MX2000)">
-                        <choice>New (MX2000)</choice>
-                    </enumChoice>
-                    <enumChoice choice="Old (MX1)">
-                        <choice>Old (MX1)</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>ZIMO Manual Function</label>
-            </variable>
-            <variable item="Emergency Stop" CV="64" default="0" mask="XXXXXVXX">
-                <enumVal>
-                    <enumChoice choice="On">
-                        <choice>On</choice>
-                    </enumChoice>
-                    <enumChoice choice="Off">
-                        <choice>Off</choice>
-                    </enumChoice>
-                </enumVal>
-                <label>Emergency Stop</label>
-            </variable>
-            <xi:include href="http://jmri.org/xml/decoders/nmra/cv67speedTableBasic.xml"/>
-        </variables>
+  <version author="W.D.Kok" version="8" lastUpdated="20210307"/>
+  <!-- ver8 - Input Reset                                        -->
+  <!--      - German and Dutch translating inserted              -->
+  <!--      - CV3 and 4 switched to v1AccelDecel_1-63.xml        -->
+  <!--      - CV2, 5 and 6 switched to v1VstartHighMid_1-63.xml  -->
+  <!--      - Impute tooltip                                     -->
+  <decoder>
+    <family name="ESU LokPilot 1.0" mfg="Electronic Solutions Ulm GmbH" lowVersionID="21">
+      <model model="LokPilotDCC V1.0" numOuts="6" numFns="8" maxMotorCurrent="1.1A" maxTotalCurrent="1.2A" formFactor="HO" connector="NEM652" nmraWarrant="yes" productID="50601">
+        <output name="1" label="Front|light" maxcurrent="140 mA">
+          <label xml:lang="de">Vorder-|Licht</label>
+          <label xml:lang="nl">Kop-|Lampen</label>
+        </output>
+        <output name="2" label="Rear|light" maxcurrent="140 mA">
+          <label xml:lang="de">Hinter-|Licht</label>
+          <label xml:lang="nl">Achter-|Licht</label>
+        </output>
+        <output name="3" label="AUX1" maxcurrent="140 mA"/>
+        <output name="4" label="AUX2" maxcurrent="140 mA"/>
+        <output name="5" label="Shunting|gear">
+          <label xml:lang="de">Rangier|gang</label>
+          <label xml:lang="nl">Rangeer|snelheid</label>
+        </output>
+        <output name="6" label="Acceleration|brake delay off">
+          <label xml:lang="de">Anfahr/Brems|Verzögerung aus</label>
+          <label xml:lang="nl">Optrek/rem|vertraging uit</label>
+        </output>
+        <size length="26.5" width="15.5" height="6.5" units="mm"/>
+      </model>
+    </family>
+    <programming direct="yes" paged="yes" register="yes" ops="yes"/>
+    <variables>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/esu/v1AccelDecel_1-63.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/esu/v1VstartHighMid_1-63.xml"/>
+      <!--readOnly="yes" -->
+      <!-- CV 7-8 -->
+      <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
+      <!-- CV=19 -->
+      <xi:include href="http://jmri.org/xml/decoders/nmra/consistAddrDirection.xml"/>
+      <!-- CV=29 -->
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29direction.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29speedSteps.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table3-28.xml"/>
+      <variable CV="33" mask="XXXXXXXV" item="FL(f) controls output 1" minOut="1" default="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 1</label>
+        <label xml:lang="de">FL(f) steuert Ausgang 1</label>
+        <label xml:lang="nl">FL(f) regelt uitgang 1</label>
+      </variable>
+      <variable CV="33" mask="XXXXXXVX" item="FL(f) controls output 2" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 2</label>
+        <label xml:lang="de">FL(f) steuert Ausgang 2</label>
+        <label xml:lang="nl">FL(f) regelt uitgang 2</label>
+      </variable>
+      <variable CV="33" mask="XXXXXVXX" item="FL(f) controls output 3" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 3</label>
+        <label xml:lang="de">FL(f) steuert Ausgang 3</label>
+        <label xml:lang="nl">FL(f) regelt uitgang 3</label>
+      </variable>
+      <variable CV="33" mask="XXXXVXXX" item="FL(f) controls output 4" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 4</label>
+        <label xml:lang="de">FL(f) steuert Ausgang 4</label>
+        <label xml:lang="nl">FL(f) regelt uitgang 4</label>
+      </variable>
+      <variable CV="33" mask="XXXVXXXX" item="FL(f) controls output 5" minOut="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 5</label>
+        <label xml:lang="de">FL(f) steuert Ausgang 5</label>
+        <label xml:lang="nl">FL(f) regelt uitgang 5</label>
+      </variable>
+      <variable CV="33" mask="XXVXXXXX" item="FL(f) controls output 6" minOut="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 6</label>
+        <label xml:lang="de">FL(f) steuert Ausgang 6</label>
+        <label xml:lang="nl">FL(f) regelt uitgang 6</label>
+      </variable>
+      <variable CV="34" mask="XXXXXXXV" item="FL(r) controls output 1" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 1</label>
+        <label xml:lang="de">FL(r) steuert Ausgang 1</label>
+        <label xml:lang="nl">FL(r) regelt uitgang 1</label>
+      </variable>
+      <variable CV="34" mask="XXXXXXVX" item="FL(r) controls output 2" minOut="2" default="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 2</label>
+        <label xml:lang="de">FL(r) steuert Ausgang 2</label>
+        <label xml:lang="nl">FL(r) regelt uitgang 2</label>
+      </variable>
+      <variable CV="34" mask="XXXXXVXX" item="FL(r) controls output 3" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 3</label>
+        <label xml:lang="de">FL(r) steuert Ausgang 3</label>
+        <label xml:lang="nl">FL(r) regelt uitgang 3</label>
+      </variable>
+      <variable CV="34" mask="XXXXVXXX" item="FL(r) controls output 4" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 4</label>
+        <label xml:lang="de">FL(r) steuert Ausgang 4</label>
+        <label xml:lang="nl">FL(r) regelt uitgang 4</label>
+      </variable>
+      <variable CV="34" mask="XXXVXXXX" item="FL(r) controls output 5" minOut="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 5</label>
+        <label xml:lang="de">FL(r) steuert Ausgang 5</label>
+        <label xml:lang="nl">FL(r) regelt uitgang 5</label>
+      </variable>
+      <variable CV="34" mask="XXVXXXXX" item="FL(r) controls output 6" minOut="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 6</label>
+        <label xml:lang="de">FL(r) steuert Ausgang 6</label>
+        <label xml:lang="nl">FL(r) regelt uitgang 6</label>
+      </variable>
+      <variable CV="35" mask="XXXXXXXV" item="F1 controls output 1" minOut="1" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 1</label>
+        <label xml:lang="de">F1 steuert Ausgang 1</label>
+        <label xml:lang="nl">F1 regelt uitgang 1</label>
+      </variable>
+      <variable CV="35" mask="XXXXXXVX" item="F1 controls output 2" minOut="2" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 2</label>
+        <label xml:lang="de">F1 steuert Ausgang 2</label>
+        <label xml:lang="nl">F1 regelt uitgang 2</label>
+      </variable>
+      <variable CV="35" mask="XXXXXVXX" item="F1 controls output 3" minOut="3" minFn="1" default="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 3</label>
+        <label xml:lang="de">F1 steuert Ausgang 3</label>
+        <label xml:lang="nl">F1 regelt uitgang 3</label>
+      </variable>
+      <variable CV="35" mask="XXXXVXXX" item="F1 controls output 4" minOut="4" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 4</label>
+        <label xml:lang="de">F1 steuert Ausgang 4</label>
+        <label xml:lang="nl">F1 regelt uitgang 4</label>
+      </variable>
+      <variable CV="35" mask="XXXVXXXX" item="F1 controls output 5" minOut="5" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 5</label>
+        <label xml:lang="de">F1 steuert Ausgang 5</label>
+        <label xml:lang="nl">F1 regelt uitgang 5</label>
+      </variable>
+      <variable CV="35" mask="XXVXXXXX" item="F1 controls output 6" minOut="6" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 6</label>
+        <label xml:lang="de">F1 steuert Ausgang 6</label>
+        <label xml:lang="nl">F1 regelt uitgang 6</label>
+      </variable>
+      <variable CV="36" mask="XXXXXXXV" item="F2 controls output 1" minOut="1" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 1</label>
+        <label xml:lang="de">F2 steuert Ausgang 1</label>
+        <label xml:lang="nl">F2 regelt uitgang 1</label>
+      </variable>
+      <variable CV="36" mask="XXXXXXVX" item="F2 controls output 2" minOut="2" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 2</label>
+        <label xml:lang="de">F2 steuert Ausgang 2</label>
+        <label xml:lang="nl">F2 regelt uitgang 2</label>
+      </variable>
+      <variable CV="36" mask="XXXXXVXX" item="F2 controls output 3" minOut="3" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 3</label>
+        <label xml:lang="de">F2 steuert Ausgang 3</label>
+        <label xml:lang="nl">F2 regelt uitgang 3</label>
+      </variable>
+      <variable CV="36" mask="XXXXVXXX" item="F2 controls output 4" minOut="4" minFn="2" default="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 4</label>
+        <label xml:lang="de">F2 steuert Ausgang 4</label>
+        <label xml:lang="nl">F2 regelt uitgang 4</label>
+      </variable>
+      <variable CV="36" mask="XXXVXXXX" item="F2 controls output 5" minOut="5" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 5</label>
+        <label xml:lang="de">F2 steuert Ausgang 5</label>
+        <label xml:lang="nl">F2 regelt uitgang 5</label>
+      </variable>
+      <variable CV="36" mask="XXVXXXXX" item="F2 controls output 6" minOut="6" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 6</label>
+        <label xml:lang="de">F2 steuert Ausgang 6</label>
+        <label xml:lang="nl">F2 regelt uitgang 6</label>
+      </variable>
+      <variable CV="37" mask="XXXXXXXV" item="F3 controls output 3" minOut="3" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 3</label>
+        <label xml:lang="de">F3 steuert Ausgang 3</label>
+        <label xml:lang="nl">F3 regelt uitgang 3</label>
+      </variable>
+      <variable CV="37" mask="XXXXXXVX" item="F3 controls output 4" minOut="4" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 4</label>
+        <label xml:lang="de">F3 steuert Ausgang 4</label>
+        <label xml:lang="nl">F3 regelt uitgang 4</label>
+      </variable>
+      <variable CV="37" mask="XXXXXVXX" item="F3 controls output 5" minOut="5" minFn="3" default="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 5</label>
+        <label xml:lang="de">F3 steuert Ausgang 5</label>
+        <label xml:lang="nl">F3 regelt uitgang 5</label>
+      </variable>
+      <variable CV="37" mask="XXXXVXXX" item="F3 controls output 6" minOut="6" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 6</label>
+        <label xml:lang="de">F3 steuert Ausgang 6</label>
+        <label xml:lang="nl">F3 regelt uitgang 6</label>
+      </variable>
+      <variable CV="38" mask="XXXXXXXV" item="F4 controls output 3" minOut="3" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 3</label>
+        <label xml:lang="de">F4 steuert Ausgang 3</label>
+        <label xml:lang="nl">F4 regelt uitgang 3</label>
+      </variable>
+      <variable CV="38" mask="XXXXXXVX" item="F4 controls output 4" minOut="4" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 4</label>
+        <label xml:lang="de">F4 steuert Ausgang 4</label>
+        <label xml:lang="nl">F4 regelt uitgang 4</label>
+      </variable>
+      <variable CV="38" mask="XXXXXVXX" item="F4 controls output 5" minOut="5" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 5</label>
+        <label xml:lang="de">F4 steuert Ausgang 5</label>
+        <label xml:lang="nl">F4 regelt uitgang 5</label>
+      </variable>
+      <variable CV="38" mask="XXXXVXXX" item="F4 controls output 6" minOut="6" minFn="4" default="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 6</label>
+        <label xml:lang="de">F4 steuert Ausgang 6</label>
+        <label xml:lang="nl">F4 regelt uitgang 6</label>
+      </variable>
+      <variable CV="39" mask="XXXXXXXV" item="F5 controls output 3" minOut="3" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 3</label>
+        <label xml:lang="de">F5 steuert Ausgang 3</label>
+        <label xml:lang="nl">F5 regelt uitgang 3</label>
+      </variable>
+      <variable CV="39" mask="XXXXXXVX" item="F5 controls output 4" minOut="4" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 4</label>
+        <label xml:lang="de">F5 steuert Ausgang 4</label>
+        <label xml:lang="nl">F5 regelt uitgang 4</label>
+      </variable>
+      <variable CV="39" mask="XXXXXVXX" item="F5 controls output 5" minOut="5" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 5</label>
+        <label xml:lang="de">F5 steuert Ausgang 5</label>
+        <label xml:lang="nl">F5 regelt uitgang 5</label>
+      </variable>
+      <variable CV="39" mask="XXXXVXXX" item="F5 controls output 6" minOut="6" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 6</label>
+        <label xml:lang="de">F5 steuert Ausgang 6</label>
+        <label xml:lang="nl">F5 regelt uitgang 6</label>
+      </variable>
+      <variable CV="40" mask="XXXXXXXV" item="F6 controls output 3" minOut="3" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 3</label>
+        <label xml:lang="de">F6 steuert Ausgang 3</label>
+        <label xml:lang="nl">F6 regelt uitgang 3</label>
+      </variable>
+      <variable CV="40" mask="XXXXXXVX" item="F6 controls output 4" minOut="4" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 4</label>
+        <label xml:lang="de">F6 steuert Ausgang 4</label>
+        <label xml:lang="nl">F6 regelt uitgang 4</label>
+      </variable>
+      <variable CV="40" mask="XXXXXVXX" item="F6 controls output 5" minOut="5" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 5</label>
+        <label xml:lang="de">F6 steuert Ausgang 5</label>
+        <label xml:lang="nl">F6 regelt uitgang 5</label>
+      </variable>
+      <variable CV="40" mask="XXXXVXXX" item="F6 controls output 6" minOut="6" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 6</label>
+        <label xml:lang="de">F6 steuert Ausgang 6</label>
+        <label xml:lang="nl">F6 regelt uitgang 6</label>
+      </variable>
+      <variable CV="49" mask="XXXXXXXV" item="EMF Static Config" default="1">
+        <enumVal>
+          <enumChoice choice="Active" value="1">
+            <choice>BEMF Active</choice>
+            <choice xml:lang="de">Lastregelung ein</choice>
+            <choice xml:lang="nl">Lastregeling aan</choice>
+          </enumChoice>
+          <enumChoice choice="Inactive" value="2">
+            <choice>BEMF Inactive</choice>
+            <choice xml:lang="de">Lastregelung aus</choice>
+            <choice xml:lang="nl">Lastregeling uit</choice>
+          </enumChoice>
+        </enumVal>
+        <label>BEMF control</label>
+        <label xml:lang="de">Lastregelung</label>
+        <label xml:lang="nl">Lastregeling</label>
+      </variable>
+      <variable CV="51" item="EMF Dynamic Config" default="56">
+        <decVal min="0" max="79"/>
+        <label>Load Control param. 1 (Voltage)</label>
+        <label xml:lang="de">Lastregelung Param. 1 (Spannung)</label>
+        <label xml:lang="nl">Lastregelings param. 1 (Spanning)</label>
+        <tooltip>&lt;html&gt;Defines the Back EMF voltage, which the motor should generate at maximum speed.&lt;br&gt;
+                             The higher the efficiency, the higher this value may be set. If the locomotive&lt;br&gt;
+                             does not reach maximum speed, reduce this parameter.&lt;br&gt;
+                             (Range: 0-79, Default: 56)&lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt die Höhe der Spannung, die vom Motor zurückkommen muss.&lt;br&gt;
+                                           Je besser der Wirkungsgrad des Motors, desto höher kann dieser&lt;br&gt;
+                                           Wert sein. Wenn die Lok nicht die Höchstgeschwindigkeit erreicht,&lt;br&gt;
+                                           diesen Parameter reduzieren.&lt;br&gt;
+                                           (Bereich: 0-79, voreingestellt: 56) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Definieert de Back EMF-spanning, die de motor bij maximale snelheid&lt;br&gt;
+                                           moet genereren. Hoe hoger de efficiëntie, hoe hoger deze waarde kan&lt;br&gt;
+                                           worden ingesteld. Als de locomotief de maximumsnelheid niet bereikt,&lt;br&gt;
+                                           verlaagt u deze parameter.&lt;br&gt;
+                                           (Bereik: 0-79, standaardinstelling: 56) &lt;/html&gt;</tooltip>
+        <comment>Range 0-79</comment>
+      </variable>
+      <variable CV="52" item="EMF Droop Config" default="32">
+        <decVal min="0" max="79"/>
+        <label>Load Control param. 2 (K Adjustment)</label>
+        <label xml:lang="de">Lastregelung Param. 2 (K-segment)</label>
+        <label xml:lang="nl">Lastregelings param. 2 (K-segment)</label>
+        <tooltip>&lt;html&gt;Defines the effect of load control. The higher the value,&lt;br&gt;
+                             the stronger the effect of Back EMF control.&lt;br&gt;
+                             (Range: 0-79, Default: 32)&lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt die Härte der Regelung. Je grösser der Wert,&lt;br&gt;
+                                           desto stärker regelt der LokPilot den Motor.&lt;br&gt;
+                                           (Bereich: 0-79, voreingestellt: 32) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Bepaalt de hardheid van de regeling. Hoe groter de waarde,&lt;br&gt;
+                                           hoe meer de LokPilot de motor regelt.&lt;br&gt;
+                                           (Bereik: 0-79, standaardinstelling: 32) &lt;/html&gt;</tooltip>
+        <comment>Range 0-79</comment>
+      </variable>
+      <variable CV="53" item="EMF Feedback Cutout" default="24">
+        <decVal min="0" max="79"/>
+        <label>Load Control param. 3 (I Adjustment)</label>
+        <label xml:lang="de">Lastregelung Param. 3 (I-segment)</label>
+        <label xml:lang="nl">Lastregelings param. 3 (I-segment)</label>
+        <tooltip>&lt;html&gt;Defines momentum of motor. The higher the momenum of the motor (large flywheel&lt;br&gt;
+                             or bigger diameter motor) the lower this value has to be set.&lt;br&gt;
+                             (Range: 0-79, Default: 24)&lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt durch die Trägheit des Motors. Je träger der Motor ist&lt;br&gt;
+                                           (wenn also viel Schwungmasse vorhanden ist oder der Motor einen&lt;br&gt;
+                                           grossen Durchmesser hat), desto kleiner muss der Wert sein.&lt;br&gt;
+                                           (Bereich: 0-79, voreingestellt: 24) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Bepaald door de traagheid van de motor. Hoe trager de motor is&lt;br&gt;
+                                           (d.w.z. als er veel vliegwielmassa is of de motor heeft een&lt;br&gt;
+                                           grote diameter), hoe kleiner de waarde moet zijn.&lt;br&gt;
+                                           (Bereik: 0-79, standaardinstelling: 24) &lt;/html&gt;</tooltip>
+        <comment>Range 0-79</comment>
+      </variable>
+      <variable CV="55" mask="XXXXXXVV" item="Analog Mode" default="3">
+        <enumVal>
+          <enumChoice choice="Off">
+            <choice>Off</choice>
+            <choice xml:lang="de">Aus</choice>
+            <choice xml:lang="nl">Uit</choice>
+          </enumChoice>
+          <enumChoice choice="AC Analog Mode">
+            <choice>AC Analog Mode</choice>
+            <choice xml:lang="de">AC Analoge Modus</choice>
+            <choice xml:lang="nl">AC analoge modus</choice>
+          </enumChoice>
+          <enumChoice choice="DC Analog Mode">
+            <choice>DC Analog Mode</choice>
+            <choice xml:lang="de">DC Analoge Modus</choice>
+            <choice xml:lang="nl">DC analoge modus</choice>
+          </enumChoice>
+          <enumChoice choice="AC+DC Analog Mode">
+            <choice>AC+DC Analog Mode</choice>
+            <choice xml:lang="de">AC+DC Analoge Modus</choice>
+            <choice xml:lang="nl">AC+DC analoge modus</choice>
+          </enumChoice>
+        </enumVal>
+        <label>Analog Mode</label>
+        <label xml:lang="de">Analog Modus</label>
+        <label xml:lang="nl">Analog modus</label>
+      </variable>
+      <variable CV="57" item="Signal Dependent Deceleration" default="0">
+        <decVal min="0" max="63"/>
+        <label>Signal Dependent Deceleration</label>
+        <label xml:lang="de">Signalabhängige Verzögerung</label>
+        <label xml:lang="nl">Signaalafhankelijke vertraging</label>
+        <tooltip>&lt;html&gt;This allows you to set a path that the locomotive travels from the beginning&lt;br&gt;
+                             of the brake section to the stop. This makes it possible to stop right in front&lt;br&gt;
+                             of the red signal, regardless of the speed of the locomotive. The LokPilotDCC&lt;br&gt;
+                             then calculates how hard the locomotive should brake.&lt;br&gt;
+                             (Range: 0-63, Default: 0)&lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Hiermit kann ein Weg eingestellt werden, den die Lok vom Anfang des Bremsabschnitts&lt;br&gt;
+                                           bis Zum Halt zurücklegt. Damit ist es möglich, unabhängig von der Geschwindigkeit&lt;br&gt;
+                                           der Lok immer genau vor dem roten Signal zum Stehen zu kommen. Der LokPilotDCC&lt;br&gt;
+                                           berechnet dann, wie stark die Lok bremsen soll.&lt;br&gt;
+                                           (Bereich: 0-63, voreingestellt: 0) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Hiermee kan u een weg instellen die de locomotief van het begin van de remweg tot de&lt;br&gt;
+                                           halte aflegt. Dit maakt het mogelijk om altijd voor het rode signaal te stoppen,&lt;br&gt;
+                                           ongeacht de snelheid van de locomotief. De LokPilotDCC berekent vervolgens hoe hard&lt;br&gt;
+                                           de locomotief moet remmen.&lt;br&gt;
+                                           (Bereik: 0-63, standaardinstelling: 0) &lt;/html&gt;</tooltip>
+        <comment>Range 0-63</comment>
+        </variable>
+      <variable CV="59" item="Global lighting option 1" default="33">
+        <decVal min="10" max="63"/>
+        <label>Blink Rate</label>
+        <label xml:lang="de">Blinkrate</label>
+        <label xml:lang="nl">Knippersnelheid</label>
+        <tooltip>&lt;html&gt;Frequency of Strobe effects. always a multiple of 32.768 ms&lt;br&gt;
+                             (Range: 10-63, Default: 33)&lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Blinkfrequenz der Strobeeffekte. Immer ein Vielfaches von 32,768 ms&lt;br&gt;
+                                           (Bereich: 10-63, voreingestellt: 33) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Knipperfrequentie van de stroboscoopeffect. Altijd een veelvoud van 32,768 ms&lt;br&gt;
+                                           (Bereik: 10-63, standaardinstelling: 33) &lt;/html&gt;</tooltip>
+        <comment>Range 10-63</comment>
+      </variable>
+      <variable CV="60" mask="XXXXVVVV" item="Output 1 effect generated" default="15">
+        <decVal min="0" max="15"/>
+        <label>Brightness head lights</label>
+        <label xml:lang="de">Lichthelligkeit Licht vorne </label>
+        <label xml:lang="nl">Helderheid van de koplampen</label>
+        <tooltip>&lt;html&gt;Defines the brightness of the head light.&lt;br&gt;
+                             The lower the value of this CV, the darker are&lt;br&gt;
+                             the bulbs connected.&lt;br&gt;
+                             (Range: 0-15, Default: 15) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt die Helligkeit von das Licht vorne.&lt;br&gt;
+                                           Je grösser der Wert, desto heller sind die Lampen&lt;br&gt;
+                                           (Bereich: 1-15, voreingestellt: 15) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Hiermee bepaalt u de helderheid van de koplampen.&lt;br&gt;
+                                           Hoe groter de waarde, hoe helderder de lampen&lt;br&gt;
+                                           (Bereik: 1-15, standaardinstelling: 15) &lt;/html&gt;</tooltip>
+      </variable>
+      <variable CV="60" mask="XVVVXXXX" item="Output 1 behavior" default="0">
+        <enumVal>
+          <enumChoice choice="Off" value="0">
+            <choice>Off</choice>
+            <choice xml:lang="de">Aus</choice>
+            <choice xml:lang="nl">Uit</choice>
+          </enumChoice>
+          <enumChoice choice="Blink (Phase 1)" value="1">
+            <choice>Blink (Phase 1)</choice>
+            <choice xml:lang="de">Blinklicht (Phase 1)</choice>
+            <choice xml:lang="nl">Knipperlicht (fase 1)</choice>
+          </enumChoice>
+          <enumChoice choice="Blink (Phase 2)" value="2">
+            <choice>Blink (Phase 2)</choice>
+            <choice xml:lang="de">Blinklicht (Phase 2)</choice>
+            <choice xml:lang="nl">Knipperlicht (fase 2)</choice>
+          </enumChoice>
+          <enumChoice choice="Strobe" value="3">
+            <choice>Strobe</choice>
+          </enumChoice>
+          <enumChoice choice="Double Strobe" value="4">
+            <choice>Double Strobe</choice>
+          </enumChoice>
+          <enumChoice choice="Marslight" value="5">
+            <choice>Marslight</choice>
+          </enumChoice>
+          <enumChoice choice="Gyrolight" value="6">
+            <choice>Gyrolight</choice>
+          </enumChoice>
+        </enumVal>
+        <label>Output Configuration Head Lights</label>
+        <label xml:lang="de">Ausgangskonfiguration Licht vorne </label>
+        <label xml:lang="nl">Uitgangsconfiguratie van de koplampen</label>
+      </variable>
+      <variable CV="61" mask="XXXXVVVV" item="Output 2 effect generated" default="15">
+        <decVal min="0" max="15"/>
+        <label>Brightness back lights</label>
+        <label xml:lang="de">Lichthelligkeit Licht hinter</label>
+        <label xml:lang="nl">Helderheid van de achterlichten</label>
+        <tooltip>&lt;html&gt;Defines the brightness of the back light.&lt;br&gt;
+                             The lower the value of this CV, the darker are&lt;br&gt;
+                             the bulbs connected.&lt;br&gt;
+                             (Range: 0-15, Default: 15) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt die Helligkeit von das Licht hinter.&lt;br&gt;
+                                           Je grösser der Wert, desto heller sind die Lampen&lt;br&gt;
+                                           (Bereich: 1-15, voreingestellt: 15) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Hiermee bepaalt u de helderheid van de achterlichten.&lt;br&gt;
+                                           Hoe groter de waarde, hoe helderder de lampen&lt;br&gt;
+                                           (Bereik: 1-15, standaardinstelling: 15) &lt;/html&gt;</tooltip>
+      </variable>
+      <variable CV="61" mask="XVVVXXXX" item="Output 2 behavior" default="0">
+        <enumVal>
+          <enumChoice choice="Off" value="0">
+            <choice>Off</choice>
+            <choice xml:lang="de">Aus</choice>
+            <choice xml:lang="nl">Uit</choice>
+          </enumChoice>
+          <enumChoice choice="Blink (Phase 1)" value="1">
+            <choice>Blink (Phase 1)</choice>
+            <choice xml:lang="de">Blinklicht (Phase 1)</choice>
+            <choice xml:lang="nl">Knipperlicht (fase 1)</choice>
+          </enumChoice>
+          <enumChoice choice="Blink (Phase 2)" value="2">
+            <choice>Blink (Phase 2)</choice>
+            <choice xml:lang="de">Blinklicht (Phase 2)</choice>
+            <choice xml:lang="nl">Knipperlicht (fase 2)</choice>
+          </enumChoice>
+          <enumChoice choice="Strobe" value="3">
+            <choice>Strobe</choice>
+          </enumChoice>
+          <enumChoice choice="Double Strobe" value="4">
+            <choice>Double Strobe</choice>
+          </enumChoice>
+          <enumChoice choice="Marslight" value="5">
+            <choice>Marslight</choice>
+          </enumChoice>
+          <enumChoice choice="Gyrolight" value="6">
+            <choice>Gyrolight</choice>
+          </enumChoice>
+        </enumVal>
+        <label>Output Configuration Back Lights</label>
+        <label xml:lang="de">Ausgangskonfiguration Licht hinter</label>
+        <label xml:lang="nl">Uitgangsconfiguratie van de achterlichten</label>
+      </variable>
+      <variable CV="62" mask="XXXXVVVV" item="Output 3 effect generated" default="15">
+        <decVal min="0" max="15"/>
+        <label>Brightness AUX1</label>
+        <label xml:lang="de">Lichthelligkeit AUX1</label>
+        <label xml:lang="nl">Helderheid AUX1</label>
+        <tooltip>&lt;html&gt;Defines the brightness of AUX1.&lt;br&gt;
+                             The lower the value of this CV, the darker are&lt;br&gt;
+                             the bulbs connected.&lt;br&gt;
+                             (Range: 0-15, Default: 15) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt die Helligkeit von AUX1.&lt;br&gt;
+                                           Je grösser der Wert, desto heller sind die Lampen&lt;br&gt;
+                                           (Bereich: 1-15, voreingestellt: 15) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Hiermee bepaalt u de helderheid van AUX1.&lt;br&gt;
+                                           Hoe groter de waarde, hoe helderder de lampen&lt;br&gt;
+                                           (Bereik: 1-15, standaardinstelling: 15) &lt;/html&gt;</tooltip>
+      </variable>
+      <variable CV="62" mask="XVVVXXXX" item="Output 3 behavior" default="0">
+        <enumVal>
+          <enumChoice choice="Off" value="0">
+            <choice>Off</choice>
+            <choice xml:lang="de">Aus</choice>
+            <choice xml:lang="nl">Uit</choice>
+          </enumChoice>
+          <enumChoice choice="Blink (Phase 1)" value="1">
+            <choice>Blink (Phase 1)</choice>
+            <choice xml:lang="de">Blinklicht (Phase 1)</choice>
+            <choice xml:lang="nl">Knipperlicht (fase 1)</choice>
+          </enumChoice>
+          <enumChoice choice="Blink (Phase 2)" value="2">
+            <choice>Blink (Phase 2)</choice>
+            <choice xml:lang="de">Blinklicht (Phase 2)</choice>
+            <choice xml:lang="nl">Knipperlicht (fase 2)</choice>
+          </enumChoice>
+          <enumChoice choice="Strobe" value="3">
+            <choice>Strobe</choice>
+          </enumChoice>
+          <enumChoice choice="Double Strobe" value="4">
+            <choice>Double Strobe</choice>
+          </enumChoice>
+          <enumChoice choice="Marslight" value="5">
+            <choice>Marslight</choice>
+          </enumChoice>
+          <enumChoice choice="Gyrolight" value="6">
+            <choice>Gyrolight</choice>
+          </enumChoice>
+        </enumVal>
+        <label>Output Configuration AUX1</label>
+        <label xml:lang="de">Ausgangskonfiguration AUX1</label>
+        <label xml:lang="nl">Uitgangsconfiguratie AUX1</label>
+      </variable>
+      <variable CV="63" mask="XXXXVVVV" item="Output 4 effect generated" default="15">
+        <decVal min="0" max="15"/>
+        <label>Brightness AUX2</label>
+        <label xml:lang="de">Lichthelligkeit AUX2</label>
+        <label xml:lang="nl">Helderheid AUX2</label>
+        <tooltip>&lt;html&gt;Defines the brightness of AUX2.&lt;br&gt;
+                             The lower the value of this CV, the darker are&lt;br&gt;
+                             the bulbs connected.&lt;br&gt;
+                             (Range: 0-15, Default: 15) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="de">&lt;html&gt;Bestimmt die Helligkeit von AUX2.&lt;br&gt;
+                                           Je grösser der Wert, desto heller sind die Lampen&lt;br&gt;
+                                           (Bereich: 1-15, voreingestellt: 15) &lt;/html&gt;</tooltip>
+        <tooltip xml:lang="nl">&lt;html&gt;Hiermee bepaalt u de helderheid van AUX2.&lt;br&gt;
+                                           Hoe groter de waarde, hoe helderder de lampen&lt;br&gt;
+                                           (Bereik: 1-15, standaardinstelling: 15) &lt;/html&gt;</tooltip>
+      </variable>
+      <variable CV="63" mask="XVVVXXXX" item="Output 4 behavior" default="0">
+        <enumVal>
+          <enumChoice choice="Off" value="0">
+            <choice>Off</choice>
+            <choice xml:lang="de">Aus</choice>
+            <choice xml:lang="nl">Uit</choice>
+          </enumChoice>
+          <enumChoice choice="Blink (Phase 1)" value="1">
+            <choice>Blink (Phase 1)</choice>
+            <choice xml:lang="de">Blinklicht (Phase 1)</choice>
+            <choice xml:lang="nl">Knipperlicht (fase 1)</choice>
+          </enumChoice>
+          <enumChoice choice="Blink (Phase 2)" value="2">
+            <choice>Blink (Phase 2)</choice>
+            <choice xml:lang="de">Blinklicht (Phase 2)</choice>
+            <choice xml:lang="nl">Knipperlicht (fase 2)</choice>
+          </enumChoice>
+          <enumChoice choice="Strobe" value="3">
+            <choice>Strobe</choice>
+          </enumChoice>
+          <enumChoice choice="Double Strobe" value="4">
+            <choice>Double Strobe</choice>
+          </enumChoice>
+          <enumChoice choice="Marslight" value="5">
+            <choice>Marslight</choice>
+          </enumChoice>
+          <enumChoice choice="Gyrolight" value="6">
+            <choice>Gyrolight</choice>
+          </enumChoice>
+        </enumVal>
+        <label>Output Configuration AUX2</label>
+        <label xml:lang="de">Ausgangskonfiguration AUX2</label>
+        <label xml:lang="nl">Uitgangsconfiguratie AUX2</label>
+      </variable>
+      <variable CV="64" mask="XXXXXXXV" item="DCC Speedstep Detection" default="1">
+        <enumVal>
+          <enumChoice choice="Off">
+            <choice>Disable DCC speed step detection</choice>
+            <choice xml:lang="de">Fahrstufenerkennung DCC aus</choice>
+            <choice xml:lang="nl">Rijstappenerkenning DCC uit</choice>
+          </enumChoice>
+          <enumChoice choice="On">
+            <choice>Enable DCC speed step detection (recomm.)</choice>
+            <choice xml:lang="de">Fahrstufenerkennung DCC ein (empfohlen)</choice>
+            <choice xml:lang="nl">Rijstappenerkenning DCC aan (aanbevolen)</choice>
+          </enumChoice>
+        </enumVal>
+        <label>DCC Speedstep Detection</label>
+        <label xml:lang="de">DCC Fahrstufenerkennung</label>
+        <label xml:lang="nl">DCC rijstappenerkenning</label>
+      </variable>
+      <variable CV="64" mask="XXXXXXVX" item="ZIMO Manual Function" default="1">
+        <enumVal>
+          <enumChoice choice="New (MX2000)">
+            <choice>New ZIMO Manual function (MX2000)</choice>
+            <choice xml:lang="de">Neue ZIMO-Manual Funktion (MX2000)</choice>
+            <choice xml:lang="nl">Nieuwe ZIMO-manual Functie (MX2000)</choice>
+          </enumChoice>
+          <enumChoice choice="Old (MX1)">
+            <choice>Old ZIMO Manual function (MX1)</choice>
+            <choice xml:lang="de">Alte ZIMO-Manual Funktion (MX1)</choice>
+            <choice xml:lang="nl">Oude ZIMO-manual Functie (MX1)</choice>
+          </enumChoice>
+        </enumVal>
+        <label>ZIMO</label>
+      </variable>
+      <variable CV="64" mask="XXXXXVXX" item="Emergency Stop" default="0">
+        <enumVal>
+          <enumChoice choice="On">
+            <choice>Motor brake (emergency stop) on</choice>
+            <choice xml:lang="de">Motorbremse (Nothalt Stop) ein</choice>
+            <choice xml:lang="nl">Motorrem (nootstop) aan</choice>
+          </enumChoice>
+          <enumChoice choice="Off">
+            <choice>Motor brake (emergency stop) off</choice>
+            <choice xml:lang="de">Motorbremse (Nothalt Stop) aus</choice>
+            <choice xml:lang="nl">Motorrem (nootstop) uit</choice>
+          </enumChoice>
+        </enumVal>
+        <label>Emergency stop</label>
+        <label xml:lang="de">Nothalt</label>
+        <label xml:lang="nl">Nootstop</label>
+      </variable>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv67speedTableBasic.xml"/>
+    </variables>
+      <resets>
+        <factReset label="HARD RESET" CV="8" default="8">
+          <label>HARD RESET, All CVs reset to default values</label>
+          <label xml:lang="de">Decoder-Reset, Alle CVs auf Standardwerte zurückgesetzt</label>
+          <label xml:lang="nl">Decoder-reset, Alle cv's worden teruggezet naar standaardwaarden</label>
+        </factReset> 
+      </resets>
     </decoder>
-    <pane>
-        <column>
-            <display item="DCC Speedstep Detection"/>
-        </column>
-        <column>
-            <display item="ZIMO Manual Function"/>
-        </column>
-        <column>
-            <display item="Emergency Stop"/>
-        </column>
-        <column>
-            <display item="Signal Dependent Deceleration"/>
-        </column>
-        <column>
-            <display item="Analog Mode"/>
-        </column>
-        <name>ESU</name>
+    <pane> <!-- Analog Controls -->
+      <column>
+        <grid gridy="1" weightx="1" ipadx="10">
+          <griditem gridx="0" gridy="0" gridwidth="1">
+            <display item="Analog (DC) Operation"/>
+          </griditem>
+          <griditem gridx="0" gridy="NEXT" gridwidth="1">
+            <label>
+              <text>  </text>
+            </label>
+          </griditem>
+          <group>
+            <qualifier>
+              <variableref>Analog (DC) Operation</variableref>
+              <relation>eq</relation>
+              <value>1</value>
+            </qualifier>
+            <griditem gridx="0" gridy="NEXT" gridwidth="1">
+              <display item="Analog Mode" label="" format="radiobuttons"/>
+            </griditem>
+          </group>
+        </grid>
+      </column>
+      <name>Analog Controls</name>
+      <name xml:lang="ca">Control Analògic</name>
+      <name xml:lang="cs">Analogové řízení</name>
+      <name xml:lang="da">Analog Kontrol</name>
+      <name xml:lang="de">Analogeinstellungen</name>
+      <name xml:lang="fr">Contrôles en Analogique</name>
+      <name xml:lang="it">Controlli Analogici</name>
+      <name xml:lang="nl">Analoge instellingen</name>
+    </pane>
+    <pane> <!-- ESU -->
+      <name>ESU</name>
+      <column>
+        <row>
+          <column>
+            <grid gridy="1" weightx="1" ipadx="10">
+              <griditem gridx="0" gridy="0" gridwidth="4">
+                <label>
+                  <text>&lt;html&gt;&lt;h2&gt;&lt;u&gt;Braking&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                  <text xml:lang="de">&lt;html&gt;&lt;h2&gt;&lt;u&gt;Bremsen&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                  <text xml:lang="nl">&lt;html&gt;&lt;h2&gt;&lt;u&gt;Remmen&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="1" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+                <label>
+                  <text>Signal Dependent Deceleration</text>
+                  <text xml:lang="de">Signalabhängige Verzögerung</text>
+                  <text xml:lang="nl">Signaalafhankelijke vertraging</text>
+                </label>
+              </griditem>
+              <griditem gridx="2" gridy="CURRENT" gridwidth="1" anchor="LINE_START">
+                <row>
+                  <display item="Signal Dependent Deceleration" label=""/>
+                  <display item="Signal Dependent Deceleration" format="hslider" label=""/>
+                </row>
+              </griditem>
+              <griditem gridx="3" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem><griditem gridx="1" gridy="NEXT" gridwidth="1" anchor="LINE_END">
+                <label>
+                  <text>Emergency stop</text>
+                  <text xml:lang="de">Nothalt</text>
+                  <text xml:lang="nl">Nootstop</text>
+                </label>
+              </griditem>
+              <griditem gridx="2" gridy="CURRENT" gridwidth="1" anchor="LINE_START">
+                <display item="Emergency Stop" label=""/>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+            </grid>
+          </column>
+        </row>
+        <separator/>
+        <separator/>
+        <row>
+          <column>
+            <grid gridy="1" weightx="1" ipadx="10">
+              <griditem gridx="0" gridy="0" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="3">
+                <label>
+                  <text>&lt;html&gt;&lt;h2&gt;&lt;u&gt;ZIMO&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="NEXT" gridy="NEXT" gridwidth="1">
+                <display item="ZIMO Manual Function" label=""/>
+              </griditem>
+              <griditem gridx="NEXT" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+            </grid>
+          </column>
+          <separator/>
+          <separator/>
+          <column>
+            <grid gridy="1" weightx="1" ipadx="10">
+              <griditem gridx="0" gridy="0" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="3">
+                <label>
+                  <text>&lt;html&gt;&lt;h2&gt;&lt;u&gt;DCC Speedstep Detection&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                  <text xml:lang="de">&lt;html&gt;&lt;h2&gt;&lt;u&gt;DCC Fahrstufenerkennung&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                  <text xml:lang="nl">&lt;html&gt;&lt;h2&gt;&lt;u&gt;DCC rijstappenerkenning&lt;/u&gt;&lt;/h2&gt;&lt;/html&gt;</text>
+                </label>
+              </griditem>
+              <griditem gridx="0" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+              <griditem gridx="NEXT" gridy="NEXT" gridwidth="1">
+                <display item="DCC Speedstep Detection" label=""/>
+              </griditem>
+              <griditem gridx="NEXT" gridy="NEXT" gridwidth="1">
+                <label>
+                  <text>  </text>
+                </label>
+              </griditem>
+            </grid>
+          </column>
+        </row>
+      </column>
     </pane>
 </decoder-config>

--- a/xml/decoders/Zimo_Unified_software_v37_MX605.xml
+++ b/xml/decoders/Zimo_Unified_software_v37_MX605.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2002, 2005, 2006, 2007 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Pierre Billon   pierre.bln@me.com" version="1.8" lastUpdated="2021/03/06"/>
+  <!-- This decoder configuration file is based on the Zimo_Unified_software_v37_MX659.xml   -->
+  <!-- V 1 file, dated 20210306.                                                             -->
+  <!--                                                                                       -->
+  <!--                                                                                       -->
+  <!-- This decoder XML is meant to be used with the "Comprehensive" programmer format.      -->
+  <!-- Continued the practice of using unrelated "item" names to place Zimo unique           -->
+  <!-- variables on the proper pane of the Comprehensive programmer.                         -->
+  <!-- V 1 new file,  Pierre Billon, 06 Mar 2021 -->
+  <!-- MX605 is special Zimo sound decoder for Kato N-scale ICE 4 (in theory usable in other Kato vehicules with the Kato in-house connector for EM13 decoder). Due to the combination with MX605FL & MX605SL installed in same engine, Front/rear lights and FO 1 for interior lighting listed as functons of this decoder -->
+  <!-- Known installed firmware version from factory: 38.5 -->
+  <decoder>
+    <family name="Zimo Unified software (version 37+)" mfg="Zimo">
+      <model  model="MX605 version 37+" replacementModel="MX605 version 39+" replacementFamily="query:Zimo Unified software (version 39+)" lowVersionID="37" highVersionID="38" maxInputVolts="30V" maxMotorCurrent="0.7A, peak=1.5A" maxTotalCurrent="0.7A" formFactor="N" connector="DropIn" numOuts="3" numFns="14" productID="189">
+        <output name="1" label="Front Light (MX605SL)">
+          <label xml:lang="de">Lvor (MX605SL)</label>
+        </output>
+        <output name="2" label="Rear Light (MX605SL)">
+          <label xml:lang="de">Lrück (MX605SL)</label>
+        </output>
+        <output name="3" label="FO 1 (MX605FL)">
+          <label xml:lang="de">FA1 (MX605FL)</label>
+        </output>
+      </model>
+    </family>
+    <programming direct="yes" paged="yes" register="yes" ops="yes"/>
+    <variables>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV1-CV99.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV20.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV100-CV152version30.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV153-CV157version28.xml"/>
+      <!-- CV158 has both sound and Railcom information -->
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV158version32.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV161-CV185Servo.xml"/>
+     <!-- CV7 set to default 37 to allow Swiss Mapping Groups 11 to 17 if creating a brand new decoder from scratch -->
+      <variable CV="7" readOnly="yes" default="37">
+        <decVal/>
+        <label>Manufacturer Version No: </label>
+        <label xml:lang="it">Versione Decoder: </label>
+        <label xml:lang="fr">Version décodeur: </label>
+        <label xml:lang="de">Decoder Version: </label>
+      </variable>
+      <variable item="Decoder ID 1" CV="250" default="189" readOnly="yes">
+        <decVal/>
+        <label>Decoder ID 1</label>
+        <label xml:lang="it">ID 1 Decoder: </label>
+        <label xml:lang="cs">Dekodér ID 1:</label>
+      </variable>
+      <variable item="Decoder ID 2" CV="251" readOnly="yes">
+        <decVal/>
+        <label>Decoder ID 2</label>
+        <label xml:lang="it">ID 2 Decoder: </label>
+        <label xml:lang="cs">Dekodér ID 2:</label>
+      </variable>
+      <variable item="Decoder ID 3" CV="252" readOnly="yes">
+        <decVal/>
+        <label>Decoder ID 3</label>
+        <label xml:lang="it">ID 3 Decoder: </label>
+        <label xml:lang="cs">Dekodér ID 3:</label>
+      </variable>
+      <variable item="Decoder ID 4" CV="253" readOnly="yes">
+        <decVal/>
+        <label>Decoder ID 4</label>
+        <label xml:lang="it">ID 4 Decoder: </label>
+        <label xml:lang="cs">Dekodér ID 4:</label>
+      </variable>
+      <!-- Begin sound-only variables -->
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV260-CV355sound_version30.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV356.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV357-CV365sound_version28.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV366-CV371sound.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV372-CV399sound.xml"/>
+      <!-- End sound-only variables -->
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV400-CV428.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CVSwissMapping_v36.xml"/>
+      <!-- more sound variables -->
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV500-CV603.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV604-CV699.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV739-CV744.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV745-CV768.xml"/>
+      <!-- end of more sound variables -->
+      <!-- Begin constant stopping distance variables -->
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV830-CV833.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CV835.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/zimo/CVs_version37.xml"/>
+    </variables>
+    <xi:include href="http://jmri.org/xml/decoders/zimo/factReset-v32.xml"/>
+  </decoder>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneConsist.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneAccelDecel.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneShuntUncouple.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneAltFunctionMap6.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSwissMapping_v36.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneFunctionOutput.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSmoke.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneZimoSpecific.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneRailcom.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneABC.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSpeedRegulation.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneServos2.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneDecoderlock.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneInputMapping.xml"/>
+  <!-- Begin sound-only panes -->
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSoundLevels.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSoundSamples.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSound.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSound-ElectricLoco.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSound-DieselLoco.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneRandomSounds.xml"/>
+  <!-- End sound-only panes -->
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneLoadCode.xml"/>
+</decoder-config>

--- a/xml/decoders/Zimo_Unified_software_v39_MX64x_MX65x.xml
+++ b/xml/decoders/Zimo_Unified_software_v39_MX64x_MX65x.xml
@@ -36,6 +36,8 @@
   <version author="Ronald Kuhn   ronald@wirkuhns.de" version="1.7" lastUpdated="2020/05/02"/>
   <!-- v1.7,  added version 37 firmware capabilities,  Ronald Kuhn, 28 Feb 2018 -->
   <!-- v1.8,  merged MX64x/MX65x-Decoder and added version 39 firmware capabilities,  Ronald Kuhn, 02 May 2020 -->
+  <version author="Pierre Billon   pierre.bln@me.com" version="1.8" lastUpdated="2021/03/06"/>
+  <!-- v1.9,  added sound decoder MX605 (special Kato version for N-scale ICE 4) . Due to the combination with MX605FL & MX605SL installed in same engine, Front/rear lights and FO 1 for interior lighting listed as functons of this decoder,  Pierre Billon, 06 Mar 2021 -->
 
   <decoder>
     <family name="Zimo Unified software (version 39+)" mfg="Zimo">
@@ -523,6 +525,17 @@
         </output>
         <size length="20" width="9.5" height="3.5" units="mm"/>
       </model>
+      <model model="MX605 version 39+" lowVersionID="39" highVersionID="40" maxInputVolts="30V" maxMotorCurrent="0.7A, peak=1.5A" maxTotalCurrent="0.7A" formFactor="N" connector="DropIn" numOuts="3" numFns="14" productID="189">
+        <output name="1" label="Front Light (MX605SL)">
+          <label xml:lang="de">Lvor (MX605SL)</label>
+        </output>
+        <output name="2" label="Rear Light (MX605SL)">
+          <label xml:lang="de">Lrück (MX605SL)</label>
+        </output>
+        <output name="3" label="FO 1 (MX605FL)">
+          <label xml:lang="de">FA1 (MX605FL)</label>
+        </output>
+      </model>
     </family>
     <programming direct="yes" paged="yes" register="yes" ops="yes"/>
     <variables>
@@ -540,7 +553,13 @@
         <label xml:lang="it">Versione Decoder: </label>
         <label xml:lang="fr">Version décodeur: </label>
         <label xml:lang="de">Decoder Version: </label>
-      </variable> 
+      </variable>
+      <variable item="Decoder ID 1" CV="250" default="189" readOnly="yes" include="189">
+        <decVal/>
+        <label>Decoder ID 1</label>
+        <label xml:lang="it">ID 1 Decoder: </label>
+        <label xml:lang="cs">Dekodér ID 1:</label>
+      </variable>
       <variable item="Decoder ID 1" CV="250" default="190" readOnly="yes" include="190">
         <decVal/>
         <label>Decoder ID 1</label>

--- a/xml/decoders/esu/v1AccelDecel_1-63.xml
+++ b/xml/decoders/esu/v1AccelDecel_1-63.xml
@@ -17,7 +17,7 @@
   </variable>
   <variable CV="4" item="Decel" default="3">
     <defaultItem default="6" include="52690"/>
-    <decVal min="1" max="31"/>
+    <decVal min="1" max="63"/>
     <label>Deceleration Rate (1-63)</label>
     <label xml:lang="it">Decellerazione (1-63)</label>
     <label xml:lang="fr">Décélération (1-63)</label>

--- a/xml/decoders/esu/v1AccelDecel_1-63.xml
+++ b/xml/decoders/esu/v1AccelDecel_1-63.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2021 All rights reserved -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <variable CV="3" item="Accel" default="4">
+    <defaultItem default="8" include="52690"/>
+    <decVal min="1" max="63"/>
+    <label>Acceleration Rate (1-63)</label>
+    <label xml:lang="it">Accellerazione (1-63)</label>
+    <label xml:lang="fr">Accelération (1-63)</label>
+    <label xml:lang="de">Anfahrverzögerung (1-63)</label>
+    <label xml:lang="cs">Míra zrychlení (1-63)</label>
+    <label xml:lang="nl">Versnelling (1-63)</label>
+  </variable>
+  <variable CV="4" item="Decel" default="3">
+    <defaultItem default="6" include="52690"/>
+    <decVal min="1" max="31"/>
+    <label>Deceleration Rate (1-63)</label>
+    <label xml:lang="it">Decellerazione (1-63)</label>
+    <label xml:lang="fr">Décélération (1-63)</label>
+    <label xml:lang="de">Bremsverzögerung (1-63)</label>
+    <label xml:lang="cs">Míra zpomalení (1-63)</label>
+    <label xml:lang="nl">Remvertraging (1-63)</label>
+  </variable>
+</variables>

--- a/xml/decoders/esu/v1VstartHighMid_1-63.xml
+++ b/xml/decoders/esu/v1VstartHighMid_1-63.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2021 All rights reserved -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <variable CV="2" item="Vstart" default="3">
+    <decVal min="1" max="63"/>
+    <label>Vstart</label>
+    <label xml:lang="it">Velocità Partenza</label>
+    <label xml:lang="fr">V démarr.</label>
+    <label xml:lang="cs">Rozjezdové napětí</label>
+    <label xml:lang="de">Abfahrgeschwindigkeit</label>
+    <label xml:lang="nl">Startsnelheid</label>
+    <comment>A value of 63 corresponds to 100%</comment>
+    <comment xml:lang="it">Un Valore di 63 corrisponde al 100%</comment>
+    <comment xml:lang="de">Der Wert 63 entspricht 100%</comment>
+    <comment xml:lang="cs">Hodnota 63 odpovídá 100 %</comment>
+    <comment xml:lang="nl">Een waarde van 63 betekent 100%</comment>
+  </variable>
+  <variable CV="5" item="Vhigh" default="63">
+    <decVal min="1" max="63"/>
+    <label>Vhigh</label>
+    <label xml:lang="it">Velocità Massimi</label>
+    <label xml:lang="fr">Vmax</label>
+    <label xml:lang="de">Höchstgeschwindigkeit</label>
+    <label xml:lang="nl">Max. snelheid</label>
+    <label xml:lang="cs">Maximální napětí</label>
+  </variable>
+  <variable CV="6" item="Vmid" default="25" exclude="52690">
+    <decVal min="1" max="63"/>
+    <label>Vmid</label>
+    <label xml:lang="it">Velocità Intermedi</label>
+    <label xml:lang="fr">Vmoy</label>
+    <label xml:lang="de">Mittengeschwindigkeit</label>
+    <label xml:lang="nl">Min. snelheid</label>
+    <label xml:lang="cs">Střední napětí</label>
+  </variable>
+</variables>


### PR DESCRIPTION
- D&H Definitions Train Decoders: added new family "Train Decoders (2020)" with fw 3.12.050 for the following decoders:
  - DH05C
  - DH10C
  - DH12A
  - DH16A
  - DH18A
  - DH21A
  - DH22A
  - PD05A
  - PD12A
- D&H Definitions Function decoders: added new family "Function Decoders (2020)" with fw 3.12.050 for the following decoders:
  - FH05B
  - FH18A
  - FH22A
- D&H Definitions Train Decoders: added update paths to Fw v3.12.050 for all the following decoder definitions:
  - 3.02 > 3.12.050     Doehler_Haass_fw3.02_DH05-10C_12-16-18A.xml
  - 3.03 > 3.12.050     Doehler_Haass_fw3.03_DH05-10C_12-16-18-21A.xml
  - 3.04 > 3.12.050     Doehler_Haass_fw3.04_DH05-10C_12-16-18-21-22A.xml
  - 3.05 > 3.12.050     Doehler_Haass_fw3.05_DH05-10C_12-16-18-21-22A.xml
  - 3.06/7 > 3.12.050   Doehler_Haass_fw3.06-07_DH05-10C_12-16-18-21-22A_PD12A.xml
  - 3.08/9 > 3.12.050   Doehler_Haass_fw3.08-09_DH05-10C_12-16-18-21-22A_PD05-12A.xml
  - 3.10 > 3.12.050     Doehler_Haass_fw3.10_DH05-10C_12-16-18-21-22A_PD05-12A.xml
  - 3.11 > 3.12.050     Doehler_Haass_fw3.11_DH05-10C_12-16-18-21-22A_PD05-12A.xml
- D&H Definitions Function Decoders: added update paths to Fw v3.12.050 for all the following decoder definitions:
  - 3.05 > 3.12.050     Doehler_Haass_fw3.05_FH05B.xml
  - 3.06/7 > 3.12.050   Doehler_Haass_fw3.06-07_FH05B-22A.xml
  - 3.10/11 > 3.12.050  Doehler_Haass_fw3.10-11_FH05B-18-22A.xml
- D&H Definitions: Added product ID detection for Doehler Haass introduced in CV 261, updated product IDs accordingly in new v3.12.050 defs.
- Modified IdentifyDecoder.java to handle D&H model ID method (using Hornby as model since D&H CV 261 is optional and only implemented in recent fw versions)