### PR TITLE
Turnout property change events

### DIFF
--- a/java/src/jmri/Turnout.java
+++ b/java/src/jmri/Turnout.java
@@ -488,6 +488,7 @@ public interface Turnout extends DigitalIO {
     /**
      * Get a human readable representation of the locking decoder type for this turnout.
      *
+     * In AbstractTurnout this String defaults to PushbuttonPacket.unknown , ie "None"
      * @return the name of the decoder type; null indicates none defined
      */
     @CheckForNull

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -232,9 +232,8 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
      * <p>
      * This method is not intended for general use, e.g. for users to set the
      * KnownState, so it doesn't appear in the Turnout interface.
-     *
+     * <p>
      * On change, fires Property Change "KnownState".
-     * 
      * @param s New state value
      */
     public void newKnownState(int s) {

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -780,7 +780,6 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
 
     /** 
      * On change, fires Property Change "TurnoutFeedbackFirstSensorChange".
-     * {@inheritDoc}
      */
     public void provideFirstFeedbackNamedSensor(NamedBeanHandle<Sensor> s) {
         // remove existing if any
@@ -834,7 +833,6 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
 
     /** 
      * On change, fires Property Change "TurnoutFeedbackSecondSensorChange".
-     * {@inheritDoc}
      */
     public void provideSecondFeedbackNamedSensor(NamedBeanHandle<Sensor> s) {
         // remove existing if any

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -232,6 +232,8 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
      * This method is not intended for general use, e.g. for users to set the
      * KnownState, so it doesn't appear in the Turnout interface.
      *
+     * On change, fires Property Change "KnownState".
+     * 
      * @param s New state value
      */
     public void newKnownState(int s) {
@@ -387,7 +389,10 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         throw new IllegalArgumentException("Unexpected mode: " + mode);
     }
 
-    /** {@inheritDoc} */
+    /** 
+     * On change, fires Property Change "feedbackchange".
+     * {@inheritDoc}
+     */
     @Override
     public void setFeedbackMode(int mode) throws IllegalArgumentException {
         // check for error - following removed the low bit from mode
@@ -438,7 +443,10 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
     }
 
-    /** {@inheritDoc} */
+    /** 
+     * On change, fires Property Change "inverted".
+     * {@inheritDoc}
+     */
     @Override
     public void setInverted(boolean inverted) {
         boolean oldInverted = _inverted;
@@ -482,11 +490,15 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
 
     /**
      * Turnouts that are locked should only respond to JMRI commands to change
-     * state. We simulate a locked turnout by monitoring the known state
-     * (turnout feedback is required) and if we detect that the known state has
-     * changed, negate it by forcing the turnout to return to the commanded
-     * state. Turnouts that have local buttons can also be locked if their
+     * state.
+     * We simulate a locked turnout by monitoring the known state (turnout 
+     * feedback is required) and if we detect that the known state has
+     * changed, 
+     * negate it by forcing the turnout to return to the commanded
+     * state.
+     * Turnouts that have local buttons can also be locked if their
      * decoder supports it.
+     * On change, fires Property Change "locked".
      *
      * @param turnoutLockout lockout state to monitor. Possible values
      *                       {@link #CABLOCKOUT}, {@link #PUSHBUTTONLOCKOUT}.
@@ -578,8 +590,10 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
 
     /**
      * When true, report to console anytime a cab attempts to change the state
-     * of a turnout on the layout. When a turnout is cab locked, only JMRI is
+     * of a turnout on the layout.
+     * When a turnout is cab locked, only JMRI is
      * allowed to change the state of a turnout.
+     * On setting changed, fires Property Change "reportlocked".
      *
      * @param reportLocked report locked state
      */
@@ -629,10 +643,17 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         return _decoderName;
     }
 
-    /** {@inheritDoc} */
+    /** 
+     * {@inheritDoc} 
+     * On change, fires Property Change "decoderNameChange".
+     */
     @Override
-    public void setDecoderName(String decoderName) {
-        _decoderName = decoderName;
+    public void setDecoderName(final String decoderName) {
+        if (!(java.util.Objects.equals(_decoderName, decoderName))) {
+            String oldName = _decoderName;
+            _decoderName = decoderName;
+            firePropertyChange("decoderNameChange", oldName, decoderName);
+        }
     }
 
     abstract protected void turnoutPushbuttonLockout(boolean locked);
@@ -660,7 +681,10 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         return myTurnoutOperation;
     }
 
-    /** {@inheritDoc} */
+    /** 
+     * {@inheritDoc} 
+     * Fires Property Change "TurnoutOperationState".
+     */
     @Override
     public void setTurnoutOperation(TurnoutOperation toper) {
         log.debug("setTurnoutOperation Called for turnout {}.  Operation type {}", this.getSystemName(), toper);
@@ -754,6 +778,10 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
     }
 
+    /** 
+     * On change, fires Property Change "TurnoutFeedbackFirstSensorChange".
+     * {@inheritDoc}
+     */
     public void provideFirstFeedbackNamedSensor(NamedBeanHandle<Sensor> s) {
         // remove existing if any
         Sensor temp = getFirstSensor();
@@ -762,6 +790,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
 
         _firstNamedSensor = s;
+        firePropertyChange("turnoutFeedbackFirstSensorChange", temp, s);
 
         // if need be, set listener
         temp = getFirstSensor();  // might have changed
@@ -803,6 +832,10 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
     }
 
+    /** 
+     * On change, fires Property Change "TurnoutFeedbackSecondSensorChange".
+     * {@inheritDoc}
+     */
     public void provideSecondFeedbackNamedSensor(NamedBeanHandle<Sensor> s) {
         // remove existing if any
         Sensor temp = getSecondSensor();
@@ -811,6 +844,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
 
         _secondNamedSensor = s;
+        firePropertyChange("turnoutFeedbackSecondSensorChange", temp, s);
 
         // if need be, set listener
         temp = getSecondSensor();  // might have changed
@@ -1041,7 +1075,10 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         return _divergeSpeed;
     }
 
-    /** {@inheritDoc} */
+    /** 
+     * {@inheritDoc} 
+     * On change, fires Property Change "TurnoutDivergingSpeedChange".
+     */
     @Override
     public void setDivergingSpeed(String s) throws JmriException {
         if (s == null) {
@@ -1107,7 +1144,10 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         return _straightSpeed;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     * On change, fires Property Change "TurnoutStraightSpeedChange".
+     */
     @Override
     public void setStraightSpeed(String s) throws JmriException {
         if (s == null) {

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -780,6 +780,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
 
     /** 
      * On change, fires Property Change "TurnoutFeedbackFirstSensorChange".
+     * @param s the Handle for First Feedback Sensor
      */
     public void provideFirstFeedbackNamedSensor(NamedBeanHandle<Sensor> s) {
         // remove existing if any
@@ -833,6 +834,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
 
     /** 
      * On change, fires Property Change "TurnoutFeedbackSecondSensorChange".
+     * @param s the Handle for Second Feedback Sensor
      */
     public void provideSecondFeedbackNamedSensor(NamedBeanHandle<Sensor> s) {
         // remove existing if any

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.*;
 
@@ -403,12 +404,12 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         // set the value
         int oldMode = _activeFeedbackType;
         _activeFeedbackType = mode;
+        // unlock turnout if feedback is changed
+        setLocked(CABLOCKOUT, false);
         if (oldMode != _activeFeedbackType) {
             firePropertyChange("feedbackchange", oldMode,
                     _activeFeedbackType);
         }
-        // unlock turnout if feedback is changed
-        setLocked(CABLOCKOUT, false);
     }
 
     /** {@inheritDoc} */
@@ -452,13 +453,13 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         boolean oldInverted = _inverted;
         _inverted = inverted;
         if (oldInverted != _inverted) {
-            firePropertyChange("inverted", oldInverted, _inverted);
             int state = _knownState;
             if (state == THROWN) {
                 newKnownState(CLOSED);
             } else if (state == CLOSED) {
                 newKnownState(THROWN);
             }
+            firePropertyChange("inverted", oldInverted, _inverted);
         }
     }
 
@@ -649,7 +650,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
      */
     @Override
     public void setDecoderName(final String decoderName) {
-        if (!(java.util.Objects.equals(_decoderName, decoderName))) {
+        if (!(Objects.equals(_decoderName, decoderName))) {
             String oldName = _decoderName;
             _decoderName = decoderName;
             firePropertyChange("decoderNameChange", oldName, decoderName);
@@ -790,7 +791,6 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
 
         _firstNamedSensor = s;
-        firePropertyChange("turnoutFeedbackFirstSensorChange", temp, s);
 
         // if need be, set listener
         temp = getFirstSensor();  // might have changed
@@ -799,6 +799,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
         // set initial state
         setInitialKnownStateFromFeedback();
+        firePropertyChange("turnoutFeedbackFirstSensorChange", temp, s);
     }
 
     /** {@inheritDoc} */
@@ -844,7 +845,6 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
 
         _secondNamedSensor = s;
-        firePropertyChange("turnoutFeedbackSecondSensorChange", temp, s);
 
         // if need be, set listener
         temp = getSecondSensor();  // might have changed
@@ -853,6 +853,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
         // set initial state
         setInitialKnownStateFromFeedback();
+        firePropertyChange("turnoutFeedbackSecondSensorChange", temp, s);
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/beantable/beanedit/TurnoutEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/TurnoutEditAction.java
@@ -95,15 +95,12 @@ public class TurnoutEditAction extends BeanEditAction<Turnout> {
         feedback = new BeanItemPanel();
         feedback.setName(Bundle.getMessage("Feedback"));
 
-        modeBox = new JComboBox<String>(bean.getValidFeedbackNames());
+        modeBox = new JComboBox<>(bean.getValidFeedbackNames());
         modeBox.setMaximumRowCount(modeBox.getItemCount());
         oldModeSelection = bean.getFeedbackModeName();
         modeBox.setSelectedItem(oldModeSelection);
-        modeBox.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                updateFeedbackOptions();
-            }
+        modeBox.addActionListener((ActionEvent e) -> {
+            updateFeedbackOptions();
         });
 
         feedback.addItem(new BeanEditItem(null, null, Bundle.getMessage("FeedbackToolTip")));
@@ -129,7 +126,7 @@ public class TurnoutEditAction extends BeanEditAction<Turnout> {
                 Bundle.getMessage("FeedbackSensorToolTip")));
 
         String[] str = new String[]{"empty"};
-        automationBox = new JComboBox<String>(str);
+        automationBox = new JComboBox<>(str);
         feedback.addItem(new BeanEditItem(automationBox,
                 Bundle.getMessage("TurnoutAutomation"),
                 Bundle.getMessage("TurnoutAutomationToolTip")));
@@ -231,11 +228,8 @@ public class TurnoutEditAction extends BeanEditAction<Turnout> {
     private TurnoutOperation currentOperation;
     private JTextField operationsName = new JTextField(10);
 
-    transient ActionListener automationSelectionListener = new ActionListener() {
-        @Override
-        public void actionPerformed(ActionEvent e) {
-            updateAutomationOptions();
-        }
+    transient ActionListener automationSelectionListener = (ActionEvent e) -> {
+        updateAutomationOptions();
     };
 
     private void updateFeedbackOptions() {
@@ -325,30 +319,27 @@ public class TurnoutEditAction extends BeanEditAction<Turnout> {
                 lockOperations.add(pushbutText);
             }
             lockOperations.add(noneText);
-            JComboBox<String> lockOperationBox = new JComboBox<String>(lockOperations);
+            JComboBox<String> lockOperationBox = new JComboBox<>(lockOperations);
             lockOperationBox.setMaximumRowCount(lockOperationBox.getItemCount());
 
             lock.addItem(new BeanEditItem(lockOperationBox,
                     Bundle.getMessage("LockMode"),
                     Bundle.getMessage("LockModeToolTip")));
-            lockOperationBox.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    String lockOp = (String) lockOperationBox.getSelectedItem();
-                    if (lockOp != null) {
-                        if (lockOp.equals(noneText)) {
-                            lockBox.setEnabled(false);
-                        } else {
-                            lockBox.setEnabled(true);
-                        }
+            lockOperationBox.addActionListener((ActionEvent e) -> {
+                String lockOp = (String) lockOperationBox.getSelectedItem();
+                if (lockOp != null) {
+                    if (lockOp.equals(noneText)) {
+                        lockBox.setEnabled(false);
+                    } else {
+                        lockBox.setEnabled(true);
                     }
                 }
             });
 
             if ((bean.getPossibleLockModes() & Turnout.PUSHBUTTONLOCKOUT) != 0) {
-                lockBox = new JComboBox<String>(bean.getValidDecoderNames());
+                lockBox = new JComboBox<>(bean.getValidDecoderNames());
             } else {
-                lockBox = new JComboBox<String>(new String[]{bean.getDecoderName()});
+                lockBox = new JComboBox<>(new String[]{bean.getDecoderName()});
             }
             lock.addItem(new BeanEditItem(lockBox,
                     Bundle.getMessage("LockModeDecoder"),
@@ -405,8 +396,8 @@ public class TurnoutEditAction extends BeanEditAction<Turnout> {
         return lock;
     }   // lock() 
 
-    private java.util.Vector<String> speedListClosed = new java.util.Vector<String>();
-    private java.util.Vector<String> speedListThrown = new java.util.Vector<String>();
+    private java.util.Vector<String> speedListClosed = new java.util.Vector<>();
+    private java.util.Vector<String> speedListThrown = new java.util.Vector<>();
 
     private JComboBox<String> closedSpeedBox;
     private JComboBox<String> thrownSpeedBox;
@@ -443,14 +434,14 @@ public class TurnoutEditAction extends BeanEditAction<Turnout> {
             }
         }
 
-        closedSpeedBox = new JComboBox<String>(speedListClosed);
+        closedSpeedBox = new JComboBox<>(speedListClosed);
         closedSpeedBox.setMaximumRowCount(closedSpeedBox.getItemCount());
         closedSpeedBox.setEditable(true);
 
         speed.addItem(new BeanEditItem(closedSpeedBox,
                 Bundle.getMessage("ClosedSpeed"),
                 Bundle.getMessage("ClosedSpeedToolTip")));
-        thrownSpeedBox = new JComboBox<String>(speedListThrown);
+        thrownSpeedBox = new JComboBox<>(speedListThrown);
         thrownSpeedBox.setMaximumRowCount(thrownSpeedBox.getItemCount());
         thrownSpeedBox.setEditable(true);
         speed.addItem(new BeanEditItem(thrownSpeedBox,

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
@@ -382,17 +382,14 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
         if (col == INVERTCOL) {
             if (t.canInvert()) {
                 t.setInverted((Boolean) value);
-                fireTableRowsUpdated(row, row);
             }
         } else if (col == LOCKCOL) {
             t.setLocked(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT, (Boolean) value);
-            fireTableRowsUpdated(row, row);
         } else if (col == MODECOL) {
             @SuppressWarnings("unchecked")
             String modeName = (String) ((JComboBox<String>) value).getSelectedItem();
             assert modeName != null;
             t.setFeedbackMode(modeName);
-            fireTableRowsUpdated(row, row);
         } else if (col == SENSOR1COL) {
             try {
                 Sensor sensor = (Sensor) value;
@@ -400,7 +397,6 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
             } catch (jmri.JmriException e) {
                 JOptionPane.showMessageDialog(null, e.toString());
             }
-            fireTableRowsUpdated(row, row);
         } else if (col == SENSOR2COL) {
             try {
                 Sensor sensor = (Sensor) value;
@@ -408,9 +404,9 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
             } catch (jmri.JmriException e) {
                 JOptionPane.showMessageDialog(null, e.toString());
             }
-            fireTableRowsUpdated(row, row);
-        //} else if (col == OPSONOFFCOL) {
+        } else if (col == OPSONOFFCOL) {
             // do nothing as this is handled by the combo box listener
+            // column still handled here to prevent call to super.setValueAt
         } else if (col == OPSEDITCOL) {
             t.setInhibitOperation(false);
             @SuppressWarnings("unchecked") // cast to JComboBox<String> required in OPSEDITCOL
@@ -459,7 +455,6 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
                     speedListClosed.add(speed);
                 }
             }
-            fireTableRowsUpdated(row, row);
         } else if (col == DIVERGCOL) {
 
             @SuppressWarnings("unchecked")
@@ -476,7 +471,6 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
                     speedListThrown.add(speed);
                 }
             }
-            fireTableRowsUpdated(row, row);
         } else if (col == FORGETCOL) {
             t.setCommandedState(Turnout.UNKNOWN);
         } else if (col == QUERYCOL) {
@@ -606,30 +600,35 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
     // update table if turnout lock or feedback changes
     @Override
     protected boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
-        if (e.getPropertyName().equals("locked")) {
-            return true;
-        }
-        if (e.getPropertyName().equals("feedbackchange")) {
-            return true;
-        }
-        if (e.getPropertyName().equals("TurnoutDivergingSpeedChange")) {
-            return true;
-        }
-        if (e.getPropertyName().equals("TurnoutStraightSpeedChange")) {
-            return true;
-        } else {
-            return super.matchPropertyName(e);
+        switch (e.getPropertyName()) {
+            case "locked":
+            case "inverted":
+            case "feedbackchange": // feedback type setting change, NOT Turnout feedback status
+            case "TurnoutDivergingSpeedChange":
+            case "TurnoutStraightSpeedChange":
+            case "turnoutFeedbackFirstSensorChange":
+            case "turnoutFeedbackSecondSensorChange":
+            case "decoderNameChange":
+            case "TurnoutOperationState":
+            case "KnownState":
+                return true;
+            default:
+                return super.matchPropertyName(e);
         }
     }
 
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
-        if (e.getPropertyName().equals("DefaultTurnoutClosedSpeedChange")) {
-            updateClosedList();
-        } else if (e.getPropertyName().equals("DefaultTurnoutThrownSpeedChange")) {
-            updateThrownList();
-        } else {
-            super.propertyChange(e);
+        switch (e.getPropertyName()) {
+            case "DefaultTurnoutClosedSpeedChange":
+                updateClosedList();
+                break;
+            case "DefaultTurnoutThrownSpeedChange":
+                updateThrownList();
+                break;
+            default:
+                super.propertyChange(e);
+                break;
         }
     }
 

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableJTable.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableJTable.java
@@ -15,8 +15,8 @@ import jmri.Sensor;
 import jmri.SensorManager;
 import jmri.Turnout;
 
-
 import jmri.swing.NamedBeanComboBox;
+import jmri.util.swing.JComboBoxUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,6 +134,7 @@ public class TurnoutTableJTable extends JTable {
             Turnout t, Sensor s) {
         NamedBeanComboBox<Sensor> c = new NamedBeanComboBox<>(InstanceManager.getDefault(SensorManager.class), s, NamedBean.DisplayOptions.DISPLAYNAME);
         c.setAllowNull(true);
+        JComboBoxUtil.setupComboBoxMaxRows(c);
 
         BeanBoxRenderer renderer = new BeanBoxRenderer();
         renderer.setSelectedItem(s);

--- a/java/src/jmri/jmrix/lenz/XNetTurnout.java
+++ b/java/src/jmri/jmrix/lenz/XNetTurnout.java
@@ -275,10 +275,12 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public synchronized void setInverted(boolean inverted) {
         log.debug("Inverting Turnout State for turnout {}T{}", _prefix, mNumber);
-        _inverted = inverted;
         if (inverted) {
             _mThrown = jmri.Turnout.CLOSED;
             _mClosed = jmri.Turnout.THROWN;

--- a/java/src/jmri/jmrix/xpa/XpaTurnout.java
+++ b/java/src/jmri/jmrix/xpa/XpaTurnout.java
@@ -70,10 +70,12 @@ public class XpaTurnout extends AbstractTurnout {
         log.debug("Send command to {} Pushbutton PT{}", (_pushButtonLockout ? "Lock" : "Unlock"), _number);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     synchronized public void setInverted(boolean inverted) {
         log.debug("Inverting Turnout State for turnout {}", getSystemName() );
-        _inverted = inverted;
         if (inverted) {
             _mThrown = Turnout.CLOSED;
             _mClosed = Turnout.THROWN;

--- a/java/test/jmri/implementation/AbstractTurnoutTestBase.java
+++ b/java/test/jmri/implementation/AbstractTurnoutTestBase.java
@@ -52,12 +52,18 @@ public abstract class AbstractTurnoutTestBase {
 
     static protected boolean listenerResult = false;
     static protected int listenStatus = Turnout.UNKNOWN;
+    static protected java.util.List<String> propChangeNames;
 
     public static class Listen implements PropertyChangeListener {
 
+        public Listen(){
+            propChangeNames = new java.util.ArrayList<>();
+        }
+        
         @Override
         public void propertyChange(java.beans.PropertyChangeEvent e) {
             listenerResult = true;
+            propChangeNames.add(e.getPropertyName());
             if (e.getPropertyName().equals("KnownState")) {
                 listenStatus = (Integer) e.getNewValue();
             }
@@ -181,10 +187,18 @@ public abstract class AbstractTurnoutTestBase {
     @Test
     public void testGetAndSetInverted() {
         if (t.canInvert()) {
-            //Assume.assumeTrue(t.canInvert());  // skip test if can't invert.
+            t.addPropertyChangeListener(new Listen());
             Assert.assertFalse("Default Inverted State", t.getInverted());
             t.setInverted(true);
             Assert.assertTrue("set Inverted", t.getInverted());
+            Assert.assertTrue("Inverted propertychange",propChangeNames.contains("inverted"));
+            
+            t.addPropertyChangeListener(new Listen()); // reset PCLs
+            
+            t.setInverted(false);
+            Assert.assertFalse("Unset Inverted", t.getInverted());
+            Assert.assertTrue("Inverted propertychange",propChangeNames.contains("inverted"));
+            
         }
     }
 
@@ -219,15 +233,78 @@ public abstract class AbstractTurnoutTestBase {
     }
 
     @Test
+    public void testSetGetReportLocked() throws InterruptedException {
+        Assert.assertTrue("Turnout starts reporting locked attempted access",t.getReportLocked());
+        t.addPropertyChangeListener(new Listen()); // reset PCLs
+        t.setReportLocked(true);
+        Assert.assertFalse("SetGetReportLocked nochange",
+            propChangeNames.contains("reportlocked"));
+        
+        t.setReportLocked(false);
+        Assert.assertFalse("SetGetReportLocked sets false",t.getReportLocked());
+        Assert.assertTrue("SetGetReportLocked propertychange",
+            propChangeNames.contains("reportlocked"));
+        
+        t.addPropertyChangeListener(new Listen()); // reset PCLs
+        t.setReportLocked(true);
+        Assert.assertTrue("SetGetReportLocked sets true",t.getReportLocked());
+        Assert.assertTrue("SetGetReportLocked propertychange",
+            propChangeNames.contains("reportlocked"));
+        
+    }
+    
+    @Test
+    public void testSetFeedbackModePCL() throws InterruptedException {
+        t.setFeedbackMode(Turnout.UNKNOWN);
+        Assert.assertEquals("No feedback set at start",Turnout.UNKNOWN,t.getFeedbackMode());
+        
+        t.addPropertyChangeListener(new Listen());
+        t.setFeedbackMode(Turnout.UNKNOWN);
+        Assert.assertFalse("setFeedbackMode propertychange",
+            propChangeNames.contains("feedbackchange"));
+        
+        t.setFeedbackMode(Turnout.ONESENSOR);
+        Assert.assertTrue("setFeedbackMode propertychange",
+            propChangeNames.contains("feedbackchange"));
+    }
+    
+    @Test
+    public void testSetDecoderNamePCL() throws InterruptedException {
+        
+        // Assert.assertEquals("No decoder set at start",null,t.getDecoderName());
+        // In AbstractTurnout this String defaults to PushbuttonPacket.unknown , ie "None"
+        // which is different to the javadoc in Turnout which indicates should return null for unset.
+        
+        // so we set it manually here so starting this particular test from a known state.
+        t.setDecoderName(null);
+        Assert.assertEquals("No decoder set at start",null,t.getDecoderName());
+        
+        t.addPropertyChangeListener(new Listen());
+        t.setDecoderName(null);
+        Assert.assertFalse("setDecoderName no change",
+            propChangeNames.contains("decoderNameChange"));
+        
+        t.setDecoderName("Test Name");
+        Assert.assertTrue("SetDecoderName propertychange",
+            propChangeNames.contains("decoderNameChange"));
+    }
+    
+    @Test
     public void testProvideFirstFeedbackSensor() throws jmri.JmriException {
+        t.addPropertyChangeListener(new Listen());
         t.provideFirstFeedbackSensor("IS1");
         Assert.assertNotNull("first feedback sensor", t.getFirstSensor());
+        Assert.assertTrue("1st feedback sensor propertychange",
+            propChangeNames.contains("turnoutFeedbackFirstSensorChange"));
     }
 
     @Test
     public void testProvideSecondFeedbackSensor() throws jmri.JmriException {
+        t.addPropertyChangeListener(new Listen());
         t.provideSecondFeedbackSensor("IS2");
         Assert.assertNotNull("first feedback sensor", t.getSecondSensor());
+        Assert.assertTrue("2nd feedback sensor propertychange",
+            propChangeNames.contains("turnoutFeedbackSecondSensorChange"));
     }
 
     @Test


### PR DESCRIPTION
AbstractTurnout -
Add firePropertyChange to
setDecoderName, provideFirstFeedbackNamedSensor, provideSecondFeedbackNamedSensor
javadoc updates
XNetTurnout / XpaTurnout setInverted flag set in super so prop change sent.
Add unit tests for Property Changes

Update Turnout Table propertyName matches
TurnoutEditAction.java - minor lint