### PR TITLE
Block Property Change Events

### DIFF
--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -6,12 +6,16 @@ import java.beans.PropertyVetoException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.annotation.Nonnull;
+
 import jmri.implementation.AbstractNamedBean;
 import jmri.implementation.SignalSpeedMap;
 import jmri.util.PhysicalLocation;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,29 +27,31 @@ import org.slf4j.LoggerFactory;
  * <p>
  * As trains move around the layout, a set of Block objects that are attached to
  * sensors can interact to keep track of which train is where, going in which
- * direction. As a result of this, the set of Block objects pass around "token"
- * (value) Objects representing the trains. This could be e.g. a Throttle to
- * control the train, or something else.
+ * direction.
+ * As a result of this, the set of Block objects pass around "token"
+ * (value) Objects representing the trains.
+ * This could be e.g. a Throttle to control the train, or something else.
  * <p>
  * A block maintains a "direction" flag that is set from the direction of the
- * incoming train. When an arriving train is detected via the connected sensor
+ * incoming train.
+ * When an arriving train is detected via the connected sensor
  * and the Block's status information is sufficient to determine that it is
- * arriving via a particular Path, that Path's getFromBlockDirection becomes the
- * direction of the train in this Block. This only works
+ * arriving via a particular Path, that Path's getFromBlockDirection
+ * becomes the direction of the train in this Block.
  * <p>
- * Optionally, a Block can be associated with a Reporter. In this case, the
- * Reporter will provide the Block with the "token" (value). This could be e.g
- * an RFID reader reading an ID tag attached to a locomotive. Depending on the
- * specific Reporter implementation, either the current reported value or the
- * last reported value will be relevant - this can be configured
+ * Optionally, a Block can be associated with a Reporter.
+ * In this case, the Reporter will provide the Block with the "token" (value).
+ * This could be e.g an RFID reader reading an ID tag attached to a locomotive.
+ * Depending on the specific Reporter implementation,
+ * either the current reported value or the last reported value will be relevant,
+ * this can be configured.
  * <p>
  * Objects of this class are Named Beans, so can be manipulated through tables,
  * have listeners, etc.
  * <p>
- * There is no functional requirement for a type letter in the System Name, but
- * by convention we use 'B' for 'Block'. The default implementation is not
- * system-specific, so a system letter of 'I' is appropriate. This leads to
- * system names like "IB201".
+ * The type letter used in the System Name is 'B' for 'Block'.
+ * The default implementation is not system-specific, so a system letter 
+ * of 'I' is appropriate. This leads to system names like "IB201".
  * <p>
  * Issues:
  * <ul>
@@ -56,22 +62,25 @@ import org.slf4j.LoggerFactory;
  * <li>When the 1st train leaves, the Sensor stays active, so the value remains
  * that of the 1st train
  * </ul>
- * <li> The assumption is that a train will only go through a set turnout. For
- * example, a train could come into the turnout block from the main even if the
+ * <li> The assumption is that a train will only go through a set turnout.
+ * For example, a train could come into the turnout block from the main even if the
  * turnout is set to the siding. (Ignoring those layouts where this would cause
  * a short; it doesn't do so on all layouts)
  * <li> Does not handle closely-following trains where there is only one
- * electrical block per signal. To do this, it probably needs some type of
- * "assume a train doesn't back up" logic. A better solution is to have multiple
+ * electrical block per signal.
+ * To do this, it probably needs some type of "assume a train doesn't back up" logic.
+ * A better solution is to have multiple
  * sensors and Block objects between each signal head.
- * <li> If a train reverses in a block and goes back the way it came (e.g. b1 to
- * b2 to b1), the block that's re-entered will get an updated direction, but the
- * direction of this block (b2 in the example) is not updated. In other words,
+ * <li> If a train reverses in a block and goes back the way it came
+ * (e.g. b1 to b2 to b1),
+ * the block that's re-entered will get an updated direction,
+ * but the direction of this block (b2 in the example) is not updated.
+ * In other words,
  * we're not noticing that the train must have reversed to go back out.
  * </ul>
  * <p>
- * Do not assume that a Block object uniquely represents a piece of track. To
- * allow independent development, it must be possible for multiple Block objects
+ * Do not assume that a Block object uniquely represents a piece of track.
+ * To allow independent development, it must be possible for multiple Block objects
  * to take care of a particular section of track.
  * <p>
  * Possible state values:
@@ -87,9 +96,9 @@ import org.slf4j.LoggerFactory;
  * <li>UNDETECTED - No sensor configured.
  * </ul>
  * <p>
- * Possible Curvature attributes (optional) User can set the curvature if
- * desired. For use in automatic running of trains, to indicate where slow down
- * is required.
+ * Possible Curvature attributes (optional)
+ * User can set the curvature if desired for use in automatic running of trains,
+ * to indicate where slow down is required.
  * <ul>
  * <li>NONE - No curvature in Block track, or Not entered.
  * <li>GRADUAL - Gradual curve - no action by engineer is warranted - full speed
@@ -98,37 +107,74 @@ import org.slf4j.LoggerFactory;
  * <li>SEVERE - Severe curve in Block track - Train should slow down a lot
  * </ul>
  * <p>
- * The length of the block may also optionally be entered if desired. This
- * attribute is for use in automatic running of trains. Length should be the
- * actual length of model railroad track in the block. It is always stored here
- * in millimeter units. A length of 0.0 indicates no entry of length by the
- * user.
+ * The length of the block may also optionally be entered if desired.
+ * This attribute is for use in automatic running of trains.
+ * Length should be the actual length of model railroad track in the block.
+ * It is always stored here in millimeter units.
+ * A length of 0.0 indicates no entry of length by the user.
  *
  * @author Bob Jacobsen Copyright (C) 2006, 2008, 2014
  * @author Dave Duchamp Copywright (C) 2009
  */
 public class Block extends AbstractNamedBean implements PhysicalLocationReporter {
 
+    /**
+     * Create a new Block.
+     * @param systemName Block System Name.
+     */
     public Block(String systemName) {
         super(systemName);
     }
 
+    /**
+     * Create a new Block.
+     * @param systemName system name.
+     * @param userName user name.
+     */
     public Block(String systemName, String userName) {
         super(systemName, userName);
     }
 
     static final public int OCCUPIED = Sensor.ACTIVE;
     static final public int UNOCCUPIED = Sensor.INACTIVE;
-    // why isn't UNDETECTED == NamedBean.UNKNOWN?
+    
+    /**
+     * Undetected status, i.e a "Dark" block.
+     * A Block with unknown status could be waiting on feedback from a Sensor,
+     * hence undetected may be more appropriate if no Sensor.
+     * <p>
+     * OBlocks use this constant in combination with other OBlock status flags.
+     * Block uses this constant as initial status, also when a Sensor is unset
+     * from the block.
+     * 
+     */
     static final public int UNDETECTED = 0x100;  // bit coded, just in case; really should be enum
 
-    // Curvature attributes
+    /**
+     * No Curvature.
+     */
     static final public int NONE = 0x00;
+    
+    /**
+     * Gradual Curvature.
+     */
     static final public int GRADUAL = 0x01;
+    
+    /**
+     * Tight Curvature.
+     */
     static final public int TIGHT = 0x02;
+    
+    /**
+     * Severe Curvature.
+     */
     static final public int SEVERE = 0x04;
 
-    // this should only be used for debugging...
+    /**
+     * Create a Debug String,
+     * this should only be used for debugging...
+     * @return Block User name, System name, current state as string value.
+     */
     public String toDebugString() {
         String result = getDisplayName(DisplayOptions.USERNAME_SYSTEMNAME) + " ";
         switch (getState()) {
@@ -151,25 +197,37 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         }
         return result;
     }
+    
+    /**
+     * Property name change fired when a Sensor is set to / removed from a Block.
+     * The fired event includes
+     * old value: Sensor Bean Object if previously set, else null
+     * new value: Sensor Bean Object if being set, may be null if Sensor removed.
+     */
+    public final static String OCC_SENSOR_CHANGE = "OccupancySensorChange"; // NOI18N
 
     /**
      * Set the sensor by name.
-     *
+     * Fires propertyChange "OccupancySensorChange" when changed.
      * @param pName the name of the Sensor to set
      * @return true if a Sensor is set and is not null; false otherwise
      */
     public boolean setSensor(String pName) {
-        if (pName == null || pName.equals("")) {
+        Sensor oldSensor = getSensor();
+        if (pName == null || pName.isEmpty()) {
             setNamedSensor(null);
+            firePropertyChange(OCC_SENSOR_CHANGE, oldSensor, null);
             return false;
         }
         if (InstanceManager.getNullableDefault(SensorManager.class) != null) {
             try {
                 Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
                 setNamedSensor(InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(pName, sensor));
+                firePropertyChange(OCC_SENSOR_CHANGE, oldSensor, sensor);
                 return true;
             } catch (IllegalArgumentException ex) {
                 setNamedSensor(null);
+                firePropertyChange(OCC_SENSOR_CHANGE, oldSensor, null);
                 log.error("Sensor '{}' not available", pName);
             }
         } else {
@@ -178,25 +236,38 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         return false;
     }
 
+    /**
+     * Set Block Occupancy Sensor.
+     * If Sensor set, Adds PCL, sets Block Occupancy Status to Sensor.
+     * Block State PropertyChange Event will fire. 
+     * Does NOT route initial Sensor Status via goingUnknown() / goingActive() etc.
+     * <p>
+     * If Sensor null, removes PCL on previous Sensor, sets Block status to UNDETECTED.
+     * @param s Handle for Sensor.
+     */
     public void setNamedSensor(NamedBeanHandle<Sensor> s) {
         if (_namedSensor != null) {
             if (_sensorListener != null) {
-                getSensor().removePropertyChangeListener(_sensorListener);
+                _namedSensor.getBean().removePropertyChangeListener(_sensorListener);
                 _sensorListener = null;
             }
         }
         _namedSensor = s;
 
         if (_namedSensor != null) {
-            getSensor().addPropertyChangeListener(_sensorListener = (PropertyChangeEvent e) -> {
+            _namedSensor.getBean().addPropertyChangeListener(_sensorListener = (PropertyChangeEvent e) -> {
                 handleSensorChange(e);
             }, s.getName(), "Block Sensor " + getDisplayName());
-            _current = getSensor().getState();
+            setState(_namedSensor.getBean().getState()); // At present does NOT route via goingUnknown() / goingActive() etc.
         } else {
-            _current = UNDETECTED;
+            setState(UNDETECTED); // Does NOT route via goingUnknown() / goingActive() etc.
         }
     }
 
+    /**
+     * Get the Block Occupancy Sensor.
+     * @return Sensor if one attached to Block, may be null.
+     */
     public Sensor getSensor() {
         if (_namedSensor != null) {
             return _namedSensor.getBean();
@@ -209,12 +280,23 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     }
 
     /**
+     * Property name change fired when a Sensor is set to / removed from a Block.
+     * The fired event includes
+     * old value: Sensor Bean Object if previously set, else null
+     * new value: Sensor Bean Object if being set, may be null if Sensor removed.
+     */
+    public final static String BLOCK_REPORTER_CHANGE = "BlockReporterChange"; // NOI18N
+    
+    /**
      * Set the Reporter that should provide the data value for this block.
-     *
+     * Fires propertyChange "BlockReporterChange" when changed.
      * @see Reporter
      * @param reporter Reporter object to link, or null to clear
      */
     public void setReporter(Reporter reporter) {
+        if (Objects.equals(reporter,_reporter)) {
+            return;
+        }
         if (_reporter != null) {
             // remove reporter listener
             if (_reporterListener != null) {
@@ -222,6 +304,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                 _reporterListener = null;
             }
         }
+        Reporter oldReporter = _reporter;
         _reporter = reporter;
         if (_reporter != null) {
             // attach listener
@@ -229,6 +312,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                 handleReporterChange(e);
             });
         }
+        firePropertyChange(BLOCK_REPORTER_CHANGE, oldReporter, reporter);
     }
 
     /**
@@ -240,18 +324,29 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     public Reporter getReporter() {
         return _reporter;
     }
+    
+    /**
+     * Property name change fired when the Block reporting Current flag changes.
+     * The fired event includes
+     * old value: previous value, Boolean.
+     * new value: new value, Boolean.
+     */
+    public final static String BLOCK_REPORTING_CURRENT = "BlockReportingCurrent"; // NOI18N
 
     /**
      * Define if the Block's value should be populated from the
      * {@link Reporter#getCurrentReport() current report} or from the
      * {@link Reporter#getLastReport() last report}.
-     *
+     * Fires propertyChange "BlockReportingCurrent" when changed.
      * @see Reporter
      * @param reportingCurrent true if to use current report; false if to use
      *                         last report
      */
     public void setReportingCurrent(boolean reportingCurrent) {
-        _reportingCurrent = reportingCurrent;
+        if (_reportingCurrent != reportingCurrent) {
+            _reportingCurrent = reportingCurrent;
+            firePropertyChange(BLOCK_REPORTING_CURRENT, !reportingCurrent, reportingCurrent);
+        }
     }
 
     /**
@@ -268,20 +363,34 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         return _reportingCurrent;
     }
 
+    /**
+     * Get the Block State.
+     * OBlocks may well return a combination of states,
+     * Blocks will return a single State.
+     * @return Block state.
+     */
     @Override
     public int getState() {
         return _current;
     }
 
-    ArrayList<Path> paths = new ArrayList<>();
+    private final ArrayList<Path> paths = new ArrayList<>();
 
-    public void addPath(Path p) {
+    /**
+     * Add a Path to List of Paths.
+     * @param p Path to add, not null.
+     */
+    public void addPath(@Nonnull Path p) {
         if (p == null) {
             throw new IllegalArgumentException("Can't add null path");
         }
         paths.add(p);
     }
 
+    /**
+     * Remove a Path from the Block.
+     * @param p Path to remove.
+     */
     public void removePath(Path p) {
         int j = -1;
         for (int i = 0; i < paths.size(); i++) {
@@ -294,6 +403,11 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         }
     }
 
+    /**
+     * Check if Block has a particular Path.
+     * @param p Path to test against.
+     * @return true if Block has the Path, else false.
+     */
     public boolean hasPath(Path p) {
         return paths.stream().anyMatch((t) -> (t.equals(p)));
     }
@@ -309,6 +423,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
 
     /**
      * Provide a general method for updating the report.
+     * Fires propertyChange "state" when called.
      *
      * @param v the new state
      */
@@ -328,10 +443,12 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     }
 
     /**
-     * Set the value retained by this Block. Also used when the Block itself
-     * gathers a value from an adjacent Block. This can be overridden in a
-     * subclass if e.g. you want to keep track of Blocks elsewhere, but make
-     * sure you also eventually invoke the super.setValue() here.
+     * Set the value retained by this Block.
+     * Also used when the Block itself gathers a value from an adjacent Block.
+     * This can be overridden in a subclass if
+     * e.g. you want to keep track of Blocks elsewhere,
+     * but make sure you also eventually invoke the super.setValue() here.
+     * Fires propertyChange "value" when changed.
      *
      * @param value The new Object resident in this block, or null if none
      */
@@ -341,14 +458,23 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
             log.debug("Block {} value changed from '{}' to '{}'", getDisplayName(), _value, value);
             _previousValue = _value;
             _value = value;
-            firePropertyChange("value", _previousValue, _value);
+            firePropertyChange("value", _previousValue, _value); // NOI18N
         }
     }
 
+    /**
+     * Get the Block Contents Value.
+     * @return object with current value, could be null.
+     */
     public Object getValue() {
         return _value;
     }
 
+    /**
+     * Set Block Direction of Travel.
+     * Fires propertyChange "direction" when changed.
+     * @param direction Path Constant form, see {@link Path Path.java}
+     */
     public void setDirection(int direction) {
         //ignore if unchanged
         if (direction != _direction) {
@@ -356,25 +482,31 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
             int oldDirection = _direction;
             _direction = direction;
             // this is a bound parameter
-            firePropertyChange("direction", oldDirection, direction);
+            firePropertyChange("direction", oldDirection, direction); // NOI18N
         }
     }
 
+    /**
+     * Get Block Direction of Travel.
+     * @return direction in Path Constant form, see {@link Path Path.java}
+     */
     public int getDirection() {
         return _direction;
     }
 
     //Deny traffic entering from this block
-    ArrayList<NamedBeanHandle<Block>> blockDenyList = new ArrayList<>(1);
+    private final ArrayList<NamedBeanHandle<Block>> blockDenyList = new ArrayList<>(1);
 
     /**
+     * Add to the Block Deny List.
+     * 
      * The block deny list, is used by higher level code, to determine if
      * traffic/trains should be allowed to enter from an attached block, the
-     * list only deals with blocks that access should be denied from. If we want
-     * to prevent traffic from following from this block to another then this
-     * block must be added to the deny list of the other block. By default no
-     * block is barred, so traffic flow is bi-directional.
-     *
+     * list only deals with blocks that access should be denied from.
+     * <p>
+     * If we want to prevent traffic from following from this Block to another,
+     * then this Block must be added to the deny list of the other Block.
+     * By default no Block is barred, so traffic flow is bi-directional.
      * @param pName name of the block to add, which must exist
      */
     public void addBlockDenyList(@Nonnull String pName) {
@@ -435,17 +567,39 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         return blockDenyList.stream().anyMatch((bean) -> (bean.getBean() == deny));
     }
 
+    /**
+     * Get if Block can have permissive working.
+     * Blocks default to non-permissive, i.e. false.
+     * @return true if permissive, else false.
+     */
     public boolean getPermissiveWorking() {
         return _permissiveWorking;
     }
 
+    /**
+     * Property name change fired when the Block Permissive Status changes.
+     * The fired event includes
+     * old value: previous permissive status.
+     * new value: new permissive status.
+     */
+    public final static String BLOCK_PERMISSIVE_CHANGE = "BlockPermissiveWorking"; // NOI18N
+    
+    /**
+     * Set Block as permissive.
+     * Fires propertyChange "BlockPermissiveWorking" when changed.
+     * @param w true permissive, false NOT permissive
+     */
     public void setPermissiveWorking(boolean w) {
-        _permissiveWorking = w;
+        if (_permissiveWorking != w) {
+            _permissiveWorking = w;
+            firePropertyChange(BLOCK_PERMISSIVE_CHANGE, !w, w); // NOI18N
+        }
     }
+    
     private boolean _permissiveWorking = false;
 
     public float getSpeedLimit() {
-        if ((_blockSpeed == null) || (_blockSpeed.equals(""))) {
+        if ((_blockSpeed == null) || (_blockSpeed.isEmpty())) {
             return -1;
         }
         String speed = _blockSpeed;
@@ -475,6 +629,21 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         return _blockSpeed;
     }
 
+    /**
+     * Property name change fired when the Block Speed changes.
+     * The fired event includes
+     * old value: previous speed String.
+     * new value: new speed String.
+     */
+    public final static String BLOCK_SPEED_CHANGE = "BlockSpeedChange"; // NOI18N
+    
+    /**
+     * Set the Block Speed Name.
+     * <p>
+     * Does not perform name validity checking.
+     * Does not send Property Change Event.
+     * @param s new Speed Name String.
+     */
     public void setBlockSpeedName(String s) {
         if (s == null) {
             _blockSpeed = "";
@@ -483,6 +652,13 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         }
     }
 
+    /**
+     * Set the Block Speed, preferred method.
+     * <p>
+     * Fires propertyChange "BlockSpeedChange" when changed.
+     * @param s Speed String
+     * @throws JmriException if Value of requested block speed is not valid.
+     */
     public void setBlockSpeed(String s) throws JmriException {
         if ((s == null) || (_blockSpeed.equals(s))) {
             return;
@@ -502,46 +678,97 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         }
         String oldSpeed = _blockSpeed;
         _blockSpeed = s;
-        firePropertyChange("BlockSpeedChange", oldSpeed, s);
-    }
-
-    public void setCurvature(int c) {
-        _curvature = c;
-    }
-
-    public int getCurvature() {
-        return _curvature;
+        firePropertyChange(BLOCK_SPEED_CHANGE, oldSpeed, s);
     }
 
     /**
+     * Property name change fired when the Block Curvature changes.
+     * The fired event includes
+     * old value: previous Block Curvature Constant.
+     * new value: new Block Curvature Constant.
+     */
+    public final static String BLOCK_CURVATURE_CHANGE = "BlockCurvatureChange"; // NOI18N
+    
+    /**
+     * Set Block Curvature Constant.
+     * Valid values :
+     * Block.NONE, Block.GRADUAL, Block.TIGHT, Block.SEVERE
+     * Fires propertyChange "BlockCurvatureChange"  when changed.
+     * @param c Constant, e.g. Block.GRADUAL
+     */
+    public void setCurvature(int c) {
+        if (_curvature!=c) {
+            int oldCurve = _curvature;
+            _curvature = c;
+            firePropertyChange(BLOCK_CURVATURE_CHANGE, oldCurve, c);
+        }
+    }
+
+    /**
+     * Get Block Curvature Constant.
+     * Defaults to Block.NONE
+     * @return constant, e.g. Block.TIGHT
+     */
+    public int getCurvature() {
+        return _curvature;
+    }
+    
+    /**
+     * Property name change fired when the Block Length changes.
+     * The fired event includes
+     * old value: previous float length (mm).
+     * new value: new float length (mm).
+     */
+    public final static String BLOCK_LENGTH_CHANGE = "BlockLengthChange"; // NOI18N
+
+    /**
      * Set length in millimeters.
-     * <p>
      * Paths will inherit this length, if their length is not specifically set.
-     * This length is the maximum length of any Path in the block. Path lengths
-     * exceeding this will be set to the default length.
-     *
+     * This length is the maximum length of any Path in the block.
+     * Path lengths exceeding this will be set to the default length.
+     * <p>
+     * Fires propertyChange "BlockLengthChange"  when changed, float values in mm.
      * @param l length in millimeters
      */
     public void setLength(float l) {
-        _length = l;
-        getPaths().stream().forEach(p -> {
-            if (p.getLength() > l) {
-                p.setLength(0); // set to default
-            }
-        });
+        float oldLen = getLengthMm();
+        if (Math.abs(oldLen - l) > 0.0001){ // length value is different
+            _length = l;
+            getPaths().stream().forEach(p -> {
+                if (p.getLength() > l) {
+                    p.setLength(0); // set to default
+                }
+            });
+            firePropertyChange(BLOCK_LENGTH_CHANGE, oldLen, l);
+        }
     }
 
+    /**
+     * Get Block Length in Millimetres.
+     * Default 0.0f.
+     * @return length in mm.
+     */
     public float getLengthMm() {
         return _length;
-    } // return length in millimeters
+    }
 
+    /**
+     * Get Block Length in Centimetres.
+     * Courtesy method using result from getLengthMm.
+     * @return length in centimetres.
+     */
     public float getLengthCm() {
         return (_length / 10.0f);
-    }  // return length in centimeters
+    }
 
+    /**
+     * Get Block Length in Inches.
+     * Courtesy method using result from getLengthMm.
+     * @return length in inches.
+     */
     public float getLengthIn() {
         return (_length / 25.4f);
-    }  // return length in inches
+    }
 
     /**
      * Note: this has to make choices about identity values (always the same)
@@ -615,8 +842,9 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * @param e the event
      */
     void handleSensorChange(PropertyChangeEvent e) {
-        if (e.getPropertyName().equals("KnownState")) {
-            int state = getSensor().getState();
+        Sensor s = getSensor();
+        if (e.getPropertyName().equals("KnownState") && s!=null) {
+            int state = s.getState();
             switch (state) {
                 case Sensor.ACTIVE:
                     goingActive();
@@ -657,6 +885,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     }
 
     private Instant _timeLastInactive;
+    
     /**
      * Handles Block sensor going INACTIVE: this block is empty
      */
@@ -883,10 +1112,13 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         return (next);
     }
 
-    /*
-     * This allows the layout block to inform any listeners to the block that the higher level layout block has been set to "useExtraColor" which is an
-     * indication that it has been allocated to a section by the AutoDispatcher.  The value set is not retained in any form by the block, it is purely to
-     * trigger a propertyChangeEvent.
+    /**
+     * This allows the layout block to inform any listeners to the block 
+     * that the higher level layout block has been set to "useExtraColor" which is an
+     * indication that it has been allocated to a section by the AutoDispatcher.
+     * The value set is not retained in any form by the block,
+     * it is purely to trigger a propertyChangeEvent.
+     * @param boo Allocation status
      */
     public void setAllocated(Boolean boo) {
         firePropertyChange("allocated", !boo, boo);
@@ -897,6 +1129,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     // If we have a Reporter that is also a PhysicalLocationReporter,
     // we will defer to that Reporter's methods.
     // Else we will assume a LocoNet style message to be parsed.
+    
     /**
      * Parse a given string and return the LocoAddress value that is presumed
      * stored within it based on this object's protocol. The Class Block
@@ -935,7 +1168,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     /**
      * Parses out a (possibly old) LnReporter-generated report string to extract
      * the direction from within it based on this object's protocol. The Class
-     * Block implementationd defers to its associated Reporter, if it exists.
+     * Block implementation defers to its associated Reporter, if it exists.
      *
      * @param rep String to be parsed
      * @return PhysicalLocationReporter.Direction direction parsed from string,
@@ -976,8 +1209,8 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     }
 
     /**
-     * Return this Block's physical location, if it exists. Defers actual work
-     * to the helper methods in class PhysicalLocation
+     * Return this Block's physical location, if it exists.
+     * Defers actual work to the helper methods in class PhysicalLocation.
      *
      * @return PhysicalLocation : this Block's location.
      */
@@ -988,9 +1221,9 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
     }
 
     /**
-     * Return this Block's physical location, if it exists. Does not use the
-     * parameter s Defers actual work to the helper methods in class
-     * PhysicalLocation
+     * Return this Block's physical location, if it exists.
+     * Does not use the parameter s.
+     * Defers actual work to the helper methods in class PhysicalLocation
      *
      * @param s (this parameter is ignored)
      * @return PhysicalLocation : this Block's location.

--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -214,14 +214,19 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      */
     public boolean setSensor(String pName) {
         Sensor oldSensor = getSensor();
-        if (pName == null || pName.isEmpty()) {
-            setNamedSensor(null);
-            firePropertyChange(OCC_SENSOR_CHANGE, oldSensor, null);
-            return false;
+        if ((pName == null || pName.isEmpty())) {
+                if (oldSensor!=null) {
+                    setNamedSensor(null);
+                    firePropertyChange(OCC_SENSOR_CHANGE, oldSensor, null);
+                }
+                return false;
         }
         if (InstanceManager.getNullableDefault(SensorManager.class) != null) {
             try {
                 Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
+                if (sensor.equals(oldSensor)) {
+                    return false;
+                }
                 setNamedSensor(InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(pName, sensor));
                 firePropertyChange(OCC_SENSOR_CHANGE, oldSensor, sensor);
                 return true;

--- a/java/test/jmri/BlockTest.java
+++ b/java/test/jmri/BlockTest.java
@@ -1,5 +1,14 @@
 package jmri;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
+
+import jmri.implementation.SignalSpeedMap;
 import jmri.jmrix.internal.InternalSensorManager;
 import jmri.jmrix.internal.InternalSystemConnectionMemo;
 import jmri.util.JUnitUtil;
@@ -361,6 +370,378 @@ public class BlockTest {
         Assert.assertEquals("direction", jmri.PhysicalLocationReporter.Direction.ENTER, b.getDirection("1234 enter"));
     }
 
+    @Test
+    public void testAddRemoveListener() throws JmriException {
+        
+        Block b = new Block("BlockSystemName");
+        b.setUserName("Start user id");
+        Listen listen = new Listen();
+        Assert.assertEquals("no listener at start of test",0, b.getNumPropertyChangeListeners());
+        
+        b.addPropertyChangeListener(listen);
+        Assert.assertEquals("1 listener added",1, b.getNumPropertyChangeListeners());
+        
+        b.setUserName("user id");
+        Assert.assertEquals("prop ev name","UserName", listen.getPropertyName(0));
+        Assert.assertEquals("old value","Start user id", listen.getOldValue(0));
+        Assert.assertEquals("new value","user id", listen.getNewValue(0));
+                
+        b.removePropertyChangeListener(listen);
+        Assert.assertEquals("listener removed",0, b.getNumPropertyChangeListeners());
+        
+        b.setUserName("Changed user id");       
+        Assert.assertEquals("list size still 1",1, listen.getNumPropChanges());
+    }
+    
+    
+    /**
+     * Test Property Changes for Adding Sensors to a block.
+     * 
+     * Add a Sensor with UNKNOWN state to Block.
+     * Prop change for Block state UNDETECTED to UNKNOWN
+     * Prop Change Block added Sensor
+     * 
+     * Change the Block Sensor to new Sensor with INACTIVE state
+     * Prop change for Block state UNKNOWN to UNOCCUPIED
+     * Prop Change Block Sensor change
+     * 
+     * Remove the Block Sensor
+     * Prop change for Block state UNOCCUPIED to UNDETECED
+     * Prop Change Block Sensor change
+     * 
+     * @throws JmriException on test error.
+     */
+    @Test
+    public void testAddSensorPropertyChange() throws JmriException {
+        
+        SensorManager sm = InstanceManager.getDefault(SensorManager.class);
+        Sensor sensorUnknownState = sm.provide("ISunknownState");
+        sensorUnknownState.setKnownState(Sensor.UNKNOWN);
+        
+        Sensor sensorInactiveState = sm.provide("ISInactiveState");
+        sensorInactiveState.setKnownState(Sensor.INACTIVE);
+        
+        Block b = new Block("BlockSystemName");
+        Assert.assertEquals("Block starts state undetected", Block.UNDETECTED, b.getState());
+        Listen listen = new Listen();
+        b.addPropertyChangeListener(listen);
+        
+        b.setSensor("ISunknownState");
+        Assert.assertEquals("list size +2, state change, occ sense change",2, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name","state", listen.getPropertyName(0));
+        Assert.assertEquals("old value",Block.UNDETECTED, (int)listen.getOldValue(0));
+        Assert.assertEquals("new value", Block.UNKNOWN, (int)listen.getNewValue(0));
+        
+        Assert.assertEquals("prop ev name",Block.OCC_SENSOR_CHANGE, listen.getPropertyName(1));
+        Assert.assertEquals("old value",null, listen.getOldValue(1));
+        Assert.assertEquals("new value",sensorUnknownState, listen.getNewValue(1));
+        
+        b.setSensor("ISunknownState");
+        Assert.assertEquals("same sensor, no prop change",2, listen.getNumPropChanges());
+        
+        b.setSensor("ISInactiveState");
+        Assert.assertEquals("list size +2, state change, occ sense change",4, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name", "state", listen.getPropertyName(2));
+        Assert.assertEquals("old value", Block.UNKNOWN, (int)listen.getOldValue(2));
+        Assert.assertEquals("new value", Block.UNOCCUPIED, (int)listen.getNewValue(2));
+        
+        Assert.assertEquals("prop ev name", Block.OCC_SENSOR_CHANGE, listen.getPropertyName(3));
+        Assert.assertEquals("old value",sensorUnknownState, listen.getOldValue(3));
+        Assert.assertEquals("new value", sensorInactiveState, listen.getNewValue(3));
+        
+        b.setSensor(null);
+        Assert.assertEquals("list size +2, state change, occ sense change",6, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name","state", listen.getPropertyName(4));
+        Assert.assertEquals("old value",Block.UNOCCUPIED, (int)listen.getOldValue(4));
+        Assert.assertEquals("setSensor sets status unoccupied to undetected", Block.UNDETECTED, (int)listen.getNewValue(4));
+        
+        Assert.assertEquals("prop ev name",Block.OCC_SENSOR_CHANGE, listen.getPropertyName(5));
+        Assert.assertEquals("old value", sensorInactiveState, listen.getOldValue(5));
+        Assert.assertEquals("new value", null, listen.getNewValue(5));
+        
+    }
+    
+    @Test
+    public void testAddReporterPropertyChange() throws JmriException {
+        
+        ReporterManager rm = jmri.InstanceManager.getDefault(ReporterManager.class);
+        Reporter rep = rm.provide("IR123");
+        
+        Block b = new Block("BlockSystemName");
+        Listen listen = new Listen();
+        b.addPropertyChangeListener(listen);
+        
+        b.setReporter(rep);
+        Assert.assertEquals("list size 1, reporter change",1, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name", Block.BLOCK_REPORTER_CHANGE, listen.getPropertyName(0));
+        Assert.assertEquals("old value", null, listen.getOldValue(0));
+        Assert.assertEquals("new value", rep, listen.getNewValue(0));
+        
+        b.setReporter(rep);
+        Assert.assertEquals("list size still 1",1, listen.getNumPropChanges());
+        
+        b.setReporter(null);
+        Assert.assertEquals("+1 property change",2, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name",Block.BLOCK_REPORTER_CHANGE, listen.getPropertyName(1));
+        Assert.assertEquals("old value", rep, listen.getOldValue(1));
+        Assert.assertEquals("new value", null, listen.getNewValue(1));
+    }
+    
+    /**
+     * Testing of the Reporting Current Flag being set, NOT of the Reporter mechanism.
+     * @throws JmriException on test error.
+     */
+    @Test
+    public void testSetReportingCurrentPropertyChange() throws JmriException {
+        
+        Block b = new Block("BlockSystemName");
+        Listen listen = new Listen();
+        
+        b.setReportingCurrent(false); // set initial test state
+        b.addPropertyChangeListener(listen);
+        
+        b.setReportingCurrent(true);
+        Assert.assertEquals("list size 1, property change",1, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name", Block.BLOCK_REPORTING_CURRENT, listen.getPropertyName(0));
+        Assert.assertEquals("old value", Boolean.FALSE, listen.getOldValue(0));
+        Assert.assertEquals("new value", Boolean.TRUE, listen.getNewValue(0));
+        
+        b.setReportingCurrent(true);
+        Assert.assertEquals("list size still 1",1, listen.getNumPropChanges());
+        
+        b.setReportingCurrent(false);
+        Assert.assertEquals("+1 property change",2, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name", Block.BLOCK_REPORTING_CURRENT, listen.getPropertyName(1));
+        Assert.assertEquals("old value", Boolean.TRUE, listen.getOldValue(1));
+        Assert.assertEquals("new value", Boolean.FALSE, listen.getNewValue(1));
+        
+    }
+    
+    @Test
+    public void testSetStatePropertyChangeName() throws JmriException {
+        
+        Block b = new Block("BlockSystemName");
+        Listen listen = new Listen();
+        
+        b.setState(Block.UNDETECTED); // set initial test state
+        b.addPropertyChangeListener(listen);
+        
+        b.setState(Block.UNOCCUPIED);
+        Assert.assertEquals("1 property change",1, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name", "state", listen.getPropertyName(0));
+        Assert.assertEquals("new value", Block.UNOCCUPIED, (int)listen.getNewValue(0));
+        
+    }
+    
+    @Test
+    public void testSetValuePropertyChange() throws JmriException {
+        
+        Block b = new Block("BlockSystemName");
+        Listen listen = new Listen();
+        
+        b.setValue(null); // set initial test state
+        b.addPropertyChangeListener(listen);
+        
+        b.setValue("String Block Value");
+        Assert.assertEquals("1 property change",1, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name", "value", listen.getPropertyName(0));
+        Assert.assertEquals("old value", null, listen.getOldValue(0));
+        Assert.assertEquals("new value", "String Block Value", listen.getNewValue(0));
+        
+        b.setValue("String Block Value");
+        Assert.assertEquals("list size still 1",1, listen.getNumPropChanges());
+        
+        b.setValue("New Block Value");
+        Assert.assertEquals("+1 property change",2, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name", "value", listen.getPropertyName(1));
+        Assert.assertEquals("old value", "String Block Value", listen.getOldValue(1));
+        Assert.assertEquals("new value", "New Block Value", listen.getNewValue(1));
+        
+        b.setValue(null);
+        Assert.assertEquals("+1 property change",3, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name", "value", listen.getPropertyName(2));
+        Assert.assertEquals("old value", "New Block Value", listen.getOldValue(2));
+        Assert.assertEquals("new value", null, listen.getNewValue(2));
+        
+    }
+    
+    @Test
+    public void testSetDirectionPropertyChange() throws JmriException {
+        
+        Block b = new Block("BlockSystemName");
+        Listen listen = new Listen();
+        
+        b.setDirection(Path.NORTH); // set initial test state
+        b.addPropertyChangeListener(listen);
+        
+        b.setDirection(Path.EAST);
+        Assert.assertEquals("1 property change",1, listen.getNumPropChanges());
+        Assert.assertEquals("Direction set",Path.EAST, b.getDirection());
+        Assert.assertEquals("prop ev name", "direction", listen.getPropertyName(0));
+        Assert.assertEquals("old value", Path.NORTH, (int)listen.getOldValue(0));
+        Assert.assertEquals("new value", Path.EAST, (int)listen.getNewValue(0));
+        
+        b.setDirection(Path.EAST);
+        Assert.assertEquals("list size still 1",1, listen.getNumPropChanges());
+        
+        b.setDirection(Path.WEST);
+        Assert.assertEquals("+1 property change",2, listen.getNumPropChanges());
+        Assert.assertEquals("Direction set",Path.WEST, b.getDirection());
+        Assert.assertEquals("prop ev name", "direction", listen.getPropertyName(1));
+        Assert.assertEquals("old value", Path.EAST, (int)listen.getOldValue(1));
+        Assert.assertEquals("new value", Path.WEST, (int)listen.getNewValue(1));
+        
+    }
+    
+    @Test
+    public void testSetGetPermissiveWorkingPropertyChange() throws JmriException {
+        
+        Block b = new Block("BlockSystemName");
+        Listen listen = new Listen();
+        
+        Assert.assertFalse("block not permissive to start", b.getPermissiveWorking());
+        b.addPropertyChangeListener(listen);
+        
+        b.setPermissiveWorking(true);
+        Assert.assertEquals("1 property change",1, listen.getNumPropChanges());
+        Assert.assertTrue("block permissive set", b.getPermissiveWorking());
+        Assert.assertEquals("prop ev name",Block.BLOCK_PERMISSIVE_CHANGE, listen.getPropertyName(0));
+        Assert.assertEquals("old value", Boolean.FALSE, listen.getOldValue(0));
+        Assert.assertEquals("new value", Boolean.TRUE, listen.getNewValue(0));
+        
+        b.setPermissiveWorking(true);
+        Assert.assertEquals("list size still 1",1, listen.getNumPropChanges());
+        
+        b.setPermissiveWorking(false);
+        Assert.assertEquals("+1 property change",2, listen.getNumPropChanges());
+        Assert.assertFalse("block not permissive when set", b.getPermissiveWorking());
+        Assert.assertEquals("prop ev name", Block.BLOCK_PERMISSIVE_CHANGE, listen.getPropertyName(1));
+        Assert.assertEquals("old value", Boolean.TRUE, listen.getOldValue(1));
+        Assert.assertEquals("new value", Boolean.FALSE, listen.getNewValue(1));
+        
+    }
+    
+    @Test
+    public void testSetSpeedPropertyChange() throws JmriException {
+        
+        Block b = new Block("BlockSystemName");
+        Listen listen = new Listen();
+        
+        String speedA = InstanceManager.getDefault(SignalSpeedMap.class).getValidSpeedNames().firstElement();
+        String speedB = InstanceManager.getDefault(SignalSpeedMap.class).getValidSpeedNames().lastElement();
+        Assert.assertFalse("Sample speed text needs changing",speedA.equals(speedB));
+        
+        b.setBlockSpeed(speedA); // set initial test state
+        Assert.assertEquals("block speedA set",speedA, b.getBlockSpeed());
+        b.addPropertyChangeListener(listen);
+        
+        b.setBlockSpeed(speedB);
+        Assert.assertEquals("1 property change",1, listen.getNumPropChanges());
+        Assert.assertEquals("block speedB set",speedB, b.getBlockSpeed());
+        Assert.assertEquals("prop ev name",Block.BLOCK_SPEED_CHANGE, listen.getPropertyName(0));
+        Assert.assertEquals("old value", speedA, (String)listen.getOldValue(0));
+        Assert.assertEquals("new value", speedB, (String)listen.getNewValue(0));
+        
+        b.setBlockSpeed(speedB);
+        Assert.assertEquals("list size still 1",1, listen.getNumPropChanges());
+        
+        b.setBlockSpeed(speedA);
+        Assert.assertEquals("+1 property change",2, listen.getNumPropChanges());
+        Assert.assertEquals("block speedA set",speedA, b.getBlockSpeed());
+        Assert.assertEquals("prop ev name",Block.BLOCK_SPEED_CHANGE, listen.getPropertyName(1));
+        Assert.assertEquals("old value", speedB, (String)listen.getOldValue(1));
+        Assert.assertEquals("new value", speedA, (String)listen.getNewValue(1));
+        
+    }
+    
+    @Test
+    public void testSetCurvaturePropertyChange() throws JmriException {
+        
+        Block b = new Block("BlockSystemName");
+        Listen listen = new Listen();
+        
+        Assert.assertEquals("no initial curvature",Block.NONE, b.getCurvature());
+        b.addPropertyChangeListener(listen);
+        
+        b.setCurvature(Block.TIGHT);
+        Assert.assertEquals("1 property change",1, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name", Block.BLOCK_CURVATURE_CHANGE, listen.getPropertyName(0));
+        Assert.assertEquals("old value", Block.NONE, (int)listen.getOldValue(0));
+        Assert.assertEquals("new value", Block.TIGHT, (int)listen.getNewValue(0));
+        
+        b.setCurvature(Block.TIGHT);
+        Assert.assertEquals("list size still 1",1, listen.getNumPropChanges());
+        
+        b.setCurvature(Block.GRADUAL);
+        Assert.assertEquals("+1 property change",2, listen.getNumPropChanges());
+        Assert.assertEquals("prop ev name",Block.BLOCK_CURVATURE_CHANGE, listen.getPropertyName(1));
+        Assert.assertEquals("old value", Block.TIGHT, (int)listen.getOldValue(1));
+        Assert.assertEquals("new value", Block.GRADUAL, (int)listen.getNewValue(1));
+    }
+    
+    @Test
+    public void testSetGetLengthPropertyChange() throws JmriException {
+        
+        Block b = new Block("BlockSystemName");
+        Listen listen = new Listen();
+        
+        Assert.assertEquals("no initial length mm",0.0f, b.getLengthMm(), 0);
+        Assert.assertEquals("no initial length cm",0.0f, b.getLengthCm(), 0);
+        Assert.assertEquals("no initial length in",0.0f, b.getLengthIn(), 0);
+        b.addPropertyChangeListener(listen);
+        
+        b.setLength(47f);
+        Assert.assertEquals("1 property change",1, listen.getNumPropChanges());
+        Assert.assertEquals("mm set to 47",47.0f, b.getLengthMm(), 0.01);
+        Assert.assertEquals("cm set to 4.7",4.7f, b.getLengthCm(), 0.01);
+        Assert.assertEquals("Inches set to ",1.850f, b.getLengthIn(), 0.01);
+        Assert.assertEquals("prop ev name", Block.BLOCK_LENGTH_CHANGE, listen.getPropertyName(0));
+        Assert.assertEquals("old value", 0.0f, (float)listen.getOldValue(0),0.01);
+        Assert.assertEquals("new value", 47.0f, (float)listen.getNewValue(0),0.01);
+        
+        b.setLength(47f);
+        Assert.assertEquals("list size still 1",1, listen.getNumPropChanges());
+        
+        b.setLength(20f);
+        Assert.assertEquals("+1 property change",2, listen.getNumPropChanges());
+        Assert.assertEquals("mm set to 20",20.0f, b.getLengthMm(), 0.001);
+        Assert.assertEquals("cm set to 2.0",2.0f, b.getLengthCm(), 0.001);
+        Assert.assertEquals("Inches set to ",0.787f, b.getLengthIn(), 0.001);
+        Assert.assertEquals("prop ev name",Block.BLOCK_LENGTH_CHANGE, listen.getPropertyName(1));
+        Assert.assertEquals("old value", 47.0f, (float)listen.getOldValue(1),0.01);
+        Assert.assertEquals("new value", 20.0f, (float)listen.getNewValue(1),0.01);
+        
+    }
+    
+    /**
+     * Class to log Property Changes.
+     */
+    private static class Listen implements PropertyChangeListener {
+        
+        List<PropertyChangeEvent> propChangeNames = Collections.synchronizedList(new ArrayList<>());
+        
+        @Override
+        public void propertyChange(PropertyChangeEvent e) {
+            propChangeNames.add(e);
+        }
+        
+        public int getNumPropChanges(){
+            return propChangeNames.size();
+        }
+        
+        public String getPropertyName(int index){
+            return propChangeNames.get(index).getPropertyName();
+        }
+        
+        public Object getOldValue(int index){
+            return propChangeNames.get(index).getOldValue();
+        }
+        
+        public Object getNewValue(int index){
+            return propChangeNames.get(index).getNewValue();
+        }
+        
+    }
 
     @BeforeEach
     public void setUp() {

--- a/java/test/jmri/BlockTest.java
+++ b/java/test/jmri/BlockTest.java
@@ -639,8 +639,8 @@ public class BlockTest {
         Assert.assertEquals("1 property change",1, listen.getNumPropChanges());
         Assert.assertEquals("block speedB set",speedB, b.getBlockSpeed());
         Assert.assertEquals("prop ev name",Block.BLOCK_SPEED_CHANGE, listen.getPropertyName(0));
-        Assert.assertEquals("old value", speedA, (String)listen.getOldValue(0));
-        Assert.assertEquals("new value", speedB, (String)listen.getNewValue(0));
+        Assert.assertEquals("old value", speedA, listen.getOldValue(0));
+        Assert.assertEquals("new value", speedB, listen.getNewValue(0));
         
         b.setBlockSpeed(speedB);
         Assert.assertEquals("list size still 1",1, listen.getNumPropChanges());
@@ -649,8 +649,8 @@ public class BlockTest {
         Assert.assertEquals("+1 property change",2, listen.getNumPropChanges());
         Assert.assertEquals("block speedA set",speedA, b.getBlockSpeed());
         Assert.assertEquals("prop ev name",Block.BLOCK_SPEED_CHANGE, listen.getPropertyName(1));
-        Assert.assertEquals("old value", speedB, (String)listen.getOldValue(1));
-        Assert.assertEquals("new value", speedA, (String)listen.getNewValue(1));
+        Assert.assertEquals("old value", speedB, listen.getOldValue(1));
+        Assert.assertEquals("new value", speedA, listen.getNewValue(1));
         
     }
     

--- a/java/test/jmri/BlockTest.java
+++ b/java/test/jmri/BlockTest.java
@@ -423,8 +423,15 @@ public class BlockTest {
         
         Block b = new Block("BlockSystemName");
         Assert.assertEquals("Block starts state undetected", Block.UNDETECTED, b.getState());
+        Assert.assertEquals("Block starts no sensor", null, b.getSensor());
         Listen listen = new Listen();
         b.addPropertyChangeListener(listen);
+        
+        b.setSensor(null);
+        Assert.assertEquals("no prop change null to null",0, listen.getNumPropChanges());
+        
+        b.setSensor("");
+        Assert.assertEquals("no prop change null to empty",0, listen.getNumPropChanges());
         
         b.setSensor("ISunknownState");
         Assert.assertEquals("list size +2, state change, occ sense change",2, listen.getNumPropChanges());


### PR DESCRIPTION
Adds Property Change Events when Block properties change, for improved performance of Block Bean Table.
Javadoc updates.
Unit tests.

setSensor(Sensor) - see Test for worked example.
Sends PCE for change in Sensor being listened to,
Sends PCE to update Block state from Sensor state.
Does not route this Block state change via the goingActive() / goingInactive() etc. methods.

setReporter(Reporter) - sends PCE for change in Reporter being listened to.
setReportingCurrent(boolean) - sends PCE on change.
setPermissiveWorking(boolean) - sends PCE on change.
setBlockSpeed(String) - sends PCE on change of Speed Name.
setCurvature(int) - sends PCE on change.
setLength(int) - sends PCE on change.