### PR TITLE
Create TSLR from Table - Use Exception text on failure

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -254,6 +254,7 @@ acelaSkippingCreation                = Skipping creation of Acela Signal Head be
 signalHeadEntryWarning               = Enter a number in the Signal Head ID field.\nIt can not be empty.
 InvalidSignalSystemName              = Cannot add Signal Head because "{0}" is not a valid System Name. Valid examples: LH5, GH88, IH41.
 
+ErrorBeanCreateFailed                = Could not create {0} "{1}"
 ErrorLightAddFailed                  = Could not create light "{0}" to add it.
 ErrorMemoryAddFailed                 = Could not create memory "{0}" to add it.
 ErrorBlockAddFailed                  = Could not create Block "{0}" to add it.

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -548,8 +548,9 @@ public class LightTableAction extends AbstractTableAction<Light> {
     }
 
     void handleCreateException(Exception ex, String sysName) {
+        status1.setText(ex.getLocalizedMessage());
         JOptionPane.showMessageDialog(addFrame,
-                Bundle.getMessage("ErrorLightAddFailed", sysName) + "\n" + Bundle.getMessage("ErrorAddFailedCheck"),
+                Bundle.getMessage("ErrorLightAddFailed", sysName) + "\n" + ex.getLocalizedMessage(),
                 Bundle.getMessage("ErrorTitle"),
                 JOptionPane.ERROR_MESSAGE);
     }

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -549,10 +549,10 @@ public class LightTableAction extends AbstractTableAction<Light> {
 
     void handleCreateException(Exception ex, String sysName) {
         status1.setText(ex.getLocalizedMessage());
-        JOptionPane.showMessageDialog(addFrame,
-                Bundle.getMessage("ErrorLightAddFailed", sysName) + "\n" + ex.getLocalizedMessage(),
-                Bundle.getMessage("ErrorTitle"),
-                JOptionPane.ERROR_MESSAGE);
+        String err = Bundle.getMessage("ErrorBeanCreateFailed",
+            InstanceManager.getDefault(LightManager.class).getBeanTypeHandled(),sysName);
+        JOptionPane.showMessageDialog(addFrame, err + "\n" + ex.getLocalizedMessage(),
+                err, JOptionPane.ERROR_MESSAGE);
     }
 
     /**

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -370,7 +370,6 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
 
         // Add some entry pattern checking, before assembling sName and handing it to the ReporterManager
         String statusMessage = Bundle.getMessage("ItemCreateFeedback", Bundle.getMessage("BeanNameReporter"));
-        String errorMessage;
         String uName = userNameTextField.getText();
         for (int x = 0; x < numberOfReporters; x++) {
             try {

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -460,10 +460,10 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
     void handleCreateException(Exception ex, String sysName) {
         statusBarLabel.setText(ex.getLocalizedMessage());
         statusBarLabel.setForeground(Color.red);
-        JOptionPane.showMessageDialog(addFrame,
-                Bundle.getMessage("ErrorReporterAddFailed", sysName) + "\n" + ex.getLocalizedMessage(),
-                Bundle.getMessage("ErrorTitle"),
-                JOptionPane.ERROR_MESSAGE);
+        String err = Bundle.getMessage("ErrorBeanCreateFailed",
+            InstanceManager.getDefault(ReporterManager.class).getBeanTypeHandled(),sysName);
+        JOptionPane.showMessageDialog(addFrame, err + "\n" + ex.getLocalizedMessage(),
+                err, JOptionPane.ERROR_MESSAGE);
     }
 
     /**

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -391,11 +391,7 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
                 r = reporterManager.provideReporter(rName);
             } catch (IllegalArgumentException ex) {
                 // user input no good
-                handleCreateException(rName); // displays message dialog to the user
-                // add to statusBarLabel as well
-                errorMessage = Bundle.getMessage("WarningInvalidEntry");
-                statusBarLabel.setText(errorMessage);
-                statusBarLabel.setForeground(Color.red);
+                handleCreateException(ex, rName); // displays message dialog to the user
                 return; // without creating
             }
 
@@ -462,9 +458,11 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
         hardwareAddressValidator.verify(hardwareAddressTextField);
     }
 
-    void handleCreateException(String sysName) {
+    void handleCreateException(Exception ex, String sysName) {
+        statusBarLabel.setText(ex.getLocalizedMessage());
+        statusBarLabel.setForeground(Color.red);
         JOptionPane.showMessageDialog(addFrame,
-                Bundle.getMessage("ErrorReporterAddFailed", sysName) + "\n" + Bundle.getMessage("ErrorAddFailedCheck"),
+                Bundle.getMessage("ErrorReporterAddFailed", sysName) + "\n" + ex.getLocalizedMessage(),
                 Bundle.getMessage("ErrorTitle"),
                 JOptionPane.ERROR_MESSAGE);
     }

--- a/java/src/jmri/jmrit/beantable/SensorTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SensorTableAction.java
@@ -218,11 +218,7 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
                 s = InstanceManager.getDefault(SensorManager.class).provideSensor(sName);
             } catch (IllegalArgumentException ex) {
                 // user input no good
-                handleCreateException(sName);
-                // Show error message in statusBarLabel
-                errorMessage = Bundle.getMessage("WarningInvalidEntry");
-                statusBarLabel.setText(errorMessage);
-                statusBarLabel.setForeground(Color.gray);
+                handleCreateException(ex, sName);
                 return;   // return without creating
             }
 
@@ -291,9 +287,10 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
         hardwareAddressValidator.verify(hardwareAddressTextField);
     }
 
-    void handleCreateException(String hwAddress) {
+    void handleCreateException(Exception ex, String hwAddress) {
+        statusBarLabel.setText(ex.getLocalizedMessage());
         JOptionPane.showMessageDialog(addFrame,
-                Bundle.getMessage("ErrorSensorAddFailed", hwAddress) + "\n" + Bundle.getMessage("ErrorAddFailedCheck"),
+                Bundle.getMessage("ErrorSensorAddFailed", hwAddress) + "\n" + ex.getLocalizedMessage(),
                 Bundle.getMessage("ErrorTitle"),
                 JOptionPane.ERROR_MESSAGE);
     }

--- a/java/src/jmri/jmrit/beantable/SensorTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SensorTableAction.java
@@ -198,7 +198,6 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
 
         // Add some entry pattern checking, before assembling sName and handing it to the SensorManager
         String statusMessage = Bundle.getMessage("ItemCreateFeedback", Bundle.getMessage("BeanNameSensor"));
-        String errorMessage;
         for (int x = 0; x < numberOfSensors; x++) {
             log.debug("b4 next valid addr for prefix {} conn choice mgr {}",sensorPrefix,connectionChoice);
             try {

--- a/java/src/jmri/jmrit/beantable/SensorTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SensorTableAction.java
@@ -288,10 +288,10 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
 
     void handleCreateException(Exception ex, String hwAddress) {
         statusBarLabel.setText(ex.getLocalizedMessage());
-        JOptionPane.showMessageDialog(addFrame,
-                Bundle.getMessage("ErrorSensorAddFailed", hwAddress) + "\n" + ex.getLocalizedMessage(),
-                Bundle.getMessage("ErrorTitle"),
-                JOptionPane.ERROR_MESSAGE);
+        String err = Bundle.getMessage("ErrorBeanCreateFailed",
+            InstanceManager.getDefault(SensorManager.class).getBeanTypeHandled(),hwAddress);
+        JOptionPane.showMessageDialog(addFrame, err + "\n" + ex.getLocalizedMessage(),
+                err, JOptionPane.ERROR_MESSAGE);
     }
 
     protected void setDefaultDebounce(JFrame _who) {

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -560,10 +560,6 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                 } catch (IllegalArgumentException ex) {
                     // user input no good
                     handleCreateException(ex, sName); // displays message dialog to the user
-                    // add to statusBarLabel as well
-                    errorMessage = Bundle.getMessage("WarningInvalidEntry");
-                    statusBarLabel.setText(errorMessage);
-                    statusBarLabel.setForeground(Color.red);
                     return; // without creating
                 }
                 if ((uName != null) && !uName.isEmpty()) {
@@ -650,18 +646,18 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
 
     void handleCreateException(Exception ex, String sysName) {
         if (ex.getMessage() != null) {
+            statusBarLabel.setText(ex.getLocalizedMessage());
             JOptionPane.showMessageDialog(addFrame,
-                    ex.getMessage(),
+                    ex.getLocalizedMessage(),
                     Bundle.getMessage("ErrorTitle"),
                     JOptionPane.ERROR_MESSAGE);
         } else {
+            statusBarLabel.setText(Bundle.getMessage("WarningInvalidRange"));
             JOptionPane.showMessageDialog(addFrame,
                     Bundle.getMessage("ErrorTurnoutAddFailed", sysName) + "\n" + Bundle.getMessage("ErrorAddFailedCheck"),
                     Bundle.getMessage("ErrorTitle"),
                     JOptionPane.ERROR_MESSAGE);
         }
-        // provide feedback to uName
-        statusBarLabel.setText(Bundle.getMessage("WarningInvalidRange"));
         statusBarLabel.setForeground(Color.red);
     }
 

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -476,9 +476,6 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
 
         // Add some entry pattern checking, before assembling sName and handing it to the TurnoutManager
         StringBuilder statusMessage = new StringBuilder(Bundle.getMessage("ItemCreateFeedback", Bundle.getMessage("BeanNameTurnout")));
-
-        String errorMessage;
-
         String lastSuccessfulAddress;
 
         int iType = 0;
@@ -517,8 +514,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                                 Bundle.getMessage("ButtonYesPlus")}, Bundle.getMessage("ButtonNo")); // default choice = No
                     if (selectedValue == 1) {
                         // Show error message in statusBarLabel
-                        errorMessage = Bundle.getMessage("WarningOverlappingAddress", sName);
-                        statusBarLabel.setText(errorMessage);
+                        statusBarLabel.setText(Bundle.getMessage("WarningOverlappingAddress", sName));
                         statusBarLabel.setForeground(Color.gray);
                         return;   // return without creating if "No" response
                     }
@@ -547,8 +543,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
             if (iNum == 0) {
                 // User specified more bits, but bits are not available - return without creating
                 // Display message in statusBarLabel
-                errorMessage = Bundle.getMessage("WarningBitsNotSupported", lastSuccessfulAddress);
-                statusBarLabel.setText(errorMessage);
+                statusBarLabel.setText(Bundle.getMessage("WarningBitsNotSupported", lastSuccessfulAddress));
                 statusBarLabel.setForeground(Color.red);
                 return;
             } else {

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -640,17 +640,19 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
     }
 
     void handleCreateException(Exception ex, String sysName) {
+        String err = Bundle.getMessage("ErrorBeanCreateFailed",
+            InstanceManager.getDefault(TurnoutManager.class).getBeanTypeHandled(),sysName);
         if (ex.getMessage() != null) {
             statusBarLabel.setText(ex.getLocalizedMessage());
             JOptionPane.showMessageDialog(addFrame,
                     ex.getLocalizedMessage(),
-                    Bundle.getMessage("ErrorTitle"),
+                    err,
                     JOptionPane.ERROR_MESSAGE);
         } else {
             statusBarLabel.setText(Bundle.getMessage("WarningInvalidRange"));
             JOptionPane.showMessageDialog(addFrame,
-                    Bundle.getMessage("ErrorTurnoutAddFailed", sysName) + "\n" + Bundle.getMessage("ErrorAddFailedCheck"),
-                    Bundle.getMessage("ErrorTitle"),
+                    err + "\n" + Bundle.getMessage("ErrorAddFailedCheck"),
+                    err,
                     JOptionPane.ERROR_MESSAGE);
         }
         statusBarLabel.setForeground(Color.red);

--- a/java/test/jmri/jmrit/beantable/LightTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LightTableActionTest.java
@@ -4,11 +4,14 @@ import jmri.util.gui.GuiLafPreferencesManager;
 
 import java.awt.GraphicsEnvironment;
 
+import javax.annotation.Nonnull;
 import javax.swing.JFrame;
 import javax.swing.JTextField;
 
 import jmri.*;
 import jmri.jmrit.beantable.light.LightTableDataModel;
+import jmri.jmrix.internal.InternalLightManager;
+import jmri.jmrix.internal.InternalSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import jmri.util.swing.JemmyUtil;
 
@@ -742,6 +745,52 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         Assert.assertEquals("Correct Light Control Type", "ON when either My Sensor Two or My Sensor One is Active.",
                 LightTableAction.getDescriptionText(created.getLightControlList().get(0),
                         created.getLightControlList().get(0).getControlType()));
+    }
+    
+    @Test
+    public void testAddFailureCreate() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
+        InstanceManager.setDefault(LightManager.class, new createNewLightAlwaysException());
+        
+        a = new LightTableAction();
+        Assume.assumeTrue(a.includeAddButton());
+        
+        a.actionPerformed(null);
+        JFrame f = JFrameOperator.waitJFrame(getTableFrameName(), true, true);
+        // find the "Add... " button and press it.
+        JemmyUtil.pressButton(new JFrameOperator(f), Bundle.getMessage("ButtonAdd"));
+        
+        JFrame f1 = JFrameOperator.waitJFrame(getAddFrameName(), true, true);
+        JTextField hwAddressField = JTextFieldOperator.findJTextField(f1, new NameComponentChooser("hwAddressTextField"));
+        Assert.assertNotNull("hwAddressTextField", hwAddressField);
+        // set to "1"
+        new JTextFieldOperator(hwAddressField).setText("1");
+        Thread add1 = JemmyUtil.createModalDialogOperatorThread(
+            Bundle.getMessage("ErrorBeanCreateFailed", "Light","IL1"), Bundle.getMessage("ButtonOK"));  // NOI18N
+        
+        //and press create
+        JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonCreate"));
+        JUnitUtil.waitFor(()->{return !(add1.isAlive());}, "dialog finished");  // NOI18N
+        
+        JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonCancel")); // not sure why this is close in this frame.
+        JUnitUtil.dispose(f1);
+        JUnitUtil.dispose(f);
+    }
+    
+    private class createNewLightAlwaysException extends InternalLightManager {
+
+        public createNewLightAlwaysException() {
+            super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        @Nonnull
+        protected Light createNewLight(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+            throw new IllegalArgumentException("createNewLight Exception Text");
+        }
+        
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/beantable/LightTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LightTableActionTest.java
@@ -751,7 +751,7 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
     public void testAddFailureCreate() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         
-        InstanceManager.setDefault(LightManager.class, new createNewLightAlwaysException());
+        InstanceManager.setDefault(LightManager.class, new CreateNewLightAlwaysException());
         
         a = new LightTableAction();
         Assume.assumeTrue(a.includeAddButton());
@@ -778,9 +778,9 @@ public class LightTableActionTest extends AbstractTableActionBase<Light> {
         JUnitUtil.dispose(f);
     }
     
-    private class createNewLightAlwaysException extends InternalLightManager {
+    private class CreateNewLightAlwaysException extends InternalLightManager {
 
-        public createNewLightAlwaysException() {
+        public CreateNewLightAlwaysException() {
             super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
         }
 

--- a/java/test/jmri/jmrit/beantable/ReporterTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/ReporterTableActionTest.java
@@ -1,14 +1,23 @@
 package jmri.jmrit.beantable;
 
 import java.awt.GraphicsEnvironment;
-import javax.swing.JFrame;
 
-import jmri.Reporter;
+import javax.annotation.Nonnull;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+
+import jmri.*;
+import jmri.jmrix.internal.InternalReporterManager;
+import jmri.jmrix.internal.InternalSystemConnectionMemo;
 import jmri.util.JUnitUtil;
+import jmri.util.swing.JemmyUtil;
+
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
-import org.netbeans.jemmy.operators.JFrameOperator;
+
+import org.netbeans.jemmy.operators.*;
+import org.netbeans.jemmy.util.NameComponentChooser;
 
 /**
  *
@@ -68,6 +77,52 @@ public class ReporterTableActionTest extends AbstractTableActionBase<Reporter> {
     @Override
     @Disabled("No Edit button on Reporter table")
     public void testEditButton() {
+    }
+    
+    @Test
+    public void testAddFailureCreate() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
+        InstanceManager.setDefault(ReporterManager.class, new createNewReporterAlwaysException());
+        
+        a = new ReporterTableAction();
+        Assume.assumeTrue(a.includeAddButton());
+        
+        a.actionPerformed(null);
+        JFrame f = JFrameOperator.waitJFrame(getTableFrameName(), true, true);
+        // find the "Add... " button and press it.
+        JemmyUtil.pressButton(new JFrameOperator(f), Bundle.getMessage("ButtonAdd"));
+        
+        JFrame f1 = JFrameOperator.waitJFrame(getAddFrameName(), true, true);
+        JTextField hwAddressField = JTextFieldOperator.findJTextField(f1, new NameComponentChooser("hwAddressTextField"));
+        Assert.assertNotNull("hwAddressTextField", hwAddressField);
+        // set to "1"
+        new JTextFieldOperator(hwAddressField).setText("1");
+        Thread add1 = JemmyUtil.createModalDialogOperatorThread(
+            Bundle.getMessage("ErrorBeanCreateFailed","Reporter", "IR1"), Bundle.getMessage("ButtonOK"));  // NOI18N
+        
+        //and press create
+        JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonCreate"));
+        JUnitUtil.waitFor(()->{return !(add1.isAlive());}, "dialog finished");  // NOI18N
+        
+        JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonClose")); // not sure why this is close in this frame.
+        JUnitUtil.dispose(f1);
+        JUnitUtil.dispose(f);
+    }
+    
+    private class createNewReporterAlwaysException extends InternalReporterManager {
+
+        public createNewReporterAlwaysException() {
+            super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        @Nonnull
+        protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+            throw new IllegalArgumentException("createNewReporter Exception Text");
+        }
+        
     }
 
     @Override

--- a/java/test/jmri/jmrit/beantable/ReporterTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/ReporterTableActionTest.java
@@ -83,7 +83,7 @@ public class ReporterTableActionTest extends AbstractTableActionBase<Reporter> {
     public void testAddFailureCreate() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         
-        InstanceManager.setDefault(ReporterManager.class, new createNewReporterAlwaysException());
+        InstanceManager.setDefault(ReporterManager.class, new CreateNewReporterAlwaysException());
         
         a = new ReporterTableAction();
         Assume.assumeTrue(a.includeAddButton());
@@ -110,9 +110,9 @@ public class ReporterTableActionTest extends AbstractTableActionBase<Reporter> {
         JUnitUtil.dispose(f);
     }
     
-    private class createNewReporterAlwaysException extends InternalReporterManager {
+    private class CreateNewReporterAlwaysException extends InternalReporterManager {
 
-        public createNewReporterAlwaysException() {
+        public CreateNewReporterAlwaysException() {
             super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
         }
 

--- a/java/test/jmri/jmrit/beantable/SensorTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/SensorTableActionTest.java
@@ -171,7 +171,7 @@ public class SensorTableActionTest extends AbstractTableActionBase<Sensor> {
     public void testAddFailureCreate() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         
-        InstanceManager.setDefault(SensorManager.class, new createNewSensorAlwaysException());
+        InstanceManager.setDefault(SensorManager.class, new CreateNewSensorAlwaysException());
         
         a = new SensorTableAction();
         Assume.assumeTrue(a.includeAddButton());
@@ -198,9 +198,9 @@ public class SensorTableActionTest extends AbstractTableActionBase<Sensor> {
         JUnitUtil.dispose(f);
     }
     
-    private class createNewSensorAlwaysException extends InternalSensorManager {
+    private class CreateNewSensorAlwaysException extends InternalSensorManager {
 
-        public createNewSensorAlwaysException() {
+        public CreateNewSensorAlwaysException() {
             super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
         }
 

--- a/java/test/jmri/jmrit/beantable/SensorTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/SensorTableActionTest.java
@@ -2,11 +2,19 @@ package jmri.jmrit.beantable;
 
 import jmri.util.gui.GuiLafPreferencesManager;
 import java.awt.GraphicsEnvironment;
+
+import javax.annotation.Nonnull;
 import javax.swing.JFrame;
 import javax.swing.JTextField;
+
 import jmri.InstanceManager;
 import jmri.Sensor;
+import jmri.SensorManager;
+import jmri.jmrix.internal.InternalSensorManager;
+import jmri.jmrix.internal.InternalSystemConnectionMemo;
 import jmri.util.JUnitUtil;
+import jmri.util.swing.JemmyUtil;
+
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
@@ -130,7 +138,7 @@ public class SensorTableActionTest extends AbstractTableActionBase<Sensor> {
 
         // find the "Add... " button and press it.
         JFrameOperator jfo = new JFrameOperator(f);
-        jmri.util.swing.JemmyUtil.pressButton(jfo,Bundle.getMessage("ButtonAdd"));
+        JemmyUtil.pressButton(jfo,Bundle.getMessage("ButtonAdd"));
         new org.netbeans.jemmy.QueueTool().waitEmpty();
         JFrame f1 = JFrameOperator.waitJFrame(getAddFrameName(), true, true);
         //Enter 1 in the text field labeled "Hardware address:"
@@ -140,7 +148,7 @@ public class SensorTableActionTest extends AbstractTableActionBase<Sensor> {
         // set to "1"
         new JTextFieldOperator(hwAddressField).typeText("1");
         //and press create 
-        jmri.util.swing.JemmyUtil.pressButton(new JFrameOperator(f1),Bundle.getMessage("ButtonCreate"));
+        JemmyUtil.pressButton(new JFrameOperator(f1),Bundle.getMessage("ButtonCreate"));
         new org.netbeans.jemmy.QueueTool().waitEmpty();
 
         JTableOperator tbl = new JTableOperator(jfo, 0);
@@ -148,7 +156,7 @@ public class SensorTableActionTest extends AbstractTableActionBase<Sensor> {
         tbl.clickOnCell(0,jmri.jmrit.beantable.sensor.SensorTableDataModel.EDITCOL);
 
         JFrame f2 = JFrameOperator.waitJFrame(getEditFrameName(), true, true);
-        jmri.util.swing.JemmyUtil.pressButton(new JFrameOperator(f2),Bundle.getMessage("ButtonCancel"));
+        JemmyUtil.pressButton(new JFrameOperator(f2),Bundle.getMessage("ButtonCancel"));
         JUnitUtil.dispose(f2);
         JUnitUtil.dispose(f1);
         JUnitUtil.dispose(f);
@@ -158,14 +166,59 @@ public class SensorTableActionTest extends AbstractTableActionBase<Sensor> {
     public String getEditFrameName(){
         return "Edit Sensor IS1";
     }
+    
+    @Test
+    public void testAddFailureCreate() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
+        InstanceManager.setDefault(SensorManager.class, new createNewSensorAlwaysException());
+        
+        a = new SensorTableAction();
+        Assume.assumeTrue(a.includeAddButton());
+        
+        a.actionPerformed(null);
+        JFrame f = JFrameOperator.waitJFrame(getTableFrameName(), true, true);
+        // find the "Add... " button and press it.
+        JemmyUtil.pressButton(new JFrameOperator(f), Bundle.getMessage("ButtonAdd"));
+        
+        JFrame f1 = JFrameOperator.waitJFrame(getAddFrameName(), true, true);
+        JTextField hwAddressField = JTextFieldOperator.findJTextField(f1, new NameComponentChooser("hwAddressTextField"));
+        Assert.assertNotNull("hwAddressTextField", hwAddressField);
+        // set to "1"
+        new JTextFieldOperator(hwAddressField).setText("1");
+        Thread add1 = JemmyUtil.createModalDialogOperatorThread(
+            Bundle.getMessage("ErrorBeanCreateFailed","Sensor" , "IS1"), Bundle.getMessage("ButtonOK"));  // NOI18N
+        
+        //and press create
+        JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonCreate"));
+        JUnitUtil.waitFor(()->{return !(add1.isAlive());}, "dialog finished");  // NOI18N
+        
+        JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonClose")); // not sure why this is close in this frame.
+        JUnitUtil.dispose(f1);
+        JUnitUtil.dispose(f);
+    }
+    
+    private class createNewSensorAlwaysException extends InternalSensorManager {
 
+        public createNewSensorAlwaysException() {
+            super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        @Nonnull
+        protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+            throw new IllegalArgumentException("createNewSensor Exception Text");
+        }
+        
+    }
 
     @Override
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
-        jmri.util.JUnitUtil.initInternalSensorManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initInternalSensorManager();
         helpTarget = "package.jmri.jmrit.beantable.SensorTable"; 
         a = new SensorTableAction();
     }

--- a/java/test/jmri/jmrit/beantable/TurnoutTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/TurnoutTableActionTest.java
@@ -174,7 +174,7 @@ public class TurnoutTableActionTest extends AbstractTableActionBase<Turnout> {
     public void testAddFailureCreate() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         
-        InstanceManager.setDefault(TurnoutManager.class, new createNewTurnoutAlwaysException());
+        InstanceManager.setDefault(TurnoutManager.class, new CreateNewTurnoutAlwaysException());
         
         a = new TurnoutTableAction();
         Assume.assumeTrue(a.includeAddButton());
@@ -201,9 +201,9 @@ public class TurnoutTableActionTest extends AbstractTableActionBase<Turnout> {
         JUnitUtil.dispose(f);
     }
     
-    private class createNewTurnoutAlwaysException extends InternalTurnoutManager {
+    private class CreateNewTurnoutAlwaysException extends InternalTurnoutManager {
 
-        public createNewTurnoutAlwaysException() {
+        public CreateNewTurnoutAlwaysException() {
             super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
         }
 

--- a/java/test/jmri/jmrit/beantable/TurnoutTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/TurnoutTableActionTest.java
@@ -1,10 +1,14 @@
 package jmri.jmrit.beantable;
 
 import jmri.util.gui.GuiLafPreferencesManager;
+
 import java.awt.GraphicsEnvironment;
+
+import javax.annotation.Nonnull;
 import javax.swing.JFrame;
 import javax.swing.JPopupMenu;
 import javax.swing.JTextField;
+
 import jmri.InstanceManager;
 import jmri.Turnout;
 import jmri.TurnoutManager;
@@ -13,6 +17,8 @@ import jmri.jmrix.internal.InternalSystemConnectionMemo;
 import jmri.jmrix.internal.InternalTurnoutManager;
 import jmri.swing.ManagerComboBox;
 import jmri.util.JUnitUtil;
+import jmri.util.swing.JemmyUtil;
+
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
@@ -113,7 +119,7 @@ public class TurnoutTableActionTest extends AbstractTableActionBase<Turnout> {
         //This is a modal JOptionPane, so create a thread to dismiss it.
         Thread t = new Thread(() -> {
             try {
-                jmri.util.swing.JemmyUtil.confirmJOptionPane(main, Bundle.getMessage("TurnoutGlobalSpeedMessageTitle"), "", "OK");
+                JemmyUtil.confirmJOptionPane(main, Bundle.getMessage("TurnoutGlobalSpeedMessageTitle"), "", "OK");
             } catch (org.netbeans.jemmy.TimeoutExpiredException tee) {
                 // we're waiting for this thread to finish in the main method,
                 // so any exception here means we failed.
@@ -157,11 +163,57 @@ public class TurnoutTableActionTest extends AbstractTableActionBase<Turnout> {
         JFrame f = JFrameOperator.waitJFrame(getTableFrameName(), true, true);
 
         // find the "Add... " button and press it.
-        jmri.util.swing.JemmyUtil.pressButton(new JFrameOperator(f), Bundle.getMessage("ButtonAdd"));
+        JemmyUtil.pressButton(new JFrameOperator(f), Bundle.getMessage("ButtonAdd"));
         JFrame f1 = JFrameOperator.waitJFrame(getAddFrameName(), true, true);
-        jmri.util.swing.JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonClose")); // not sure why this is close in this frame.
+        JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonClose")); // not sure why this is close in this frame.
         JUnitUtil.dispose(f1);
         JUnitUtil.dispose(f);
+    }
+    
+    @Test
+    public void testAddFailureCreate() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
+        InstanceManager.setDefault(TurnoutManager.class, new createNewTurnoutAlwaysException());
+        
+        a = new TurnoutTableAction();
+        Assume.assumeTrue(a.includeAddButton());
+        
+        a.actionPerformed(null);
+        JFrame f = JFrameOperator.waitJFrame(getTableFrameName(), true, true);
+        // find the "Add... " button and press it.
+        JemmyUtil.pressButton(new JFrameOperator(f), Bundle.getMessage("ButtonAdd"));
+        
+        JFrame f1 = JFrameOperator.waitJFrame(getAddFrameName(), true, true);
+        JTextField hwAddressField = JTextFieldOperator.findJTextField(f1, new NameComponentChooser("hwAddressTextField"));
+        Assert.assertNotNull("hwAddressTextField", hwAddressField);
+        // set to "1"
+        new JTextFieldOperator(hwAddressField).setText("1");
+        Thread add1 = JemmyUtil.createModalDialogOperatorThread(
+            Bundle.getMessage("ErrorBeanCreateFailed", "Turnout","IT1"), Bundle.getMessage("ButtonOK"));  // NOI18N
+        
+        //and press create
+        JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonCreate"));
+        JUnitUtil.waitFor(()->{return !(add1.isAlive());}, "dialog finished");  // NOI18N
+        
+        JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonClose")); // not sure why this is close in this frame.
+        JUnitUtil.dispose(f1);
+        JUnitUtil.dispose(f);
+    }
+    
+    private class createNewTurnoutAlwaysException extends InternalTurnoutManager {
+
+        public createNewTurnoutAlwaysException() {
+            super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        @Nonnull
+        protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+            throw new IllegalArgumentException("createNewTurnout Exception Text");
+        }
+        
     }
 
     @Test
@@ -218,9 +270,9 @@ public class TurnoutTableActionTest extends AbstractTableActionBase<Turnout> {
     @Override
     public void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
-        jmri.util.JUnitUtil.initInternalTurnoutManager();
-        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initDefaultUserMessagePreferences();
         helpTarget = "package.jmri.jmrit.beantable.TurnoutTable";
         a = new TurnoutTableAction();
     }


### PR DESCRIPTION
When creating a TSLR from the BeanTables, if a new Bean hardware address passes validation but can't actually be created ( eg #9210 ), an exception is thrown.
This PR adds the exception text to the UI.

Current Sensor and Reporter error message for this condition includes Bundle.getMessage("WarningInvalidEntry") which refers to Turnouts.

Also adds unit tests.