### PR TITLE
QualifierCombiner fix pane handling

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/AbstractQualifier.java
+++ b/java/src/jmri/jmrit/symbolicprog/AbstractQualifier.java
@@ -25,6 +25,9 @@ public abstract class AbstractQualifier implements Qualifier, java.beans.Propert
     }
 
     VariableValue watchedVal;
+    public VariableValue getWatchedVariable() {
+        return this.watchedVal;
+    }
 
     /**
      * Process property change from the qualifier Variable (one being watched).

--- a/java/src/jmri/jmrit/symbolicprog/QualifierAdder.java
+++ b/java/src/jmri/jmrit/symbolicprog/QualifierAdder.java
@@ -57,7 +57,6 @@ public abstract class QualifierAdder {
         // Add the AND logic - listen for change and ensure result correct
         if (lq.size() > 1) {
             QualifierCombiner qc = new QualifierCombiner(lq);
-            addListener(qc);
         }
     }
 

--- a/java/src/jmri/jmrit/symbolicprog/QualifierAdder.java
+++ b/java/src/jmri/jmrit/symbolicprog/QualifierAdder.java
@@ -56,7 +56,7 @@ public abstract class QualifierAdder {
 
         // Add the AND logic - listen for change and ensure result correct
         if (lq.size() > 1) {
-            QualifierCombiner qc = new QualifierCombiner(lq);
+            new QualifierCombiner(lq);
         }
     }
 


### PR DESCRIPTION
QualifierCombiner propertyChange listener was not getting called when used with Panes (tested on Windows 10). The cause appeared to be that PaneProgPane did not generate propertyChange events when its Enabled state was changed.  In addition the PaneProgPane did generate two propertyChange events on Close which resulted in an unhandled exception in QualifierCombiner.

Changed QualifierCombiner to listen to propertyChange events on the VariableValues used by its component qualifiers.  Also removed the component qualifier propertyChange listeners since those are now redundant.  QualifierCombiner now recalculates properly for both Pane and Variable qualifiers, and does not generate an exception when the template is closed.