### PR TITLE
Extend-CV-read-hints-to-Other-Programmer-facades

### DIFF
--- a/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
+++ b/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
  * @see jmri.implementation.ProgrammerFacadeSelector
  *
  * @author Bob Jacobsen Copyright (C) 2014
+ * @author Andrew Crosland Copyright (C) 2021
  */
 // @ToDo("transform to annotations requires e.g. http://alchemy.grimoire.ca/m2/sites/ca.grimoire/todo-annotations/")
 // @ToDo("get address from underlyng programmer (which might require adding a new subclass structure to Programmer)")
@@ -188,9 +189,14 @@ public class AccessoryOpsModeProgrammerFacade extends AbstractProgrammerFacade i
 
     @Override
     public synchronized void readCV(String cv, jmri.ProgListener p) throws jmri.ProgrammerException {
+        readCV(cv, p, 0);
+    }
+
+    @Override
+    public synchronized void readCV(String cv, jmri.ProgListener p, int startVal) throws jmri.ProgrammerException {
         useProgrammer(p);
         state = ProgState.PROGRAMMING;
-        prog.readCV(cv, this);
+        prog.readCV(cv, this, startVal);
     }
 
     @Override

--- a/java/src/jmri/implementation/OpsModeDelayedProgrammerFacade.java
+++ b/java/src/jmri/implementation/OpsModeDelayedProgrammerFacade.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
  * @see jmri.implementation.ProgrammerFacadeSelector
  *
  * @author Bob Jacobsen Copyright (C) 2014
+ * @author Andrew Crosland Copyright (C) 2021
  */
 // @ToDo("transform to annotations requires e.g. http://alchemy.grimoire.ca/m2/sites/ca.grimoire/todo-annotations/")
 // @ToDo("read handling needs to be aligned with other ops mode programmers")
@@ -67,9 +68,14 @@ public class OpsModeDelayedProgrammerFacade extends AbstractProgrammerFacade imp
 
     @Override
     public synchronized void readCV(String cv, jmri.ProgListener p) throws jmri.ProgrammerException {
+        readCV(cv, p, 0);
+    }
+
+    @Override
+    public synchronized void readCV(String cv, jmri.ProgListener p, int startVal) throws jmri.ProgrammerException {
         useProgrammer(p);
         state = ProgState.READCOMMANDSENT;
-        prog.readCV(cv, this);
+        prog.readCV(cv, this, startVal);
     }
 
     @Override

--- a/java/src/jmri/implementation/ResettingOffsetHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/ResettingOffsetHighCvProgrammerFacade.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
  * @see jmri.implementation.ProgrammerFacadeSelector
  *
  * @author Bob Jacobsen Copyright (C) 2013
+ * @author Andrew Crosland Copyright (C) 2021
  */
 public class ResettingOffsetHighCvProgrammerFacade extends AbstractProgrammerFacade implements ProgListener {
 
@@ -61,6 +62,7 @@ public class ResettingOffsetHighCvProgrammerFacade extends AbstractProgrammerFac
     // members for handling the programmer interface
     int _val; // remember the value being read/written for confirmative reply
     int _cv; // remember the cv being read/written
+    int _startVal; // remember the starting value (hint)
 
     @Override
     public void writeCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
@@ -80,12 +82,18 @@ public class ResettingOffsetHighCvProgrammerFacade extends AbstractProgrammerFac
 
     @Override
     public void readCV(String CV, jmri.ProgListener p) throws jmri.ProgrammerException {
+        readCV(CV, p, 0);
+    }
+
+    @Override
+    public void readCV(String CV, jmri.ProgListener p, int startVal) throws jmri.ProgrammerException {
         log.debug("start readCV");
         _cv = Integer.parseInt(CV);
+        _startVal = startVal;
         useProgrammer(p);
         if (prog.getCanRead(CV) || _cv <= top) {
             state = ProgState.PROGRAMMING;
-            prog.readCV(CV, this);
+            prog.readCV(CV, this, startVal);
         } else {
             // write index first
             state = ProgState.FINISHREAD;
@@ -142,7 +150,7 @@ public class ResettingOffsetHighCvProgrammerFacade extends AbstractProgrammerFac
             case FINISHREAD:
                 try {
                     state = ProgState.RESET;
-                    prog.readCV(""+(_cv % modulo), this);
+                    prog.readCV(""+(_cv % modulo), this, _startVal);
                 } catch (jmri.ProgrammerException e) {
                     log.error("Exception doing final read", e);
                 }

--- a/java/src/jmri/implementation/TwoIndexTcsProgrammerFacade.java
+++ b/java/src/jmri/implementation/TwoIndexTcsProgrammerFacade.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
  * @see jmri.implementation.ProgrammerFacadeSelector
  *
  * @author Bob Jacobsen Copyright (C) 2013, 2016
+ * @author Andrew Crosland Copyright (C) 2021
  */
 public class TwoIndexTcsProgrammerFacade extends AbstractProgrammerFacade implements ProgListener {
 
@@ -62,6 +63,8 @@ public class TwoIndexTcsProgrammerFacade extends AbstractProgrammerFacade implem
     int valueMSB;  //  value to write to MSB or -1
     int valueLSB;  //  value to write to LSB or -1
     int _startVal; // Current CV value hint
+    int _startMSB;
+    int _startLSB;
 
     private void parseCV(String cv) throws IllegalArgumentException {
         valuePI = -1;
@@ -110,6 +113,8 @@ public class TwoIndexTcsProgrammerFacade extends AbstractProgrammerFacade implem
         useProgrammer(p);
         parseCV(CV);
         _startVal = startVal;
+        _startMSB = startVal/256;
+        _startLSB = startVal%256;
         upperByte = 0;
         if (valuePI == -1) {
             state = ProgState.PROGRAMMING;
@@ -221,7 +226,7 @@ public class TwoIndexTcsProgrammerFacade extends AbstractProgrammerFacade implem
             case DOREADFIRST:
                 try {
                     state = ProgState.FINISHREAD;
-                    prog.readCV(valMSB, this, _startVal);
+                    prog.readCV(valMSB, this, _startMSB);
                 } catch (jmri.ProgrammerException e) {
                     log.error("Exception doing read first", e);
                 }
@@ -234,7 +239,7 @@ public class TwoIndexTcsProgrammerFacade extends AbstractProgrammerFacade implem
                         prog.readCV(indexSI, this, _startVal);
                     } else {
                         upperByte = value;
-                        prog.readCV(valLSB, this, _startVal);
+                        prog.readCV(valLSB, this, _startLSB);
                     }
                 } catch (jmri.ProgrammerException e) {
                     log.error("Exception doing final read", e);

--- a/java/src/jmri/implementation/TwoIndexTcsProgrammerFacade.java
+++ b/java/src/jmri/implementation/TwoIndexTcsProgrammerFacade.java
@@ -113,8 +113,8 @@ public class TwoIndexTcsProgrammerFacade extends AbstractProgrammerFacade implem
         useProgrammer(p);
         parseCV(CV);
         _startVal = startVal;
-        _startMSB = startVal/256;
-        _startLSB = startVal%256;
+        _startMSB = startVal / 256;
+        _startLSB = startVal % 256;
         upperByte = 0;
         if (valuePI == -1) {
             state = ProgState.PROGRAMMING;


### PR DESCRIPTION
Starting with update to the TwoIndexTcsProgrammerFacade.

@mstevetodd Would you be able to try this? It's quite a simple change but I think it will do the job for the TCS indexed CVs.