### PR TITLE
Add Not expression. Fix bug in ImportConditional

### DIFF
--- a/java/src/jmri/jmrit/logixng/MaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/MaleSocket.java
@@ -61,6 +61,10 @@ public interface MaleSocket extends Debugable {
     @Override
     public boolean isEnabled();
     
+    public boolean getListen();
+    
+    public void setListen(boolean listen);
+    
     public void addLocalVariable(
             String name,
             InitialValueType initialValueType,

--- a/java/src/jmri/jmrit/logixng/expressions/DigitalFactory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/DigitalFactory.java
@@ -39,6 +39,7 @@ public class DigitalFactory implements DigitalExpressionFactory {
         expressionClasses.add(new AbstractMap.SimpleEntry<>(Category.COMMON, DigitalFormula.class));
         expressionClasses.add(new AbstractMap.SimpleEntry<>(Category.OTHER, Hold.class));
         expressionClasses.add(new AbstractMap.SimpleEntry<>(Category.OTHER, LastResultOfDigitalExpression.class));
+        expressionClasses.add(new AbstractMap.SimpleEntry<>(Category.COMMON, Not.class));
         expressionClasses.add(new AbstractMap.SimpleEntry<>(Category.COMMON, Or.class));
         expressionClasses.add(new AbstractMap.SimpleEntry<>(Category.OTHER, TriggerOnce.class));
         expressionClasses.add(new AbstractMap.SimpleEntry<>(Category.OTHER, True.class));

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBundle.properties
@@ -121,6 +121,12 @@ Memory_CompareTo_RegularExpression  = Regular expression
 Memory_MemoryInUseMemoryExpressionVeto  = Memory is in use by Memory expression "{0}"
 
 
+Not_Short               = Not
+Not_Long                = Not
+# Important! These strings MUST be valid female socket names!!
+Not_SocketName          = E
+
+
 OBlock_Short            = OBlock
 OBlock_Long             = OBlock {0} {1} {2}
 OBlock_OBlockInUseOBlockExpressionVeto  = OBlock is in use by OBlock expression "{0}"

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionLocalVariable.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionLocalVariable.java
@@ -259,12 +259,12 @@ public class ExpressionLocalVariable extends AbstractDigitalExpression
                         throw new IllegalArgumentException("_memoryOperation has unknown value: "+_variableOperation.name());
                 }
             } catch (NumberFormatException nfe) {
-                return false;   // n1 is a number, n2 is not
+                return _variableOperation == VariableOperation.NotEqual;   // n1 is a number, n2 is not
             }
         } catch (NumberFormatException nfe) {
             try {
                 Integer.parseInt(value2);
-                return false;     // n1 is not a number, n2 is
+                return _variableOperation == VariableOperation.NotEqual;     // n1 is not a number, n2 is
             } catch (NumberFormatException ex) { // OK neither a number
             }
         }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionMemory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionMemory.java
@@ -288,12 +288,12 @@ public class ExpressionMemory extends AbstractDigitalExpression
                         throw new IllegalArgumentException("_memoryOperation has unknown value: "+_memoryOperation.name());
                 }
             } catch (NumberFormatException nfe) {
-                return false;   // n1 is a number, n2 is not
+                return _memoryOperation == MemoryOperation.NotEqual;   // n1 is a number, n2 is not
             }
         } catch (NumberFormatException nfe) {
             try {
                 Integer.parseInt(value2);
-                return false;     // n1 is not a number, n2 is
+                return _memoryOperation == MemoryOperation.NotEqual;     // n1 is not a number, n2 is
             } catch (NumberFormatException ex) { // OK neither a number
             }
         }

--- a/java/src/jmri/jmrit/logixng/expressions/Not.java
+++ b/java/src/jmri/jmrit/logixng/expressions/Not.java
@@ -1,0 +1,173 @@
+package jmri.jmrit.logixng.expressions;
+
+import java.util.Locale;
+import java.util.Map;
+
+import jmri.InstanceManager;
+import jmri.JmriException;
+import jmri.jmrit.logixng.Base;
+import jmri.jmrit.logixng.Category;
+import jmri.jmrit.logixng.FemaleSocket;
+import jmri.jmrit.logixng.FemaleSocketListener;
+import jmri.jmrit.logixng.DigitalExpressionManager;
+import jmri.jmrit.logixng.FemaleDigitalExpressionSocket;
+import jmri.jmrit.logixng.MaleSocket;
+import jmri.jmrit.logixng.SocketAlreadyConnectedException;
+
+/**
+ * An Expression that keeps its status even if its child expression doesn't.
+ * 
+ * This expression stays False until both the 'hold' expression and the 'trigger'
+ * expression becomes True. It stays true until the 'hold' expression goes to
+ * False. The 'trigger' expression can for example be a push button that stays
+ * True for a short time.
+ * 
+ * @author Daniel Bergqvist Copyright 2018
+ */
+public class Not extends AbstractDigitalExpression implements FemaleSocketListener {
+
+    private String _socketSystemName;
+    private final FemaleDigitalExpressionSocket _socket;
+    
+    public Not(String sys, String user)
+            throws BadUserNameException, BadSystemNameException {
+        
+        super(sys, user);
+        
+        _socket = InstanceManager.getDefault(DigitalExpressionManager.class)
+                .createFemaleSocket(this, this, Bundle.getMessage("Not_SocketName"));
+    }
+    
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws JmriException {
+        DigitalExpressionManager manager = InstanceManager.getDefault(DigitalExpressionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        Not copy = new Not(sysName, userName);
+        copy.setComment(getComment());
+        return manager.registerExpression(copy).deepCopyChildren(this, systemNames, userNames);
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public Category getCategory() {
+        return Category.COMMON;
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public boolean isExternal() {
+        return false;
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public boolean evaluate() throws JmriException {
+        return !_socket.evaluate();
+    }
+    
+    @Override
+    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
+        switch (index) {
+            case 0:
+                return _socket;
+                
+            default:
+                throw new IllegalArgumentException(
+                        String.format("index has invalid value: %d", index));
+        }
+    }
+
+    @Override
+    public int getChildCount() {
+        return 1;
+    }
+    
+    @Override
+    public void connected(FemaleSocket socket) {
+        if (socket == _socket) {
+            _socketSystemName = socket.getConnectedSocket().getSystemName();
+        } else {
+            throw new IllegalArgumentException("unkown socket");
+        }
+    }
+    
+    @Override
+    public void disconnected(FemaleSocket socket) {
+        if (socket == _socket) {
+            _socketSystemName = null;
+        } else {
+            throw new IllegalArgumentException("unkown socket");
+        }
+    }
+    
+    @Override
+    public String getShortDescription(Locale locale) {
+        return Bundle.getMessage(locale, "Not_Short");
+    }
+    
+    @Override
+    public String getLongDescription(Locale locale) {
+        return Bundle.getMessage(locale, "Not_Long");
+    }
+
+    public String getSocketSystemName() {
+        return _socketSystemName;
+    }
+
+    public void setSocketSystemName(String systemName) {
+        _socketSystemName = systemName;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setup() {
+        try {
+            if ( !_socket.isConnected()
+                    || !_socket.getConnectedSocket().getSystemName()
+                            .equals(_socketSystemName)) {
+                
+                String socketSystemName = _socketSystemName;
+                _socket.disconnect();
+                if (socketSystemName != null) {
+                    MaleSocket maleSocket =
+                            InstanceManager.getDefault(DigitalExpressionManager.class)
+                                    .getBySystemName(socketSystemName);
+                    _socket.disconnect();
+                    if (maleSocket != null) {
+                        _socket.connect(maleSocket);
+                        maleSocket.setup();
+                    } else {
+                        log.error("cannot load digital expression " + socketSystemName);
+                    }
+                }
+            } else {
+                _socket.getConnectedSocket().setup();
+            }
+        } catch (SocketAlreadyConnectedException ex) {
+            // This shouldn't happen and is a runtime error if it does.
+            throw new RuntimeException("socket is already connected");
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+        // Do nothing
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Not.class);
+
+}

--- a/java/src/jmri/jmrit/logixng/expressions/Not.java
+++ b/java/src/jmri/jmrit/logixng/expressions/Not.java
@@ -15,14 +15,12 @@ import jmri.jmrit.logixng.MaleSocket;
 import jmri.jmrit.logixng.SocketAlreadyConnectedException;
 
 /**
- * An Expression that keeps its status even if its child expression doesn't.
+ * An Expression that negates the result of its child expression.
  * 
- * This expression stays False until both the 'hold' expression and the 'trigger'
- * expression becomes True. It stays true until the 'hold' expression goes to
- * False. The 'trigger' expression can for example be a push button that stays
- * True for a short time.
+ * This expression returns False if the child returns True. It returns True
+ * if the child returns False. It returns False if no child is connected.
  * 
- * @author Daniel Bergqvist Copyright 2018
+ * @author Daniel Bergqvist Copyright 2021
  */
 public class Not extends AbstractDigitalExpression implements FemaleSocketListener {
 

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/NotXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/NotXml.java
@@ -8,10 +8,10 @@ import jmri.jmrit.logixng.expressions.Not;
 import org.jdom2.Element;
 
 /**
- * Handle XML configuration for ActionLightXml objects.
+ * Handle XML configuration for Not objects.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
- * @author Daniel Bergqvist Copyright (C) 2019
+ * @author Daniel Bergqvist Copyright (C) 2021
  */
 public class NotXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
 

--- a/java/src/jmri/jmrit/logixng/expressions/configurexml/NotXml.java
+++ b/java/src/jmri/jmrit/logixng/expressions/configurexml/NotXml.java
@@ -1,0 +1,77 @@
+package jmri.jmrit.logixng.expressions.configurexml;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.DigitalExpressionManager;
+import jmri.jmrit.logixng.MaleSocket;
+import jmri.jmrit.logixng.expressions.Not;
+
+import org.jdom2.Element;
+
+/**
+ * Handle XML configuration for ActionLightXml objects.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
+ * @author Daniel Bergqvist Copyright (C) 2019
+ */
+public class NotXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+
+    public NotXml() {
+    }
+    
+    /**
+     * Default implementation for storing the contents of a ActionMany
+     *
+     * @param o Object to store, of type ActionMany
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        Not p = (Not) o;
+
+        Element element = new Element("Not");
+        element.setAttribute("class", this.getClass().getName());
+        element.addContent(new Element("systemName").addContent(p.getSystemName()));
+        
+        storeCommon(p, element);
+        
+        Element e2 = new Element("Socket");
+        e2.addContent(new Element("socketName").addContent(p.getChild(0).getName()));
+        MaleSocket socket = p.getChild(0).getConnectedSocket();
+        String socketSystemName;
+        if (socket != null) {
+            socketSystemName = socket.getSystemName();
+        } else {
+            socketSystemName = p.getSocketSystemName();
+        }
+        if (socketSystemName != null) {
+            e2.addContent(new Element("systemName").addContent(socketSystemName));
+        }
+        element.addContent(e2);
+        
+        return element;
+    }
+    
+    @Override
+    public boolean load(Element shared, Element perNode) {
+        String sys = getSystemName(shared);
+        String uname = getUserName(shared);
+        Not h = new Not(sys, uname);
+
+        loadCommon(h, shared);
+
+        Element socketElement = shared.getChild("Socket");
+        String socketName = socketElement.getChild("socketName").getTextTrim();
+        Element systemNameElement = socketElement.getChild("systemName");
+        String systemName = null;
+        if (systemNameElement != null) {
+            systemName = systemNameElement.getTextTrim();
+        }
+        h.getChild(0).setName(socketName);
+        h.setSocketSystemName(systemName);
+        
+        InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(h);
+        return true;
+    }
+    
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NotXml.class);
+}

--- a/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/DigitalExpressionSwingBundle.properties
@@ -35,8 +35,10 @@ ExpressionEntryExit_Components          = Entry exit {0} {1} {2}
 ExpressionLight_Components              = Light {0} {1} {2}
 
 ExpressionLocalVariable_Components      = Local variable{0} {1} {2}
+ExpressionLocalVariable_CaseInsensitive = Case insensitive
 
 ExpressionMemory_Components             = Memory {0} {1} {2}
+ExpressionMemory_CaseInsensitive        = Case insensitive
 
 ExpressionOBlock_Components             = OBlock {0} {1} {2}
 

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionLocalVariableSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionLocalVariableSwing.java
@@ -22,6 +22,7 @@ public class ExpressionLocalVariableSwing extends AbstractDigitalExpressionSwing
 
     private JTextField _localVariableTextField;
     private JComboBox<VariableOperation> _variableOperationComboBox;
+    private JCheckBox _caseInsensitiveCheckBox;
     
     private JTabbedPane _tabbedPane;
     
@@ -59,13 +60,20 @@ public class ExpressionLocalVariableSwing extends AbstractDigitalExpressionSwing
         
         _localVariableTextField = new JTextField(30);
         
+        JPanel operationAndCasePanel = new JPanel();
+        operationAndCasePanel.setLayout(new BoxLayout(operationAndCasePanel, BoxLayout.Y_AXIS));
+        
         _variableOperationComboBox = new JComboBox<>();
         for (VariableOperation e : VariableOperation.values()) {
             _variableOperationComboBox.addItem(e);
         }
         JComboBoxUtil.setupComboBoxMaxRows(_variableOperationComboBox);
+        operationAndCasePanel.add(_variableOperationComboBox);
         
         _variableOperationComboBox.addActionListener((e) -> { enableDisableCompareTo(); });
+        
+        _caseInsensitiveCheckBox = new JCheckBox(Bundle.getMessage("ExpressionLocalVariable_CaseInsensitive"));
+        operationAndCasePanel.add(_caseInsensitiveCheckBox);
         
         _tabbedPane = new JTabbedPane();
         
@@ -111,6 +119,7 @@ public class ExpressionLocalVariableSwing extends AbstractDigitalExpressionSwing
                 default: throw new IllegalArgumentException("invalid _addressing state: " + expression.getCompareTo().name());
             }
             _variableOperationComboBox.setSelectedItem(expression.getVariableOperation());
+            _caseInsensitiveCheckBox.setSelected(expression.getCaseInsensitive());
             _compareToConstantTextField.setText(expression.getConstantValue());
             _compareToLocalVariableTextField.setText(expression.getOtherLocalVariable());
             _compareToRegExTextField.setText(expression.getRegEx());
@@ -118,7 +127,7 @@ public class ExpressionLocalVariableSwing extends AbstractDigitalExpressionSwing
         
         JComponent[] components = new JComponent[]{
             _localVariableTextField,
-            _variableOperationComboBox,
+            operationAndCasePanel,
             _tabbedPane
         };
         
@@ -154,6 +163,7 @@ public class ExpressionLocalVariableSwing extends AbstractDigitalExpressionSwing
         
         expression.setLocalVariable(_localVariableTextField.getText());
         expression.setVariableOperation(_variableOperationComboBox.getItemAt(_variableOperationComboBox.getSelectedIndex()));
+        expression.setCaseInsensitive(_caseInsensitiveCheckBox.isSelected());
         
         
         try {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionMemorySwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionMemorySwing.java
@@ -22,6 +22,7 @@ public class ExpressionMemorySwing extends AbstractDigitalExpressionSwing {
 
     private BeanSelectCreatePanel<Memory> _memoryBeanPanel;
     private JComboBox<MemoryOperation> _memoryOperationComboBox;
+    private JCheckBox _caseInsensitiveCheckBox;
     
     private JTabbedPane _tabbedPane;
     
@@ -59,13 +60,20 @@ public class ExpressionMemorySwing extends AbstractDigitalExpressionSwing {
         
         _memoryBeanPanel = new BeanSelectCreatePanel<>(InstanceManager.getDefault(MemoryManager.class), null);
         
+        JPanel operationAndCasePanel = new JPanel();
+        operationAndCasePanel.setLayout(new BoxLayout(operationAndCasePanel, BoxLayout.Y_AXIS));
+        
         _memoryOperationComboBox = new JComboBox<>();
         for (MemoryOperation e : MemoryOperation.values()) {
             _memoryOperationComboBox.addItem(e);
         }
         JComboBoxUtil.setupComboBoxMaxRows(_memoryOperationComboBox);
+        operationAndCasePanel.add(_memoryOperationComboBox);
         
         _memoryOperationComboBox.addActionListener((e) -> { enableDisableCompareTo(); });
+        
+        _caseInsensitiveCheckBox = new JCheckBox(Bundle.getMessage("ExpressionMemory_CaseInsensitive"));
+        operationAndCasePanel.add(_caseInsensitiveCheckBox);
         
         _tabbedPane = new JTabbedPane();
         
@@ -111,6 +119,7 @@ public class ExpressionMemorySwing extends AbstractDigitalExpressionSwing {
                 default: throw new IllegalArgumentException("invalid _addressing state: " + expression.getCompareTo().name());
             }
             _memoryOperationComboBox.setSelectedItem(expression.getMemoryOperation());
+            _caseInsensitiveCheckBox.setSelected(expression.getCaseInsensitive());
             _compareToConstantTextField.setText(expression.getConstantValue());
             _compareToLocalVariableTextField.setText(expression.getLocalVariable());
             _compareToRegExTextField.setText(expression.getRegEx());
@@ -118,7 +127,7 @@ public class ExpressionMemorySwing extends AbstractDigitalExpressionSwing {
         
         JComponent[] components = new JComponent[]{
             _memoryBeanPanel,
-            _memoryOperationComboBox,
+            operationAndCasePanel,
             _tabbedPane
         };
         
@@ -165,6 +174,7 @@ public class ExpressionMemorySwing extends AbstractDigitalExpressionSwing {
             log.error("Cannot get NamedBeanHandle for memory", ex);
         }
         expression.setMemoryOperation(_memoryOperationComboBox.getItemAt(_memoryOperationComboBox.getSelectedIndex()));
+        expression.setCaseInsensitive(_caseInsensitiveCheckBox.isSelected());
         
         
         try {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/NotSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/NotSwing.java
@@ -1,0 +1,54 @@
+package jmri.jmrit.logixng.expressions.swing;
+
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.JPanel;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.Base;
+import jmri.jmrit.logixng.DigitalExpressionManager;
+import jmri.jmrit.logixng.MaleSocket;
+import jmri.jmrit.logixng.expressions.Not;
+
+/**
+ * Configures an Not object with a Swing JPanel.
+ */
+public class NotSwing extends AbstractDigitalExpressionSwing {
+
+    @Override
+    protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        panel = new JPanel();
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public boolean validate(@Nonnull List<String> errorMessages) {
+        return true;
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
+        Not expression = new Not(systemName, userName);
+        return InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expression);
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        // Do nothing
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return Bundle.getMessage("Not_Short");
+    }
+    
+    @Override
+    public void dispose() {
+    }
+    
+}

--- a/java/src/jmri/jmrit/logixng/expressions/swing/NotSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/NotSwing.java
@@ -14,6 +14,8 @@ import jmri.jmrit.logixng.expressions.Not;
 
 /**
  * Configures an Not object with a Swing JPanel.
+ * 
+ * @author Daniel Bergqvist Copyright (C) 2021
  */
 public class NotSwing extends AbstractDigitalExpressionSwing {
 

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.implementation;
 
+import java.beans.*;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,14 +24,177 @@ import org.slf4j.Logger;
  */
 public abstract class AbstractMaleSocket implements MaleSocket {
 
+    private final Base _object;
     protected final List<VariableData> _localVariables = new ArrayList<>();
     private final BaseManager<? extends NamedBean> _manager;
     private Base _parent;
     private ErrorHandlingType _errorHandlingType = ErrorHandlingType.LogError;
     private boolean _catchAbortExecution;
+    private boolean _listen = true;     // By default, actions and expressions listen
     
-    public AbstractMaleSocket(BaseManager<? extends NamedBean> manager) {
+    public AbstractMaleSocket(BaseManager<? extends NamedBean> manager, Base object) {
         _manager = manager;
+        _object = object;
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public final Base getObject() {
+        return _object;
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public final Base getRoot() {
+        return _object.getRoot();
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public final Lock getLock() {
+        return _object.getLock();
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public final void setLock(Lock lock) {
+        _object.setLock(lock);
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public final Category getCategory() {
+        return _object.getCategory();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public final boolean isExternal() {
+        return _object.isExternal();
+    }
+    
+    @Override
+    public final FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
+        return _object.getChild(index);
+    }
+
+    @Override
+    public final int getChildCount() {
+        return _object.getChildCount();
+    }
+
+    @Override
+    public final String getShortDescription(Locale locale) {
+        return _object.getShortDescription(locale);
+    }
+
+    @Override
+    public final String getLongDescription(Locale locale) {
+        return _object.getLongDescription(locale);
+    }
+
+    @Override
+    public final String getUserName() {
+        return _object.getUserName();
+    }
+
+    @Override
+    public final void setUserName(String s) throws NamedBean.BadUserNameException {
+        _object.setUserName(s);
+    }
+
+    @Override
+    public final String getSystemName() {
+        return _object.getSystemName();
+    }
+
+    @Override
+    public final void addPropertyChangeListener(PropertyChangeListener l, String name, String listenerRef) {
+        _object.addPropertyChangeListener(l, name, listenerRef);
+    }
+
+    @Override
+    public final void addPropertyChangeListener(String propertyName, PropertyChangeListener l, String name, String listenerRef) {
+        _object.addPropertyChangeListener(propertyName, l, name, listenerRef);
+    }
+
+    @Override
+    public final void addPropertyChangeListener(PropertyChangeListener l) {
+        _object.addPropertyChangeListener(l);
+    }
+
+    @Override
+    public final void addPropertyChangeListener(String propertyName, PropertyChangeListener l) {
+        _object.addPropertyChangeListener(propertyName, l);
+    }
+
+    @Override
+    public final void removePropertyChangeListener(PropertyChangeListener l) {
+        _object.removePropertyChangeListener(l);
+    }
+
+    @Override
+    public final void removePropertyChangeListener(String propertyName, PropertyChangeListener l) {
+        _object.removePropertyChangeListener(propertyName, l);
+    }
+
+    @Override
+    public final void updateListenerRef(PropertyChangeListener l, String newName) {
+        _object.updateListenerRef(l, newName);
+    }
+
+    @Override
+    public final void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
+        _object.vetoableChange(evt);
+    }
+
+    @Override
+    public final String getListenerRef(PropertyChangeListener l) {
+        return _object.getListenerRef(l);
+    }
+
+    @Override
+    public final ArrayList<String> getListenerRefs() {
+        return _object.getListenerRefs();
+    }
+
+    @Override
+    public final int getNumPropertyChangeListeners() {
+        return _object.getNumPropertyChangeListeners();
+    }
+
+    @Override
+    public final synchronized PropertyChangeListener[] getPropertyChangeListeners() {
+        return _object.getPropertyChangeListeners();
+    }
+
+    @Override
+    public final synchronized PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
+        return _object.getPropertyChangeListeners(propertyName);
+    }
+
+    @Override
+    public final PropertyChangeListener[] getPropertyChangeListenersByReference(String name) {
+        return _object.getPropertyChangeListenersByReference(name);
+    }
+
+    @Override
+    public String getComment() {
+        return _object.getComment();
+    }
+
+    @Override
+    public void setComment(String comment) {
+        _object.setComment(comment);
+    }
+
+    public boolean getListen() {
+        return _listen;
+    }
+    
+    public void setListen(boolean listen)
+    {
+        _listen = listen;
     }
     
     public boolean getCatchAbortExecution() {
@@ -138,18 +302,28 @@ public abstract class AbstractMaleSocket implements MaleSocket {
     /** {@inheritDoc} */
     @Override
     public final void registerListeners() {
-        registerListenersForThisClass();
-        for (int i=0; i < getChildCount(); i++) {
-            getChild(i).registerListeners();
+        if (getObject() instanceof MaleSocket) {
+            getObject().registerListeners();
+        } else {
+            if (_listen) {
+                registerListenersForThisClass();
+                for (int i=0; i < getChildCount(); i++) {
+                    getChild(i).registerListeners();
+                }
+            }
         }
     }
     
     /** {@inheritDoc} */
     @Override
     public final void unregisterListeners() {
-        unregisterListenersForThisClass();
-        for (int i=0; i < getChildCount(); i++) {
-            getChild(i).unregisterListeners();
+        if (getObject() instanceof MaleSocket) {
+            getObject().unregisterListeners();
+        } else {
+            unregisterListenersForThisClass();
+            for (int i=0; i < getChildCount(); i++) {
+                getChild(i).unregisterListeners();
+            }
         }
     }
     

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
@@ -1,9 +1,6 @@
 package jmri.jmrit.logixng.implementation;
 
-import java.beans.*;
 import java.util.*;
-
-import javax.annotation.Nonnull;
 
 import jmri.*;
 import jmri.jmrit.logixng.*;
@@ -200,7 +197,7 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
     private class MaleRootSocket extends AbstractMaleSocket {
 
         public MaleRootSocket(BaseManager<? extends NamedBean> manager) {
-            super(manager);
+            super(manager, _clipboardItems);
         }
         
         @Override
@@ -234,11 +231,6 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
         }
 
         @Override
-        public Base getObject() {
-            return _clipboardItems;
-        }
-
-        @Override
         public void setDebugConfig(DebugConfig config) {
             throw new UnsupportedOperationException("Not supported");
         }
@@ -254,21 +246,6 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
         }
 
         @Override
-        public String getSystemName() {
-            return _clipboardItems.getSystemName();
-        }
-
-        @Override
-        public String getUserName() {
-            return _clipboardItems.getUserName();
-        }
-
-        @Override
-        public void setUserName(String s) throws NamedBean.BadUserNameException {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
         public String getComment() {
             return _clipboardItems.getComment();
         }
@@ -278,131 +255,6 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
             throw new UnsupportedOperationException("Not supported");
         }
 
-        @Override
-        public String getShortDescription(Locale locale) {
-            return _clipboardItems.getShortDescription(locale);
-        }
-
-        @Override
-        public String getLongDescription(Locale locale) {
-            return _clipboardItems.getLongDescription(locale);
-        }
-/*
-        @Override
-        public ConditionalNG getConditionalNG() {
-            return null;
-        }
-
-        @Override
-        public LogixNG getLogixNG() {
-            return null;
-        }
-*/
-        @Override
-        public Base getRoot() {
-            return this;
-        }
-
-        @Override
-        public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
-            return _clipboardItems.getChild(index);
-        }
-
-        @Override
-        public int getChildCount() {
-            return _clipboardItems.getChildCount();
-        }
-
-        @Override
-        public Category getCategory() {
-            return _clipboardItems.getCategory();
-        }
-
-        @Override
-        public boolean isExternal() {
-            return _clipboardItems.isExternal();
-        }
-
-        @Override
-        public Lock getLock() {
-            return _clipboardItems.getLock();
-        }
-
-        @Override
-        public void setLock(Lock lock) {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
-        public void addPropertyChangeListener(PropertyChangeListener listener, String name, String listenerRef) {
-            _clipboardItems.addPropertyChangeListener(listener, name, listenerRef);
-        }
-
-        @Override
-        public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener, String name, String listenerRef) {
-            _clipboardItems.addPropertyChangeListener(propertyName, listener, name, listenerRef);
-        }
-
-        @Override
-        public void updateListenerRef(PropertyChangeListener l, String newName) {
-            _clipboardItems.updateListenerRef(l, newName);
-        }
-
-        @Override
-        public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-            _clipboardItems.vetoableChange(evt);
-        }
-
-        @Override
-        public String getListenerRef(PropertyChangeListener l) {
-            return _clipboardItems.getListenerRef(l);
-        }
-
-        @Override
-        public ArrayList<String> getListenerRefs() {
-            return _clipboardItems.getListenerRefs();
-        }
-
-        @Override
-        public int getNumPropertyChangeListeners() {
-            return _clipboardItems.getNumPropertyChangeListeners();
-        }
-
-        @Override
-        public PropertyChangeListener[] getPropertyChangeListenersByReference(String name) {
-            return _clipboardItems.getPropertyChangeListenersByReference(name);
-        }
-
-        @Override
-        public void addPropertyChangeListener(PropertyChangeListener listener) {
-            _clipboardItems.addPropertyChangeListener(listener);
-        }
-
-        @Override
-        public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener) {
-            _clipboardItems.addPropertyChangeListener(propertyName, listener);
-        }
-
-        @Override
-        public PropertyChangeListener[] getPropertyChangeListeners() {
-            return _clipboardItems.getPropertyChangeListeners();
-        }
-
-        @Override
-        public PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
-            return _clipboardItems.getPropertyChangeListeners(propertyName);
-        }
-
-        @Override
-        public void removePropertyChangeListener(PropertyChangeListener listener) {
-            _clipboardItems.removePropertyChangeListener(listener);
-        }
-
-        @Override
-        public void removePropertyChangeListener(String propertyName, PropertyChangeListener listener) {
-            _clipboardItems.removePropertyChangeListener(propertyName, listener);
-        }
-        
     }
     
 }

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocket.java
@@ -17,44 +17,13 @@ import jmri.jmrit.logixng.*;
  */
 public class DefaultMaleAnalogActionSocket extends AbstractMaleSocket implements MaleAnalogActionSocket {
 
-    private final AnalogActionBean _action;
+//    private final AnalogActionBean ((AnalogActionBean)getObject());
     private DebugConfig _debugConfig = null;
     private boolean _enabled = true;
     
     
     public DefaultMaleAnalogActionSocket(@Nonnull BaseManager<? extends NamedBean> manager, @Nonnull AnalogActionBean action) {
-        super(manager);
-        _action = action;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public final Base getRoot() {
-        return _action.getRoot();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Lock getLock() {
-        return _action.getLock();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public void setLock(Lock lock) {
-        _action.setLock(lock);
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Category getCategory() {
-        return _action.getCategory();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return _action.isExternal();
+        super(manager, action);
     }
     
     /**
@@ -70,7 +39,7 @@ public class DefaultMaleAnalogActionSocket extends AbstractMaleSocket implements
         if (value == Double.POSITIVE_INFINITY) {
             throw new IllegalArgumentException("The value is positive infinity");
         }
-        _action.setValue(value);
+        ((AnalogActionBean)getObject()).setValue(value);
     }
     
     /** {@inheritDoc} */
@@ -103,114 +72,8 @@ public class DefaultMaleAnalogActionSocket extends AbstractMaleSocket implements
     }
 
     @Override
-    public String getShortDescription(Locale locale) {
-        return _action.getShortDescription(locale);
-    }
-
-    @Override
-    public String getLongDescription(Locale locale) {
-        return _action.getLongDescription(locale);
-    }
-
-    @Override
-    public FemaleSocket getChild(int index)
-            throws IllegalArgumentException, UnsupportedOperationException {
-        return _action.getChild(index);
-    }
-
-    @Override
-    public int getChildCount() {
-        return _action.getChildCount();
-    }
-
-    @Override
-    public String getUserName() {
-        return _action.getUserName();
-    }
-
-    @Override
-    public void setUserName(String s) throws BadUserNameException {
-        _action.setUserName(s);
-    }
-
-    @Override
-    public String getSystemName() {
-        return _action.getSystemName();
-    }
-
-    @Override
     public String getDisplayName() {
-        return _action.getDisplayName();
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l, String name, String listenerRef) {
-        _action.addPropertyChangeListener(l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l, String name, String listenerRef) {
-        _action.addPropertyChangeListener(propertyName, l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l) {
-        _action.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _action.addPropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener l) {
-        _action.removePropertyChangeListener(l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _action.removePropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void updateListenerRef(PropertyChangeListener l, String newName) {
-        _action.updateListenerRef(l, newName);
-    }
-
-    @Override
-    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-        _action.vetoableChange(evt);
-    }
-
-    @Override
-    public String getListenerRef(PropertyChangeListener l) {
-        return _action.getListenerRef(l);
-    }
-
-    @Override
-    public ArrayList<String> getListenerRefs() {
-        return _action.getListenerRefs();
-    }
-
-    @Override
-    public int getNumPropertyChangeListeners() {
-        return _action.getNumPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners() {
-        return _action.getPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
-        return _action.getPropertyChangeListeners(propertyName);
-    }
-
-    @Override
-    public PropertyChangeListener[] getPropertyChangeListenersByReference(String name) {
-        return _action.getPropertyChangeListenersByReference(name);
+        return ((AnalogActionBean)getObject()).getDisplayName();
     }
 
     /**
@@ -218,7 +81,7 @@ public class DefaultMaleAnalogActionSocket extends AbstractMaleSocket implements
      */
     @Override
     public void registerListenersForThisClass() {
-        _action.registerListeners();
+        ((AnalogActionBean)getObject()).registerListeners();
     }
     
     /**
@@ -226,62 +89,62 @@ public class DefaultMaleAnalogActionSocket extends AbstractMaleSocket implements
      */
     @Override
     public void unregisterListenersForThisClass() {
-        _action.unregisterListeners();
+        ((AnalogActionBean)getObject()).unregisterListeners();
     }
     
     @Override
     public void setState(int s) throws JmriException {
-        _action.setState(s);
+        ((AnalogActionBean)getObject()).setState(s);
     }
 
     @Override
     public int getState() {
-        return _action.getState();
+        return ((AnalogActionBean)getObject()).getState();
     }
 
     @Override
     public String describeState(int state) {
-        return _action.describeState(state);
+        return ((AnalogActionBean)getObject()).describeState(state);
     }
 
     @Override
     public String getComment() {
-        return _action.getComment();
+        return ((AnalogActionBean)getObject()).getComment();
     }
 
     @Override
     public void setComment(String comment) {
-        _action.setComment(comment);
+        ((AnalogActionBean)getObject()).setComment(comment);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        _action.setProperty(key, value);
+        ((AnalogActionBean)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return _action.getProperty(key);
+        return ((AnalogActionBean)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        _action.removeProperty(key);
+        ((AnalogActionBean)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return _action.getPropertyKeys();
+        return ((AnalogActionBean)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return _action.getBeanType();
+        return ((AnalogActionBean)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return _action.compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((AnalogActionBean)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
 
     /** {@inheritDoc} */
@@ -302,12 +165,6 @@ public class DefaultMaleAnalogActionSocket extends AbstractMaleSocket implements
         return new AnalogActionDebugConfig();
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Base getObject() {
-        return _action;
-    }
-    
     /** {@inheritDoc} */
     @Override
     public void setEnabled(boolean enable) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogExpressionSocket.java
@@ -17,63 +17,32 @@ import jmri.jmrit.logixng.*;
  */
 public class DefaultMaleAnalogExpressionSocket extends AbstractMaleSocket implements MaleAnalogExpressionSocket {
 
-    private final AnalogExpressionBean _expression;
+//    private final AnalogExpressionBean ((AnalogExpressionBean)getObject());
     private DebugConfig _debugConfig = null;
     private boolean _enabled = true;
 
 
     public DefaultMaleAnalogExpressionSocket(@Nonnull BaseManager<? extends NamedBean> manager, @Nonnull AnalogExpressionBean expression) {
-        super(manager);
-        _expression = expression;
+        super(manager, expression);
     }
 
     /** {@inheritDoc} */
     @Override
-    public final Base getRoot() {
-        return _expression.getRoot();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Lock getLock() {
-        return _expression.getLock();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public void setLock(Lock lock) {
-        _expression.setLock(lock);
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean getTriggerOnChange() {
-        return _expression.getTriggerOnChange();
+        return ((AnalogExpressionBean)getObject()).getTriggerOnChange();
     }
     
     /** {@inheritDoc} */
     @Override
     public void setTriggerOnChange(boolean triggerOnChange) {
-        _expression.setTriggerOnChange(triggerOnChange);
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Category getCategory() {
-        return _expression.getCategory();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return _expression.isExternal();
+        ((AnalogExpressionBean)getObject()).setTriggerOnChange(triggerOnChange);
     }
     
     /**
      * Get the value of the AnalogExpressionBean.
      */
     private double internalEvaluate() throws JmriException {
-        double result = _expression.evaluate();
+        double result = ((AnalogExpressionBean)getObject()).evaluate();
         
         if (Double.isNaN(result)) {
             throw new IllegalArgumentException("The result is NaN");
@@ -121,122 +90,17 @@ public class DefaultMaleAnalogExpressionSocket extends AbstractMaleSocket implem
     
     @Override
     public int getState() {
-        return _expression.getState();
-    }
-
-    @Override
-    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
-        return _expression.getChild(index);
-    }
-
-    @Override
-    public int getChildCount() {
-        return _expression.getChildCount();
-    }
-
-    @Override
-    public String getShortDescription(Locale locale) {
-        return _expression.getShortDescription(locale);
-    }
-
-    @Override
-    public String getLongDescription(Locale locale) {
-        return _expression.getLongDescription(locale);
-    }
-
-    @Override
-    public String getUserName() {
-        return _expression.getUserName();
-    }
-
-    @Override
-    public void setUserName(String s) throws BadUserNameException {
-        _expression.setUserName(s);
-    }
-
-    @Override
-    public String getSystemName() {
-        return _expression.getSystemName();
+        return ((AnalogExpressionBean)getObject()).getState();
     }
 
     @Override
     public String getDisplayName() {
-        return _expression.getDisplayName();
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l, String name, String listenerRef) {
-        _expression.addPropertyChangeListener(l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l, String name, String listenerRef) {
-        _expression.addPropertyChangeListener(propertyName, l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l) {
-        _expression.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _expression.addPropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener l) {
-        _expression.removePropertyChangeListener(l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _expression.removePropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void updateListenerRef(PropertyChangeListener l, String newName) {
-        _expression.updateListenerRef(l, newName);
-    }
-
-    @Override
-    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-        _expression.vetoableChange(evt);
-    }
-
-    @Override
-    public String getListenerRef(PropertyChangeListener l) {
-        return _expression.getListenerRef(l);
-    }
-
-    @Override
-    public ArrayList<String> getListenerRefs() {
-        return _expression.getListenerRefs();
-    }
-
-    @Override
-    public int getNumPropertyChangeListeners() {
-        return _expression.getNumPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners() {
-        return _expression.getPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
-        return _expression.getPropertyChangeListeners(propertyName);
-    }
-
-    @Override
-    public PropertyChangeListener[] getPropertyChangeListenersByReference(String name) {
-        return _expression.getPropertyChangeListenersByReference(name);
+        return ((AnalogExpressionBean)getObject()).getDisplayName();
     }
 
     @Override
     public void disposeMe() {
-        _expression.dispose();
+        ((AnalogExpressionBean)getObject()).dispose();
     }
 
     /**
@@ -244,7 +108,7 @@ public class DefaultMaleAnalogExpressionSocket extends AbstractMaleSocket implem
      */
     @Override
     public void registerListenersForThisClass() {
-        _expression.registerListeners();
+        ((AnalogExpressionBean)getObject()).registerListeners();
     }
     
     /**
@@ -252,12 +116,12 @@ public class DefaultMaleAnalogExpressionSocket extends AbstractMaleSocket implem
      */
     @Override
     public void unregisterListenersForThisClass() {
-        _expression.unregisterListeners();
+        ((AnalogExpressionBean)getObject()).unregisterListeners();
     }
     
     @Override
     public void setState(int s) throws JmriException {
-        _expression.setState(s);
+        ((AnalogExpressionBean)getObject()).setState(s);
     }
 
     @Override
@@ -267,42 +131,42 @@ public class DefaultMaleAnalogExpressionSocket extends AbstractMaleSocket implem
 
     @Override
     public String getComment() {
-        return _expression.getComment();
+        return ((AnalogExpressionBean)getObject()).getComment();
     }
 
     @Override
     public void setComment(String comment) {
-        _expression.setComment(comment);
+        ((AnalogExpressionBean)getObject()).setComment(comment);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        _expression.setProperty(key, value);
+        ((AnalogExpressionBean)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return _expression.getProperty(key);
+        return ((AnalogExpressionBean)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        _expression.removeProperty(key);
+        ((AnalogExpressionBean)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return _expression.getPropertyKeys();
+        return ((AnalogExpressionBean)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return _expression.getBeanType();
+        return ((AnalogExpressionBean)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return _expression.compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((AnalogExpressionBean)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
 
     /** {@inheritDoc} */
@@ -323,12 +187,6 @@ public class DefaultMaleAnalogExpressionSocket extends AbstractMaleSocket implem
         return new AnalogExpressionDebugConfig();
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Base getObject() {
-        return _expression;
-    }
-    
     /** {@inheritDoc} */
     @Override
     public void setEnabled(boolean enable) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalActionSocket.java
@@ -1,8 +1,5 @@
 package jmri.jmrit.logixng.implementation;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyVetoException;
 import java.util.*;
 
 import javax.annotation.Nonnull;
@@ -18,44 +15,13 @@ import jmri.jmrit.logixng.*;
 public class DefaultMaleDigitalActionSocket
         extends AbstractMaleSocket implements MaleDigitalActionSocket {
 
-    private final DigitalActionBean _action;
+//    private final DigitalActionBean ((DigitalActionBean)getObject());
     private DebugConfig _debugConfig = null;
     private boolean _enabled = true;
     
     
     public DefaultMaleDigitalActionSocket(@Nonnull BaseManager<? extends NamedBean> manager, @Nonnull DigitalActionBean action) {
-        super(manager);
-        _action = action;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public final Base getRoot() {
-        return _action.getRoot();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Lock getLock() {
-        return _action.getLock();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public void setLock(Lock lock) {
-        _action.setLock(lock);
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Category getCategory() {
-        return _action.getCategory();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return _action.isExternal();
+        super(manager, action);
     }
     
     /** {@inheritDoc} */
@@ -76,7 +42,7 @@ public class DefaultMaleDigitalActionSocket
         
         try {
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
-            _action.execute();
+            ((DigitalActionBean)getObject()).execute();
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionExecuteAction", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {
@@ -88,119 +54,8 @@ public class DefaultMaleDigitalActionSocket
     }
 
     @Override
-    public String getShortDescription(Locale locale) {
-        return _action.getShortDescription(locale);
-    }
-
-    @Override
-    public String getLongDescription(Locale locale) {
-        return _action.getLongDescription(locale);
-    }
-
-    @Override
-    public FemaleSocket getChild(int index)
-            throws IllegalArgumentException, UnsupportedOperationException {
-        return _action.getChild(index);
-    }
-
-    @Override
-    public int getChildCount() {
-        return _action.getChildCount();
-    }
-
-    @Override
-    public String getUserName() {
-        return _action.getUserName();
-    }
-
-    @Override
-    public void setUserName(String s) throws BadUserNameException {
-        _action.setUserName(s);
-    }
-
-    @Override
-    public String getSystemName() {
-        return _action.getSystemName();
-    }
-
-    @Override
-    public String getDisplayName() {
-        return _action.getDisplayName();
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l, String name, String listenerRef) {
-        _action.addPropertyChangeListener(l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l, String name, String listenerRef) {
-        _action.addPropertyChangeListener(propertyName, l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l) {
-        _action.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _action.addPropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener l) {
-        _action.removePropertyChangeListener(l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _action.removePropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void updateListenerRef(PropertyChangeListener l, String newName) {
-        _action.updateListenerRef(l, newName);
-    }
-
-    @Override
-    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-        _action.vetoableChange(evt);
-    }
-
-    @Override
-    public String getListenerRef(PropertyChangeListener l) {
-        return _action.getListenerRef(l);
-    }
-
-    @Override
-    public ArrayList<String> getListenerRefs() {
-        return _action.getListenerRefs();
-    }
-
-    @Override
-    public int getNumPropertyChangeListeners() {
-        return _action.getNumPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners() {
-        return _action.getPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
-        return _action.getPropertyChangeListeners(propertyName);
-    }
-
-    @Override
-    public PropertyChangeListener[] getPropertyChangeListenersByReference(String name) {
-        return _action.getPropertyChangeListenersByReference(name);
-    }
-
-    @Override
     public void disposeMe() {
-        _action.dispose();
+        ((DigitalActionBean)getObject()).dispose();
     }
 
     /**
@@ -208,7 +63,7 @@ public class DefaultMaleDigitalActionSocket
      */
     @Override
     public void registerListenersForThisClass() {
-        _action.registerListeners();
+        ((DigitalActionBean)getObject()).registerListeners();
     }
     
     /**
@@ -216,62 +71,62 @@ public class DefaultMaleDigitalActionSocket
      */
     @Override
     public void unregisterListenersForThisClass() {
-        _action.unregisterListeners();
+        ((DigitalActionBean)getObject()).unregisterListeners();
     }
     
     @Override
     public void setState(int s) throws JmriException {
-        _action.setState(s);
+        ((DigitalActionBean)getObject()).setState(s);
     }
 
     @Override
     public int getState() {
-        return _action.getState();
+        return ((DigitalActionBean)getObject()).getState();
     }
 
     @Override
     public String describeState(int state) {
-        return _action.describeState(state);
+        return ((DigitalActionBean)getObject()).describeState(state);
     }
 
     @Override
     public String getComment() {
-        return _action.getComment();
+        return ((DigitalActionBean)getObject()).getComment();
     }
 
     @Override
     public void setComment(String comment) {
-        _action.setComment(comment);
+        ((DigitalActionBean)getObject()).setComment(comment);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        _action.setProperty(key, value);
+        ((DigitalActionBean)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return _action.getProperty(key);
+        return ((DigitalActionBean)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        _action.removeProperty(key);
+        ((DigitalActionBean)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return _action.getPropertyKeys();
+        return ((DigitalActionBean)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return _action.getBeanType();
+        return ((DigitalActionBean)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return _action.compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((DigitalActionBean)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
 
     /** {@inheritDoc} */
@@ -292,12 +147,6 @@ public class DefaultMaleDigitalActionSocket
         return new DigitalActionDebugConfig();
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Base getObject() {
-        return _action;
-    }
-    
     /** {@inheritDoc} */
     @Override
     public void setEnabled(boolean enable) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalBooleanActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalBooleanActionSocket.java
@@ -1,8 +1,5 @@
 package jmri.jmrit.logixng.implementation;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyVetoException;
 import java.util.*;
 
 import javax.annotation.Nonnull;
@@ -18,44 +15,13 @@ import jmri.jmrit.logixng.*;
 public class DefaultMaleDigitalBooleanActionSocket
         extends AbstractMaleSocket implements MaleDigitalBooleanActionSocket {
 
-    private final DigitalBooleanActionBean _action;
+//    private final DigitalBooleanActionBean ((DigitalBooleanActionBean)getObject());
     private DebugConfig _debugConfig = null;
     private boolean _enabled = true;
     
     
     public DefaultMaleDigitalBooleanActionSocket(@Nonnull BaseManager<? extends NamedBean> manager, @Nonnull DigitalBooleanActionBean action) {
-        super(manager);
-        _action = action;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public final Base getRoot() {
-        return _action.getRoot();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Lock getLock() {
-        return _action.getLock();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public void setLock(Lock lock) {
-        _action.setLock(lock);
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Category getCategory() {
-        return _action.getCategory();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return _action.isExternal();
+        super(manager, action);
     }
     
     /** {@inheritDoc} */
@@ -76,7 +42,7 @@ public class DefaultMaleDigitalBooleanActionSocket
         
         try {
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
-            _action.execute(hasChangedToTrue, hasChangedToFalse);
+            ((DigitalBooleanActionBean)getObject()).execute(hasChangedToTrue, hasChangedToFalse);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionExecuteBooleanAction", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {
@@ -88,119 +54,13 @@ public class DefaultMaleDigitalBooleanActionSocket
     }
 
     @Override
-    public String getShortDescription(Locale locale) {
-        return _action.getShortDescription(locale);
-    }
-
-    @Override
-    public String getLongDescription(Locale locale) {
-        return _action.getLongDescription(locale);
-    }
-
-    @Override
-    public FemaleSocket getChild(int index)
-            throws IllegalArgumentException, UnsupportedOperationException {
-        return _action.getChild(index);
-    }
-
-    @Override
-    public int getChildCount() {
-        return _action.getChildCount();
-    }
-
-    @Override
-    public String getUserName() {
-        return _action.getUserName();
-    }
-
-    @Override
-    public void setUserName(String s) throws BadUserNameException {
-        _action.setUserName(s);
-    }
-
-    @Override
-    public String getSystemName() {
-        return _action.getSystemName();
-    }
-
-    @Override
     public String getDisplayName() {
-        return _action.getDisplayName();
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l, String name, String listenerRef) {
-        _action.addPropertyChangeListener(l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l, String name, String listenerRef) {
-        _action.addPropertyChangeListener(propertyName, l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l) {
-        _action.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _action.addPropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener l) {
-        _action.removePropertyChangeListener(l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _action.removePropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void updateListenerRef(PropertyChangeListener l, String newName) {
-        _action.updateListenerRef(l, newName);
-    }
-
-    @Override
-    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-        _action.vetoableChange(evt);
-    }
-
-    @Override
-    public String getListenerRef(PropertyChangeListener l) {
-        return _action.getListenerRef(l);
-    }
-
-    @Override
-    public ArrayList<String> getListenerRefs() {
-        return _action.getListenerRefs();
-    }
-
-    @Override
-    public int getNumPropertyChangeListeners() {
-        return _action.getNumPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners() {
-        return _action.getPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
-        return _action.getPropertyChangeListeners(propertyName);
-    }
-
-    @Override
-    public PropertyChangeListener[] getPropertyChangeListenersByReference(String name) {
-        return _action.getPropertyChangeListenersByReference(name);
+        return ((DigitalBooleanActionBean)getObject()).getDisplayName();
     }
 
     @Override
     public void disposeMe() {
-        _action.dispose();
+        ((DigitalBooleanActionBean)getObject()).dispose();
     }
 
     /**
@@ -208,7 +68,7 @@ public class DefaultMaleDigitalBooleanActionSocket
      */
     @Override
     public void registerListenersForThisClass() {
-        _action.registerListeners();
+        ((DigitalBooleanActionBean)getObject()).registerListeners();
     }
     
     /**
@@ -216,62 +76,62 @@ public class DefaultMaleDigitalBooleanActionSocket
      */
     @Override
     public void unregisterListenersForThisClass() {
-        _action.unregisterListeners();
+        ((DigitalBooleanActionBean)getObject()).unregisterListeners();
     }
     
     @Override
     public void setState(int s) throws JmriException {
-        _action.setState(s);
+        ((DigitalBooleanActionBean)getObject()).setState(s);
     }
 
     @Override
     public int getState() {
-        return _action.getState();
+        return ((DigitalBooleanActionBean)getObject()).getState();
     }
 
     @Override
     public String describeState(int state) {
-        return _action.describeState(state);
+        return ((DigitalBooleanActionBean)getObject()).describeState(state);
     }
 
     @Override
     public String getComment() {
-        return _action.getComment();
+        return ((DigitalBooleanActionBean)getObject()).getComment();
     }
 
     @Override
     public void setComment(String comment) {
-        _action.setComment(comment);
+        ((DigitalBooleanActionBean)getObject()).setComment(comment);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        _action.setProperty(key, value);
+        ((DigitalBooleanActionBean)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return _action.getProperty(key);
+        return ((DigitalBooleanActionBean)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        _action.removeProperty(key);
+        ((DigitalBooleanActionBean)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return _action.getPropertyKeys();
+        return ((DigitalBooleanActionBean)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return _action.getBeanType();
+        return ((DigitalBooleanActionBean)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return _action.compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((DigitalBooleanActionBean)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
 
     /** {@inheritDoc} */
@@ -292,12 +152,6 @@ public class DefaultMaleDigitalBooleanActionSocket
         return new DigitalBooleanActionDebugConfig();
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Base getObject() {
-        return _action;
-    }
-    
     /** {@inheritDoc} */
     @Override
     public void setEnabled(boolean enable) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocket.java
@@ -1,10 +1,5 @@
 package jmri.jmrit.logixng.implementation;
 
-import jmri.jmrit.logixng.Category;
-
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyVetoException;
 import java.util.*;
 
 import javax.annotation.Nonnull;
@@ -18,68 +13,37 @@ import jmri.jmrit.logixng.*;
  */
 public class DefaultMaleDigitalExpressionSocket extends AbstractMaleSocket implements MaleDigitalExpressionSocket {
 
-    private final DigitalExpressionBean _expression;
     private boolean lastEvaluationResult = false;
     private DebugConfig _debugConfig = null;
     private boolean _enabled = true;
 
 
     public DefaultMaleDigitalExpressionSocket(@Nonnull BaseManager<? extends NamedBean> manager, @Nonnull DigitalExpressionBean expression) {
-        super(manager);
-        _expression = expression;
+        super(manager, expression);
     }
 
     /** {@inheritDoc} */
     @Override
     public void notifyChangedResult(boolean oldResult, boolean newResult) {
-        _expression.notifyChangedResult(oldResult, newResult);
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public final Base getRoot() {
-        return _expression.getRoot();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Lock getLock() {
-        return _expression.getLock();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public void setLock(Lock lock) {
-        _expression.setLock(lock);
+        ((DigitalExpressionBean)getObject()).notifyChangedResult(oldResult, newResult);
     }
     
     /** {@inheritDoc} */
     @Override
     public boolean getTriggerOnChange() {
-        return _expression.getTriggerOnChange();
+        return ((DigitalExpressionBean)getObject()).getTriggerOnChange();
     }
     
     /** {@inheritDoc} */
     @Override
     public void setTriggerOnChange(boolean triggerOnChange) {
-        _expression.setTriggerOnChange(triggerOnChange);
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Category getCategory() {
-        return _expression.getCategory();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return _expression.isExternal();
+        ((DigitalExpressionBean)getObject()).setTriggerOnChange(triggerOnChange);
     }
     
     private void checkChangedLastResult(boolean savedLastResult) {
         if (savedLastResult != lastEvaluationResult) {
-            _expression.notifyChangedResult(savedLastResult, lastEvaluationResult);
+            ((DigitalExpressionBean)getObject())
+                    .notifyChangedResult(savedLastResult, lastEvaluationResult);
         }
     }
     
@@ -106,7 +70,7 @@ public class DefaultMaleDigitalExpressionSocket extends AbstractMaleSocket imple
         
         try {
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
-            lastEvaluationResult = _expression.evaluate();
+            lastEvaluationResult = ((DigitalExpressionBean)getObject()).evaluate();
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionEvaluateExpression", e.getLocalizedMessage()), e, log);
             lastEvaluationResult = false;
@@ -129,188 +93,47 @@ public class DefaultMaleDigitalExpressionSocket extends AbstractMaleSocket imple
 
     @Override
     public int getState() {
-        return _expression.getState();
+        return ((DigitalExpressionBean)getObject()).getState();
     }
 
-    @Override
-    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
-        return _expression.getChild(index);
-    }
-
-    @Override
-    public int getChildCount() {
-        return _expression.getChildCount();
-    }
-
-    @Override
-    public String getShortDescription(Locale locale) {
-        return _expression.getShortDescription(locale);
-    }
-
-    @Override
-    public String getLongDescription(Locale locale) {
-        return _expression.getLongDescription(locale);
-    }
-
-    @Override
-    public String getUserName() {
-        return _expression.getUserName();
-    }
-
-    @Override
-    public void setUserName(String s) throws BadUserNameException {
-        _expression.setUserName(s);
-    }
-
-    @Override
-    public String getSystemName() {
-        return _expression.getSystemName();
-    }
-
-    @Override
-    public String getDisplayName() {
-        return _expression.getDisplayName();
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l, String name, String listenerRef) {
-        _expression.addPropertyChangeListener(l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l, String name, String listenerRef) {
-        _expression.addPropertyChangeListener(propertyName, l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l) {
-        _expression.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _expression.addPropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener l) {
-        _expression.removePropertyChangeListener(l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _expression.removePropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void updateListenerRef(PropertyChangeListener l, String newName) {
-        _expression.updateListenerRef(l, newName);
-    }
-
-    @Override
-    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-        _expression.vetoableChange(evt);
-    }
-
-    @Override
-    public String getListenerRef(PropertyChangeListener l) {
-        return _expression.getListenerRef(l);
-    }
-
-    @Override
-    public ArrayList<String> getListenerRefs() {
-        return _expression.getListenerRefs();
-    }
-
-    @Override
-    public int getNumPropertyChangeListeners() {
-        return _expression.getNumPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners() {
-        return _expression.getPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
-        return _expression.getPropertyChangeListeners(propertyName);
-    }
-
-    @Override
-    public PropertyChangeListener[] getPropertyChangeListenersByReference(String name) {
-        return _expression.getPropertyChangeListenersByReference(name);
-    }
-
-    @Override
-    public void disposeMe() {
-        _expression.dispose();
-    }
-
-    /**
-     * Register listeners if this object needs that.
-     */
-    @Override
-    public void registerListenersForThisClass() {
-        _expression.registerListeners();
-    }
-    
-    /**
-     * Register listeners if this object needs that.
-     */
-    @Override
-    public void unregisterListenersForThisClass() {
-        _expression.unregisterListeners();
-    }
-    
     @Override
     public void setState(int s) throws JmriException {
-        _expression.setState(s);
+        ((DigitalExpressionBean)getObject()).setState(s);
     }
 
     @Override
     public String describeState(int state) {
-        return _expression.describeState(state);
-    }
-
-    @Override
-    public String getComment() {
-        return _expression.getComment();
-    }
-
-    @Override
-    public void setComment(String comment) {
-        _expression.setComment(comment);
+        return ((DigitalExpressionBean)getObject()).describeState(state);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        _expression.setProperty(key, value);
+        ((DigitalExpressionBean)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return _expression.getProperty(key);
+        return ((DigitalExpressionBean)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        _expression.removeProperty(key);
+        ((DigitalExpressionBean)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return _expression.getPropertyKeys();
+        return ((DigitalExpressionBean)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return _expression.getBeanType();
+        return ((DigitalExpressionBean)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return _expression.compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((DigitalExpressionBean)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
 
     /** {@inheritDoc} */
@@ -333,12 +156,6 @@ public class DefaultMaleDigitalExpressionSocket extends AbstractMaleSocket imple
 
     /** {@inheritDoc} */
     @Override
-    public Base getObject() {
-        return _expression;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void setEnabled(boolean enable) {
         _enabled = enable;
         if (isActive()) {
@@ -358,6 +175,32 @@ public class DefaultMaleDigitalExpressionSocket extends AbstractMaleSocket imple
     @Override
     public boolean isEnabled() {
         return _enabled;
+    }
+
+    @Override
+    public void disposeMe() {
+        ((DigitalExpressionBean)getObject()).dispose();
+    }
+
+    /**
+     * Register listeners if this object needs that.
+     */
+    @Override
+    public void registerListenersForThisClass() {
+        ((DigitalExpressionBean)getObject()).registerListeners();
+    }
+    
+    /**
+     * Register listeners if this object needs that.
+     */
+    @Override
+    public void unregisterListenersForThisClass() {
+        ((DigitalExpressionBean)getObject()).unregisterListeners();
+    }
+    
+    @Override
+    public String getDisplayName() {
+        return ((DigitalExpressionBean)getObject()).getDisplayName();
     }
 
 

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringActionSocket.java
@@ -17,44 +17,13 @@ import javax.annotation.Nonnull;
  */
 public class DefaultMaleStringActionSocket extends AbstractMaleSocket implements MaleStringActionSocket {
 
-    private final StringActionBean _action;
+//    private final StringActionBean ((StringActionBean)getObject());
     private DebugConfig _debugConfig = null;
     private boolean _enabled = true;
     
     
     public DefaultMaleStringActionSocket(@Nonnull BaseManager<? extends NamedBean> manager, @Nonnull StringActionBean stringAction) {
-        super(manager);
-        _action = stringAction;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public final Base getRoot() {
-        return _action.getRoot();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Lock getLock() {
-        return _action.getLock();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public void setLock(Lock lock) {
-        _action.setLock(lock);
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Category getCategory() {
-        return _action.getCategory();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return _action.isExternal();
+        super(manager, stringAction);
     }
     
     /** {@inheritDoc} */
@@ -78,7 +47,7 @@ public class DefaultMaleStringActionSocket extends AbstractMaleSocket implements
         
         try {
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
-            _action.setValue(value);
+            ((StringActionBean)getObject()).setValue(value);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionSetValue", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {
@@ -90,119 +59,13 @@ public class DefaultMaleStringActionSocket extends AbstractMaleSocket implements
     }
 
     @Override
-    public String getShortDescription(Locale locale) {
-        return _action.getShortDescription(locale);
-    }
-
-    @Override
-    public String getLongDescription(Locale locale) {
-        return _action.getLongDescription(locale);
-    }
-
-    @Override
-    public FemaleSocket getChild(int index)
-            throws IllegalArgumentException, UnsupportedOperationException {
-        return _action.getChild(index);
-    }
-
-    @Override
-    public int getChildCount() {
-        return _action.getChildCount();
-    }
-
-    @Override
-    public String getUserName() {
-        return _action.getUserName();
-    }
-
-    @Override
-    public void setUserName(String s) throws BadUserNameException {
-        _action.setUserName(s);
-    }
-
-    @Override
-    public String getSystemName() {
-        return _action.getSystemName();
-    }
-
-    @Override
     public String getDisplayName() {
-        return _action.getDisplayName();
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l, String name, String listenerRef) {
-        _action.addPropertyChangeListener(l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l, String name, String listenerRef) {
-        _action.addPropertyChangeListener(propertyName, l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l) {
-        _action.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _action.addPropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener l) {
-        _action.removePropertyChangeListener(l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _action.removePropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void updateListenerRef(PropertyChangeListener l, String newName) {
-        _action.updateListenerRef(l, newName);
-    }
-
-    @Override
-    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-        _action.vetoableChange(evt);
-    }
-
-    @Override
-    public String getListenerRef(PropertyChangeListener l) {
-        return _action.getListenerRef(l);
-    }
-
-    @Override
-    public ArrayList<String> getListenerRefs() {
-        return _action.getListenerRefs();
-    }
-
-    @Override
-    public int getNumPropertyChangeListeners() {
-        return _action.getNumPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners() {
-        return _action.getPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
-        return _action.getPropertyChangeListeners(propertyName);
-    }
-
-    @Override
-    public PropertyChangeListener[] getPropertyChangeListenersByReference(String name) {
-        return _action.getPropertyChangeListenersByReference(name);
+        return ((StringActionBean)getObject()).getDisplayName();
     }
 
     @Override
     public void disposeMe() {
-        _action.dispose();
+        ((StringActionBean)getObject()).dispose();
     }
 
     /**
@@ -210,7 +73,7 @@ public class DefaultMaleStringActionSocket extends AbstractMaleSocket implements
      */
     @Override
     public void registerListenersForThisClass() {
-        _action.registerListeners();
+        ((StringActionBean)getObject()).registerListeners();
     }
     
     /**
@@ -218,62 +81,62 @@ public class DefaultMaleStringActionSocket extends AbstractMaleSocket implements
      */
     @Override
     public void unregisterListenersForThisClass() {
-        _action.unregisterListeners();
+        ((StringActionBean)getObject()).unregisterListeners();
     }
     
     @Override
     public void setState(int s) throws JmriException {
-        _action.setState(s);
+        ((StringActionBean)getObject()).setState(s);
     }
 
     @Override
     public int getState() {
-        return _action.getState();
+        return ((StringActionBean)getObject()).getState();
     }
 
     @Override
     public String describeState(int state) {
-        return _action.describeState(state);
+        return ((StringActionBean)getObject()).describeState(state);
     }
 
     @Override
     public String getComment() {
-        return _action.getComment();
+        return ((StringActionBean)getObject()).getComment();
     }
 
     @Override
     public void setComment(String comment) {
-        _action.setComment(comment);
+        ((StringActionBean)getObject()).setComment(comment);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        _action.setProperty(key, value);
+        ((StringActionBean)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return _action.getProperty(key);
+        return ((StringActionBean)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        _action.removeProperty(key);
+        ((StringActionBean)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return _action.getPropertyKeys();
+        return ((StringActionBean)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return _action.getBeanType();
+        return ((StringActionBean)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return _action.compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((StringActionBean)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
 
     /** {@inheritDoc} */
@@ -294,12 +157,6 @@ public class DefaultMaleStringActionSocket extends AbstractMaleSocket implements
         return new StringActionDebugConfig();
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Base getObject() {
-        return _action;
-    }
-    
     /** {@inheritDoc} */
     @Override
     public void setEnabled(boolean enable) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringExpressionSocket.java
@@ -1,10 +1,5 @@
 package jmri.jmrit.logixng.implementation;
 
-import jmri.jmrit.logixng.Category;
-
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.beans.PropertyVetoException;
 import java.util.*;
 
 import javax.annotation.Nonnull;
@@ -20,56 +15,25 @@ import jmri.jmrit.logixng.*;
 public class DefaultMaleStringExpressionSocket extends AbstractMaleSocket
         implements MaleStringExpressionSocket {
 
-    private final StringExpressionBean _expression;
+//    private final StringExpressionBean ((StringExpressionBean)getObject());
     private DebugConfig _debugConfig = null;
     private boolean _enabled = true;
 
 
     public DefaultMaleStringExpressionSocket(@Nonnull BaseManager<? extends NamedBean> manager, @Nonnull StringExpressionBean stringExpression) {
-        super(manager);
-        _expression = stringExpression;
+        super(manager, stringExpression);
     }
 
     /** {@inheritDoc} */
     @Override
-    public final Base getRoot() {
-        return _expression.getRoot();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Lock getLock() {
-        return _expression.getLock();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public void setLock(Lock lock) {
-        _expression.setLock(lock);
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean getTriggerOnChange() {
-        return _expression.getTriggerOnChange();
+        return ((StringExpressionBean)getObject()).getTriggerOnChange();
     }
     
     /** {@inheritDoc} */
     @Override
     public void setTriggerOnChange(boolean triggerOnChange) {
-        _expression.setTriggerOnChange(triggerOnChange);
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public Category getCategory() {
-        return _expression.getCategory();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return _expression.isExternal();
+        ((StringExpressionBean)getObject()).setTriggerOnChange(triggerOnChange);
     }
     
     /** {@inheritDoc} */
@@ -91,7 +55,7 @@ public class DefaultMaleStringExpressionSocket extends AbstractMaleSocket
         String result = "";
         try {
             currentConditionalNG.getSymbolTable().createSymbols(_localVariables);
-            result = _expression.evaluate();
+            result = ((StringExpressionBean)getObject()).evaluate();
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionEvaluate", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {
@@ -106,122 +70,17 @@ public class DefaultMaleStringExpressionSocket extends AbstractMaleSocket
     
     @Override
     public int getState() {
-        return _expression.getState();
-    }
-
-    @Override
-    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
-        return _expression.getChild(index);
-    }
-
-    @Override
-    public int getChildCount() {
-        return _expression.getChildCount();
-    }
-
-    @Override
-    public String getShortDescription(Locale locale) {
-        return _expression.getShortDescription(locale);
-    }
-
-    @Override
-    public String getLongDescription(Locale locale) {
-        return _expression.getLongDescription(locale);
-    }
-
-    @Override
-    public String getUserName() {
-        return _expression.getUserName();
-    }
-
-    @Override
-    public void setUserName(String s) throws BadUserNameException {
-        _expression.setUserName(s);
-    }
-
-    @Override
-    public String getSystemName() {
-        return _expression.getSystemName();
+        return ((StringExpressionBean)getObject()).getState();
     }
 
     @Override
     public String getDisplayName() {
-        return _expression.getDisplayName();
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l, String name, String listenerRef) {
-        _expression.addPropertyChangeListener(l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l, String name, String listenerRef) {
-        _expression.addPropertyChangeListener(propertyName, l, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener l) {
-        _expression.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _expression.addPropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener l) {
-        _expression.removePropertyChangeListener(l);
-    }
-
-    @Override
-    public void removePropertyChangeListener(String propertyName, PropertyChangeListener l) {
-        _expression.removePropertyChangeListener(propertyName, l);
-    }
-
-    @Override
-    public void updateListenerRef(PropertyChangeListener l, String newName) {
-        _expression.updateListenerRef(l, newName);
-    }
-
-    @Override
-    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-        _expression.vetoableChange(evt);
-    }
-
-    @Override
-    public String getListenerRef(PropertyChangeListener l) {
-        return _expression.getListenerRef(l);
-    }
-
-    @Override
-    public ArrayList<String> getListenerRefs() {
-        return _expression.getListenerRefs();
-    }
-
-    @Override
-    public int getNumPropertyChangeListeners() {
-        return _expression.getNumPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners() {
-        return _expression.getPropertyChangeListeners();
-    }
-
-    @Override
-    public synchronized PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
-        return _expression.getPropertyChangeListeners(propertyName);
-    }
-
-    @Override
-    public PropertyChangeListener[] getPropertyChangeListenersByReference(String name) {
-        return _expression.getPropertyChangeListenersByReference(name);
+        return ((StringExpressionBean)getObject()).getDisplayName();
     }
 
     @Override
     public void disposeMe() {
-        _expression.dispose();
+        ((StringExpressionBean)getObject()).dispose();
     }
 
     /**
@@ -229,7 +88,7 @@ public class DefaultMaleStringExpressionSocket extends AbstractMaleSocket
      */
     @Override
     public void registerListenersForThisClass() {
-        _expression.registerListeners();
+        ((StringExpressionBean)getObject()).registerListeners();
     }
     
     /**
@@ -237,12 +96,12 @@ public class DefaultMaleStringExpressionSocket extends AbstractMaleSocket
      */
     @Override
     public void unregisterListenersForThisClass() {
-        _expression.unregisterListeners();
+        ((StringExpressionBean)getObject()).unregisterListeners();
     }
     
     @Override
     public void setState(int s) throws JmriException {
-        _expression.setState(s);
+        ((StringExpressionBean)getObject()).setState(s);
     }
 
     @Override
@@ -252,42 +111,42 @@ public class DefaultMaleStringExpressionSocket extends AbstractMaleSocket
 
     @Override
     public String getComment() {
-        return _expression.getComment();
+        return ((StringExpressionBean)getObject()).getComment();
     }
 
     @Override
     public void setComment(String comment) {
-        _expression.setComment(comment);
+        ((StringExpressionBean)getObject()).setComment(comment);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        _expression.setProperty(key, value);
+        ((StringExpressionBean)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return _expression.getProperty(key);
+        return ((StringExpressionBean)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        _expression.removeProperty(key);
+        ((StringExpressionBean)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return _expression.getPropertyKeys();
+        return ((StringExpressionBean)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return _expression.getBeanType();
+        return ((StringExpressionBean)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return _expression.compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((StringExpressionBean)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
 
     /** {@inheritDoc} */
@@ -308,12 +167,6 @@ public class DefaultMaleStringExpressionSocket extends AbstractMaleSocket
         return new StringExpressionDebugConfig();
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Base getObject() {
-        return _expression;
-    }
-    
     /** {@inheritDoc} */
     @Override
     public void setEnabled(boolean enable) {

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogActionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogActionManagerXml.java
@@ -29,12 +29,6 @@ public class DefaultAnalogActionManagerXml extends AbstractManagerXml {
     public DefaultAnalogActionManagerXml() {
     }
 
-    private AnalogActionBean getAction(AnalogActionBean action) throws IllegalAccessException, IllegalArgumentException, NoSuchFieldException {
-        Field f = action.getClass().getDeclaredField("_action");
-        f.setAccessible(true);
-        return (AnalogActionBean) f.get(action);
-    }
-    
     /**
      * Default implementation for storing the contents of a AnalogActionManager
      *
@@ -58,15 +52,15 @@ public class DefaultAnalogActionManagerXml extends AbstractManagerXml {
                         elements.add(storeMaleSocket(a));
                         a = (MaleAnalogActionSocket) a.getObject();
                     }
-                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(getAction(a));
+                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
 //                        e.addContent(storeMaleSocket(a));
                         actions.addContent(e);
                     } else {
-                        throw new RuntimeException("Cannot load xml configurator for " + getAction(a).getClass().getName());
+                        throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());
                     }
-                } catch (RuntimeException | IllegalAccessException | NoSuchFieldException e) {
+                } catch (RuntimeException e) {
                     log.error("Error storing action: {}", e, e);
                 }
             }

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogExpressionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogExpressionManagerXml.java
@@ -29,12 +29,6 @@ public class DefaultAnalogExpressionManagerXml extends AbstractManagerXml {
     public DefaultAnalogExpressionManagerXml() {
     }
 
-    private AnalogExpressionBean getExpression(AnalogExpressionBean expression) throws IllegalAccessException, IllegalArgumentException, NoSuchFieldException {
-        Field f = expression.getClass().getDeclaredField("_expression");
-        f.setAccessible(true);
-        return (AnalogExpressionBean) f.get(expression);
-    }
-    
     /**
      * Default implementation for storing the contents of a LogixManager
      *
@@ -58,15 +52,15 @@ public class DefaultAnalogExpressionManagerXml extends AbstractManagerXml {
                         elements.add(storeMaleSocket(a));
                         a = (MaleAnalogExpressionSocket) a.getObject();
                     }
-                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(getExpression(a));
+                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
 //                        e.addContent(storeMaleSocket(expression));
                         expressions.addContent(e);
                     } else {
-                        throw new RuntimeException("Cannot load xml configurator for " + getExpression(a).getClass().getName());
+                        throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());
                     }
-                } catch (RuntimeException | IllegalAccessException | NoSuchFieldException e) {
+                } catch (RuntimeException e) {
                     log.error("Error storing action: {}", e, e);
                 }
             }

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalActionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalActionManagerXml.java
@@ -29,14 +29,6 @@ public class DefaultDigitalActionManagerXml extends AbstractManagerXml {
     public DefaultDigitalActionManagerXml() {
     }
 
-    private DigitalActionBean getAction(DigitalActionBean action)
-            throws IllegalAccessException, IllegalArgumentException, NoSuchFieldException {
-        
-        Field f = action.getClass().getDeclaredField("_action");
-        f.setAccessible(true);
-        return (DigitalActionBean) f.get(action);
-    }
-    
     /**
      * Default implementation for storing the contents of a DigitalActionManager
      *
@@ -61,15 +53,16 @@ public class DefaultDigitalActionManagerXml extends AbstractManagerXml {
                         elements.add(storeMaleSocket(a));
                         a = (MaleDigitalActionSocket) a.getObject();
                     }
-                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(getAction(a));
+//                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(getAction(a));
+                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
 //                        e.addContent(storeMaleSocket(a));
                         actions.addContent(e);
                     } else {
-                        throw new RuntimeException("Cannot load xml configurator for " + getAction(a).getClass().getName());
+                        throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());
                     }
-                } catch (RuntimeException | IllegalAccessException | NoSuchFieldException e) {
+                } catch (RuntimeException e) {
                     log.error("Error storing action: {}", e, e);
                 }
             }

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalBooleanActionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalBooleanActionManagerXml.java
@@ -29,14 +29,6 @@ public class DefaultDigitalBooleanActionManagerXml extends AbstractManagerXml {
     public DefaultDigitalBooleanActionManagerXml() {
     }
 
-    private DigitalBooleanActionBean getAction(DigitalBooleanActionBean action)
-            throws IllegalAccessException, IllegalArgumentException, NoSuchFieldException {
-        
-        Field f = action.getClass().getDeclaredField("_action");
-        f.setAccessible(true);
-        return (DigitalBooleanActionBean) f.get(action);
-    }
-    
     /**
      * Default implementation for storing the contents of a DigitalBooleanActionManager
      *
@@ -61,15 +53,15 @@ public class DefaultDigitalBooleanActionManagerXml extends AbstractManagerXml {
                         elements.add(storeMaleSocket(a));
                         a = (MaleDigitalBooleanActionSocket) a.getObject();
                     }
-                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(getAction(a));
+                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
 //                        e.addContent(storeMaleSocket(a));
                         actions.addContent(e);
                     } else {
-                        throw new RuntimeException("Cannot load xml configurator for " + getAction(a).getClass().getName());
+                        throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());
                     }
-                } catch (RuntimeException | IllegalAccessException | NoSuchFieldException e) {
+                } catch (RuntimeException e) {
                     log.error("Error storing action: {}", e, e);
                 }
             }

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalExpressionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalExpressionManagerXml.java
@@ -32,12 +32,6 @@ public class DefaultDigitalExpressionManagerXml extends AbstractManagerXml {
     public DefaultDigitalExpressionManagerXml() {
     }
 
-    private DigitalExpressionBean getExpression(DigitalExpressionBean expression) throws IllegalAccessException, IllegalArgumentException, NoSuchFieldException {
-        Field f = expression.getClass().getDeclaredField("_expression");
-        f.setAccessible(true);
-        return (DigitalExpressionBean) f.get(expression);
-    }
-    
     /**
      * Default implementation for storing the contents of a LogixManager
      *
@@ -62,15 +56,15 @@ public class DefaultDigitalExpressionManagerXml extends AbstractManagerXml {
                         elements.add(storeMaleSocket(a));
                         a = (MaleDigitalExpressionSocket) a.getObject();
                     }
-                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(getExpression(a));
+                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
 //                        e.addContent(storeMaleSocket(a));
                         expressions.addContent(e);
                     } else {
-                        throw new RuntimeException("Cannot load xml configurator for " + getExpression(a).getClass().getName());
+                        throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());
                     }
-                } catch (RuntimeException | IllegalAccessException | NoSuchFieldException e) {
+                } catch (RuntimeException e) {
                     log.error("Error storing action: {}", e, e);
                 }
             }

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultMaleDigitalExpressionSocketXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultMaleDigitalExpressionSocketXml.java
@@ -1,5 +1,11 @@
 package jmri.jmrit.logixng.implementation.configurexml;
 
+import jmri.jmrit.logixng.MaleSocket;
+import jmri.jmrit.logixng.implementation.DefaultMaleDigitalExpressionSocket;
+
+import org.jdom2.Attribute;
+import org.jdom2.Element;
+
 /**
  * Handle XML configuration for ActionLightXml objects.
  *
@@ -8,4 +14,38 @@ package jmri.jmrit.logixng.implementation.configurexml;
  */
 public class DefaultMaleDigitalExpressionSocketXml extends AbstractMaleSocketXml {
 
+    /**
+     * Default implementation for storing the contents of a ActionMany
+     *
+     * @param o Object to store, of type ActionMany
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        Element element = super.store(o);
+        
+        DefaultMaleDigitalExpressionSocket maleSocket = (DefaultMaleDigitalExpressionSocket) o;
+        
+        element.setAttribute("DefaultMaleDigitalExpressionSocketListen", maleSocket.getListen()? "yes" : "no");  // NOI18N
+        
+        return element;
+    }
+    
+    @Override
+    public boolean load(Element maleSocketElement, MaleSocket maleSocket) {
+        if (!(maleSocket instanceof DefaultMaleDigitalExpressionSocket)) {
+            throw new IllegalArgumentException("maleSocket is not an AbstractMaleSocket: "+maleSocket.getClass().getName());
+        }
+        
+        String listen = "yes";
+        Attribute attribute = maleSocketElement.getAttribute("DefaultMaleDigitalExpressionSocketListen");
+        if (attribute != null) {  // NOI18N
+            listen = attribute.getValue();  // NOI18N
+        }
+        ((DefaultMaleDigitalExpressionSocket)maleSocket).setListen("yes".equals(listen));
+        
+        return super.load(maleSocketElement, maleSocket);
+    }
+    
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultMaleDigitalExpressionSocketXml.class);
 }

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultStringActionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultStringActionManagerXml.java
@@ -29,12 +29,6 @@ public class DefaultStringActionManagerXml extends AbstractManagerXml {
     public DefaultStringActionManagerXml() {
     }
 
-    private StringActionBean getAction(StringActionBean action) throws IllegalAccessException, IllegalArgumentException, NoSuchFieldException {
-        Field f = action.getClass().getDeclaredField("_action");
-        f.setAccessible(true);
-        return (StringActionBean) f.get(action);
-    }
-    
     /**
      * Default implementation for storing the contents of a StringActionManager
      *
@@ -58,15 +52,15 @@ public class DefaultStringActionManagerXml extends AbstractManagerXml {
                         elements.add(storeMaleSocket(a));
                         a = (MaleStringActionSocket) a.getObject();
                     }
-                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(getAction(a));
+                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
 //                        e.addContent(storeMaleSocket(a));
                         actions.addContent(e);
                     } else {
-                        throw new RuntimeException("Cannot load xml configurator for " + getAction(a).getClass().getName());
+                        throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());
                     }
-                } catch (RuntimeException | IllegalAccessException | NoSuchFieldException e) {
+                } catch (RuntimeException e) {
                     log.error("Error storing action: {}", e, e);
                 }
             }

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultStringExpressionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultStringExpressionManagerXml.java
@@ -29,12 +29,6 @@ public class DefaultStringExpressionManagerXml extends AbstractManagerXml {
     public DefaultStringExpressionManagerXml() {
     }
 
-    private StringExpressionBean getExpression(StringExpressionBean expression) throws IllegalAccessException, IllegalArgumentException, NoSuchFieldException {
-        Field f = expression.getClass().getDeclaredField("_expression");
-        f.setAccessible(true);
-        return (StringExpressionBean) f.get(expression);
-    }
-    
     /**
      * Default implementation for storing the contents of a LogixManager
      *
@@ -58,15 +52,15 @@ public class DefaultStringExpressionManagerXml extends AbstractManagerXml {
                         elements.add(storeMaleSocket(a));
                         a = (MaleStringExpressionSocket) a.getObject();
                     }
-                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(getExpression(a));
+                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
 //                        e.addContent(storeMaleSocket(expression));
                         expressions.addContent(e);
                     } else {
-                        throw new RuntimeException("Cannot load xml configurator for " + getExpression(a).getClass().getName());
+                        throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());
                     }
-                } catch (RuntimeException | IllegalAccessException | NoSuchFieldException e) {
+                } catch (RuntimeException e) {
                     log.error("Error storing action: {}", e, e);
                 }
             }

--- a/java/src/jmri/jmrit/logixng/implementation/swing/AbstractMaleSocketSwing.java
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/AbstractMaleSocketSwing.java
@@ -24,7 +24,12 @@ public abstract class AbstractMaleSocketSwing extends AbstractSwingConfigurator 
     private final JLabel catchAbortExecutionLabel = new JLabel(Bundle.getMessage("MaleSocket_CatchAbortExecutionCheckBox"));
     private JComboBox<ErrorHandlingType> errorHandlingComboBox;
     private JCheckBox catchAbortExecutionCheckBox;
+    private JPanel subPanel;
     
+    
+    protected JPanel getSubPanel(@CheckForNull Base object) {
+        return null;
+    }
     
     /** {@inheritDoc} */
     @Override
@@ -89,6 +94,15 @@ public abstract class AbstractMaleSocketSwing extends AbstractSwingConfigurator 
 //        catchAbortExecutionCheckBox.setAlignmentX(0);
         catchAbortExecutionLabel.setLabelFor(catchAbortExecutionCheckBox);
         panel.add(catchAbortExecutionCheckBox, c);
+        
+        subPanel = getSubPanel(object);
+        if (subPanel != null) {
+            JPanel thisPanel = panel;
+            panel = new JPanel();
+            panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+            panel.add(thisPanel);
+            panel.add(subPanel);
+        }
     }
     
     /** {@inheritDoc} */
@@ -106,7 +120,7 @@ public abstract class AbstractMaleSocketSwing extends AbstractSwingConfigurator 
     
     /** {@inheritDoc} */
     @Override
-    public final void updateObject(@Nonnull Base object) {
+    public void updateObject(@Nonnull Base object) {
         if (! (object instanceof AbstractMaleSocket)) {
             throw new IllegalArgumentException("object is not an AbstractMaleSocket: " + object.getClass().getName());
         }

--- a/java/src/jmri/jmrit/logixng/implementation/swing/DefaultMaleDigitalExpressionSocketSwing.java
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/DefaultMaleDigitalExpressionSocketSwing.java
@@ -1,10 +1,53 @@
 package jmri.jmrit.logixng.implementation.swing;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.implementation.DefaultMaleDigitalExpressionSocket;
+
 /**
  * Configures an DefaultMaleDigitalActionSocket object with a Swing JPanel.
  */
 public class DefaultMaleDigitalExpressionSocketSwing extends AbstractMaleSocketSwing {
 
+    private JPanel _panel;
+    private final JLabel _listenLabel = new JLabel(Bundle.getMessage("DefaultMaleDigitalExpressionSocketSwing_Listen"));
+    private JCheckBox _listenCheckBox;
+    
+    @Override
+    protected JPanel getSubPanel(@CheckForNull Base object) {
+        if ((object != null) && (! (object instanceof DefaultMaleDigitalExpressionSocket))) {
+            throw new IllegalArgumentException("object is not an DefaultMaleDigitalExpressionSocket: " + object.getClass().getName());
+        }
+        
+        _panel = new JPanel();
+        _listenCheckBox = new JCheckBox();
+        
+        DefaultMaleDigitalExpressionSocket maleSocket = (DefaultMaleDigitalExpressionSocket)object;
+        if (maleSocket != null) {
+            _listenCheckBox.setSelected(maleSocket.getListen());
+        }
+        
+        _listenLabel.setLabelFor(_listenCheckBox);
+        _panel.add(_listenLabel);
+        _panel.add(_listenCheckBox);
+        
+        return _panel;
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        if (! (object instanceof DefaultMaleDigitalExpressionSocket)) {
+            throw new IllegalArgumentException("object is not an DefaultMaleDigitalExpressionSocket: " + object.getClass().getName());
+        }
+        
+        DefaultMaleDigitalExpressionSocket maleSocket = (DefaultMaleDigitalExpressionSocket)object;
+        maleSocket.setListen(_listenCheckBox.isSelected());
+    }
+    
 //    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(OrSwing.class);
     
 }

--- a/java/src/jmri/jmrit/logixng/implementation/swing/DefaultMaleDigitalExpressionSocketSwing.java
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/DefaultMaleDigitalExpressionSocketSwing.java
@@ -24,6 +24,7 @@ public class DefaultMaleDigitalExpressionSocketSwing extends AbstractMaleSocketS
         
         _panel = new JPanel();
         _listenCheckBox = new JCheckBox();
+        _listenCheckBox.setSelected(true);  // Listen should be true if not changed by the user
         
         DefaultMaleDigitalExpressionSocket maleSocket = (DefaultMaleDigitalExpressionSocket)object;
         if (maleSocket != null) {

--- a/java/src/jmri/jmrit/logixng/implementation/swing/ImplementationSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/ImplementationSwingBundle.properties
@@ -18,3 +18,6 @@ ErrorHandlingDialog_DisableLogixNG          = Disable this LogixNG
 ErrorHandlingDialog_StopAllLogixNGs         = Stop all LogixNGs
 ErrorHandlingDialog_Abort                   = Abort
 ErrorHandlingDialog_Continue                = Continue
+
+
+DefaultMaleDigitalExpressionSocketSwing_Listen      = Listen

--- a/java/src/jmri/jmrit/logixng/tools/ImportConditional.java
+++ b/java/src/jmri/jmrit/logixng/tools/ImportConditional.java
@@ -231,12 +231,17 @@ public class ImportConditional {
             }
             
             if (newExpression != null) {
+                
+                boolean doTriggerActions = cv.doTriggerActions();
+                
                 if (cv.isNegated()) {
                     Not notExpression = new Not(InstanceManager.getDefault(DigitalExpressionManager.class)
                             .getAutoSystemName(), null);
 
                     if (!_dryRun) {
                         MaleSocket newExpressionSocket = InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(newExpression);
+                        newExpressionSocket.setListen(doTriggerActions);
+                        doTriggerActions = true;    // We don't want the Not expression to disable listen.
                         notExpression.getChild(0).connect(newExpressionSocket);
                     }
                     newExpression = notExpression;
@@ -244,6 +249,7 @@ public class ImportConditional {
                 
                 if (!_dryRun) {
                     MaleSocket newExpressionSocket = InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(newExpression);
+                    newExpressionSocket.setListen(doTriggerActions);
                     expression.getChild(i).connect(newExpressionSocket);
                 }
             } else {

--- a/java/src/jmri/jmrit/logixng/tools/ImportConditional.java
+++ b/java/src/jmri/jmrit/logixng/tools/ImportConditional.java
@@ -175,6 +175,7 @@ public class ImportConditional {
     
     private void buildExpression(DigitalExpressionBean expression, List<ConditionalVariable> conditionalVariables)
             throws SocketAlreadyConnectedException, JmriException {
+        
         for (int i=0; i < conditionalVariables.size(); i++) {
             jmri.ConditionalVariable cv = conditionalVariables.get(i);
             NamedBean nb = cv.getBean();
@@ -230,6 +231,17 @@ public class ImportConditional {
             }
             
             if (newExpression != null) {
+                if (cv.isNegated()) {
+                    Not notExpression = new Not(InstanceManager.getDefault(DigitalExpressionManager.class)
+                            .getAutoSystemName(), null);
+
+                    if (!_dryRun) {
+                        MaleSocket newExpressionSocket = InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(newExpression);
+                        notExpression.getChild(0).connect(newExpressionSocket);
+                    }
+                    newExpression = notExpression;
+                }
+                
                 if (!_dryRun) {
                     MaleSocket newExpressionSocket = InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(newExpression);
                     expression.getChild(i).connect(newExpressionSocket);

--- a/java/src/jmri/jmrit/logixng/tools/debugger/AbstractDebuggerMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/AbstractDebuggerMaleSocket.java
@@ -1,10 +1,6 @@
 package jmri.jmrit.logixng.tools.debugger;
 
-import java.beans.*;
-import java.util.*;
-
 import jmri.InstanceManager;
-import jmri.NamedBean;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.implementation.AbstractMaleSocket;
 
@@ -15,7 +11,7 @@ import jmri.jmrit.logixng.implementation.AbstractMaleSocket;
 public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
     
     private final Debugger _debugger = InstanceManager.getDefault(Debugger.class);
-    protected final MaleSocket _maleSocket;
+//    protected final MaleSocket ((MaleSocket)getObject());
     
     private boolean _breakpointBefore = false;
     private boolean _breakpointAfter = false;
@@ -25,8 +21,7 @@ public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
     
     
     public AbstractDebuggerMaleSocket(BaseManager<? extends MaleSocket> manager, MaleSocket maleSocket) {
-        super(manager);
-        _maleSocket = maleSocket;
+        super(manager, maleSocket);
     }
     
     /**
@@ -89,22 +84,22 @@ public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
     
     @Override
     protected final void registerListenersForThisClass() {
-        _maleSocket.registerListeners();
+        ((MaleSocket)getObject()).registerListeners();
     }
 
     @Override
     protected final void unregisterListenersForThisClass() {
-        _maleSocket.unregisterListeners();
+        ((MaleSocket)getObject()).unregisterListeners();
     }
 
     @Override
     protected final void disposeMe() {
-        _maleSocket.dispose();
+        ((MaleSocket)getObject()).dispose();
     }
 
     @Override
     public final void setEnabled(boolean enable) {
-        _maleSocket.setEnabled(enable);
+        ((MaleSocket)getObject()).setEnabled(enable);
     }
 
     @Override
@@ -114,173 +109,38 @@ public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
 
     @Override
     public final boolean isEnabled() {
-        return _maleSocket.isEnabled();
-    }
-
-    @Override
-    public final Base getObject() {
-        return _maleSocket;
+        return ((MaleSocket)getObject()).isEnabled();
     }
 
     @Override
     public final void setDebugConfig(DebugConfig config) {
-        _maleSocket.setDebugConfig(config);
+        ((MaleSocket)getObject()).setDebugConfig(config);
     }
 
     @Override
     public final DebugConfig getDebugConfig() {
-        return _maleSocket.getDebugConfig();
+        return ((MaleSocket)getObject()).getDebugConfig();
     }
 
     @Override
     public final DebugConfig createDebugConfig() {
-        return _maleSocket.createDebugConfig();
-    }
-
-    @Override
-    public final String getSystemName() {
-        return _maleSocket.getSystemName();
-    }
-
-    @Override
-    public final String getUserName() {
-        return _maleSocket.getUserName();
+        return ((MaleSocket)getObject()).createDebugConfig();
     }
 
     @Override
     public final String getComment() {
-        return _maleSocket.getComment();
-    }
-
-    @Override
-    public final void setUserName(String s) throws NamedBean.BadUserNameException {
-        _maleSocket.setUserName(s);
+        return ((MaleSocket)getObject()).getComment();
     }
 
     @Override
     public final void setComment(String comment) {
-        _maleSocket.setComment(comment);
-    }
-
-    @Override
-    public final String getShortDescription(Locale locale) {
-        return _maleSocket.getShortDescription(locale);
-    }
-
-    @Override
-    public final String getLongDescription(Locale locale) {
-        return _maleSocket.getLongDescription(locale);
+        ((MaleSocket)getObject()).setComment(comment);
     }
 
     @Override
     public void setParent(Base parent) {
         super.setParent(parent);
-        _maleSocket.setParent(this);
-    }
-
-    @Override
-    public final Base getRoot() {
-        return _maleSocket.getRoot();
-    }
-
-    @Override
-    public final FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
-        return _maleSocket.getChild(index);
-    }
-
-    @Override
-    public final int getChildCount() {
-        return _maleSocket.getChildCount();
-    }
-
-    @Override
-    public final Category getCategory() {
-        return _maleSocket.getCategory();
-    }
-
-    @Override
-    public final boolean isExternal() {
-        return _maleSocket.isExternal();
-    }
-
-    @Override
-    public final Lock getLock() {
-        return _maleSocket.getLock();
-    }
-
-    @Override
-    public final void setLock(Lock lock) {
-        _maleSocket.setLock(lock);
-    }
-
-    @Override
-    public final void addPropertyChangeListener(PropertyChangeListener listener, String name, String listenerRef) {
-        _maleSocket.addPropertyChangeListener(listener, name, listenerRef);
-    }
-
-    @Override
-    public final void addPropertyChangeListener(String propertyName, PropertyChangeListener listener, String name, String listenerRef) {
-        _maleSocket.addPropertyChangeListener(propertyName, listener, name, listenerRef);
-    }
-
-    @Override
-    public final void updateListenerRef(PropertyChangeListener l, String newName) {
-        _maleSocket.updateListenerRef(l, newName);
-    }
-
-    @Override
-    public final void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-        _maleSocket.vetoableChange(evt);
-    }
-
-    @Override
-    public final String getListenerRef(PropertyChangeListener l) {
-        return _maleSocket.getListenerRef(l);
-    }
-
-    @Override
-    public final ArrayList<String> getListenerRefs() {
-        return _maleSocket.getListenerRefs();
-    }
-
-    @Override
-    public final int getNumPropertyChangeListeners() {
-        return _maleSocket.getNumPropertyChangeListeners();
-    }
-
-    @Override
-    public final PropertyChangeListener[] getPropertyChangeListenersByReference(String name) {
-        return _maleSocket.getPropertyChangeListenersByReference(name);
-    }
-
-    @Override
-    public final void addPropertyChangeListener(PropertyChangeListener listener) {
-        _maleSocket.addPropertyChangeListener(listener);
-    }
-
-    @Override
-    public final void addPropertyChangeListener(String propertyName, PropertyChangeListener listener) {
-        _maleSocket.addPropertyChangeListener(propertyName, listener);
-    }
-
-    @Override
-    public final PropertyChangeListener[] getPropertyChangeListeners() {
-        return _maleSocket.getPropertyChangeListeners();
-    }
-
-    @Override
-    public final PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
-        return _maleSocket.getPropertyChangeListeners(propertyName);
-    }
-
-    @Override
-    public final void removePropertyChangeListener(PropertyChangeListener listener) {
-        _maleSocket.removePropertyChangeListener(listener);
-    }
-
-    @Override
-    public final void removePropertyChangeListener(String propertyName, PropertyChangeListener listener) {
-        _maleSocket.removePropertyChangeListener(propertyName, listener);
+        ((MaleSocket)getObject()).setParent(this);
     }
 
 }

--- a/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleAnalogActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleAnalogActionSocket.java
@@ -35,53 +35,53 @@ public class DebuggerMaleAnalogActionSocket extends AbstractDebuggerMaleSocket i
     public void setValue(double value) throws JmriException {
         _nextValue = value;
         before();
-        ((MaleAnalogActionSocket) _maleSocket).setValue(_nextValue);
+        ((MaleAnalogActionSocket)getObject()).setValue(_nextValue);
         after();
     }
 
     @Override
     public void setState(int s) throws JmriException {
-        ((MaleAnalogActionSocket) _maleSocket).setState(s);
+        ((MaleAnalogActionSocket)getObject()).setState(s);
     }
 
     @Override
     public int getState() {
-        return ((MaleAnalogActionSocket) _maleSocket).getState();
+        return ((MaleAnalogActionSocket)getObject()).getState();
     }
 
     @Override
     public String describeState(int state) {
-        return ((MaleAnalogActionSocket) _maleSocket).describeState(state);
+        return ((MaleAnalogActionSocket)getObject()).describeState(state);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        ((MaleAnalogActionSocket) _maleSocket).setProperty(key, value);
+        ((MaleAnalogActionSocket)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return ((MaleAnalogActionSocket) _maleSocket).getProperty(key);
+        return ((MaleAnalogActionSocket)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        ((MaleAnalogActionSocket) _maleSocket).removeProperty(key);
+        ((MaleAnalogActionSocket)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return ((MaleAnalogActionSocket) _maleSocket).getPropertyKeys();
+        return ((MaleAnalogActionSocket)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return ((MaleAnalogActionSocket) _maleSocket).getBeanType();
+        return ((MaleAnalogActionSocket)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return ((MaleAnalogActionSocket) _maleSocket).compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((MaleAnalogActionSocket)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
     
 }

--- a/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleAnalogExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleAnalogExpressionSocket.java
@@ -34,64 +34,64 @@ public class DebuggerMaleAnalogExpressionSocket extends AbstractDebuggerMaleSock
     @Override
     public double evaluate() throws JmriException {
         before();
-        _lastResult = ((MaleAnalogExpressionSocket) _maleSocket).evaluate();
+        _lastResult = ((MaleAnalogExpressionSocket)getObject()).evaluate();
         after();
         return _lastResult;
     }
 
     @Override
     public void setState(int s) throws JmriException {
-        ((MaleAnalogExpressionSocket) _maleSocket).setState(s);
+        ((MaleAnalogExpressionSocket)getObject()).setState(s);
     }
 
     @Override
     public int getState() {
-        return ((MaleAnalogExpressionSocket) _maleSocket).getState();
+        return ((MaleAnalogExpressionSocket)getObject()).getState();
     }
 
     @Override
     public String describeState(int state) {
-        return ((MaleAnalogExpressionSocket) _maleSocket).describeState(state);
+        return ((MaleAnalogExpressionSocket)getObject()).describeState(state);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        ((MaleAnalogExpressionSocket) _maleSocket).setProperty(key, value);
+        ((MaleAnalogExpressionSocket)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return ((MaleAnalogExpressionSocket) _maleSocket).getProperty(key);
+        return ((MaleAnalogExpressionSocket)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        ((MaleAnalogExpressionSocket) _maleSocket).removeProperty(key);
+        ((MaleAnalogExpressionSocket)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return ((MaleAnalogExpressionSocket) _maleSocket).getPropertyKeys();
+        return ((MaleAnalogExpressionSocket)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return ((MaleAnalogExpressionSocket) _maleSocket).getBeanType();
+        return ((MaleAnalogExpressionSocket)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return ((MaleAnalogExpressionSocket) _maleSocket).compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((MaleAnalogExpressionSocket)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
 
     @Override
     public void setTriggerOnChange(boolean triggerOnChange) {
-        ((MaleAnalogExpressionSocket) _maleSocket).setTriggerOnChange(triggerOnChange);
+        ((MaleAnalogExpressionSocket)getObject()).setTriggerOnChange(triggerOnChange);
     }
 
     @Override
     public boolean getTriggerOnChange() {
-        return ((MaleAnalogExpressionSocket) _maleSocket).getTriggerOnChange();
+        return ((MaleAnalogExpressionSocket)getObject()).getTriggerOnChange();
     }
     
 }

--- a/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleDigitalActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleDigitalActionSocket.java
@@ -32,53 +32,53 @@ public class DebuggerMaleDigitalActionSocket extends AbstractDebuggerMaleSocket 
     @Override
     public void execute() throws JmriException {
         before();
-        ((MaleDigitalActionSocket) _maleSocket).execute();
+        ((MaleDigitalActionSocket)getObject()).execute();
         after();
     }
 
     @Override
     public void setState(int s) throws JmriException {
-        ((MaleDigitalActionSocket) _maleSocket).setState(s);
+        ((MaleDigitalActionSocket)getObject()).setState(s);
     }
 
     @Override
     public int getState() {
-        return ((MaleDigitalActionSocket) _maleSocket).getState();
+        return ((MaleDigitalActionSocket)getObject()).getState();
     }
 
     @Override
     public String describeState(int state) {
-        return ((MaleDigitalActionSocket) _maleSocket).describeState(state);
+        return ((MaleDigitalActionSocket)getObject()).describeState(state);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        ((MaleDigitalActionSocket) _maleSocket).setProperty(key, value);
+        ((MaleDigitalActionSocket)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return ((MaleDigitalActionSocket) _maleSocket).getProperty(key);
+        return ((MaleDigitalActionSocket)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        ((MaleDigitalActionSocket) _maleSocket).removeProperty(key);
+        ((MaleDigitalActionSocket)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return ((MaleDigitalActionSocket) _maleSocket).getPropertyKeys();
+        return ((MaleDigitalActionSocket)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return ((MaleDigitalActionSocket) _maleSocket).getBeanType();
+        return ((MaleDigitalActionSocket)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return ((MaleDigitalActionSocket) _maleSocket).compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((MaleDigitalActionSocket)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
     
 }

--- a/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleDigitalBooleanActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleDigitalBooleanActionSocket.java
@@ -39,53 +39,53 @@ public class DebuggerMaleDigitalBooleanActionSocket extends AbstractDebuggerMale
         _nextHasChangedToTrue = hasChangedToTrue;
         _nextHasChangedToFalse = hasChangedToFalse;
         before();
-        ((MaleDigitalBooleanActionSocket) _maleSocket).execute(hasChangedToTrue, hasChangedToFalse);
+        ((MaleDigitalBooleanActionSocket)getObject()).execute(hasChangedToTrue, hasChangedToFalse);
         after();
     }
 
     @Override
     public void setState(int s) throws JmriException {
-        ((MaleDigitalBooleanActionSocket) _maleSocket).setState(s);
+        ((MaleDigitalBooleanActionSocket)getObject()).setState(s);
     }
 
     @Override
     public int getState() {
-        return ((MaleDigitalBooleanActionSocket) _maleSocket).getState();
+        return ((MaleDigitalBooleanActionSocket)getObject()).getState();
     }
 
     @Override
     public String describeState(int state) {
-        return ((MaleDigitalBooleanActionSocket) _maleSocket).describeState(state);
+        return ((MaleDigitalBooleanActionSocket)getObject()).describeState(state);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        ((MaleDigitalBooleanActionSocket) _maleSocket).setProperty(key, value);
+        ((MaleDigitalBooleanActionSocket)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return ((MaleDigitalBooleanActionSocket) _maleSocket).getProperty(key);
+        return ((MaleDigitalBooleanActionSocket)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        ((MaleDigitalBooleanActionSocket) _maleSocket).removeProperty(key);
+        ((MaleDigitalBooleanActionSocket)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return ((MaleDigitalBooleanActionSocket) _maleSocket).getPropertyKeys();
+        return ((MaleDigitalBooleanActionSocket)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return ((MaleDigitalBooleanActionSocket) _maleSocket).getBeanType();
+        return ((MaleDigitalBooleanActionSocket)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return ((MaleDigitalBooleanActionSocket) _maleSocket).compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((MaleDigitalBooleanActionSocket)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
     
 }

--- a/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleDigitalExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleDigitalExpressionSocket.java
@@ -22,7 +22,7 @@ public class DebuggerMaleDigitalExpressionSocket extends AbstractDebuggerMaleSoc
     /** {@inheritDoc} */
     @Override
     public void notifyChangedResult(boolean oldResult, boolean newResult) {
-        ((MaleDigitalExpressionSocket) _maleSocket).notifyChangedResult(oldResult, newResult);
+        ((MaleDigitalExpressionSocket)getObject()).notifyChangedResult(oldResult, newResult);
     }
 
     /** {@inheritDoc} */
@@ -40,69 +40,69 @@ public class DebuggerMaleDigitalExpressionSocket extends AbstractDebuggerMaleSoc
     @Override
     public boolean evaluate() throws JmriException {
         before();
-        _lastResult = ((MaleDigitalExpressionSocket) _maleSocket).evaluate();
+        _lastResult = ((MaleDigitalExpressionSocket)getObject()).evaluate();
         after();
         return _lastResult;
     }
 
     @Override
     public boolean getLastResult() {
-        return ((MaleDigitalExpressionSocket) _maleSocket).getLastResult();
+        return ((MaleDigitalExpressionSocket)getObject()).getLastResult();
     }
 
     @Override
     public void setState(int s) throws JmriException {
-        ((MaleDigitalExpressionSocket) _maleSocket).setState(s);
+        ((MaleDigitalExpressionSocket)getObject()).setState(s);
     }
 
     @Override
     public int getState() {
-        return ((MaleDigitalExpressionSocket) _maleSocket).getState();
+        return ((MaleDigitalExpressionSocket)getObject()).getState();
     }
 
     @Override
     public String describeState(int state) {
-        return ((MaleDigitalExpressionSocket) _maleSocket).describeState(state);
+        return ((MaleDigitalExpressionSocket)getObject()).describeState(state);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        ((MaleDigitalExpressionSocket) _maleSocket).setProperty(key, value);
+        ((MaleDigitalExpressionSocket)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return ((MaleDigitalExpressionSocket) _maleSocket).getProperty(key);
+        return ((MaleDigitalExpressionSocket)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        ((MaleDigitalExpressionSocket) _maleSocket).removeProperty(key);
+        ((MaleDigitalExpressionSocket)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return ((MaleDigitalExpressionSocket) _maleSocket).getPropertyKeys();
+        return ((MaleDigitalExpressionSocket)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return ((MaleDigitalExpressionSocket) _maleSocket).getBeanType();
+        return ((MaleDigitalExpressionSocket)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return ((MaleDigitalExpressionSocket) _maleSocket).compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((MaleDigitalExpressionSocket)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
 
     @Override
     public void setTriggerOnChange(boolean triggerOnChange) {
-        ((MaleDigitalExpressionSocket) _maleSocket).setTriggerOnChange(triggerOnChange);
+        ((MaleDigitalExpressionSocket)getObject()).setTriggerOnChange(triggerOnChange);
     }
 
     @Override
     public boolean getTriggerOnChange() {
-        return ((MaleDigitalExpressionSocket) _maleSocket).getTriggerOnChange();
+        return ((MaleDigitalExpressionSocket)getObject()).getTriggerOnChange();
     }
     
 }

--- a/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleStringActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleStringActionSocket.java
@@ -37,53 +37,53 @@ public class DebuggerMaleStringActionSocket extends AbstractDebuggerMaleSocket i
     public void setValue(@Nonnull String value) throws JmriException {
         _nextValue = value;
         before();
-        ((MaleStringActionSocket) _maleSocket).setValue(_nextValue);
+        ((MaleStringActionSocket)getObject()).setValue(_nextValue);
         after();
     }
 
     @Override
     public void setState(int s) throws JmriException {
-        ((MaleStringActionSocket) _maleSocket).setState(s);
+        ((MaleStringActionSocket)getObject()).setState(s);
     }
 
     @Override
     public int getState() {
-        return ((MaleStringActionSocket) _maleSocket).getState();
+        return ((MaleStringActionSocket)getObject()).getState();
     }
 
     @Override
     public String describeState(int state) {
-        return ((MaleStringActionSocket) _maleSocket).describeState(state);
+        return ((MaleStringActionSocket)getObject()).describeState(state);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        ((MaleStringActionSocket) _maleSocket).setProperty(key, value);
+        ((MaleStringActionSocket)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return ((MaleStringActionSocket) _maleSocket).getProperty(key);
+        return ((MaleStringActionSocket)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        ((MaleStringActionSocket) _maleSocket).removeProperty(key);
+        ((MaleStringActionSocket)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return ((MaleStringActionSocket) _maleSocket).getPropertyKeys();
+        return ((MaleStringActionSocket)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return ((MaleStringActionSocket) _maleSocket).getBeanType();
+        return ((MaleStringActionSocket)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return ((MaleStringActionSocket) _maleSocket).compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((MaleStringActionSocket)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
     
 }

--- a/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleStringExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleStringExpressionSocket.java
@@ -34,64 +34,64 @@ public class DebuggerMaleStringExpressionSocket extends AbstractDebuggerMaleSock
     @Override
     public String evaluate() throws JmriException {
         before();
-        _lastResult = ((MaleStringExpressionSocket) _maleSocket).evaluate();
+        _lastResult = ((MaleStringExpressionSocket)getObject()).evaluate();
         after();
         return _lastResult;
     }
 
     @Override
     public void setState(int s) throws JmriException {
-        ((MaleStringExpressionSocket) _maleSocket).setState(s);
+        ((MaleStringExpressionSocket)getObject()).setState(s);
     }
 
     @Override
     public int getState() {
-        return ((MaleStringExpressionSocket) _maleSocket).getState();
+        return ((MaleStringExpressionSocket)getObject()).getState();
     }
 
     @Override
     public String describeState(int state) {
-        return ((MaleStringExpressionSocket) _maleSocket).describeState(state);
+        return ((MaleStringExpressionSocket)getObject()).describeState(state);
     }
 
     @Override
     public void setProperty(String key, Object value) {
-        ((MaleStringExpressionSocket) _maleSocket).setProperty(key, value);
+        ((MaleStringExpressionSocket)getObject()).setProperty(key, value);
     }
 
     @Override
     public Object getProperty(String key) {
-        return ((MaleStringExpressionSocket) _maleSocket).getProperty(key);
+        return ((MaleStringExpressionSocket)getObject()).getProperty(key);
     }
 
     @Override
     public void removeProperty(String key) {
-        ((MaleStringExpressionSocket) _maleSocket).removeProperty(key);
+        ((MaleStringExpressionSocket)getObject()).removeProperty(key);
     }
 
     @Override
     public Set<String> getPropertyKeys() {
-        return ((MaleStringExpressionSocket) _maleSocket).getPropertyKeys();
+        return ((MaleStringExpressionSocket)getObject()).getPropertyKeys();
     }
 
     @Override
     public String getBeanType() {
-        return ((MaleStringExpressionSocket) _maleSocket).getBeanType();
+        return ((MaleStringExpressionSocket)getObject()).getBeanType();
     }
 
     @Override
     public int compareSystemNameSuffix(String suffix1, String suffix2, NamedBean n2) {
-        return ((MaleStringExpressionSocket) _maleSocket).compareSystemNameSuffix(suffix1, suffix2, n2);
+        return ((MaleStringExpressionSocket)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
 
     @Override
     public void setTriggerOnChange(boolean triggerOnChange) {
-        ((MaleStringExpressionSocket) _maleSocket).setTriggerOnChange(triggerOnChange);
+        ((MaleStringExpressionSocket)getObject()).setTriggerOnChange(triggerOnChange);
     }
 
     @Override
     public boolean getTriggerOnChange() {
-        return ((MaleStringExpressionSocket) _maleSocket).getTriggerOnChange();
+        return ((MaleStringExpressionSocket)getObject()).getTriggerOnChange();
     }
     
 }

--- a/java/src/jmri/jmrit/logixng/tools/swing/ModuleEditorMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/ModuleEditorMaleSocket.java
@@ -17,11 +17,10 @@ import jmri.jmrit.logixng.implementation.AbstractMaleSocket;
  */
 class ModuleEditorMaleSocket extends AbstractMaleSocket {
     
-    Module _module;
+//    Module _module;
 
     public ModuleEditorMaleSocket(BaseManager<? extends NamedBean> manager, Module module) {
-        super(manager);
-        _module = module;
+        super(manager, module);
     }
 
     @Override
@@ -36,7 +35,7 @@ class ModuleEditorMaleSocket extends AbstractMaleSocket {
 
     @Override
     protected void disposeMe() {
-        _module.dispose();
+        ((Module)getObject()).dispose();
     }
 
     @Override
@@ -55,11 +54,6 @@ class ModuleEditorMaleSocket extends AbstractMaleSocket {
     }
 
     @Override
-    public Base getObject() {
-        return _module;
-    }
-
-    @Override
     public void setDebugConfig(DebugConfig config) {
         throw new UnsupportedOperationException("Not supported");
     }
@@ -75,154 +69,14 @@ class ModuleEditorMaleSocket extends AbstractMaleSocket {
     }
 
     @Override
-    public String getSystemName() {
-        return _module.getSystemName();
-    }
-
-    @Override
-    public String getUserName() {
-        return _module.getUserName();
-    }
-
-    @Override
     public String getComment() {
-        return _module.getComment();
-    }
-
-    @Override
-    public void setUserName(String s) throws NamedBean.BadUserNameException {
-        _module.setUserName(s);
+        return ((Module)getObject()).getComment();
     }
 
     @Override
     public void setComment(String comment) {
-        _module.setComment(comment);
+        ((Module)getObject()).setComment(comment);
     }
 
-    @Override
-    public String getShortDescription(Locale locale) {
-        return _module.getShortDescription(locale);
-    }
-
-    @Override
-    public String getLongDescription(Locale locale) {
-        return _module.getLongDescription(locale);
-    }
-/*
-    @Override
-    public ConditionalNG getConditionalNG() {
-        return null;
-    }
-
-    @Override
-    public LogixNG getLogixNG() {
-        return null;
-    }
-*/
-    @Override
-    public Base getRoot() {
-        return _module.getRoot();
-    }
-
-    @Override
-    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
-        return _module.getChild(index);
-    }
-
-    @Override
-    public int getChildCount() {
-        return _module.getChildCount();
-    }
-
-    @Override
-    public Category getCategory() {
-        return _module.getCategory();
-    }
-
-    @Override
-    public boolean isExternal() {
-        return _module.isExternal();
-    }
-
-    @Override
-    public Lock getLock() {
-        return _module.getLock();
-    }
-
-    @Override
-    public void setLock(Lock lock) {
-        _module.setLock(lock);
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener listener, String name, String listenerRef) {
-        _module.addPropertyChangeListener(listener, name, listenerRef);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener, String name, String listenerRef) {
-        _module.addPropertyChangeListener(propertyName, listener, name, listenerRef);
-    }
-
-    @Override
-    public void updateListenerRef(PropertyChangeListener l, String newName) {
-        _module.updateListenerRef(l, newName);
-    }
-
-    @Override
-    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-        _module.vetoableChange(evt);
-    }
-
-    @Override
-    public String getListenerRef(PropertyChangeListener l) {
-        return _module.getListenerRef(l);
-    }
-
-    @Override
-    public ArrayList<String> getListenerRefs() {
-        return _module.getListenerRefs();
-    }
-
-    @Override
-    public int getNumPropertyChangeListeners() {
-        return _module.getNumPropertyChangeListeners();
-    }
-
-    @Override
-    public PropertyChangeListener[] getPropertyChangeListenersByReference(String name) {
-        return _module.getPropertyChangeListenersByReference(name);
-    }
-
-    @Override
-    public void addPropertyChangeListener(PropertyChangeListener listener) {
-        _module.addPropertyChangeListener(listener);
-    }
-
-    @Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener) {
-        _module.addPropertyChangeListener(propertyName, listener);
-    }
-
-    @Override
-    public PropertyChangeListener[] getPropertyChangeListeners() {
-        return _module.getPropertyChangeListeners();
-    }
-
-    @Override
-    public PropertyChangeListener[] getPropertyChangeListeners(String propertyName) {
-        return _module.getPropertyChangeListeners(propertyName);
-    }
-
-    @Override
-    public void removePropertyChangeListener(PropertyChangeListener listener) {
-        _module.removePropertyChangeListener(listener);
-    }
-
-    @Override
-    public void removePropertyChangeListener(String propertyName, PropertyChangeListener listener) {
-        _module.removePropertyChangeListener(propertyName, listener);
-    }
-    
 }
 //    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ConditionalNGEditor.class);

--- a/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
@@ -574,7 +574,10 @@ public class TreeEditor extends TreeViewer {
                             _editActionExpressionDialog = null;
                             _treePane._tree.updateUI();
                             
-                            if (femaleSocket.isActive()) femaleSocket.registerListeners();
+//                            if (femaleSocket.isActive()) femaleSocket.registerListeners();
+                            if (_treePane._femaleRootSocket.isActive()) {
+                                _treePane._femaleRootSocket.registerListeners();
+                            }
                         });
                     } else {
                         StringBuilder errorMsg = new StringBuilder();

--- a/java/test/jmri/jmrit/logixng/FemaleSocketTestBase.java
+++ b/java/test/jmri/jmrit/logixng/FemaleSocketTestBase.java
@@ -756,6 +756,16 @@ public abstract class FemaleSocketTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
+
+        @Override
+        public boolean getListen() {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
+        @Override
+        public void setListen(boolean listen) {
+            throw new UnsupportedOperationException("Not supported");
+        }
         
     }
     

--- a/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
@@ -2273,6 +2273,17 @@ public class StoreAndLoadTest {
         and.getChild(indexExpr++).connect(maleSocket);
         
         
+        Not not = new Not(digitalExpressionManager.getAutoSystemName(), null);
+        maleSocket = digitalExpressionManager.registerExpression(not);
+        maleSocket.setEnabled(false);
+        and.getChild(indexExpr++).connect(maleSocket);
+        
+        not = new Not(digitalExpressionManager.getAutoSystemName(), null);
+        not.setComment("A comment");
+        maleSocket = digitalExpressionManager.registerExpression(not);
+        and.getChild(indexExpr++).connect(maleSocket);
+        
+        
         Or or = new Or(digitalExpressionManager.getAutoSystemName(), null);
         maleSocket = digitalExpressionManager.registerExpression(or);
         maleSocket.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
@@ -18,8 +18,8 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
   <jmriversion>
     <major>4</major>
     <minor>23</minor>
-    <test>1</test>
-    <modifier>ish-logixng</modifier>
+    <test>3</test>
+    <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
@@ -77,7 +77,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <memory>
       <systemName>IM3</systemName>
     </memory>
-    <memory value="6:07 PM">
+    <memory value="1:52 AM">
       <systemName>IMCURRENTTIME</systemName>
     </memory>
     <memory value="1.0">
@@ -116,7 +116,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <userName>First conditional</userName>
     </conditional>
   </conditionals>
-  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sun Mar 07 18:07:31 CET 2021" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Mar 27 01:51:59 CET 2021" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <LogixNGs class="jmri.jmrit.logixng.implementation.configurexml.DefaultLogixNGManagerXml">
     <Thread>
       <id>0</id>
@@ -225,7 +225,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <userName>Yet another conditionalNG</userName>
       <thread>0</thread>
       <Socket>
-        <socketName>MiGxhMInPZ</socketName>
+        <socketName>cDfRMUPNDR</socketName>
         <systemName>IQDA:AUTO:0001</systemName>
       </Socket>
     </ConditionalNG>
@@ -243,12 +243,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Start expression</comment>
       <Expressions>
         <Socket>
-          <socketName>wqaKeDrnve</socketName>
+          <socketName>zPgGbObKPi</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -298,12 +298,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Stop expression</comment>
       <Expressions>
         <Socket>
-          <socketName>PhaHIsRpPH</socketName>
+          <socketName>kFHOKliKMQ</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -353,12 +353,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Start expression</comment>
       <Expressions>
         <Socket>
-          <socketName>ytNWVpbhFQ</socketName>
+          <socketName>QoJEPaPqgT</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -408,12 +408,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Stop expression</comment>
       <Expressions>
         <Socket>
-          <socketName>hUPZTadNUD</socketName>
+          <socketName>jYzIQZdkXZ</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -463,12 +463,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Reset expression</comment>
       <Expressions>
         <Socket>
-          <socketName>osqWKelgWB</socketName>
+          <socketName>ymAoXGBCPg</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -518,12 +518,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Expression socket 1</comment>
       <Expressions>
         <Socket>
-          <socketName>NZPTXWgUyp</socketName>
+          <socketName>TKUVubhgws</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -573,12 +573,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Expression socket 2</comment>
       <Expressions>
         <Socket>
-          <socketName>eqeDnhRAWM</socketName>
+          <socketName>BLKKaRtZQi</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -633,7 +633,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -682,16 +682,16 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0009</systemName>
       <Expressions>
         <Socket>
-          <socketName>SYnhfraGeW</socketName>
+          <socketName>mhLYmhNivk</socketName>
           <systemName>IQDE:AUTO:0010</systemName>
         </Socket>
         <Socket>
-          <socketName>CItqYMgXCj</socketName>
+          <socketName>klIsrdxcGh</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -741,352 +741,360 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>TUUssfznRS</socketName>
+          <socketName>zweXYbZpFQ</socketName>
           <systemName>IQDE:AUTO:0011</systemName>
         </Socket>
         <Socket>
-          <socketName>iQaruuPjHi</socketName>
+          <socketName>GVjCBRkERf</socketName>
           <systemName>IQDE:AUTO:0012</systemName>
         </Socket>
         <Socket>
-          <socketName>ZHPvtGbmbt</socketName>
+          <socketName>RocWhfTIOE</socketName>
           <systemName>IQDE:AUTO:0013</systemName>
         </Socket>
         <Socket>
-          <socketName>CYDfJXyTBp</socketName>
+          <socketName>zsBNncMIod</socketName>
           <systemName>IQDE:AUTO:0014</systemName>
         </Socket>
         <Socket>
-          <socketName>ZibxrtvHxU</socketName>
+          <socketName>WaZdNZCwkP</socketName>
           <systemName>IQDE:AUTO:0015</systemName>
         </Socket>
         <Socket>
-          <socketName>aBTstMdTfc</socketName>
+          <socketName>KxeBsYRqSP</socketName>
           <systemName>IQDE:AUTO:0016</systemName>
         </Socket>
         <Socket>
-          <socketName>auxjuntXhh</socketName>
+          <socketName>NhjZfaRclY</socketName>
           <systemName>IQDE:AUTO:0017</systemName>
         </Socket>
         <Socket>
-          <socketName>RhRaAJwvOc</socketName>
+          <socketName>jCraGuuUWN</socketName>
           <systemName>IQDE:AUTO:0018</systemName>
         </Socket>
         <Socket>
-          <socketName>TxGvIVDtzX</socketName>
+          <socketName>LqsJVmEyuv</socketName>
           <systemName>IQDE:AUTO:0019</systemName>
         </Socket>
         <Socket>
-          <socketName>GsVCICWrcL</socketName>
+          <socketName>yxUxTktIGt</socketName>
           <systemName>IQDE:AUTO:0020</systemName>
         </Socket>
         <Socket>
-          <socketName>dyXwcJzOQU</socketName>
+          <socketName>BSCaVATmRD</socketName>
           <systemName>IQDE:AUTO:0021</systemName>
         </Socket>
         <Socket>
-          <socketName>wflfMaPBee</socketName>
+          <socketName>nMWkNHciIh</socketName>
           <systemName>IQDE:AUTO:0022</systemName>
         </Socket>
         <Socket>
-          <socketName>OAywuNJiQz</socketName>
+          <socketName>FNsJLuGJAd</socketName>
           <systemName>IQDE:AUTO:0023</systemName>
         </Socket>
         <Socket>
-          <socketName>GNwNKRgmQa</socketName>
+          <socketName>HJZIULMHlk</socketName>
           <systemName>IQDE:AUTO:0024</systemName>
         </Socket>
         <Socket>
-          <socketName>FyWubrJhDu</socketName>
+          <socketName>slDWQcGUUu</socketName>
           <systemName>IQDE:AUTO:0025</systemName>
         </Socket>
         <Socket>
-          <socketName>NKZWGnstVE</socketName>
+          <socketName>QLDVHYgeSF</socketName>
           <systemName>IQDE:AUTO:0026</systemName>
         </Socket>
         <Socket>
-          <socketName>lJyTQbchru</socketName>
+          <socketName>DnFYhqlgzY</socketName>
           <systemName>IQDE:AUTO:0027</systemName>
         </Socket>
         <Socket>
-          <socketName>leYuUVBVtx</socketName>
+          <socketName>jGRMphiysM</socketName>
           <systemName>IQDE:AUTO:0028</systemName>
         </Socket>
         <Socket>
-          <socketName>HFCEWsZzta</socketName>
+          <socketName>NJmjymHlBl</socketName>
           <systemName>IQDE:AUTO:0029</systemName>
         </Socket>
         <Socket>
-          <socketName>PTZljGwNKq</socketName>
+          <socketName>QwKDLsMNwP</socketName>
           <systemName>IQDE:AUTO:0030</systemName>
         </Socket>
         <Socket>
-          <socketName>GwZDZkhEQq</socketName>
+          <socketName>JJToCJHVtr</socketName>
           <systemName>IQDE:AUTO:0031</systemName>
         </Socket>
         <Socket>
-          <socketName>uZjCsAkCuE</socketName>
+          <socketName>KFfiQzzUZD</socketName>
           <systemName>IQDE:AUTO:0032</systemName>
         </Socket>
         <Socket>
-          <socketName>JoHIgvZzhS</socketName>
+          <socketName>WZDuqDLgmT</socketName>
           <systemName>IQDE:AUTO:0033</systemName>
         </Socket>
         <Socket>
-          <socketName>KyGERRasiX</socketName>
+          <socketName>zfCjQqbDEq</socketName>
           <systemName>IQDE:AUTO:0034</systemName>
         </Socket>
         <Socket>
-          <socketName>xvJKclYiZS</socketName>
+          <socketName>OeEqqCwDUX</socketName>
           <systemName>IQDE:AUTO:0035</systemName>
         </Socket>
         <Socket>
-          <socketName>evnshfrlbY</socketName>
+          <socketName>RZyngJLkYk</socketName>
           <systemName>IQDE:AUTO:0036</systemName>
         </Socket>
         <Socket>
-          <socketName>PQvnfvYevP</socketName>
+          <socketName>nOhSbtmLuU</socketName>
           <systemName>IQDE:AUTO:0037</systemName>
         </Socket>
         <Socket>
-          <socketName>zOKGtYuiIu</socketName>
+          <socketName>dAOVHfVpkZ</socketName>
           <systemName>IQDE:AUTO:0038</systemName>
         </Socket>
         <Socket>
-          <socketName>eDnTFVUExm</socketName>
+          <socketName>cFTWwIKEti</socketName>
           <systemName>IQDE:AUTO:0039</systemName>
         </Socket>
         <Socket>
-          <socketName>meMTIgbNKv</socketName>
+          <socketName>okIpGPUbMT</socketName>
           <systemName>IQDE:AUTO:0040</systemName>
         </Socket>
         <Socket>
-          <socketName>EMLkatiVoL</socketName>
+          <socketName>QxucnBROtq</socketName>
           <systemName>IQDE:AUTO:0041</systemName>
         </Socket>
         <Socket>
-          <socketName>cXNXEbVMTB</socketName>
+          <socketName>nRCnTLuSeN</socketName>
           <systemName>IQDE:AUTO:0042</systemName>
         </Socket>
         <Socket>
-          <socketName>eihdWOWhxN</socketName>
+          <socketName>uXIcKobZUn</socketName>
           <systemName>IQDE:AUTO:0043</systemName>
         </Socket>
         <Socket>
-          <socketName>FqTXXwseAu</socketName>
+          <socketName>XFtsXVziKs</socketName>
           <systemName>IQDE:AUTO:0044</systemName>
         </Socket>
         <Socket>
-          <socketName>oQlEHtwTaL</socketName>
+          <socketName>DMzZnwMujN</socketName>
           <systemName>IQDE:AUTO:0045</systemName>
         </Socket>
         <Socket>
-          <socketName>ESQEGeKcmC</socketName>
+          <socketName>zAgbFdgbPW</socketName>
           <systemName>IQDE:AUTO:0046</systemName>
         </Socket>
         <Socket>
-          <socketName>bUDyoArDKP</socketName>
+          <socketName>ThVsRVOunE</socketName>
           <systemName>IQDE:AUTO:0047</systemName>
         </Socket>
         <Socket>
-          <socketName>LhGpyrLDrQ</socketName>
+          <socketName>hhPfayKIWj</socketName>
           <systemName>IQDE:AUTO:0048</systemName>
         </Socket>
         <Socket>
-          <socketName>nQsGLjFTvI</socketName>
+          <socketName>GJktNqwZWI</socketName>
           <systemName>IQDE:AUTO:0049</systemName>
         </Socket>
         <Socket>
-          <socketName>WqNSIvZYjt</socketName>
+          <socketName>rGAQusasbl</socketName>
           <systemName>IQDE:AUTO:0050</systemName>
         </Socket>
         <Socket>
-          <socketName>IVgnUKFtiw</socketName>
+          <socketName>coXkYIgXil</socketName>
           <systemName>IQDE:AUTO:0051</systemName>
         </Socket>
         <Socket>
-          <socketName>NKSVZlaYAH</socketName>
+          <socketName>FUKCqHyKKy</socketName>
           <systemName>IQDE:AUTO:0052</systemName>
         </Socket>
         <Socket>
-          <socketName>RADVGmIKFQ</socketName>
+          <socketName>UapefLhmbf</socketName>
           <systemName>IQDE:AUTO:0053</systemName>
         </Socket>
         <Socket>
-          <socketName>LHkpoLztUj</socketName>
+          <socketName>oqyMwZlSUv</socketName>
           <systemName>IQDE:AUTO:0054</systemName>
         </Socket>
         <Socket>
-          <socketName>czKoFBNrGS</socketName>
+          <socketName>FFtGFhGioS</socketName>
           <systemName>IQDE:AUTO:0055</systemName>
         </Socket>
         <Socket>
-          <socketName>TJJgrhJDvY</socketName>
+          <socketName>CUpVlDUiZG</socketName>
           <systemName>IQDE:AUTO:0056</systemName>
         </Socket>
         <Socket>
-          <socketName>cZHusExlMN</socketName>
+          <socketName>QxDntVICxu</socketName>
           <systemName>IQDE:AUTO:0057</systemName>
         </Socket>
         <Socket>
-          <socketName>fGQaJsapPI</socketName>
+          <socketName>lZDEYpWmFS</socketName>
           <systemName>IQDE:AUTO:0058</systemName>
         </Socket>
         <Socket>
-          <socketName>fOgrsuNKDE</socketName>
+          <socketName>meAgScqrHq</socketName>
           <systemName>IQDE:AUTO:0059</systemName>
         </Socket>
         <Socket>
-          <socketName>dmexmEFYOl</socketName>
+          <socketName>ViPnoHVwcC</socketName>
           <systemName>IQDE:AUTO:0060</systemName>
         </Socket>
         <Socket>
-          <socketName>YzxNEdzCxW</socketName>
+          <socketName>XCeZrJAsMP</socketName>
           <systemName>IQDE:AUTO:0061</systemName>
         </Socket>
         <Socket>
-          <socketName>bQBWDlFYRC</socketName>
+          <socketName>zhQbkFhGRU</socketName>
           <systemName>IQDE:AUTO:0062</systemName>
         </Socket>
         <Socket>
-          <socketName>BAMrpssWvr</socketName>
+          <socketName>VNyHiLgVcW</socketName>
           <systemName>IQDE:AUTO:0063</systemName>
         </Socket>
         <Socket>
-          <socketName>rdRFXBVeyK</socketName>
+          <socketName>WeaZExZFlK</socketName>
           <systemName>IQDE:AUTO:0064</systemName>
         </Socket>
         <Socket>
-          <socketName>fSoKkxopTV</socketName>
+          <socketName>WHxqyUWhhS</socketName>
           <systemName>IQDE:AUTO:0065</systemName>
         </Socket>
         <Socket>
-          <socketName>euvYNTSGYd</socketName>
+          <socketName>wYcakEPlKc</socketName>
           <systemName>IQDE:AUTO:0066</systemName>
         </Socket>
         <Socket>
-          <socketName>vYDPVxuVOh</socketName>
+          <socketName>fYDDiZxtHO</socketName>
           <systemName>IQDE:AUTO:0067</systemName>
         </Socket>
         <Socket>
-          <socketName>KHhxajxoHy</socketName>
+          <socketName>FpSsNXWThh</socketName>
           <systemName>IQDE:AUTO:0068</systemName>
         </Socket>
         <Socket>
-          <socketName>aHICceMDUe</socketName>
+          <socketName>heniivDQhC</socketName>
           <systemName>IQDE:AUTO:0069</systemName>
         </Socket>
         <Socket>
-          <socketName>EJoapraVSP</socketName>
+          <socketName>bEEVCYGTxc</socketName>
           <systemName>IQDE:AUTO:0070</systemName>
         </Socket>
         <Socket>
-          <socketName>oSSDadcCzN</socketName>
+          <socketName>CcTdHGbGpa</socketName>
           <systemName>IQDE:AUTO:0071</systemName>
         </Socket>
         <Socket>
-          <socketName>TRYwSglLpI</socketName>
+          <socketName>LdXzgVUtHP</socketName>
           <systemName>IQDE:AUTO:0072</systemName>
         </Socket>
         <Socket>
-          <socketName>dFnkiPGESj</socketName>
+          <socketName>bHbRaiughV</socketName>
           <systemName>IQDE:AUTO:0073</systemName>
         </Socket>
         <Socket>
-          <socketName>vcXaynJyqM</socketName>
+          <socketName>cvqrkmyYrc</socketName>
           <systemName>IQDE:AUTO:0074</systemName>
         </Socket>
         <Socket>
-          <socketName>gJDzGYvAGs</socketName>
+          <socketName>rfEgtOqocL</socketName>
           <systemName>IQDE:AUTO:0075</systemName>
         </Socket>
         <Socket>
-          <socketName>mOWOZmlEzn</socketName>
+          <socketName>tlxyrZIkXD</socketName>
           <systemName>IQDE:AUTO:0076</systemName>
         </Socket>
         <Socket>
-          <socketName>bDmbUOyznZ</socketName>
+          <socketName>WGAFvAdQWM</socketName>
           <systemName>IQDE:AUTO:0077</systemName>
         </Socket>
         <Socket>
-          <socketName>TaTMujKeup</socketName>
+          <socketName>qgUPHeguOx</socketName>
           <systemName>IQDE:AUTO:0078</systemName>
         </Socket>
         <Socket>
-          <socketName>oyxhhZHGok</socketName>
+          <socketName>LEdVgfIkFK</socketName>
           <systemName>IQDE:AUTO:0079</systemName>
         </Socket>
         <Socket>
-          <socketName>evrEyqYujx</socketName>
+          <socketName>mGCmirFFCf</socketName>
           <systemName>IQDE:AUTO:0080</systemName>
         </Socket>
         <Socket>
-          <socketName>rAXoUceNfc</socketName>
+          <socketName>gxYnODdqjz</socketName>
           <systemName>IQDE:AUTO:0081</systemName>
         </Socket>
         <Socket>
-          <socketName>cXOHgXvvTK</socketName>
+          <socketName>JHPWhvAath</socketName>
           <systemName>IQDE:AUTO:0082</systemName>
         </Socket>
         <Socket>
-          <socketName>GvyVihkYLM</socketName>
+          <socketName>baoRcHpuhC</socketName>
           <systemName>IQDE:AUTO:0083</systemName>
         </Socket>
         <Socket>
-          <socketName>BjdFwxBCFI</socketName>
+          <socketName>sLdnJqHUGj</socketName>
           <systemName>IQDE:AUTO:0084</systemName>
         </Socket>
         <Socket>
-          <socketName>HBYAKoaUpR</socketName>
+          <socketName>sOnVgdJMCM</socketName>
           <systemName>IQDE:AUTO:0085</systemName>
         </Socket>
         <Socket>
-          <socketName>nqygcKUIjO</socketName>
+          <socketName>liNsTsKUnh</socketName>
           <systemName>IQDE:AUTO:0086</systemName>
         </Socket>
         <Socket>
-          <socketName>yRIOFXzOjy</socketName>
+          <socketName>UlCxAOioVy</socketName>
           <systemName>IQDE:AUTO:0087</systemName>
         </Socket>
         <Socket>
-          <socketName>xUeGMNIXZO</socketName>
+          <socketName>lCXhaYUQSf</socketName>
           <systemName>IQDE:AUTO:0088</systemName>
         </Socket>
         <Socket>
-          <socketName>wfkoRwBWvr</socketName>
+          <socketName>gNnJIwKjEP</socketName>
           <systemName>IQDE:AUTO:0089</systemName>
         </Socket>
         <Socket>
-          <socketName>BcjXeiDDBi</socketName>
+          <socketName>cGRKzfphJF</socketName>
           <systemName>IQDE:AUTO:0090</systemName>
         </Socket>
         <Socket>
-          <socketName>ahGkrImtuQ</socketName>
+          <socketName>zakNGdJbzu</socketName>
           <systemName>IQDE:AUTO:0091</systemName>
         </Socket>
         <Socket>
-          <socketName>hxxFEBrsud</socketName>
+          <socketName>vrixXqLwqu</socketName>
           <systemName>IQDE:AUTO:0092</systemName>
         </Socket>
         <Socket>
-          <socketName>LciKyhwNnR</socketName>
+          <socketName>CzTnAKdKzK</socketName>
           <systemName>IQDE:AUTO:0093</systemName>
         </Socket>
         <Socket>
-          <socketName>LCpDsVDwbU</socketName>
+          <socketName>XIlypFPIjL</socketName>
           <systemName>IQDE:AUTO:0094</systemName>
         </Socket>
         <Socket>
-          <socketName>wKKRbRSIOg</socketName>
+          <socketName>THRPzKNPCj</socketName>
           <systemName>IQDE:AUTO:0095</systemName>
         </Socket>
         <Socket>
-          <socketName>yHWcPxJjjJ</socketName>
+          <socketName>tOwtiPHbZl</socketName>
+          <systemName>IQDE:AUTO:0096</systemName>
+        </Socket>
+        <Socket>
+          <socketName>FhgsRgIxnL</socketName>
+          <systemName>IQDE:AUTO:0097</systemName>
+        </Socket>
+        <Socket>
+          <socketName>RblxrXMyvv</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1136,12 +1144,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent />
       <Expressions>
         <Socket>
-          <socketName>pyWqxDwmbj</socketName>
+          <socketName>kHBplSaxGL</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1191,12 +1199,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent />
       <Expressions>
         <Socket>
-          <socketName>ZONsQEWGfe</socketName>
+          <socketName>ZSHibKqiiU</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1247,12 +1255,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent>R1 or R2</antecedent>
       <Expressions>
         <Socket>
-          <socketName>pWJZsJwoeo</socketName>
+          <socketName>ilZKYRdFRv</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1302,12 +1310,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent />
       <Expressions>
         <Socket>
-          <socketName>zUgesPGJfm</socketName>
+          <socketName>aRzGIdTPkS</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogErrorOnce</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1357,12 +1365,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent />
       <Expressions>
         <Socket>
-          <socketName>gBTuszkzoS</socketName>
+          <socketName>GbdYAPjCgj</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>ShowDialogBox</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1412,12 +1420,12 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <antecedent />
       <Expressions>
         <Socket>
-          <socketName>hSQzhxmwEc</socketName>
+          <socketName>JQMmPvkciV</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>ThrowException</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1470,7 +1478,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <endTime>0</endTime>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1524,7 +1532,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <endTime>20</endTime>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1583,7 +1591,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1644,7 +1652,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1705,7 +1713,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1766,7 +1774,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1827,7 +1835,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1886,7 +1894,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -1946,7 +1954,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2006,7 +2014,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2066,7 +2074,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2126,7 +2134,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2185,7 +2193,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2246,7 +2254,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2307,7 +2315,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2368,7 +2376,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2429,7 +2437,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2484,7 +2492,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2540,7 +2548,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2598,7 +2606,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2656,7 +2664,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2714,7 +2722,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx>/^Test$/</regEx>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2769,7 +2777,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2826,7 +2834,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2884,7 +2892,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -2942,7 +2950,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3000,7 +3008,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <regEx>/^Hello$/</regEx>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3059,7 +3067,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3120,7 +3128,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3181,7 +3189,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3242,7 +3250,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3303,7 +3311,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3354,7 +3362,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <powerState>On</powerState>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3406,7 +3414,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <powerState>Off</powerState>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3458,7 +3466,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <powerState>On</powerState>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3510,7 +3518,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <powerState>Other</powerState>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3562,7 +3570,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <pointsTo>LogixNGTable</pointsTo>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3615,7 +3623,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <pointsTo>Light</pointsTo>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3664,7 +3672,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0055</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3714,7 +3722,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3773,7 +3781,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3834,7 +3842,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3895,7 +3903,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -3956,7 +3964,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4017,7 +4025,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4080,7 +4088,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <appearanceFormula />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4146,7 +4154,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <exampleSignalHead>IH2</exampleSignalHead>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4211,7 +4219,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <appearanceFormula>"IT"+index3</appearanceFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4276,7 +4284,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <appearanceFormula>"IT"+index3</appearanceFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4341,7 +4349,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <appearanceFormula>"IT"+index3</appearanceFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4404,7 +4412,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <aspectFormula />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4470,7 +4478,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <exampleSignalMast>IF$shsm:AAR-1946:CPL(IH1)</exampleSignalMast>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4535,7 +4543,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <aspectFormula>"IT"+index3</aspectFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4600,7 +4608,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <aspectFormula>"IT"+index3</aspectFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4665,7 +4673,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <aspectFormula>"IT"+index3</aspectFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4724,7 +4732,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4785,7 +4793,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4846,7 +4854,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4907,7 +4915,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -4968,7 +4976,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5027,7 +5035,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5087,7 +5095,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5147,7 +5155,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5207,7 +5215,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5267,7 +5275,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <stateFormula>"IT"+index2</stateFormula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5316,7 +5324,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0082</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5366,7 +5374,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5415,13 +5423,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0084</systemName>
       <Expressions>
         <Socket>
-          <socketName>mYInfKVhMX</socketName>
+          <socketName>hGWIdaAadL</socketName>
         </Socket>
       </Expressions>
       <formula />
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5471,13 +5479,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>qlifmQiTXp</socketName>
+          <socketName>tDBJIplYbN</socketName>
         </Socket>
       </Expressions>
       <formula>n + 1</formula>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5525,14 +5533,14 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <Hold class="jmri.jmrit.logixng.expressions.configurexml.HoldXml">
       <systemName>IQDE:AUTO:0086</systemName>
       <TriggerSocket>
-        <socketName>WXiMDMYIau</socketName>
+        <socketName>rEyfqNlrGg</socketName>
       </TriggerSocket>
       <HoldSocket>
-        <socketName>UtOKDKjJbP</socketName>
+        <socketName>ciHYUdahvW</socketName>
       </HoldSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5582,14 +5590,14 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <userName>A hold expression</userName>
       <comment>A comment</comment>
       <TriggerSocket>
-        <socketName>fUNDDOPZRe</socketName>
+        <socketName>JItDvizhoK</socketName>
       </TriggerSocket>
       <HoldSocket>
-        <socketName>ELeXnNRwaU</socketName>
+        <socketName>vTFnUSToMD</socketName>
       </HoldSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5638,7 +5646,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDE:AUTO:0088</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5689,7 +5697,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <expression>A hold expression</expression>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5734,16 +5742,121 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         </AbstractMaleSocket>
       </MaleSocket>
     </LastResultOfDigitalExpression>
-    <Or class="jmri.jmrit.logixng.expressions.configurexml.OrXml">
+    <Not class="jmri.jmrit.logixng.expressions.configurexml.NotXml">
       <systemName>IQDE:AUTO:0090</systemName>
+      <Socket>
+        <socketName>wtKXyjrnqE</socketName>
+      </Socket>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
+          <errorHandling>LogError</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </Not>
+    <Not class="jmri.jmrit.logixng.expressions.configurexml.NotXml">
+      <systemName>IQDE:AUTO:0091</systemName>
+      <comment>A comment</comment>
+      <Socket>
+        <socketName>RDSuLlTMNk</socketName>
+      </Socket>
+      <MaleSocket>
+        <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
+          <errorHandling>LogError</errorHandling>
+          <LocalVariable>
+            <name>A1</name>
+            <type>None</type>
+            <data />
+          </LocalVariable>
+          <LocalVariable>
+            <name>A2</name>
+            <type>Integer</type>
+            <data>32</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A3</name>
+            <type>FloatingNumber</type>
+            <data>41.429</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A4</name>
+            <type>String</type>
+            <data>My string</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A5</name>
+            <type>LocalVariable</type>
+            <data>index</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A6</name>
+            <type>Memory</type>
+            <data>IM2</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A7</name>
+            <type>Reference</type>
+            <data>{IM3}</data>
+          </LocalVariable>
+          <LocalVariable>
+            <name>A8</name>
+            <type>Formula</type>
+            <data>index * 2</data>
+          </LocalVariable>
+        </AbstractMaleSocket>
+      </MaleSocket>
+    </Not>
+    <Or class="jmri.jmrit.logixng.expressions.configurexml.OrXml">
+      <systemName>IQDE:AUTO:0092</systemName>
       <Expressions>
         <Socket>
-          <socketName>BxbWUXteuz</socketName>
+          <socketName>MGDPeVyvnI</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5789,16 +5902,16 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Or>
     <Or class="jmri.jmrit.logixng.expressions.configurexml.OrXml">
-      <systemName>IQDE:AUTO:0091</systemName>
+      <systemName>IQDE:AUTO:0093</systemName>
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>RjKiIlOpTQ</socketName>
+          <socketName>OQRPxxHhqf</socketName>
         </Socket>
       </Expressions>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5844,13 +5957,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </Or>
     <TriggerOnce class="jmri.jmrit.logixng.expressions.configurexml.TriggerOnceXml">
-      <systemName>IQDE:AUTO:0092</systemName>
+      <systemName>IQDE:AUTO:0094</systemName>
       <Socket>
-        <socketName>VrsvDiBKsr</socketName>
+        <socketName>MNSfNZyEmy</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5896,14 +6009,14 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </TriggerOnce>
     <TriggerOnce class="jmri.jmrit.logixng.expressions.configurexml.TriggerOnceXml">
-      <systemName>IQDE:AUTO:0093</systemName>
+      <systemName>IQDE:AUTO:0095</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>OMppydoCnO</socketName>
+        <socketName>RYqEyyxHxa</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5949,10 +6062,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </TriggerOnce>
     <True class="jmri.jmrit.logixng.expressions.configurexml.TrueXml">
-      <systemName>IQDE:AUTO:0094</systemName>
+      <systemName>IQDE:AUTO:0096</systemName>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -5998,11 +6111,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       </MaleSocket>
     </True>
     <True class="jmri.jmrit.logixng.expressions.configurexml.TrueXml">
-      <systemName>IQDE:AUTO:0095</systemName>
+      <systemName>IQDE:AUTO:0097</systemName>
       <comment>A comment</comment>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
-        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml">
+        <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
           <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
@@ -6067,491 +6180,491 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0001</systemName>
       <Actions>
         <Socket>
-          <socketName>VWxFrSsvSU</socketName>
+          <socketName>IUTJHmLQHr</socketName>
           <systemName>IQDA:AUTO:0002</systemName>
         </Socket>
         <Socket>
-          <socketName>JDYClqqhqK</socketName>
+          <socketName>lBVHgJtxBK</socketName>
           <systemName>IQDA:AUTO:0003</systemName>
         </Socket>
         <Socket>
-          <socketName>DZIqMCjEJW</socketName>
+          <socketName>BDruktloSE</socketName>
           <systemName>IQDA:AUTO:0004</systemName>
         </Socket>
         <Socket>
-          <socketName>TIqgFoxHLw</socketName>
+          <socketName>BHflFKGCra</socketName>
           <systemName>IQDA:AUTO:0005</systemName>
         </Socket>
         <Socket>
-          <socketName>YiRovPKAMv</socketName>
+          <socketName>piNNJYJqdV</socketName>
           <systemName>IQDA:AUTO:0006</systemName>
         </Socket>
         <Socket>
-          <socketName>VDKWtlQiJS</socketName>
+          <socketName>aIxcbmGjig</socketName>
           <systemName>IQDA:AUTO:0007</systemName>
         </Socket>
         <Socket>
-          <socketName>jywIBTYnsT</socketName>
+          <socketName>NmuNiPYLvR</socketName>
           <systemName>IQDA:AUTO:0008</systemName>
         </Socket>
         <Socket>
-          <socketName>vvKDvPCiJn</socketName>
+          <socketName>UIwMmyJWHh</socketName>
           <systemName>IQDA:AUTO:0009</systemName>
         </Socket>
         <Socket>
-          <socketName>tjMrOrRovX</socketName>
+          <socketName>huxbBqdGMJ</socketName>
           <systemName>IQDA:AUTO:0010</systemName>
         </Socket>
         <Socket>
-          <socketName>UyzOmEZfZK</socketName>
+          <socketName>pMrDiohMAu</socketName>
           <systemName>IQDA:AUTO:0011</systemName>
         </Socket>
         <Socket>
-          <socketName>rmcCUtCoVa</socketName>
+          <socketName>KkkUMixCLM</socketName>
           <systemName>IQDA:AUTO:0012</systemName>
         </Socket>
         <Socket>
-          <socketName>cYBfTTuXzE</socketName>
+          <socketName>nPRfJFNVyr</socketName>
           <systemName>IQDA:AUTO:0013</systemName>
         </Socket>
         <Socket>
-          <socketName>QCqTpvmfOR</socketName>
+          <socketName>UjSubCqVMI</socketName>
           <systemName>IQDA:AUTO:0014</systemName>
         </Socket>
         <Socket>
-          <socketName>HbooEGFoxO</socketName>
+          <socketName>GVZHDjWxWf</socketName>
           <systemName>IQDA:AUTO:0015</systemName>
         </Socket>
         <Socket>
-          <socketName>UXbMpTmllM</socketName>
+          <socketName>rHzUpOArUB</socketName>
           <systemName>IQDA:AUTO:0016</systemName>
         </Socket>
         <Socket>
-          <socketName>YyOEMfOqWP</socketName>
+          <socketName>OTGgTBYEaD</socketName>
           <systemName>IQDA:AUTO:0017</systemName>
         </Socket>
         <Socket>
-          <socketName>iwvnIFlwDJ</socketName>
+          <socketName>NzZxncwklX</socketName>
           <systemName>IQDA:AUTO:0018</systemName>
         </Socket>
         <Socket>
-          <socketName>GEjkJkpBWp</socketName>
+          <socketName>zCXWqPCTIg</socketName>
           <systemName>IQDA:AUTO:0019</systemName>
         </Socket>
         <Socket>
-          <socketName>OQkCkuQhpW</socketName>
+          <socketName>eFzufOsufa</socketName>
           <systemName>IQDA:AUTO:0020</systemName>
         </Socket>
         <Socket>
-          <socketName>xtvbEcPxlt</socketName>
+          <socketName>jpCVHKnAdM</socketName>
           <systemName>IQDA:AUTO:0021</systemName>
         </Socket>
         <Socket>
-          <socketName>jIsLWNNAlg</socketName>
+          <socketName>QtDUXxssyd</socketName>
           <systemName>IQDA:AUTO:0022</systemName>
         </Socket>
         <Socket>
-          <socketName>xAeOSQQWUZ</socketName>
+          <socketName>oBwtAemxRV</socketName>
           <systemName>IQDA:AUTO:0023</systemName>
         </Socket>
         <Socket>
-          <socketName>SZncrARFOx</socketName>
+          <socketName>SAufQddOmW</socketName>
           <systemName>IQDA:AUTO:0024</systemName>
         </Socket>
         <Socket>
-          <socketName>CpgVQRpWiz</socketName>
+          <socketName>XxdOywCknD</socketName>
           <systemName>IQDA:AUTO:0025</systemName>
         </Socket>
         <Socket>
-          <socketName>GgVJfqfRGP</socketName>
+          <socketName>CZAtMWOyFH</socketName>
           <systemName>IQDA:AUTO:0026</systemName>
         </Socket>
         <Socket>
-          <socketName>NPGivxMbWA</socketName>
+          <socketName>BVZHXzmQmO</socketName>
           <systemName>IQDA:AUTO:0027</systemName>
         </Socket>
         <Socket>
-          <socketName>nPttGgSOYW</socketName>
+          <socketName>aLxjQIsnII</socketName>
           <systemName>IQDA:AUTO:0028</systemName>
         </Socket>
         <Socket>
-          <socketName>PnvmrVzHEA</socketName>
+          <socketName>HPzaamwLuw</socketName>
           <systemName>IQDA:AUTO:0029</systemName>
         </Socket>
         <Socket>
-          <socketName>cRJDhIPExM</socketName>
+          <socketName>OgJdtKthKe</socketName>
           <systemName>IQDA:AUTO:0030</systemName>
         </Socket>
         <Socket>
-          <socketName>BosfsTfYOD</socketName>
+          <socketName>RhWuAXWZJq</socketName>
           <systemName>IQDA:AUTO:0031</systemName>
         </Socket>
         <Socket>
-          <socketName>VgBmloLIkv</socketName>
+          <socketName>TWEucREAzY</socketName>
           <systemName>IQDA:AUTO:0032</systemName>
         </Socket>
         <Socket>
-          <socketName>CwUGEmLWnS</socketName>
+          <socketName>dahpvGrQuX</socketName>
           <systemName>IQDA:AUTO:0033</systemName>
         </Socket>
         <Socket>
-          <socketName>JeLudBdmsb</socketName>
+          <socketName>SfjCxfcSmq</socketName>
           <systemName>IQDA:AUTO:0034</systemName>
         </Socket>
         <Socket>
-          <socketName>gYcdXVJpSX</socketName>
+          <socketName>RqvOJDciLC</socketName>
           <systemName>IQDA:AUTO:0035</systemName>
         </Socket>
         <Socket>
-          <socketName>sNqHkBrjaD</socketName>
+          <socketName>NWPjhNEbUs</socketName>
           <systemName>IQDA:AUTO:0036</systemName>
         </Socket>
         <Socket>
-          <socketName>jqHqAqQTlr</socketName>
+          <socketName>EfvKVLMiLA</socketName>
           <systemName>IQDA:AUTO:0037</systemName>
         </Socket>
         <Socket>
-          <socketName>wUakjYxCMv</socketName>
+          <socketName>LMqshRewwp</socketName>
           <systemName>IQDA:AUTO:0038</systemName>
         </Socket>
         <Socket>
-          <socketName>OWWFRXgFoU</socketName>
+          <socketName>LqEgyxwcuf</socketName>
           <systemName>IQDA:AUTO:0039</systemName>
         </Socket>
         <Socket>
-          <socketName>TjkwbhRhwy</socketName>
+          <socketName>JbyIfdbuPJ</socketName>
           <systemName>IQDA:AUTO:0040</systemName>
         </Socket>
         <Socket>
-          <socketName>vihccBKYzT</socketName>
+          <socketName>jZkTuFItpc</socketName>
           <systemName>IQDA:AUTO:0041</systemName>
         </Socket>
         <Socket>
-          <socketName>cIuWMXqFPg</socketName>
+          <socketName>qAxmxBpvPj</socketName>
           <systemName>IQDA:AUTO:0042</systemName>
         </Socket>
         <Socket>
-          <socketName>KRMziIAUCr</socketName>
+          <socketName>hdwSFQuLbL</socketName>
           <systemName>IQDA:AUTO:0043</systemName>
         </Socket>
         <Socket>
-          <socketName>BVJzpLiPrk</socketName>
+          <socketName>vsLEccaRWZ</socketName>
           <systemName>IQDA:AUTO:0044</systemName>
         </Socket>
         <Socket>
-          <socketName>lEAIvTfaTk</socketName>
+          <socketName>FZPLlRLyDG</socketName>
           <systemName>IQDA:AUTO:0045</systemName>
         </Socket>
         <Socket>
-          <socketName>omtsIirlxg</socketName>
+          <socketName>XMoEiLaNdP</socketName>
           <systemName>IQDA:AUTO:0046</systemName>
         </Socket>
         <Socket>
-          <socketName>DrIRYHbGZI</socketName>
+          <socketName>dJnBmxOkSc</socketName>
           <systemName>IQDA:AUTO:0047</systemName>
         </Socket>
         <Socket>
-          <socketName>bdZokHlESr</socketName>
+          <socketName>MfbUGwYSxC</socketName>
           <systemName>IQDA:AUTO:0048</systemName>
         </Socket>
         <Socket>
-          <socketName>OMllQKunBO</socketName>
+          <socketName>CzpVzeIzoV</socketName>
           <systemName>IQDA:AUTO:0049</systemName>
         </Socket>
         <Socket>
-          <socketName>YprWbTcDHI</socketName>
+          <socketName>hVkDMPvuSU</socketName>
           <systemName>IQDA:AUTO:0050</systemName>
         </Socket>
         <Socket>
-          <socketName>hbyszcRgLh</socketName>
+          <socketName>wuIiZJkCop</socketName>
           <systemName>IQDA:AUTO:0051</systemName>
         </Socket>
         <Socket>
-          <socketName>aVQGOlQRna</socketName>
+          <socketName>tOSGuMyPeZ</socketName>
           <systemName>IQDA:AUTO:0052</systemName>
         </Socket>
         <Socket>
-          <socketName>TURHUcFLci</socketName>
+          <socketName>uIsQpZWpAQ</socketName>
           <systemName>IQDA:AUTO:0053</systemName>
         </Socket>
         <Socket>
-          <socketName>EyJkPTXgkW</socketName>
+          <socketName>SgeZdZDQfX</socketName>
           <systemName>IQDA:AUTO:0054</systemName>
         </Socket>
         <Socket>
-          <socketName>wuHePVknXN</socketName>
+          <socketName>wxSgAnrebC</socketName>
           <systemName>IQDA:AUTO:0055</systemName>
         </Socket>
         <Socket>
-          <socketName>HHKFglRHpo</socketName>
+          <socketName>VphoXmsBZD</socketName>
           <systemName>IQDA:AUTO:0056</systemName>
         </Socket>
         <Socket>
-          <socketName>dbCnZmBPfu</socketName>
+          <socketName>wLYgKBoJzK</socketName>
           <systemName>IQDA:AUTO:0057</systemName>
         </Socket>
         <Socket>
-          <socketName>ihZUFcyIEr</socketName>
+          <socketName>xQUiGUfXrf</socketName>
           <systemName>IQDA:AUTO:0058</systemName>
         </Socket>
         <Socket>
-          <socketName>YOWiywZsHG</socketName>
+          <socketName>OattmUnUEq</socketName>
           <systemName>IQDA:AUTO:0059</systemName>
         </Socket>
         <Socket>
-          <socketName>WpfkYJyxxd</socketName>
+          <socketName>MRznzhByvX</socketName>
           <systemName>IQDA:AUTO:0062</systemName>
         </Socket>
         <Socket>
-          <socketName>jJRGNsOTwi</socketName>
+          <socketName>fYgrYFtJsA</socketName>
           <systemName>IQDA:AUTO:0063</systemName>
         </Socket>
         <Socket>
-          <socketName>MJDfVZjOfD</socketName>
+          <socketName>CyeWAbWonl</socketName>
           <systemName>IQDA:AUTO:0064</systemName>
         </Socket>
         <Socket>
-          <socketName>ybNMSDlvbZ</socketName>
+          <socketName>SoaIjWunfg</socketName>
           <systemName>IQDA:AUTO:0065</systemName>
         </Socket>
         <Socket>
-          <socketName>eMfRcqfCgn</socketName>
+          <socketName>aLnGHkmFpf</socketName>
           <systemName>IQDA:AUTO:0066</systemName>
         </Socket>
         <Socket>
-          <socketName>SupsbtNTVW</socketName>
+          <socketName>tRReaQRGec</socketName>
           <systemName>IQDA:AUTO:0067</systemName>
         </Socket>
         <Socket>
-          <socketName>nlTdNmaMPL</socketName>
+          <socketName>OEutWFLbDI</socketName>
           <systemName>IQDA:AUTO:0068</systemName>
         </Socket>
         <Socket>
-          <socketName>VyRvOSsqeP</socketName>
+          <socketName>OySTMtXnWN</socketName>
           <systemName>IQDA:AUTO:0069</systemName>
         </Socket>
         <Socket>
-          <socketName>QmehqQMmOQ</socketName>
+          <socketName>OUdZNzkwSp</socketName>
           <systemName>IQDA:AUTO:0070</systemName>
         </Socket>
         <Socket>
-          <socketName>VwyeYIhDzm</socketName>
+          <socketName>jAHnMLmIEG</socketName>
           <systemName>IQDA:AUTO:0071</systemName>
         </Socket>
         <Socket>
-          <socketName>qvnbxSllaZ</socketName>
+          <socketName>HFMVVcQxVk</socketName>
           <systemName>IQDA:AUTO:0072</systemName>
         </Socket>
         <Socket>
-          <socketName>zBRFVgQlbR</socketName>
+          <socketName>kInkXOJbaJ</socketName>
           <systemName>IQDA:AUTO:0073</systemName>
         </Socket>
         <Socket>
-          <socketName>JXrLjAcbOr</socketName>
+          <socketName>VAVZljUEXI</socketName>
           <systemName>IQDA:AUTO:0074</systemName>
         </Socket>
         <Socket>
-          <socketName>sZVCEMkimr</socketName>
+          <socketName>PoMktllNiN</socketName>
           <systemName>IQDA:AUTO:0075</systemName>
         </Socket>
         <Socket>
-          <socketName>CFKSEaIDgW</socketName>
+          <socketName>YPNvbUbfHu</socketName>
           <systemName>IQDA:AUTO:0076</systemName>
         </Socket>
         <Socket>
-          <socketName>CoELeRcPSM</socketName>
+          <socketName>pavnhSxlrM</socketName>
           <systemName>IQDA:AUTO:0077</systemName>
         </Socket>
         <Socket>
-          <socketName>OtlZwVjnLs</socketName>
+          <socketName>HChyvDqHvW</socketName>
           <systemName>IQDA:AUTO:0078</systemName>
         </Socket>
         <Socket>
-          <socketName>JLeTgrTdUA</socketName>
+          <socketName>jBPiWiDbOQ</socketName>
           <systemName>IQDA:AUTO:0079</systemName>
         </Socket>
         <Socket>
-          <socketName>lLCyUGoKwY</socketName>
+          <socketName>mnTxpbmCUf</socketName>
           <systemName>IQDA:AUTO:0080</systemName>
         </Socket>
         <Socket>
-          <socketName>dApaZomNKg</socketName>
+          <socketName>mTrVzibmWW</socketName>
           <systemName>IQDA:AUTO:0081</systemName>
         </Socket>
         <Socket>
-          <socketName>qcDcTUzDxV</socketName>
+          <socketName>JuqRnBJLhx</socketName>
           <systemName>IQDA:AUTO:0082</systemName>
         </Socket>
         <Socket>
-          <socketName>kspNVkkLdy</socketName>
+          <socketName>QfHJjcuJKm</socketName>
           <systemName>IQDA:AUTO:0083</systemName>
         </Socket>
         <Socket>
-          <socketName>cjOdZBdwEW</socketName>
+          <socketName>xeogyQtCBO</socketName>
           <systemName>IQDA:AUTO:0084</systemName>
         </Socket>
         <Socket>
-          <socketName>MNHePqTtjK</socketName>
+          <socketName>nJkCPSHQQS</socketName>
           <systemName>IQDA:AUTO:0085</systemName>
         </Socket>
         <Socket>
-          <socketName>mUGXBosGBo</socketName>
+          <socketName>YLgTYuxcft</socketName>
           <systemName>IQDA:AUTO:0086</systemName>
         </Socket>
         <Socket>
-          <socketName>kBiJyGoDJX</socketName>
+          <socketName>xsvJIqJIOK</socketName>
           <systemName>IQDA:AUTO:0087</systemName>
         </Socket>
         <Socket>
-          <socketName>uQAjusgFbP</socketName>
+          <socketName>kQFDTeIPQW</socketName>
           <systemName>IQDA:AUTO:0088</systemName>
         </Socket>
         <Socket>
-          <socketName>vrCytNAKbM</socketName>
+          <socketName>WknZxbvjTR</socketName>
           <systemName>IQDA:AUTO:0089</systemName>
         </Socket>
         <Socket>
-          <socketName>AENzvJrMvp</socketName>
+          <socketName>ClYVnuqFEO</socketName>
           <systemName>IQDA:AUTO:0090</systemName>
         </Socket>
         <Socket>
-          <socketName>CBSgPsXMGQ</socketName>
+          <socketName>jqZOvTbJsf</socketName>
           <systemName>IQDA:AUTO:0091</systemName>
         </Socket>
         <Socket>
-          <socketName>NYAVxhZIcw</socketName>
+          <socketName>PaUzgPtQfH</socketName>
           <systemName>IQDA:AUTO:0092</systemName>
         </Socket>
         <Socket>
-          <socketName>KHSRudNOza</socketName>
+          <socketName>HTbQptIJRn</socketName>
           <systemName>IQDA:AUTO:0093</systemName>
         </Socket>
         <Socket>
-          <socketName>AhTVwfWBBn</socketName>
+          <socketName>OjQDtLgLPd</socketName>
           <systemName>IQDA:AUTO:0094</systemName>
         </Socket>
         <Socket>
-          <socketName>FTvsKHxtNW</socketName>
+          <socketName>YzFcGqWqwb</socketName>
           <systemName>IQDA:AUTO:0095</systemName>
         </Socket>
         <Socket>
-          <socketName>SapjHLbnfp</socketName>
+          <socketName>fWIIcvNQuY</socketName>
           <systemName>IQDA:AUTO:0096</systemName>
         </Socket>
         <Socket>
-          <socketName>rMjkaKlWUp</socketName>
+          <socketName>wrfwQxeaMV</socketName>
           <systemName>IQDA:AUTO:0097</systemName>
         </Socket>
         <Socket>
-          <socketName>zRValqFjPF</socketName>
+          <socketName>clFyaKxugO</socketName>
           <systemName>IQDA:AUTO:0098</systemName>
         </Socket>
         <Socket>
-          <socketName>uJtKNXlndq</socketName>
+          <socketName>ESMUJXjqDl</socketName>
           <systemName>IQDA:AUTO:0099</systemName>
         </Socket>
         <Socket>
-          <socketName>lNABWsDlNy</socketName>
+          <socketName>BtUlEhitNe</socketName>
           <systemName>IQDA:AUTO:0100</systemName>
         </Socket>
         <Socket>
-          <socketName>lsWcOExbyq</socketName>
+          <socketName>DTBgUSJGce</socketName>
           <systemName>IQDA:AUTO:0103</systemName>
         </Socket>
         <Socket>
-          <socketName>vtyOiMsRQP</socketName>
+          <socketName>gIOAFNaJIe</socketName>
           <systemName>IQDA:AUTO:0104</systemName>
         </Socket>
         <Socket>
-          <socketName>MzLnTSsXQY</socketName>
+          <socketName>uLSmPuIafc</socketName>
           <systemName>IQDA:AUTO:0105</systemName>
         </Socket>
         <Socket>
-          <socketName>ntVrseIriT</socketName>
+          <socketName>ukPUjrfipG</socketName>
           <systemName>IQDA:AUTO:0106</systemName>
         </Socket>
         <Socket>
-          <socketName>qjyfVljXCU</socketName>
+          <socketName>jCOykwnWXV</socketName>
           <systemName>IQDA:AUTO:0107</systemName>
         </Socket>
         <Socket>
-          <socketName>naSLvZgqUz</socketName>
+          <socketName>cDIqFfLByR</socketName>
           <systemName>IQDA:AUTO:0108</systemName>
         </Socket>
         <Socket>
-          <socketName>xnLjgHunLV</socketName>
+          <socketName>yVdmidKutU</socketName>
           <systemName>IQDA:AUTO:0109</systemName>
         </Socket>
         <Socket>
-          <socketName>iTlZgmKpLj</socketName>
+          <socketName>jBQMrGRjcA</socketName>
           <systemName>IQDA:AUTO:0111</systemName>
         </Socket>
         <Socket>
-          <socketName>IcsgiTNIad</socketName>
+          <socketName>fAeEUIqrwC</socketName>
           <systemName>IQDA:AUTO:0113</systemName>
         </Socket>
         <Socket>
-          <socketName>pJLeOAfVSZ</socketName>
+          <socketName>unYnZSsgPl</socketName>
           <systemName>IQDA:AUTO:0114</systemName>
         </Socket>
         <Socket>
-          <socketName>llncaCCxbu</socketName>
+          <socketName>qqlUxCfFxW</socketName>
           <systemName>IQDA:AUTO:0115</systemName>
         </Socket>
         <Socket>
-          <socketName>PXkovEDhjn</socketName>
+          <socketName>EDMoOCwVku</socketName>
           <systemName>IQDA:AUTO:0116</systemName>
         </Socket>
         <Socket>
-          <socketName>gVKTiPdPBS</socketName>
+          <socketName>jdvnDCLJoP</socketName>
           <systemName>IQDA:AUTO:0117</systemName>
         </Socket>
         <Socket>
-          <socketName>fBrxbjGokw</socketName>
+          <socketName>CyiNDzEjNa</socketName>
           <systemName>IQDA:AUTO:0118</systemName>
         </Socket>
         <Socket>
-          <socketName>LHYRRHqEsn</socketName>
+          <socketName>DOBuemLmey</socketName>
           <systemName>IQDA:AUTO:0119</systemName>
         </Socket>
         <Socket>
-          <socketName>CXPdDgbhNG</socketName>
+          <socketName>wgOIjAajsM</socketName>
           <systemName>IQDA:AUTO:0120</systemName>
         </Socket>
         <Socket>
-          <socketName>ZKklIRxMLl</socketName>
+          <socketName>aelzxRDnCw</socketName>
           <systemName>IQDA:AUTO:0121</systemName>
         </Socket>
         <Socket>
-          <socketName>vjQfTntHsP</socketName>
+          <socketName>bQqthiLivA</socketName>
           <systemName>IQDA:AUTO:0122</systemName>
         </Socket>
         <Socket>
-          <socketName>gsFDARVKLE</socketName>
+          <socketName>yjbhVBRMNY</socketName>
           <systemName>IQDA:AUTO:0123</systemName>
         </Socket>
         <Socket>
-          <socketName>JAadohJYXq</socketName>
+          <socketName>KEbreBemOT</socketName>
           <systemName>IQDA:AUTO:0124</systemName>
         </Socket>
         <Socket>
-          <socketName>LeYqjRWhET</socketName>
+          <socketName>TmFFKplPUp</socketName>
           <systemName>IQDA:AUTO:0125</systemName>
         </Socket>
         <Socket>
-          <socketName>qTCBTpbTds</socketName>
+          <socketName>SFCsMTqzcZ</socketName>
           <systemName>IQDA:AUTO:0126</systemName>
         </Socket>
         <Socket>
-          <socketName>jMlfwPpaXn</socketName>
+          <socketName>DaGQfialZK</socketName>
           <systemName>IQDA:AUTO:0127</systemName>
         </Socket>
         <Socket>
-          <socketName>XiPInVmqDl</socketName>
+          <socketName>JkOSfBGkDX</socketName>
           <systemName>IQDA:AUTO:0128</systemName>
         </Socket>
         <Socket>
-          <socketName>iIgHtCvxbR</socketName>
+          <socketName>QpxdOWDySv</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -9705,13 +9818,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <Throttle class="jmri.jmrit.logixng.actions.configurexml.ActionThrottleXml">
       <systemName>IQDA:AUTO:0055</systemName>
       <LocoAddressSocket>
-        <socketName>HPxGHNLrpB</socketName>
+        <socketName>iPLcwoBsHD</socketName>
       </LocoAddressSocket>
       <LocoSpeedSocket>
-        <socketName>bRMvrRizUR</socketName>
+        <socketName>JhZMrHpYQG</socketName>
       </LocoSpeedSocket>
       <LocoDirectionSocket>
-        <socketName>aDXEjeNKKn</socketName>
+        <socketName>GhQphnLpnJ</socketName>
       </LocoDirectionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -9764,13 +9877,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0056</systemName>
       <comment>A comment</comment>
       <LocoAddressSocket>
-        <socketName>cJMUCunYeI</socketName>
+        <socketName>ZyOhrcXzOt</socketName>
       </LocoAddressSocket>
       <LocoSpeedSocket>
-        <socketName>pmEbuZknkc</socketName>
+        <socketName>ReLDBMBsXF</socketName>
       </LocoSpeedSocket>
       <LocoDirectionSocket>
-        <socketName>sALBdLMRgZ</socketName>
+        <socketName>HjAnrrluPN</socketName>
       </LocoDirectionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -9822,15 +9935,15 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <ActionTimer class="jmri.jmrit.logixng.actions.configurexml.ActionTimerXml">
       <systemName>IQDA:AUTO:0057</systemName>
       <StartSocket>
-        <socketName>AAUGzNzLgC</socketName>
+        <socketName>YQOXDXorwD</socketName>
       </StartSocket>
       <StopSocket>
-        <socketName>kNqblMpTvY</socketName>
+        <socketName>lgPAHuFucW</socketName>
       </StopSocket>
       <Actions>
         <Socket>
           <delay>0</delay>
-          <socketName>mfvGoRWoow</socketName>
+          <socketName>GbpCvoHwxz</socketName>
         </Socket>
       </Actions>
       <startImmediately>no</startImmediately>
@@ -9887,15 +10000,15 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0058</systemName>
       <comment>A comment</comment>
       <StartSocket>
-        <socketName>MAlWMtpqXs</socketName>
+        <socketName>ATNwNEhTlV</socketName>
       </StartSocket>
       <StopSocket>
-        <socketName>ftkhkxPBoD</socketName>
+        <socketName>UBiAMLVfHR</socketName>
       </StopSocket>
       <Actions>
         <Socket>
           <delay>100</delay>
-          <socketName>iymUMNmWUZ</socketName>
+          <socketName>cFxXJYSTFk</socketName>
         </Socket>
       </Actions>
       <startImmediately>no</startImmediately>
@@ -9952,22 +10065,22 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0059</systemName>
       <comment>A comment</comment>
       <StartSocket>
-        <socketName>xvmWOdbuQs</socketName>
+        <socketName>PGIcbPRpWg</socketName>
         <systemName>IQDE:AUTO:0001</systemName>
       </StartSocket>
       <StopSocket>
-        <socketName>ojWtYjsXaV</socketName>
+        <socketName>BKqyJMmfSg</socketName>
         <systemName>IQDE:AUTO:0002</systemName>
       </StopSocket>
       <Actions>
         <Socket>
           <delay>2400</delay>
-          <socketName>mOSZTFYirG</socketName>
+          <socketName>GtEdbjMPby</socketName>
           <systemName>IQDA:AUTO:0060</systemName>
         </Socket>
         <Socket>
           <delay>10</delay>
-          <socketName>kLaTlNkEjW</socketName>
+          <socketName>xowGKQDiEf</socketName>
           <systemName>IQDA:AUTO:0061</systemName>
         </Socket>
       </Actions>
@@ -10026,7 +10139,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Action socket 1</comment>
       <Actions>
         <Socket>
-          <socketName>NrCoDxhrPB</socketName>
+          <socketName>uuVEuCingQ</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -10081,7 +10194,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Action socket 2</comment>
       <Actions>
         <Socket>
-          <socketName>UYAoWgbIcH</socketName>
+          <socketName>ExCpneDByu</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -10591,10 +10704,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0069</systemName>
       <ExpressionSocket>
-        <socketName>pqSGUbSXgI</socketName>
+        <socketName>gQHDnIpDHT</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>FHftAtWBiX</socketName>
+        <socketName>TlkrmwiBLX</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -10647,10 +10760,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0070</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>haJsNTLeah</socketName>
+        <socketName>UmFVokSkTD</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>nspHLrcXfw</socketName>
+        <socketName>llTCeQhUTu</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -10702,10 +10815,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
       <systemName>IQDA:AUTO:0071</systemName>
       <ExpressionSocket>
-        <socketName>jXDeieBVrx</socketName>
+        <socketName>ZrDKruxucn</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>DaVtEWIXhl</socketName>
+        <socketName>tDKUXrOIAF</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -10758,10 +10871,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0072</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>zvRTIMXwdp</socketName>
+        <socketName>GylifAgkQc</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>ZWYKQHlQVd</socketName>
+        <socketName>NMgLDkqDTK</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -11405,7 +11518,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <ExecuteDelayed class="jmri.jmrit.logixng.actions.configurexml.ExecuteDelayedXml">
       <systemName>IQDA:AUTO:0083</systemName>
       <Socket>
-        <socketName>YHtIgdTMsb</socketName>
+        <socketName>grvdcmEsAJ</socketName>
       </Socket>
       <delayAddressing>Direct</delayAddressing>
       <delay>0</delay>
@@ -11465,7 +11578,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0084</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>JXpvdhrUZd</socketName>
+        <socketName>IuUFpWFLlT</socketName>
       </Socket>
       <delayAddressing>Direct</delayAddressing>
       <delay>100</delay>
@@ -11525,7 +11638,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0085</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>DyCpDDjavM</socketName>
+        <socketName>wPCHyPxqvG</socketName>
       </Socket>
       <delayAddressing>LocalVariable</delayAddressing>
       <delay>0</delay>
@@ -11585,7 +11698,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0086</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>TNtDqEbltE</socketName>
+        <socketName>zUatRldBnx</socketName>
       </Socket>
       <delayAddressing>Reference</delayAddressing>
       <delay>0</delay>
@@ -11645,7 +11758,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0087</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>wLAnpaORmF</socketName>
+        <socketName>oFrzgjBYJD</socketName>
       </Socket>
       <delayAddressing>Formula</delayAddressing>
       <delay>0</delay>
@@ -11704,16 +11817,16 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <For class="jmri.jmrit.logixng.actions.configurexml.ForXml">
       <systemName>IQDA:AUTO:0088</systemName>
       <InitSocket>
-        <socketName>EdWUzxSKpk</socketName>
+        <socketName>aVVqHRyjWb</socketName>
       </InitSocket>
       <WhileSocket>
-        <socketName>QYWravEbCc</socketName>
+        <socketName>TQrqFGZQKE</socketName>
       </WhileSocket>
       <AfterEachSocket>
-        <socketName>xhNvgvxfxx</socketName>
+        <socketName>OoKWUEjpxl</socketName>
       </AfterEachSocket>
       <DoSocket>
-        <socketName>oRNMIBkGKR</socketName>
+        <socketName>dUDVNCYHcS</socketName>
       </DoSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -11766,16 +11879,16 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0089</systemName>
       <comment>A comment</comment>
       <InitSocket>
-        <socketName>nYdouKSdmq</socketName>
+        <socketName>awdSGGkPWW</socketName>
       </InitSocket>
       <WhileSocket>
-        <socketName>TAnhixnSBw</socketName>
+        <socketName>WmDxaBxoxa</socketName>
       </WhileSocket>
       <AfterEachSocket>
-        <socketName>jYcsXIbSgF</socketName>
+        <socketName>HQxsgDMtDu</socketName>
       </AfterEachSocket>
       <DoSocket>
-        <socketName>VDRSlPlyTN</socketName>
+        <socketName>IhCwlshOUB</socketName>
       </DoSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -11827,13 +11940,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <IfThenElse class="jmri.jmrit.logixng.actions.configurexml.IfThenElseXml" type="TriggerAction">
       <systemName>IQDA:AUTO:0090</systemName>
       <IfSocket>
-        <socketName>PtGzDDCYff</socketName>
+        <socketName>ejCpuGqMps</socketName>
       </IfSocket>
       <ThenSocket>
-        <socketName>iOgObDNYfF</socketName>
+        <socketName>fRuXWElEkd</socketName>
       </ThenSocket>
       <ElseSocket>
-        <socketName>kmNYyhYkFR</socketName>
+        <socketName>gMEFtdfpWF</socketName>
       </ElseSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -11886,13 +11999,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0091</systemName>
       <comment>A comment</comment>
       <IfSocket>
-        <socketName>sfQZSOeXdk</socketName>
+        <socketName>JyQmXdwazv</socketName>
       </IfSocket>
       <ThenSocket>
-        <socketName>PGmdGbsRiD</socketName>
+        <socketName>dcwDXCBZVY</socketName>
       </ThenSocket>
       <ElseSocket>
-        <socketName>bmFAUdOqIU</socketName>
+        <socketName>bQOvAFgRTT</socketName>
       </ElseSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -11945,13 +12058,13 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0092</systemName>
       <comment>A comment</comment>
       <IfSocket>
-        <socketName>RbMdbszJhY</socketName>
+        <socketName>ewLWzdxeeF</socketName>
       </IfSocket>
       <ThenSocket>
-        <socketName>LEuhFyowHd</socketName>
+        <socketName>JAnoURUoDL</socketName>
       </ThenSocket>
       <ElseSocket>
-        <socketName>fTQzjtIVcF</socketName>
+        <socketName>LLWwQLsjxH</socketName>
       </ElseSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -12003,10 +12116,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <Logix class="jmri.jmrit.logixng.actions.configurexml.LogixXml">
       <systemName>IQDA:AUTO:0093</systemName>
       <ExpressionSocket>
-        <socketName>oJtcihzaMC</socketName>
+        <socketName>YWkzBlhLCr</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>NZMeVnNfAF</socketName>
+        <socketName>ycShtNZXKl</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -12059,10 +12172,10 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0094</systemName>
       <comment>A comment</comment>
       <ExpressionSocket>
-        <socketName>HFtoEYwHrG</socketName>
+        <socketName>chqUykCiGz</socketName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>ooXAhPLzOB</socketName>
+        <socketName>HkIQuOWAnC</socketName>
         <systemName>IQDB:AUTO:0001</systemName>
       </ActionSocket>
       <MaleSocket>
@@ -12215,7 +12328,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0097</systemName>
       <Actions>
         <Socket>
-          <socketName>LnDmeSYidg</socketName>
+          <socketName>iCOoNzACvA</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -12270,7 +12383,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Actions>
         <Socket>
-          <socketName>nRNqLDtfoW</socketName>
+          <socketName>sZdKvnwnvn</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -12323,22 +12436,22 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <Sequence class="jmri.jmrit.logixng.actions.configurexml.SequenceXml">
       <systemName>IQDA:AUTO:0099</systemName>
       <StartSocket>
-        <socketName>nnPHiaNZzk</socketName>
+        <socketName>zJDLZgkVKf</socketName>
       </StartSocket>
       <StopSocket>
-        <socketName>LpZQAybkNv</socketName>
+        <socketName>bqeGEyMTOP</socketName>
       </StopSocket>
       <ResetSocket>
-        <socketName>pcHRdDNlbS</socketName>
+        <socketName>hHNcXjFEiQ</socketName>
       </ResetSocket>
       <Expressions>
         <Socket>
-          <socketName>owJwSFEBXy</socketName>
+          <socketName>JaRYDTKyOY</socketName>
         </Socket>
       </Expressions>
       <Actions>
         <Socket>
-          <socketName>uSKGTxJmXy</socketName>
+          <socketName>wJDufUiLaa</socketName>
         </Socket>
       </Actions>
       <startImmediately>yes</startImmediately>
@@ -12394,34 +12507,34 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0100</systemName>
       <comment>A comment</comment>
       <StartSocket>
-        <socketName>zMbdhfHNLh</socketName>
+        <socketName>aBvAmCTdPX</socketName>
         <systemName>IQDE:AUTO:0003</systemName>
       </StartSocket>
       <StopSocket>
-        <socketName>ipozflawzi</socketName>
+        <socketName>GlZmQBVrXH</socketName>
         <systemName>IQDE:AUTO:0004</systemName>
       </StopSocket>
       <ResetSocket>
-        <socketName>uMnMDbkhBK</socketName>
+        <socketName>ALrggJnKBO</socketName>
         <systemName>IQDE:AUTO:0005</systemName>
       </ResetSocket>
       <Expressions>
         <Socket>
-          <socketName>TPsGuChOIW</socketName>
+          <socketName>LruBwwiZav</socketName>
           <systemName>IQDE:AUTO:0006</systemName>
         </Socket>
         <Socket>
-          <socketName>HqGowOokzW</socketName>
+          <socketName>LyXbkEYskD</socketName>
           <systemName>IQDE:AUTO:0007</systemName>
         </Socket>
       </Expressions>
       <Actions>
         <Socket>
-          <socketName>ygtSfMuztt</socketName>
+          <socketName>ggJfiZfLeF</socketName>
           <systemName>IQDA:AUTO:0101</systemName>
         </Socket>
         <Socket>
-          <socketName>RLIWdzWEdf</socketName>
+          <socketName>jLsRjTBoxt</socketName>
           <systemName>IQDA:AUTO:0102</systemName>
         </Socket>
       </Actions>
@@ -12479,7 +12592,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Action socket 1</comment>
       <Actions>
         <Socket>
-          <socketName>MXVfzhSBHy</socketName>
+          <socketName>MsLFZcfZee</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -12534,7 +12647,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>Action socket 2</comment>
       <Actions>
         <Socket>
-          <socketName>WIxBJVaZCu</socketName>
+          <socketName>nCXSycpQgv</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -12844,7 +12957,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <rowOrColumnName />
       <tableRowOrColumn>Column</tableRowOrColumn>
       <Socket>
-        <socketName>skRxhYUSFS</socketName>
+        <socketName>VWERSDhtHF</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -12901,7 +13014,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <rowOrColumnName>North yard</rowOrColumnName>
       <tableRowOrColumn>Row</tableRowOrColumn>
       <Socket>
-        <socketName>SsVwDoBqLj</socketName>
+        <socketName>bctQuUFbpV</socketName>
         <systemName>IQDA:AUTO:0110</systemName>
       </Socket>
       <MaleSocket>
@@ -12955,7 +13068,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0110</systemName>
       <Actions>
         <Socket>
-          <socketName>vWVyURrGsv</socketName>
+          <socketName>vGlhSvDfVc</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -13013,7 +13126,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <rowOrColumnName>Second turnout</rowOrColumnName>
       <tableRowOrColumn>Column</tableRowOrColumn>
       <Socket>
-        <socketName>CzjTfhcxua</socketName>
+        <socketName>zTVFWpZfih</socketName>
         <systemName>IQDA:AUTO:0112</systemName>
       </Socket>
       <MaleSocket>
@@ -13067,7 +13180,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0112</systemName>
       <Actions>
         <Socket>
-          <socketName>rLdEXbJueJ</socketName>
+          <socketName>oxKkPXYDtr</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -13121,15 +13234,15 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0113</systemName>
       <comment>A comment</comment>
       <LocoAddressSocket>
-        <socketName>pUhroRVOBD</socketName>
+        <socketName>gYKxvxcDSP</socketName>
         <systemName>IQAE:AUTO:0001</systemName>
       </LocoAddressSocket>
       <LocoSpeedSocket>
-        <socketName>vJOqSSMZYV</socketName>
+        <socketName>xFdfnrjIdH</socketName>
         <systemName>IQAE:AUTO:0002</systemName>
       </LocoSpeedSocket>
       <LocoDirectionSocket>
-        <socketName>ASFgbPinPg</socketName>
+        <socketName>bohWIHWOyu</socketName>
         <systemName>IQDE:AUTO:0008</systemName>
       </LocoDirectionSocket>
       <MaleSocket>
@@ -13300,14 +13413,14 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDA:AUTO:0116</systemName>
       <comment>A comment</comment>
       <IfSocket>
-        <socketName>xrlpfqEaqM</socketName>
+        <socketName>jqEFOgBXfi</socketName>
         <systemName>IQDE:AUTO:0009</systemName>
       </IfSocket>
       <ThenSocket>
-        <socketName>aBlPJoWogk</socketName>
+        <socketName>jxlCIPwXmU</socketName>
       </ThenSocket>
       <ElseSocket>
-        <socketName>BINkWsIUhB</socketName>
+        <socketName>gmfbUYlAZH</socketName>
       </ElseSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -13359,11 +13472,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0117</systemName>
       <ExpressionSocket>
-        <socketName>gJtFgqnPTc</socketName>
+        <socketName>aLCoIETSuh</socketName>
         <systemName>IQAE:AUTO:0003</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>jAdPSUEtMC</socketName>
+        <socketName>tuCFHzECfL</socketName>
         <systemName>IQAA:AUTO:0001</systemName>
       </ActionSocket>
       <MaleSocket>
@@ -13416,11 +13529,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0118</systemName>
       <ExpressionSocket>
-        <socketName>kNyZHPXjFf</socketName>
+        <socketName>qDCMEqhRvC</socketName>
         <systemName>IQAE:AUTO:0004</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>tUtjRIkzrp</socketName>
+        <socketName>syYxLmWNyF</socketName>
         <systemName>IQAA:AUTO:0002</systemName>
       </ActionSocket>
       <MaleSocket>
@@ -13473,11 +13586,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0119</systemName>
       <ExpressionSocket>
-        <socketName>vhmuFNkffe</socketName>
+        <socketName>VVAIjPYLPU</socketName>
         <systemName>IQAE:AUTO:0005</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>njYAVwHrvk</socketName>
+        <socketName>wDKtzEpmtm</socketName>
         <systemName>IQAA:AUTO:0003</systemName>
       </ActionSocket>
       <MaleSocket>
@@ -13530,11 +13643,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0120</systemName>
       <ExpressionSocket>
-        <socketName>nAmtJPXqPD</socketName>
+        <socketName>LnGsPnFmUE</socketName>
         <systemName>IQAE:AUTO:0006</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>ZbCeIxOSBy</socketName>
+        <socketName>ZFhxXJICiM</socketName>
         <systemName>IQAA:AUTO:0004</systemName>
       </ActionSocket>
       <MaleSocket>
@@ -13587,11 +13700,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0121</systemName>
       <ExpressionSocket>
-        <socketName>RRXVzjvAmj</socketName>
+        <socketName>KFzFDQTqrN</socketName>
         <systemName>IQAE:AUTO:0007</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>KlBesbkMge</socketName>
+        <socketName>JluRsGXanr</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -13643,11 +13756,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoAnalogAction class="jmri.jmrit.logixng.actions.configurexml.DoAnalogActionXml">
       <systemName>IQDA:AUTO:0122</systemName>
       <ExpressionSocket>
-        <socketName>QLhgJdhsMi</socketName>
+        <socketName>mbYTSSImgZ</socketName>
         <systemName>IQAE:AUTO:0008</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>oJZBoDzkvv</socketName>
+        <socketName>aXMfXgdCxD</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -13699,11 +13812,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
       <systemName>IQDA:AUTO:0123</systemName>
       <ExpressionSocket>
-        <socketName>eTJuTZVjaq</socketName>
+        <socketName>MJPxyRwyeY</socketName>
         <systemName>IQSE:AUTO:0001</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>mzIcHGjtzK</socketName>
+        <socketName>oOLcxDzhEg</socketName>
         <systemName>IQSA:AUTO:0001</systemName>
       </ActionSocket>
       <MaleSocket>
@@ -13756,11 +13869,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
       <systemName>IQDA:AUTO:0124</systemName>
       <ExpressionSocket>
-        <socketName>ChByLZUTeZ</socketName>
+        <socketName>OEhZjiVBnx</socketName>
         <systemName>IQSE:AUTO:0002</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>uakUwXavty</socketName>
+        <socketName>aujgjmPHSJ</socketName>
         <systemName>IQSA:AUTO:0002</systemName>
       </ActionSocket>
       <MaleSocket>
@@ -13813,11 +13926,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
       <systemName>IQDA:AUTO:0125</systemName>
       <ExpressionSocket>
-        <socketName>UsdjWNnPmk</socketName>
+        <socketName>HonFnPbkNK</socketName>
         <systemName>IQSE:AUTO:0003</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>Zvggwhvilo</socketName>
+        <socketName>NRNqNTMIhM</socketName>
         <systemName>IQSA:AUTO:0003</systemName>
       </ActionSocket>
       <MaleSocket>
@@ -13870,11 +13983,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
       <systemName>IQDA:AUTO:0126</systemName>
       <ExpressionSocket>
-        <socketName>KBZFoXGzSi</socketName>
+        <socketName>nGTFnMypWu</socketName>
         <systemName>IQSE:AUTO:0004</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>KWGDKiTRHk</socketName>
+        <socketName>WqDMlhmwEn</socketName>
         <systemName>IQSA:AUTO:0004</systemName>
       </ActionSocket>
       <MaleSocket>
@@ -13927,11 +14040,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
       <systemName>IQDA:AUTO:0127</systemName>
       <ExpressionSocket>
-        <socketName>XTDmgrPvpU</socketName>
+        <socketName>zvJWKGJMxF</socketName>
         <systemName>IQSE:AUTO:0005</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>RyvTfMTLYB</socketName>
+        <socketName>mAaiDmhAlk</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -13983,11 +14096,11 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <DoStringAction class="jmri.jmrit.logixng.actions.configurexml.DoStringActionXml">
       <systemName>IQDA:AUTO:0128</systemName>
       <ExpressionSocket>
-        <socketName>rPsMkrpsEv</socketName>
+        <socketName>AwyLsknrBo</socketName>
         <systemName>IQSE:AUTO:0006</systemName>
       </ExpressionSocket>
       <ActionSocket>
-        <socketName>wLCgloqPOY</socketName>
+        <socketName>RYusdouFyF</socketName>
       </ActionSocket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -14042,19 +14155,19 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDB:AUTO:0001</systemName>
       <Actions>
         <Socket>
-          <socketName>CVChtsveXu</socketName>
+          <socketName>AxNsBZcbfb</socketName>
           <systemName>IQDB:AUTO:0002</systemName>
         </Socket>
         <Socket>
-          <socketName>qknouVhhQm</socketName>
+          <socketName>jJfBieIJcr</socketName>
           <systemName>IQDB:AUTO:0003</systemName>
         </Socket>
         <Socket>
-          <socketName>cMCabZhbSF</socketName>
+          <socketName>kBiftBaWpR</socketName>
           <systemName>IQDB:AUTO:0004</systemName>
         </Socket>
         <Socket>
-          <socketName>ppSZygtlnf</socketName>
+          <socketName>irMpSiyrmh</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -14109,7 +14222,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Actions>
         <Socket>
-          <socketName>BiikpsDvzB</socketName>
+          <socketName>GryfgSYvXI</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -14162,7 +14275,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <OnChange class="jmri.jmrit.logixng.actions.configurexml.DigitalBooleanOnChangeXml" trigger="CHANGE">
       <systemName>IQDB:AUTO:0003</systemName>
       <Socket>
-        <socketName>UuShBjyTgA</socketName>
+        <socketName>vhrMRgEtRK</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalBooleanActionSocketXml" />
@@ -14215,7 +14328,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQDB:AUTO:0004</systemName>
       <comment>A comment</comment>
       <Socket>
-        <socketName>aEGasgYgqf</socketName>
+        <socketName>uIcRnSzxyx</socketName>
       </Socket>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalBooleanActionSocketXml" />
@@ -14569,7 +14682,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQAE:AUTO:0007</systemName>
       <Expressions>
         <Socket>
-          <socketName>oRsdwxqoDD</socketName>
+          <socketName>WbPZMPePSa</socketName>
         </Socket>
       </Expressions>
       <formula />
@@ -14625,7 +14738,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>PFmqHDCzFd</socketName>
+          <socketName>xPHvuVeGUe</socketName>
         </Socket>
       </Expressions>
       <formula>sin(a)*2 + 14</formula>
@@ -14782,7 +14895,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQAA:AUTO:0003</systemName>
       <Actions>
         <Socket>
-          <socketName>vQIyHjAscD</socketName>
+          <socketName>JilwjPzAYh</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -14837,7 +14950,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Actions>
         <Socket>
-          <socketName>PTpvGduSbD</socketName>
+          <socketName>uVMUleihIZ</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -15094,7 +15207,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQSE:AUTO:0005</systemName>
       <Expressions>
         <Socket>
-          <socketName>nsvzOZHNEx</socketName>
+          <socketName>VdExgGqgnT</socketName>
         </Socket>
       </Expressions>
       <formula />
@@ -15150,7 +15263,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Expressions>
         <Socket>
-          <socketName>caxFsRhHVG</socketName>
+          <socketName>RvBqDFSvGd</socketName>
         </Socket>
       </Expressions>
       <formula>sin(a)*2 + 14</formula>
@@ -15307,7 +15420,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <systemName>IQSA:AUTO:0003</systemName>
       <Actions>
         <Socket>
-          <socketName>vbomJWCXmR</socketName>
+          <socketName>vIHvIZvxws</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -15362,7 +15475,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <comment>A comment</comment>
       <Actions>
         <Socket>
-          <socketName>tOBRrSgMNz</socketName>
+          <socketName>arkmdnLCxa</socketName>
         </Socket>
       </Actions>
       <MaleSocket>
@@ -15416,9 +15529,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
   <filehistory>
     <operation>
       <type>Store</type>
-      <date>Sun Mar 07 18:07:46 CET 2021</date>
+      <date>Sat Mar 27 01:52:24 CET 2021</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.23.1ish-logixng+daniel+2021-03-07T17:04:04Z+RUNKNOWN on Sun Mar 07 18:07:46 CET 2021-->
+  <!--Written by JMRI version 4.23.3ish+daniel+2021-03-27T00:51:34Z+RUNKNOWN on Sat Mar 27 01:52:24 CET 2021-->
 </layout-config>

--- a/java/test/jmri/jmrit/logixng/expressions/NotTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/NotTest.java
@@ -19,7 +19,7 @@ import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
 /**
  * Test Not
  * 
- * @author Daniel Bergqvist 2018
+ * @author Daniel Bergqvist 2021
  */
 public class NotTest extends AbstractDigitalExpressionTestBase {
 

--- a/java/test/jmri/jmrit/logixng/expressions/NotTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/NotTest.java
@@ -1,0 +1,325 @@
+package jmri.jmrit.logixng.expressions;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jmri.InstanceManager;
+import jmri.NamedBean;
+import jmri.jmrit.logixng.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import jmri.jmrit.logixng.actions.ActionAtomicBoolean;
+import jmri.jmrit.logixng.actions.IfThenElse;
+import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
+
+/**
+ * Test Not
+ * 
+ * @author Daniel Bergqvist 2018
+ */
+public class NotTest extends AbstractDigitalExpressionTestBase {
+
+    private LogixNG logixNG;
+    private ConditionalNG conditionalNG;
+    private Not expressionNot;
+    private ActionAtomicBoolean actionAtomicBoolean;
+    private AtomicBoolean atomicBoolean;
+    
+    
+    @Override
+    public ConditionalNG getConditionalNG() {
+        return conditionalNG;
+    }
+    
+    @Override
+    public LogixNG getLogixNG() {
+        return logixNG;
+    }
+    
+    private static int beanID = 901;
+    
+    @Override
+    public MaleSocket getConnectableChild() {
+        DigitalExpressionBean childExpression = new True("IQDE"+Integer.toString(beanID++), null);
+        MaleSocket maleSocketChild =
+                InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(childExpression);
+        return maleSocketChild;
+    }
+    
+    @Override
+    public String getExpectedPrintedTree() {
+        return String.format(
+                "Not ::: Log error%n" +
+                "   ? E%n" +
+                "      Socket not connected%n");
+    }
+    
+    @Override
+    public String getExpectedPrintedTreeFromRoot() {
+        return String.format(
+                "LogixNG: A new logix for test%n" +
+                "   ConditionalNG: A conditionalNG%n" +
+                "      ! A%n" +
+                "         If Then Else. Trigger action ::: Log error%n" +
+                "            ? If%n" +
+                "               Not ::: Log error%n" +
+                "                  ? E%n" +
+                "                     Socket not connected%n" +
+                "            ! Then%n" +
+                "               Set the atomic boolean to true ::: Log error%n" +
+                "            ! Else%n" +
+                "               Socket not connected%n");
+    }
+    
+    @Override
+    public NamedBean createNewBean(String systemName) {
+        return new Not(systemName, null);
+    }
+    
+    @Override
+    public boolean addNewSocket() {
+        return false;
+    }
+    
+    @Test
+    public void testCtor() {
+        Not expression2;
+        
+        expression2 = new Not("IQDE321", null);
+        Assert.assertNotNull("object exists", expression2);
+        Assert.assertNull("Username matches", expression2.getUserName());
+        Assert.assertEquals("String matches", "Not", expression2.getLongDescription());
+        
+        expression2 = new Not("IQDE321", "My expression");
+        Assert.assertNotNull("object exists", expression2);
+        Assert.assertEquals("Username matches", "My expression", expression2.getUserName());
+        Assert.assertEquals("String matches", "Not", expression2.getLongDescription());
+        
+        boolean thrown = false;
+        try {
+            // Illegal system name
+            new Not("IQE55:12:XY11", null);
+        } catch (IllegalArgumentException ex) {
+            thrown = true;
+        }
+        Assert.assertTrue("Expected exception thrown", thrown);
+        
+        thrown = false;
+        try {
+            // Illegal system name
+            new Not("IQE55:12:XY11", "A name");
+        } catch (IllegalArgumentException ex) {
+            thrown = true;
+        }
+        Assert.assertTrue("Expected exception thrown", thrown);
+    }
+    
+    @Test
+    public void testCtorAndSetup1() {
+        Not expression = new Not("IQDE321", null);
+        Assert.assertNotNull("exists", expression);
+        Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
+        expression.getChild(0).setName("XYZ123");
+        expression.setSocketSystemName("IQDE52");
+        
+        Assert.assertEquals("expression female socket name is XYZ123",
+                "XYZ123", expression.getChild(0).getName());
+        Assert.assertEquals("expression female socket is of correct class",
+//                "jmri.jmrit.logixng.implementation.DefaultFemaleGenericExpressionSocket$DigitalSocket",
+                "jmri.jmrit.logixng.implementation.DefaultFemaleDigitalExpressionSocket",
+                expression.getChild(0).getClass().getName());
+        Assert.assertFalse("expression female socket is not connected",
+                expression.getChild(0).isConnected());
+        
+        // Setup action. This connects the child actions to this action
+        expression.setup();
+        
+        jmri.util.JUnitAppender.assertMessage("cannot load digital expression IQDE52");
+        
+        Assert.assertEquals("expression female socket name is XYZ123",
+                "XYZ123", expression.getChild(0).getName());
+        Assert.assertEquals("expression female socket is of correct class",
+//                "jmri.jmrit.logixng.implementation.DefaultFemaleGenericExpressionSocket$DigitalSocket",
+                "jmri.jmrit.logixng.implementation.DefaultFemaleDigitalExpressionSocket",
+                expression.getChild(0).getClass().getName());
+        Assert.assertFalse("expression female socket is not connected",
+                expression.getChild(0).isConnected());
+        
+        Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
+    }
+    
+    @Test
+    public void testCtorAndSetup2() {
+        Not expression = new Not("IQDE321", null);
+        Assert.assertNotNull("exists", expression);
+        Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
+        expression.getChild(0).setName("XYZ123");
+        expression.setSocketSystemName(null);
+        
+        Assert.assertEquals("expression female socket name is XYZ123",
+                "XYZ123", expression.getChild(0).getName());
+        Assert.assertEquals("expression female socket is of correct class",
+//                "jmri.jmrit.logixng.implementation.DefaultFemaleGenericExpressionSocket$DigitalSocket",
+                "jmri.jmrit.logixng.implementation.DefaultFemaleDigitalExpressionSocket",
+                expression.getChild(0).getClass().getName());
+        Assert.assertFalse("expression female socket is not connected",
+                expression.getChild(0).isConnected());
+        
+        // Setup action. This connects the child actions to this action
+        expression.setup();
+        
+        Assert.assertEquals("expression female socket name is XYZ123",
+                "XYZ123", expression.getChild(0).getName());
+        Assert.assertEquals("expression female socket is of correct class",
+//                "jmri.jmrit.logixng.implementation.DefaultFemaleGenericExpressionSocket$DigitalSocket",
+                "jmri.jmrit.logixng.implementation.DefaultFemaleDigitalExpressionSocket",
+                expression.getChild(0).getClass().getName());
+        Assert.assertFalse("expression female socket is not connected",
+                expression.getChild(0).isConnected());
+        
+        Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
+    }
+    
+    @Test
+    public void testCtorAndSetup3() {
+        DigitalExpressionManager m = InstanceManager.getDefault(DigitalExpressionManager.class);
+        
+        m.registerExpression(new ExpressionMemory("IQDE52", null));
+        m.registerExpression(new ExpressionMemory("IQDE554", null));
+        
+        Not expression = new Not("IQDE321", null);
+        Assert.assertNotNull("exists", expression);
+        Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
+        expression.getChild(0).setName("XYZ123");
+        expression.setSocketSystemName("IQDE52");
+        
+        Assert.assertEquals("expression female socket name is XYZ123",
+                "XYZ123", expression.getChild(0).getName());
+        Assert.assertEquals("expression female socket is of correct class",
+//                "jmri.jmrit.logixng.implementation.DefaultFemaleGenericExpressionSocket$DigitalSocket",
+                "jmri.jmrit.logixng.implementation.DefaultFemaleDigitalExpressionSocket",
+                expression.getChild(0).getClass().getName());
+        Assert.assertFalse("expression female socket is not connected",
+                expression.getChild(0).isConnected());
+        
+        // Setup action. This connects the child actions to this action
+        expression.setup();
+        
+        Assert.assertTrue("expression female socket is connected",
+                expression.getChild(0).isConnected());
+//        Assert.assertEquals("child is correct bean",
+//                childSocket0,
+//                expression.getChild(0).getConnectedSocket());
+        Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
+        
+        // Try run setup() again. That should not cause any problems.
+        expression.setup();
+        
+        Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
+    }
+    
+    @Test
+    public void testGetChild() {
+        Assert.assertTrue("getChildCount() returns 1", 1 == expressionNot.getChildCount());
+        
+        Assert.assertNotNull("getChild(0) returns a non null value",
+                expressionNot.getChild(0));
+        
+        boolean hasThrown = false;
+        try {
+            expressionNot.getChild(1);
+        } catch (IllegalArgumentException ex) {
+            hasThrown = true;
+            Assert.assertEquals("Error message is correct", "index has invalid value: 1", ex.getMessage());
+        }
+        Assert.assertTrue("Exception is thrown", hasThrown);
+    }
+    
+    @Test
+    public void testCategory() {
+        Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
+    }
+    
+    @Test
+    public void testIsExternal() {
+        Assert.assertFalse("is external", _base.isExternal());
+    }
+    
+    @Test
+    public void testDescription() {
+        Not e1 = new Not("IQDE321", null);
+        Assert.assertTrue("Not".equals(e1.getShortDescription()));
+        Assert.assertTrue("Not".equals(e1.getLongDescription()));
+    }
+    
+    @Test
+    @Override
+    public void testEnableAndEvaluate() {
+        // Not implemented.
+        // This method is implemented for other digital expressions so no need
+        // to add support here. It doesn't need to be tested for every digital
+        // expression.
+    }
+    
+    @Test
+    @Override
+    public void testDebugConfig() {
+        // Not implemented.
+        // This method is implemented for other digital expressions so no need
+        // to add support here. It doesn't need to be tested for every digital
+        // expression.
+    }
+    
+    // The minimal setup for log4J
+    @Before
+    public void setUp() throws SocketAlreadyConnectedException {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initLogixNGManager();
+        
+        _category = Category.OTHER;
+        _isExternal = false;
+        
+        logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
+        conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
+        InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
+        conditionalNG.setRunDelayed(false);
+        conditionalNG.setEnabled(true);
+        logixNG.addConditionalNG(conditionalNG);
+        IfThenElse ifThenElse = new IfThenElse("IQDA321", null);
+        MaleSocket maleSocket =
+                InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
+        conditionalNG.getChild(0).connect(maleSocket);
+        
+        expressionNot = new Not("IQDE321", null);
+        MaleSocket maleSocket2 =
+                InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionNot);
+        ifThenElse.getChild(0).connect(maleSocket2);
+        
+        _base = expressionNot;
+        _baseMaleSocket = maleSocket2;
+        
+        atomicBoolean = new AtomicBoolean(false);
+        actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
+        MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
+        ifThenElse.getChild(1).connect(socketAtomicBoolean);
+        
+        logixNG.setParentForAllChildren();
+        logixNG.setEnabled(true);
+    }
+
+    @After
+    public void tearDown() {
+        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.tearDown();
+    }
+    
+}

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
@@ -111,6 +111,7 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
         classes.add(jmri.jmrit.logixng.expressions.And.class);
         classes.add(jmri.jmrit.logixng.expressions.Antecedent.class);
         classes.add(jmri.jmrit.logixng.expressions.DigitalFormula.class);
+        classes.add(jmri.jmrit.logixng.expressions.Not.class);
         classes.add(jmri.jmrit.logixng.expressions.Or.class);
         map.put(Category.COMMON, classes);
         

--- a/xml/schema/logixng/digital-expressions/digital-expressions-4.23.1.xsd
+++ b/xml/schema/logixng/digital-expressions/digital-expressions-4.23.1.xsd
@@ -47,6 +47,7 @@
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/formula-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/hold-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/last-result-of-digital-expression-4.23.1.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/not-4.23.3.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/or-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/reset-on-true-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-expressions/timer-4.23.1.xsd"/>
@@ -89,6 +90,7 @@
             <xs:element name="DigitalFormula"     type="LogixNG_DigitalExpression_FormulaType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="Hold"               type="LogixNG_DigitalExpression_HoldType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="LastResultOfDigitalExpression"  type="LogixNG_DigitalExpression_LastResultOfDigitalExpressionType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="Not"                type="LogixNG_DigitalExpression_NotType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="Or"                 type="LogixNG_DigitalExpression_OrType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ResetOnTrue"        type="LogixNG_DigitalExpression_ResetOnTrueType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="Timer"              type="LogixNG_DigitalExpression_TimerType" minOccurs="0" maxOccurs="unbounded" />

--- a/xml/schema/logixng/digital-expressions/not-4.23.3.xsd
+++ b/xml/schema/logixng/digital-expressions/not-4.23.3.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2018.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- This file contains definitions for LogixNG                             -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+        >
+
+    <xs:complexType name="LogixNG_DigitalExpression_NotType">
+      <xs:annotation>
+        <xs:documentation>
+          Define the XML stucture for storing the contents of a Not class.
+        </xs:documentation>
+        <xs:appinfo>
+            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.digital.expressions.configurexml.HoldXml</jmri:usingclass>
+        </xs:appinfo>
+      </xs:annotation>
+
+            <xs:sequence>
+              <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+              <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="Socket" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="socketName" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                    <xs:element name="systemName" type="systemNameType" minOccurs="0" maxOccurs="1"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+
+              <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
+
+            </xs:sequence>
+            <xs:attribute name="enabled" type="yesNoType" />
+            <xs:attribute name="class" type="classType" use="required"/>
+
+    </xs:complexType>
+
+</xs:schema>

--- a/xml/schema/logixng/male-socket-4.23.1.xsd
+++ b/xml/schema/logixng/male-socket-4.23.1.xsd
@@ -91,6 +91,14 @@
 
               <xs:attribute name="catchAbortExecution" type="yesNoType" />
 
+
+              <!-- Sub classes to AbstractMaleSocket may add things here - Start -->
+
+			  <xs:attribute name="DefaultMaleDigitalExpressionSocketListen" type="yesNoType" />
+
+              <!-- Sub classes to AbstractMaleSocket may add things here - End -->
+
+
               <xs:attribute name="enabled" type="yesNoType" />
               <xs:attribute name="class" type="classType" use="required"/>
             </xs:complexType>


### PR DESCRIPTION
If a conditional variable has `Not` set, the ImportLogix tool previously ignored that. This is now fixed.

To fix that, a new expression Not is added in this PR. It negates the result of its child.

---

This PR also adds the feature to expressions to not listen on changes.

Note: If an expression doesn't listen, then none of its children will listen. So you can make a whole sub tree to not listen by deselect "listen" on the root expression.

If a Logix is imported to LogixNG, the import tool will now set the "Listen" flag to "Do trigger actions" of the conditional variable.

![LogixNG_Listen](https://user-images.githubusercontent.com/20255317/112706735-97f40880-8ea6-11eb-8253-96d5ec81b7eb.png)

---

While working on this PR, I found a bug. To fix that bug I needed to some refactoring. That's why there is so many changed files in this PR.