### PR TITLE
BeanTables - Disable "Windows Key" or "Meta Key" press editing Bean

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -708,14 +708,16 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
             }
             
             /**
-             * Disable windows key being pressed as a go for editing a cell,
-             * causes unexpected behaviour, i.e. button presses.
+             * Disable Windows Key or Mac Meta Keys being pressed acting
+             * as a trigger for editing the focused cell.
+             * Causes unexpected behaviour, i.e. button presses.
              * {@inheritDoc}
              */
             @Override
             public boolean editCellAt(int row, int column, EventObject e) {
                 if (e instanceof KeyEvent) {
-                    if ( ((KeyEvent) e).getKeyCode() == KeyEvent.VK_WINDOWS ) {
+                    if ( ((KeyEvent) e).getKeyCode() == KeyEvent.VK_WINDOWS
+                        || ( (KeyEvent) e).getKeyCode() == KeyEvent.VK_META ) {
                         return false;
                     }
                 }

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.EventObject;
 import java.util.List;
 import java.util.Objects;
 
@@ -693,6 +694,9 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         Objects.requireNonNull(model, "the table model must be nonnull");
         JTable table = new JTable(model) {
 
+            // TODO: Create base BeanTableJTable.java,
+            // extend TurnoutTableJTable from it as next 2 classes duplicate.
+            
             @Override
             public String getToolTipText(MouseEvent e) {
                 java.awt.Point p = e.getPoint();
@@ -701,6 +705,21 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
                 int realRowIndex = convertRowIndexToModel(rowIndex);
                 int realColumnIndex = convertColumnIndexToModel(colIndex);
                 return getCellToolTip(this, realRowIndex, realColumnIndex);
+            }
+            
+            /**
+             * Disable windows key being pressed as a go for editing a cell,
+             * causes unexpected behaviour, i.e. button presses.
+             * {@inheritDoc}
+             */
+            @Override
+            public boolean editCellAt(int row, int column, EventObject e) {
+                if (e instanceof KeyEvent) {
+                    if ( ((KeyEvent) e).getKeyCode() == KeyEvent.VK_WINDOWS ) {
+                        return false;
+                    }
+                }
+                return super.editCellAt(row, column, e);
             }
         };
         return this.configureJTable(name, table, sorter);

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableJTable.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableJTable.java
@@ -1,7 +1,10 @@
 package jmri.jmrit.beantable.turnout;
 
 import java.awt.Component;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
+
+import java.util.EventObject;
 import java.util.Hashtable;
 
 import javax.annotation.Nonnull;
@@ -52,6 +55,21 @@ public class TurnoutTableJTable extends JTable {
         int realRowIndex = convertRowIndexToModel(rowIndex);
         int realColumnIndex = convertColumnIndexToModel(colIndex);
         return model.getCellToolTip(this, realRowIndex, realColumnIndex);
+    }
+    
+    /**
+     * Disable windows key being pressed as a go for editing a cell,
+     * causes unexpected behaviour, i.e. button presses.
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean editCellAt(int row, int column, EventObject e) {
+        if (e instanceof KeyEvent) {
+            if ( ((KeyEvent) e).getKeyCode() == KeyEvent.VK_WINDOWS ) {
+                return false;
+            }
+        }
+        return super.editCellAt(row, column, e);
     }
 
     @Override

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableJTable.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableJTable.java
@@ -58,14 +58,16 @@ public class TurnoutTableJTable extends JTable {
     }
     
     /**
-     * Disable windows key being pressed as a go for editing a cell,
-     * causes unexpected behaviour, i.e. button presses.
+     * Disable Windows Key or Mac Meta Keys being pressed acting
+     * as a trigger for editing the focused cell.
+     * Causes unexpected behaviour, i.e. button presses.
      * {@inheritDoc}
      */
     @Override
     public boolean editCellAt(int row, int column, EventObject e) {
         if (e instanceof KeyEvent) {
-            if ( ((KeyEvent) e).getKeyCode() == KeyEvent.VK_WINDOWS ) {
+            if ( ((KeyEvent) e).getKeyCode() == KeyEvent.VK_WINDOWS
+                || ( (KeyEvent) e).getKeyCode() == KeyEvent.VK_META ) {
                 return false;
             }
         }


### PR DESCRIPTION
When a BeanTable has focus, the Windows key currently triggers the edit action for whichever cell is selected.
This disables this happening, fixes #8015 