### PR TITLE
Fix Layout Editor Options / Track Options / Hide Track Construction Lines

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -407,7 +407,7 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
-	        <li></li>
+            <li>Fix <strong>Options &rArr; Track Options &rArr; Hide Track Construction Lines</strong>.</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -1339,14 +1339,14 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         hideTrackSegmentConstructionLinesCheckBoxMenuItem = new JCheckBoxMenuItem(Bundle.getMessage("HideTrackConLines"));
         trackMenu.add(hideTrackSegmentConstructionLinesCheckBoxMenuItem);
         hideTrackSegmentConstructionLinesCheckBoxMenuItem.addActionListener((ActionEvent event) -> {
-            int show = TrackSegment.SHOWCON;
+            int show = TrackSegmentView.SHOWCON;
 
             if (hideTrackSegmentConstructionLinesCheckBoxMenuItem.isSelected()) {
-                show = TrackSegment.HIDECONALL;
+                show = TrackSegmentView.HIDECONALL;
             }
 
-            for (TrackSegment ts : getTrackSegments()) {
-                ts.hideConstructionLines(show);
+            for (TrackSegmentView tsv : getTrackSegmentViews()) {
+                tsv.hideConstructionLines(show);
             }
             redrawPanel();
         });

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -262,12 +262,12 @@ public class TrackSegment extends LayoutTrack {
         type1 = type;
         connect1 = o;
     }
-    
+
     public void setConnect2(@CheckForNull LayoutTrack o, HitPointType type) {
         type2 = type;
         connect2 = o;
     }
-    
+
     /**
      * Set up a LayoutBlock for this Track Segment.
      *
@@ -528,56 +528,6 @@ public class TrackSegment extends LayoutTrack {
      */
     public boolean isActive() {
         return active;
-    }
-
-    public static final int SHOWCON = 0x01;
-    public static final int HIDECON = 0x02;     // flag set on a segment basis.
-    public static final int HIDECONALL = 0x04;  // Used by layout editor for hiding all
-
-    public int showConstructionLine = SHOWCON;
-
-    /**
-     * @return true if HIDECON is not set and HIDECONALL is not set
-     */
-    public boolean isShowConstructionLines() {
-        return (((showConstructionLine & HIDECON) != HIDECON)
-                && ((showConstructionLine & HIDECONALL) != HIDECONALL));
-    }
-
-    /**
-     * Method used by LayoutEditor.
-     * <p>
-     * If the argument is
-     * <ul>
-     * <li>HIDECONALL then set HIDECONALL
-     * <li>SHOWCON reset HIDECONALL is set, other wise set SHOWCON
-     * <li>HIDECON or otherwise set HIDECON
-     * </ul>
-     * Then always redraw the LayoutEditor panel and set it dirty.
-     *
-     * @param hide HIDECONALL, SHOWCON, HIDECON.
-     */
-    public void hideConstructionLines(int hide) {
-        if (hide == HIDECONALL) {
-            showConstructionLine |= HIDECONALL;
-        } else if (hide == SHOWCON) {
-            if ((showConstructionLine & HIDECONALL) == HIDECONALL) {
-                showConstructionLine &= ~HIDECONALL;
-            } else {
-                showConstructionLine = hide;
-            }
-        } else {
-            showConstructionLine = HIDECON;
-        }
-        models.redrawPanel();
-        models.setDirty();
-    }
-
-    /**
-     * @return true if SHOWCON is not set
-     */
-    public boolean hideConstructionLines() {
-        return ((showConstructionLine & SHOWCON) != SHOWCON);
     }
 
     /**

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentViewXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentViewXml.java
@@ -285,7 +285,7 @@ public class TrackSegmentViewXml extends AbstractXmlAdapter {
         }
 
         if ( getAttributeBooleanValue(element, "hideConLines", false) ) {
-            lv.hideConstructionLines(TrackSegment.HIDECON);
+            lv.hideConstructionLines(TrackSegmentView.HIDECON);
         }
         // load decorations
         Element decorationsElement = element.getChild("decorations");

--- a/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentTest.java
@@ -17,9 +17,9 @@ import org.netbeans.jemmy.operators.Operator;
  *
  * Note this uses <code>@BeforeClass</code> and <code>@AfterClass</code>
  * to do static setup.
- * 
+ *
  * Should not involve geometry or graphics, as the class undertest is pure layout
- * information.  But at least for now, it needs a LayoutEditor, and that requires 
+ * information.  But at least for now, it needs a LayoutEditor, and that requires
  * AWT graphics at run time.
  * <p>
  * Note this uses <code>@BeforeAll</code> and <code>@AfterAll</code> to do
@@ -36,147 +36,13 @@ public class TrackSegmentTest extends LayoutTrackTest {
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertTrue((layoutEditor != null) && (trackSegment != null));
-        
+
         // Invalid parameters in TrackSegment constructor call
         TrackSegment ts = new TrackSegment("TS01", (TrackSegment) null, HitPointType.NONE, (TrackSegment) null, HitPointType.NONE, false, layoutEditor);
         Assert.assertNotNull("TrackSegment TS01 not null", ts);
         JUnitAppender.assertErrorMessage("Invalid object in TrackSegment constructor call - TS01");
         JUnitAppender.assertErrorMessage("Invalid connect type 1 ('NONE') in TrackSegment constructor - TS01");
         JUnitAppender.assertErrorMessage("Invalid connect type 2 ('NONE') in TrackSegment constructor - TS01");
-    }
-
-    @Test
-    public void testConstructionLinesRead() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-
-        trackSegment.showConstructionLine = 0;
-        Assert.assertTrue("From 0", trackSegment.isShowConstructionLines());
-        Assert.assertTrue("From 0", trackSegment.hideConstructionLines());
-
-        trackSegment.showConstructionLine = TrackSegment.HIDECONALL;
-        Assert.assertFalse("HIDECONALL", trackSegment.isShowConstructionLines());
-        Assert.assertTrue("HIDECONALL", trackSegment.hideConstructionLines());
-
-        trackSegment.showConstructionLine = TrackSegment.HIDECON;
-        Assert.assertFalse("HIDECON", trackSegment.isShowConstructionLines());
-        Assert.assertTrue("HIDECON", trackSegment.hideConstructionLines());
-
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON;
-        Assert.assertTrue("SHOWCON", trackSegment.isShowConstructionLines());
-        Assert.assertFalse("SHOWCON", trackSegment.hideConstructionLines());
-
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON | TrackSegment.HIDECON | TrackSegment.HIDECONALL;
-        Assert.assertFalse("all", trackSegment.isShowConstructionLines());
-        Assert.assertFalse("all", trackSegment.hideConstructionLines());
-
-    }
-
-    @Test
-    public void hideConstructionLinesOfInt() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-
-        trackSegment.showConstructionLine = 0;
-        trackSegment.hideConstructionLines(TrackSegment.SHOWCON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.SHOWCON);
-
-        trackSegment.showConstructionLine = 0;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECON);
-
-        trackSegment.showConstructionLine = 0;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECONALL);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECONALL);
-
-        // ----
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON;
-        trackSegment.hideConstructionLines(TrackSegment.SHOWCON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.SHOWCON);
-
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECON);
-
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECONALL);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.SHOWCON | TrackSegment.HIDECONALL);
-
-        // ----
-        trackSegment.showConstructionLine = TrackSegment.HIDECON;
-        trackSegment.hideConstructionLines(TrackSegment.SHOWCON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.SHOWCON);
-
-        trackSegment.showConstructionLine = TrackSegment.HIDECON;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECON);
-
-        trackSegment.showConstructionLine = TrackSegment.HIDECON;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECONALL);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECON | TrackSegment.HIDECONALL);
-
-        // ----
-        trackSegment.showConstructionLine = TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.SHOWCON);
-        Assert.assertEquals(trackSegment.showConstructionLine, 0);
-
-        trackSegment.showConstructionLine = TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECON);
-
-        trackSegment.showConstructionLine = TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECONALL);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECONALL);
-
-        // ----
-        trackSegment.showConstructionLine = TrackSegment.HIDECON | TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.SHOWCON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECON);
-
-        trackSegment.showConstructionLine = TrackSegment.HIDECON | TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECON);
-
-        trackSegment.showConstructionLine = TrackSegment.HIDECON | TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECONALL);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECON | TrackSegment.HIDECONALL);
-
-        // ----
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON | TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.SHOWCON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.SHOWCON);
-
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON | TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECON);
-
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON | TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECONALL);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.SHOWCON | TrackSegment.HIDECONALL);
-
-        // ----
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON | TrackSegment.HIDECON;
-        trackSegment.hideConstructionLines(TrackSegment.SHOWCON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.SHOWCON);
-
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON | TrackSegment.HIDECON;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECON);
-
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON | TrackSegment.HIDECON;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECONALL);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.SHOWCON | TrackSegment.HIDECON | TrackSegment.HIDECONALL);
-
-        // ----
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON | TrackSegment.HIDECON | TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.SHOWCON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.SHOWCON | TrackSegment.HIDECON);
-
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON | TrackSegment.HIDECON | TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECON);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.HIDECON);
-
-        trackSegment.showConstructionLine = TrackSegment.SHOWCON | TrackSegment.HIDECON | TrackSegment.HIDECONALL;
-        trackSegment.hideConstructionLines(TrackSegment.HIDECONALL);
-        Assert.assertEquals(trackSegment.showConstructionLine, TrackSegment.SHOWCON | TrackSegment.HIDECON | TrackSegment.HIDECONALL);
     }
 
     @Test
@@ -204,7 +70,7 @@ public class TrackSegmentTest extends LayoutTrackTest {
     public void testToString() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertTrue((layoutEditor != null) && (trackSegment != null));
-        
+
         Assert.assertEquals("trackSegment.toString()", "TrackSegment TS1 c1:{A1 (POS_POINT)}, c2:{A2 (POS_POINT)}", trackSegment.toString());
     }
 
@@ -212,7 +78,7 @@ public class TrackSegmentTest extends LayoutTrackTest {
     public void testSetNewConnect() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertTrue((layoutEditor != null) && (trackSegment != null));
-        
+
         trackSegment.setNewConnect1(null, HitPointType.NONE);
         Assert.assertEquals("trackSegment.setNewConnect1(null, NONE)", null, trackSegment.getConnect1());
         Assert.assertEquals("trackSegment.setNewConnect1(null, NONE)", HitPointType.NONE, trackSegment.getType1());
@@ -226,7 +92,7 @@ public class TrackSegmentTest extends LayoutTrackTest {
     public void test_getConnection() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertTrue((layoutEditor != null) && (trackSegment != null));
-        
+
         boolean fail = true;
         try {
             Assert.assertNull("trackSegment.getConnection()", trackSegment.getConnection(HitPointType.NONE));
@@ -240,7 +106,7 @@ public class TrackSegmentTest extends LayoutTrackTest {
     public void test_getSetLayoutBlock() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertTrue((layoutEditor != null) && (trackSegment != null));
-        
+
         Assert.assertNull("trackSegment.getLayoutBlock()", trackSegment.getLayoutBlock());
         trackSegment.setLayoutBlock(null);
         Assert.assertNull("trackSegment.getLayoutBlock()", trackSegment.getLayoutBlock());
@@ -256,9 +122,9 @@ public class TrackSegmentTest extends LayoutTrackTest {
     @Test
     public void test_setLayoutBlockByName() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         Assert.assertTrue((layoutEditor != null) && (trackSegment != null));
-        
+
         Assert.assertNull("trackSegment.getLayoutBlock() == null (default)", trackSegment.getLayoutBlock());
         trackSegment.setLayoutBlockByName(null);
         Assert.assertNull("trackSegment.getLayoutBlock(null) == null", trackSegment.getLayoutBlock());
@@ -270,7 +136,7 @@ public class TrackSegmentTest extends LayoutTrackTest {
     }
 
 
-    
+
     //
     // from here down is testing infrastructure
     //
@@ -320,13 +186,13 @@ public class TrackSegmentTest extends LayoutTrackTest {
         super.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.resetInstanceManager();
-        
+
         if (!GraphicsEnvironment.isHeadless()) {
             layoutEditor = new LayoutEditor();
 
             PositionablePoint p1 = new PositionablePoint("A1", PositionablePoint.PointType.ANCHOR, layoutEditor);
             // PositionablePointView p1v = new PositionablePointView(p1, new Point2D.Double(10.0, 20.0), layoutEditor);
-            
+
             PositionablePoint p2 = new PositionablePoint("A2", PositionablePoint.PointType.ANCHOR, layoutEditor);
             // PositionablePointView p2v = new PositionablePointView(p2, new Point2D.Double(20.0, 33.0), layoutEditor);
 
@@ -347,7 +213,7 @@ public class TrackSegmentTest extends LayoutTrackTest {
             // release refereces to layout editor
             layoutEditor = null;
         }
-        
+
         // release refereces to track segment
         trackSegment = null;
         JUnitUtil.deregisterBlockManagerShutdownTask();

--- a/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentViewTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentViewTest.java
@@ -196,6 +196,139 @@ public class TrackSegmentViewTest extends LayoutTrackViewTest {
         }
     }
 
+    @Test
+    public void testConstructionLinesRead() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+        segmentView.showConstructionLine = 0;
+        Assert.assertTrue("From 0", segmentView.isShowConstructionLines());
+        Assert.assertTrue("From 0", segmentView.hideConstructionLines());
+
+        segmentView.showConstructionLine = TrackSegmentView.HIDECONALL;
+        Assert.assertFalse("HIDECONALL", segmentView.isShowConstructionLines());
+        Assert.assertTrue("HIDECONALL", segmentView.hideConstructionLines());
+
+        segmentView.showConstructionLine = TrackSegmentView.HIDECON;
+        Assert.assertFalse("HIDECON", segmentView.isShowConstructionLines());
+        Assert.assertTrue("HIDECON", segmentView.hideConstructionLines());
+
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON;
+        Assert.assertTrue("SHOWCON", segmentView.isShowConstructionLines());
+        Assert.assertFalse("SHOWCON", segmentView.hideConstructionLines());
+
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON | TrackSegmentView.HIDECON | TrackSegmentView.HIDECONALL;
+        Assert.assertFalse("all", segmentView.isShowConstructionLines());
+        Assert.assertFalse("all", segmentView.hideConstructionLines());
+
+    }
+
+    @Test
+    public void hideConstructionLinesOfInt() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+        segmentView.showConstructionLine = 0;
+        segmentView.hideConstructionLines(TrackSegmentView.SHOWCON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.SHOWCON);
+
+        segmentView.showConstructionLine = 0;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECON);
+
+        segmentView.showConstructionLine = 0;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECONALL);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECONALL);
+
+        // ----
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON;
+        segmentView.hideConstructionLines(TrackSegmentView.SHOWCON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.SHOWCON);
+
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECON);
+
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECONALL);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.SHOWCON | TrackSegmentView.HIDECONALL);
+
+        // ----
+        segmentView.showConstructionLine = TrackSegmentView.HIDECON;
+        segmentView.hideConstructionLines(TrackSegmentView.SHOWCON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.SHOWCON);
+
+        segmentView.showConstructionLine = TrackSegmentView.HIDECON;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECON);
+
+        segmentView.showConstructionLine = TrackSegmentView.HIDECON;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECONALL);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECON | TrackSegmentView.HIDECONALL);
+
+        // ----
+        segmentView.showConstructionLine = TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.SHOWCON);
+        Assert.assertEquals(segmentView.showConstructionLine, 0);
+
+        segmentView.showConstructionLine = TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECON);
+
+        segmentView.showConstructionLine = TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECONALL);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECONALL);
+
+        // ----
+        segmentView.showConstructionLine = TrackSegmentView.HIDECON | TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.SHOWCON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECON);
+
+        segmentView.showConstructionLine = TrackSegmentView.HIDECON | TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECON);
+
+        segmentView.showConstructionLine = TrackSegmentView.HIDECON | TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECONALL);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECON | TrackSegmentView.HIDECONALL);
+
+        // ----
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON | TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.SHOWCON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.SHOWCON);
+
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON | TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECON);
+
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON | TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECONALL);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.SHOWCON | TrackSegmentView.HIDECONALL);
+
+        // ----
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON | TrackSegmentView.HIDECON;
+        segmentView.hideConstructionLines(TrackSegmentView.SHOWCON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.SHOWCON);
+
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON | TrackSegmentView.HIDECON;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECON);
+
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON | TrackSegmentView.HIDECON;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECONALL);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.SHOWCON | TrackSegmentView.HIDECON | TrackSegmentView.HIDECONALL);
+
+        // ----
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON | TrackSegmentView.HIDECON | TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.SHOWCON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.SHOWCON | TrackSegmentView.HIDECON);
+
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON | TrackSegmentView.HIDECON | TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECON);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.HIDECON);
+
+        segmentView.showConstructionLine = TrackSegmentView.SHOWCON | TrackSegmentView.HIDECON | TrackSegmentView.HIDECONALL;
+        segmentView.hideConstructionLines(TrackSegmentView.HIDECONALL);
+        Assert.assertEquals(segmentView.showConstructionLine, TrackSegmentView.SHOWCON | TrackSegmentView.HIDECON | TrackSegmentView.HIDECONALL);
+    }
 
     /*
         Bridge Decorations


### PR DESCRIPTION
Changes:
- LayoutEditor was not using the TrackSegmentView class for setting construction line changes.
- Removed the view code for construction lines from TrackSegment.
- Moved the construction line tests from TrackSegmentTest to TrackSegmentViewTest.

This will fix issue #9515.
