### PR TITLE
Update master release note: add LCC to OpenLCB hardware section name

### DIFF
--- a/help/en/releasenotes/jmri4.23-master.shtml
+++ b/help/en/releasenotes/jmri4.23-master.shtml
@@ -109,7 +109,7 @@
                 <li></li>
             </ul>
 
-        <h4><a href="http://openlcb.org">OpenLCB</a></h4>
+        <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
                 <li></li>
             </ul>


### PR DESCRIPTION
Really, this is a test of the automation that adds the Documentation label, but it's also a valid change.