### PR TITLE
Fix bug when importing Logix to LogixNG

### DIFF
--- a/java/src/jmri/jmrit/logixng/tools/ImportConditional.java
+++ b/java/src/jmri/jmrit/logixng/tools/ImportConditional.java
@@ -789,19 +789,24 @@ public class ImportConditional {
                 
                 String sNumber = ca.getActionString();
                 try {
-                    float time = Float.parseFloat(sNumber);
-                    delayedAction.setDelay((int) (time * 1000));
+                    int time = Integer.parseInt(sNumber);
+                    delayedAction.setDelay(time);
+                    delayedAction.setUnit(TimerUnit.Seconds);
                 } catch (NumberFormatException e) {
-                    // If here, assume that sNumber has the name of a memory
-                    if (sNumber.charAt(0) == '@') {
-                        sNumber = sNumber.substring(1);
+                    try {
+                        float time = Float.parseFloat(sNumber);
+                        delayedAction.setDelay((int) (time * 1000));
+                        delayedAction.setUnit(TimerUnit.MilliSeconds);
+                    } catch (NumberFormatException e2) {
+                        // If here, assume that sNumber has the name of a memory
+                        if (sNumber.charAt(0) == '@') {
+                            sNumber = sNumber.substring(1);
+                        }
+                        delayedAction.setDelayAddressing(NamedBeanAddressing.Reference);
+                        delayedAction.setDelayReference("{" + sNumber + "}");
                     }
-                    delayedAction.setDelayAddressing(NamedBeanAddressing.Reference);
-                    delayedAction.setDelayReference("{" + sNumber + "}");
                 }
                 
-                delayedAction.setDelay(0);
-                delayedAction.setUnit(TimerUnit.MilliSeconds);
                 delayedAction.setResetIfAlreadyStarted(ca.getType() == Conditional.Action.RESET_DELAYED_SENSOR);
                 if (!_dryRun) {
                     MaleSocket subActionSocket = InstanceManager.getDefault(DigitalActionManager.class)
@@ -872,19 +877,24 @@ public class ImportConditional {
                 
                 String sNumber = ca.getActionString();
                 try {
-                    float time = Float.parseFloat(sNumber);
-                    delayedAction.setDelay((int) (time * 1000));
+                    int time = Integer.parseInt(sNumber);
+                    delayedAction.setDelay(time);
+                    delayedAction.setUnit(TimerUnit.Seconds);
                 } catch (NumberFormatException e) {
-                    // If here, assume that sNumber has the name of a memory
-                    if (sNumber.charAt(0) == '@') {
-                        sNumber = sNumber.substring(1);
+                    try {
+                        float time = Float.parseFloat(sNumber);
+                        delayedAction.setDelay((int) (time * 1000));
+                        delayedAction.setUnit(TimerUnit.MilliSeconds);
+                    } catch (NumberFormatException e2) {
+                        // If here, assume that sNumber has the name of a memory
+                        if (sNumber.charAt(0) == '@') {
+                            sNumber = sNumber.substring(1);
+                        }
+                        delayedAction.setDelayAddressing(NamedBeanAddressing.Reference);
+                        delayedAction.setDelayReference("{" + sNumber + "}");
                     }
-                    delayedAction.setDelayAddressing(NamedBeanAddressing.Reference);
-                    delayedAction.setDelayReference("{" + sNumber + "}");
                 }
                 
-                delayedAction.setDelay(0);
-                delayedAction.setUnit(TimerUnit.MilliSeconds);
                 delayedAction.setResetIfAlreadyStarted(ca.getType() == Conditional.Action.RESET_DELAYED_TURNOUT);
                 if (!_dryRun) {
                     MaleSocket subActionSocket = InstanceManager.getDefault(DigitalActionManager.class)

--- a/java/src/jmri/jmrit/logixng/tools/ImportConditional.java
+++ b/java/src/jmri/jmrit/logixng/tools/ImportConditional.java
@@ -798,12 +798,15 @@ public class ImportConditional {
                         delayedAction.setDelay((int) (time * 1000));
                         delayedAction.setUnit(TimerUnit.MilliSeconds);
                     } catch (NumberFormatException e2) {
-                        // If here, assume that sNumber has the name of a memory
+                        // If here, assume that sNumber has the name of a memory.
+                        // Logix supports this memory to have a floating point value
+                        // but LogixNG requires this memory to have an integer value.
                         if (sNumber.charAt(0) == '@') {
                             sNumber = sNumber.substring(1);
                         }
                         delayedAction.setDelayAddressing(NamedBeanAddressing.Reference);
                         delayedAction.setDelayReference("{" + sNumber + "}");
+                        delayedAction.setUnit(TimerUnit.Seconds);
                     }
                 }
                 
@@ -886,12 +889,15 @@ public class ImportConditional {
                         delayedAction.setDelay((int) (time * 1000));
                         delayedAction.setUnit(TimerUnit.MilliSeconds);
                     } catch (NumberFormatException e2) {
-                        // If here, assume that sNumber has the name of a memory
+                        // If here, assume that sNumber has the name of a memory.
+                        // Logix supports this memory to have a floating point value
+                        // but LogixNG requires this memory to have an integer value.
                         if (sNumber.charAt(0) == '@') {
                             sNumber = sNumber.substring(1);
                         }
                         delayedAction.setDelayAddressing(NamedBeanAddressing.Reference);
                         delayedAction.setDelayReference("{" + sNumber + "}");
+                        delayedAction.setUnit(TimerUnit.Seconds);
                     }
                 }
                 

--- a/java/src/jmri/jmrit/logixng/util/UtilBundle.properties
+++ b/java/src/jmri/jmrit/logixng/util/UtilBundle.properties
@@ -11,7 +11,7 @@ TimerUnit_UnitSeconds           = Seconds
 TimerUnit_UnitMinutes           = Minutes
 TimerUnit_UnitHours             = Hours
 
-TimerUnit_TimeMilliSeconds      = {0} milli seconds
+TimerUnit_TimeMilliSeconds      = {0} milliseconds
 TimerUnit_TimeSeconds           = {0} seconds
 TimerUnit_TimeMinutes           = {0} minutes
 TimerUnit_TimeHours             = {0} hours

--- a/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
@@ -47,7 +47,7 @@ public class ExecuteDelayedTest extends AbstractDigitalActionTestBase {
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
-                "Execute A after 0 milli seconds. Ignore on repeat ::: Log error%n" +
+                "Execute A after 0 milliseconds. Ignore on repeat ::: Log error%n" +
                 "   ! A%n" +
                 "      Socket not connected%n");
     }
@@ -58,7 +58,7 @@ public class ExecuteDelayedTest extends AbstractDigitalActionTestBase {
                 "LogixNG: A new logix for test%n" +
                 "   ConditionalNG: A conditionalNG%n" +
                 "      ! A%n" +
-                "         Execute A after 0 milli seconds. Ignore on repeat ::: Log error%n" +
+                "         Execute A after 0 milliseconds. Ignore on repeat ::: Log error%n" +
                 "            ! A%n" +
                 "               Socket not connected%n");
     }
@@ -105,7 +105,7 @@ public class ExecuteDelayedTest extends AbstractDigitalActionTestBase {
         ExecuteDelayed a1 = new ExecuteDelayed("IQDA321", null);
         Assert.assertEquals("strings are equal", "Execute delayed", a1.getShortDescription());
         ExecuteDelayed a2 = new ExecuteDelayed("IQDA321", null);
-        Assert.assertEquals("strings are equal", "Execute A after 0 milli seconds. Ignore on repeat", a2.getLongDescription());
+        Assert.assertEquals("strings are equal", "Execute A after 0 milliseconds. Ignore on repeat", a2.getLongDescription());
         a2.setDelay(26);
         a2.setUnit(TimerUnit.Minutes);
         a2.setResetIfAlreadyStarted(true);


### PR DESCRIPTION
When importing Delayed Sensor or Delayed Turnout, the delay was always set to 0 seconds. This PR fixes that.

Note that Logix stores the delay in seconds as a decimal number while LogixNG lets the user select the time unit and the delay is stored as an integer. If the delay is a whole number, LogixNG will set the unit to seconds, but if the delay is stored as a decimal number, the unit will be milliseconds.

---

There is one possible issue with the import. Logix supports indirect addressing of the delay, by entering `@memory` instead of a number. LogixNG supports it too, but Logix allows the number to be a decimal number, but LogixNG requires it to be an integer. And since it's indirect addressed, the import tool cannot resolve this issue, but needs to assume that the memory has an integer value.

The question is if anyone is using this feature. If not, this is not a problem. If someone is using it and if they use floating point number in the memory, then they will have to do manually changes for it to work with LogixNG.

---

Should `milliseconds` be "milliseconds" or "milli seconds"? With or without a space in between milli and second?