### PR TITLE
CbusSensorManager updateAll() send delay

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
@@ -125,17 +125,24 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager {
     }
 
     /**
-     * {@inheritDoc} Send a query message to each sensor using the active
-     * address eg. for a CBUS address "-7;+5", the query will go to event 7.
+     * Update All Sensors by Requesting Event Status.
+     * Sends a query message to each sensor using the active Sensor address.
+     * e.g. for a CBUS address "-7;+5", the query will go to event 7.
+     * Delay between sends is determined by the Connection Output Interval Setting.
+     * {@inheritDoc}
      */
     @Override
     public void updateAll() {
         log.info("Requesting status for all sensors");
-        getNamedBeanSet().forEach((nb) -> {
+        int i = 0;
+        for (Sensor nb : getNamedBeanSet()) {
             if (nb instanceof CbusSensor) {
-                nb.requestUpdateFromLayout();
+                jmri.util.ThreadingUtil.runOnLayoutDelayed( () -> {
+                    nb.requestUpdateFromLayout();
+                }, (i * getMemo().getOutputInterval()) );
+                i++;
             }
-        });
+        }
     }
     
     @Override

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
@@ -285,19 +285,21 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
     @Test
     public void testQueryAll() {
         tcis.outbound.clear();
+        memo.setOutputInterval(2); // reduce output interval for tests
+        
         Sensor t1 = l.provideSensor("MS+N123E456");
         Sensor t2 = l.provideSensor("MS-N9875E45670");
 
         Assert.assertTrue(tcis.outbound.isEmpty());
 
         l.updateAll();
-
-        // log.warn("size {}",tcis.outbound);
+        JUnitUtil.waitFor(() -> ( 2 == tcis.outbound.size()));
         Assert.assertEquals(2, tcis.outbound.size());
 
         Sensor t3 = l.provideSensor("MSX0A;X5E6DEEF4");
         tcis.outbound.clear();
         l.updateAll();
+        JUnitUtil.waitFor(() -> ( 3 == tcis.outbound.size()));
         Assert.assertEquals(3, tcis.outbound.size());
         Assert.assertNotNull("exists", t1);
         Assert.assertNotNull("exists", t2);


### PR DESCRIPTION
Adds delay between sending event status requests.
Delay uses the Connection Output Interval setting.