### PR TITLE
Update Consist Tool Frame Test

### DIFF
--- a/java/test/jmri/jmrit/consisttool/ConsistToolFrameTest.java
+++ b/java/test/jmri/jmrit/consisttool/ConsistToolFrameTest.java
@@ -163,7 +163,7 @@ public class ConsistToolFrameTest {
         to.getQueueTool().waitEmpty();  // pause for frame to close
         
         cs.requestClose();
-        new org.netbeans.jemmy.QueueTool().waitEmpty(100);  //pause for frame tot close
+        cs.getQueueTool().waitEmpty();  // pause for frame to close
     }
 
     @Test


### PR DESCRIPTION
Test still failing, https://builds.jmri.org/jenkins/job/development/job/alltest/602/testReport/junit/

#9594 moved the timeout fail further down the Test so this may help.