### PR TITLE
Prevent NPE in Create new Bean Manager ComboBox

### DIFF
--- a/java/src/jmri/jmrit/beantable/AbstractTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableAction.java
@@ -275,7 +275,12 @@ public abstract class AbstractTableAction<E extends NamedBean> extends AbstractA
             if (upm.getComboBoxLastSelection(systemSelectionCombo) != null) {
                 SystemConnectionMemo memo = SystemConnectionMemoManager.getDefault()
                         .getSystemConnectionMemoForUserName(upm.getComboBoxLastSelection(systemSelectionCombo));
-                comboBox.setSelectedItem(memo.get(managerClass));
+                if (memo!=null) {
+                    comboBox.setSelectedItem(memo.get(managerClass));
+                } else {
+                    ProxyManager<E> proxy = (ProxyManager<E>) manager;
+                    comboBox.setSelectedItem(proxy.getDefaultManager());
+                }
             } else {
                 ProxyManager<E> proxy = (ProxyManager<E>) manager;
                 comboBox.setSelectedItem(proxy.getDefaultManager());

--- a/java/src/jmri/jmrix/SystemConnectionMemoManager.java
+++ b/java/src/jmri/jmrix/SystemConnectionMemoManager.java
@@ -1,6 +1,7 @@
 package jmri.jmrix;
 
 import java.util.List;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jmri.InstanceManager;
 import jmri.InstanceManagerAutoDefault;
@@ -71,6 +72,12 @@ public class SystemConnectionMemoManager extends Bean implements InstanceManager
         return null;
     }
 
+    /**
+     * For a given System UserName, get the Connection Memo.
+     * @param userName system UserName to search for.
+     * @return connection memo, else null if no memo located.
+     */
+    @CheckForNull
     public synchronized SystemConnectionMemo getSystemConnectionMemoForUserName(@Nonnull String userName) {
         for (SystemConnectionMemo memo: InstanceManager.getList(SystemConnectionMemo.class)) {
             if (memo.getUserName().equals(userName)) {


### PR DESCRIPTION
In AbstractTableAction.configureManagerComboBox(),
If previously selected memo is null, proxy default is now selected as initial selected option.
Fixes #9003