### PR TITLE
Remove the "Frame Border Off" feature for throttles

### DIFF
--- a/java/src/jmri/jmrit/throttle/ThrottleBundle.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle.properties
@@ -11,9 +11,6 @@ EditThrottleFrameTitle = Edit Throttle Frame
 FrameTitlePrompt = Frame Title:
 ErrorOnPage = Errors on page
 SelectTitleTypePrompt = Frame Title Components:
-FrameDecorationsTitle = Frame Decorations:
-FrameBorderOffTitle = Frame Border Off
-FrameSize = 23
 
 # ThrottleFrameTitleTypes parts
 SelectTitleTypeADDRESS = Address

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_ca.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_ca.properties
@@ -12,9 +12,6 @@ EditThrottleFrameTitle = Edita la finestra del regulador
 FrameTitlePrompt = T\u00edtol de la finestra
 ErrorOnPage = Errors a la p\u00e0gina
 SelectTitleTypePrompt = Components de la Finestra de t\u00edtol:
-FrameDecorationsTitle = Decoracions de la finestra:
-FrameBorderOffTitle = Sense marge
-FrameSize = 23
 
 # ThrottleFrameTitleTypes parts
 SelectTitleTypeADDRESS = Adre\u00e7a

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_cs.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_cs.properties
@@ -11,9 +11,6 @@ EditThrottleFrameTitle = Upravit ok\u00e9nka ovlada\u010d
 FrameTitlePrompt = Nadpis ok\u00e9nka:
 ErrorOnPage = Chyba na str\u00e1nce
 SelectTitleTypePrompt = Nadpis ok\u00e9nka komponent:
-FrameDecorationsTitle = Dekorace ok\u00e9nka:
-FrameBorderOffTitle = Vypnout ohrani\u010den\u00ed ok\u00e9nka
-FrameSize = 23
 
 # ThrottleFrameTitleTypes parts
 SelectTitleTypeADDRESS = Adresa

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_da.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_da.properties
@@ -10,9 +10,6 @@ EditThrottleFrameTitle = Rediger K\u00f8rekontrol Ramme
 FrameTitlePrompt = Ramme Titel:
 ErrorOnPage = Fejl p\u00e5 siden
 SelectTitleTypePrompt = Ramme Titel Komponenter:
-FrameDecorationsTitle = Ramme Dekorationer:
-FrameBorderOffTitle = Ramme Overskrift Off
-FrameSize = 23
 
 # ThrottleFrameTitleTypes parts
 SelectTitleTypeADDRESS = Adresse

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_de.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_de.properties
@@ -11,9 +11,6 @@ EditThrottleFrameTitle = Bearbeite Fahrreglerfenster
 FrameTitlePrompt = Fenstertitel:
 ErrorOnPage = Fehler auf dieser Seite
 SelectTitleTypePrompt = Komponententitel des Fensters:
-FrameDecorationsTitle = Fensterdekoration:
-FrameBorderOffTitle = Unsichtbarer Rahmen dieses Fensters
-FrameSize = 23
 
 # ThrottleFrameTitleTypes parts
 SelectTitleTypeADDRESS = Adresse

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_fr.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_fr.properties
@@ -11,9 +11,6 @@ EditThrottleFrameTitle = Editer les propri\u00e9t\u00e9s de la fen\u00eatre
 FrameTitlePrompt = Titre de la fen\u00eatre:
 ErrorOnPage = Erreurs sur la page
 SelectTitleTypePrompt = Composition du titre de la fen\u00eatre:
-FrameDecorationsTitle = D\u00e9corations de la fen\u00eatre:
-FrameBorderOffTitle = Pas de bordure
-FrameSize = 23
 
 # ThrottleFrameTitleTypes parts
 SelectTitleTypeADDRESS = Adresse

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_it.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_it.properties
@@ -11,9 +11,6 @@ EditThrottleFrameTitle = Modifica Cornice Palmare
 FrameTitlePrompt = Titolo Cornice:
 ErrorOnPage = Errore sulla Pagina
 SelectTitleTypePrompt = Componenti Titolo Cornice:
-FrameDecorationsTitle = Decorazioni Cornice:
-FrameBorderOffTitle = Nessun Bordo Cornice
-FrameSize = 23
 
 # ThrottleFrameTitleTypes parts
 SelectTitleTypeADDRESS = Indirizzo

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_ja_JP.properties
@@ -8,9 +8,6 @@ EditThrottleFrameTitle = \u30b9\u30ed\u30c3\u30c8\u30eb\u67a0\u7de8\u96c6
 FrameTitlePrompt = \u67a0\u306e\u30bf\u30a4\u30c8\u30eb:
 ErrorOnPage = \u30da\u30fc\u30b8\u306e\u30a8\u30e9\u30fc
 SelectTitleTypePrompt = \u67a0\u306e\u30bf\u30a4\u30c8\u30eb\u306e\u540d\u79f0:
-FrameDecorationsTitle = \u67a0\u88c5\u98fe:
-FrameBorderOffTitle = \u67a0\u7121\u3057
-FrameSize = 23
 
 # ThrottleFrameTitleTypes parts
 SelectTitleTypeADDRESS = \u30a2\u30c9\u30ec\u30b9

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_nl.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_nl.properties
@@ -11,9 +11,6 @@ EditThrottleFrameTitle = Pas Rijregelaar aan
 FrameTitlePrompt = Frame-titel:
 ErrorOnPage = Fouten op deze pagina
 SelectTitleTypePrompt = Onderdelen voor titel:
-FrameDecorationsTitle = Opmaak:
-FrameBorderOffTitle = Rand uit
-FrameSize = 23
 
 # ThrottleFrameTitleTypes parts
 SelectTitleTypeADDRESS = Adres

--- a/java/src/jmri/jmrit/throttle/ThrottleFramePropertyEditor.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleFramePropertyEditor.java
@@ -33,8 +33,6 @@ public class ThrottleFramePropertyEditor extends JDialog {
 
     private JList<String> titleType;
 
-    private JCheckBox borderOff;
-
     private String[] titleTextTypes = {"address", "text", "textAddress", "addressText", "rosterID"};
     private String[] titleTextTypeNames = {
         Bundle.getMessage("SelectTitleTypeADDRESS"),
@@ -109,16 +107,6 @@ public class ThrottleFramePropertyEditor extends JDialog {
         constraints.gridx++;
         propertyPanel.add(titleType, constraints);
 
-        // add a checkbox for borders off, but only if that's actually possible.
-        // this code uses details of internal UI code
-        if (((javax.swing.plaf.basic.BasicInternalFrameUI) frame.getCurrentThrottleFrame().getControlPanel().getUI()).getNorthPane() != null) {
-            borderOff = new JCheckBox(Bundle.getMessage("FrameBorderOffTitle"), false);
-            constraints.gridy++;
-            constraints.gridx = 0;
-            propertyPanel.add(new JLabel(Bundle.getMessage("FrameDecorationsTitle")), constraints);
-            constraints.gridx++;
-            propertyPanel.add(borderOff, constraints);
-        }
 
         JPanel buttonPanel = new JPanel();
         buttonPanel.setLayout(new GridLayout(1, 2, 4, 4));
@@ -155,15 +143,6 @@ public class ThrottleFramePropertyEditor extends JDialog {
         pack();
         titleField.setText(frame.getTitleText());
         titleField.selectAll();
-
-        if (((javax.swing.plaf.basic.BasicInternalFrameUI) frame.getCurrentThrottleFrame().getControlPanel().getUI()).getNorthPane() != null) {
-            Dimension bSize = ((javax.swing.plaf.basic.BasicInternalFrameUI) frame.getCurrentThrottleFrame().getControlPanel().getUI()).getNorthPane().getPreferredSize();
-            if (bSize.height == 0) {
-                borderOff.setSelected(true);
-            } else {
-                borderOff.setSelected(false);
-            }
-        }
     }
 
     /**
@@ -183,35 +162,9 @@ public class ThrottleFramePropertyEditor extends JDialog {
      */
     private void saveProperties() {
         if (isDataValid()) {
-            int bSize = Integer.parseInt(Bundle.getMessage("FrameSize"));
-            JInternalFrame myFrame;
             frame.setTitleText(titleField.getText());
             frame.setTitleTextType(titleTextTypes[titleType.getSelectedIndex()]);
             frame.getCurrentThrottleFrame().setFrameTitle();
-
-            if (((javax.swing.plaf.basic.BasicInternalFrameUI) frame.getCurrentThrottleFrame().getControlPanel().getUI()).getNorthPane() != null) {
-                if (borderOff.isSelected()) {
-                    bSize = 0;
-                }
-                myFrame = frame.getCurrentThrottleFrame().getControlPanel();
-                ((javax.swing.plaf.basic.BasicInternalFrameUI) myFrame.getUI()).getNorthPane().setPreferredSize(new Dimension(0, bSize));
-                if (myFrame.isVisible()) {
-                    myFrame.setVisible(false);
-                    myFrame.setVisible(true);
-                }
-                myFrame = frame.getCurrentThrottleFrame().getFunctionPanel();
-                ((javax.swing.plaf.basic.BasicInternalFrameUI) myFrame.getUI()).getNorthPane().setPreferredSize(new Dimension(0, bSize));
-                if (myFrame.isVisible()) {
-                    myFrame.setVisible(false);
-                    myFrame.setVisible(true);
-                }
-                myFrame = frame.getCurrentThrottleFrame().getAddressPanel();
-                ((javax.swing.plaf.basic.BasicInternalFrameUI) myFrame.getUI()).getNorthPane().setPreferredSize(new Dimension(0, bSize));
-                if (myFrame.isVisible()) {
-                    myFrame.setVisible(false);
-                    myFrame.setVisible(true);
-                }
-            }
             finishEdit();
         }
     }


### PR DESCRIPTION
Remove this old Swing hack. Furthermore same feature is covered by transparency that was introduced since, through the edit/play button in the toolbar, that one is correctly serialized on save and better polished.

Would fix issue https://github.com/JMRI/JMRI/issues/5320