### PR TITLE
LightTableAction refactor

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -166,6 +166,7 @@ LightTimedDurationOn                 = Duration ON (ms):
 LightTimedDurationOnHint             = Enter duration of Timed ON in milliseconds
 LightNoneSelected                    = No Automated Controller Selected
 LightControlBorder                   = Light Controller
+LightControllerTitlePlural           = Light Controllers
 LightVariableBorder                  = Variable Intensity
 LightCreateButtonHint                = Click here to create a new Light
 LightUpdateButtonHint                = Click here to change this Light
@@ -212,7 +213,7 @@ LightError12                         = Format error in time entry, please reente
 LightError13                         = Number out of range in time entry, please reenter as hh:mm.
 LightError14                         = Bad character in time field, please reenter as hh:mm.
 LightError15                         = Warning: System Name refers to an address already used by
-LightError16                         = Intensity out of range
+# LightError16                        = Intensity out of range
 LightError17                         = Error: No Hardware Address was entered.
 LightError18                         = Error: Entered hardware address does not convert to a number.
 LightError19                         = Error: Requested range of hardware addresses is not free.
@@ -358,6 +359,7 @@ LightMaxIntensity                    = Maximum Intensity:
 LightMaxIntensityHint                = 0 to 100%, must be equal or greater than min
 LightTransitionTime                  = Transition Time:
 LightTransitionTimeHint              = Time in fast minutes to go from 0% to 100%
+NoLightIntensityForHardware          = {0} Lights do not support Variable Intensity.
 
 HideNullAudioWarningMessage          = Hide Null Audio Warning Message
 

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -442,6 +442,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
             default:
                 NamedBeanPropertyDescriptor<?> desc = getPropertyColumnDescriptor(col);
                 if (desc == null) {
+                    log.error("btdm setvalueat {} {}",row,col);
                     break;
                 }
                 if (value instanceof JComboBox) {
@@ -466,7 +467,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
      *
      * @param bean NamedBean to delete
      */
-    void doDelete(T bean) {
+    protected void doDelete(T bean) {
         try {
             getManager().deleteBean(bean, "DoDelete");
         } catch (PropertyVetoException e) {

--- a/java/src/jmri/jmrit/beantable/LRouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LRouteTableAction.java
@@ -130,7 +130,7 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
             }
             // not actually used due to the configDeleteColumn, setColumnToHoldButton, configureButton
             if (col == EDITCOL) {
-                return new JTextField(Bundle.getMessage("ButtonEdit")).getPreferredSize().width;
+                return new JTextField(Bundle.getMessage("ButtonEdit")).getPreferredSize().width+4;
             }
             // not actually used due to the configValueColumn, setColumnToHoldButton, configureButton
             if (col == ENABLECOL) {
@@ -193,7 +193,7 @@ public class LRouteTableAction extends AbstractTableAction<Logix> {
          * Deactivate the Logix and remove its conditionals.
          */
         @Override
-        void doDelete(Logix logix) {
+        protected void doDelete(Logix logix) {
             if (logix != null) {
                 logix.deActivateLogix();
                 // delete the Logix and all its Conditionals

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -1,43 +1,27 @@
 package jmri.jmrit.beantable;
 
+import com.alexandriasoftware.swing.Validation;
+
 import java.awt.*;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.image.BufferedImage;
 import java.beans.PropertyChangeListener;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
-import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.swing.border.Border;
-import javax.swing.table.TableCellEditor;
-import javax.swing.table.TableCellRenderer;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableColumnModel;
+
+import jmri.*;
+import jmri.jmrit.beantable.light.LightControlPane;
+import jmri.jmrit.beantable.light.LightIntensityPane;
+import jmri.jmrit.beantable.light.LightTableDataModel;
+import jmri.NamedBean.DisplayOptions;
+import jmri.swing.ManagerComboBox;
+import jmri.swing.SystemNameValidator;
+import jmri.util.JmriJFrame;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jmri.util.gui.GuiLafPreferencesManager;
-
-import com.alexandriasoftware.swing.Validation;
-
-import jmri.*;
-import jmri.NamedBean.DisplayOptions;
-import jmri.implementation.DefaultLightControl;
-import jmri.swing.ManagerComboBox;
-import jmri.swing.NamedBeanComboBox;
-import jmri.swing.SystemNameValidator;
-import jmri.util.JmriJFrame;
-import jmri.util.swing.ComboBoxToolTipRenderer;
-import jmri.util.table.ButtonEditor;
-import jmri.util.table.ButtonRenderer;
 
 /**
  * Swing action to create and register a LightTable GUI.
@@ -61,7 +45,7 @@ public class LightTableAction extends AbstractTableAction<Light> {
         super(s);
         // disable ourself if there is no primary Light manager available
         if (lightManager == null) {
-            setEnabled(false);
+            super.setEnabled(false);
         }
     }
 
@@ -70,8 +54,6 @@ public class LightTableAction extends AbstractTableAction<Light> {
     }
 
     protected LightManager lightManager = InstanceManager.getNullableDefault(jmri.LightManager.class);
-    // for icon state col
-    protected boolean _graphicState = false; // updated from prefs
 
     /**
      * {@inheritDoc}
@@ -89,395 +71,7 @@ public class LightTableAction extends AbstractTableAction<Light> {
      */
     @Override
     protected void createModel() {
-        // load graphic state column display preference
-        _graphicState = InstanceManager.getDefault(GuiLafPreferencesManager.class).isGraphicTableState();
-
-        m = new BeanTableDataModel<Light>() {
-            static public final int ENABLECOL = BeanTableDataModel.NUMCOLUMN;
-            static public final int INTENSITYCOL = ENABLECOL + 1;
-            static public final int EDITCOL = INTENSITYCOL + 1;
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public int getColumnCount() {
-                return EDITCOL + 1 + getPropertyColumnCount();
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public String getColumnName(int col) {
-                switch (col) {
-                    case EDITCOL:
-                        return ""; // no heading on "Edit"
-                    case INTENSITYCOL:
-                        return Bundle.getMessage("ColumnHeadIntensity");
-                    case ENABLECOL:
-                        return Bundle.getMessage("ColumnHeadEnabled");
-                    default:
-                        return super.getColumnName(col);
-                }
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public Class<?> getColumnClass(int col) {
-                switch (col) {
-                    case EDITCOL:
-                        return JButton.class;
-                    case INTENSITYCOL:
-                        return Double.class;
-                    case ENABLECOL:
-                        return Boolean.class;
-                    case VALUECOL:  // may use an image to show light state
-                        return ( _graphicState ? JLabel.class : JButton.class );
-                    default:
-                        return super.getColumnClass(col);
-                }
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public int getPreferredWidth(int col) {
-                switch (col) {
-                    case USERNAMECOL: // override default value for UserName column
-                        return new JTextField(16).getPreferredSize().width;
-                    case EDITCOL:
-                        return new JButton(Bundle.getMessage("ButtonEdit")).getPreferredSize().width+4;
-                    case INTENSITYCOL:
-                    case ENABLECOL:
-                        return new JTextField(6).getPreferredSize().width;
-                    default:
-                        return super.getPreferredWidth(col);
-                }
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public boolean isCellEditable(int row, int col) {
-                switch (col) {
-                    case INTENSITYCOL:
-                        return getValueAt(row, SYSNAMECOL) instanceof VariableLight;
-                    case EDITCOL:
-                    case ENABLECOL:
-                        return true;
-                    default:
-                        return super.isCellEditable(row, col);
-                }
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public String getValue(String name) {
-                Light l = lightManager.getBySystemName(name);
-                return (l==null ? ("Failed to find " + name) : l.describeState(l.getState()));
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public Object getValueAt(int row, int col) {
-                switch (col) {
-                    case EDITCOL:
-                        return Bundle.getMessage("ButtonEdit");
-                    case INTENSITYCOL:
-                        Object o = getValueAt(row, SYSNAMECOL);
-                        if (o instanceof VariableLight) {
-                            return ((VariableLight)o).getTargetIntensity();
-                        } else {
-                            return 0.0;
-                        }
-                    case ENABLECOL:
-                        return ((Light) getValueAt(row, SYSNAMECOL)).getEnabled();
-                    default:
-                        return super.getValueAt(row, col);
-                }
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public void setValueAt(Object value, int row, int col) {
-                switch (col) {
-                    case EDITCOL:
-                        // Use separate Runnable so window is created on top
-                        class WindowMaker implements Runnable {
-
-                            final int row;
-
-                            WindowMaker(int r) {
-                                row = r;
-                            }
-
-                            @Override
-                            public void run() {
-                                // set up to edit
-                                addPressed(null);
-                                fixedSystemName.setText(((Light) getValueAt(row, SYSNAMECOL)).getSystemName());
-                                editPressed(); // don't really want to stop Light w/o user action
-                            }
-                        }
-                        WindowMaker t = new WindowMaker(row);
-                        javax.swing.SwingUtilities.invokeLater(t);
-                        break;
-                    case INTENSITYCOL:
-                        // alternate
-                        try {
-                            if (getValueAt(row, SYSNAMECOL) instanceof VariableLight) {
-                                VariableLight l = (VariableLight) getValueAt(row, SYSNAMECOL);
-                                double intensity = Math.max(0, Math.min(1.0, (Double) value));
-                                l.setTargetIntensity(intensity);
-                            } else {
-                                Light l = (Light) getValueAt(row, SYSNAMECOL);
-                                double intensity = ((Double) value);
-                                l.setCommandedState( intensity > 0.5 ? Light.ON : Light.OFF);
-                            }
-                        } catch (IllegalArgumentException e1) {
-                            status1.setText(Bundle.getMessage("LightError16"));
-                            status1.setForeground(Color.red);
-                        }
-                        break;
-                    case ENABLECOL:
-                        // alternate
-                        Light l = (Light) getValueAt(row, SYSNAMECOL);
-                        l.setEnabled(!l.getEnabled());
-                        break;
-                    case VALUECOL:
-                        Light ll = (Light) getValueAt(row, SYSNAMECOL);
-                        clickOn(ll);
-                        fireTableRowsUpdated(row, row);
-                        break;
-                    default:
-                        super.setValueAt(value, row, col);
-                        break;
-                }
-            }
-
-            /**
-             * Delete the bean after all the checking has been done.
-             * <p>
-             * Deactivate the light, then use the superclass to delete it.
-             */
-            @Override
-            void doDelete(Light bean) {
-                bean.deactivateLight();
-                super.doDelete(bean);
-            }
-
-            // all properties update for now
-            @Override
-            protected boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
-                return true;
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public LightManager getManager() {
-                return lightManager;
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public Light getBySystemName(@Nonnull String name) {
-                return lightManager.getBySystemName(name);
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public Light getByUserName(@Nonnull String name) {
-                return InstanceManager.getDefault(LightManager.class).getByUserName(name);
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            protected String getMasterClassName() {
-                return getClassName();
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public void clickOn(Light t) {
-                t.setState( t.getState()==Light.OFF ? Light.ON : Light.OFF );
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public JButton configureButton() {
-                return new JButton(" " + Bundle.getMessage("StateOff") + " ");
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            protected String getBeanType() {
-                return Bundle.getMessage("BeanNameLight");
-            }
-
-            /**
-             * Customize the light table Value (State) column to show an
-             * appropriate graphic for the light state if _graphicState = true,
-             * or (default) just show the localized state text when the
-             * TableDataModel is being called from ListedTableAction.
-             *
-             * @param table a JTable of Lights
-             */
-            @Override
-            protected void configValueColumn(JTable table) {
-                // have the value column hold a JPanel (icon)
-                //setColumnToHoldButton(table, VALUECOL, new JLabel("123456")); // for small round icon, but cannot be converted to JButton
-                // add extras, override BeanTableDataModel
-                log.debug("Light configValueColumn (I am {})", this);
-                if (_graphicState) { // load icons, only once
-                    table.setDefaultEditor(JLabel.class, new ImageIconRenderer()); // editor
-                    table.setDefaultRenderer(JLabel.class, new ImageIconRenderer()); // item class copied from SwitchboardEditor panel
-                } else {
-                    super.configValueColumn(table); // classic text style state indication
-                }
-            }
-
-            /**
-             * Visualize state in table as a graphic, customized for Lights (2
-             * states + ... for transitioning). Renderer and Editor are
-             * identical, as the cell contents are not actually edited, only
-             * used to toggle state using {@link #clickOn(Light)}.
-             *
-             * @see jmri.jmrit.beantable.BlockTableAction#createModel()
-             * @see jmri.jmrit.beantable.TurnoutTableAction#createModel()
-             */
-            class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
-
-                protected JLabel label;
-                protected String rootPath = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor
-                protected char beanTypeChar = 'L'; // for Light
-                protected String onIconPath = rootPath + beanTypeChar + "-on-s.png";
-                protected String offIconPath = rootPath + beanTypeChar + "-off-s.png";
-                protected BufferedImage onImage;
-                protected BufferedImage offImage;
-                protected ImageIcon onIcon;
-                protected ImageIcon offIcon;
-                protected int iconHeight = -1;
-
-                @Override
-                public Component getTableCellRendererComponent(
-                        JTable table, Object value, boolean isSelected,
-                        boolean hasFocus, int row, int column) {
-                    log.debug("Renderer Item = {}, State = {}", row, value);
-                    if (iconHeight < 0) { // load resources only first time, either for renderer or editor
-                        loadIcons();
-                        log.debug("icons loaded");
-                    }
-                    return updateLabel((String) value, row);
-                }
-
-                @Override
-                public Component getTableCellEditorComponent(
-                        JTable table, Object value, boolean isSelected,
-                        int row, int column) {
-                    log.debug("Renderer Item = {}, State = {}", row, value);
-                    if (iconHeight < 0) { // load resources only first time, either for renderer or editor
-                        loadIcons();
-                        log.debug("icons loaded");
-                    }
-                    return updateLabel((String) value, row);
-                }
-
-                public JLabel updateLabel(String value, int row) {
-                    if (iconHeight > 0) { // if necessary, increase row height;
-                        log.debug("TODO adjust table row height for Lights?");
-                        //table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5));
-                    }
-                    if (value.equals(Bundle.getMessage("StateOff")) && offIcon != null) {
-                        label = new JLabel(offIcon);
-                        label.setVerticalAlignment(JLabel.BOTTOM);
-                        log.debug("offIcon set");
-                    } else if (value.equals(Bundle.getMessage("StateOn")) && onIcon != null) {
-                        label = new JLabel(onIcon);
-                        label.setVerticalAlignment(JLabel.BOTTOM);
-                        log.debug("onIcon set");
-                    } else if (value.equals(Bundle.getMessage("BeanStateInconsistent"))) {
-                        label = new JLabel("X", JLabel.CENTER); // centered text alignment
-                        label.setForeground(Color.red);
-                        log.debug("Light state inconsistent");
-                        iconHeight = 0;
-                    } else if (value.equals(Bundle.getMessage("LightStateIntermediate"))) {
-                        label = new JLabel("...", JLabel.CENTER); // centered text alignment
-                        log.debug("Light state in transition");
-                        iconHeight = 0;
-                    } else { // failed to load icon
-                        label = new JLabel(value, JLabel.CENTER); // centered text alignment
-                        log.warn("Error reading icons for LightTable");
-                        iconHeight = 0;
-                    }
-                    label.setToolTipText(value);
-                    label.addMouseListener(new MouseAdapter() {
-                        @Override
-                        public final void mousePressed(MouseEvent evt) {
-                            log.debug("Clicked on icon in row {}", row);
-                            stopCellEditing();
-                        }
-                    });
-                    return label;
-                }
-
-                @Override
-                public Object getCellEditorValue() {
-                    log.debug("getCellEditorValue, me = {})", this);
-                    return this.toString();
-                }
-
-                /**
-                 * Read and buffer graphics. Only called once for this table.
-                 *
-                 * @see #getTableCellEditorComponent(JTable, Object, boolean,
-                 * int, int)
-                 */
-                protected void loadIcons() {
-                    try {
-                        onImage = ImageIO.read(new File(onIconPath));
-                        offImage = ImageIO.read(new File(offIconPath));
-                    } catch (IOException ex) {
-                        log.error("error reading image from {} or {}", onIconPath, offIconPath, ex);
-                    }
-                    log.debug("Success reading images");
-                    int imageWidth = onImage.getWidth();
-                    int imageHeight = onImage.getHeight();
-                    // scale icons 50% to fit in table rows
-                    Image smallOnImage = onImage.getScaledInstance(imageWidth / 2, imageHeight / 2, Image.SCALE_DEFAULT);
-                    Image smallOffImage = offImage.getScaledInstance(imageWidth / 2, imageHeight / 2, Image.SCALE_DEFAULT);
-                    onIcon = new ImageIcon(smallOnImage);
-                    offIcon = new ImageIcon(smallOffImage);
-                    iconHeight = onIcon.getIconHeight();
-                }
-
-            } // end of ImageIconRenderer class
-
-        }; // end of custom data model
+        m = new LightTableDataModel(lightManager);
     }
 
     /**
@@ -500,8 +94,6 @@ public class LightTableAction extends AbstractTableAction<Light> {
     Light curLight = null;
     boolean lightCreatedOrUpdated = false;
     boolean noWarn = false;
-    boolean inEditMode = false;
-    private boolean lightControlChanged = false;
 
     // items for Add/Edit Light frame
     JLabel systemLabel = new JLabel(Bundle.getMessage("SystemConnectionLabel"));
@@ -513,51 +105,27 @@ public class LightTableAction extends AbstractTableAction<Light> {
     JSpinner numberToAdd = new JSpinner(rangeSpinner);
     JLabel labelNumToAdd = new JLabel("   " + Bundle.getMessage("LabelNumberToAdd"));
     String systemSelectionCombo = this.getClass().getName() + ".SystemSelected";
-    JPanel panel1a = null;
-    JPanel varPanel = null;
+
     JLabel systemNameLabel = new JLabel(Bundle.getMessage("LabelSystemName") + " ");
-    JLabel fixedSystemName = new JLabel("xxxxxxxxxxx");
     JTextField userName = new JTextField(20);
     JLabel userNameLabel = new JLabel(Bundle.getMessage("LabelUserName") + " ");
-    LightControlTableModel lightControlTableModel = null;
     JButton create;
-    JButton update;
     JButton cancel = new JButton(Bundle.getMessage("ButtonCancel"));
-    JButton addControl;
     PropertyChangeListener colorChangeListener;
-
-    ArrayList<LightControl> controlList = new ArrayList<>();
-    static String sensorControl = Bundle.getMessage("LightSensorControl");
-    static String fastClockControl = Bundle.getMessage("LightFastClockControl");
-    static String turnoutStatusControl = Bundle.getMessage("LightTurnoutStatusControl");
-    static String timedOnControl = Bundle.getMessage("LightTimedOnControl");
-    static String twoSensorControl = Bundle.getMessage("LightTwoSensorControl");
-    static String noControl = Bundle.getMessage("LightNoControl");
-    public static String lightControlTitle = Bundle.getMessage("LightControlBorder");
 
     JLabel status1 = new JLabel(Bundle.getMessage("LightCreateInst"));
     JLabel status2 = new JLabel("");
     Manager<Light> connectionChoice = null;
-
-    // parts for supporting variable intensity, transition
-    JLabel labelMinIntensity = new JLabel(Bundle.getMessage("LightMinIntensity"));
-    JSpinner minIntensity = new JSpinner();
-    JLabel labelMinIntensityTail = new JLabel("   "); // just a spacer
-    JLabel labelMaxIntensity = new JLabel(Bundle.getMessage("LightMaxIntensity"));
-    JSpinner maxIntensity = new JSpinner();
-    JLabel labelMaxIntensityTail = new JLabel("   "); // another spaces
-    JLabel labelTransitionTime = new JLabel(Bundle.getMessage("LightTransitionTime"));
-    JSpinner transitionTime = new JSpinner(); // 2 digit decimal format field, initialized later as instance
+    private LightIntensityPane lightIntensityPanel;
+    private LightControlPane lightControlPanel;
 
     /**
      * {@inheritDoc}
      */
     @Override
     protected void addPressed(ActionEvent e) {
-        if (inEditMode) {
-            // cancel Edit and reactivate the edited light
-            cancelPressed(null);
-        }
+        cancelPressed(null);
+
         if (addFrame == null) {
             addFrame = new JmriJFrame(Bundle.getMessage("TitleAddLight"), false, true);
             addFrame.addHelpMenu("package.jmri.jmrit.beantable.LightAddEdit", true);
@@ -576,15 +144,13 @@ public class LightTableAction extends AbstractTableAction<Light> {
             addRangeBox.addActionListener((ActionEvent e1) -> addRangeChanged());
             panel1.add(systemNameLabel);
             systemNameLabel.setVisible(false);
-            panel1.add(fixedSystemName);
-            fixedSystemName.setVisible(false);
             prefixBox.setToolTipText(Bundle.getMessage("LightSystemHint"));
             prefixBox.addActionListener((ActionEvent e1) -> prefixChanged());
             contentPane.add(panel1);
-            panel1a = new JPanel();
-            panel1a.setLayout(new FlowLayout());
-            panel1a.add(new JLabel(Bundle.getMessage("LabelHardwareAddress")));
-            panel1a.add(hardwareAddressTextField);
+            JPanel hardwareAddressPanel = new JPanel();
+            hardwareAddressPanel.setLayout(new FlowLayout());
+            hardwareAddressPanel.add(new JLabel(Bundle.getMessage("LabelHardwareAddress")));
+            hardwareAddressPanel.add(hardwareAddressTextField);
             hardwareAddressTextField.setText(""); // reset from possible previous use
             hardwareAddressTextField.setToolTipText(Bundle.getMessage("LightHardwareAddressHint"));
             hardwareAddressTextField.setName("hwAddressTextField"); // for GUI test NOI18N
@@ -594,7 +160,6 @@ public class LightTableAction extends AbstractTableAction<Light> {
             } else {
                 hardwareAddressValidator.setManager(prefixBox.getSelectedItem());
             }
-            
             
             hardwareAddressTextField.setInputVerifier(hardwareAddressValidator);
             prefixBox.addActionListener((evt) -> hardwareAddressValidator.setManager(prefixBox.getSelectedItem()));
@@ -617,10 +182,10 @@ public class LightTableAction extends AbstractTableAction<Light> {
                 }
             });
             // tooltip and entry mask for sysNameTextField will be assigned later by prefixChanged()
-            panel1a.add(labelNumToAdd);
-            panel1a.add(numberToAdd);
+            hardwareAddressPanel.add(labelNumToAdd);
+            hardwareAddressPanel.add(numberToAdd);
             numberToAdd.setToolTipText(Bundle.getMessage("LightNumberToAddHint"));
-            contentPane.add(panel1a);
+            contentPane.add(hardwareAddressPanel);
             JPanel panel2 = new JPanel();
             panel2.setLayout(new FlowLayout());
             panel2.add(userNameLabel);
@@ -630,82 +195,17 @@ public class LightTableAction extends AbstractTableAction<Light> {
             userName.setName("userName"); // for GUI test NOI18N
             prefixBox.setName("prefixBox"); // for GUI test NOI18N
             contentPane.add(panel2);
-            // items for variable intensity lights
-            varPanel = new JPanel();
-            varPanel.setLayout(new BoxLayout(varPanel, BoxLayout.X_AXIS));
-            varPanel.add(new JLabel(" "));
-            varPanel.add(labelMinIntensity);
-            minIntensity.setModel(
-                    new SpinnerNumberModel(Double.valueOf(0.0d), Double.valueOf(0.0d), Double.valueOf(0.99d), Double.valueOf(0.01d))); // 0 - 99%
-            minIntensity.setEditor(new JSpinner.NumberEditor(minIntensity, "##0 %"));
-            minIntensity.setToolTipText(Bundle.getMessage("LightMinIntensityHint"));
-            minIntensity.setValue(0.0d); // reset JSpinner1
-            varPanel.add(minIntensity);
-            varPanel.add(labelMinIntensityTail);
-            varPanel.add(labelMaxIntensity);
-            maxIntensity.setModel(
-                    new SpinnerNumberModel(Double.valueOf(1.0d), Double.valueOf(0.01d), Double.valueOf(1.0d), Double.valueOf(0.01d))); // 100 - 1%
-            maxIntensity.setEditor(new JSpinner.NumberEditor(maxIntensity, "##0 %"));
-            maxIntensity.setToolTipText(Bundle.getMessage("LightMaxIntensityHint"));
-            maxIntensity.setValue(1.0d); // reset JSpinner2
-            varPanel.add(maxIntensity);
-            varPanel.add(labelMaxIntensityTail);
-            varPanel.add(labelTransitionTime);
-            transitionTime.setModel(
-                    new SpinnerNumberModel(Double.valueOf(0d), Double.valueOf(0d), Double.valueOf(1000000d), Double.valueOf(0.01d)));
-            transitionTime.setEditor(new JSpinner.NumberEditor(transitionTime, "###0.00"));
-            transitionTime.setPreferredSize(new JTextField(8).getPreferredSize());
-            transitionTime.setToolTipText(Bundle.getMessage("LightTransitionTimeHint"));
-            transitionTime.setValue(0.0); // reset from possible previous use
-            varPanel.add(transitionTime);
-            varPanel.add(new JLabel(" "));
-            Border varPanelBorder = BorderFactory.createEtchedBorder();
-            Border varPanelTitled = BorderFactory.createTitledBorder(varPanelBorder,
-                    Bundle.getMessage("LightVariableBorder"));
-            varPanel.setBorder(varPanelTitled);
-            contentPane.add(varPanel);
+            lightIntensityPanel = new LightIntensityPane(false);
+            Border varPanelTitled = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+                Bundle.getMessage("LightVariableBorder"));
+            lightIntensityPanel.setBorder(varPanelTitled);
+            contentPane.add(lightIntensityPanel);
             // light control table
-            JPanel panel3 = new JPanel();
-            panel3.setLayout(new BoxLayout(panel3, BoxLayout.Y_AXIS));
-            lightControlTableModel = new LightControlTableModel();
-            JTable lightControlTable = new JTable(lightControlTableModel);
-            lightControlTable.setRowSelectionAllowed(false);
-            lightControlTable.setPreferredScrollableViewportSize(new java.awt.Dimension(600, 100));
-            TableColumnModel lightControlColumnModel = lightControlTable.getColumnModel();
-            TableColumn typeColumn = lightControlColumnModel.getColumn(LightControlTableModel.TYPE_COLUMN);
-            typeColumn.setResizable(true);
-            typeColumn.setMinWidth(130);
-            typeColumn.setMaxWidth(170);
-            TableColumn descriptionColumn = lightControlColumnModel.getColumn(
-                    LightControlTableModel.DESCRIPTION_COLUMN);
-            descriptionColumn.setResizable(true);
-            descriptionColumn.setMinWidth(270);
-            descriptionColumn.setMaxWidth(380);
-            ButtonRenderer buttonRenderer = new ButtonRenderer();
-            lightControlTable.setDefaultRenderer(JButton.class, buttonRenderer);
-            TableCellEditor buttonEditor = new ButtonEditor(new JButton());
-            lightControlTable.setDefaultEditor(JButton.class, buttonEditor);
-            JButton testButton = new JButton(Bundle.getMessage("ButtonDelete"));
-            lightControlTable.setRowHeight(testButton.getPreferredSize().height);
-            TableColumn editColumn = lightControlColumnModel.getColumn(LightControlTableModel.EDIT_COLUMN);
-            editColumn.setResizable(false);
-            editColumn.setMinWidth(testButton.getPreferredSize().width);
-            TableColumn removeColumn = lightControlColumnModel.getColumn(LightControlTableModel.REMOVE_COLUMN);
-            removeColumn.setResizable(false);
-            removeColumn.setMinWidth(testButton.getPreferredSize().width);
-            JScrollPane lightControlTableScrollPane = new JScrollPane(lightControlTable);
-            panel3.add(lightControlTableScrollPane);
-            JPanel panel35 = new JPanel();
-            panel35.setLayout(new FlowLayout());
-            panel35.add(addControl = new JButton(Bundle.getMessage("LightAddControlButton")));
-            addControl.addActionListener(this::addControlPressed);
-            addControl.setToolTipText(Bundle.getMessage("LightAddControlButtonHint"));
-            panel3.add(panel35);
-            Border panel3Border = BorderFactory.createEtchedBorder();
-            Border panel3Titled = BorderFactory.createTitledBorder(panel3Border,
-                    Bundle.getMessage("LightControlBorder"));
-            panel3.setBorder(panel3Titled);
-            contentPane.add(panel3);
+            lightControlPanel = new LightControlPane();
+            Border panel3Titled = BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+                Bundle.getMessage("LightControllerTitlePlural"));
+            lightControlPanel.setBorder(panel3Titled);
+            contentPane.add(lightControlPanel);
             // message items
             JPanel panel4 = new JPanel();
             panel4.setLayout(new BoxLayout(panel4, BoxLayout.Y_AXIS));
@@ -738,11 +238,7 @@ public class LightTableAction extends AbstractTableAction<Light> {
             create.addActionListener(this::createPressed);
             create.setToolTipText(Bundle.getMessage("LightCreateButtonHint"));
             create.setName("createButton"); // for GUI test NOI18N
-            panel5.add(update = new JButton(Bundle.getMessage("ButtonUpdate")));
-            update.addActionListener(this::updatePressed);
-            update.setToolTipText(Bundle.getMessage("LightUpdateButtonHint"));
             create.setVisible(true);
-            update.setVisible(false);
             contentPane.add(panel5);
             hardwareAddressValidator.verify(hardwareAddressTextField);
         }
@@ -766,11 +262,7 @@ public class LightTableAction extends AbstractTableAction<Light> {
 
     protected void prefixChanged() {
         if (prefixBox.getSelectedItem() != null) {
-            if (supportsVariableLights()) {
-                setupVariableDisplay(true, true);
-            } else {
-                varPanel.setVisible(false);
-            }
+            lightIntensityPanel.setVisible(supportsVariableLights());
             // behaves like the AddNewHardwareDevice pane (dim if not available, do not hide)
             addRangeBox.setEnabled(canAddRange());
             addRangeBox.setSelected(false);
@@ -803,17 +295,13 @@ public class LightTableAction extends AbstractTableAction<Light> {
     }
 
     protected void addRangeChanged() {
-        if (addRangeBox.isSelected()) {
-            numberToAdd.setEnabled(true);
-            labelNumToAdd.setEnabled(true);
-        } else {
-            numberToAdd.setEnabled(false);
-            labelNumToAdd.setEnabled(false);
-        }
+        numberToAdd.setEnabled(addRangeBox.isSelected());
+        labelNumToAdd.setEnabled(addRangeBox.isSelected());
     }
 
     /**
      * Activate Add a range option if manager accepts adding more than 1 Light.
+     * TODO: Will only verify against formats which accept "11" as a Hardware address.
      */
     private boolean canAddRange() {
         String testSysName = Objects.requireNonNull(prefixBox.getSelectedItem()).getSystemPrefix() + "L11";
@@ -821,27 +309,10 @@ public class LightTableAction extends AbstractTableAction<Light> {
     }
 
     /**
-     * Set up panel for Variable Options.
-     *
-     * @param showIntensity  true to show light intensity; false otherwise
-     * @param showTransition true to show time light takes to transition between
-     *                       states; false otherwise
-     */
-    void setupVariableDisplay(boolean showIntensity, boolean showTransition) {
-
-        labelMinIntensity.setVisible(showIntensity);
-        minIntensity.setVisible(showIntensity);
-        labelMinIntensityTail.setVisible(showIntensity);
-        labelMaxIntensity.setVisible(showIntensity);
-        maxIntensity.setVisible(showIntensity);
-        labelMaxIntensityTail.setVisible(showIntensity);
-        labelTransitionTime.setVisible(showTransition);
-        transitionTime.setVisible(showTransition);
-        varPanel.setVisible(showIntensity || showTransition);
-    }
-
-    /**
-     * @return true if system can support variable lights
+     * Check if LightManager supports variable Lights.
+     * TODO: Will only verify against formats which accept "11" as a Hardware address.
+     * 
+     * @return true if system can support variable lights.
      */
     boolean supportsVariableLights() {
         String testSysName = Objects.requireNonNull(prefixBox.getSelectedItem()).getSystemPrefix() + "L11";
@@ -1027,28 +498,16 @@ public class LightTableAction extends AbstractTableAction<Light> {
             handleCreateException(ex, suName);
             return; // without creating
         }
-        // set control information if any
-        setLightControlInformation(g);
-        clearLightControlsTable(); // remove all controls from local list
+        lightControlPanel.setLightFromControlTable(g);
+        if (g instanceof VariableLight) {
+            lightIntensityPanel.setLightFromPane((VariableLight)g);
+        }
         g.activateLight();
         lightCreatedOrUpdated = true;
 
         status2.setText("");
         status2.setVisible(false);
-        if (g instanceof VariableLight) {
-            if ((Double) minIntensity.getValue() >= (Double) maxIntensity.getValue()) {
-                log.debug("minInt value entered: {}", minIntensity.getValue());
-                // do not set intensity
-                status2.setText(Bundle.getMessage("LightWarn9"));
-                status2.setVisible(true);
-            } else {
-                ((VariableLight)g).setMinIntensity((Double) minIntensity.getValue());
-                ((VariableLight)g).setMaxIntensity((Double) maxIntensity.getValue());
-            }
-            if (((VariableLight)g).isTransitionAvailable()) {
-                ((VariableLight)g).setTransitionTime((Double) transitionTime.getValue());
-            }
-        }
+        
         // provide feedback to user
         String feedback = Bundle.getMessage("LightCreateFeedback") + " " + g.getDisplayName(DisplayOptions.USERNAME_SYSTEMNAME);
         // create additional lights if requested
@@ -1063,7 +522,12 @@ public class LightTableAction extends AbstractTableAction<Light> {
                 }
                 try {
                     g = lightManager.newLight(sxName, uxName);
-                    // TODO: set up this light the same as the first light?
+                    log.debug("Light {} created",g);
+                    // set up this light the same as the first light
+                    lightControlPanel.setLightFromControlTable(g);
+                    if (g instanceof VariableLight) {
+                        lightIntensityPanel.setLightFromPane((VariableLight)g);
+                    }
                 } catch (IllegalArgumentException ex) {
                     // user input no good
                     handleCreateException(ex, suName);
@@ -1072,94 +536,12 @@ public class LightTableAction extends AbstractTableAction<Light> {
             }
             feedback = feedback + " - " + sxName + ", " + uxName;
         }
+        create.setEnabled(false);
         status1.setText(feedback);
         status1.setForeground(Color.gray);
         cancel.setText(Bundle.getMessage("ButtonClose")); // when Create/Apply has been clicked at least once, this is not Revert/Cancel
         addFrame.pack();
         addFrame.setVisible(true);
-    }
-
-    /**
-     * Respond to the Edit button in the Light table. Panel has already been
-     * created.
-     */
-    void editPressed() {
-        // check if a Light with this name already exists
-        String sName = fixedSystemName.getText();
-        if (sName.isEmpty()) {
-            // Entered system name has invalid format
-            status1.setText(Bundle.getMessage("LightError3"));
-            status1.setForeground(Color.red);
-            status2.setText(Bundle.getMessage("LightError6"));
-            status2.setVisible(true);
-            addFrame.pack();
-            addFrame.setVisible(true);
-            return;
-        }
-        Light g = InstanceManager.getDefault(LightManager.class).getBySystemName(sName);
-        if (g == null) {
-            // check if Light exists under an alternate name if an alternate name exists
-            String altName = InstanceManager.getDefault(LightManager.class).convertSystemNameToAlternate(sName);
-            if (!altName.isEmpty()) {
-                g = InstanceManager.getDefault(LightManager.class).getBySystemName(altName);
-                if (g != null) {
-                    sName = altName;
-                }
-            }
-            if (g == null) {
-                // Light does not exist, so cannot be edited
-                status1.setText(Bundle.getMessage("LightError7"));
-                status1.setForeground(Color.red);
-                status2.setText(Bundle.getMessage("LightError6"));
-                status2.setVisible(true);
-                addFrame.pack();
-                addFrame.setVisible(true);
-                return;
-            }
-        }
-        // Light was found, make its system name not changeable
-        curLight = g;
-        fixedSystemName.setText(sName);
-        fixedSystemName.setVisible(true);
-        prefixBox.setVisible(false);
-        systemNameLabel.setVisible(true);
-        systemLabel.setVisible(false);
-        panel1a.setVisible(false);
-        addRangeBox.setVisible(false);
-        // deactivate this Light
-        curLight.deactivateLight();
-        inEditMode = true;
-        // get information for this Light
-        userName.setText(g.getUserName());
-        clearLightControlsTable(); // remove all controls from local list
-
-        // Get a copy of the LightControl list
-        controlList = new ArrayList<>();
-        curLight.getLightControlList().forEach((lightControlList1) -> controlList.add(new DefaultLightControl(lightControlList1)));
-
-        // variable intensity
-        if (g instanceof VariableLight) {
-            minIntensity.setValue(((VariableLight)g).getMinIntensity()); // displayed as percentage
-            maxIntensity.setValue(((VariableLight)g).getMaxIntensity());
-            if (((VariableLight)g).isTransitionAvailable()) {
-                transitionTime.setValue(((VariableLight)g).getTransitionTime()); // displays i18n decimal separator eg. 0,00 in _nl
-            }
-            setupVariableDisplay(true, ((VariableLight)g).isTransitionAvailable());
-        } else {
-            setupVariableDisplay(false, false);
-        }
-
-        update.setVisible(true);
-        create.setVisible(false);
-        status1.setText(Bundle.getMessage("LightUpdateInst"));
-        status1.setForeground(Color.gray); // reset color
-        status2.setText("");
-        status2.setVisible(false);
-        addFrame.setTitle(Bundle.getMessage("TitleEditLight")); // for edit
-        cancel.setText(Bundle.getMessage("ButtonCancel")); // when Create/Apply has been clicked at least once, this will read Close
-        addFrame.pack();
-        addFrame.setVisible(true);
-        lightControlTableModel.fireTableDataChanged();
     }
 
     void handleCreateException(Exception ex, String sysName) {
@@ -1170,90 +552,16 @@ public class LightTableAction extends AbstractTableAction<Light> {
     }
 
     /**
-     * Respond to the Update button on the Add/Update Light pane. Set Light
-     * configuration from entries in pane.
-     *
-     * @param e the button press action
-     */
-    void updatePressed(ActionEvent e) {
-        Light g = curLight;
-        // Check if the User Name has been changed
-        String uName = userName.getText();
-        if (uName.isEmpty()) {
-            uName = null; // a blank field means no user name
-        }
-        String prevUName = g.getUserName();
-        if ((uName != null) && !(uName.equals(prevUName))) {
-            // user name has changed - check if already in use
-            Light p = InstanceManager.getDefault(LightManager.class).getByUserName(uName);
-            if (p != null) {
-                // Light with this user name already exists
-                status1.setText(Bundle.getMessage("LightError8"));
-                status1.setForeground(Color.red);
-                status2.setText(Bundle.getMessage("LightError9"));
-                status2.setVisible(true);
-                return;
-            }
-            // user name is unique, change it
-            g.setUserName(uName);
-        } else if ((uName == null) && (prevUName != null)) {
-            // user name has been cleared
-            g.setUserName(null);
-        }
-        setLightControlInformation(g);
-        // Variable intensity, transitions
-        if (g instanceof VariableLight) {
-            ((VariableLight)g).setMinIntensity((Double) minIntensity.getValue());
-            ((VariableLight)g).setMaxIntensity((Double) maxIntensity.getValue());
-            if (((VariableLight)g).isTransitionAvailable()) {
-                ((VariableLight)g).setTransitionTime((Double) transitionTime.getValue());
-            }
-        }
-        g.activateLight();
-        lightCreatedOrUpdated = true;
-        cancelPressed(null);
-        status1.setText(Bundle.getMessage("LightUpdateFeedback") + " " + g.getUserName()); //provide some feedback
-        status1.setForeground(Color.gray);
-        cancel.setText("ButtonClose"); // after first Create, the no button cannot cancel 1st addition
-    }
-
-    private void setLightControlInformation(Light g) {
-        if (inEditMode && !lightControlChanged) {
-            return;
-        }
-        g.clearLightControls(); // clear list on Light
-        for (LightControl control : controlList) {
-            control.setParentLight(g);
-            g.addLightControl(control);
-        }
-    }
-
-    /**
      * Respond to the Cancel/Close button on the Add/Edit Light pane.
      *
      * @param e the button press action
      */
     void cancelPressed(ActionEvent e) {
-        if (inEditMode) {
-            // if in Edit mode, cancel the Edit and reactivate the Light
-            status1.setText(Bundle.getMessage("LightCreateInst"));
-            status1.setForeground(Color.gray);
-            update.setVisible(false);
-            create.setVisible(true);
-            fixedSystemName.setVisible(false);
-            prefixBox.setVisible(true);
-            systemNameLabel.setVisible(false);
-            systemLabel.setVisible(true);
-            panel1a.setVisible(true);
-            // reactivate the light, never null here
-            curLight.activateLight();
-            inEditMode = false;
-        }
+
         if (addFrame != null) {
             addFrame.setVisible(false); // hide first for cleaner display
         }
-        clearLightControlsTable(); // remove all controls from local list
-        status2.setText("");
+        
         // remind to save, if Light was created or edited
         if (lightCreatedOrUpdated) {
             InstanceManager.getDefault(jmri.UserPreferencesManager.class).
@@ -1265,691 +573,23 @@ public class LightTableAction extends AbstractTableAction<Light> {
         lightCreatedOrUpdated = false;
         // finally, get rid of the add/edit Frame
         if (addFrame != null) {
+            
+            lightControlPanel.dispose(); // closes any popup windows
+            
             removePrefixBoxListener(prefixBox);
             addFrame.dispose();
             addFrame = null;
             create.removePropertyChangeListener(colorChangeListener);
+            
         }
     }
 
-    private void clearLightControlsTable() {
-        log.debug("Clear LightControls");
-        for (int i = controlList.size(); i > 0; i--) {
-            controlList.remove(i - 1);
-        }
-        lightControlTableModel.fireTableDataChanged();
-    }
 
-    // items for Add/Edit Light Control pane
-    private JmriJFrame addControlFrame = null;
-    private JComboBox<String> typeBox;
-    private final JLabel typeBoxLabel = new JLabel(Bundle.getMessage("LightControlType"));
-    private int defaultControlIndex = Light.NO_CONTROL;
-    private boolean inEditControlMode = false;
-    private LightControl lc = null;
-    private final NamedBeanComboBox<Sensor> sensor1Box = new NamedBeanComboBox<>( // Sensor (1 or only)
-            InstanceManager.sensorManagerInstance(), null, DisplayOptions.DISPLAYNAME);
-    private final NamedBeanComboBox<Sensor> sensor2Box = new NamedBeanComboBox<>( // Sensor 2
-            InstanceManager.sensorManagerInstance(), null, DisplayOptions.DISPLAYNAME);
-
-    private final SpinnerNumberModel fastHourSpinnerModel1 = new SpinnerNumberModel(0, 0, 23, 1); // 0 - 23 h
-    private final JSpinner fastHourSpinner1 = new JSpinner(fastHourSpinnerModel1); // Fast Clock1 hours
-    private final SpinnerNumberModel fastMinuteSpinnerModel1 = new SpinnerNumberModel(0, 0, 59, 1); // 0 - 59 min
-    private final JSpinner fastMinuteSpinner1 = new JSpinner(fastMinuteSpinnerModel1); // Fast Clock1 minutes
-    private final JLabel clockSep1 = new JLabel(" : ");
-
-    private final NamedBeanComboBox<Turnout> turnoutBox = new NamedBeanComboBox<>( // Turnout
-            InstanceManager.turnoutManagerInstance(), null, DisplayOptions.DISPLAYNAME);
-    private final NamedBeanComboBox<Sensor> sensorOnBox = new NamedBeanComboBox<>( // Timed ON
-            InstanceManager.sensorManagerInstance(), null, DisplayOptions.DISPLAYNAME);
-    private final JLabel f1Label = new JLabel(Bundle.getMessage("LightSensor", Bundle.getMessage("MakeLabel", ""))); // for 1 sensor
-    private final JLabel f1aLabel = new JLabel(Bundle.getMessage("LightSensor", Bundle.getMessage("MakeLabel", " 2"))); // for 2nd sensor
-
-    private final SpinnerNumberModel fastHourSpinnerModel2 = new SpinnerNumberModel(0, 0, 23, 1); // 0 - 23 h
-    private final JSpinner fastHourSpinner2 = new JSpinner(fastHourSpinnerModel2); // Fast Clock2 hours
-    private final SpinnerNumberModel fastMinuteSpinnerModel2 = new SpinnerNumberModel(0, 0, 59, 1); // 0 - 59 min
-    private final JSpinner fastMinuteSpinner2 = new JSpinner(fastMinuteSpinnerModel2); // Fast Clock2 minutes
-    private final JLabel clockSep2 = new JLabel(" : ");
-
-    private final SpinnerNumberModel timedOnSpinnerModel = new SpinnerNumberModel(0, 0, 1000000, 1); // 0 - 1,000,000 msec
-    private final JSpinner timedOnSpinner = new JSpinner(timedOnSpinnerModel); // Timed ON
-    private final JLabel f2Label = new JLabel(Bundle.getMessage("LightSensorSense"));
-    private JComboBox<String> stateBox;
-    private ComboBoxToolTipRenderer stateBoxToolTipRenderer;
-    private final int sensorActiveIndex = 0;
-    private final int sensorInactiveIndex = 1;
-    private final int turnoutClosedIndex = 0;
-    private final int turnoutThrownIndex = 1;
-    private JButton createControl;
-    private JButton updateControl;
-    private JButton cancelControl;
-
-    private JPanel panel34;
-
-    /**
-     * Respond to pressing the Add Control button.
-     *
-     * @param e the event containing the press action
-     */
-    protected void addControlPressed(ActionEvent e) {
-        if (inEditControlMode) {
-            // cancel Edit and reactivate the edited light
-            cancelControlPressed(null);
-        }
-        // set up to edit. Use separate Runnable so window is created on top
-        class WindowMaker implements Runnable {
-
-            WindowMaker() {
-            }
-
-            @Override
-            public void run() {
-                addEditControlWindow();
-            }
-        }
-        WindowMaker t = new WindowMaker();
-        javax.swing.SwingUtilities.invokeLater(t);
-    }
-
-    /**
-     * Create the Add/Edit Light Control pane.
-     */
-    private void addEditControlWindow() {
-        if (addControlFrame == null) {
-            addControlFrame = new JmriJFrame(Bundle.getMessage("TitleAddLightControl"), false, true);
-            addControlFrame.addHelpMenu("package.jmri.jmrit.beantable.LightAddEdit", true);
-            addControlFrame.setLocation(120, 40);
-            Container contentPane = addControlFrame.getContentPane();
-            contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
-            JPanel panel3 = new JPanel();
-            panel3.setLayout(new BoxLayout(panel3, BoxLayout.Y_AXIS));
-            JPanel panel31 = new JPanel();
-            panel31.setLayout(new FlowLayout());
-            panel31.add(typeBoxLabel);
-            panel31.add(typeBox = new JComboBox<>(new String[]{
-                noControl,
-                sensorControl,
-                fastClockControl,
-                turnoutStatusControl,
-                timedOnControl,
-                twoSensorControl
-            }));
-
-            ComboBoxToolTipRenderer typeBoxToolTipRenderer = new ComboBoxToolTipRenderer();
-            typeBox.setRenderer(typeBoxToolTipRenderer);
-
-            List<String> typeTooltips = new ArrayList<>();
-            typeTooltips.add(null); // no Control Type selected
-            typeTooltips.add(Bundle.getMessage("LightSensorControlTip"));
-            typeTooltips.add(Bundle.getMessage("LightFastClockControlTip"));
-            typeTooltips.add(Bundle.getMessage("LightTurnoutStatusControlTip",
-                    InstanceManager.turnoutManagerInstance().getClosedText(),
-                    InstanceManager.turnoutManagerInstance().getThrownText()));
-            typeTooltips.add(Bundle.getMessage("LightTimedOnControlTip"));
-            typeTooltips.add(Bundle.getMessage("LightTwoSensorControlTip"));
-            typeBoxToolTipRenderer.setTooltips(typeTooltips);
-
-            typeBox.addActionListener((ActionEvent e) -> controlTypeChanged());
-            typeBox.setToolTipText(Bundle.getMessage("LightControlTypeHint"));
-            JPanel panel32 = new JPanel();
-            panel32.setLayout(new FlowLayout());
-            panel32.add(f1Label);
-            panel32.add(sensor1Box);
-
-            // set up number formatting
-            JSpinner.NumberEditor ne1b = new JSpinner.NumberEditor(fastHourSpinner1, "00"); // 2 digits "01" format
-            fastHourSpinner1.setEditor(ne1b);
-            panel32.add(fastHourSpinner1);  // hours ON
-            panel32.add(clockSep1);
-            JSpinner.NumberEditor ne1b1 = new JSpinner.NumberEditor(fastMinuteSpinner1, "00"); // 2 digits "01" format
-            fastMinuteSpinner1.setEditor(ne1b1);
-            panel32.add(fastMinuteSpinner1); // minutes ON
-            panel32.add(turnoutBox);
-            panel32.add(sensorOnBox);
-
-            sensor1Box.setAllowNull(true);
-            sensor1Box.setToolTipText(Bundle.getMessage("LightSensorHint"));
-
-            sensor2Box.setAllowNull(true);
-            sensor2Box.setToolTipText(Bundle.getMessage("LightTwoSensorHint"));
-
-            fastHourSpinner1.setValue(0);  // reset needed
-            fastHourSpinner1.setVisible(false);
-            fastMinuteSpinner1.setValue(0); // reset needed
-            fastMinuteSpinner1.setVisible(false);
-
-            sensorOnBox.setAllowNull(true);
-            sensorOnBox.setVisible(false);
-            clockSep1.setVisible(false);
-
-            turnoutBox.setAllowNull(true);
-            turnoutBox.setVisible(false);
-
-            panel34 = new JPanel();
-            panel34.setLayout(new FlowLayout());
-            panel34.add(f1aLabel);
-            panel34.add(sensor2Box);
-
-            JPanel panel33 = new JPanel();
-            panel33.setLayout(new FlowLayout());
-
-            panel33.add(f2Label);
-            panel33.add(stateBox = new JComboBox<>(new String[]{
-                Bundle.getMessage("SensorStateActive"), Bundle.getMessage("SensorStateInactive"),}));
-            stateBox.setToolTipText(Bundle.getMessage("LightSensorSenseHint"));
-            stateBoxToolTipRenderer = new ComboBoxToolTipRenderer();
-            stateBox.setRenderer(stateBoxToolTipRenderer);
-
-            JSpinner.NumberEditor ne2a = new JSpinner.NumberEditor(fastHourSpinner2, "00"); // 2 digits "01" format
-            fastHourSpinner2.setEditor(ne2a);
-            panel33.add(fastHourSpinner2);  // hours OFF
-            panel33.add(clockSep2);
-            JSpinner.NumberEditor ne2a1 = new JSpinner.NumberEditor(fastMinuteSpinner2, "00"); // 2 digits "01" format
-            fastMinuteSpinner2.setEditor(ne2a1);
-            panel33.add(fastMinuteSpinner2); // minutes OFF
-            panel33.add(timedOnSpinner);
-
-            fastHourSpinner2.setValue(0);  // reset needed
-            fastHourSpinner2.setVisible(false);
-            fastMinuteSpinner2.setValue(0); // reset needed
-            fastMinuteSpinner2.setVisible(false);
-
-            timedOnSpinner.setValue(5000);  // reset needed, default to 5,000 ms
-            timedOnSpinner.setVisible(false);
-            clockSep2.setVisible(false);
-
-            panel3.add(panel31);
-            panel3.add(panel32);
-            panel3.add(panel34);
-            panel3.add(panel33);
-            Border panel3Border = BorderFactory.createEtchedBorder();
-            panel3.setBorder(panel3Border);
-            contentPane.add(panel3);
-            JPanel panel5 = new JPanel();
-            panel5.setLayout(new FlowLayout(FlowLayout.TRAILING));
-            panel5.add(cancelControl = new JButton(Bundle.getMessage("ButtonCancel")));
-            cancelControl.addActionListener(this::cancelControlPressed);
-            cancelControl.setToolTipText(Bundle.getMessage("LightCancelButtonHint"));
-            panel5.add(createControl = new JButton(Bundle.getMessage("ButtonCreate")));
-            createControl.addActionListener(this::createControlPressed);
-            createControl.setToolTipText(Bundle.getMessage("LightCreateControlButtonHint"));
-            panel5.add(updateControl = new JButton(Bundle.getMessage("ButtonUpdate")));
-            updateControl.addActionListener(this::updateControlPressed);
-            updateControl.setToolTipText(Bundle.getMessage("LightUpdateControlButtonHint"));
-            cancelControl.setVisible(true);
-            updateControl.setVisible(false);
-            createControl.setVisible(true);
-            contentPane.add(panel5);
-            addControlFrame.addWindowListener(new java.awt.event.WindowAdapter() {
-                @Override
-                public void windowClosing(java.awt.event.WindowEvent e) {
-                    cancelControlPressed(null);
-                }
-            });
-        }
-        typeBox.setSelectedIndex(defaultControlIndex); // force GUI status consistent
-        addControlFrame.pack();
-        addControlFrame.setVisible(true);
-    }
-
-    /**
-     * Reacts to a control type change.
-     */
-    private void controlTypeChanged() {
-        setUpControlType(typeBox.getSelectedIndex());
-
-    }
-
-    /**
-     * Set the Control Information according to control type.
-     *
-     * @param ctype the control type
-     */
-    private void setUpControlType(int ctype) {
-        // set everything non-visible by default
-        clockSep1.setVisible(false);
-        clockSep2.setVisible(false);
-        fastHourSpinner1.setVisible(false);
-        fastHourSpinner2.setVisible(false);
-        fastMinuteSpinner1.setVisible(false);
-        fastMinuteSpinner2.setVisible(false);
-        f1aLabel.setVisible(false);
-        sensorOnBox.setVisible(false);
-        sensor1Box.setVisible(false);
-        sensor2Box.setVisible(false);
-        stateBox.setVisible(false);
-        timedOnSpinner.setVisible(false);
-        turnoutBox.setVisible(false);
-        panel34.setVisible(false);
-        typeBox.setSelectedIndex(ctype);
-        createControl.setEnabled(true);
-        updateControl.setEnabled(true);
-
-        if (ctype == Light.SENSOR_CONTROL) {
-            // set up panel for sensor control
-            f1Label.setText(Bundle.getMessage("LightSensor", Bundle.getMessage("MakeLabel", ""))); // insert nothing before colon
-            sensor1Box.setToolTipText(Bundle.getMessage("LightSensorHint"));
-            f2Label.setText(Bundle.getMessage("LightSensorSense"));
-            stateBox.removeAllItems();
-            stateBox.addItem(Bundle.getMessage("SensorStateActive"));
-            stateBox.addItem(Bundle.getMessage("SensorStateInactive"));
-            List<String> stateTooltips = new ArrayList<>();
-            stateTooltips.add(Bundle.getMessage("LightSensorSenseActivTip"));
-            stateTooltips.add(Bundle.getMessage("LightSensorSenseInactivTip"));
-            stateBoxToolTipRenderer.setTooltips(stateTooltips);
-            stateBox.setToolTipText(Bundle.getMessage("LightSensorSenseHint"));
-            f2Label.setVisible(true);
-            sensor1Box.setVisible(true);
-            stateBox.setVisible(true);
-            defaultControlIndex = Light.SENSOR_CONTROL;
-        } else if (ctype == Light.FAST_CLOCK_CONTROL) {
-            // set up panel for fast clock control
-            f1Label.setText(Bundle.getMessage("LightScheduleOn"));
-            fastHourSpinner1.setToolTipText(Bundle.getMessage("LightScheduleHint"));
-            fastMinuteSpinner1.setToolTipText(Bundle.getMessage("LightScheduleHintMinutes"));
-            f2Label.setText(Bundle.getMessage("LightScheduleOff"));
-            fastHourSpinner2.setToolTipText(Bundle.getMessage("LightScheduleHint"));
-            fastMinuteSpinner2.setToolTipText(Bundle.getMessage("LightScheduleHintMinutes"));
-            clockSep1.setVisible(true);
-            clockSep2.setVisible(true);
-            fastHourSpinner1.setVisible(true);
-            fastHourSpinner2.setVisible(true);
-            fastMinuteSpinner1.setVisible(true);
-            fastMinuteSpinner2.setVisible(true);
-            f2Label.setVisible(true);
-            defaultControlIndex = Light.FAST_CLOCK_CONTROL;
-        } else if (ctype == Light.TURNOUT_STATUS_CONTROL) {
-            // set up panel for turnout status control
-            f1Label.setText(Bundle.getMessage("LightTurnout"));
-            turnoutBox.setToolTipText(Bundle.getMessage("LightTurnoutHint"));
-            f2Label.setText(Bundle.getMessage("LightTurnoutSense"));
-            stateBox.removeAllItems();
-            stateBox.addItem(InstanceManager.turnoutManagerInstance().getClosedText());
-            stateBox.addItem(InstanceManager.turnoutManagerInstance().getThrownText());
-            stateBox.setToolTipText(Bundle.getMessage("LightTurnoutSenseHint"));
-            List<String> stateTooltips = new ArrayList<>();
-            stateTooltips.add(Bundle.getMessage("LightConToClosedOrThrownTip",
-                    InstanceManager.turnoutManagerInstance().getClosedText(),
-                    InstanceManager.turnoutManagerInstance().getThrownText()));
-            stateTooltips.add(Bundle.getMessage("LightConToClosedOrThrownTip",
-                    InstanceManager.turnoutManagerInstance().getThrownText(),
-                    InstanceManager.turnoutManagerInstance().getClosedText()));
-            stateBoxToolTipRenderer.setTooltips(stateTooltips);
-            f2Label.setVisible(true);
-            turnoutBox.setVisible(true);
-            stateBox.setVisible(true);
-            defaultControlIndex = Light.TURNOUT_STATUS_CONTROL;
-        } else if (ctype == Light.TIMED_ON_CONTROL) {
-            // set up panel for sensor control
-            f1Label.setText(Bundle.getMessage("LightTimedSensor"));
-            sensorOnBox.setToolTipText(Bundle.getMessage("LightTimedSensorHint"));
-            f2Label.setText(Bundle.getMessage("LightTimedDurationOn"));
-            timedOnSpinner.setToolTipText(Bundle.getMessage("LightTimedDurationOnHint"));
-            f2Label.setVisible(true);
-            sensorOnBox.setVisible(true);
-            timedOnSpinner.setVisible(true);
-            defaultControlIndex = Light.TIMED_ON_CONTROL;
-        } else if (ctype == Light.TWO_SENSOR_CONTROL) {
-            // set up panel for two sensor control
-            panel34.setVisible(true);
-            f1Label.setText(Bundle.getMessage("LightSensor", " " + Bundle.getMessage("MakeLabel", "1"))); // for 2-sensor use, insert number "1" before colon
-            f1aLabel.setVisible(true);
-            sensor1Box.setToolTipText(Bundle.getMessage("LightSensorHint"));
-            f2Label.setText(Bundle.getMessage("LightSensorSense"));
-            stateBox.removeAllItems();
-            stateBox.addItem(Bundle.getMessage("SensorStateActive"));
-            stateBox.addItem(Bundle.getMessage("SensorStateInactive"));
-            stateBox.setToolTipText(Bundle.getMessage("LightSensorSenseHint"));
-
-            List<String> stateTooltips = new ArrayList<>();
-            stateTooltips.add(Bundle.getMessage("Light2SensorSenseActivTip"));
-            stateTooltips.add(Bundle.getMessage("Light2SensorSenseInactivTip"));
-            stateBoxToolTipRenderer.setTooltips(stateTooltips);
-
-            f2Label.setVisible(true);
-            sensor1Box.setVisible(true);
-            sensor2Box.setVisible(true);
-            sensor1Box.setToolTipText(Bundle.getMessage("LightTwoSensorHint"));
-            stateBox.setVisible(true);
-            defaultControlIndex = Light.TWO_SENSOR_CONTROL;
-        } else if (ctype == Light.NO_CONTROL) {
-            // set up panel for no control
-            f1Label.setText(Bundle.getMessage("LightNoneSelected"));
-            defaultControlIndex = Light.NO_CONTROL;
-            f2Label.setVisible(false);
-            createControl.setEnabled(false);
-            updateControl.setEnabled(false);
-        } else {
-            log.error("Unexpected control type in controlTypeChanged: {}", ctype);
-        }
-        addControlFrame.pack();
-        addControlFrame.setVisible(true);
-    }
-
-    protected void createControlPressed(ActionEvent e) {
-        if (Objects.equals(typeBox.getSelectedItem(), noControl)) {
-            return;
-        }
-        try {
-
-            fastHourSpinner1.commitEdit();
-            fastHourSpinner2.commitEdit();
-            fastMinuteSpinner1.commitEdit();
-            fastMinuteSpinner2.commitEdit();
-            timedOnSpinner.commitEdit();
-        } catch (java.text.ParseException pe) {
-            // unlikely to be thrown as values set to original if incorrect on commitEdit()
-            log.error("Incorrect value found in a Time: ", pe);
-            return;
-        }
-        lc = new DefaultLightControl();
-        if (setControlInformation(lc,controlList)) {
-            controlList.add(lc);
-            lightControlChanged = true;
-            lightControlTableModel.fireTableDataChanged();
-            cancelControlPressed(e);
-        } else {
-            try { // prevent NPE when addFrame has been closed before AddControlPane is closed
-                addFrame.pack();
-            } catch (NullPointerException npe) {
-                log.error("addFrame not found");
-            }
-            addControlFrame.setVisible(true);
-        }
-    }
-
-    protected void updateControlPressed(ActionEvent e) {
-        try {
-            fastHourSpinner1.commitEdit();
-            fastHourSpinner2.commitEdit();
-            fastMinuteSpinner1.commitEdit();
-            fastMinuteSpinner2.commitEdit();
-            timedOnSpinner.commitEdit();
-        } catch (java.text.ParseException pe) {
-            // unlikely to be thrown as values set to original if incorrect on commitEdit()
-            log.error("Incorrect value found in a FastClock Time: ", pe);
-            return;
-        }
-        if (setControlInformation(lc,controlList)) {
-            lightControlChanged = true;
-            lightControlTableModel.fireTableDataChanged();
-            cancelControlPressed(e);
-        } else {
-            try { // prevent NPE when addFrame has been closed before AddControlPane is closed
-                addFrame.pack();
-            } catch (NullPointerException npe) {
-                log.error("addFrame not found");
-            }
-            addControlFrame.setVisible(true);
-        }
-    }
-
-    protected void cancelControlPressed(ActionEvent e) {
-        if (inEditControlMode) {
-            inEditControlMode = false;
-        }
-        if (inEditMode) {
-            status1.setText(Bundle.getMessage("LightUpdateInst"));
-        } else {
-            status1.setText(Bundle.getMessage("LightCreateInst"));
-        }
-        status1.setForeground(Color.gray);
-        status2.setText("");
-        status2.setVisible(false);
-        try { // prevent NPE when addFrame has been closed before AddControlPane is closed
-            addFrame.pack();
-            addFrame.setVisible(true);
-        } catch (NullPointerException npe) {
-            log.error("frame not found");
-        }
-        addControlFrame.setVisible(false);
-        addControlFrame.dispose();
-        addControlFrame = null;
-    }
-
-    /**
-     * Retrieve control information from pane and update Light Control.
-     *
-     * @return 'true' if no errors or warnings
-     */
-    private boolean setControlInformation(LightControl g, ArrayList<LightControl> currentList) {
-        // Get control information
-        if (sensorControl.equals(typeBox.getSelectedItem())) {
-            // Set type of control
-            g.setControlType(Light.SENSOR_CONTROL);
-            // Get sensor control information
-            Sensor s = null;
-            String sensorName = sensor1Box.getSelectedItemDisplayName();
-            if (sensorName == null) {
-                // no sensor selected
-                g.setControlType(Light.NO_CONTROL);
-                status1.setText(Bundle.getMessage("LightWarn8"));
-                status1.setForeground(Color.gray);
-            } else {
-                // name was selected, check for user name first
-                s = InstanceManager.sensorManagerInstance().
-                        getByUserName(sensorName);
-                if (s == null) {
-                    // not user name, try system name
-                    s = InstanceManager.sensorManagerInstance().
-                            getBySystemName(sensorName);
-                    if (s != null) {
-                        // update sensor system name in case it changed
-                        sensorName = s.getSystemName();
-                        sensor1Box.setSelectedItem(s);
-                    }
-                }
-            }
-            int sState = Sensor.ACTIVE;
-            if (Objects.equals(stateBox.getSelectedItem(), Bundle.getMessage("SensorStateInactive"))) {
-                sState = Sensor.INACTIVE;
-            }
-            g.setControlSensorName(sensorName);
-            g.setControlSensorSense(sState);
-            if (s == null) {
-                status1.setText(Bundle.getMessage("LightWarn1"));
-                status1.setForeground(Color.red);
-                return (false);
-            }
-        } else if (fastClockControl.equals(typeBox.getSelectedItem())) {
-            // Set type of control
-            g.setControlType(Light.FAST_CLOCK_CONTROL);
-            // read and parse the hours and minutes in the 2 x 2 spinners
-            int onHour = (Integer) fastHourSpinner1.getValue();  // hours
-            int onMin = (Integer) fastMinuteSpinner1.getValue();  // minutes
-            int offHour = (Integer) fastHourSpinner2.getValue(); // hours
-            int offMin = (Integer) fastMinuteSpinner2.getValue(); // minutes
-
-            g.setFastClockControlSchedule(onHour, onMin, offHour, offMin);
-
-            if (g.onOffTimesFaulty()) {
-                status1.setText(Bundle.getMessage("LightWarn11"));
-                status1.setForeground(Color.red);
-                return false;
-            }
-
-            if (g.areFollowerTimesFaulty(currentList)) {
-                status1.setText(Bundle.getMessage("LightWarn12"));
-                status1.setForeground(Color.red);
-                return false;
-            }
-
-        } else if (turnoutStatusControl.equals(typeBox.getSelectedItem())) {
-            boolean error = false;
-            Turnout t = null;
-            // Set type of control
-            g.setControlType(Light.TURNOUT_STATUS_CONTROL);
-            // Get turnout control information
-            String turnoutName = turnoutBox.getSelectedItemSystemName();
-            if (turnoutName == null) {
-                // no turnout selected
-                g.setControlType(Light.NO_CONTROL);
-                status1.setText(Bundle.getMessage("LightWarn10"));
-                status1.setForeground(Color.gray);
-            } else {
-                // Ensure that this Turnout is not already a Light
-                String prefix = Objects.requireNonNull(prefixBox.getSelectedItem()).getSystemPrefix();
-                if (turnoutName.charAt(prefix.length()) == 'T') {
-                    // must be a standard format name (not just a number)
-                    String testSN = prefix + "L"
-                            + turnoutName.substring(prefix.length() + 1);
-                    Light testLight = InstanceManager.getDefault(LightManager.class).
-                            getBySystemName(testSN);
-                    if (testLight != null) {
-                        // Requested turnout bit is already assigned to a Light
-                        status2.setText(Bundle.getMessage("LightWarn3") + " " + testSN + ".");
-                        status2.setVisible(true);
-                        error = true;
-                    }
-                }
-                if (!error) {
-                    // Requested turnout bit is not assigned to a Light
-                    t = InstanceManager.turnoutManagerInstance().
-                            getByUserName(turnoutName);
-                    if (t == null) {
-                        // not user name, try system name
-                        t = InstanceManager.turnoutManagerInstance().
-                                getBySystemName(turnoutName);
-                        if (t != null) {
-                            // update turnout system name in case it changed
-                            turnoutName = t.getSystemName();
-                            turnoutBox.setSelectedItem(t);
-                        }
-                    }
-                }
-            }
-            // Initialize the requested Turnout State
-            int tState = Turnout.CLOSED;
-            if (Objects.equals(stateBox.getSelectedItem(), InstanceManager.
-                    turnoutManagerInstance().getThrownText())) {
-                tState = Turnout.THROWN;
-            }
-            g.setControlTurnout(turnoutName);
-            g.setControlTurnoutState(tState);
-            if (t == null) {
-                status1.setText(Bundle.getMessage("LightWarn2"));
-                status1.setForeground(Color.red);
-                return (false);
-            }
-        } else if (timedOnControl.equals(typeBox.getSelectedItem())) {
-            Sensor s = null;
-            // Set type of control
-            g.setControlType(Light.TIMED_ON_CONTROL);
-            // Get trigger sensor control information
-            String triggerSensorName = sensorOnBox.getSelectedItemDisplayName();
-            if (triggerSensorName == null) {
-                // Trigger sensor not selected
-                g.setControlType(Light.NO_CONTROL);
-                status1.setText(Bundle.getMessage("LightWarn8"));
-                status1.setForeground(Color.gray);
-            } else {
-                // sensor was selected, try user name first
-                s = InstanceManager.sensorManagerInstance().getByUserName(triggerSensorName);
-                if (s == null) {
-                    // not user name, try system name
-                    s = InstanceManager.sensorManagerInstance().
-                            getBySystemName(triggerSensorName);
-                    if (s != null) {
-                        // update sensor system name in case it changed
-                        triggerSensorName = s.getSystemName();
-                        sensorOnBox.setSelectedItem(s);
-                    }
-                }
-            }
-            g.setControlTimedOnSensorName(triggerSensorName);
-            int dur = (Integer) timedOnSpinner.getValue();
-            g.setTimedOnDuration(dur);
-            if (s == null) {
-                status1.setText(Bundle.getMessage("LightWarn8"));
-                status1.setForeground(Color.red);
-                return (false);
-            }
-        } else if (twoSensorControl.equals(typeBox.getSelectedItem())) {
-            Sensor s = null;
-            Sensor s2;
-            // Set type of control
-            g.setControlType(Light.TWO_SENSOR_CONTROL);
-            // Get sensor control information
-            String sensorName = sensor1Box.getSelectedItemDisplayName();
-            String sensor2Name = sensor2Box.getSelectedItemDisplayName();
-            if (sensorName == null || sensor2Name == null) {
-                // no sensor(s) selected
-                g.setControlType(Light.NO_CONTROL);
-                status1.setText(Bundle.getMessage("LightWarn8"));
-                status1.setForeground(Color.gray);
-            } else {
-                // name was selected, check for user name first
-                s = InstanceManager.sensorManagerInstance().
-                        getByUserName(sensorName);
-                if (s == null) {
-                    // not user name, try system name
-                    s = InstanceManager.sensorManagerInstance().
-                            getBySystemName(sensorName);
-                    if (s != null) {
-                        // update sensor system name in case it changed
-                        sensorName = s.getSystemName();
-                        sensor1Box.setSelectedItem(s);
-                    }
-                }
-                s2 = InstanceManager.sensorManagerInstance().
-                        getByUserName(sensor2Name);
-                if (s2 == null) {
-                    // not user name, try system name
-                    s2 = InstanceManager.sensorManagerInstance().
-                            getBySystemName(sensor2Name);
-                    if (s2 != null) {
-                        // update sensor system name in case it changed
-                        sensor2Name = s2.getSystemName();
-                        sensor2Box.setSelectedItem(s2);
-                    }
-                }
-            }
-            int sState = Sensor.ACTIVE;
-            if (Objects.equals(stateBox.getSelectedItem(), Bundle.getMessage("SensorStateInactive"))) {
-                sState = Sensor.INACTIVE;
-            }
-            g.setControlSensorName(sensorName);
-            g.setControlSensor2Name(sensor2Name);
-            g.setControlSensorSense(sState);
-            if (s == null) {
-                status1.setText(Bundle.getMessage("LightWarn1"));
-                status1.setForeground(Color.red);
-                return (false);
-            }
-        } else if (noControl.equals(typeBox.getSelectedItem())) {
-            // Set type of control
-            g.setControlType(Light.NO_CONTROL);
-        } else {
-            log.error("Unexpected control type: {}", typeBox.getSelectedItem());
-        }
-        return (true);
-    }
-
-    /**
-     * Get text showing the type of Light Control.
-     *
-     * @param type the type of Light Control
-     * @return name of type or the description for {@link jmri.Light#NO_CONTROL}
-     *         if type is not recognized
-     */
-    public static String getControlTypeText(int type) {
-        switch (type) {
-            case Light.SENSOR_CONTROL:
-                return sensorControl;
-            case Light.FAST_CLOCK_CONTROL:
-                return fastClockControl;
-            case Light.TURNOUT_STATUS_CONTROL:
-                return turnoutStatusControl;
-            case Light.TIMED_ON_CONTROL:
-                return timedOnControl;
-            case Light.TWO_SENSOR_CONTROL:
-                return twoSensorControl;
-            case Light.NO_CONTROL:
-            default:
-                return noControl;
-        }
-    }
-
+    // TODO: Move the next few static String methods to more appropriate place.
+    // LightControl.java ?  Multiple Bundle property files will need changing.
+    
+    public static String lightControlTitle = Bundle.getMessage("LightControlBorder");
+    
     /**
      * Get the description of the type of Light Control.
      *
@@ -1989,242 +629,6 @@ public class LightTableAction extends AbstractTableAction<Light> {
             return InstanceManager.turnoutManagerInstance().getClosedText();
         }
         return InstanceManager.turnoutManagerInstance().getThrownText();
-    }
-
-    /**
-     * Respond to Edit button on row in the Light Control Table.
-     *
-     * @param row the row containing the pressed button
-     */
-    protected void editControlAction(int row) {
-        lc = controlList.get(row);
-        if (lc == null) {
-            log.error("Invalid light control edit specified");
-            return;
-        }
-        inEditControlMode = true;
-        addEditControlWindow();
-        int ctType = lc.getControlType();
-        switch (ctType) {
-            case Light.SENSOR_CONTROL:
-                setUpControlType(Light.SENSOR_CONTROL);
-                sensor1Box.setSelectedItemByName(lc.getControlSensorName());
-                stateBox.setSelectedIndex(sensorActiveIndex);
-                if (lc.getControlSensorSense() == Sensor.INACTIVE) {
-                    stateBox.setSelectedIndex(sensorInactiveIndex);
-                }
-                break;
-            case Light.FAST_CLOCK_CONTROL:
-                setUpControlType(Light.FAST_CLOCK_CONTROL);
-                int onHour = lc.getFastClockOnHour();
-                int onMin = lc.getFastClockOnMin();
-                int offHour = lc.getFastClockOffHour();
-                int offMin = lc.getFastClockOffMin();
-                fastHourSpinner1.setValue(onHour);
-                fastMinuteSpinner1.setValue(onMin);
-                fastHourSpinner2.setValue(offHour);
-                fastMinuteSpinner2.setValue(offMin);
-                break;
-            case Light.TURNOUT_STATUS_CONTROL:
-                setUpControlType(Light.TURNOUT_STATUS_CONTROL);
-                turnoutBox.setSelectedItemByName(lc.getControlTurnoutName());
-                stateBox.setSelectedIndex(turnoutClosedIndex);
-                if (lc.getControlTurnoutState() == Turnout.THROWN) {
-                    stateBox.setSelectedIndex(turnoutThrownIndex);
-                }
-                break;
-            case Light.TIMED_ON_CONTROL:
-                setUpControlType(Light.TIMED_ON_CONTROL);
-                int duration = lc.getTimedOnDuration();
-                sensorOnBox.setSelectedItemByName(lc.getControlTimedOnSensorName());
-                timedOnSpinner.setValue(duration);
-                break;
-            case Light.TWO_SENSOR_CONTROL:
-                setUpControlType(Light.TWO_SENSOR_CONTROL);
-                sensor1Box.setSelectedItemByName(lc.getControlSensorName());
-                sensor2Box.setSelectedItemByName(lc.getControlSensor2Name());
-                stateBox.setSelectedIndex(sensorActiveIndex);
-                if (lc.getControlSensorSense() == Sensor.INACTIVE) {
-                    stateBox.setSelectedIndex(sensorInactiveIndex);
-                }
-                break;
-            case Light.NO_CONTROL:
-                // Set up as "None"
-                setUpControlType(Light.NO_CONTROL);
-                break;
-            default:
-                log.error("Unhandled light control type: {}", ctType);
-                break;
-        }
-        updateControl.setVisible(true);
-        createControl.setVisible(false);
-        addControlFrame.setTitle(Bundle.getMessage("TitleEditLightControl"));
-        addControlFrame.pack();
-        addControlFrame.setVisible(true);
-    }
-
-    /**
-     * Respond to Delete button on row in the Light Control Table.
-     *
-     * @param row the row containing the pressed button
-     */
-    protected void deleteControlAction(int row) {
-        controlList.remove(row);
-        lightControlTableModel.fireTableDataChanged();
-        lightControlChanged = true;
-    }
-
-    /**
-     * Table model for Light Controls in the Add/Edit Light window.
-     */
-    public class LightControlTableModel extends javax.swing.table.AbstractTableModel implements
-            java.beans.PropertyChangeListener {
-
-        public static final int TYPE_COLUMN = 0;
-        public static final int DESCRIPTION_COLUMN = 1;
-        public static final int EDIT_COLUMN = 2;
-        public static final int REMOVE_COLUMN = 3;
-
-        public LightControlTableModel() {
-            super();
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public void propertyChange(java.beans.PropertyChangeEvent e) {
-            if (e.getPropertyName().equals("length")) {
-                // a new LightControl item is available in the manager
-                fireTableDataChanged();
-            }
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public Class<?> getColumnClass(int c) {
-            switch (c) {
-                case EDIT_COLUMN:
-                case REMOVE_COLUMN:
-                    return JButton.class;
-                case TYPE_COLUMN:
-                case DESCRIPTION_COLUMN:
-                default:
-                    return String.class;
-            }
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public int getColumnCount() {
-            return REMOVE_COLUMN + 1;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public int getRowCount() {
-            return (controlList.size());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean isCellEditable(int r, int c) {
-            switch (c) {
-                case EDIT_COLUMN:
-                case REMOVE_COLUMN:
-                    return true;
-                case TYPE_COLUMN:
-                case DESCRIPTION_COLUMN:
-                default:
-                    return false;
-            }
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String getColumnName(int col) {
-            if (col == TYPE_COLUMN) {
-                return Bundle.getMessage("LightControlType");
-            } else if (col == DESCRIPTION_COLUMN) {
-                return Bundle.getMessage("LightControlDescription");
-            }
-            return "";
-        }
-
-        public int getPreferredWidth(int col) {
-            switch (col) {
-                case TYPE_COLUMN:
-                    return new JTextField(20).getPreferredSize().width;
-                case DESCRIPTION_COLUMN:
-                    return new JTextField(70).getPreferredSize().width;
-                case EDIT_COLUMN:
-                    return new JButton(Bundle.getMessage("ButtonEdit")).getPreferredSize().width+4;
-                case REMOVE_COLUMN:
-                    default:
-                    return new JTextField(8).getPreferredSize().width;
-            }
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public Object getValueAt(int r, int c) {
-            if (r > controlList.size()) {
-                return null;
-            }
-            LightControl lc = controlList.get(r);
-            switch (c) {
-                case TYPE_COLUMN:
-                    return (getControlTypeText(lc.getControlType()));
-                case DESCRIPTION_COLUMN:
-                    return (getDescriptionText(lc, lc.getControlType()));
-                case EDIT_COLUMN:
-                    return Bundle.getMessage("ButtonEdit");
-                case REMOVE_COLUMN:
-                    return Bundle.getMessage("ButtonDelete");
-                default:
-                    return "";
-            }
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public void setValueAt(Object value, int row, int col) {
-            if (col == EDIT_COLUMN) {
-                // set up to edit. Use separate Runnable so window is created on top
-                class WindowMaker implements Runnable {
-
-                    WindowMaker(int _row) {
-                        row = _row;
-                    }
-                    final int row;
-
-
-                    @Override
-                    public void run() {
-                        editControlAction(row);
-                    }
-                }
-                WindowMaker t = new WindowMaker(row);
-                javax.swing.SwingUtilities.invokeLater(t);
-            }
-            else if (col == REMOVE_COLUMN) {
-                deleteControlAction(row);
-            }
-        }
     }
 
     /**

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -241,7 +241,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
              * @param bean of the Logix to delete
              */
             @Override
-            void doDelete(Logix bean) {
+            protected void doDelete(Logix bean) {
                 bean.deActivateLogix();
                 // delete the Logix and all its Conditionals
                 _logixManager.deleteLogix(bean);

--- a/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
@@ -266,7 +266,7 @@ public class SignalGroupTableAction extends AbstractTableAction<SignalGroup> imp
              * it.
              */
             @Override
-            void doDelete(SignalGroup bean) {
+            protected void doDelete(SignalGroup bean) {
                 //((SignalGroup)bean).deActivateSignalGroup();
                 super.doDelete(bean);
             }

--- a/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
@@ -8,39 +8,21 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
-import javax.swing.AbstractAction;
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JColorChooser;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
-import javax.swing.JTabbedPane;
-import javax.swing.JTable;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
-import javax.swing.JTextPane;
-import javax.swing.ListSelectionModel;
+
+import javax.annotation.OverridingMethodsMustInvokeSuper;
+import javax.swing.*;
 import javax.swing.table.AbstractTableModel;
 
-import jmri.InstanceManager;
-import jmri.NamedBean;
-import jmri.NamedBeanHandleManager;
+import jmri.*;
 import jmri.NamedBean.DisplayOptions;
 import jmri.jmrit.display.layoutEditor.LayoutBlock;
 import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 import jmri.util.JmriJFrame;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,10 +57,17 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         basicDetails();
     }
 
+    /**
+     * Initialise panels to be at start of Tabbed Panel menu.
+     * Default empty.
+     */
     protected void initPanelsFirst() {
-
     }
 
+    /**
+     * Initialise panels to be at end of Tabbed Panel menu.
+     * Startup usage details and Properties.
+     */
     protected void initPanelsLast() {
         usageDetails();
         propertiesDetails();
@@ -124,6 +113,11 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         return basic;
     }
 
+    /**
+     * Create a generic panel that holds Bean usage details.
+     *
+     * @return a new panel
+     */
     BeanItemPanel usageDetails() {
         BeanItemPanel usage = new BeanItemPanel();
 
@@ -132,7 +126,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
 
         usage.addItem(new BeanEditItem(null, null, Bundle.getMessage("UsageText", bean.getDisplayName())));
 
-        ArrayList<String> listeners = new ArrayList<String>();
+        ArrayList<String> listeners = new ArrayList<>();
         for (String ref : bean.getListenerRefs()) {
             if (!listeners.contains(ref)) {
                 listeners.add(ref);
@@ -141,7 +135,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
 
         Object[] strArray = new Object[listeners.size()];
         listeners.toArray(strArray);
-        JList<Object> list = new JList<Object>(strArray);
+        JList<Object> list = new JList<>(strArray);
         list.setLayoutOrientation(JList.VERTICAL);
         list.setVisibleRowCount(-1);
         list.setSelectionMode(ListSelectionModel.SINGLE_INTERVAL_SELECTION);
@@ -153,8 +147,13 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         bei.add(usage);
         return usage;
     }
-    BeanPropertiesTableModel<B> propertiesModel;
+    private BeanPropertiesTableModel<B> propertiesModel;
 
+    /**
+     * Create a generic panel that holds Bean Property details.
+     *
+     * @return a new panel
+     */
     BeanItemPanel propertiesDetails() {
         BeanItemPanel properties = new BeanItemPanel();
         properties.setName(Bundle.getMessage("Properties"));
@@ -186,12 +185,13 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         return properties;
     }
 
+    @OverridingMethodsMustInvokeSuper
     protected void saveBasicItems(ActionEvent e) {
         String uname = bean.getUserName();
-        if (uname == null && !userNameField.getText().equals("")) {
+        if (uname == null && !userNameField.getText().isEmpty()) {
             renameBean(userNameField.getText());
         } else if (uname != null && !uname.equals(userNameField.getText())) {
-            if (userNameField.getText().equals("")) {
+            if (userNameField.getText().isEmpty()) {
                 removeName();
             } else {
                 renameBean(userNameField.getText());
@@ -200,6 +200,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         bean.setComment(commentField.getText());
     }
 
+    @OverridingMethodsMustInvokeSuper
     protected void resetBasicItems(ActionEvent e) {
         userNameField.setText(bean.getUserName());
         commentField.setText(bean.getComment());
@@ -207,12 +208,18 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
 
     abstract protected String helpTarget();
 
-    protected ArrayList<BeanItemPanel> bei = new ArrayList<BeanItemPanel>(5);
+    protected ArrayList<BeanItemPanel> bei = new ArrayList<>(5);
     JmriJFrame f;
 
     protected Component selectedTab = null;
-    private JTabbedPane detailsTab = new JTabbedPane();
+    private final JTabbedPane detailsTab = new JTabbedPane();
 
+    /**
+     * Apply Button.
+     * Accessible so Edit Actions can set custom tool tip.
+     */
+    protected JButton applyBut;
+    
     public void setSelectedComponent(Component c) {
         selectedTab = c;
     }
@@ -227,14 +234,19 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         if (f == null) {
             f = new JmriJFrame(Bundle.getMessage("EditBean", getBeanType(), bean.getDisplayName()), false, false);
             f.addHelpMenu(helpTarget(), true);
+            applyBut = new JButton(Bundle.getMessage("ButtonApply")); // create before initPanels()
             java.awt.Container containerPanel = f.getContentPane();
             initPanelsFirst();
             initPanels();
             initPanelsLast();
 
+            int i=0;
             for (BeanItemPanel bi : bei) {
                 addToPanel(bi, bi.getListOfItems());
-                detailsTab.addTab(bi.getName(), bi);
+                detailsTab.add(bi, bi.getName(), i);
+                detailsTab.setEnabledAt(i, bi.isEnabled());
+                detailsTab.setToolTipTextAt(i, bi.getToolTipText());
+                i++;
             }
             containerPanel.add(detailsTab, BorderLayout.CENTER);
 
@@ -250,28 +262,14 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
 
             // shared buttons
             JPanel buttons = new JPanel();
-            JButton applyBut = new JButton(Bundle.getMessage("ButtonApply"));
-            applyBut.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    applyButtonAction(e);
-                }
-            });
+            applyBut.addActionListener(this::applyButtonAction);
             JButton okBut = new JButton(Bundle.getMessage("ButtonOK"));
-            okBut.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    applyButtonAction(e);
-                    f.dispose();
-                }
+            okBut.addActionListener((ActionEvent e1) -> {
+                applyButtonAction(e1);
+                f.dispose();
             });
             JButton cancelBut = new JButton(Bundle.getMessage("ButtonCancel"));
-            cancelBut.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    cancelButtonAction(e);
-                }
-            });
+            cancelBut.addActionListener(this::cancelButtonAction);
             buttons.add(applyBut);
             buttons.add(okBut);
             buttons.add(cancelBut);
@@ -284,6 +282,12 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         if (selectedTab != null) {
             detailsTab.setSelectedComponent(selectedTab);
         }
+        f.addWindowListener(new java.awt.event.WindowAdapter() {
+            @Override
+            public void windowClosing(java.awt.event.WindowEvent e) {
+                cancelButtonAction(null);
+            }
+        });
         f.pack();
         f.setVisible(true);
     }
@@ -322,7 +326,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
             // add the 3 elements on a JPanel to the parent panel grid layout
             if (it.getDescription() != null && it.getComponent() != null) {
                 JLabel descript = new JLabel(it.getDescription() + ":", JLabel.LEFT);
-                if (it.getDescription().equals("")) {
+                if (it.getDescription().isEmpty()) {
                     descript.setText("");
                 }
                 cL.gridx = 0;
@@ -403,6 +407,10 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
 
     NamedBeanHandleManager nbMan = InstanceManager.getDefault(NamedBeanHandleManager.class);
 
+    /**
+     * Get Human Readable form of Bean Type.
+     * @return localised single Bean type String.
+     */
     abstract protected String getBeanType();
 
     abstract protected B getByUserName(String name);
@@ -437,8 +445,8 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         }
 
         nBean.setUserName(value);
-        if (!value.equals("")) {
-            if (oldName == null || oldName.equals("")) {
+        if (!value.isEmpty()) {
+            if (oldName == null || oldName.isEmpty()) {
                 if (!nbMan.inUse(nBean.getSystemName(), nBean)) {
                     return;
                 }
@@ -482,11 +490,11 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         bean.setUserName(null);
     }
 
-    /*
+    /**
      * Determine whether it is safe to rename/remove a Block user name.
      * <p>The user name is used by the LayoutBlock to link to the block and
      * by Layout Editor track components to link to the layout block.
-     * @oaram changeType This will be Remove or Rename.
+     * @param changeType This will be Remove or Rename.
      * @param newName For Remove this will be empty, for Rename it will be the new user name.
      * @return true to continue with the user name change.
      */
@@ -514,10 +522,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
                 Bundle.getMessage("BlockChangeUserName", oldName, newName),  // NOI18N
                 Bundle.getMessage("QuestionTitle"),  // NOI18N
                 JOptionPane.YES_NO_OPTION);
-        if (optionPane == JOptionPane.YES_OPTION) {
-            return true;
-        }
-        return false;
+        return optionPane == JOptionPane.YES_OPTION;
     }
 
     /**
@@ -550,7 +555,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         }
 
         public void setModel(B nb) {
-            attributes = new Vector<KeyValueModel>(nb.getPropertyKeys().size());
+            attributes = new Vector<>(nb.getPropertyKeys().size());
             Iterator<String> ite = nb.getPropertyKeys().iterator();
             while (ite.hasNext()) {
                 String key = ite.next();
@@ -657,7 +662,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
             } else {
                 attributes.add(row, kv); // new one
             }
-            if ((col == 0) && (kv.key.equals(""))) {
+            if ((col == 0) && (kv.key.isEmpty())) {
                 attributes.remove(row); // actually maybe remove
             }
             wasModified = true;

--- a/java/src/jmri/jmrit/beantable/beanedit/BeanItemPanel.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/BeanItemPanel.java
@@ -7,6 +7,7 @@ import javax.swing.JPanel;
 
 /**
  * Hold the information for each bean panel in a structured manner.
+ * The Panel enabled status and Tool-tip are used in the Tab Selection Menu Titles.
  */
 public class BeanItemPanel extends JPanel {
 
@@ -44,20 +45,24 @@ public class BeanItemPanel extends JPanel {
         this.reset = reset;
     }
 
-    AbstractAction save;
-    AbstractAction reset;
+    private AbstractAction save;
+    private AbstractAction reset;
 
-    ArrayList<BeanEditItem> items = new ArrayList<BeanEditItem>();
+    private final ArrayList<BeanEditItem> items = new ArrayList<>();
 
     public void addItem(BeanEditItem bei) {
         items.add(bei);
     }
 
+    /**
+     * Get Copy of List of Bean Edit Items
+     * @return copy of Array List.
+     */
     public List<BeanEditItem> getListOfItems() {
-        return items;
+        return new ArrayList<>(items);
     }
 
-    String name;
+    private String name;
 
     @Override
     public void setName(String name) {

--- a/java/src/jmri/jmrit/beantable/beanedit/BeanItemPanel.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/BeanItemPanel.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.beantable.beanedit;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.swing.AbstractAction;
 import javax.swing.JPanel;
@@ -55,11 +56,11 @@ public class BeanItemPanel extends JPanel {
     }
 
     /**
-     * Get Copy of List of Bean Edit Items
-     * @return copy of Array List.
+     * Get List of Bean Edit Items
+     * @return unmodifiable List.
      */
     public List<BeanEditItem> getListOfItems() {
-        return new ArrayList<>(items);
+        return Collections.unmodifiableList(items);
     }
 
     private String name;

--- a/java/src/jmri/jmrit/beantable/beanedit/LightEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/LightEditAction.java
@@ -1,0 +1,143 @@
+package jmri.jmrit.beantable.beanedit;
+
+import java.awt.event.ActionEvent;
+
+import javax.annotation.Nonnull;
+import javax.swing.AbstractAction;
+
+import jmri.*;
+import jmri.jmrit.beantable.light.LightControlPane;
+import jmri.jmrit.beantable.light.LightIntensityPane;
+
+/**
+ * Provides an edit panel for a Light object.
+ *
+ * @author Kevin Dickerson Copyright (C) 2011
+ * @author Steve Young Copyright (C) 2021
+ */
+public class LightEditAction extends BeanEditAction<Light> {
+
+    private LightControlPane lcp;
+    private LightIntensityPane lip;
+
+    @Override
+    protected void initPanels() {
+        if (InstanceManager.getNullableDefault(LightManager.class) == null) {
+            setEnabled(false);
+        }
+        super.initPanels();
+        lightControlPanel();
+        lightIntensityPanel();
+        
+        applyBut.setToolTipText(Bundle.getMessage("LightUpdateButtonHint"));
+    }
+
+    @Override
+    public String getBeanType() {
+        return Bundle.getMessage("BeanNameLight");
+    }
+
+    @Override
+    public String helpTarget() {
+        return "package.jmri.jmrit.beantable.LightAddEdit";
+    } // NOI18N
+    
+    @Override
+    public Light getByUserName(String name) {
+        return InstanceManager.lightManagerInstance().getByUserName(name);
+    }
+    
+    @Override
+    protected void cancelButtonAction(ActionEvent e) {
+        if (lcp!=null) {
+            lcp.dispose(); // ensures add / edit single LightControl Frame is closed
+        }
+        super.cancelButtonAction(e);
+    }
+    
+    /**
+     * Hide the Bean Properties Tab.
+     * @return null
+     */
+    @Override
+    BeanItemPanel propertiesDetails() {
+        return null;
+    }
+    
+    BeanItemPanel lightControlPanel() {
+        BeanItemPanel lcPanel = new BeanItemPanel();
+        lcPanel.setName(Bundle.getMessage("LightControllerTitlePlural"));
+
+        lcp = new LightControlPane(bean);        
+        lcPanel.add(lcp);
+        
+        lcPanel.setResetItem(new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                lcp.setToLight(bean);
+            }
+        });
+
+        lcPanel.setSaveItem(new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                lcp.setLightFromControlTable(bean);
+            }
+        });
+        bei.add(lcPanel);
+        return lcPanel;
+    }
+
+    BeanItemPanel lightIntensityPanel() {
+        BeanItemPanel liPanel = new BeanItemPanel();
+        liPanel.setName(Bundle.getMessage("LightVariableBorder"));
+        lip = new LightIntensityPane(true);
+        lip.setToLight(bean);
+        liPanel.add(lip);
+        
+        liPanel.setResetItem(new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                lip.setToLight(bean);
+            }
+        });
+
+        liPanel.setSaveItem(new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                if (bean instanceof VariableLight) {
+                    lip.setLightFromPane((VariableLight)bean);
+                }
+            }
+        });
+        bei.add(liPanel);
+
+        if (!(bean instanceof VariableLight)) {
+            liPanel.setEnabled(false);
+            liPanel.setToolTipText(Bundle.getMessage("NoLightIntensityForHardware",getBeanManagerSystemUserName()));
+        }
+        return liPanel;
+    }
+    
+    /**
+     * Get Bean Manager System UserName.
+     * Human readable form of System Username.
+     * e.g. "Internal", "MERG"
+     * 
+     * @return Manager UserName, else empty String.
+     */
+    @Nonnull
+    private String getBeanManagerSystemUserName(){
+        Manager<Light> lm = InstanceManager.getDefault(LightManager.class);
+        if (lm instanceof ProxyManager){
+            ProxyManager<Light> plm = (ProxyManager<Light>)lm;
+            for (Manager<Light> m : plm.getManagerList()) {
+                if (bean.getSystemName().startsWith(m.getSystemNamePrefix())) {
+                    return m.getMemo().getUserName();
+                }
+            }
+        }
+        return "";
+    }
+    
+}

--- a/java/src/jmri/jmrit/beantable/light/AddEditSingleLightControlFrame.java
+++ b/java/src/jmri/jmrit/beantable/light/AddEditSingleLightControlFrame.java
@@ -399,7 +399,7 @@ public class AddEditSingleLightControlFrame extends jmri.util.JmriJFrame {
     protected void updateControlPressed(ActionEvent e) {
         commitEdits();
         LightControl newLc = new DefaultLightControl();
-        List<LightControl> withoutExistingLc = lcp.getControlList();
+        ArrayList<LightControl> withoutExistingLc = new ArrayList<>(lcp.getControlList());
         withoutExistingLc.remove(lc);
         if (setControlInformation(newLc,withoutExistingLc)) {
             lcp.updateControlPressed(lc,newLc);

--- a/java/src/jmri/jmrit/beantable/light/AddEditSingleLightControlFrame.java
+++ b/java/src/jmri/jmrit/beantable/light/AddEditSingleLightControlFrame.java
@@ -399,7 +399,7 @@ public class AddEditSingleLightControlFrame extends jmri.util.JmriJFrame {
     protected void updateControlPressed(ActionEvent e) {
         commitEdits();
         LightControl newLc = new DefaultLightControl();
-        ArrayList<LightControl> withoutExistingLc = lcp.getControlList();
+        List<LightControl> withoutExistingLc = lcp.getControlList();
         withoutExistingLc.remove(lc);
         if (setControlInformation(newLc,withoutExistingLc)) {
             lcp.updateControlPressed(lc,newLc);
@@ -442,7 +442,7 @@ public class AddEditSingleLightControlFrame extends jmri.util.JmriJFrame {
      * @param currentList current Light Control List, used to check that Fast Clock Times are OK.
      * @return 'true' if no errors or warnings
      */
-    private boolean setControlInformation(LightControl g, ArrayList<LightControl> currentList) {
+    private boolean setControlInformation(LightControl g, List<LightControl> currentList) {
         // Get control information
         if (LightControlTableModel.sensorControl.equals(typeBox.getSelectedItem())) {
             // Set type of control

--- a/java/src/jmri/jmrit/beantable/light/AddEditSingleLightControlFrame.java
+++ b/java/src/jmri/jmrit/beantable/light/AddEditSingleLightControlFrame.java
@@ -1,0 +1,694 @@
+package jmri.jmrit.beantable.light;
+
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.util.List;
+import java.util.*;
+
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.*;
+import jmri.implementation.DefaultLightControl;
+import jmri.swing.NamedBeanComboBox;
+import jmri.util.swing.ComboBoxToolTipRenderer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Frame to add or edit a single Light Control.
+ * Code originally within LightTableAction.
+ * 
+ * @author Dave Duchamp Copyright (C) 2004
+ * @author Egbert Broerse Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class AddEditSingleLightControlFrame extends jmri.util.JmriJFrame {
+    
+    final LightControl lc;
+    private JComboBox<String> typeBox;
+    
+    private final JLabel status1 = new JLabel();
+    
+    private final NamedBeanComboBox<Sensor> sensor1Box = new NamedBeanComboBox<>( // Sensor (1 or only)
+            InstanceManager.sensorManagerInstance(), null, NamedBean.DisplayOptions.DISPLAYNAME);
+    private final NamedBeanComboBox<Sensor> sensor2Box = new NamedBeanComboBox<>( // Sensor 2
+            InstanceManager.sensorManagerInstance(), null, NamedBean.DisplayOptions.DISPLAYNAME);
+    
+    private final JLabel f1Label = new JLabel(Bundle.getMessage("LightSensor", Bundle.getMessage("MakeLabel", ""))); // for 1 sensor
+    private final JLabel f1aLabel = new JLabel(Bundle.getMessage("LightSensor", Bundle.getMessage("MakeLabel", " 2"))); // for 2nd sensor
+
+    private final SpinnerNumberModel fastHourSpinnerModel1 = new SpinnerNumberModel(0, 0, 23, 1); // 0 - 23 h
+    private final JSpinner fastHourSpinner1 = new JSpinner(fastHourSpinnerModel1); // Fast Clock1 hours
+    private final SpinnerNumberModel fastMinuteSpinnerModel1 = new SpinnerNumberModel(0, 0, 59, 1); // 0 - 59 min
+    private final JSpinner fastMinuteSpinner1 = new JSpinner(fastMinuteSpinnerModel1); // Fast Clock1 minutes
+    private final JLabel clockSep1 = new JLabel(" : ");
+    private final JLabel clockSep2 = new JLabel(" : ");
+    
+    private final SpinnerNumberModel fastHourSpinnerModel2 = new SpinnerNumberModel(0, 0, 23, 1); // 0 - 23 h
+    private final JSpinner fastHourSpinner2 = new JSpinner(fastHourSpinnerModel2); // Fast Clock2 hours
+    private final SpinnerNumberModel fastMinuteSpinnerModel2 = new SpinnerNumberModel(0, 0, 59, 1); // 0 - 59 min
+    private final JSpinner fastMinuteSpinner2 = new JSpinner(fastMinuteSpinnerModel2); // Fast Clock2 minutes
+    
+    private final NamedBeanComboBox<Turnout> turnoutBox = new NamedBeanComboBox<>( // Turnout
+            InstanceManager.turnoutManagerInstance(), null, NamedBean.DisplayOptions.DISPLAYNAME);
+    private final NamedBeanComboBox<Sensor> sensorOnBox = new NamedBeanComboBox<>( // Timed ON
+            InstanceManager.sensorManagerInstance(), null, NamedBean.DisplayOptions.DISPLAYNAME);
+    
+    private JComboBox<String> stateBox;
+    private ComboBoxToolTipRenderer stateBoxToolTipRenderer;
+    
+    private final SpinnerNumberModel timedOnSpinnerModel = new SpinnerNumberModel(0, 0, 1000000, 1); // 0 - 1,000,000 msec
+    private final JSpinner timedOnSpinner = new JSpinner(timedOnSpinnerModel); // Timed ON
+    
+    private JPanel sensorTwoPanel;
+    
+    private final JLabel f2Label = new JLabel(Bundle.getMessage("LightSensorSense"));
+    
+    private final int sensorActiveIndex = 0;
+    private final int sensorInactiveIndex = 1;
+    private final int turnoutClosedIndex = 0;
+    private final int turnoutThrownIndex = 1;
+    
+    private JButton createControl;
+    private JButton updateControl;
+    private JButton cancelControl;
+    
+    final LightControlPane lcp;
+    
+    /**
+     * Create a new Frame to Add or Edit a Light Control.
+     * 
+     * @param pane Light Control Pane which instigated the action.
+     * @param ctrl If LightControl is null, is a Add Control Window.
+     *              If LightControl specified, is an Edit Control window.
+     */
+    public AddEditSingleLightControlFrame(@Nonnull LightControlPane pane, LightControl ctrl){
+        super(Bundle.getMessage("TitleAddLightControl"), false, true);
+        lc = ctrl;
+        lcp = pane;
+        init();
+    }
+    
+    private void init(){
+    
+        addHelpMenu("package.jmri.jmrit.beantable.LightAddEdit", true);
+        
+        Container contentPane = getContentPane();
+        contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
+        
+        JPanel mainContentPanel = new JPanel();
+        mainContentPanel.setLayout(new BoxLayout(mainContentPanel, BoxLayout.Y_AXIS));
+        
+        JPanel controlTypePanel = new JPanel();
+        controlTypePanel.setLayout(new FlowLayout());
+        controlTypePanel.add(new JLabel(Bundle.getMessage("LightControlType")));
+        typeBox = new JComboBox<>(LightControlTableModel.controlTypes);
+        ComboBoxToolTipRenderer typeBoxToolTipRenderer = new ComboBoxToolTipRenderer();
+        typeBoxToolTipRenderer.setTooltips(LightControlTableModel.getControlTypeTips());
+        typeBox.setRenderer(typeBoxToolTipRenderer);
+        
+        typeBox.addActionListener((ActionEvent e) -> setUpControlType(typeBox.getSelectedIndex()));
+        typeBox.setToolTipText(Bundle.getMessage("LightControlTypeHint"));
+        
+        controlTypePanel.add(typeBox);
+        
+        JPanel mainOptionsPanel = new JPanel();
+        mainOptionsPanel.setLayout(new FlowLayout());
+        mainOptionsPanel.add(f1Label);
+        mainOptionsPanel.add(sensor1Box);
+        
+        // set up number formatting
+        JSpinner.NumberEditor ne1b = new JSpinner.NumberEditor(fastHourSpinner1, "00"); // 2 digits "01" format
+        fastHourSpinner1.setEditor(ne1b);
+        mainOptionsPanel.add(fastHourSpinner1);  // hours ON
+        mainOptionsPanel.add(clockSep1);
+        JSpinner.NumberEditor ne1b1 = new JSpinner.NumberEditor(fastMinuteSpinner1, "00"); // 2 digits "01" format
+        fastMinuteSpinner1.setEditor(ne1b1);
+        mainOptionsPanel.add(fastMinuteSpinner1); // minutes ON
+        mainOptionsPanel.add(turnoutBox);
+        mainOptionsPanel.add(sensorOnBox);
+
+        sensor1Box.setAllowNull(true);
+        sensor1Box.setToolTipText(Bundle.getMessage("LightSensorHint"));
+
+        sensor2Box.setAllowNull(true);
+        sensor2Box.setToolTipText(Bundle.getMessage("LightTwoSensorHint"));
+
+        fastHourSpinner1.setValue(0);  // reset needed
+        fastHourSpinner1.setVisible(false);
+        fastMinuteSpinner1.setValue(0); // reset needed
+        fastMinuteSpinner1.setVisible(false);
+
+        sensorOnBox.setAllowNull(true);
+        sensorOnBox.setVisible(false);
+        clockSep1.setVisible(false);
+
+        turnoutBox.setAllowNull(true);
+        turnoutBox.setVisible(false);
+
+        sensorTwoPanel = new JPanel();
+        sensorTwoPanel.setLayout(new FlowLayout());
+        sensorTwoPanel.add(f1aLabel);
+        sensorTwoPanel.add(sensor2Box);
+
+        JPanel panel33 = new JPanel();
+        panel33.setLayout(new FlowLayout());
+        
+        
+        panel33.add(f2Label);
+        
+        stateBox = new JComboBox<>(new String[]{
+            Bundle.getMessage("SensorStateActive"), Bundle.getMessage("SensorStateInactive")});
+        stateBox.setToolTipText(Bundle.getMessage("LightSensorSenseHint"));
+        stateBoxToolTipRenderer = new ComboBoxToolTipRenderer();
+        stateBox.setRenderer(stateBoxToolTipRenderer);
+        panel33.add(stateBox);
+
+        JSpinner.NumberEditor ne2a = new JSpinner.NumberEditor(fastHourSpinner2, "00"); // 2 digits "01" format
+        fastHourSpinner2.setEditor(ne2a);
+        panel33.add(fastHourSpinner2);  // hours OFF
+        panel33.add(clockSep2);
+        
+        JSpinner.NumberEditor ne2a1 = new JSpinner.NumberEditor(fastMinuteSpinner2, "00"); // 2 digits "01" format
+        fastMinuteSpinner2.setEditor(ne2a1);
+        panel33.add(fastMinuteSpinner2); // minutes OFF
+        panel33.add(timedOnSpinner);
+
+        fastHourSpinner2.setValue(0);  // reset needed
+        fastHourSpinner2.setVisible(false);
+        fastMinuteSpinner2.setValue(0); // reset needed
+        fastMinuteSpinner2.setVisible(false);
+
+        timedOnSpinner.setValue(5000);  // reset needed, default to 5,000 ms
+        timedOnSpinner.setVisible(false);
+        clockSep2.setVisible(false);
+
+        mainContentPanel.add(controlTypePanel);
+        mainContentPanel.add(mainOptionsPanel);
+        mainContentPanel.add(sensorTwoPanel);
+        mainContentPanel.add(panel33);
+        mainContentPanel.setBorder(BorderFactory.createEtchedBorder());
+        contentPane.add(mainContentPanel);
+        contentPane.add(getButtonPanel());
+        
+        JPanel statusPanel = new JPanel();
+        statusPanel.add(status1);
+        contentPane.add(statusPanel);
+        
+        addWindowListener(new java.awt.event.WindowAdapter() {
+            @Override
+            public void windowClosing(java.awt.event.WindowEvent e) {
+                cancelControlPressed(null);
+            }
+        });
+        
+        typeBox.setSelectedIndex(lcp.getLastSelectedControlIndex()); // force GUI status consistent
+        
+        if (lc!=null){
+            setTitle(Bundle.getMessage("TitleEditLightControl"));
+            setFrameToControl(lc);
+        }
+        
+    }
+    
+    private JPanel getButtonPanel(){
+    
+        JPanel buttonPanel = new JPanel();
+        buttonPanel.setLayout(new FlowLayout(FlowLayout.TRAILING));
+        cancelControl = new JButton(Bundle.getMessage("ButtonCancel"));
+        buttonPanel.add(cancelControl);
+        cancelControl.addActionListener(this::cancelControlPressed);
+        cancelControl.setToolTipText(Bundle.getMessage("LightCancelButtonHint"));
+        createControl = new JButton(Bundle.getMessage("ButtonCreate"));
+        buttonPanel.add(createControl);
+        createControl.addActionListener(this::createControlPressed);
+        createControl.setToolTipText(Bundle.getMessage("LightCreateControlButtonHint"));
+        updateControl = new JButton(Bundle.getMessage("ButtonUpdate"));
+        buttonPanel.add(updateControl);
+        updateControl.addActionListener(this::updateControlPressed);
+        updateControl.setToolTipText(Bundle.getMessage("LightUpdateControlButtonHint"));
+        
+        cancelControl.setVisible(true);
+        updateControl.setVisible(lc!=null);
+        createControl.setVisible(lc==null);
+    
+        return buttonPanel;
+    }
+
+    /**
+     * Set the Control Information according to control type.
+     *
+     * @param ctype the control type
+     */
+    private void setUpControlType(int ctype) {
+        // set everything non-visible by default
+        clockSep1.setVisible(false);
+        clockSep2.setVisible(false);
+        fastHourSpinner1.setVisible(false);
+        fastHourSpinner2.setVisible(false);
+        fastMinuteSpinner1.setVisible(false);
+        fastMinuteSpinner2.setVisible(false);
+        f1aLabel.setVisible(false);
+        sensorOnBox.setVisible(false);
+        sensor1Box.setVisible(false);
+        sensor2Box.setVisible(false);
+        stateBox.setVisible(false);
+        timedOnSpinner.setVisible(false);
+        turnoutBox.setVisible(false);
+        sensorTwoPanel.setVisible(false);
+        typeBox.setSelectedIndex(ctype);
+        createControl.setEnabled(true);
+        updateControl.setEnabled(true);
+        
+        lcp.setLastSelectedControlIndex(ctype);
+        
+        List<String> stateTooltips;
+
+        switch (ctype) {
+            case Light.SENSOR_CONTROL:
+                // set up panel for sensor control
+                f1Label.setText(Bundle.getMessage("LightSensor", Bundle.getMessage("MakeLabel", ""))); // insert nothing before colon
+                sensor1Box.setToolTipText(Bundle.getMessage("LightSensorHint"));
+                f2Label.setText(Bundle.getMessage("LightSensorSense"));
+                stateBox.removeAllItems();
+                stateBox.addItem(Bundle.getMessage("SensorStateActive"));
+                stateBox.addItem(Bundle.getMessage("SensorStateInactive"));
+                stateTooltips = new ArrayList<>();
+                stateTooltips.add(Bundle.getMessage("LightSensorSenseActivTip"));
+                stateTooltips.add(Bundle.getMessage("LightSensorSenseInactivTip"));
+                stateBoxToolTipRenderer.setTooltips(stateTooltips);
+                stateBox.setToolTipText(Bundle.getMessage("LightSensorSenseHint"));
+                f2Label.setVisible(true);
+                sensor1Box.setVisible(true);
+                stateBox.setVisible(true);
+                
+                break;
+            case Light.FAST_CLOCK_CONTROL:
+                // set up panel for fast clock control
+                f1Label.setText(Bundle.getMessage("LightScheduleOn"));
+                fastHourSpinner1.setToolTipText(Bundle.getMessage("LightScheduleHint"));
+                fastMinuteSpinner1.setToolTipText(Bundle.getMessage("LightScheduleHintMinutes"));
+                f2Label.setText(Bundle.getMessage("LightScheduleOff"));
+                fastHourSpinner2.setToolTipText(Bundle.getMessage("LightScheduleHint"));
+                fastMinuteSpinner2.setToolTipText(Bundle.getMessage("LightScheduleHintMinutes"));
+                clockSep1.setVisible(true);
+                clockSep2.setVisible(true);
+                fastHourSpinner1.setVisible(true);
+                fastHourSpinner2.setVisible(true);
+                fastMinuteSpinner1.setVisible(true);
+                fastMinuteSpinner2.setVisible(true);
+                f2Label.setVisible(true);
+                
+                break;
+            case Light.TURNOUT_STATUS_CONTROL:
+                // set up panel for turnout status control
+                f1Label.setText(Bundle.getMessage("LightTurnout"));
+                turnoutBox.setToolTipText(Bundle.getMessage("LightTurnoutHint"));
+                f2Label.setText(Bundle.getMessage("LightTurnoutSense"));
+
+                stateBox.removeAllItems();
+                stateBox.addItem(InstanceManager.turnoutManagerInstance().getClosedText());
+                stateBox.addItem(InstanceManager.turnoutManagerInstance().getThrownText());
+                stateBox.setToolTipText(Bundle.getMessage("LightTurnoutSenseHint"));
+
+                stateTooltips = new ArrayList<>();
+                stateTooltips.add(Bundle.getMessage("LightConToClosedOrThrownTip",
+                        InstanceManager.turnoutManagerInstance().getClosedText(),
+                        InstanceManager.turnoutManagerInstance().getThrownText()));
+
+                stateTooltips.add(Bundle.getMessage("LightConToClosedOrThrownTip",
+                        InstanceManager.turnoutManagerInstance().getThrownText(),
+                        InstanceManager.turnoutManagerInstance().getClosedText()));
+                stateBoxToolTipRenderer.setTooltips(stateTooltips);
+
+
+                f2Label.setVisible(true);
+                turnoutBox.setVisible(true);
+                stateBox.setVisible(true);
+
+                break;
+            case Light.TIMED_ON_CONTROL:
+                // set up panel for sensor control
+                f1Label.setText(Bundle.getMessage("LightTimedSensor"));
+                sensorOnBox.setToolTipText(Bundle.getMessage("LightTimedSensorHint"));
+                f2Label.setText(Bundle.getMessage("LightTimedDurationOn"));
+                timedOnSpinner.setToolTipText(Bundle.getMessage("LightTimedDurationOnHint"));
+                f2Label.setVisible(true);
+                sensorOnBox.setVisible(true);
+                timedOnSpinner.setVisible(true);
+                
+                break;
+            case Light.TWO_SENSOR_CONTROL:
+                // set up panel for two sensor control
+                sensorTwoPanel.setVisible(true);
+                f1Label.setText(Bundle.getMessage("LightSensor", " " + Bundle.getMessage("MakeLabel", "1"))); // for 2-sensor use, insert number "1" before colon
+                f1aLabel.setVisible(true);
+                sensor1Box.setToolTipText(Bundle.getMessage("LightSensorHint"));
+                f2Label.setText(Bundle.getMessage("LightSensorSense"));
+
+                stateBox.removeAllItems();
+                stateBox.addItem(Bundle.getMessage("SensorStateActive"));
+                stateBox.addItem(Bundle.getMessage("SensorStateInactive"));
+                stateBox.setToolTipText(Bundle.getMessage("LightSensorSenseHint"));
+
+                stateTooltips = new ArrayList<>();
+                stateTooltips.add(Bundle.getMessage("Light2SensorSenseActivTip"));
+                stateTooltips.add(Bundle.getMessage("Light2SensorSenseInactivTip"));
+                stateBoxToolTipRenderer.setTooltips(stateTooltips);
+
+                f2Label.setVisible(true);
+                sensor1Box.setVisible(true);
+                sensor2Box.setVisible(true);
+                sensor1Box.setToolTipText(Bundle.getMessage("LightTwoSensorHint"));
+                stateBox.setVisible(true);
+
+                break;
+            case Light.NO_CONTROL:
+                // set up panel for no control
+                f1Label.setText(Bundle.getMessage("LightNoneSelected"));
+                f2Label.setVisible(false);
+                createControl.setEnabled(false);
+                updateControl.setEnabled(false);
+                break;
+            default:
+                log.error("Unexpected control type in controlTypeChanged: {}", ctype);
+                break;
+        }
+        pack();
+        setVisible(true);
+    }
+    
+    protected void cancelControlPressed(ActionEvent e) {
+        lcp.closeEditControlWindow();
+    }
+    
+    private void commitEdits(){
+        try {
+            fastHourSpinner1.commitEdit();
+            fastHourSpinner2.commitEdit();
+            fastMinuteSpinner1.commitEdit();
+            fastMinuteSpinner2.commitEdit();
+            timedOnSpinner.commitEdit();
+        } catch (java.text.ParseException pe) {
+            // unlikely to be thrown as values set to original if incorrect on commitEdit()
+        }
+    }
+    
+    protected void updateControlPressed(ActionEvent e) {
+        commitEdits();
+        LightControl newLc = new DefaultLightControl();
+        ArrayList<LightControl> withoutExistingLc = lcp.getControlList();
+        withoutExistingLc.remove(lc);
+        if (setControlInformation(newLc,withoutExistingLc)) {
+            lcp.updateControlPressed(lc,newLc);
+            cancelControlPressed(e);
+        } else {
+            pack();
+            setVisible(true);
+        }
+    }
+    
+    protected void createControlPressed(ActionEvent e) {
+        if (Objects.equals(typeBox.getSelectedItem(), LightControlTableModel.noControl)) {
+            return;
+        }
+        
+        commitEdits();
+        LightControl newLc = new DefaultLightControl();
+        if (setControlInformation(newLc,lcp.getControlList())) {
+            lcp.addControlToTable(newLc);
+            cancelControlPressed(e);
+        } else {
+            pack();
+            setVisible(true);
+        }
+    }
+    
+    private void notifyUser(String message, Color color){
+        status1.setText(message);
+        status1.setForeground(color);
+        jmri.util.ThreadingUtil.runOnGUIDelayed( ()->{
+            status1.setText(" ");
+        },5000);
+    
+    }
+    
+    /**
+     * Retrieve control information from pane and update Light Control.
+     *
+     * @param g LightControl to set to User Settings.
+     * @param currentList current Light Control List, used to check that Fast Clock Times are OK.
+     * @return 'true' if no errors or warnings
+     */
+    private boolean setControlInformation(LightControl g, ArrayList<LightControl> currentList) {
+        // Get control information
+        if (LightControlTableModel.sensorControl.equals(typeBox.getSelectedItem())) {
+            // Set type of control
+            g.setControlType(Light.SENSOR_CONTROL);
+            // Get sensor control information
+            Sensor s = null;
+            String sensorName = sensor1Box.getSelectedItemDisplayName();
+            if (sensorName == null) {
+                // no sensor selected
+                g.setControlType(Light.NO_CONTROL);
+                notifyUser(Bundle.getMessage("LightWarn8"),Color.gray);
+            } else {
+                // name was selected, check for user name first
+                s = InstanceManager.sensorManagerInstance().
+                        getByUserName(sensorName);
+                if (s == null) {
+                    // not user name, try system name
+                    s = InstanceManager.sensorManagerInstance().
+                            getBySystemName(sensorName);
+                    if (s != null) {
+                        // update sensor system name in case it changed
+                        sensorName = s.getSystemName();
+                        sensor1Box.setSelectedItem(s);
+                    }
+                }
+            }
+            int sState =  ( Bundle.getMessage("SensorStateInactive").equals(stateBox.getSelectedItem()) 
+                ? Sensor.INACTIVE : Sensor.ACTIVE);
+            g.setControlSensorName(sensorName);
+            g.setControlSensorSense(sState);
+            if (s == null) {
+                notifyUser(Bundle.getMessage("LightWarn1"),Color.red);
+                return false;
+            }
+        } else if (LightControlTableModel.fastClockControl.equals(typeBox.getSelectedItem())) {
+            // Set type of control
+            g.setControlType(Light.FAST_CLOCK_CONTROL);
+            // read and parse the hours and minutes in the 2 x 2 spinners
+            int onHour = (Integer) fastHourSpinner1.getValue();  // hours
+            int onMin = (Integer) fastMinuteSpinner1.getValue();  // minutes
+            int offHour = (Integer) fastHourSpinner2.getValue(); // hours
+            int offMin = (Integer) fastMinuteSpinner2.getValue(); // minutes
+
+            g.setFastClockControlSchedule(onHour, onMin, offHour, offMin);
+
+            if (g.onOffTimesFaulty()) {
+                notifyUser(Bundle.getMessage("LightWarn11"),Color.red);
+                return false;
+            }
+
+            if (g.areFollowerTimesFaulty(currentList)) {
+                notifyUser(Bundle.getMessage("LightWarn12"),Color.red);
+                return false;
+            }
+
+        } else if (LightControlTableModel.turnoutStatusControl.equals(typeBox.getSelectedItem())) {
+            boolean error = false;
+            Turnout t = null;
+            // Set type of control
+            g.setControlType(Light.TURNOUT_STATUS_CONTROL);
+            // Get turnout control information
+            String turnoutName = turnoutBox.getSelectedItemSystemName();
+            if (turnoutName == null) {
+                // no turnout selected
+                g.setControlType(Light.NO_CONTROL);
+                notifyUser(Bundle.getMessage("LightWarn10"),Color.gray);
+            } else {
+
+                // TODO : Remove Turnouts which are actually lights ( ???? )
+                // from the JComboBox list, not after the user has selected one.
+
+                // Ensure that this Turnout is not already a Light
+                // String prefix = Objects.requireNonNull(prefixBox.getSelectedItem()).getSystemPrefix();                
+                String prefix = InstanceManager.getDefault(LightManager.class).getSystemPrefix();
+                if (turnoutName.charAt(prefix.length()) == 'T') {
+                    // must be a standard format name (not just a number)
+                    String testSN = prefix + "L"
+                            + turnoutName.substring(prefix.length() + 1);
+                    Light testLight = InstanceManager.getDefault(LightManager.class).
+                            getBySystemName(testSN);
+                    if (testLight != null) {
+                        // Requested turnout bit is already assigned to a Light
+                        notifyUser(Bundle.getMessage("LightWarn3") + " " + testSN + ".",Color.red);
+                        error = true;
+                    }
+                }
+                if (!error) {
+                    // Requested turnout bit is not assigned to a Light
+                    t = InstanceManager.turnoutManagerInstance().
+                            getByUserName(turnoutName);
+                    if (t == null) {
+                        // not user name, try system name
+                        t = InstanceManager.turnoutManagerInstance().
+                                getBySystemName(turnoutName);
+                        if (t != null) {
+                            // update turnout system name in case it changed
+                            turnoutName = t.getSystemName();
+                            turnoutBox.setSelectedItem(t);
+                        }
+                    }
+                }
+            }
+            // Initialize the requested Turnout State
+            int tState = Turnout.CLOSED;
+            if (Objects.equals(stateBox.getSelectedItem(), InstanceManager.
+                    turnoutManagerInstance().getThrownText())) {
+                tState = Turnout.THROWN;
+            }
+            g.setControlTurnout(turnoutName);
+            g.setControlTurnoutState(tState);
+            if (t == null) {
+                notifyUser(Bundle.getMessage("LightWarn2"),Color.red);
+                return false;
+            }
+        } else if (LightControlTableModel.timedOnControl.equals(typeBox.getSelectedItem())) {
+            Sensor s = null;
+            // Set type of control
+            g.setControlType(Light.TIMED_ON_CONTROL);
+            // Get trigger sensor control information
+            String triggerSensorName = sensorOnBox.getSelectedItemDisplayName();
+            if (triggerSensorName == null) {
+                // Trigger sensor not selected
+                g.setControlType(Light.NO_CONTROL);
+                notifyUser(Bundle.getMessage("LightWarn8"),Color.gray);
+            } else {
+                // sensor was selected, try user name first
+                s = InstanceManager.sensorManagerInstance().getByUserName(triggerSensorName);
+                if (s == null) {
+                    // not user name, try system name
+                    s = InstanceManager.sensorManagerInstance().
+                            getBySystemName(triggerSensorName);
+                    if (s != null) {
+                        // update sensor system name in case it changed
+                        triggerSensorName = s.getSystemName();
+                        sensorOnBox.setSelectedItem(s);
+                    }
+                }
+            }
+            g.setControlTimedOnSensorName(triggerSensorName);
+            int dur = (Integer) timedOnSpinner.getValue();
+            g.setTimedOnDuration(dur);
+            if (s == null) {
+                notifyUser(Bundle.getMessage("LightWarn8"),Color.red);
+                return false;
+            }
+        } else if (LightControlTableModel.twoSensorControl.equals(typeBox.getSelectedItem())) {
+            Sensor s = null;
+            Sensor s2;
+            // Set type of control
+            g.setControlType(Light.TWO_SENSOR_CONTROL);
+            // Get sensor control information
+            String sensorName = sensor1Box.getSelectedItemDisplayName();
+            String sensor2Name = sensor2Box.getSelectedItemDisplayName();
+            if (sensorName == null || sensor2Name == null) {
+                // no sensor(s) selected
+                g.setControlType(Light.NO_CONTROL);
+                notifyUser(Bundle.getMessage("LightWarn8"),Color.gray);
+            } else {
+                // name was selected, check for user name first
+                s = InstanceManager.sensorManagerInstance().
+                        getByUserName(sensorName);
+                if (s == null) {
+                    // not user name, try system name
+                    s = InstanceManager.sensorManagerInstance().
+                            getBySystemName(sensorName);
+                    if (s != null) {
+                        // update sensor system name in case it changed
+                        sensorName = s.getSystemName();
+                        sensor1Box.setSelectedItem(s);
+                    }
+                }
+                s2 = InstanceManager.sensorManagerInstance().
+                        getByUserName(sensor2Name);
+                if (s2 == null) {
+                    // not user name, try system name
+                    s2 = InstanceManager.sensorManagerInstance().
+                            getBySystemName(sensor2Name);
+                    if (s2 != null) {
+                        // update sensor system name in case it changed
+                        sensor2Name = s2.getSystemName();
+                        sensor2Box.setSelectedItem(s2);
+                    }
+                }
+            }
+            int sState = Sensor.ACTIVE;
+            if (Objects.equals(stateBox.getSelectedItem(), Bundle.getMessage("SensorStateInactive"))) {
+                sState = Sensor.INACTIVE;
+            }
+            g.setControlSensorName(sensorName);
+            g.setControlSensor2Name(sensor2Name);
+            g.setControlSensorSense(sState);
+            if (s == null) {
+                notifyUser(Bundle.getMessage("LightWarn1"),Color.red);
+                return false;
+            }
+        } else if (LightControlTableModel.noControl.equals(typeBox.getSelectedItem())) {
+            // Set type of control
+            g.setControlType(Light.NO_CONTROL);
+        } else {
+            log.error("Unexpected control type: {}", typeBox.getSelectedItem());
+        }
+        return (true);
+    }
+    
+    private void setFrameToControl(LightControl lc){
+    
+        int ctType = lc.getControlType();
+        switch (ctType) {
+            case Light.SENSOR_CONTROL:
+                setUpControlType(Light.SENSOR_CONTROL);
+                sensor1Box.setSelectedItemByName(lc.getControlSensorName());
+                stateBox.setSelectedIndex( (lc.getControlSensorSense() == Sensor.ACTIVE)? sensorActiveIndex : sensorInactiveIndex);
+                break;
+            case Light.FAST_CLOCK_CONTROL:
+                setUpControlType(Light.FAST_CLOCK_CONTROL);
+                fastHourSpinner1.setValue(lc.getFastClockOnHour());
+                fastMinuteSpinner1.setValue(lc.getFastClockOnMin());
+                fastHourSpinner2.setValue(lc.getFastClockOffHour());
+                fastMinuteSpinner2.setValue(lc.getFastClockOffMin());
+                break;
+            case Light.TURNOUT_STATUS_CONTROL:
+                setUpControlType(Light.TURNOUT_STATUS_CONTROL);
+                turnoutBox.setSelectedItemByName(lc.getControlTurnoutName());
+                stateBox.setSelectedIndex( (lc.getControlTurnoutState() == Turnout.THROWN)? turnoutThrownIndex : turnoutClosedIndex);
+                break;
+            case Light.TIMED_ON_CONTROL:
+                setUpControlType(Light.TIMED_ON_CONTROL);
+                sensorOnBox.setSelectedItemByName(lc.getControlTimedOnSensorName());
+                timedOnSpinner.setValue(lc.getTimedOnDuration());
+                break;
+            case Light.TWO_SENSOR_CONTROL:
+                setUpControlType(Light.TWO_SENSOR_CONTROL);
+                sensor1Box.setSelectedItemByName(lc.getControlSensorName());
+                sensor2Box.setSelectedItemByName(lc.getControlSensor2Name());
+                stateBox.setSelectedIndex( (lc.getControlSensorSense() == Sensor.ACTIVE)? sensorActiveIndex : sensorInactiveIndex);
+                break;
+            case Light.NO_CONTROL:
+                setUpControlType(Light.NO_CONTROL);
+                break;
+            default:
+                log.error("Unhandled light control type: {}", ctType);
+                break;
+        }
+
+    }
+    
+    private final static Logger log = LoggerFactory.getLogger(AddEditSingleLightControlFrame.class);
+    
+}

--- a/java/src/jmri/jmrit/beantable/light/Bundle.java
+++ b/java/src/jmri/jmrit/beantable/light/Bundle.java
@@ -1,0 +1,99 @@
+package jmri.jmrit.beantable.light;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Locale;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.jmrit.beantable.Bundle {
+
+    @CheckForNull
+    private static final String name = null; // no local resources
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static public String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    @CheckForNull
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/src/jmri/jmrit/beantable/light/LightControlPane.java
+++ b/java/src/jmri/jmrit/beantable/light/LightControlPane.java
@@ -2,7 +2,7 @@ package jmri.jmrit.beantable.light;
 
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
-import java.util.ArrayList;
+import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.swing.*;
@@ -122,20 +122,38 @@ public class LightControlPane extends JPanel {
         addEditControlWindow(lc);
     }
     
+    /**
+     * Add a Single Light Control to the Table.
+     * @param lc the Light Control to add.
+     */
     protected void addControlToTable(LightControl lc) {
         lightControlTableModel.addControl(lc);
     }
 
-    public ArrayList<LightControl> getControlList(){
+    /**
+     * Get Light Control List currently displayed in the Table.
+     * Returned by the TableModel as unmodifiable.
+     * @return List of Light Controls.
+     */
+    public List<LightControl> getControlList(){
         return lightControlTableModel.getControlList();
     }
     
+    /**
+     * Set the Table to the Light Controls of a single Light.
+     * @param l the Light to set display for.
+     */
     public final void setToLight(Light l){
         lightControlTableModel.setTableToLight(l);
     }
     
     private AddEditSingleLightControlFrame addEditCtrlFrame;
     
+    /**
+     * UI Function to get Last Selected Light Control Index within
+     * AddEditSingleLightControl.java
+     * @return Light Control Index.
+     */
     protected int getLastSelectedControlIndex(){
         return defaultControlIndex;
     }

--- a/java/src/jmri/jmrit/beantable/light/LightControlPane.java
+++ b/java/src/jmri/jmrit/beantable/light/LightControlPane.java
@@ -1,0 +1,170 @@
+package jmri.jmrit.beantable.light;
+
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.Light;
+import jmri.LightControl;
+
+// import org.slf4j.Logger;
+// import org.slf4j.LoggerFactory;
+
+/**
+ * Pane to add / edit Light Controls for a new or given Light.
+ * <p>
+ * Light Control Table with new control / edit individual Control buttons.
+ * Uses separate JFrame to Edit a Single Control.
+ * <p>
+ * Defaults to No Light Controls for a New Light.
+ * <p>
+ * Code originally within LightTableAction.
+ * 
+ * @author Dave Duchamp Copyright (C) 2004
+ * @author Egbert Broerse Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class LightControlPane extends JPanel {
+
+    private LightControlTableModel lightControlTableModel;
+    private JButton addControl;
+    
+    /**
+     * Create a Panel for Light Controls.
+     * No Controls as default.
+     */
+    public LightControlPane(){
+        super();
+        init();
+    }
+    
+    /**
+     * Create a Panel for Light Controls.
+     * @param l Light to display Light Controls for.
+     */
+    public LightControlPane(Light l){
+        super();
+        init();
+        setToLight(l);
+    }
+    
+    private void init(){
+        
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        lightControlTableModel = new LightControlTableModel(this);
+        JTable lightControlTable = new JTable(lightControlTableModel);
+        
+        lightControlTableModel.configureJTable(lightControlTable);
+        lightControlTable.setPreferredScrollableViewportSize(new java.awt.Dimension(600, 100));
+        JScrollPane lightControlTableScrollPane = new JScrollPane(lightControlTable);
+        add(lightControlTableScrollPane);
+
+        addControl = new JButton(Bundle.getMessage("LightAddControlButton"));
+        addControl.addActionListener(this::addControlPressed);
+        addControl.setToolTipText(Bundle.getMessage("LightAddControlButtonHint"));
+        
+        JPanel panel35 = new JPanel();
+        panel35.setLayout(new FlowLayout());
+        panel35.add(addControl);
+        add(panel35);
+        
+    }
+    
+    /**
+     * Respond to pressing the Add Control button.
+     *
+     * @param e the event containing the press action
+     */
+    protected void addControlPressed(ActionEvent e) {
+        // Use separate Runnable so window is created on top
+        javax.swing.SwingUtilities.invokeLater(() -> {
+                addEditControlWindow(null);
+        });
+    }
+    
+    /**
+     * Respond to pressing the Update Control button in the New / Edit Control Frame.
+     *
+     * @param oldControl the LightControl to remove
+     * @param newControl the LightControl to add
+     */
+    protected void updateControlPressed(LightControl oldControl, LightControl newControl) {
+        lightControlTableModel.removeControl(oldControl);
+        lightControlTableModel.addControl(newControl);
+    }
+    
+    /**
+     * Set Controls from the Control Table to the Light.
+     * Removes any existing Light Controls on the Light.
+     * @param g Light to set Controls to.
+     */
+    public void setLightFromControlTable(Light g) {
+        g.deactivateLight();
+        g.clearLightControls(); // clear list on Light
+        getControlList().stream().map(control -> {
+            control.setParentLight(g);
+            return control;
+        }).forEachOrdered(control -> {
+            g.addLightControl(control);
+        });
+        g.activateLight();
+    }
+    
+    /**
+     * Respond to Edit button on row in the Light Control Table.
+     *
+     * @param lc the Light Control to edit.
+     */
+    protected void editControlAction(@Nonnull LightControl lc) {
+        addEditControlWindow(lc);
+    }
+    
+    protected void addControlToTable(LightControl lc) {
+        lightControlTableModel.addControl(lc);
+    }
+
+    public ArrayList<LightControl> getControlList(){
+        return lightControlTableModel.getControlList();
+    }
+    
+    public final void setToLight(Light l){
+        lightControlTableModel.setTableToLight(l);
+    }
+    
+    private AddEditSingleLightControlFrame addEditCtrlFrame;
+    
+    protected int getLastSelectedControlIndex(){
+        return defaultControlIndex;
+    }
+    
+    protected void setLastSelectedControlIndex(int newIndex){
+        defaultControlIndex = newIndex;
+    }
+    
+    private int defaultControlIndex = Light.NO_CONTROL;
+    
+    /**
+     * Create the Add/Edit Light Control pane.
+     */
+    private void addEditControlWindow(LightControl lc) {
+        closeEditControlWindow();
+        addEditCtrlFrame = new AddEditSingleLightControlFrame(this, lc);
+    }
+    
+    protected void closeEditControlWindow(){
+        if (!(addEditCtrlFrame == null)) {
+            addEditCtrlFrame.dispose();
+            addEditCtrlFrame = null;
+        }
+    }
+    
+    public void dispose(){
+        closeEditControlWindow();
+    }
+    
+    // private final static Logger log = LoggerFactory.getLogger(LightControlPane.class);
+    
+}

--- a/java/src/jmri/jmrit/beantable/light/LightControlTableModel.java
+++ b/java/src/jmri/jmrit/beantable/light/LightControlTableModel.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import javax.swing.JButton;
 import javax.swing.JTable;
-import javax.swing.JTextField;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 
@@ -23,6 +22,8 @@ import static jmri.jmrit.beantable.LightTableAction.getDescriptionText;
 
 /**
  * Table model for Light Controls in the Add/Edit Light windows.
+ * No direct access to this class is normally required, access via
+ * LightControlPane.java
  * 
  * Code originally within LightTableAction.
  * 
@@ -98,8 +99,12 @@ public class LightControlTableModel extends javax.swing.table.AbstractTableModel
         lcp = pane;
     }
     
-    public ArrayList<LightControl> getControlList(){
-        return new ArrayList<>(controlList);
+    /**
+     * Get the Current Light Control List for the Table.
+     * @return unmodifiable List of Light Controls.
+     */
+    public List<LightControl> getControlList(){
+        return java.util.Collections.unmodifiableList(controlList);
     }
     
     public void setTableToLight(Light light){

--- a/java/src/jmri/jmrit/beantable/light/LightControlTableModel.java
+++ b/java/src/jmri/jmrit/beantable/light/LightControlTableModel.java
@@ -1,0 +1,251 @@
+package jmri.jmrit.beantable.light;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JButton;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
+
+import jmri.implementation.DefaultLightControl;
+import jmri.InstanceManager;
+import jmri.Light;
+import jmri.LightControl;
+import jmri.util.table.ButtonEditor;
+import jmri.util.table.ButtonRenderer;
+
+import static jmri.jmrit.beantable.LightTableAction.getDescriptionText;
+
+// import org.slf4j.Logger;
+// import org.slf4j.LoggerFactory;
+
+/**
+ * Table model for Light Controls in the Add/Edit Light windows.
+ * 
+ * Code originally within LightTableAction.
+ * 
+ * @author Dave Duchamp Copyright (C) 2004
+ * @author Egbert Broerse Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class LightControlTableModel extends javax.swing.table.AbstractTableModel {
+
+    public static final int TYPE_COLUMN = 0;
+    public static final int DESCRIPTION_COLUMN = 1;
+    public static final int EDIT_COLUMN = 2;
+    public static final int REMOVE_COLUMN = 3;
+    
+    private final LightControlPane lcp;
+    private final ArrayList<LightControl> controlList;
+    
+    protected static final String sensorControl = Bundle.getMessage("LightSensorControl");
+    protected static final String fastClockControl = Bundle.getMessage("LightFastClockControl");
+    protected static final String turnoutStatusControl = Bundle.getMessage("LightTurnoutStatusControl");
+    protected static final String timedOnControl = Bundle.getMessage("LightTimedOnControl");
+    protected static final String twoSensorControl = Bundle.getMessage("LightTwoSensorControl");
+    protected static final String noControl = Bundle.getMessage("LightNoControl");
+    
+    protected static final String[] controlTypes = new String[]{
+        noControl,
+        sensorControl,
+        fastClockControl,
+        turnoutStatusControl,
+        timedOnControl,
+        twoSensorControl };
+    
+    protected static final List<String> getControlTypeTips(){
+        ArrayList<String> typeTooltips = new ArrayList<>();
+        typeTooltips.add(null); // no Control Type selected
+        typeTooltips.add(Bundle.getMessage("LightSensorControlTip"));
+        typeTooltips.add(Bundle.getMessage("LightFastClockControlTip"));
+        typeTooltips.add(Bundle.getMessage("LightTurnoutStatusControlTip",
+                InstanceManager.turnoutManagerInstance().getClosedText(),
+                InstanceManager.turnoutManagerInstance().getThrownText()));
+        typeTooltips.add(Bundle.getMessage("LightTimedOnControlTip"));
+        typeTooltips.add(Bundle.getMessage("LightTwoSensorControlTip"));
+        return typeTooltips;
+    }
+    /**
+     * Get text showing the type of Light Control.
+     *
+     * @param type the type of Light Control
+     * @return name of type or the description for {@link jmri.Light#NO_CONTROL}
+     *         if type is not recognized
+     */
+    public static String getControlTypeText(int type) {
+        switch (type) {
+            case Light.SENSOR_CONTROL:
+                return sensorControl;
+            case Light.FAST_CLOCK_CONTROL:
+                return fastClockControl;
+            case Light.TURNOUT_STATUS_CONTROL:
+                return turnoutStatusControl;
+            case Light.TIMED_ON_CONTROL:
+                return timedOnControl;
+            case Light.TWO_SENSOR_CONTROL:
+                return twoSensorControl;
+            case Light.NO_CONTROL:
+            default:
+                return noControl;
+        }
+    }
+
+    public LightControlTableModel(LightControlPane pane) {
+        super();
+        controlList = new ArrayList<>();
+        lcp = pane;
+    }
+    
+    public ArrayList<LightControl> getControlList(){
+        return new ArrayList<>(controlList);
+    }
+    
+    public void setTableToLight(Light light){
+        // Get a fresh copy of the LightControl list
+        controlList.clear();
+        light.getLightControlList().forEach((lightControlList1) -> controlList.add(new DefaultLightControl(lightControlList1)));
+        fireTableDataChanged();
+    }
+    
+    public void addControl(LightControl lc){
+        controlList.add(lc);
+        fireTableDataChanged();
+    }
+    
+    public void removeControl(LightControl lc){
+        controlList.remove(lc);
+        fireTableDataChanged();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<?> getColumnClass(int c) {
+        switch (c) {
+            case EDIT_COLUMN:
+            case REMOVE_COLUMN:
+                return JButton.class;
+            case TYPE_COLUMN:
+            case DESCRIPTION_COLUMN:
+            default:
+                return String.class;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getColumnCount() {
+        return REMOVE_COLUMN + 1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getRowCount() {
+        return controlList.size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCellEditable(int r, int c) {
+        switch (c) {
+            case EDIT_COLUMN:
+            case REMOVE_COLUMN:
+                return true;
+            case TYPE_COLUMN:
+            case DESCRIPTION_COLUMN:
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getColumnName(int col) {
+        if (col == TYPE_COLUMN) {
+            return Bundle.getMessage("LightControlType");
+        } else if (col == DESCRIPTION_COLUMN) {
+            return Bundle.getMessage("LightControlDescription");
+        }
+        return "";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getValueAt(int r, int c) {
+        LightControl lc = controlList.get(r);
+        switch (c) {
+            case TYPE_COLUMN:
+                return (getControlTypeText(lc.getControlType()));
+            case DESCRIPTION_COLUMN:
+                return (getDescriptionText(lc, lc.getControlType()));
+            case EDIT_COLUMN:
+                return Bundle.getMessage("ButtonEdit");
+            case REMOVE_COLUMN:
+                return Bundle.getMessage("ButtonDelete");
+            default:
+                return "";
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setValueAt(Object value, int row, int col) {
+        if (col == EDIT_COLUMN) {
+            // set up to edit. Use separate Runnable so window is created on top
+            javax.swing.SwingUtilities.invokeLater(() -> {
+                lcp.editControlAction(controlList.get(row));
+            });
+        }
+        else if (col == REMOVE_COLUMN) {
+            controlList.remove(row);
+            fireTableDataChanged();
+        }
+    }
+    
+    protected void configureJTable(JTable table){
+    
+        table.setRowSelectionAllowed(false);
+    
+        TableColumnModel lightControlColumnModel = table.getColumnModel();
+        TableColumn typeColumn = lightControlColumnModel.getColumn(LightControlTableModel.TYPE_COLUMN);
+        typeColumn.setResizable(true);
+        typeColumn.setMinWidth(130);
+        typeColumn.setMaxWidth(170);
+        TableColumn descriptionColumn = lightControlColumnModel.getColumn(
+                LightControlTableModel.DESCRIPTION_COLUMN);
+        descriptionColumn.setResizable(true);
+        descriptionColumn.setMinWidth(270);
+        descriptionColumn.setMaxWidth(380);
+
+        table.setDefaultRenderer(JButton.class, new ButtonRenderer());
+        table.setDefaultEditor(JButton.class, new ButtonEditor(new JButton()));
+
+        JButton testButton = new JButton(Bundle.getMessage("ButtonDelete"));
+        table.setRowHeight(testButton.getPreferredSize().height);
+        TableColumn editColumn = lightControlColumnModel.getColumn(LightControlTableModel.EDIT_COLUMN);
+        editColumn.setResizable(false);
+        editColumn.setMinWidth(new JButton(Bundle.getMessage("ButtonEdit")).getPreferredSize().width);
+        TableColumn removeColumn = lightControlColumnModel.getColumn(LightControlTableModel.REMOVE_COLUMN);
+        removeColumn.setResizable(false);
+        removeColumn.setMinWidth(testButton.getPreferredSize().width);
+        
+    }
+
+    // private final static Logger log = LoggerFactory.getLogger(LightControlTableModel.class);
+
+}

--- a/java/src/jmri/jmrit/beantable/light/LightIntensityPane.java
+++ b/java/src/jmri/jmrit/beantable/light/LightIntensityPane.java
@@ -1,0 +1,149 @@
+package jmri.jmrit.beantable.light;
+
+import javax.swing.*;
+
+import jmri.Light;
+import jmri.VariableLight;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Panel to display Light Intensity options.
+ * 
+ * Code originally within LightTableAction.
+ * 
+ * @author Dave Duchamp Copyright (C) 2004
+ * @author Egbert Broerse Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class LightIntensityPane extends JPanel {
+    
+    private JPanel minPan;
+    private JPanel maxPan;
+    private JPanel transitionPan;
+    
+    private JSpinner minIntensity;
+    private JSpinner maxIntensity;
+    private JSpinner transitionTime;
+    
+    private final JLabel status1 = new JLabel();
+    
+    /**
+     * Create a new Light Intensity Panel.
+     * 
+     * @param vertical true for vertical, false for horizontal display.
+     */
+    public LightIntensityPane( boolean vertical){
+        super();
+        init(vertical);
+    }
+    
+    
+    private void init(boolean vertical){
+    
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS ));
+        minIntensity = new JSpinner();
+        maxIntensity = new JSpinner();
+        transitionTime = new JSpinner();
+        JPanel mainPanel = new JPanel();
+        mainPanel.setLayout(new BoxLayout(mainPanel, ( vertical ? BoxLayout.Y_AXIS : BoxLayout.X_AXIS)));
+        
+        minPan = new JPanel();
+        minPan.add(new JLabel(" "));
+        minPan.add(new JLabel(Bundle.getMessage("LightMinIntensity")));
+        minIntensity.setModel(
+                new SpinnerNumberModel(Double.valueOf(0.0d), Double.valueOf(0.0d), Double.valueOf(0.99d), Double.valueOf(0.01d))); // 0 - 99%
+        minIntensity.setEditor(new JSpinner.NumberEditor(minIntensity, "##0 %"));
+        minIntensity.setToolTipText(Bundle.getMessage("LightMinIntensityHint"));
+        minIntensity.setValue(0.0d); // reset JSpinner1
+        minPan.add(minIntensity);
+        minPan.add(new JLabel("   "));
+        mainPanel.add(minPan);
+        
+        maxPan = new JPanel();
+        maxPan.add(new JLabel(Bundle.getMessage("LightMaxIntensity")));
+        maxIntensity.setModel(
+                new SpinnerNumberModel(Double.valueOf(1.0d), Double.valueOf(0.01d), Double.valueOf(1.0d), Double.valueOf(0.01d))); // 100 - 1%
+        maxIntensity.setEditor(new JSpinner.NumberEditor(maxIntensity, "##0 %"));
+        maxIntensity.setToolTipText(Bundle.getMessage("LightMaxIntensityHint"));
+        maxIntensity.setValue(1.0d); // reset JSpinner2
+        maxPan.add(maxIntensity);
+        maxPan.add(new JLabel("   "));
+        mainPanel.add(maxPan);
+        
+        transitionPan = new JPanel();
+        transitionPan.add(new JLabel(Bundle.getMessage("LightTransitionTime")));
+        transitionTime.setModel(
+                new SpinnerNumberModel(Double.valueOf(0d), Double.valueOf(0d), Double.valueOf(1000000d), Double.valueOf(0.01d)));
+        transitionTime.setEditor(new JSpinner.NumberEditor(transitionTime, "###0.00"));
+        transitionTime.setPreferredSize(new JTextField(8).getPreferredSize());
+        transitionTime.setToolTipText(Bundle.getMessage("LightTransitionTimeHint"));
+        transitionTime.setValue(0.0); // reset from possible previous use
+        transitionPan.add(transitionTime);
+        transitionPan.add(new JLabel(" "));
+        mainPanel.add(transitionPan);
+        
+        add(mainPanel);
+        
+        JPanel statusPanel = new JPanel();
+        statusPanel.add(status1);
+        add(statusPanel);
+    
+    }
+    
+    /**
+     * Set the panel to match a Light.
+     * @param light the Light to set Panel for.
+     */
+    public void setToLight(Light light){
+        if (light instanceof VariableLight) {
+            minIntensity.setValue(((VariableLight)light).getMinIntensity()); // displayed as percentage
+            maxIntensity.setValue(((VariableLight)light).getMaxIntensity());
+            if (((VariableLight)light).isTransitionAvailable()) {
+                transitionTime.setValue(((VariableLight)light).getTransitionTime()); // displays i18n decimal separator eg. 0,00 in _nl
+            }
+            setupVariableDisplay(true, ((VariableLight)light).isTransitionAvailable());
+        } else {
+            setupVariableDisplay(false, false);
+        }
+    }
+    
+    /**
+     * Set a Light to match the Panel.
+     * @param light The Light to edit details for.
+     */
+    public void setLightFromPane(VariableLight light){
+    
+        if ((Double) minIntensity.getValue() >= (Double) maxIntensity.getValue()) {
+            log.error("minInt value entered: {}", minIntensity.getValue());
+            // do not set intensity
+            status1.setText(Bundle.getMessage("LightWarn9"));
+            status1.setVisible(true);
+        } else {
+            light.setMinIntensity((Double) minIntensity.getValue());
+            light.setMaxIntensity((Double) maxIntensity.getValue());
+        }
+        if (light.isTransitionAvailable()) {
+            light.setTransitionTime((Double) transitionTime.getValue());
+        }
+    
+    }
+    
+    /**
+     * Set up panel for Variable Options.
+     *
+     * @param showIntensity  true to show light intensity; false otherwise
+     * @param showTransition true to show time light takes to transition between
+     *                       states; false otherwise
+     */
+    private void setupVariableDisplay(boolean showIntensity, boolean showTransition) {
+        minPan.setVisible(showIntensity);
+        maxPan.setVisible(showIntensity);
+        transitionPan.setVisible(showTransition);
+        setVisible(showIntensity || showTransition);
+    }
+    
+    private final static Logger log = LoggerFactory.getLogger(LightIntensityPane.class);
+    
+}

--- a/java/src/jmri/jmrit/beantable/light/LightTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/light/LightTableDataModel.java
@@ -1,0 +1,464 @@
+package jmri.jmrit.beantable.light;
+
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.annotation.Nonnull;
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableCellRenderer;
+
+import jmri.*;
+import jmri.jmrit.beantable.BeanTableDataModel;
+import static jmri.jmrit.beantable.LightTableAction.getDescriptionText;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Data model for a Light Table.
+ * Code originally within LightTableAction.
+ * 
+ * @author Dave Duchamp Copyright (C) 2004
+ * @author Egbert Broerse Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class LightTableDataModel extends BeanTableDataModel<Light> {
+    
+    static public final int ENABLECOL = BeanTableDataModel.NUMCOLUMN;
+    static public final int INTENSITYCOL = ENABLECOL + 1;
+    static public final int EDITCOL = INTENSITYCOL + 1;
+    static public final int CONTROLCOL = EDITCOL + 1;
+
+    // for icon state col
+    protected boolean _graphicState = false; // updated from prefs
+    
+    public LightTableDataModel(){
+        super();
+        initTable();
+    }
+
+    public LightTableDataModel(Manager<Light> mgr){
+        super(mgr);
+        initTable();
+    }
+    
+    private void initTable() {
+
+        _graphicState = InstanceManager.getDefault(jmri.util.gui.GuiLafPreferencesManager.class).isGraphicTableState();
+        
+    }
+    
+    private Manager<Light> lightManager;
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
+    @Override
+    public Manager<Light> getManager() {
+        if (lightManager == null) {
+            lightManager = InstanceManager.getDefault(LightManager.class);
+        }
+        return lightManager;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected final void setManager(@Nonnull Manager<Light> manager) {
+        if (!(manager instanceof LightManager)) {
+            return;
+        }
+        getManager().removePropertyChangeListener(this);
+        if (sysNameList != null) {
+            for (int i = 0; i < sysNameList.size(); i++) {
+                // if object has been deleted, it's not here; ignore it
+                NamedBean b = getBySystemName(sysNameList.get(i));
+                if (b != null) {
+                    b.removePropertyChangeListener(this);
+                }
+            }
+        }
+        lightManager = manager;
+        getManager().addPropertyChangeListener(this);
+        updateNameList();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getColumnCount() {
+        return CONTROLCOL + 1 + getPropertyColumnCount();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getColumnName(int col) {
+        switch (col) {
+            case EDITCOL:
+                return ""; // no heading on "Edit"
+            case INTENSITYCOL:
+                return Bundle.getMessage("ColumnHeadIntensity");
+            case ENABLECOL:
+                return Bundle.getMessage("ColumnHeadEnabled");
+            case CONTROLCOL:
+                return Bundle.getMessage("LightControllerTitlePlural");
+            default:
+                return super.getColumnName(col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<?> getColumnClass(int col) {
+        switch (col) {
+            case EDITCOL:
+                return JButton.class;
+            case INTENSITYCOL:
+                return Double.class;
+            case ENABLECOL:
+                return Boolean.class;
+            case CONTROLCOL:
+                return String.class;
+            case VALUECOL:  // may use an image to show light state
+                return ( _graphicState ? JLabel.class : JButton.class );
+            default:
+                return super.getColumnClass(col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPreferredWidth(int col) {
+        switch (col) {
+            case USERNAMECOL: // override default value for UserName column
+            case CONTROLCOL:
+                return new JTextField(16).getPreferredSize().width;
+            case EDITCOL:
+                return new JButton(Bundle.getMessage("ButtonEdit")).getPreferredSize().width+4;
+            case INTENSITYCOL:
+            case ENABLECOL:
+                return new JTextField(6).getPreferredSize().width;
+            default:
+                return super.getPreferredWidth(col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCellEditable(int row, int col) {
+        switch (col) {
+            case INTENSITYCOL:
+                return getValueAt(row, SYSNAMECOL) instanceof VariableLight;
+            case EDITCOL:
+            case ENABLECOL:
+                return true;
+            case CONTROLCOL:
+                return false;
+            default:
+                return super.isCellEditable(row, col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getValue(String name) {
+        Light l = lightManager.getBySystemName(name);
+        return (l==null ? ("Failed to find " + name) : l.describeState(l.getState()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object getValueAt(int row, int col) {
+        Light l = (Light) super.getValueAt(row, SYSNAMECOL);
+        if (l == null){
+            return null;
+        }
+        switch (col) {
+            case EDITCOL:
+                return Bundle.getMessage("ButtonEdit");
+            case INTENSITYCOL:
+                if (l instanceof VariableLight) {
+                    return ((VariableLight)l).getTargetIntensity();
+                } else {
+                    return 0.0;
+                }
+            case ENABLECOL:
+                return l.getEnabled();
+            case CONTROLCOL:
+                StringBuilder sb = new StringBuilder();
+                for (LightControl lc : l.getLightControlList()) {
+                    sb.append(getDescriptionText(lc, lc.getControlType()));
+                    sb.append(" ");
+                }
+                return sb.toString();
+            default:
+                return super.getValueAt(row, col);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setValueAt(Object value, int row, int col) {
+        Light l = (Light) getValueAt(row, SYSNAMECOL);
+        if (l == null){
+            return;
+        }
+        switch (col) {
+            case EDITCOL:
+                // Use separate Runnable so window is created on top
+                javax.swing.SwingUtilities.invokeLater(() -> {
+                    editButton(l);
+                });
+                break;
+            case INTENSITYCOL:
+                // alternate
+                try {
+                    if (l instanceof VariableLight) {
+                        double intensity = Math.max(0, Math.min(1.0, (Double) value));
+                        ((VariableLight)l).setTargetIntensity(intensity);
+                    } else {
+                        double intensity = ((Double) value);
+                        l.setCommandedState( intensity > 0.5 ? Light.ON : Light.OFF);
+                    }
+                } catch (IllegalArgumentException e1) {
+                    JOptionPane.showMessageDialog(null,  e1.getMessage());
+                }
+                break;
+            case ENABLECOL:
+                l.setEnabled(!l.getEnabled());
+                break;
+            case VALUECOL:
+                clickOn(l);
+                fireTableRowsUpdated(row, row);
+                break;
+            default:
+                super.setValueAt(value, row, col);
+                break;
+        }
+    }
+    
+    private void editButton(Light bean){
+        jmri.jmrit.beantable.beanedit.LightEditAction beanEdit = new jmri.jmrit.beantable.beanedit.LightEditAction();
+        beanEdit.setBean(bean);
+        beanEdit.actionPerformed(null);
+    }
+
+    /**
+     * Delete the bean after all the checking has been done.
+     * <p>
+     * Deactivate the light, then use the superclass to delete it.
+     */
+    @Override
+    protected void doDelete(Light bean) {
+        bean.deactivateLight();
+        super.doDelete(bean);
+    }
+
+    // all properties update for now
+    @Override
+    protected boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Light getBySystemName(@Nonnull String name) {
+        return lightManager.getBySystemName(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Light getByUserName(@Nonnull String name) {
+        return InstanceManager.getDefault(LightManager.class).getByUserName(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getMasterClassName() {
+        return jmri.jmrit.beantable.LightTableAction.class.getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clickOn(Light t) {
+        t.setState( t.getState()==Light.OFF ? Light.ON : Light.OFF );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JButton configureButton() {
+        return new JButton(" " + Bundle.getMessage("StateOff") + " ");
+    }
+
+    /**
+     * Customize the light table Value (State) column to show an
+     * appropriate graphic for the light state if _graphicState = true,
+     * or (default) just show the localized state text when the
+     * TableDataModel is being called from ListedTableAction.
+     *
+     * @param table a JTable of Lights
+     */
+    @Override
+    protected void configValueColumn(JTable table) {
+        // have the value column hold a JPanel (icon)
+        //setColumnToHoldButton(table, VALUECOL, new JLabel("123456")); // for small round icon, but cannot be converted to JButton
+        // add extras, override BeanTableDataModel
+        log.debug("Light configValueColumn (I am {})", this);
+        if (_graphicState) { // load icons, only once
+            table.setDefaultEditor(JLabel.class, new ImageIconRenderer()); // editor
+            table.setDefaultRenderer(JLabel.class, new ImageIconRenderer()); // item class copied from SwitchboardEditor panel
+        } else {
+            super.configValueColumn(table); // classic text style state indication
+        }
+    }
+
+    /**
+     * Visualize state in table as a graphic, customized for Lights (2
+     * states + ... for transitioning). Renderer and Editor are
+     * identical, as the cell contents are not actually edited, only
+     * used to toggle state using {@link #clickOn(Light)}.
+     *
+     */
+    static class ImageIconRenderer extends AbstractCellEditor implements TableCellEditor, TableCellRenderer {
+
+        protected JLabel label;
+        protected String rootPath = "resources/icons/misc/switchboard/"; // also used in display.switchboardEditor
+        protected char beanTypeChar = 'L'; // for Light
+        protected String onIconPath = rootPath + beanTypeChar + "-on-s.png";
+        protected String offIconPath = rootPath + beanTypeChar + "-off-s.png";
+        protected BufferedImage onImage;
+        protected BufferedImage offImage;
+        protected ImageIcon onIcon;
+        protected ImageIcon offIcon;
+        protected int iconHeight = -1;
+
+        @Override
+        public Component getTableCellRendererComponent(
+                JTable table, Object value, boolean isSelected,
+                boolean hasFocus, int row, int column) {
+            log.debug("Renderer Item = {}, State = {}", row, value);
+            if (iconHeight < 0) { // load resources only first time, either for renderer or editor
+                loadIcons();
+                log.debug("icons loaded");
+            }
+            return updateLabel((String) value, row);
+        }
+
+        @Override
+        public Component getTableCellEditorComponent(
+                JTable table, Object value, boolean isSelected,
+                int row, int column) {
+            log.debug("Renderer Item = {}, State = {}", row, value);
+            if (iconHeight < 0) { // load resources only first time, either for renderer or editor
+                loadIcons();
+                log.debug("icons loaded");
+            }
+            return updateLabel((String) value, row);
+        }
+
+        public JLabel updateLabel(String value, int row) {
+            if (iconHeight > 0) { // if necessary, increase row height;
+                log.debug("TODO adjust table row height for Lights?");
+                //table.setRowHeight(row, Math.max(table.getRowHeight(), iconHeight - 5));
+            }
+            if (value.equals(Bundle.getMessage("StateOff")) && offIcon != null) {
+                label = new JLabel(offIcon);
+                label.setVerticalAlignment(JLabel.BOTTOM);
+                log.debug("offIcon set");
+            } else if (value.equals(Bundle.getMessage("StateOn")) && onIcon != null) {
+                label = new JLabel(onIcon);
+                label.setVerticalAlignment(JLabel.BOTTOM);
+                log.debug("onIcon set");
+            } else if (value.equals(Bundle.getMessage("BeanStateInconsistent"))) {
+                label = new JLabel("X", JLabel.CENTER); // centered text alignment
+                label.setForeground(Color.red);
+                log.debug("Light state inconsistent");
+                iconHeight = 0;
+            } else if (value.equals(Bundle.getMessage("LightStateIntermediate"))) {
+                label = new JLabel("...", JLabel.CENTER); // centered text alignment
+                log.debug("Light state in transition");
+                iconHeight = 0;
+            } else { // failed to load icon
+                label = new JLabel(value, JLabel.CENTER); // centered text alignment
+                log.warn("Error reading icons for LightTable");
+                iconHeight = 0;
+            }
+            label.setToolTipText(value);
+            label.addMouseListener(new MouseAdapter() {
+                @Override
+                public final void mousePressed(MouseEvent evt) {
+                    log.debug("Clicked on icon in row {}", row);
+                    stopCellEditing();
+                }
+            });
+            return label;
+        }
+
+        @Override
+        public Object getCellEditorValue() {
+            log.debug("getCellEditorValue, me = {})", this);
+            return this.toString();
+        }
+
+        /**
+         * Read and buffer graphics. Only called once for this table.
+         *
+         * @see #getTableCellEditorComponent(JTable, Object, boolean,
+         * int, int)
+         */
+        protected void loadIcons() {
+            try {
+                onImage = ImageIO.read(new File(onIconPath));
+                offImage = ImageIO.read(new File(offIconPath));
+            } catch (IOException ex) {
+                log.error("error reading image from {} or {}", onIconPath, offIconPath, ex);
+            }
+            log.debug("Success reading images");
+            int imageWidth = onImage.getWidth();
+            int imageHeight = onImage.getHeight();
+            // scale icons 50% to fit in table rows
+            Image smallOnImage = onImage.getScaledInstance(imageWidth / 2, imageHeight / 2, Image.SCALE_DEFAULT);
+            Image smallOffImage = offImage.getScaledInstance(imageWidth / 2, imageHeight / 2, Image.SCALE_DEFAULT);
+            onIcon = new ImageIcon(smallOnImage);
+            offIcon = new ImageIcon(smallOffImage);
+            iconHeight = onIcon.getIconHeight();
+        }
+
+    }
+    
+    private final static Logger log = LoggerFactory.getLogger(LightTableDataModel.class);
+            
+}

--- a/java/test/jmri/jmrit/beantable/AbstractBeanTableDataModelBase.java
+++ b/java/test/jmri/jmrit/beantable/AbstractBeanTableDataModelBase.java
@@ -113,6 +113,17 @@ public abstract class AbstractBeanTableDataModelBase<B extends jmri.NamedBean> {
     }
     
     /**
+     * Test of setValueAt method with no column in model.
+     * Should NOT be overridden by implementing Tests.
+     */
+    @Test
+    public void testSetValueAtNoColumn() {
+        createBean(); // ensure there is a row 0
+        t.setValueAt(null,0,t.getColumnCount());
+        JUnitAppender.assertErrorMessage("btdm setvalueat 0 " + t.getColumnCount());
+    }
+    
+    /**
      * Test of getValueAt method with no column in model.
      * Should NOT be overridden by implementing Tests
      */

--- a/java/test/jmri/jmrit/beantable/LightTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LightTableActionTest.java
@@ -8,6 +8,7 @@ import javax.swing.JFrame;
 import javax.swing.JTextField;
 
 import jmri.*;
+import jmri.jmrit.beantable.light.LightTableDataModel;
 import jmri.util.JUnitUtil;
 import jmri.util.swing.JemmyUtil;
 
@@ -15,11 +16,7 @@ import org.junit.jupiter.api.*;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.netbeans.jemmy.QueueTool;
-import org.netbeans.jemmy.operators.JComboBoxOperator;
-import org.netbeans.jemmy.operators.JFrameOperator;
-import org.netbeans.jemmy.operators.JLabelOperator;
-import org.netbeans.jemmy.operators.JTableOperator;
-import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.netbeans.jemmy.operators.*;
 import org.netbeans.jemmy.util.NameComponentChooser;
 
 /**
@@ -131,7 +128,7 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         new QueueTool().waitEmpty();
         JTableOperator tbl = new JTableOperator(jfo, 0);
         // find the "Edit" button and press it.  This is in the table body.
-        tbl.clickOnCell(0, tbl.getColumnCount() - 1); // edit column is last in light table.
+        tbl.clickOnCell(0, LightTableDataModel.EDITCOL); // edit column
         new QueueTool().waitEmpty();
         JFrame f2 = JFrameOperator.waitJFrame(getEditFrameName(), true, true);
         JemmyUtil.pressButton(new JFrameOperator(f2), Bundle.getMessage("ButtonCancel"));
@@ -141,7 +138,7 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
 
     @Override
     public String getEditFrameName() {
-        return Bundle.getMessage("TitleEditLight");
+        return Bundle.getMessage("TitleEditLight") + " IL1";
     }
 
     @Test
@@ -202,11 +199,13 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         // now we find the Light in the table and edit it
         JTableOperator tbl = new JTableOperator(jfo, 0);
         // find the "Edit" button and press it.  This is in the table body.
-        tbl.clickOnCell(0, tbl.getColumnCount() - 1); // edit column is last in light table.
+        tbl.clickOnCell(0, LightTableDataModel.EDITCOL); // edit column
 
         new QueueTool().waitEmpty();
-        JFrame f2 = JFrameOperator.waitJFrame(getEditFrameName(), true, true);
+        JFrame f2 = JFrameOperator.waitJFrame("Edit Light IL1234", true, true);
         JFrameOperator jfoce = new JFrameOperator(f2);
+        JTabbedPaneOperator tabOperator = new JTabbedPaneOperator(jfoce);
+        tabOperator.selectPage(Bundle.getMessage("LightControllerTitlePlural"));
         JTableOperator controltbl = new JTableOperator(jfoce, 0);
         // find the "Edit" button and press it.  This is in the table body.
         controltbl.clickOnCell(0, 2); // click edit button in column 2.
@@ -230,7 +229,7 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
 
         sOne.setState(Sensor.OFF);
         Assert.assertEquals("Light still ON", Light.ON, created.getState());
-        JemmyUtil.pressButton(jfob, Bundle.getMessage("ButtonUpdate"));
+        JemmyUtil.pressButton(jfoce, Bundle.getMessage("ButtonOK"));
         // light edit frame closes
 
         // light should now be updaed to S1
@@ -299,12 +298,15 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         // now we find the Light in the table and edit it
         JTableOperator tbl = new JTableOperator(jfo, 0);
         // find the "Edit" button and press it.  This is in the table body.
-        tbl.clickOnCell(0, tbl.getColumnCount() - 1); // edit column is last in light table.
+        tbl.clickOnCell(0, LightTableDataModel.EDITCOL); // edit column
 
         new QueueTool().waitEmpty();
-        JFrame f2 = JFrameOperator.waitJFrame(getEditFrameName(), true, true);
+        JFrame f2 = JFrameOperator.waitJFrame("Edit Light IL4321", true, true);
 
         JFrameOperator jfoce = new JFrameOperator(f2);
+        JTabbedPaneOperator tabOperator = new JTabbedPaneOperator(jfoce);
+        tabOperator.selectPage(Bundle.getMessage("LightControllerTitlePlural"));
+        
         JTableOperator controltbl = new JTableOperator(jfoce, 0);
         // find the "Edit" button and press it.  This is in the table body.
 
@@ -330,7 +332,7 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         JemmyUtil.pressButton(jfof3, Bundle.getMessage("ButtonUpdate"));
         // light control edit frame closes
 
-        JemmyUtil.pressButton(jfob, Bundle.getMessage("ButtonUpdate"));
+        JemmyUtil.pressButton(jfoce, Bundle.getMessage("ButtonOK"));
         // light edit frame closes
 
         Assert.assertEquals("Correct Light Control Type and Times", "ON at 21:22, OFF at 23:24.",
@@ -338,11 +340,13 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
                         created.getLightControlList().get(0).getControlType()));
 
         // now we edit the control then cancel the edit
-        tbl.clickOnCell(0, tbl.getColumnCount() - 1); // edit column is last in light table.
+        tbl.clickOnCell(0, LightTableDataModel.EDITCOL); // edit column
         new QueueTool().waitEmpty();
-        JFrame f4 = JFrameOperator.waitJFrame(getEditFrameName(), true, true);
+        JFrame f4 = JFrameOperator.waitJFrame("Edit Light IL4321", true, true);
 
         JFrameOperator jfocef4 = new JFrameOperator(f4);
+        JTabbedPaneOperator tabOperator4 = new JTabbedPaneOperator(jfocef4);
+        tabOperator4.selectPage(Bundle.getMessage("LightControllerTitlePlural"));
         new JTableOperator(jfocef4, 0).clickOnCell(0, 2); // click edit button in column 2.
         // find the "Edit" Control button and press it.  This is in the table body.
 
@@ -364,7 +368,8 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         JemmyUtil.pressButton(jfof5, Bundle.getMessage("ButtonUpdate"));
         // light control edit frame does not close as the on and off times are the same
         
-        checkEditLightFeedback( Bundle.getMessage("LightWarn11"), jfocef4);
+        JLabelOperator lblFeedback = new JLabelOperator(jfof5, 5);
+        Assert.assertEquals("Message did not appear", Bundle.getMessage("LightWarn11"), lblFeedback.getText());
         
         new JTextFieldOperator(jfof5, 2).setText("03");
         new JTextFieldOperator(jfof5, 3).setText("04");
@@ -388,7 +393,8 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         JemmyUtil.pressButton(jfoc, Bundle.getMessage("ButtonCreate"));
         // light control edit frame does not close as the on and off times are the same
         
-        checkEditLightFeedback( Bundle.getMessage("LightWarn12"), jfocef4);
+        lblFeedback = new JLabelOperator(jfoc, 5);
+        Assert.assertEquals("Message did not appear", Bundle.getMessage("LightWarn12"), lblFeedback.getText());
         
         new JTextFieldOperator(jfoc, 0).setText("05");
         new JTextFieldOperator(jfoc, 1).setText("06");
@@ -396,11 +402,9 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         new JTextFieldOperator(jfoc, 3).setText("08");
         
         JemmyUtil.pressButton(jfoc, Bundle.getMessage("ButtonCreate"));
-        
-        checkEditLightFeedback( Bundle.getMessage("LightUpdateInst"), jfocef4);
 
         // now we click cancel on the edit light and ensure changes from the edited control are not passed
-        JemmyUtil.pressButton(new JFrameOperator(f4), Bundle.getMessage("ButtonCancel"));
+        JemmyUtil.pressButton(jfocef4, Bundle.getMessage("ButtonCancel"));
 
         Assert.assertEquals("Unchanged Light Control Type and Times", "ON at 21:22, OFF at 23:24.",
                 LightTableAction.getDescriptionText(created.getLightControlList().get(0),
@@ -457,12 +461,16 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         // now we find the Light in the table and edit it
         JTableOperator tbl = new JTableOperator(jfo, 0);
         // find the "Edit" button and press it.  This is in the table body.
-        tbl.clickOnCell(0, tbl.getColumnCount() - 1); // edit column is last in light table.
+        tbl.clickOnCell(0, LightTableDataModel.EDITCOL); // edit column
 
         new QueueTool().waitEmpty();
-        JFrame f2 = JFrameOperator.waitJFrame(getEditFrameName(), true, true);
+        JFrame f2 = JFrameOperator.waitJFrame("Edit Light IL333", true, true);
         // JemmyUtil.pressButton(new JFrameOperator(f2),Bundle.getMessage("ButtonCancel"));
+        
         JFrameOperator jfoce = new JFrameOperator(f2);
+        JTabbedPaneOperator tabOperator = new JTabbedPaneOperator(jfoce);
+        tabOperator.selectPage(Bundle.getMessage("LightControllerTitlePlural"));
+        
         JTableOperator controltbl = new JTableOperator(jfoce, 0);
         // find the "Edit" button and press it.  This is in the table body.
         controltbl.clickOnCell(0, 2); // click edit button in column 2.
@@ -484,7 +492,7 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         JemmyUtil.pressButton(jfof3, Bundle.getMessage("ButtonUpdate"));
         // light new control frame closes
 
-        JemmyUtil.pressButton(jfoce, Bundle.getMessage("ButtonUpdate"));
+        JemmyUtil.pressButton(jfoce, Bundle.getMessage("ButtonOK"));
         // light edit frame closes
 
         // confirm light has been created with correct control        
@@ -541,12 +549,15 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         // now we find the Light in the table and edit it
         JTableOperator tbl = new JTableOperator(jfo, 0);
         // find the "Edit" button and press it.  This is in the table body.
-        tbl.clickOnCell(0, tbl.getColumnCount() - 1); // edit column is last in light table.
+        tbl.clickOnCell(0, LightTableDataModel.EDITCOL); // edit column
 
         new QueueTool().waitEmpty();
-        JFrame f2 = JFrameOperator.waitJFrame(getEditFrameName(), true, true);
+        JFrame f2 = JFrameOperator.waitJFrame("Edit Light IL444", true, true);
 
         JFrameOperator jfoce = new JFrameOperator(f2);
+        JTabbedPaneOperator tabOperator = new JTabbedPaneOperator(jfoce);
+        tabOperator.selectPage(Bundle.getMessage("LightControllerTitlePlural"));
+        
         JTableOperator controltbl = new JTableOperator(jfoce, 0);
         // find the "Edit" button and press it.  This is in the table body.
 
@@ -569,7 +580,7 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         JemmyUtil.pressButton(jfof3, Bundle.getMessage("ButtonUpdate"));
         // light control edit frame closes
 
-        JemmyUtil.pressButton(jfob, Bundle.getMessage("ButtonUpdate"));
+        JemmyUtil.pressButton(jfoce, Bundle.getMessage("ButtonOK"));
         // light edit frame closes
 
         // light should now be updaed to S1
@@ -634,12 +645,16 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         // now we find the Light in the table and edit it
         JTableOperator tbl = new JTableOperator(jfo, 0);
         // find the "Edit" button and press it.  This is in the table body.
-        tbl.clickOnCell(0, tbl.getColumnCount() - 1); // edit column is last in light table.
+        tbl.clickOnCell(0, LightTableDataModel.EDITCOL); // edit column
 
         new QueueTool().waitEmpty();
-        JFrame f2 = JFrameOperator.waitJFrame(getEditFrameName(), true, true);
+        JFrame f2 = JFrameOperator.waitJFrame("Edit Light IL555", true, true);
 
         JFrameOperator jfoce = new JFrameOperator(f2);
+        
+        JTabbedPaneOperator tabOperator = new JTabbedPaneOperator(jfoce);
+        tabOperator.selectPage(Bundle.getMessage("LightControllerTitlePlural"));
+        
         JTableOperator controltbl = new JTableOperator(jfoce, 0);
         // find the "Edit" button and press it.  This is in the table body.
         controltbl.clickOnCell(0, 2); // click edit button in column 2.
@@ -667,7 +682,7 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         JemmyUtil.pressButton(jfof3, Bundle.getMessage("ButtonUpdate"));
         // light control edit frame closes
 
-        JemmyUtil.pressButton(jfoce, Bundle.getMessage("ButtonUpdate"));
+        JemmyUtil.pressButton(jfoce, Bundle.getMessage("ButtonOK"));
         // light edit frame closes
 
         // light should now be updaed
@@ -741,9 +756,6 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
-        jmri.util.JUnitUtil.initInternalLightManager();
-        jmri.util.JUnitUtil.initInternalSensorManager();
-        jmri.util.JUnitUtil.initInternalTurnoutManager();
         jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
         helpTarget = "package.jmri.jmrit.beantable.LightTable";
         a = new LightTableAction();

--- a/java/test/jmri/jmrit/beantable/LightTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LightTableActionTest.java
@@ -744,12 +744,6 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
                         created.getLightControlList().get(0).getControlType()));
     }
 
-    // test the feedback message displayed in-pane for an Edit / New Light pane WITH variable intensity
-    private void checkEditLightFeedback( String toTest, JFrameOperator jfo){
-        JLabelOperator lblFeedback = new JLabelOperator(jfo, 11);
-        Assert.assertEquals("Message did not appear", toTest, lblFeedback.getText());
-    }
-
     @BeforeEach
     @Override
     public void setUp() {

--- a/java/test/jmri/jmrit/beantable/beanedit/LightEditActionTest.java
+++ b/java/test/jmri/jmrit/beantable/beanedit/LightEditActionTest.java
@@ -1,0 +1,32 @@
+package jmri.jmrit.beantable.beanedit;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+
+/**
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class LightEditActionTest {
+    
+    @Test
+    public void testCTor() {
+        LightEditAction t = new LightEditAction();
+        Assert.assertNotNull("exists",t);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    // private final static Logger log = LoggerFactory.getLogger(LightEditActionTest.class);
+    
+}

--- a/java/test/jmri/jmrit/beantable/light/AddEditSingleLightControlFrameTest.java
+++ b/java/test/jmri/jmrit/beantable/light/AddEditSingleLightControlFrameTest.java
@@ -1,0 +1,35 @@
+package jmri.jmrit.beantable.light;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class AddEditSingleLightControlFrameTest {
+    
+    @Test
+    public void testCTor() {
+        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
+        LightControlPane lcp = new LightControlPane();
+        AddEditSingleLightControlFrame t = new AddEditSingleLightControlFrame(lcp,null);
+        Assert.assertNotNull("exists",t);
+        lcp.dispose();
+    }
+    
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+    
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+    
+}

--- a/java/test/jmri/jmrit/beantable/light/BundleTest.java
+++ b/java/test/jmri/jmrit/beantable/light/BundleTest.java
@@ -1,0 +1,43 @@
+package jmri.jmrit.beantable.light;
+
+import java.util.Locale;
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+
+/**
+ * Tests for the Bundle class
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ */
+public class BundleTest  {
+
+    @Test public void testGoodKeyMessage() {
+        Assert.assertEquals("Turnout", Bundle.getMessage("BeanNameTurnout"));
+    }
+
+    @Test
+    public void testBadKeyMessage() {
+        Assert.assertThrows(java.util.MissingResourceException.class, () -> Bundle.getMessage("FFFFFTTTTTTT"));
+    }
+
+    @Test public void testGoodKeyMessageArg() {
+        Assert.assertEquals("Sensor", Bundle.getMessage("BeanNameSensor", new Object[]{}));
+        Assert.assertEquals("About Test", Bundle.getMessage("TitleAbout", "Test"));
+    }
+
+    @Test
+    public void testBadKeyMessageArg() {
+        Assert.assertThrows(java.util.MissingResourceException.class, () -> Bundle.getMessage("FFFFFTTTTTTT", new Object[]{}));
+    }
+
+    @Test public void testLocaleMessage() {
+        Assert.assertEquals("Scambio", Bundle.getMessage(Locale.ITALY, "BeanNameTurnout"));
+    }
+
+    @Test public void testLocaleMessageArg() {
+        Assert.assertEquals("Scambio", Bundle.getMessage(Locale.ITALY, "BeanNameTurnout", new Object[]{}));
+        Assert.assertEquals("Informazioni su Test", Bundle.getMessage(Locale.ITALY, "TitleAbout", "Test"));
+    }
+
+
+}

--- a/java/test/jmri/jmrit/beantable/light/LightControlPaneTest.java
+++ b/java/test/jmri/jmrit/beantable/light/LightControlPaneTest.java
@@ -1,0 +1,33 @@
+package jmri.jmrit.beantable.light;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class LightControlPaneTest {
+    
+    @Test
+    public void testCTor() {
+        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
+        LightControlPane t = new LightControlPane();
+        Assert.assertNotNull("exists",t);
+    }
+    
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+    
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+    
+}

--- a/java/test/jmri/jmrit/beantable/light/LightControlTableModelTest.java
+++ b/java/test/jmri/jmrit/beantable/light/LightControlTableModelTest.java
@@ -1,0 +1,43 @@
+package jmri.jmrit.beantable.light;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class LightControlTableModelTest {
+    
+    private LightControlTableModel t;
+    
+    @Test
+    public void testCTor() {
+        t = new LightControlTableModel(null);
+        Assert.assertNotNull("exists",t);
+    }
+    
+    @Test
+    public void testGetColumnCount() {
+        t = new LightControlTableModel(null);
+        assertEquals(4, t.getColumnCount());
+    }
+    
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+
+    }
+    
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+    
+}

--- a/java/test/jmri/jmrit/beantable/light/LightIntensityPaneTest.java
+++ b/java/test/jmri/jmrit/beantable/light/LightIntensityPaneTest.java
@@ -1,0 +1,33 @@
+package jmri.jmrit.beantable.light;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class LightIntensityPaneTest {
+    
+    @Test
+    public void testCTor() {
+        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
+        LightIntensityPane t = new LightIntensityPane(true);
+        Assert.assertNotNull("exists",t);
+    }
+    
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+    
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+    
+}

--- a/java/test/jmri/jmrit/beantable/light/LightTableDataModelTest.java
+++ b/java/test/jmri/jmrit/beantable/light/LightTableDataModelTest.java
@@ -1,0 +1,47 @@
+package jmri.jmrit.beantable.light;
+
+import jmri.Light;
+import jmri.util.JUnitUtil;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2021
+ */
+public class LightTableDataModelTest extends jmri.jmrit.beantable.AbstractBeanTableDataModelBase<Light> {
+    
+    
+    @Test
+    public void testCTor() {
+        Assert.assertNotNull("exists",t);
+    }
+    
+    @Override
+    public int getModelColumnCount(){
+        return 9;
+    }
+    
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.initInternalLightManager();
+        t = new LightTableDataModel();
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        if (t!=null){
+            t.dispose();
+        }
+        t = null;
+        JUnitUtil.tearDown();
+    }
+    
+}


### PR DESCRIPTION
Improve maintainability of LightTableAction ( more clarity between New Bean UI functions and Table Display )

Light Table - Added Column Light Controllers - Light Control summary text

![image](https://user-images.githubusercontent.com/39652002/110691842-8f7cac00-81dd-11eb-98dc-59702949a3b6.png)


Light Table -Edit window uses standard JMRI Bean edit window, custom tabs for Light Controls, Intensity

![image](https://user-images.githubusercontent.com/39652002/110692145-ee422580-81dd-11eb-90d2-ea1ab0dad1df.png)

Intensity tab disabled if not available for hardware type.
![image](https://user-images.githubusercontent.com/39652002/110692298-234e7800-81de-11eb-9608-e220ac64872d.png)


Adds
AddEditSingleLightControlFrame.java
LightControlPane.java
LightControlTableModel.java
LightIntensityPane.java
LightTableDataModel.java
LightEditAction.java
and associated Bundle / tests.