### PR TITLE
CAN Simulation Output Interval

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -21,7 +21,7 @@
 
         <h4>CBUS</h4>
             <ul>
-                <li></li>
+                <li>Simulated Connections - Output Interval option added to Additional Connection Settings.</li>
             </ul>
 
         <h4>C/MRI</h4>
@@ -111,7 +111,7 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a></h4>
             <ul>
-                <li></li>
+                <li>Simulated Connections - Output Interval option added to Additional Connection Settings.</li>
             </ul>
 
         <h4>RFID</h4>

--- a/java/src/jmri/jmrix/can/adapters/loopback/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/can/adapters/loopback/ConnectionConfig.java
@@ -42,9 +42,9 @@ public class ConnectionConfig extends jmri.jmrix.can.adapters.ConnectionConfig {
         portBox.setVisible(false);      // hide portBox combo idem
         baudBoxLabel.setVisible(false); // hide baudBoxLabel idem
         baudBox.setVisible(false);      // hide baudBox combo idem
-        outputIntervalLabel.setVisible(false);   // hide interval JSpinner idem
-        outputIntervalSpinner.setVisible(false); // hide intervalLabel idem
-        outputIntervalReset.setVisible(false);   // hide Interval Reset button
+        outputIntervalLabel.setVisible(true);   // show interval JSpinner idem
+        outputIntervalSpinner.setVisible(true); // show intervalLabel idem
+        outputIntervalReset.setVisible(true);   // show Interval Reset button
     }
 
     @Override

--- a/java/src/jmri/jmrix/can/adapters/loopback/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/can/adapters/loopback/configurexml/ConnectionConfigXml.java
@@ -28,6 +28,7 @@ public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
      * A simulated connection needs no extra information, so we reimplement the
      * superclass method to just write the necessary parts.
      *
+     * @param o object to store
      * @return formatted element containing no attributes except the class name
      */
     @Override
@@ -55,6 +56,8 @@ public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
         }
 
         saveOptions(e, adapter);
+        
+        setOutputInterval(adapter, e);
 
         e.setAttribute("class", this.getClass().getName());
 
@@ -94,7 +97,7 @@ public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
 
         if (shared.getAttribute("disabled") != null) {
             String yesno = shared.getAttribute("disabled").getValue();
-            if ((yesno != null) && (!yesno.equals(""))) {
+            if ((yesno != null) && (!yesno.isEmpty())) {
                 if (yesno.equals("no")) {
                     adapter.setDisabled(false);
                 } else if (yesno.equals("yes")) {
@@ -111,6 +114,10 @@ public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
             return result;
         }
         adapter.configure();
+        
+        if (perNode.getAttribute("turnoutInterval") != null) {
+            adapter.getSystemConnectionMemo().setOutputInterval(Integer.parseInt(perNode.getAttribute("turnoutInterval").getValue()));
+        }
 
         return result;
     }


### PR DESCRIPTION
CAN Simulated Connections -
Output Interval option added to Additional Connection Settings.
Enables offline demonstration of feature.