### PR TITLE
Proxy Managers getEntryToolTip() - use default Manager ToolTip

### DIFF
--- a/java/src/jmri/SensorManager.java
+++ b/java/src/jmri/SensorManager.java
@@ -42,8 +42,8 @@ public interface SensorManager extends ProvidingManager<Sensor> {
     @Nonnull
     public Sensor provideSensor(@Nonnull String name) throws IllegalArgumentException;
 
-    @Override
     /** {@inheritDoc} */
+    @Override
     default public Sensor provide(@Nonnull String name) throws IllegalArgumentException { return provideSensor(name); }
 
     /**

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -371,6 +371,15 @@ abstract public class AbstractProxyManager<E extends NamedBean> extends Vetoable
     }
     
     /**
+     * Get the Default Manager ToolTip.
+     * {@inheritDoc}
+     */
+    @Override
+    public String getEntryToolTip() {
+        return getDefaultManager().getEntryToolTip();
+    }
+    
+    /**
      * Try to create a system manager.
      *
      * @param systemPrefix the system prefix

--- a/java/src/jmri/managers/ProxyIdTagManager.java
+++ b/java/src/jmri/managers/ProxyIdTagManager.java
@@ -156,14 +156,6 @@ public class ProxyIdTagManager extends AbstractProvidingProxyManager<IdTag>
         return getBySystemName(makeSystemName(tagID));
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getEntryToolTip() {
-        return "Enter a number from 1 to 9999"; // Basic number format help
-    }
-
     @Override
     @Nonnull
     public String getBeanTypeHandled(boolean plural) {

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -159,14 +159,6 @@ public class ProxyLightManager extends AbstractProvidingProxyManager<Light>
         return getNextValidAddress(curAddress, prefix, ignoreInitialExisting, typeLetter());
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getEntryToolTip() {
-        return Bundle.getMessage("EnterNumber1to9999ToolTip");
-    }
-
     @Override
     @Nonnull
     public String getBeanTypeHandled(boolean plural) {

--- a/java/src/jmri/managers/ProxyReporterManager.java
+++ b/java/src/jmri/managers/ProxyReporterManager.java
@@ -115,14 +115,6 @@ public class ProxyReporterManager extends AbstractProvidingProxyManager<Reporter
         return getNextValidAddress(curAddress, prefix, ignoreInitialExisting, typeLetter());
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getEntryToolTip() {
-        return "Enter a number from 1 to 9999"; // Basic number format help
-    }
-
     @Override
     @Nonnull
     public String getBeanTypeHandled(boolean plural) {

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -106,14 +106,6 @@ public class ProxySensorManager extends AbstractProvidingProxyManager<Sensor>
         return getNextValidAddress(curAddress, prefix, ignoreInitialExisting, typeLetter());
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getEntryToolTip() {
-        return "Enter a number from 1 to 9999"; // Basic number format help
-    }
-
     @Override
     public long getDefaultSensorDebounceGoingActive() {
         return ((SensorManager) getDefaultManager()).getDefaultSensorDebounceGoingActive();

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -225,14 +225,6 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
         return ((TurnoutManager) getDefaultManager()).getDefaultClosedSpeed();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getEntryToolTip() {
-        return "Enter a number from 1 to 9999"; // Basic number format help
-    }
-
     /** {@inheritDoc}
      * @return outputInterval from default TurnoutManager
      */


### PR DESCRIPTION
No need for ProxyManagers to define ToolTips, leave it to actual Manager.