### PR TITLE
Start CbusClockControl after CbusSensorManager

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -21,6 +21,7 @@
 
         <h4>CBUS</h4>
             <ul>
+                <li>Fixed Internal Sensor Manager set as default, not CBUS Sensor Manager, affecting 4.19.6 onwards.</li>
                 <li>Simulated Connections - Output Interval option added to Additional Connection Settings.</li>
             </ul>
 

--- a/java/src/jmri/jmrix/can/cbus/CbusConfigurationManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusConfigurationManager.java
@@ -50,8 +50,6 @@ public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManage
         InstanceManager.store(getCbusPreferences(), CbusPreferences.class);
         InstanceManager.store(getPowerManager(), jmri.PowerManager.class);
         
-        InstanceManager.setDefault(ClockControl.class, getClockControl());
-
         InstanceManager.setSensorManager(getSensorManager());
 
         InstanceManager.setTurnoutManager(getTurnoutManager());
@@ -76,6 +74,10 @@ public class CbusConfigurationManager extends jmri.jmrix.can.ConfigurationManage
         InstanceManager.setLightManager(getLightManager());
         
         InstanceManager.setDefault(CabSignalManager.class,getCabSignalManager());
+        
+        // Clock Control initialised last so CbusSensorManager is first, not
+        // InternalSensorManager when ISCLOCKRUNNING may be created.
+        InstanceManager.setDefault(ClockControl.class, getClockControl());
         
     }
 


### PR DESCRIPTION
CbusSensorManager sets as default, not InternalSensorManager.
Fixes #9548 