### PR TITLE
Sensor / Turnout Tables, Forget / Query Column headings

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -326,8 +326,8 @@ SpeedsMenuItemDefaults               = Defaults...
 TurnoutAutomationMenu                = Automation
 TurnoutAutomationMenuItemEdit        = Edit...
 
-StateForgetHeader                    = State
-StateQueryHeader                     = State
+StateForgetHeader                    = Forget
+StateQueryHeader                     = Query
 StateForgetButton                    = Forget
 StateQueryButton                     = Query
 

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_ca.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_ca.properties
@@ -310,8 +310,8 @@ SpeedsMenuItemDefaults = Per defecte...
 TurnoutAutomationMenu = Automatitzaci\u00f3
 TurnoutAutomationMenuItemEdit = Edita...
 
-StateForgetHeader = Estat
-StateQueryHeader = Estat
+StateForgetHeader = Oblida
+StateQueryHeader = Consulta
 StateForgetButton = Oblida
 StateQueryButton = Consulta
 

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_cs.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_cs.properties
@@ -325,8 +325,8 @@ SpeedsMenuItemDefaults = V\u00fdchoz\u00ed hodnoty...
 TurnoutAutomationMenu = Automatizace
 TurnoutAutomationMenuItemEdit = Upravit...
 
-StateForgetHeader=Stav
-StateQueryHeader=Stav
+StateForgetHeader=Zapomenut
+StateQueryHeader=Dotaz
 StateForgetButton=Zapomenut
 StateQueryButton=Dotaz
 

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_nl.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_nl.properties
@@ -325,8 +325,8 @@ SpeedsMenuItemDefaults = Standaard...
 TurnoutAutomationMenu = Automatisering
 TurnoutAutomationMenuItemEdit = Bewerk...
 
-StateForgetHeader = Stand-
-StateQueryHeader = Stand+
+StateForgetHeader = Vergeet
+StateQueryHeader = Vraag op
 StateForgetButton = Vergeet
 StateQueryButton = Vraag op
 

--- a/java/src/jmri/jmrit/beantable/beanedit/LightEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/LightEditAction.java
@@ -132,7 +132,7 @@ public class LightEditAction extends BeanEditAction<Light> {
         if (lm instanceof ProxyManager){
             ProxyManager<Light> plm = (ProxyManager<Light>)lm;
             for (Manager<Light> m : plm.getManagerList()) {
-                if (bean.getSystemName().startsWith(m.getSystemNamePrefix())) {
+                if (m.getBySystemName(bean.getSystemName())!=null) {
                     return m.getMemo().getUserName();
                 }
             }

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -559,6 +559,9 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
     @Override
     public void configureTable(JTable table) {
         super.configureTable(table);
+        XTableColumnModel columnModel = (XTableColumnModel) table.getColumnModel();
+        columnModel.getColumnByModelIndex(FORGETCOL).setHeaderValue(null);
+        columnModel.getColumnByModelIndex(QUERYCOL).setHeaderValue(null);
     }
 
     void editButton(Sensor s) {

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
@@ -419,21 +419,9 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
             editTurnoutOperation(t, cb);
             fireTableRowsUpdated(row, row);
         } else if (col == EDITCOL) {
-            class WindowMaker implements Runnable {
-
-                final Turnout t;
-
-                WindowMaker(Turnout t) {
-                    this.t = t;
-                }
-
-                @Override
-                public void run() {
-                    editButton(t);
-                }
-            }
-            WindowMaker w = new WindowMaker(t);
-            javax.swing.SwingUtilities.invokeLater(w);
+            javax.swing.SwingUtilities.invokeLater(() -> {
+                editButton(t);
+            });
         } else if (col == LOCKOPRCOL) {
             @SuppressWarnings("unchecked")
             String lockOpName = (String) ((JComboBox<String>) value)
@@ -609,6 +597,9 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
         
         // and then set user prefs
         super.configureTable(tbl);
+        
+        columnModel.getColumnByModelIndex(FORGETCOL).setHeaderValue(null);
+        columnModel.getColumnByModelIndex(QUERYCOL).setHeaderValue(null);
         
     }
 


### PR DESCRIPTION
Sensor and Turnout Tables.
Remove column header values - Forget / Query columns.
Update Forget / Query Column Menu text.

Fixes #5491 

![image](https://user-images.githubusercontent.com/39652002/111083087-93713c80-8503-11eb-8881-ba2d2db9f1b6.png)
