### PR TITLE
Add a `New PR` label to new PRs and removes once 1 day old

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -78,12 +78,18 @@ mergeable: # see https://github.com/mergeability/mergeable
         payload:
           title: 'PR old enough'
           summary: 'PR over one day old, can be merged.'
+      - do: labels
+        labels: [ 'New PR' ]
+        mode: 'delete'
     fail:
       - do: checks
         status: 'failure'
         payload:
           title: 'PR too young'
           summary: 'Waiting for the PR to be one day old.'
+      - do: labels
+        labels: [ 'New PR' ]
+        mode: 'add'
   - when: pull_request.*, pull_request_review.*
     name: 'Approved after last commit, no changes requested'
     validate:


### PR DESCRIPTION
To aid with the automation of new PRs, this adds a label `New PR` whenever a new PR is made and removes this label once it is more than 1 day old.

If, for some reason, PR age automation does not trigger and, thereby, blocking merging, the `New PR` label can be removed manually. As this then triggers a PR change, automation will then run.