### PR TITLE
Logix listeners order

### DIFF
--- a/java/src/jmri/implementation/DefaultLogix.java
+++ b/java/src/jmri/implementation/DefaultLogix.java
@@ -47,7 +47,7 @@ public class DefaultLogix extends AbstractNamedBean
     }
 
     /**
-     * Persistant instance variables (saved between runs)
+     * Persistant instance variables (saved between runs). Order is significant.
      */
     ArrayList<String> _conditionalSystemNames = new ArrayList<String>();
     ArrayList<JmriSimplePropertyListener> _listeners = new ArrayList<JmriSimplePropertyListener>();
@@ -236,15 +236,10 @@ public class DefaultLogix extends AbstractNamedBean
      */
     @Override
     public void calculateConditionals() {
-        // are there Conditionals to calculate?
-        // There are conditionals to calculate
-        String cName = "";
-        Conditional c = null;
-        for (int i = 0; i < _conditionalSystemNames.size(); i++) {
-            cName = _conditionalSystemNames.get(i);
-            c = getConditional(cName);
+        for (String conditionalSystemName : _conditionalSystemNames) {
+            Conditional c = getConditional(conditionalSystemName);
             if (c == null) {
-                log.error("Invalid conditional system name when calculating Logix - {}", cName);  // NOI18N
+                log.error("Invalid conditional system name when calculating Logix - {}", conditionalSystemName);  // NOI18N
             } else {
                 // calculate without taking any action unless Logix is enabled
                 c.calculate(mEnabled, null);
@@ -271,8 +266,8 @@ public class DefaultLogix extends AbstractNamedBean
         assembleListenerList();
         // create and attach the needed property change listeners
         // start a minute Listener if needed
-        for (int i = 0; i < _listeners.size(); i++) {
-            startListener(_listeners.get(i));
+        for (JmriSimplePropertyListener listener : _listeners) {
+            startListener(listener);
         }
         // mark this Logix as busy
         _isActivated = true;
@@ -281,13 +276,12 @@ public class DefaultLogix extends AbstractNamedBean
     }
 
     private void resetConditionals() {
-        for (int i = 0; i < _conditionalSystemNames.size(); i++) {
-            Conditional conditional = getConditional(_conditionalSystemNames.get(i));
+        for (String conditionalSystemName : _conditionalSystemNames) {
+            Conditional conditional = getConditional(conditionalSystemName);
             if (conditional != null) {
                 try {
                     conditional.setState(NamedBean.UNKNOWN);
-                } catch (JmriException e) {
-                    // ignore
+                } catch (JmriException ignore) {
                 }
             }
         }
@@ -323,14 +317,13 @@ public class DefaultLogix extends AbstractNamedBean
             _isGuiSet = true;
             return;
         }
-        for (int i = 0; i < _conditionalSystemNames.size(); i++) {
-            String cName = _conditionalSystemNames.get(i);
+        for (String cName : _conditionalSystemNames) {
             Conditional conditional = getConditional(cName);
             if (conditional == null) {
                 // A Logix index entry exists without a corresponding conditional.  This
                 // should never happen.
                 log.error("setGuiNames: Missing conditional for Logix index entry,  Logix name = '{}', Conditional index name = '{}'",  // NOI18N
-                    getSystemName(), cName);
+                        getSystemName(), cName);
                 continue;
             }
             List<ConditionalVariable> varList = conditional.getCopyOfStateVariables();
@@ -338,8 +331,7 @@ public class DefaultLogix extends AbstractNamedBean
             ArrayList<ConditionalVariable> badVariable = new ArrayList<>();
             for (ConditionalVariable var : varList) {
                 // Find any Conditional State Variables
-                if (var.getType() == Conditional.Type.CONDITIONAL_TRUE
-                        || var.getType() == Conditional.Type.CONDITIONAL_FALSE) {
+                if (var.getType() == Conditional.Type.CONDITIONAL_TRUE || var.getType() == Conditional.Type.CONDITIONAL_FALSE) {
                     // Get the referenced (target) conditonal -- The name can be either a system name or a user name
                     Conditional cRef = conditionalManager.getConditional(var.getName());
                     if (cRef != null) {
@@ -356,17 +348,15 @@ public class DefaultLogix extends AbstractNamedBean
                         isDirty = true;
                     } else {
                         log.error("setGuiNames: For conditional '{}' in logix '{}', the referenced conditional, '{}',  does not exist",  // NOI18N
-                             cName, getSystemName(), var.getName());
+                                cName, getSystemName(), var.getName());
                     }
                 }
 
                 // Find any Entry/Exit State Variables
-                if (var.getType() == Conditional.Type.ENTRYEXIT_ACTIVE
-                        || var.getType() == Conditional.Type.ENTRYEXIT_INACTIVE) {
+                if (var.getType() == Conditional.Type.ENTRYEXIT_ACTIVE || var.getType() == Conditional.Type.ENTRYEXIT_INACTIVE) {
                     if (!NXUUID.matcher(var.getName()).find()) {
                         // Either a user name or an old style system name (plain UUID)
-                        jmri.jmrit.entryexit.DestinationPoints dp =
-                                InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
+                        jmri.jmrit.entryexit.DestinationPoints dp = InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
                                 getNamedBean(var.getName());
                         if (dp != null) {
                             // Replace name with current system name
@@ -374,7 +364,7 @@ public class DefaultLogix extends AbstractNamedBean
                             isDirty = true;
                         } else {
                             log.error("setGuiNames: For conditional '{}' in logix '{}', the referenced Entry Exit Pair, '{}',  does not exist",  // NOI18N
-                                 cName, getSystemName(), var.getName());
+                                    cName, getSystemName(), var.getName());
                             badVariable.add(var);
                         }
                     }
@@ -382,7 +372,7 @@ public class DefaultLogix extends AbstractNamedBean
             }
             if (badVariable.size() > 0) {
                 isDirty = true;
-                badVariable.forEach((badVar) -> varList.remove(badVar));
+                badVariable.forEach(varList::remove);
             }
             if (isDirty) {
                 conditional.setStateVariables(varList);
@@ -393,13 +383,10 @@ public class DefaultLogix extends AbstractNamedBean
             ArrayList<ConditionalAction> badAction = new ArrayList<>();
             for (ConditionalAction action : actionList) {
                 // Find any Entry/Exit Actions
-                if (action.getType() == Conditional.Action.SET_NXPAIR_ENABLED
-                        || action.getType() == Conditional.Action.SET_NXPAIR_DISABLED
-                        || action.getType() == Conditional.Action.SET_NXPAIR_SEGMENT) {
+                if (action.getType() == Conditional.Action.SET_NXPAIR_ENABLED || action.getType() == Conditional.Action.SET_NXPAIR_DISABLED || action.getType() == Conditional.Action.SET_NXPAIR_SEGMENT) {
                     if (!NXUUID.matcher(action.getDeviceName()).find()) {
                         // Either a user name or an old style system name (plain UUID)
-                        jmri.jmrit.entryexit.DestinationPoints dp =
-                                InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
+                        jmri.jmrit.entryexit.DestinationPoints dp = InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
                                 getNamedBean(action.getDeviceName());
                         if (dp != null) {
                             // Replace name with current system name
@@ -407,7 +394,7 @@ public class DefaultLogix extends AbstractNamedBean
                             isDirty = true;
                         } else {
                             log.error("setGuiNames: For conditional '{}' in logix '{}', the referenced Entry Exit Pair, '{}',  does not exist",  // NOI18N
-                                 cName, getSystemName(), action.getDeviceName());
+                                    cName, getSystemName(), action.getDeviceName());
                             badAction.add(action);
                         }
                     }
@@ -415,7 +402,7 @@ public class DefaultLogix extends AbstractNamedBean
             }
             if (badAction.size() > 0) {
                 isDirty = true;
-                badAction.forEach((badAct) -> actionList.remove(badAct));
+                badAction.forEach(actionList::remove);
             }
             if (isDirty) {
                 conditional.setAction(actionList);
@@ -428,19 +415,18 @@ public class DefaultLogix extends AbstractNamedBean
      * Assemble a list of Listeners needed to activate this Logix.
      */
     private void assembleListenerList() {
-        // initialize
+        // initialize by cleaning up
+        // start from end down to safely delete preventing concurrent modification ex
         for (int i = _listeners.size() - 1; i >= 0; i--) {
             removeListener(_listeners.get(i));
         }
-        _listeners = new ArrayList<JmriSimplePropertyListener>();
+        _listeners = new ArrayList<>();
         // cycle thru Conditionals to find objects to listen to
-        // start from end down to safely delete preventing concurrent modification ex
-        for (int i = _conditionalSystemNames.size() - 1; i >= 0; i--) {
+        for (int i = 0; i < _conditionalSystemNames.size(); i++) {
             Conditional conditional = getConditional(_conditionalSystemNames.get(i));
             if (conditional != null) {
                 List<ConditionalVariable> variableList = conditional.getCopyOfStateVariables();
-                for (int k = 0; k < variableList.size(); k++) {
-                    ConditionalVariable variable = variableList.get(k);
+                for (ConditionalVariable variable : variableList) {
                     // check if listening for a change has been suppressed
                     int varListenerType = 0;
                     String varName = variable.getName();
@@ -566,13 +552,11 @@ public class DefaultLogix extends AbstractNamedBean
                                         namedBean, varType, conditional);
                                 break;
                             case LISTENER_TYPE_WARRANT:
-                                listener = new JmriSimplePropertyListener(null, LISTENER_TYPE_WARRANT,
-                                        namedBean, varType, conditional);
+                                listener = new JmriSimplePropertyListener(null, LISTENER_TYPE_WARRANT, namedBean, varType, conditional);
                                 break;
                             case LISTENER_TYPE_FASTCLOCK:
                                 listener = new JmriClockPropertyListener("minutes", LISTENER_TYPE_FASTCLOCK,  // NOI18N
-                                        varName, varType, conditional,
-                                        variable.getNum1(), variable.getNum2());
+                                        varName, varType, conditional, variable.getNum1(), variable.getNum2());
                                 break;
                             case LISTENER_TYPE_SIGNALHEAD:
                                 if (signalAspect < 0) {
@@ -631,8 +615,7 @@ public class DefaultLogix extends AbstractNamedBean
                                 listener.addConditional(conditional);
                                 break;
                             case LISTENER_TYPE_FASTCLOCK:
-                                JmriClockPropertyListener cpl
-                                        = (JmriClockPropertyListener) _listeners.get(positionOfListener);
+                                JmriClockPropertyListener cpl = (JmriClockPropertyListener) _listeners.get(positionOfListener);
                                 cpl.setRange(variable.getNum1(), variable.getNum2());
                                 cpl.addConditional(conditional);
                                 break;
@@ -641,31 +624,27 @@ public class DefaultLogix extends AbstractNamedBean
                                     listener = _listeners.get(positionOfListener);
                                     listener.addConditional(conditional);
                                 } else {
-                                    JmriMultiStatePropertyListener mpl
-                                            = (JmriMultiStatePropertyListener) _listeners.get(positionOfListener);
+                                    JmriMultiStatePropertyListener mpl = (JmriMultiStatePropertyListener) _listeners.get(positionOfListener);
                                     mpl.addConditional(conditional);
                                     mpl.setState(signalAspect);
                                 }
                                 break;
                             default:
-                                log.error("Unknown (old) Variable Listener type= {}, for varName= {}, varType= {} in Conditional, {}", varListenerType, varName, varType, _conditionalSystemNames.get(i));
+                                log.error("Unknown (old) Variable Listener type= {}, for varName= {}, varType= {} in Conditional, {}",
+                                        varListenerType, varName, varType, _conditionalSystemNames.get(i));
                         }
                     }
                     // addition listeners needed for memory compare
-                    if (varType == Conditional.Type.MEMORY_COMPARE
-                            || varType == Conditional.Type.MEMORY_COMPARE_INSENSITIVE) {
-                        positionOfListener = getPositionOfListener(varListenerType, varType,
-                                variable.getDataString());
+                    if (varType == Conditional.Type.MEMORY_COMPARE || varType == Conditional.Type.MEMORY_COMPARE_INSENSITIVE) {
+                        positionOfListener = getPositionOfListener(varListenerType, varType, variable.getDataString());
                         if (positionOfListener == -1) {
                             String name = variable.getDataString();
                             try {
                                 Memory my = InstanceManager.memoryManagerInstance().provideMemory(name);
-                                NamedBeanHandle<?> nb = jmri.InstanceManager.getDefault(
-                                        jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, my);
+                                NamedBeanHandle<?> nb = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(name, my);
 
                                 listener = new JmriTwoStatePropertyListener("value", LISTENER_TYPE_MEMORY,  // NOI18N
-                                        nb, varType,
-                                        conditional);
+                                        nb, varType, conditional);
                                 _listeners.add(listener);
                             } catch (IllegalArgumentException ex) {
                                 log.error("invalid memory name= \"{}\" in state variable", name);  // NOI18N
@@ -822,61 +801,57 @@ public class DefaultLogix extends AbstractNamedBean
         NamedBean nb;
         NamedBeanHandle<?> namedBeanHandle;
 
-        switch (listener.getType()) {
-            case LISTENER_TYPE_FASTCLOCK:
-                Timebase tb = InstanceManager.getDefault(jmri.Timebase.class);
-                tb.addMinuteChangeListener(listener);
-                return;
-            default:
-                namedBeanHandle = listener.getNamedBean();
-                if (namedBeanHandle == null) {
-                    switch (listener.getType()) {
-                        case LISTENER_TYPE_SENSOR:
-                            msg = "sensor";  // NOI18N
-                            break;
-                        case LISTENER_TYPE_TURNOUT:
-                            msg = "turnout";  // NOI18N
-                            break;
-                        case LISTENER_TYPE_LIGHT:
-                            msg = "light";  // NOI18N
-                            break;
-                        case LISTENER_TYPE_CONDITIONAL:
-                            msg = "conditional";  // NOI18N
-                            break;
-                        case LISTENER_TYPE_SIGNALHEAD:
-                            msg = "signalhead";  // NOI18N
-                            break;
-                        case LISTENER_TYPE_SIGNALMAST:
-                            msg = "signalmast";  // NOI18N
-                            break;
-                        case LISTENER_TYPE_MEMORY:
-                            msg = "memory";  // NOI18N
-                            break;
-                        case LISTENER_TYPE_WARRANT:
-                            msg = "warrant";  // NOI18N
-                            break;
-                        case LISTENER_TYPE_OBLOCK:
-                            msg = "oblock";  // NOI18N
-                            break;
-                        case LISTENER_TYPE_ENTRYEXIT:
-                            msg = "entry exit";  // NOI18N
-                            break;
-                        default:
-                            msg = "unknown";  // NOI18N
-                    }
-                    break;
+        if (listener.getType() == LISTENER_TYPE_FASTCLOCK) {
+            Timebase tb = InstanceManager.getDefault(jmri.Timebase.class);
+            tb.addMinuteChangeListener(listener);
+        } else {
+            namedBeanHandle = listener.getNamedBean();
+            if (namedBeanHandle == null) {
+                switch (listener.getType()) {
+                    case LISTENER_TYPE_SENSOR:
+                        msg = "sensor";  // NOI18N
+                        break;
+                    case LISTENER_TYPE_TURNOUT:
+                        msg = "turnout";  // NOI18N
+                        break;
+                    case LISTENER_TYPE_LIGHT:
+                        msg = "light";  // NOI18N
+                        break;
+                    case LISTENER_TYPE_CONDITIONAL:
+                        msg = "conditional";  // NOI18N
+                        break;
+                    case LISTENER_TYPE_SIGNALHEAD:
+                        msg = "signalhead";  // NOI18N
+                        break;
+                    case LISTENER_TYPE_SIGNALMAST:
+                        msg = "signalmast";  // NOI18N
+                        break;
+                    case LISTENER_TYPE_MEMORY:
+                        msg = "memory";  // NOI18N
+                        break;
+                    case LISTENER_TYPE_WARRANT:
+                        msg = "warrant";  // NOI18N
+                        break;
+                    case LISTENER_TYPE_OBLOCK:
+                        msg = "oblock";  // NOI18N
+                        break;
+                    case LISTENER_TYPE_ENTRYEXIT:
+                        msg = "entry exit";  // NOI18N
+                        break;
+                    default:
+                        msg = "unknown";  // NOI18N
                 }
+                log.error("Bad name for {} '{}' when setting up Logix listener [ {} ]", // NOI18N
+                        msg, listener.getDevName(), this.getSystemName());
+            } else {
                 nb = namedBeanHandle.getBean();
-                nb.addPropertyChangeListener(listener, namedBeanHandle.getName(),
-                        "Logix " + getDisplayName());  // NOI18N
-                return;
+                nb.addPropertyChangeListener(listener, namedBeanHandle.getName(), "Logix " + getDisplayName());  // NOI18N
+            }
         }
-        log.error("Bad name for {} '{}' when setting up Logix listener [ {} ]", // NOI18N
-                msg, listener.getDevName(), this.getSystemName());
     }
 
     /**
-     * Removes a listener of the required type
+     * Remove a listener of the required type
      */
     private void removeListener(JmriSimplePropertyListener listener) {
         String msg = null;
@@ -1086,11 +1061,11 @@ public class DefaultLogix extends AbstractNamedBean
 
             String cName = "";
             Conditional c = null;
-            for (int i = 0; i < _conditionalSystemNames.size(); i++) {
-                cName = _conditionalSystemNames.get(i);
+            for (String conditionalSystemName : _conditionalSystemNames) {
+                cName = conditionalSystemName;
                 c = conditionalManager.getBySystemName(cName);
                 if (c != null) {
-                    for (jmri.ConditionalAction ca : c.getCopyOfActions()) {
+                    for (ConditionalAction ca : c.getCopyOfActions()) {
                         if (nb.equals(ca.getBean())) {
                             java.beans.PropertyChangeEvent e = new java.beans.PropertyChangeEvent(this, "DoNotDelete", null, null);  // NOI18N
                             throw new java.beans.PropertyVetoException(Bundle.getMessage("InUseLogixAction", nb.getBeanType(), getDisplayName()), e);   // NOI18N

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -1013,7 +1013,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
             if (x != null) {
                 // Logix with this user name already exists
                 JOptionPane.showMessageDialog(getFrame(),
-                        Bundle.getMessage("LogixError3"), Bundle.getMessage("ErrorTitle"), // NOI18N
+                        Bundle.getMessage("LogixError3"), Bundle.getMessage("ErrorTitle"),
                         JOptionPane.ERROR_MESSAGE);
                 return false;
             }
@@ -1023,9 +1023,9 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
 
     /**
      * Check for a valid Logix system name.
-     * A valid name has a Logix prefix, normally IX, and at least 1 additional character.
-     * The prefix will be added if necessary.
-     * makeSystemName errors are logged to the system console and a dialog is displayed.
+     * A valid name starts with the Logix prefix consisting of the Internal system prefix (normally I) + X,
+     * and at least 1 additional character. The prefix will be added if necessary.
+     * Any makeSystemName errors are logged to the system console and a dialog is displayed.
      * @return true if the name is now valid.
      */
     boolean checkLogixSysName() {
@@ -1035,7 +1035,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
             sName = InstanceManager.getDefault(jmri.LogixManager.class).makeSystemName(sName);
         } catch (jmri.NamedBean.BadSystemNameException ex) {
             JOptionPane.showMessageDialog(getFrame(),
-                    Bundle.getMessage("LogixError8"), Bundle.getMessage("ErrorTitle"), // NOI18N
+                    Bundle.getMessage("LogixError8"), Bundle.getMessage("ErrorTitle"),
                     JOptionPane.ERROR_MESSAGE);
             return false;
         }

--- a/java/src/jmri/jmrit/conditional/ConditionalFrame.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalFrame.java
@@ -33,7 +33,7 @@ public class ConditionalFrame extends JmriJFrame {
     List<ConditionalAction> _actionList;
 
     Conditional.AntecedentOperator _logicType = Conditional.AntecedentOperator.ALL_AND;
-    String _antecedent = null;
+    String _antecedent;
     boolean _trigger;
     boolean _referenceByMemory;
 
@@ -57,21 +57,22 @@ public class ConditionalFrame extends JmriJFrame {
         JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
         JPanel panel1 = new JPanel();
-        panel1.add(new JLabel(Bundle.getMessage("ColumnSystemName") + ":"));  // NOI18N
+        panel1.add(new JLabel(Bundle.getMessage("MakeLabel", Bundle.getMessage("ColumnSystemName"))));
         JTextField systemName =  new JTextField(30);
         systemName.setText(conditional.getSystemName());
         systemName.setEditable(false);
         panel1.add(systemName);
         panel.add(panel1);
         JPanel panel2 = new JPanel();
-        panel2.add(new JLabel(Bundle.getMessage("ColumnUserName") + ":"));  // NOI18N
+        panel2.add(new JLabel(Bundle.getMessage("MakeLabel", Bundle.getMessage("ColumnUserName"))));
         _conditionalUserName = new JTextField(30);
         panel2.add(_conditionalUserName);
         _conditionalUserName.setText(conditional.getUserName());
-        _conditionalUserName.setToolTipText(Bundle.getMessage("ConditionalUserNameHint"));  // NOI18N
+        _conditionalUserName.setToolTipText(Bundle.getMessage("ConditionalUserNameHint"));
         panel.add(panel2);
         return panel;
     }
+
     /**
      * Create Variable and Action editing pane center part. (Utility)
      *
@@ -103,9 +104,11 @@ public class ConditionalFrame extends JmriJFrame {
      */
     boolean updateConditionalPressed(ActionEvent e) {
         log.debug("updateConditionalPressed");
+        String pref = InstanceManager.getDefault(jmri.LogixManager.class).getSystemPrefix();
         // The IX:RTXINITIALIZER keyword has a type of NONE
-        // Safely remove elements from the list
-        _variableList.removeIf(cvar -> cvar.getType() == Conditional.Type.NONE && !cvar.getName().equals("IX:RTXINITIALIZER"));
+        // Safely remove elements from the list  (or use array.remove) if more than 1
+        _variableList.removeIf(cvar -> (cvar.getType() == Conditional.Type.NONE && !cvar.getName().equals(pref + "X:RTXINITIALIZER")));
+        // and actions
         _actionList.removeIf(cact -> cact.getType() == Conditional.Action.NONE);
         if (_parent.updateConditional(_conditionalUserName.getText(), _logicType, _trigger, _antecedent)) {
             if (_dataChanged) {
@@ -205,4 +208,5 @@ public class ConditionalFrame extends JmriJFrame {
     }
 
     private final static Logger log = LoggerFactory.getLogger(ConditionalFrame.class);
+
 }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
@@ -5989,7 +5989,7 @@ final public class LayoutEditorTools {
     /*
      * Sets up a Logix to set a sensor active if a turnout is set against
      *  a track.  This routine creates an internal sensor for the purpose.
-     * Note: The sensor and logix are named IS or IX followed by TTT_X_HHH where
+     * Note: The sensor and logix are named pref + S or pref + X followed by TTT_X_HHH where
      *  TTT is the system name of the turnout, X is either C or T depending
      *  on "continuing", and HHH is the system name of the signal head.
      * Note: If there is any problem, a string of "" is returned, and a warning
@@ -6002,8 +6002,9 @@ final public class LayoutEditorTools {
         if (!continuing) {
             namer = turnoutName + "_C_" + head.getSystemName();
         }
-        String sensorName = "IS" + namer;
-        String logixName = "IX" + namer;
+        String pref = InstanceManager.getDefault(jmri.LogixManager.class).getSystemPrefix();
+        String sensorName = pref + "S" + namer;
+        String logixName = pref + "X" + namer;
         try {
             InstanceManager.sensorManagerInstance().provideSensor(sensorName);
         } catch (IllegalArgumentException ex) {
@@ -6011,18 +6012,15 @@ final public class LayoutEditorTools {
             return "";
 
         }
-        if (InstanceManager.getDefault(LogixManager.class
-        ).getBySystemName(logixName) == null) {
+        if (InstanceManager.getDefault(LogixManager.class).getBySystemName(logixName) == null) {
             //Logix does not exist, create it
-            Logix x = InstanceManager.getDefault(LogixManager.class
-            ).createNewLogix(logixName, "");
+            Logix x = InstanceManager.getDefault(LogixManager.class).createNewLogix(logixName, "");
             if (x == null) {
                 log.error("Trouble creating logix {} while setting up signal logic.", logixName);
                 return "";
             }
             String cName = x.getSystemName() + "C1";
-            Conditional c = InstanceManager.getDefault(ConditionalManager.class
-            ).
+            Conditional c = InstanceManager.getDefault(ConditionalManager.class).
                     createNewConditional(cName, "");
             if (c == null) {
                 log.error("Trouble creating conditional {} while setting up Logix.", cName);
@@ -6043,12 +6041,12 @@ final public class LayoutEditorTools {
             actionList.add(new DefaultConditionalAction(Conditional.ACTION_OPTION_ON_CHANGE_TO_FALSE,
                     Conditional.Action.SET_SENSOR, sensorName,
                     Sensor.INACTIVE, ""));
-            c.setAction(actionList); //string data
+            c.setAction(actionList); // string data
             x.addConditional(cName, -1);
             x.activateLogix();
         }
         return sensorName;
-    }   //setupNearLogix
+    }
 
     /*
      * Adds the sensor specified to the open BlockBossLogic, provided it is not already there and
@@ -13639,8 +13637,9 @@ final public class LayoutEditorTools {
         String farTurnoutName = farTurn.getDisplayName();
 
         String logixPrefix = InstanceManager.getDefault(jmri.LogixManager.class).getSystemNamePrefix();
+        String pref = InstanceManager.getDefault(jmri.LogixManager.class).getSystemPrefix();
         String logixName = logixPrefix + ":IX_LAYOUTSLIP:" + slip.getId();
-        String sensorName = "IS:" + logixName + "C" + number;
+        String sensorName = pref + "S:" + logixName + "C" + number;
         try {
             InstanceManager.sensorManagerInstance().provideSensor(sensorName);
         } catch (IllegalArgumentException ex) {

--- a/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
 
+import javax.annotation.Nonnull;
 import javax.swing.JOptionPane;
 
 import jmri.Conditional;
@@ -162,7 +163,7 @@ public class DefaultConditionalManagerXml extends jmri.managers.configurexml.Abs
      * @return true if successful
      */
     @Override
-    public boolean load(Element sharedConditionals, Element perNodeConditionals) {
+    public boolean load(@Nonnull Element sharedConditionals, Element perNodeConditionals) {
         // create the master object
         replaceConditionalManager();
         // load individual logixs
@@ -284,12 +285,8 @@ public class DefaultConditionalManagerXml extends jmri.managers.configurexml.Abs
                     variable.setOpern(operator);
                 }
                 if (cvar.getAttribute("negated") != null) {  // NOI18N
-                    if ("yes".equals(cvar
-                            .getAttribute("negated").getValue())) {  // NOI18N
-                        variable.setNegation(true);
-                    } else {
-                        variable.setNegation(false);
-                    }
+                    // NOI18N
+                    variable.setNegation("yes".equals(cvar.getAttribute("negated").getValue()));
                 }
                 variable.setType(Conditional.Type.getOperatorFromIntValue(
                         Integer.parseInt(cvar.getAttribute("type").getValue())));  // NOI18N
@@ -330,7 +327,7 @@ public class DefaultConditionalManagerXml extends jmri.managers.configurexml.Abs
             //    log.warn("No actions found for conditional {}", sysName);
             //}
             List<ConditionalAction> actionList = ((DefaultConditional)c).getActionList();
-            org.jdom2.Attribute attr = null;
+            org.jdom2.Attribute attr;
             for (Element cact : conditionalActionList) {
                 ConditionalAction action = new DefaultConditionalAction();
                 attr = cact.getAttribute("option");  // NOI18N

--- a/java/test/jmri/implementation/DefaultLogixTest.java
+++ b/java/test/jmri/implementation/DefaultLogixTest.java
@@ -40,7 +40,6 @@ public class DefaultLogixTest extends NamedBeanTest {
         Assert.assertTrue("object not equals reverse", !ix2.equals(ix1));
 
         Assert.assertTrue("hash not equals", ix1.hashCode() != ix2.hashCode());
-
     }
 
     @BeforeEach
@@ -55,4 +54,5 @@ public class DefaultLogixTest extends NamedBeanTest {
     public void tearDown() throws Exception {
         jmri.util.JUnitUtil.tearDown();
     }
+
 }


### PR DESCRIPTION
Fix issue #9535: restore adding Logix listeners in desired order.
Adds check against customizable internal system prefix
and some faster for loops.