### PR TITLE
Consist Tool Frame Test Failures

### DIFF
--- a/java/src/jmri/jmrit/consisttool/ConsistToolFrame.java
+++ b/java/src/jmri/jmrit/consisttool/ConsistToolFrame.java
@@ -60,7 +60,10 @@ public class ConsistToolFrame extends jmri.util.JmriJFrame implements jmri.Consi
 
     public ConsistToolFrame() {
         super();
+        init();
+    }
 
+    private void init() {
         consistManager = InstanceManager.getDefault(jmri.ConsistManager.class);
 
         consistFile = new ConsistFile();

--- a/java/test/jmri/jmrit/consisttool/ConsistToolFrameTest.java
+++ b/java/test/jmri/jmrit/consisttool/ConsistToolFrameTest.java
@@ -155,10 +155,13 @@ public class ConsistToolFrameTest {
         Assert.assertEquals("Throttle has right consist address",
                 new DccLocoAddress(1, false),
                 to.getConsistAddressValue());
+        
         to.pushReleaseButton();
+        to.getQueueTool().waitEmpty();  // pause for Throttle to release
+        
         to.requestClose();
-
-        new org.netbeans.jemmy.QueueTool().waitEmpty(100);  //pause for frame tot close
+        to.getQueueTool().waitEmpty();  // pause for frame to close
+        
         cs.requestClose();
         new org.netbeans.jemmy.QueueTool().waitEmpty(100);  //pause for frame tot close
     }


### PR DESCRIPTION
AllTest has been failing for a few runs now with 
jmri.jmrit.consisttool.ConsistToolFrameTest.testThrottle()
e.g. https://builds.jmri.org/jenkins/job/development/job/alltest/595/testReport/junit/jmri.jmrit.consisttool/ConsistToolFrameTest/testThrottle__/

Adds wait between throttle button press and close throttle frame to see if improves.