### PR TITLE
createNewSensor / createNewLight throw Exception, not return null

### DIFF
--- a/java/src/jmri/LightManager.java
+++ b/java/src/jmri/LightManager.java
@@ -40,7 +40,7 @@ public interface LightManager extends ProvidingManager<Light> {
      * @return Never null under normal circumstances
      */
     @Nonnull
-    public Light provideLight(@Nonnull String name);
+    public Light provideLight(@Nonnull String name) throws IllegalArgumentException;
 
     /** {@inheritDoc} */
     @Override
@@ -52,24 +52,20 @@ public interface LightManager extends ProvidingManager<Light> {
     public void dispose();
 
     /**
-     * Get an existing Light or return null if it doesn't exist. 
-     * 
-     * Locates via user name, then system name if needed.
-     *
+     * Get an existing Light or return null if it doesn't exist.
+     * <p>
+     * Locates via user name, then system name if needed. 
      * @param name User name, system name, or address which can be promoted to
      *             system name
-     * @return Never null
-     * @throws IllegalArgumentException if Light doesn't already exist and the
-     *                                  manager cannot create the Light due to
-     *                                  an illegal name or name that can't be
-     *                                  parsed.
+     * @return Light, or null if no existing Light.
      */
     @CheckReturnValue
     @CheckForNull
     public Light getLight(@Nonnull String name);
 
     /**
-     * Return a Light with the specified system and user names. 
+     * Return a Light with the specified user or system name.
+     * Lookup Light by UserName, then Provide New Light by SystemName.
      * Note that
      * two calls with the same arguments will get the same instance; there is
      * only one Light object representing a given physical Light and therefore
@@ -99,7 +95,7 @@ public interface LightManager extends ProvidingManager<Light> {
      *                                  parsed.
      */
     @Nonnull
-    public Light newLight(@Nonnull String systemName, @CheckForNull String userName);
+    public Light newLight(@Nonnull String systemName, @CheckForNull String userName) throws IllegalArgumentException;
 
     /**
      * Locate a Light by its user name.

--- a/java/src/jmri/SensorManager.java
+++ b/java/src/jmri/SensorManager.java
@@ -63,7 +63,9 @@ public interface SensorManager extends ProvidingManager<Sensor> {
     public void dispose();
 
     /**
-     * Return a Sensor with the specified system and user names. 
+     * Return a Sensor with the specified user or system name.
+     * Return Sensor by UserName else provide by SystemName.
+     * <p>
      * Note that
      * two calls with the same arguments will get the same instance; there is
      * only one Sensor object representing a given physical turnout and

--- a/java/src/jmri/TurnoutManager.java
+++ b/java/src/jmri/TurnoutManager.java
@@ -66,6 +66,7 @@ public interface TurnoutManager extends ProvidingManager<Turnout> {
 
     /** {@inheritDoc} */
     @Override
+    @Nonnull
     default public Turnout provide(@Nonnull String name) throws IllegalArgumentException { return provideTurnout(name); }
     
     /**
@@ -102,7 +103,9 @@ public interface TurnoutManager extends ProvidingManager<Turnout> {
     public Turnout getByUserName(@Nonnull String userName);
 
     /**
-     * Return a Turnout with the specified system and user names. 
+     * Return a Turnout with the specified system and user names.
+     * Provide by UserName then System Name.
+     * <p>
      * Note that
      * two calls with the same arguments will get the same instance; there is
      * only one Turnout object representing a given physical turnout and

--- a/java/src/jmri/jmrix/acela/AcelaLightManager.java
+++ b/java/src/jmri/jmrix/acela/AcelaLightManager.java
@@ -40,17 +40,17 @@ public class AcelaLightManager extends AbstractLightManager {
      * @return null if the system name is not in a valid format
      */
     @Override
-    protected Light createNewLight(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Light lgt = null;
         // check if the output bit is available
-        int nAddress = -1;
-        nAddress = AcelaAddress.getNodeAddressFromSystemName(systemName, getMemo());
+        int nAddress = AcelaAddress.getNodeAddressFromSystemName(systemName, getMemo());
         if (nAddress == -1) {
-            return (null);
+            throw new IllegalArgumentException("Invalid Node Address from System Name: " + systemName);
         }
         int bitNum = AcelaAddress.getBitFromSystemName(systemName, getSystemPrefix());
         if (bitNum == -1) {
-            return (null);
+            throw new IllegalArgumentException("Invalid Bit from System Name: " + systemName);
         }
 
         // Validate the systemName

--- a/java/src/jmri/jmrix/acela/AcelaSensorManager.java
+++ b/java/src/jmri/jmrix/acela/AcelaSensorManager.java
@@ -47,7 +47,7 @@ public class AcelaSensorManager extends jmri.managers.AbstractSensorManager
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // Validate the systemName
         if (AcelaAddress.validSystemNameFormat(systemName, 'S', getSystemPrefix()) == NameValidity.INVALID) {
             log.error("Invalid Sensor system Name format: {}", systemName);
@@ -55,7 +55,7 @@ public class AcelaSensorManager extends jmri.managers.AbstractSensorManager
         }
         Sensor s;
         String sName = systemName;
-        if (sName.equals("")) {
+        if (sName.isEmpty()) {
             // system name is not valid
             throw new IllegalArgumentException("Invalid Acela Sensor system name - " +  // NOI18N
                     systemName);

--- a/java/src/jmri/jmrix/anyma/UsbLightManager.java
+++ b/java/src/jmri/jmrix/anyma/UsbLightManager.java
@@ -43,16 +43,14 @@ public class UsbLightManager extends AbstractLightManager {
      * <p>
      * Assumes calling method has checked that a Light with this system name
      * does not already exist.
-     *
-     * @param systemName the system name to use for this light
-     * @param userName   the user name to use for this light
-     * @return null if the system name is not in a valid format or if the system
+     * {@inheritDoc}
+     * @throws IllegalArgumentException if the system name is not in a valid format or if the system
      *         name does not correspond to a valid channel
      */
     @Override
-    public Light createNewLight(@Nonnull String systemName, String userName) {
+    @Nonnull
+    public Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         log.debug("*    UsbLightManager.createNewLight() called");
-        Light result = null;    // assume failure
 
         int nAddress = getMemo().getNodeAddressFromSystemName(systemName);
         if (nAddress != -1) {
@@ -61,18 +59,21 @@ public class UsbLightManager extends AbstractLightManager {
                 // Validate the systemName
                 if (getMemo().validSystemNameFormat(systemName, 'L') == Manager.NameValidity.VALID) {
                     if (getMemo().validSystemNameConfig(systemName, 'L')) {
-                        result = new AnymaDMX_UsbLight(systemName, userName, getMemo());
+                        return new AnymaDMX_UsbLight(systemName, userName, getMemo());
                     } else {
                         log.warn("Light System Name does not refer to configured hardware: {}", systemName);
+                        throw new IllegalArgumentException("Light System Name " + systemName + " does not refer to configured hardware");
                     }
                 } else {
                     log.error("Invalid Light System Name format: {}", systemName);
+                    throw new IllegalArgumentException("Invalid Light System Name format: " + systemName);
                 }
             } else {
                 log.error("Invalid channel number from System Name: {}", systemName);
+                throw new IllegalArgumentException("Invalid channel number from System Name: " + systemName);
             }
         }
-        return result;
+        throw new IllegalArgumentException("Invalid Node Address from System Name: " + systemName);
     }
 
     /**

--- a/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
@@ -45,8 +45,9 @@ public class CbusLightManager extends AbstractLightManager {
      *
      * @return never null
      */
+    @Nonnull
     @Override
-    protected Light createNewLight(@Nonnull String systemName, String userName) {
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         String addr;
         // first, check validity
         try {            

--- a/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
@@ -36,7 +36,7 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager {
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         String addr = systemName.substring(getSystemNamePrefix().length());
         // first, check validity
         String newAddress;

--- a/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
@@ -39,29 +39,30 @@ public class SerialLightManager extends AbstractLightManager {
      * Assumes calling method has checked that a Light with this system
      * name does not already exist.
      *
-     * @return null if the
+     * @throws IllegalArgumentException if the
      * system name is not in a valid format or if the system name does not
-     * correspond to a configured C/MRI digital output bit
+     * correspond to a configured C/MRI digital output bit.
+     * @return New Light.
      */
     @Override
-    public Light createNewLight(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Light lgt = null;
         // check if the output bit is available
         int nAddress;
         nAddress = getMemo().getNodeAddressFromSystemName(systemName);
         if (nAddress == -1) {
-            return null;
+            throw new IllegalArgumentException("Invalid Node Address from System Name: " + systemName);
         }
         int bitNum = getMemo().getBitFromSystemName(systemName);
         if (bitNum == 0) {
-            return null;
+            throw new IllegalArgumentException("Invalid Bit from System Name: " + systemName);
         }
         String conflict;
         conflict = getMemo().isOutputBitFree(nAddress, bitNum);
-        if (!conflict.equals("")) {
+        if (!conflict.isEmpty()) {
             log.error("Assignment conflict with {}.  Light not created.", conflict);
-            notifyLightCreationError(conflict, bitNum);
-            return null;
+            throw new IllegalArgumentException(Bundle.getMessage("ErrorAssignDialog", bitNum, conflict));
         }
         // Validate the systemName
         if (getMemo().validSystemNameFormat(systemName, 'L') == NameValidity.VALID) {
@@ -71,19 +72,9 @@ public class SerialLightManager extends AbstractLightManager {
             }
         } else {
             log.error("Invalid Light system Name format: {}", systemName);
+            throw new IllegalArgumentException("Invalid Light system Name format: " + systemName);
         }
         return lgt;
-    }
-
-    /**
-     * Public method to notify user of Light creation error.
-     * @param conflict human readable light name of light in conflict.
-     * @param bitNum bit number of light in conflict.
-     */
-    public void notifyLightCreationError(String conflict, int bitNum) {
-        javax.swing.JOptionPane.showMessageDialog(null, Bundle.getMessage("ErrorAssignDialog", bitNum, conflict) + "\n" +
-                Bundle.getMessage("ErrorAssignLine2L"), Bundle.getMessage("ErrorAssignTitle"),
-                javax.swing.JOptionPane.INFORMATION_MESSAGE, null);
     }
 
     /**

--- a/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
@@ -61,11 +61,11 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Sensor s;
         // validate the system name, and normalize it
         String sName = getMemo().normalizeSystemName(systemName);
-        if (sName.equals("")) {
+        if (sName.isEmpty()) {
             // system name is not valid
             throw new IllegalArgumentException("Invalid C/MRI Sensor system name - " +  // NOI18N
                     systemName);

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcSensorManager.java
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcSensorManager.java
@@ -62,7 +62,7 @@ public class Dcc4PcSensorManager extends jmri.managers.AbstractSensorManager
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Sensor s = new Dcc4PcSensor(systemName, userName);
         s.setUserName(userName);
         extractBoardID(systemName);

--- a/java/src/jmri/jmrix/dccpp/DCCppLightManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppLightManager.java
@@ -48,11 +48,12 @@ public class DCCppLightManager extends AbstractLightManager {
      * @return null if the system name is not in a valid format
      */
     @Override
-    protected Light createNewLight(String systemName, String userName) {
+    @Nonnull
+    protected Light createNewLight(String systemName, String userName) throws IllegalArgumentException {
         // check if the output bit is available
         int bitNum = getBitFromSystemName(systemName);
         if (bitNum == 0) {
-            return null;
+            throw new IllegalArgumentException("Invalid Bit from System Name: " + systemName);
         }
         // Normalize the systemName
         String sName = getSystemNamePrefix() + bitNum;   // removes any leading zeros

--- a/java/src/jmri/jmrix/dccpp/DCCppSensorManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppSensorManager.java
@@ -63,7 +63,7 @@ public class DCCppSensorManager extends jmri.managers.AbstractSensorManager impl
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         int addr;
         try {
             addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));

--- a/java/src/jmri/jmrix/ecos/EcosSensorManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosSensorManager.java
@@ -53,7 +53,7 @@ public class EcosSensorManager extends jmri.managers.AbstractSensorManager
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         //int ports = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
         return new EcosSensor(systemName, userName);
     }

--- a/java/src/jmri/jmrix/grapevine/SerialLightManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialLightManager.java
@@ -38,26 +38,27 @@ public class SerialLightManager extends AbstractLightManager {
      * <p>
      * Assumes calling method has checked that a Light with this
      * system name does not already exist.
-     *
-     * @return null if the system name is not in a valid format or if
+     * {@inheritDoc}
+     * @throws IllegalArgumentException if system name is not in valid format or
      * the system name does not correspond to a configured Grapevine
      * digital output bit
      */
     @Override
-    public Light createNewLight(@Nonnull String systemName, @Nonnull String userName) {
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         String prefix = getSystemPrefix();
-        Light lgt = null;
         // Validate the systemName
         if (SerialAddress.validSystemNameFormat(systemName, 'L', prefix) == NameValidity.VALID) {
-            lgt = new SerialLight(systemName, userName, getMemo());
+            Light lgt = new SerialLight(systemName, userName, getMemo());
             if (!SerialAddress.validSystemNameConfig(systemName, 'L', getMemo().getTrafficController())) {
                 log.warn("Light system Name does not refer to configured hardware: {}", systemName);
             }
+            log.debug("new light {} for prefix {}", systemName, prefix);
+            return lgt;
         } else {
             log.warn("Invalid Light system Name format: {}", systemName);
+            throw new IllegalArgumentException("Invalid Light system Name format: " + systemName);
         }
-        log.debug("new light {} for prefix {}", systemName, prefix);
-        return lgt;
     }
 
     /**
@@ -90,7 +91,7 @@ public class SerialLightManager extends AbstractLightManager {
 
     /**
      * Public method to convert system name to its alternate format.
-     *
+     * {@inheritDoc}
      * @return a normalized system name if system name is valid and has a valid
      * alternate representation, else return ""
      */

--- a/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
@@ -61,7 +61,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
         Sensor s;
         // validate the system name, and normalize it
         String sName = SerialAddress.normalizeSystemName(systemName, prefix);
-        if (sName.equals("")) {
+        if (sName.isEmpty()) {
             // system name is not valid
             throw new IllegalArgumentException("Invalid Grapevine Sensor system name - " +  // NOI18N
                     systemName);

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeLightManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeLightManager.java
@@ -40,8 +40,9 @@ public class XBeeLightManager extends AbstractLightManager {
     }
 
     @Override
-    public Light createNewLight(@Nonnull String systemName, @Nonnull String userName) {
-        XBeeNode curNode = null;
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        XBeeNode curNode;
         String name = addressFromSystemName(systemName);
         if ((curNode = (XBeeNode) tc.getNodeFromName(name)) == null) {
             if ((curNode = (XBeeNode) tc.getNodeFromAddress(name)) == null) {
@@ -50,9 +51,7 @@ public class XBeeLightManager extends AbstractLightManager {
                 } catch (java.lang.NumberFormatException nfe) {
                     // if there was a number format exception, we couldn't
                     // find the node.
-                    curNode = null;
-                    log.debug("failed to create light {}", systemName);
-                    return null;
+                    throw new IllegalArgumentException("failed to find node to create Light: " + systemName);
                 }
             }
         }
@@ -62,8 +61,7 @@ public class XBeeLightManager extends AbstractLightManager {
             curNode.setPinBean(pin, new XBeeLight(systemName, userName, tc));
             return (XBeeLight) curNode.getPinBean(pin);
         } else {
-            log.debug("failed to create light {}", systemName);
-            return null;
+            throw new IllegalArgumentException("failed to create Light: " + systemName);
         }
     }
 

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeSensorManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeSensorManager.java
@@ -66,8 +66,8 @@ public class XBeeSensorManager extends jmri.managers.AbstractSensorManager imple
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
-        XBeeNode curNode = null;
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        XBeeNode curNode;
         String name = addressFromSystemName(systemName);
         if ((curNode = (XBeeNode) tc.getNodeFromName(name)) == null) {
             if ((curNode = (XBeeNode) tc.getNodeFromAddress(name)) == null) {

--- a/java/src/jmri/jmrix/ipocs/IpocsLightManager.java
+++ b/java/src/jmri/jmrix/ipocs/IpocsLightManager.java
@@ -27,7 +27,8 @@ public class IpocsLightManager extends AbstractLightManager {
   }
 
   @Override
-  protected Light createNewLight(@Nonnull String systemName, String userName) {
+  @Nonnull
+  protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
     return new IpocsLight(getPortController(), systemName, userName);
   }
   

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientLightManager.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientLightManager.java
@@ -28,7 +28,8 @@ public class JMRIClientLightManager extends jmri.managers.AbstractLightManager {
     }
 
     @Override
-    public Light createNewLight(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Light t;
         int addr = Integer.parseInt(systemName.substring(getSystemNamePrefix().length()));
         t = new JMRIClientLight(addr, getMemo());

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientSensorManager.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientSensorManager.java
@@ -33,7 +33,7 @@ public class JMRIClientSensorManager extends jmri.managers.AbstractSensorManager
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Sensor t;
         int addr;
         try {

--- a/java/src/jmri/jmrix/lenz/XNetLightManager.java
+++ b/java/src/jmri/jmrix/lenz/XNetLightManager.java
@@ -44,18 +44,17 @@ public class XNetLightManager extends AbstractLightManager {
      * @return null if the system name is not in a valid format
      */
     @Override
-    public Light createNewLight(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // check if the output bit is available
         int bitNum = XNetAddress.getBitFromSystemName(systemName, getSystemPrefix());
         if (bitNum == -1) {
-            return (null);
+            throw new IllegalArgumentException("Invalid Bit from System Name: " + systemName);
         }
-        Light lgt;
         // Normalize the System Name
         String sName = getSystemNamePrefix() + bitNum; // removes any leading zeros
         // create the new Light object
-        lgt = new XNetLight(tc, this, sName, userName);
-        return lgt;
+        return new XNetLight(tc, this, sName, userName);
     }
 
     /**

--- a/java/src/jmri/jmrix/lenz/XNetSensorManager.java
+++ b/java/src/jmri/jmrix/lenz/XNetSensorManager.java
@@ -56,7 +56,7 @@ public class XNetSensorManager extends jmri.managers.AbstractSensorManager imple
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // check if the output bit is available
         int bitNum = XNetAddress.getBitFromSystemName(systemName, getSystemPrefix());
         if (bitNum == -1) {

--- a/java/src/jmri/jmrix/loconet/LnLightManager.java
+++ b/java/src/jmri/jmrix/loconet/LnLightManager.java
@@ -39,12 +39,13 @@ public class LnLightManager extends AbstractLightManager {
      * @return null if the system name is not in a valid format
      */
     @Override
-    public Light createNewLight(@Nonnull String systemName, String userName) {
-        Light lgt = null;
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        Light lgt;
         // check if the output bit is available
         int bitNum = getBitFromSystemName(systemName);
         if (bitNum == 0) {
-            return (null);
+            throw new IllegalArgumentException("Invalid Bit from System Name: " + systemName);
         }
         // Normalize the systemName
         String sName = getSystemPrefix() + "L" + bitNum;   // removes any leading zeros

--- a/java/src/jmri/jmrix/loconet/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/LnSensorManager.java
@@ -91,7 +91,7 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
     /** {@inheritDoc} */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         return new LnSensor(systemName, userName, tc, getSystemPrefix());
     }
 

--- a/java/src/jmri/jmrix/loconet/hexfile/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/LnSensorManager.java
@@ -32,7 +32,7 @@ public class LnSensorManager extends jmri.jmrix.loconet.LnSensorManager {
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Sensor s = new LnSensor(systemName, userName, tc, getSystemPrefix());
         if (defaultSensorState != Sensor.UNKNOWN) {
             try {

--- a/java/src/jmri/jmrix/maple/SerialLightManager.java
+++ b/java/src/jmri/jmrix/maple/SerialLightManager.java
@@ -37,50 +37,38 @@ public class SerialLightManager extends AbstractLightManager {
      * {@inheritDoc}
      */
     @Override
-    public Light createNewLight(@Nonnull String systemName, String userName) {
-        Light lgt = null;
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        
         // check if the output bit is available
         int bitNum = SerialAddress.getBitFromSystemName(systemName, getSystemPrefix());
         if (bitNum == 0) {
-            return (null);
+            throw new IllegalArgumentException("Invalid Bit from System Name: " + systemName);
         }
-        String conflict = "";
-        conflict = SerialAddress.isOutputBitFree(bitNum, getSystemPrefix());
-        if (!conflict.equals("")) {
+        String conflict = SerialAddress.isOutputBitFree(bitNum, getSystemPrefix());
+        if (!conflict.isEmpty()) {
             log.error("Assignment conflict with '{}'. Light not created.", conflict);
-            notifyLightCreationError(conflict, bitNum);
-            return (null);
+            throw new IllegalArgumentException("The output bit, " + bitNum + ", is currently assigned to " + conflict);
         }
         // Validate the System Name
         String sysName = SerialAddress.normalizeSystemName(systemName, getSystemPrefix());
-        if (sysName.equals("")) {
+        if (sysName.isEmpty()) {
             log.error("error when normalizing system name {}", systemName);
-            return null;
+            throw new IllegalArgumentException("Error when normalizing system name: "+systemName);
         }
         if (SerialAddress.validSystemNameFormat(systemName, 'L', getSystemPrefix()) == NameValidity.VALID) {
-            lgt = new SerialLight(sysName, userName, getMemo());
+            Light lgt = new SerialLight(sysName, userName, getMemo());
             if (!SerialAddress.validSystemNameConfig(sysName, 'L', getMemo())) {
                 log.warn("Light system Name '{}' does not refer to configured hardware.", sysName);
                 javax.swing.JOptionPane.showMessageDialog(null, "WARNING - The Light just added, " + sysName
                         + ", refers to an unconfigured output bit.", "Configuration Warning",
                         javax.swing.JOptionPane.INFORMATION_MESSAGE, null);
             }
+            return lgt;
         } else {
             log.error("Invalid Light system Name format: {}", systemName);
+            throw new IllegalArgumentException("Invalid Light system Name format: " + systemName);
         }
-        return lgt;
-    }
-
-    /**
-     * Public method to notify user of Light creation error.
-     * @param conflict human readable name of conflicting light.
-     * @param bitNum bit number of conflicting light.
-     */
-    public void notifyLightCreationError(String conflict, int bitNum) {
-        javax.swing.JOptionPane.showMessageDialog(null, "The output bit, " + bitNum
-                + ", is currently assigned to " + conflict + ". Light cannot be created as "
-                + "you specified.", "Assignment Conflict",
-                javax.swing.JOptionPane.INFORMATION_MESSAGE, null);
     }
 
     /**

--- a/java/src/jmri/jmrix/maple/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/maple/SerialSensorManager.java
@@ -58,11 +58,11 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Sensor s;
         // validate the system name, and normalize it
         String sName = SerialAddress.normalizeSystemName(systemName, getSystemPrefix());
-        if (sName.equals("")) {
+        if (sName.isEmpty()) {
             // system name is not valid
             throw new IllegalArgumentException("Invalid Maple Sensor system name - " +  // NOI18N
                     systemName);

--- a/java/src/jmri/jmrix/marklin/MarklinSensorManager.java
+++ b/java/src/jmri/jmrix/marklin/MarklinSensorManager.java
@@ -49,7 +49,7 @@ public class MarklinSensorManager extends jmri.managers.AbstractSensorManager
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         MarklinSensor s = new MarklinSensor(systemName, userName);
         if (systemName.contains(":")) {
             int board = 0;
@@ -60,7 +60,7 @@ public class MarklinSensorManager extends jmri.managers.AbstractSensorManager
             try {
                 board = Integer.parseInt(curAddress.substring(0, seperator));
                 if (!_tmarklin.containsKey(board)) {
-                    _tmarklin.put(board, new Hashtable<Integer, MarklinSensor>());
+                    _tmarklin.put(board, new Hashtable<>());
                     MarklinMessage m = MarklinMessage.sensorPollMessage(board);
                     tc.sendMarklinMessage(m, this);
                 }

--- a/java/src/jmri/jmrix/mqtt/MqttLightManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttLightManager.java
@@ -40,7 +40,8 @@ public class MqttLightManager extends jmri.managers.AbstractLightManager {
     }
 
     @Override
-    public Light createNewLight(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         String suffix = systemName.substring(getSystemNamePrefix().length());
 
         String sendTopic = java.text.MessageFormat.format(

--- a/java/src/jmri/jmrix/mqtt/MqttSensorManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttSensorManager.java
@@ -56,12 +56,13 @@ public class MqttSensorManager extends jmri.managers.AbstractSensorManager {
     }
     
     /**
-     * Create an new sensor object
-     *
-     * @return new null
+     * Create an new sensor object.
+     * {@inheritDoc}
+     * @return never null
      */
+    @Nonnull
     @Override
-    protected Sensor createNewSensor(String systemName, String userName) {
+    protected Sensor createNewSensor(String systemName, String userName) throws IllegalArgumentException {
         MqttSensor s;
         String suffix = systemName.substring(getSystemPrefix().length() + 1);
 

--- a/java/src/jmri/jmrix/nce/NceLightManager.java
+++ b/java/src/jmri/jmrix/nce/NceLightManager.java
@@ -34,17 +34,18 @@ public class NceLightManager extends AbstractLightManager {
     }
 
     /**
-     * Method to create a new Light based on the system name Returns null if the
-     * system name is not in a valid format Assumes calling method has checked
+     * Method to create a new Light based on the system name
+     * Assumes calling method has checked
      * that a Light with this system name does not already exist
      */
     @Override
-    public Light createNewLight(String systemName, String userName) {
-        Light lgt = null;
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        Light lgt;
         // check if the output bit is available
         int bitNum = getBitFromSystemName(systemName);
         if (bitNum == 0) {
-            return (null);
+            throw new IllegalArgumentException("Invalid Bit from System Name: " + systemName);
         }
         // Normalize the systemName
         String sName = getSystemPrefix() + "L" + bitNum;   // removes any leading zeros

--- a/java/src/jmri/jmrix/nce/NceSensorManager.java
+++ b/java/src/jmri/jmrix/nce/NceSensorManager.java
@@ -82,7 +82,7 @@ public class NceSensorManager extends jmri.managers.AbstractSensorManager
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         int number = 0;
         try {
             number = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));

--- a/java/src/jmri/jmrix/oaktree/SerialLightManager.java
+++ b/java/src/jmri/jmrix/oaktree/SerialLightManager.java
@@ -37,23 +37,24 @@ public class SerialLightManager extends AbstractLightManager {
      * Create a new Light based on the system name.
      * Assumes calling method has checked that a Light with this system name
      * does not already exist.
-     *
-     * @return null if the system name is not in a valid format or if the
+     * {@inheritDoc}
+     * @throws IllegalArgumentException if the system name is not in a valid format or if the
      * system name does not correspond to a configured OakTree digital output bit
      */
     @Override
-    public Light createNewLight(@Nonnull String systemName, String userName) {
-        Light lgt = null;
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // Validate the systemName
         if (SerialAddress.validSystemNameFormat(systemName, 'L', getSystemPrefix()) == NameValidity.VALID) {
-            lgt = new SerialLight(systemName, userName, getMemo());
+            Light lgt = new SerialLight(systemName, userName, getMemo());
             if (!SerialAddress.validSystemNameConfig(systemName, 'L', getMemo())) {
                 log.warn("Light system Name does not refer to configured hardware: {}", systemName);
             }
+            return lgt;
         } else {
             log.error("Invalid Light system Name format: {}", systemName);
+            throw new IllegalArgumentException("Invalid Light system Name format: " + systemName);
         }
-        return lgt;
     }
 
     /**

--- a/java/src/jmri/jmrix/oaktree/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/oaktree/SerialSensorManager.java
@@ -56,11 +56,11 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Sensor s;
         // validate the system name, and normalize it
         String sName = SerialAddress.normalizeSystemName(systemName, getSystemPrefix());
-        if (sName.equals("")) {
+        if (sName.isEmpty()) {
             // system name is not valid
             throw new IllegalArgumentException("Invalid Oaktree Sensor system name - " +  // NOI18N
                     systemName);

--- a/java/src/jmri/jmrix/openlcb/OlcbLightManager.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbLightManager.java
@@ -73,7 +73,8 @@ public class OlcbLightManager extends AbstractLightManager {
      * @return never null
      */
     @Override
-    protected Light createNewLight(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         String addr = systemName.substring(getSystemPrefix().length() + 1);
         OlcbLight l = new OlcbLight(getSystemPrefix(), addr, memo.get(OlcbInterface.class));
         l.setUserName(userName);

--- a/java/src/jmri/jmrix/openlcb/OlcbSensorManager.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSensorManager.java
@@ -91,7 +91,7 @@ public class OlcbSensorManager extends jmri.managers.AbstractSensorManager imple
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         String addr = systemName.substring(getSystemNamePrefix().length());
         // first, check validity
         try {

--- a/java/src/jmri/jmrix/pi/RaspberryPiSensorManager.java
+++ b/java/src/jmri/jmrix/pi/RaspberryPiSensorManager.java
@@ -32,7 +32,7 @@ public class RaspberryPiSensorManager extends jmri.managers.AbstractSensorManage
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         return new RaspberryPiSensor(systemName, userName);
     }
 

--- a/java/src/jmri/jmrix/powerline/SerialLightManager.java
+++ b/java/src/jmri/jmrix/powerline/SerialLightManager.java
@@ -47,18 +47,19 @@ abstract public class SerialLightManager extends AbstractLightManager {
      * that a Light with this system name does not already exist
      */
     @Override
-    public Light createNewLight(@Nonnull String systemName, String userName) {
-        Light lgt = null;
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // Validate the systemName
         if (tc.getAdapterMemo().getSerialAddress().validSystemNameFormat(systemName, 'L') == NameValidity.VALID) {
-            lgt = createNewSpecificLight(systemName, userName);
+            Light lgt = createNewSpecificLight(systemName, userName);
             if (!tc.getAdapterMemo().getSerialAddress().validSystemNameConfig(systemName, 'L')) {
                 log.warn("Light system Name does not refer to configured hardware: {}", systemName);
             }
+            return lgt;
         } else {
             log.error("Invalid Light system Name format: {}", systemName);
+            throw new IllegalArgumentException("Invalid Light system Name format: " + systemName);
         }
-        return lgt;
     }
 
     /**

--- a/java/src/jmri/jmrix/powerline/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/powerline/SerialSensorManager.java
@@ -49,7 +49,7 @@ abstract public class SerialSensorManager extends jmri.managers.AbstractSensorMa
         Sensor s;
         // validate the system name, and normalize it
         String sName = tc.getAdapterMemo().getSerialAddress().normalizeSystemName(systemName);
-        if (sName.equals("")) {
+        if (sName.isEmpty()) {
             // system name is not valid
             throw new IllegalArgumentException("Invalid Powerline Sensor system name - " +  // NOI18N
                     systemName);

--- a/java/src/jmri/jmrix/rfid/generic/standalone/StandaloneSensorManager.java
+++ b/java/src/jmri/jmrix/rfid/generic/standalone/StandaloneSensorManager.java
@@ -42,10 +42,9 @@ public class StandaloneSensorManager extends RfidSensorManager {
      */
     @Override
     @Nonnull
-    protected Sensor createNewSensor(@Nonnull String systemName, String userName) {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         log.debug("Create new Sensor");
-        TimeoutRfidSensor s;
-        s = new TimeoutRfidSensor(systemName, userName);
+        TimeoutRfidSensor s = new TimeoutRfidSensor(systemName, userName);
         s.addPropertyChangeListener(this);
         return s;
     }

--- a/java/src/jmri/jmrix/rfid/merg/concentrator/ConcentratorSensorManager.java
+++ b/java/src/jmri/jmrix/rfid/merg/concentrator/ConcentratorSensorManager.java
@@ -42,10 +42,9 @@ public class ConcentratorSensorManager extends RfidSensorManager {
      */
     @Override
     @Nonnull
-    protected Sensor createNewSensor(@Nonnull String systemName, String userName) {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         log.debug("Create new Sensor");
-        TimeoutRfidSensor s;
-        s = new TimeoutRfidSensor(systemName, userName);
+        TimeoutRfidSensor s = new TimeoutRfidSensor(systemName, userName);
         s.addPropertyChangeListener(this);
         return s;
     }

--- a/java/src/jmri/jmrix/roco/z21/Z21SensorManager.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21SensorManager.java
@@ -68,7 +68,7 @@ public class Z21SensorManager extends jmri.managers.AbstractSensorManager implem
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName)  throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName)  throws IllegalArgumentException {
         if (systemName.contains(":")) {
             // check for CAN format.
             int bitNum = Z21CanBusAddress.getBitFromSystemName(systemName, getSystemPrefix());

--- a/java/src/jmri/jmrix/rps/RpsSensorManager.java
+++ b/java/src/jmri/jmrix/rps/RpsSensorManager.java
@@ -29,12 +29,6 @@ public class RpsSensorManager extends jmri.managers.AbstractSensorManager {
         return (RpsSystemConnectionMemo) memo;
     }
 
-    // to free resources when no longer used
-    @Override
-    public void dispose() {
-        super.dispose();
-    }
-
     /**
      * {@inheritDoc}
      * <p>
@@ -46,7 +40,7 @@ public class RpsSensorManager extends jmri.managers.AbstractSensorManager {
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         try {
            RpsSensor r = new RpsSensor(systemName, userName, getSystemPrefix());
            Distributor.instance().addMeasurementListener(r);

--- a/java/src/jmri/jmrix/secsi/SerialLightManager.java
+++ b/java/src/jmri/jmrix/secsi/SerialLightManager.java
@@ -38,22 +38,24 @@ public class SerialLightManager extends AbstractLightManager {
      * Assumes calling method has checked that a Light with this system
      * name does not already exist.
      *
-     * @return null if system name is not in a valid format or if the
+     * @throws IllegalArgumentException if system name is not in a valid format 
+     * or if the
      * system name does not correspond to a configured C/MRI digital output bit
      */
     @Override
-    public Light createNewLight(@Nonnull String systemName, String userName) {
-        Light lgt = null;
+    @Nonnull
+    protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // Validate the systemName
         if (SerialAddress.validSystemNameFormat(systemName, 'L', getSystemPrefix()) == NameValidity.VALID) {
-            lgt = new SerialLight(systemName, userName,getMemo());
+            Light lgt = new SerialLight(systemName, userName,getMemo());
             if (!SerialAddress.validSystemNameConfig(systemName, 'L', getMemo().getTrafficController())) {
                 log.warn("Light system Name does not refer to configured hardware: {}", systemName);
             }
+            return lgt;
         } else {
             log.error("Invalid Light system Name format: {}", systemName);
+            throw new IllegalArgumentException("Invalid Light system Name format: " + systemName);
         }
-        return lgt;
     }
 
     /**

--- a/java/src/jmri/jmrix/secsi/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/secsi/SerialSensorManager.java
@@ -59,11 +59,11 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Sensor s;
         // validate the system name, and normalize it
         String sName = SerialAddress.normalizeSystemName(systemName, getSystemPrefix());
-        if (sName.equals("")) {
+        if (sName.isEmpty()) {
             // system name is not valid
             throw new IllegalArgumentException("Invalid Secsi Sensor system name - " +  // NOI18N
                     systemName);

--- a/java/src/jmri/jmrix/srcp/SRCPSensorManager.java
+++ b/java/src/jmri/jmrix/srcp/SRCPSensorManager.java
@@ -45,7 +45,7 @@ public class SRCPSensorManager extends jmri.managers.AbstractSensorManager {
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Sensor t;
         int addr;
         try {

--- a/java/src/jmri/jmrix/tams/TamsSensorManager.java
+++ b/java/src/jmri/jmrix/tams/TamsSensorManager.java
@@ -68,7 +68,7 @@ public class TamsSensorManager extends jmri.managers.AbstractSensorManager imple
      */
     @Override
     @Nonnull
-    public Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         TamsTrafficController tc = getMemo().getTrafficController();
         TamsSensor s = new TamsSensor(systemName, userName);
         log.debug("Creating new TamsSensor: {}", systemName);

--- a/java/src/jmri/managers/AbstractLightManager.java
+++ b/java/src/jmri/managers/AbstractLightManager.java
@@ -1,11 +1,15 @@
 package jmri.managers;
 
+import java.util.Objects;
+
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
 import jmri.Light;
 import jmri.LightManager;
 import jmri.Manager;
 import jmri.SystemConnectionMemo;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,25 +71,30 @@ public abstract class AbstractLightManager extends AbstractManager<Light>
     }
 
     /**
+     * Lookup Light by UserName, then provide by SystemName.
      * {@inheritDoc}
      */
     @Override
     @Nonnull
-    public Light newLight(@Nonnull String systemName, @CheckForNull String userName) {
-        log.debug("newLight: {};{}",
-                ((systemName == null) ? "null" : systemName),
-                ((userName == null) ? "null" : userName));
+    public Light newLight(@Nonnull String systemName, @CheckForNull String userName) throws IllegalArgumentException {
+        Objects.requireNonNull(systemName, "SystemName cannot be null. UserName was " + ((userName == null) ? "null" : userName));  // NOI18N
+        log.debug("newLight: {};{}", systemName, userName);
+        
         systemName = validateSystemNameFormat(systemName);
         // return existing if there is one
         Light l;
-        if ((userName != null) && ((l = getByUserName(userName)) != null)) {
-            if (getBySystemName(systemName) != l) {
-                log.error("inconsistent user '{}' and system name '{}' results; user name related to {}",
+        if (userName != null) {
+            l = getByUserName(userName);
+            if (l != null) {
+                if (getBySystemName(systemName) != l) {
+                    log.error("inconsistent user '{}' and system name '{}' results; user name related to {}",
                         userName, systemName, l.getSystemName());
+                }
+                return l;
             }
-            return l;
         }
-        if ((l = getBySystemName(systemName)) != null) {
+        l = getBySystemName(systemName);
+        if (l != null) {
             if ((l.getUserName() == null) && (userName != null)) {
                 l.setUserName(userName);
             } else if (userName != null) {
@@ -96,11 +105,6 @@ public abstract class AbstractLightManager extends AbstractManager<Light>
         }
         // doesn't exist, make a new one
         l = createNewLight(systemName, userName);
-
-        // if that failed, blame it on the input arguments
-        if (l == null) {
-            throw new IllegalArgumentException("cannot create new light " + systemName);
-        }
         // save in the maps
         register(l);
 
@@ -115,8 +119,8 @@ public abstract class AbstractLightManager extends AbstractManager<Light>
      * @param userName   the user name to use for this light
      * @return the new light or null if unsuccessful
      */
-    @CheckForNull
-    abstract protected Light createNewLight(@Nonnull String systemName, String userName);
+    @Nonnull
+    abstract protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException;
 
     /**
      * {@inheritDoc}

--- a/java/src/jmri/managers/AbstractProvidingProxyManager.java
+++ b/java/src/jmri/managers/AbstractProvidingProxyManager.java
@@ -1,5 +1,7 @@
 package jmri.managers;
 
+import javax.annotation.Nonnull;
+
 import jmri.*;
 
 /**
@@ -33,6 +35,7 @@ abstract public class AbstractProvidingProxyManager<E extends NamedBean> extends
      * @return an existing or new NamedBean
      * @throws IllegalArgumentException if name is not usable in a bean
      */
+    @Nonnull
     protected E provideNamedBean(String name) throws IllegalArgumentException {
         // make sure internal present
         initInternal();
@@ -51,7 +54,11 @@ abstract public class AbstractProvidingProxyManager<E extends NamedBean> extends
     }
 
     /**
-     * Return an instance with the specified system and user names. Note that
+     * Return an instance with the specified user or system name. 
+     * <p>
+     * Lookup by UserName, then provide by System Name.
+     * <p>
+     * Note that
      * two calls with the same arguments will get the same instance; there is
      * i.e. only one Sensor object representing a given physical sensor and
      * therefore only one with a specific system or user name.
@@ -62,25 +69,30 @@ abstract public class AbstractProvidingProxyManager<E extends NamedBean> extends
      * <li>If a null reference is given for user name, no user name will be
      * associated with the NamedBean object created; a valid system name must be
      * provided
-     * <li>If a null reference is given for the system name, a system name will
-     * _somehow_ be inferred from the user name. How this is done is system
-     * specific. Note: a future extension of this interface will add an
-     * exception to signal that this was not possible.
      * <li>If both names are provided, the system name defines the hardware
      * access of the desired turnout, and the user address is associated with
      * it.
+     * <li>If a matching UserName is located, that will be returned.
+     * <li>Else If a matching SystemName is located, that will be returned.
+     * <li>Else A New Bean will be created with the given System Name.
+     * The UserName will be added to the New Bean if no existing.
      * </ul>
      * Note that it is possible to make an inconsistent request if both
      * addresses are provided, but the given values are associated with
      * different objects. This is a problem, and we don't have a good solution
      * except to issue warnings. This will mostly happen if you're creating
      * NamedBean when you should be looking them up.
+     * <p>
+     * If the System Name contains the start of a specified Manager, that will be used,
+     * else the default manager will be used.
+     * @see #getManager(java.lang.String)
      *
      * @param systemName the system name
      * @param userName   the user name
      * @return requested NamedBean object (never null)
      */
-    public E newNamedBean(String systemName, String userName) {
+    @Nonnull
+    public E newNamedBean(String systemName, String userName) throws IllegalArgumentException {
         // make sure internal present
         initInternal();
 
@@ -101,9 +113,11 @@ abstract public class AbstractProvidingProxyManager<E extends NamedBean> extends
      * @param manager    the manager to invoke
      * @param systemName the system name
      * @param userName   the user name
+     * @throws IllegalArgumentException if unable to make.
      * @return a bean
      */
-    abstract protected E makeBean(Manager<E> manager, String systemName, String userName);
+    @Nonnull
+    abstract protected E makeBean(Manager<E> manager, String systemName, String userName) throws IllegalArgumentException;
 
     // initialize logging
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractProvidingProxyManager.class);

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -80,7 +80,10 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         return _tsys.get(key);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * Create a New Sensor.
+     * {@inheritDoc}
+     */
     @Override
     @Nonnull
     public Sensor newSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
@@ -90,13 +93,17 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         systemName = validateSystemNameFormat(systemName);
         // return existing if there is one
         Sensor s;
-        if ((userName != null) && ((s = getByUserName(userName)) != null)) {
-            if (getBySystemName(systemName) != s) {
-                log.error("inconsistent user ({}) and system name ({}) results; userName related to ({})", userName, systemName, s.getSystemName());
+        if (userName != null) {
+            s = getByUserName(userName);
+            if (s != null) {
+                if (getBySystemName(systemName) != s) {
+                    log.error("inconsistent user ({}) and system name ({}) results; userName related to ({})", userName, systemName, s.getSystemName());
+                }
+                return s;
             }
-            return s;
         }
-        if ((s = getBySystemName(systemName)) != null) {
+        s = getBySystemName(systemName);
+        if (s != null) {
             if ((s.getUserName() == null) && (userName != null)) {
                 s.setUserName(userName);
             } else if (userName != null) {
@@ -129,15 +136,21 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
     }
 
     /**
-     * Internal method to invoke the factory and create a new Sensor based on the system
-     * name and optional user name, after all the logic for returning an existing Sensor
+     * Internal method to invoke the factory and create a new Sensor.
+     * 
+     * Called after all the logic for returning an existing Sensor
      * has been invoked.
-     *
+     * An existing SystemName is not found, existing UserName not found.
+     * 
+     * Implementing classes should base Sensor on the system name, then add user name.
+     * 
      * @param systemName the system name to use for the new Sensor
      * @param userName   the optional user name to use for the new Sensor
-     * @return the new Sensor or null if unsuccessful
+     * @return the new Sensor
+     * @throws IllegalArgumentException if unsuccessful with reason for fail.
      */
-    abstract protected Sensor createNewSensor(@Nonnull String systemName, String userName);
+    @Nonnull
+    abstract protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException;
 
     /**
      * {@inheritDoc}

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -39,8 +39,10 @@ public class ProxyLightManager extends AbstractProvidingProxyManager<Light>
         return super.getNamedBean(name);
     }
 
+    /** {@inheritDoc} */
     @Override
-    protected Light makeBean(Manager<Light> manager, String systemName, String userName) {
+    @Nonnull
+    protected Light makeBean(Manager<Light> manager, String systemName, String userName) throws IllegalArgumentException {
         return ((LightManager) manager).newLight(systemName, userName);
     }
 
@@ -63,37 +65,10 @@ public class ProxyLightManager extends AbstractProvidingProxyManager<Light>
         return super.provideNamedBean(name);
     }
 
-    /**
-     * Return an instance with the specified system and user names. Note that
-     * two calls with the same arguments will get the same instance; there is
-     * only one Light object representing a given physical light and therefore
-     * only one with a specific system or user name.
-     * <p>
-     * This will always return a valid object reference for a valid request; a
-     * new object will be created if necessary. In that case:
-     * <ul>
-     * <li>If a null reference is given for user name, no user name will be
-     * associated with the Light object created; a valid system name must be
-     * provided
-     * <li>If a null reference is given for the system name, a system name will
-     * _somehow_ be inferred from the user name. How this is done is system
-     * specific. Note: a future extension of this interface will add an
-     * exception to signal that this was not possible.
-     * <li>If both names are provided, the system name defines the hardware
-     * access of the desired turnout, and the user address is associated with
-     * it.
-     * </ul>
-     * Note that it is possible to make an inconsistent request if both
-     * addresses are provided, but the given values are associated with
-     * different objects. This is a problem, and we don't have a good solution
-     * except to issue warnings. This will mostly happen if you're creating
-     * Lights when you should be looking them up.
-     *
-     * @return requested Light object (never null)
-     */
+    /** {@inheritDoc} */
     @Override
     @Nonnull
-    public Light newLight(@Nonnull String systemName, String userName) {
+    public Light newLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         return newNamedBean(systemName, userName);
     }
 

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -1,9 +1,9 @@
 package jmri.managers;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jmri.Manager;
 
-import jmri.DigitalIO;
 import jmri.Sensor;
 import jmri.SensorManager;
 
@@ -31,12 +31,15 @@ public class ProxySensorManager extends AbstractProvidingProxyManager<Sensor>
      * @return Null if nothing by that name exists
      */
     @Override
+    @CheckForNull
     public Sensor getSensor(@Nonnull String name) {
         return super.getNamedBean(name);
     }
 
+    /** {@inheritDoc} */
     @Override
-    protected Sensor makeBean(Manager<Sensor> manager, String systemName, String userName) {
+    @Nonnull
+    protected Sensor makeBean(Manager<Sensor> manager, String systemName, String userName) throws IllegalArgumentException {
         return ((SensorManager) manager).newSensor(systemName, userName);
     }
 
@@ -51,37 +54,10 @@ public class ProxySensorManager extends AbstractProvidingProxyManager<Sensor>
     @Nonnull
     public Sensor provide(@Nonnull String name) throws IllegalArgumentException { return provideSensor(name); }
 
-    /**
-     * Return an instance with the specified system and user names. Note that
-     * two calls with the same arguments will get the same instance; there is
-     * only one Sensor object representing a given physical turnout and
-     * therefore only one with a specific system or user name.
-     * <p>
-     * This will always return a valid object reference for a valid request; a
-     * new object will be created if necessary. In that case:
-     * <ul>
-     * <li>If a null reference is given for user name, no user name will be
-     * associated with the Turnout object created; a valid system name must be
-     * provided
-     * <li>If a null reference is given for the system name, a system name will
-     * _somehow_ be inferred from the user name. How this is done is system
-     * specific. Note: a future extension of this interface will add an
-     * exception to signal that this was not possible.
-     * <li>If both names are provided, the system name defines the hardware
-     * access of the desired turnout, and the user address is associated with
-     * it.
-     * </ul>
-     * Note that it is possible to make an inconsistent request if both
-     * addresses are provided, but the given values are associated with
-     * different objects. This is a problem, and we don't have a good solution
-     * except to issue warnings. This will mostly happen if you're creating
-     * Sensors when you should be looking them up.
-     *
-     * @return requested Sensor object (never null)
-     */
+    /** {@inheritDoc} */
     @Override
     @Nonnull
-    public Sensor newSensor(@Nonnull String systemName, String userName) {
+    public Sensor newSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         return newNamedBean(systemName, userName);
     }
 

--- a/java/test/jmri/jmrix/cmri/serial/SerialAddressTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialAddressTest.java
@@ -44,11 +44,7 @@ public class SerialAddressTest {
         };
         jmri.InstanceManager.setTurnoutManager(l);
 
-        jmri.LightManager lgt = new SerialLightManager(memo) {
-            @Override
-            public void notifyLightCreationError(String conflict, int bitNum) {
-            }
-        };
+        jmri.LightManager lgt = new SerialLightManager(memo);
         jmri.InstanceManager.setLightManager(lgt);
 
         jmri.SensorManager s = new SerialSensorManager(memo);

--- a/java/test/jmri/jmrix/cmri/serial/SerialAddressTwoSystemTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialAddressTwoSystemTest.java
@@ -42,17 +42,9 @@ public class SerialAddressTwoSystemTest {
         c10 = new SerialNode(10, SerialNode.SMINI, stcs1);
         c18 = new SerialNode(18, SerialNode.SMINI, stcs1);
         // create and register the 1st manager objects
-        jmri.TurnoutManager l1 = new SerialTurnoutManager(memo1) {
-            @Override
-            public void notifyTurnoutCreationError(String conflict, int bitNum) {
-            }
-        };
+        jmri.TurnoutManager l1 = new SerialTurnoutManager(memo1);
         jmri.InstanceManager.setTurnoutManager(l1);
-        jmri.LightManager lgt1 = new SerialLightManager(memo1) {
-            @Override
-            public void notifyLightCreationError(String conflict, int bitNum) {
-            }
-        };
+        jmri.LightManager lgt1 = new SerialLightManager(memo1);
         jmri.InstanceManager.setLightManager(lgt1);
         jmri.SensorManager s1 = new SerialSensorManager(memo1);
         jmri.InstanceManager.setSensorManager(s1);
@@ -71,11 +63,7 @@ public class SerialAddressTwoSystemTest {
             }
         };
         jmri.InstanceManager.setTurnoutManager(l2);
-        jmri.LightManager lgt2 = new SerialLightManager(memo2) {
-            @Override
-            public void notifyLightCreationError(String conflict, int bitNum) {
-            }
-        };
+        jmri.LightManager lgt2 = new SerialLightManager(memo2);
         jmri.InstanceManager.setLightManager(lgt2);
         jmri.SensorManager s2 = new SerialSensorManager(memo2);
         jmri.InstanceManager.setSensorManager(s2);

--- a/java/test/jmri/jmrix/maple/SerialAddressTest.java
+++ b/java/test/jmri/jmrix/maple/SerialAddressTest.java
@@ -214,11 +214,7 @@ public class SerialAddressTest {
 
         memo.setTurnoutManager(l);
 
-        SerialLightManager lgt = new SerialLightManager(memo) {
-            @Override
-            public void notifyLightCreationError(String conflict, int bitNum) {
-            }
-        };
+        SerialLightManager lgt = new SerialLightManager(memo);
         jmri.InstanceManager.setLightManager(lgt);
         memo.setLightManager(lgt);
 


### PR DESCRIPTION
See #7661 though further dev. required before this can be closed.

Lint SensorManager createNewSensor and LightManager createNewLight methods.
All annotated Nonnull / IllegalArgumentException
All moved to protected to prevent duplicates.
Various Annotation and Javadoc improvements.
Creation error dialogues removed from Maple & CMRI SerialLightManager, text used in Exception.