### PR TITLE
 Various Dispatcher Fixes.

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -403,7 +403,7 @@
    <h3>Dispatcher</h3>
         <a id="Dispatcher" name="Dispatcher"></a>
         <ul>
-             <li></li>
+             <li>Use full length of section when stopping by speed profile.</li>
         </ul>
 
     <h3>Dispatcher System</h3>

--- a/java/src/jmri/implementation/DccSignalMast.java
+++ b/java/src/jmri/implementation/DccSignalMast.java
@@ -152,6 +152,10 @@ public class DccSignalMast extends AbstractSignalMast {
 
     @Override
     public void setAspect(@Nonnull String aspect) {
+        // if already set do not send again.
+        if ( getAspect() != null && getAspect().equals(aspect) ) {
+            return;
+        }
         if (appearanceToOutput.containsKey(aspect) && appearanceToOutput.get(aspect) != -1) {
             c.sendPacket(NmraPacket.altAccSignalDecoderPkt(dccSignalDecoderAddress, appearanceToOutput.get(aspect)), packetSendCount);
         } else {

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -142,7 +142,7 @@ public class AutoActiveTrain implements ThrottleListener {
     public synchronized void setTargetSpeed(float speed) {
         _targetSpeed = speed;
         if (speed > 0.002) {
-            _autoEngineer.slowToStop(false);
+            cancelStopInCurrentSection();
         }
     }
 
@@ -256,7 +256,6 @@ public class AutoActiveTrain implements ThrottleListener {
         //clear all flags
         _pausingActive = false;
         _stoppingBySensor = false;
-        _stoppingForStopSignal = false;
         _stoppingByBlockOccupancy = false;
         _stoppingUsingSpeedProfile = false;
 
@@ -390,7 +389,6 @@ public class AutoActiveTrain implements ThrottleListener {
     private Sensor _stopSensor = null;
     private PropertyChangeListener _stopSensorListener = null;
     private PropertyChangeListener _turnoutStateListener = null;
-    private boolean _stoppingForStopSignal = false;    // if true, stopping because of signal appearance
     private boolean _stoppingByBlockOccupancy = false;    // if true, stop when _stoppingBlock goes UNOCCUPIED
     private boolean _stoppingUsingSpeedProfile = false;     // if true, using the speed profile against the roster entry to bring the loco to a stop in a specific distance
     private volatile Block _stoppingBlock = null;
@@ -473,7 +471,7 @@ public class AutoActiveTrain implements ThrottleListener {
                 // defer setting the next/previous blocks until we know if its required and in what fashion
                 // for stopping blocks that action happens after the train has stopped.
                 // first check for entering the end point
-                if (_currentBlock == _activeTrain.getEndBlock() && as.getSequence() == _activeTrain.getEndBlockSectionSequenceNumber()) {
+                if (!_activeTrain.isTransitReversed() && as.getSequence() == _activeTrain.getEndBlockSectionSequenceNumber()) {
                     // are we going to reverse at end
                     if ( _activeTrain.getReverseAtEnd() ) {
                         removeCurrentSignal();
@@ -510,7 +508,7 @@ public class AutoActiveTrain implements ThrottleListener {
                     }
                 }
                 // are we entering the start point
-                else if (_currentBlock == _activeTrain.getStartBlock() && as.getSequence() == _activeTrain.getStartBlockSectionSequenceNumber()) {
+                else if (_activeTrain.isTransitReversed() && as.getSequence() == _activeTrain.getStartBlockSectionSequenceNumber()) {
                      // are we coming back from a reverse and running continiuosly
                     if ( _activeTrain.getResetWhenDone() && _activeTrain.isTransitReversed() ) {
                         removeCurrentSignal();
@@ -695,10 +693,6 @@ public class AutoActiveTrain implements ThrottleListener {
                     if (e.getPropertyName().equals("Appearance")) {
                         // controlling signal has changed appearance
                         setSpeedBySignal();
-                        if (_stoppingForStopSignal && (_targetSpeed > 0.0)) {
-                            cancelStopInCurrentSection();
-                            _stoppingForStopSignal = false;
-                        }
                     }
                 });
                 log.debug("new current signal = {}", sh.getDisplayName(USERSYS));
@@ -739,10 +733,6 @@ public class AutoActiveTrain implements ThrottleListener {
                         // controlling signal has changed appearance or a hold has been released
                         // even if its a hold we still have to use target speed etc else we override pauses and other stop events.
                         setSpeedBySignal();
-                        if (_stoppingForStopSignal && (_targetSpeed > 0.0)) {
-                            cancelStopInCurrentSection();
-                            _stoppingForStopSignal = false;
-                        }
                     }
                 });
                 log.debug("{}: new current signalmast {}({}) for section {}", _activeTrain.getTrainName(), sm.getDisplayName(USERSYS),
@@ -753,7 +743,7 @@ public class AutoActiveTrain implements ThrottleListener {
             } // Note: null signal head will result when exiting throat-to-throat blocks.
             else {
                 log.debug("{}: new current signalmast is null for section {} - sometimes OK", _activeTrain.getTrainName(),
-                        as.getSection().getDisplayName(USERSYS));
+                        as == null ? "Null" : as.getSection().getDisplayName(USERSYS));
             }
         } else {
             setSpeedBySignal();
@@ -841,6 +831,7 @@ public class AutoActiveTrain implements ThrottleListener {
                 || (_activeTrain.getMode() != ActiveTrain.AUTOMATIC)) {
             // train is pausing or not RUNNING or WAITING in AUTOMATIC mode, or no controlling signal,
             //   don't set speed based on controlling signal
+            log.trace("Skip Set Speed By Signal");
             return;
         }
         // only bother to check signal if the next allocation is ours.
@@ -962,6 +953,7 @@ public class AutoActiveTrain implements ThrottleListener {
                         _conSignalProtectedBlock.getBlockSpeed());
             }
         }
+
         if ((_controllingSignalMast.getAppearanceMap().getSpecificAppearance(jmri.SignalAppearanceMap.DANGER).equals(displayedAspect))
                 || !_controllingSignalMast.getLit() || _controllingSignalMast.getHeld()) {
             if ( (_currentAllocatedSection.isInActiveBlockList(_conSignalProtectedBlock) ||
@@ -972,7 +964,6 @@ public class AutoActiveTrain implements ThrottleListener {
             } else {
                 log.debug("{}: Signal {} at Held or Danger so Stop", _activeTrain.getTrainName(), _controllingSignalMast.getDisplayName(USERSYS));
                 stopInCurrentSection(NO_TASK);
-                _stoppingForStopSignal = true;
             }
         } else if (_controllingSignalMast.getAppearanceMap().getSpecificAppearance(jmri.SignalAppearanceMap.PERMISSIVE) != null
                 && _controllingSignalMast.getAppearanceMap().getSpecificAppearance(jmri.SignalAppearanceMap.PERMISSIVE).equals(displayedAspect)) {
@@ -1053,7 +1044,6 @@ public class AutoActiveTrain implements ThrottleListener {
         if ( _controllingSignal != null && _controllingSignal.getAppearance() == SignalHead.HELD ) {
             // Held - Stop
             stopInCurrentSection(NO_TASK);
-            _stoppingForStopSignal = true;
             return;
         }
 
@@ -1093,7 +1083,6 @@ public class AutoActiveTrain implements ThrottleListener {
                     log.debug("{}:Ignoring red signal [{}]",_activeTrain.getTrainName(),_controllingSignal.getDisplayName(USERSYS));
                 } else {
                     stopInCurrentSection(NO_TASK);
-                    _stoppingForStopSignal = true;
                 }
             } else {
                 setTargetSpeedByProfile(useSpeed);
@@ -1115,7 +1104,6 @@ public class AutoActiveTrain implements ThrottleListener {
                                 _controllingSignal.getDisplayName(USERSYS));
                     } else {
                         stopInCurrentSection(NO_TASK);
-                        _stoppingForStopSignal = true;
                     }
                     break;
                 case SignalHead.YELLOW:
@@ -1136,7 +1124,6 @@ public class AutoActiveTrain implements ThrottleListener {
                 default:
                     log.warn("Signal Head[{}] has invalid Appearence - using stop",_controllingSignal.getAppearance());
                     stopInCurrentSection(NO_TASK);
-                    _stoppingForStopSignal = true;
             }
 
         }
@@ -1171,21 +1158,13 @@ public class AutoActiveTrain implements ThrottleListener {
 
     // called to cancel a stopping action that is in progress
     private synchronized void cancelStopInCurrentSection() {
-        if (isStopping()) {
-            if (_stoppingBySensor) {
-                // cancel stopping by stop sensor
-                cancelStoppingBySensor();
-            } else if (_stoppingByBlockOccupancy) {
-                // cancel stopping by block occupancy
-                _stoppingByBlockOccupancy = false;
-                _stoppingBlock = null;
-            } else if (_stoppingUsingSpeedProfile) {
-                _stoppingUsingSpeedProfile = false;
-                _stoppingBlock = null;
-                _autoEngineer.slowToStop(false);
-            }
-            // here add other stopping methods if any are added
-        }
+        log.trace("[{}]:Cancel Stopping", _activeTrain.getTrainName());
+        cancelStoppingBySensor();
+        _stoppingByBlockOccupancy = false;
+        _stoppingBlock = null;
+        _stoppingUsingSpeedProfile = false;
+        _stoppingBlock = null;
+        _autoEngineer.slowToStop(false);
     }
 
     private synchronized void stopInCurrentSection(int task) {
@@ -1526,13 +1505,16 @@ public class AutoActiveTrain implements ThrottleListener {
         log.trace("{}: setTargetSpeedState:({})",_activeTrain.getTrainName(),speedState);
         _autoEngineer.slowToStop(false);
         if (speedState > STOP_SPEED) {
+            cancelStopInCurrentSection();
             _targetSpeed = applyMaxThrottleAndFactor(_speedRatio[speedState]);
         } else if (useSpeedProfile && _stopBySpeedProfile) {
             // we are going to stop by profile
             _stoppingUsingSpeedProfile = true;
             _autoEngineer.slowToStop(true);
+            _targetSpeed = 0.0f;
         } else {
             _autoEngineer.setHalt(true);
+            _targetSpeed = 0.0f;
         }
     }
 
@@ -1542,9 +1524,7 @@ public class AutoActiveTrain implements ThrottleListener {
                 float throttleSetting = _activeTrain.getRosterEntry().getSpeedProfile().getThrottleSettingFromSignalMapSpeed(speedState, _forward);
                 log.debug("{}: setTargetSpeedByProfile: SpeedState[{}]",_activeTrain.getTrainName(),throttleSetting,speedState);
                 if (throttleSetting > 0.009) {
-                    _autoEngineer.setHalt(false);
-                    _autoEngineer.slowToStop(false);
-                    //TODO is this next bit correct do we need to apply max speed?
+                    cancelStopInCurrentSection();
                     _targetSpeed = throttleSetting * _speedFactor;  // only apply speed factor not max
                  } else if (useSpeedProfile && _stopBySpeedProfile) {
                     _targetSpeed = 0.0f;
@@ -1582,6 +1562,7 @@ public class AutoActiveTrain implements ThrottleListener {
         }
         float decSpeed = (speed / mls);
         if (decSpeed > 0.0f) {
+            cancelStopInCurrentSection();
             _targetSpeed = applyMaxThrottleAndFactor(decSpeed);
         } else {
             _targetSpeed = 0.0f;
@@ -1883,7 +1864,7 @@ public class AutoActiveTrain implements ThrottleListener {
                     // this only sets to speed zero, stop
                     if (useSpeedProfile && !_speedProfileStoppingIsRunning) {
                         re.getSpeedProfile().setExtraInitialDelay(1500f);
-                        re.getSpeedProfile().changeLocoSpeed(_throttle, _currentBlock, 0,
+                        re.getSpeedProfile().changeLocoSpeed(_throttle, _currentAllocatedSection.getSection(), 0,
                                 _stopBySpeedProfileAdjust);
                         _speedProfileStoppingIsRunning = true;
                         _targetSpeed = 0.0f;

--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -206,8 +206,8 @@ public class AutoAllocate implements Runnable {
                         continue;
                     }
                     // is the train held
-                    if (activeTrain.holdAllocation) {
-                        log.debug("[{}]:Allocation is Holding", trainName);
+                    if (activeTrain.holdAllocation || (!activeTrain.getStarted()) && activeTrain.getDelayedStart() != ActiveTrain.NODELAY) {
+                        log.debug("[{}]:Allocation is Holding or Delayed", trainName);
                         continue;
                     }
 
@@ -323,6 +323,8 @@ public class AutoAllocate implements Runnable {
 
                             log.trace("ForwardsFree[{}]", areForwardsFree);
                             if (!areForwardsFree) {
+                                // delete all reserves for this train
+                                removeAllReservesForTrain(trainName);
                                 continue;
                             }
                         }

--- a/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
@@ -1604,6 +1604,7 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
                 queueAllocate(ar);
             } else {
                 // manual
+                allocationRequests.add(ar);
             }
         }
         activeTrainsTableModel.fireTableDataChanged();

--- a/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
+++ b/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
@@ -488,7 +488,33 @@ public class RosterSpeedProfile {
             referenced = blk;
         }
         changeLocoSpeed(t, blockLength, speed);
+    }
 
+    /**
+     * Set speed of a throttle.
+     *
+     * @param t     the throttle to set
+     * @param sec   the section used for length details
+     * @param speed the speed to set
+     * @param usePercentage the percentage of the block to be used for stopping
+     */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "FE_FLOATING_POINT_EQUALITY",
+        justification = "OK to compare floats, as even tiny differences should trigger update")
+    public void changeLocoSpeed(DccThrottle t, Section sec, float speed, float usePercentage) {
+        if (sec == referenced && speed == desiredSpeedStep) {
+            log.debug("Already setting to desired speed step for this Section");
+            return;
+        }
+        float sectionLength = sec.getActualLength() * usePercentage;
+        if (sec == referenced) {
+            distanceRemaining = distanceRemaining - getDistanceTravelled(_throttle.getIsForward(), _throttle.getSpeedSetting(), ((float) (System.nanoTime() - lastTimeTimerStarted) / 1000000000));
+            sectionLength = distanceRemaining;
+            //Not entirely reliable at this stage as the loco could still be running and not completed the calculation of the distance, this could result in an over run
+            log.debug("Block passed is the same as we are currently processing");
+        } else {
+            referenced = sec;
+        }
+        changeLocoSpeed(t, sectionLength, speed);
     }
 
     /**
@@ -499,7 +525,7 @@ public class RosterSpeedProfile {
      * @param speed the speed to set
      * @param usePercentage the percentage of the block to be used for stopping
      */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "FE_FLOATING_POINT_EQUALITY", 
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "FE_FLOATING_POINT_EQUALITY",
         justification = "OK to compare floats, as even tiny differences should trigger update")
     public void changeLocoSpeed(DccThrottle t, Block blk, float speed, float usePercentage) {
         if (blk == referenced && speed == desiredSpeedStep) {


### PR DESCRIPTION
    1 - do not resend SM aspects if aspect already set correctly.
    2 - remove redundant flag for need to setspeed
    3 - move resetting stopping flags to one place and simplyfy code.
    4 - stop by speed profile to use full length of section.
    5 - detect last section, rather than specific block, as blocks used are dependant on type of stopping.
    6 - fix missing queueing of manual allocations.
    7 - fix npe in debug code
    8 - remove reserved sections on allocation failure.
