### PR TITLE
Minor change to test 'documentation' labeling

### DIFF
--- a/help/en/html/doc/Technical/Help.shtml
+++ b/help/en/html/doc/Technical/Help.shtml
@@ -307,7 +307,6 @@
              <p><a href="#helpTop">[Go to top of page]</a></p>
        </div>
 
-
 <!-- = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = -->
       <a name= "check" id="check"></a>
       <h2>Checking Your Changes</h2>
@@ -366,7 +365,6 @@
 
              <p><a href="#helpTop">[Go to top of page]</a></p>
        </div>
-
 
 <!-- = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = -->
       <a name="jhelpdev" id="jhelpdev"></a>


### PR DESCRIPTION
A benign-but-valid change to check that the Mergeable automation to set the `Documentation` label is still working.