### PR TITLE
Bean edit action tabs - add persistence

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -398,6 +398,7 @@ SensorInActiveDebounce               = Delay to Inactive
 SensorPullUp                         = Pull-Up/Down
 SensorPullUpCheckBox                 = Show Pull-Up/Down Information
 SensorPullUpToolTip                  = Show extra columns for configuring sensor pull-up or pull-down.
+SensorGlobalActiveInactiveDelays     = Global Active Delay: {0}ms. Global Inactive Delay: {1}ms.
 
 #These are used in the Signal Mast Logic
 Destination                          = Destination

--- a/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
@@ -281,10 +281,10 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         for (BeanItemPanel bi : bei) {
             bi.resetField();
         }
+        persistSelectedTab(); // use persistence unless specified by overriding class
         if (selectedTab != null) {
             detailsTab.setSelectedComponent(selectedTab);
         }
-        persistSelectedTab(); // use persistence after 1st load
         f.addWindowListener(new java.awt.event.WindowAdapter() {
             @Override
             public void windowClosing(java.awt.event.WindowEvent e) {

--- a/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
@@ -8,6 +8,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.Vector;
 
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 import javax.swing.*;
+import javax.swing.event.ChangeEvent;
 import javax.swing.table.AbstractTableModel;
 
 import jmri.*;
@@ -232,7 +234,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
             return;
         }
         if (f == null) {
-            f = new JmriJFrame(Bundle.getMessage("EditBean", getBeanType(), bean.getDisplayName()), false, false);
+            f = new JmriJFrame(Bundle.getMessage("EditBean", bean.getBeanType(), bean.getDisplayName()), false, false);
             f.addHelpMenu(helpTarget(), true);
             applyBut = new JButton(Bundle.getMessage("ButtonApply")); // create before initPanels()
             java.awt.Container containerPanel = f.getContentPane();
@@ -282,6 +284,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         if (selectedTab != null) {
             detailsTab.setSelectedComponent(selectedTab);
         }
+        persistSelectedTab(); // use persistence after 1st load
         f.addWindowListener(new java.awt.event.WindowAdapter() {
             @Override
             public void windowClosing(java.awt.event.WindowEvent e) {
@@ -290,6 +293,25 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         });
         f.pack();
         f.setVisible(true);
+    }
+
+    /**
+     * Selects previously selected Tab Index for override class name.
+     * Adds listener when Tab changed update UI preference.
+     */
+    private void persistSelectedTab(){
+        String TAB_SELECT_STRING = "selectedTabIndex"; // NOI18N
+        Object obj = InstanceManager.getDefault(UserPreferencesManager.class)
+            .getProperty(getClass().getName(), TAB_SELECT_STRING);
+        int previoustab = (obj!=null ? (Integer) obj : 0);
+        // make sure that valid index selected in case a tab is removed in future.
+        detailsTab.setSelectedIndex(Math.max(Math.min(detailsTab.getTabCount()-1, previoustab),0));
+        // add listener
+        detailsTab.getModel().addChangeListener((ChangeEvent evt) -> {
+            InstanceManager.getDefault(UserPreferencesManager.class)
+                .setProperty(getClass().getName(), TAB_SELECT_STRING, detailsTab.getSelectedIndex());
+        });
+    
     }
 
     protected void applyButtonAction(ActionEvent e) {
@@ -384,7 +406,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
     }
 
     public void save() {
-        String feedback = Bundle.getMessage("ItemUpdateFeedback", getBeanType())
+        String feedback = Bundle.getMessage("ItemUpdateFeedback", bean.getBeanType())
                 + " " + bean.getDisplayName(DisplayOptions.USERNAME_SYSTEMNAME);
         // provide feedback to user, can be overwritten by save action error handler
         statusBar.setText(feedback);
@@ -406,12 +428,6 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
     }
 
     NamedBeanHandleManager nbMan = InstanceManager.getDefault(NamedBeanHandleManager.class);
-
-    /**
-     * Get Human Readable form of Bean Type.
-     * @return localised single Bean type String.
-     */
-    abstract protected String getBeanType();
 
     abstract protected B getByUserName(String name);
 
@@ -437,7 +453,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
                 String msg;
                 msg = java.text.MessageFormat.format(Bundle.getMessage("WarningUserName"),
                         new Object[]{("" + value)});
-                JOptionPane.showMessageDialog(null, msg,
+                JOptionPane.showMessageDialog(f, msg,
                         Bundle.getMessage("WarningTitle"),
                         JOptionPane.ERROR_MESSAGE);
                 return;
@@ -451,8 +467,8 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
                     return;
                 }
                 String msg = Bundle.getMessage("UpdateToUserName",
-                        new Object[]{getBeanType(), value, nBean.getSystemName()});
-                int optionPane = JOptionPane.showConfirmDialog(null,
+                        new Object[]{nBean.getBeanType(), value, nBean.getSystemName()});
+                int optionPane = JOptionPane.showConfirmDialog(f,
                         msg, Bundle.getMessage("UpdateToUserNameTitle"),
                         JOptionPane.YES_NO_OPTION);
                 if (optionPane == JOptionPane.YES_OPTION) {
@@ -480,8 +496,8 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
     public void removeName() {
         if (!allowBlockNameChange("Remove", "")) return;  // NOI18N
         String msg = java.text.MessageFormat.format(Bundle.getMessage("UpdateToSystemName"),
-                new Object[]{getBeanType()});
-        int optionPane = JOptionPane.showConfirmDialog(null,
+                new Object[]{bean.getBeanType()});
+        int optionPane = JOptionPane.showConfirmDialog(f,
                 msg, Bundle.getMessage("UpdateToSystemNameTitle"),
                 JOptionPane.YES_NO_OPTION);
         if (optionPane == JOptionPane.YES_OPTION) {
@@ -510,7 +526,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         // Remove is not allowed if there is a layout block
         if (changeType.equals("Remove")) {
             log.warn("Cannot remove user name for block {}", oldName);  // NOI18N
-                JOptionPane.showMessageDialog(null,
+                JOptionPane.showMessageDialog(f,
                         Bundle.getMessage("BlockRemoveUserNameWarning", oldName),  // NOI18N
                         Bundle.getMessage("WarningTitle"),  // NOI18N
                         JOptionPane.WARNING_MESSAGE);
@@ -518,7 +534,7 @@ public abstract class BeanEditAction<B extends NamedBean> extends AbstractAction
         }
 
         // Confirmation dialog
-        int optionPane = JOptionPane.showConfirmDialog(null,
+        int optionPane = JOptionPane.showConfirmDialog(f,
                 Bundle.getMessage("BlockChangeUserName", oldName, newName),  // NOI18N
                 Bundle.getMessage("QuestionTitle"),  // NOI18N
                 JOptionPane.YES_NO_OPTION);

--- a/java/src/jmri/jmrit/beantable/beanedit/BlockEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/BlockEditAction.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.beantable.beanedit;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 import javax.swing.*;
 
@@ -37,11 +36,6 @@ public class BlockEditAction extends BeanEditAction<Block> {
         sensor();
         reporterDetails();
         physicalDetails();
-    }
-
-    @Override
-    public String getBeanType() {
-        return Bundle.getMessage("BeanNameBlock");
     }
 
     @Override

--- a/java/src/jmri/jmrit/beantable/beanedit/LightEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/LightEditAction.java
@@ -33,11 +33,6 @@ public class LightEditAction extends BeanEditAction<Light> {
     }
 
     @Override
-    public String getBeanType() {
-        return Bundle.getMessage("BeanNameLight");
-    }
-
-    @Override
     public String helpTarget() {
         return "package.jmri.jmrit.beantable.LightAddEdit";
     } // NOI18N

--- a/java/src/jmri/jmrit/beantable/beanedit/OBlockEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/OBlockEditAction.java
@@ -56,11 +56,6 @@ public class OBlockEditAction extends BeanEditAction<OBlock> {
     }
 
     @Override
-    public String getBeanType() {
-        return Bundle.getMessage("BeanNameOBlock");
-    }
-
-    @Override
     public OBlock getByUserName(String name) {
         return InstanceManager.getDefault(OBlockManager.class).getByUserName(name);
     }

--- a/java/src/jmri/jmrit/beantable/beanedit/SensorEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/SensorEditAction.java
@@ -32,11 +32,6 @@ public class SensorEditAction extends BeanEditAction<Sensor> {
     }
 
     @Override
-    public String getBeanType() {
-        return Bundle.getMessage("BeanNameSensor");
-    }
-
-    @Override
     public Sensor getByUserName(String name) {
         return InstanceManager.sensorManagerInstance().getByUserName(name);
     }

--- a/java/src/jmri/jmrit/beantable/beanedit/SensorPullUpEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/SensorPullUpEditAction.java
@@ -22,16 +22,11 @@ public class SensorPullUpEditAction extends BeanEditAction<Sensor> {
     } // NOI18N
 
     @Override
-    public String getBeanType() {
-        return Bundle.getMessage("BeanNameSensor");
-    }
-
-    @Override
     public Sensor getByUserName(String name) {
         return InstanceManager.sensorManagerInstance().getByUserName(name);
     }
 
-    JComboBox<Sensor.PullResistance> sensorPullUpComboBox = new JComboBox<Sensor.PullResistance>(Sensor.PullResistance.values());
+    JComboBox<Sensor.PullResistance> sensorPullUpComboBox = new JComboBox<>(Sensor.PullResistance.values());
 
     @Override
     protected void initPanels() {

--- a/java/src/jmri/jmrit/beantable/beanedit/TurnoutEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/TurnoutEditAction.java
@@ -46,11 +46,6 @@ public class TurnoutEditAction extends BeanEditAction<Turnout> {
     }
 
     @Override
-    public String getBeanType() {
-        return Bundle.getMessage("BeanNameTurnout");
-    }
-
-    @Override
     public Turnout getByUserName(String name) {
         return InstanceManager.turnoutManagerInstance().getByUserName(name);
     }

--- a/java/test/jmri/jmrit/beantable/beanedit/SensorDebounceEditActionTest.java
+++ b/java/test/jmri/jmrit/beantable/beanedit/SensorDebounceEditActionTest.java
@@ -51,12 +51,15 @@ public class SensorDebounceEditActionTest {
         SensorDebounceEditAction t = new SensorDebounceEditAction();
 
         Assert.assertEquals("package.jmri.jmrit.beantable.SensorAddEdit", t.helpTarget());
-        Assert.assertEquals("Sensor", t.getBeanType());
         
         t.initPanels();
         
         Sensor is1 = InstanceManager.sensorManagerInstance().newSensor("IS1", "user1");
         Assert.assertEquals(is1, t.getByUserName("user1"));
+        
+        // to ensure t.bean.getBeanType() equals removed method t.getBeanType()
+        t.setBean(is1);
+        Assert.assertEquals("Sensor", t.bean.getBeanType());
         
     }
     

--- a/java/test/jmri/jmrit/beantable/beanedit/SensorPullUpEditActionTest.java
+++ b/java/test/jmri/jmrit/beantable/beanedit/SensorPullUpEditActionTest.java
@@ -52,12 +52,15 @@ public class SensorPullUpEditActionTest {
         SensorPullUpEditAction t = new SensorPullUpEditAction();
 
         Assert.assertEquals("package.jmri.jmrit.beantable.SensorAddEdit", t.helpTarget());
-        Assert.assertEquals("Sensor", t.getBeanType());
         
         t.initPanels();
         
         Sensor is1 = InstanceManager.sensorManagerInstance().newSensor("IS1", "user1");
         Assert.assertEquals(is1, t.getByUserName("user1"));
+        
+        // to ensure t.bean.getBeanType() equals removed method t.getBeanType()
+        t.setBean(is1);
+        Assert.assertEquals("Sensor", t.bean.getBeanType());
         
     }
 


### PR DESCRIPTION
Adds tab selected persistence to each BeanEditAction
remove #getBeanType() as can be obtained direct from bean
Adds global Sensor debounce values as extra text to global checkbox

![image](https://user-images.githubusercontent.com/39652002/113142394-b9e0e880-9222-11eb-80de-dc5d55dbb7e5.png)
