### PR TITLE
Git rule to add documentation label automatically

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -65,6 +65,25 @@ mergeable: # see https://github.com/mergeability/mergeable
         mode: 'add'
       - do: checks
         status: 'success'
+  - when: pull_request.opened
+    name: 'Add label for documentation changes'
+    validate:
+      - do: changeset
+        must_include:
+          regex: '^help/'
+    pass:
+      - do: comment
+        payload:
+          body: > 
+            This PR includes files in the help hierarchy so the 'Documentation' label has been added.  Other labels may also be applied."
+      - do: labels
+        labels: [ 'Documentation' ]
+        mode: 'add'
+      - do: checks
+        status: 'success'        
+    fail:
+      - do: checks
+        status: 'success'
   - when: pull_request.*, pull_request_review.*
     name: 'Allow merge after one day'
     validate:
@@ -103,4 +122,3 @@ mergeable: # see https://github.com/mergeability/mergeable
         #limit:
         #  teams: ['org/team_slug'] # when the option is present, only the approvals from the team members will count
         #  owners: true # Optional boolean. When true, the file .github/CODEOWNER is read and only owners approval will count
-


### PR DESCRIPTION
New code follows model of code for adding other labels.   initially asked in Issue #9597 but edited since then.