### PR TITLE
WIP - Window groups

### DIFF
--- a/java/src/apps/AppsMainMenu.java
+++ b/java/src/apps/AppsMainMenu.java
@@ -32,6 +32,7 @@ import jmri.util.HelpUtil;
 import jmri.util.JmriJFrame;
 import jmri.util.SystemType;
 import jmri.util.WindowMenu;
+import jmri.util.WindowGroupsMenu;
 import jmri.util.swing.WindowInterface;
 import jmri.web.server.WebServerAction;
 
@@ -75,6 +76,7 @@ public class AppsMainMenu {
         systemsMenu(menuBar, wi);
         debugMenu(menuBar, wi, pane);
         menuBar.add(new WindowMenu(wi));
+        menuBar.add(new WindowGroupsMenu(wi));
         helpMenu(menuBar, wi, pane, windowHelpID);
     }
 

--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -266,6 +266,12 @@ JavaVersionCredit                = Java version {0} ({1})
 Copyright                        = Copyright \u00a9 {0} JMRI Community
 
 MenuWindow                       = Window
+MenuWindowGroups                 = Window groups
+
+MenuWindowGroups_Create          = Create...
+MenuWindowGroups_Remove          = Remove...
+MenuWindowGroups_Store           = Store
+
 MenuItemMinimize                 = Minimize
 MenuHelp                         = Help
 MenuItemWindowHelp               = Window Help...

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -27,10 +27,12 @@ import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import javax.annotation.CheckForNull;
 import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
+
 import jmri.AddressedProgrammerManager;
 import jmri.GlobalProgrammerManager;
 import jmri.InstanceManager;
@@ -50,6 +52,7 @@ import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.jmrit.roster.RosterEntrySelector;
 import jmri.jmrit.roster.rostergroup.RosterGroupSelector;
+import jmri.jmrit.roster.swing.Bundle;
 import jmri.jmrit.symbolicprog.ProgrammerConfigManager;
 import jmri.jmrit.symbolicprog.tabbedframe.PaneOpsProgFrame;
 import jmri.jmrit.symbolicprog.tabbedframe.PaneProgFrame;
@@ -65,14 +68,13 @@ import jmri.profile.Profile;
 import jmri.profile.ProfileManager;
 import jmri.swing.JTablePersistenceManager;
 import jmri.swing.RowSorterUtil;
-import jmri.util.FileUtil;
-import jmri.util.HelpUtil;
-import jmri.util.WindowMenu;
+import jmri.util.*;
 import jmri.util.datatransfer.RosterEntrySelection;
 import jmri.util.swing.JmriAbstractAction;
 import jmri.util.swing.ResizableImagePanel;
 import jmri.util.swing.WindowInterface;
 import jmri.util.swing.multipane.TwoPaneTBWindow;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1405,6 +1407,7 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
     protected void systemsMenu() {
         ActiveSystemsMenu.addItems(getMenu());
         getMenu().add(new WindowMenu(this));
+        getMenu().add(new WindowGroupsMenu(this));
     }
 
     void updateDetails() {

--- a/java/src/jmri/swing/WindowGroup.java
+++ b/java/src/jmri/swing/WindowGroup.java
@@ -1,0 +1,86 @@
+package jmri.swing;
+
+import java.util.*;
+
+import jmri.util.JmriJFrame;
+
+/**
+ * Window group.
+ * 
+ * @author Daniel Bergqvist Copyright 2021
+ */
+public class WindowGroup {
+    
+    private String _name;
+    private Map<String, WindowData> _windowData = new HashMap<>();
+    
+    
+    public WindowGroup(String name) {
+        _name = name;
+    }
+    
+    /**
+     * Get the name of the window group.
+     * @return the name
+     */
+    public String getName() {
+        return _name;
+    }
+    
+    /**
+     * Set the name of the window group.
+     * @param name the name
+     */
+    public void setName(String name) {
+        _name = name;
+    }
+    
+    /**
+     * Select this window group and shows/hides the windows this window group
+     * are aware of.
+     */
+    public void select() {
+        for (JmriJFrame f : JmriJFrame.getFrameList()) {
+            WindowData wd = _windowData.get(f.getWindowFrameRef());
+            if (wd != null) {
+                f.setExtendedState(wd._state);
+                f.setBounds(wd._x, wd._y, wd._width, wd._height);
+            }
+        }
+    }
+    
+    /**
+     * Store the windows in the window group.
+     */
+    public void store() {
+        for (JmriJFrame f : JmriJFrame.getFrameList()) {
+            WindowData wd = _windowData.get(f.getWindowFrameRef());
+            if (wd == null) {
+                wd = new WindowData();
+                wd._windowRef = f.getWindowFrameRef();
+                _windowData.put(f.getWindowFrameRef(), wd);
+            }
+            wd._isVisible = f.isActive();
+            wd._state = f.getExtendedState();
+            wd._x = f.getX();
+            wd._y = f.getY();
+            wd._width = f.getWidth();
+            wd._height = f.getHeight();
+        }
+//        InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(prefsMgr -> {
+//        }
+    }
+    
+    
+    
+    private static class WindowData {
+        private String _windowRef;
+        private boolean _isVisible;
+        private int _state;
+        private int _x;
+        private int _y;
+        private int _width;
+        private int _height;
+    }
+    
+}

--- a/java/src/jmri/swing/WindowGroup.java
+++ b/java/src/jmri/swing/WindowGroup.java
@@ -12,7 +12,7 @@ import jmri.util.JmriJFrame;
 public class WindowGroup {
     
     private String _name;
-    private Map<String, WindowData> _windowData = new HashMap<>();
+    private final Map<String, WindowData> _windowData = new HashMap<>();
     
     
     public WindowGroup(String name) {

--- a/java/src/jmri/swing/WindowGroupManager.java
+++ b/java/src/jmri/swing/WindowGroupManager.java
@@ -12,8 +12,8 @@ import jmri.JmriException;
  */
 public class WindowGroupManager implements InstanceManagerAutoDefault {
     
-    private List<WindowGroup> _windowGroups = new ArrayList();
-    private Map<String, WindowGroup> _windowGroupsMap = new HashMap();
+    private final List<WindowGroup> _windowGroups = new ArrayList<>();
+    private final Map<String, WindowGroup> _windowGroupsMap = new HashMap<>();
     private WindowGroup _selectedWindowGroup = null;
     
     /**

--- a/java/src/jmri/swing/WindowGroupManager.java
+++ b/java/src/jmri/swing/WindowGroupManager.java
@@ -1,0 +1,131 @@
+package jmri.swing;
+
+import java.util.*;
+
+import jmri.InstanceManagerAutoDefault;
+import jmri.JmriException;
+
+/**
+ * Manager of Window groups.
+ * 
+ * @author Daniel Bergqvist Copyright 2021
+ */
+public class WindowGroupManager implements InstanceManagerAutoDefault {
+    
+    private List<WindowGroup> _windowGroups = new ArrayList();
+    private Map<String, WindowGroup> _windowGroupsMap = new HashMap();
+    private WindowGroup _selectedWindowGroup = null;
+    
+    /**
+     * Creates a new window group and selects it.
+     * The current windows is stored in the new window group.
+     * 
+     * @param name the name of the new group
+     * @return the new window group
+     * @throws jmri.swing.WindowGroupManager.DuplicateWindowGroupException
+     *         if the name already exists in another window group
+     */
+    public WindowGroup create(String name)
+            throws DuplicateWindowGroupException {
+        
+        if (_windowGroupsMap.containsKey(name)) {
+            throw new DuplicateWindowGroupException("A window group with the name " + name + " already exists");
+        }
+        
+        WindowGroup wg = new WindowGroup(name);
+        _windowGroups.add(wg);
+        _windowGroupsMap.put(name, wg);
+        
+        _selectedWindowGroup = wg;
+        
+        return wg;
+    }
+    
+    /**
+     * Remove the window group.
+     * No window group gets selected when the current window group is removed.
+     */
+    public void removeSelected() {
+        _windowGroups.remove(_selectedWindowGroup);
+        _windowGroupsMap.remove(_selectedWindowGroup.getName());
+    }
+    
+    /**
+     * Get a list of all the window groups.
+     * @return the list
+     */
+    public List<WindowGroup> getAll() {
+        return Collections.unmodifiableList(_windowGroups);
+    }
+    
+    /**
+     * Get the window group.
+     * @param name the name
+     * @return the window group
+     */
+    public WindowGroup getByName(String name) {
+        return _windowGroupsMap.get(name);
+    }
+    
+    /**
+     * Select the window group.
+     * @param wg the window group to select
+     */
+    public void select(WindowGroup wg) {
+        _selectedWindowGroup = wg;
+    }
+    
+    /**
+     * Select the window group by name.
+     * @param name the name of the window group to select
+     */
+    public void select(String name) {
+        WindowGroup wg = _windowGroupsMap.get(name);
+        if (wg == null) throw new IllegalArgumentException("Window group " + name + " is not found");
+        
+        wg.select();
+        _selectedWindowGroup = wg;
+    }
+    
+    /**
+     * Get the current selected window group.
+     * @return the selected window group or null if no one is selected
+     */
+    public WindowGroup getSelected() {
+        return _selectedWindowGroup;
+    }
+    
+    /**
+     * Store the windows in the current window group.
+     */
+    public void store() {
+        if (_selectedWindowGroup == null) {
+            log.debug("No window group is selected so we cannot store the windows");
+        }
+        _selectedWindowGroup.store();
+    }
+    
+    
+    
+    public static class DuplicateWindowGroupException extends JmriException {
+
+        public DuplicateWindowGroupException(String s, Throwable t) {
+            super(s, t);
+        }
+
+        public DuplicateWindowGroupException(String s) {
+            super(s);
+        }
+
+        public DuplicateWindowGroupException(Throwable t) {
+            super(t);
+        }
+
+        public DuplicateWindowGroupException() {
+        }
+
+    }
+    
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(WindowGroupManager.class);
+    
+}

--- a/java/src/jmri/swing/WindowGroupManager.java
+++ b/java/src/jmri/swing/WindowGroupManager.java
@@ -18,7 +18,6 @@ public class WindowGroupManager implements InstanceManagerAutoDefault {
     
     /**
      * Creates a new window group and selects it.
-     * The current windows is stored in the new window group.
      * 
      * @param name the name of the new group
      * @return the new window group

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -486,6 +486,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         }
         // add Window menu
         bar.add(new WindowMenu(this));
+        bar.add(new WindowGroupsMenu(this));
         // add Help menu
         jmri.util.HelpUtil.helpMenu(bar, ref, direct);
         setJMenuBar(bar);

--- a/java/src/jmri/util/UtilBundle.properties
+++ b/java/src/jmri/util/UtilBundle.properties
@@ -41,3 +41,4 @@ MenuWindowGroups_CreateWindowGroup_TitleError       = Error
 MenuWindowGroups_CreateWindowGroup_DuplicateName    = The name already exists
 
 MenuWindowGroups_RemoveWindowGroup_TitleRemove      = Remove window group?
+MenuWindowGroups_RemoveWindowGroup_ConfirmRemoval   = Do you want to remove the window group {0}?

--- a/java/src/jmri/util/UtilBundle.properties
+++ b/java/src/jmri/util/UtilBundle.properties
@@ -35,3 +35,9 @@ NumberCheckOutOfRangeMax=The value ''{0}'' must be at most {2}
 NumberCheckOutOfRangeBoth2=The value must be between {1} and {2}
 NumberCheckOutOfRangeMin2=The value must be at least {1}
 NumberCheckOutOfRangeMax2=The value must be at most {2}
+
+MenuWindowGroups_CreateWindowGroup_EnterName        = Enter name: 
+MenuWindowGroups_CreateWindowGroup_TitleError       = Error
+MenuWindowGroups_CreateWindowGroup_DuplicateName    = The name already exists
+
+MenuWindowGroups_RemoveWindowGroup_TitleRemove      = Remove window group?

--- a/java/src/jmri/util/WindowGroupsMenu.java
+++ b/java/src/jmri/util/WindowGroupsMenu.java
@@ -100,53 +100,6 @@ public class WindowGroupsMenu extends JMenu implements javax.swing.event.MenuLis
             }
             add(newItem);
         }
-        
-/*
-        add(new AbstractAction(Bundle.getMessage("MenuItemMinimize")) {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                // the next line works on Java 2, but not 1.1.8
-                if (parentFrame != null) {
-                    parentFrame.setState(Frame.ICONIFIED);
-                }
-            }
-        });
-        add(new JSeparator());
-
-        int framesNumber = framesList.size();
-        for (int i = 0; i < framesNumber; i++) {
-            JmriJFrame iFrame = framesList.get(i);
-            windowName = iFrame.getTitle();
-            if (windowName.equals("")) {
-                windowName = "Untitled";
-            }
-            JCheckBoxMenuItem newItem = new JCheckBoxMenuItem(new AbstractAction(windowName) {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    JMenuItem selectedItem = (JMenuItem) e.getSource();
-                    // Since different windows can have the same name, look for the position of the selected menu item
-                    int itemCount = getItemCount();
-                    // Skip possible other items at the top of the menu (for example, "Minimize")
-                    int firstItem = itemCount - framesList.size();
-                    for (int i = firstItem; i < itemCount; i++) {
-                        if (selectedItem == getItem(i)) {
-                            i -= firstItem;
-                            // Retrieve the corresponding window
-                            if (i < framesList.size()) { // "i" should always be < framesList.size(), but it's better to make sure
-                                framesList.get(i).setVisible(true);
-                                framesList.get(i).setExtendedState(Frame.NORMAL);
-                                return;
-                            }
-                        }
-                    }
-                }
-            });
-            if (iFrame == parentFrame) {
-                newItem.setState(true);
-            }
-            add(newItem);
-        }
-*/
     }
 
     @Override

--- a/java/src/jmri/util/WindowGroupsMenu.java
+++ b/java/src/jmri/util/WindowGroupsMenu.java
@@ -19,7 +19,8 @@ import jmri.util.swing.WindowInterface;
 /**
  * Creates a menu showing all open windows and allows to bring one in front
  *
- * @author Giorgio Terdina Copyright 2008
+ * @author Giorgio Terdina   Copyright 2008
+ * @author Daniel Bergqvist  Copyright 2021
  */
 public class WindowGroupsMenu extends JMenu implements javax.swing.event.MenuListener {
 

--- a/java/src/jmri/util/WindowGroupsMenu.java
+++ b/java/src/jmri/util/WindowGroupsMenu.java
@@ -1,0 +1,159 @@
+package jmri.util;
+
+import jmri.swing.WindowGroupManager;
+import jmri.swing.WindowGroup;
+
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
+import javax.swing.JSeparator;
+import javax.swing.event.MenuEvent;
+
+import jmri.*;
+import jmri.util.swing.WindowInterface;
+
+/**
+ * Creates a menu showing all open windows and allows to bring one in front
+ *
+ * @author Giorgio Terdina Copyright 2008
+ */
+public class WindowGroupsMenu extends JMenu implements javax.swing.event.MenuListener {
+
+    public WindowGroupsMenu(WindowInterface wi) {
+        super(Bundle.getMessage("MenuWindowGroups"));
+        addMenuListener(this);
+    }
+
+    @Override
+    public void menuSelected(MenuEvent e) {
+        WindowGroup selectedWindowGroup =
+                InstanceManager.getDefault(WindowGroupManager.class).getSelected();
+        
+        removeAll();
+        
+        add(new AbstractAction(Bundle.getMessage("MenuWindowGroups_Create")) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                String name = "";
+                while (true) {
+                    name = JOptionPane.showInputDialog(Bundle.getMessage("MenuWindowGroups_CreateWindowGroup_EnterName"), name);
+                    if (name == null) break;
+                    try {
+                        InstanceManager.getDefault(WindowGroupManager.class).create(name);
+                        break;
+                    } catch (WindowGroupManager.DuplicateWindowGroupException ignore) {
+                        int n = JOptionPane.showOptionDialog(null,
+                                Bundle.getMessage("MenuWindowGroups_CreateWindowGroup_DuplicateName"),
+                                Bundle.getMessage("MenuWindowGroups_CreateWindowGroup_TitleError"),
+                                JOptionPane.OK_CANCEL_OPTION,
+                                JOptionPane.ERROR_MESSAGE,
+                                null,
+                                null,
+                                null);
+                        if (n == JOptionPane.CANCEL_OPTION) break;
+                    }
+                }
+            }
+        });
+        
+        AbstractAction abstractAction = new AbstractAction(Bundle.getMessage("MenuWindowGroups_Remove")) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                int n = JOptionPane.showConfirmDialog(
+                        null,
+                        Bundle.getMessage("MenuWindowGroups_RemoveWindowGroup_ConfirmRemoval",
+                                selectedWindowGroup.getName()),
+                        Bundle.getMessage("MenuWindowGroups_RemoveWindowGroup_TitleRemove"),
+                        JOptionPane.YES_NO_OPTION);
+                if (n == JOptionPane.YES_OPTION) {
+                    InstanceManager.getDefault(WindowGroupManager.class).removeSelected();
+                }
+            }
+        };
+        abstractAction.setEnabled(selectedWindowGroup != null);
+        add(abstractAction);
+        
+        add(new AbstractAction(Bundle.getMessage("MenuWindowGroups_Store")) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                InstanceManager.getDefault(WindowGroupManager.class).store();
+            }
+        });
+        
+        add(new JSeparator());
+        
+        for (WindowGroup wg : InstanceManager.getDefault(WindowGroupManager.class).getAll()) {
+            JCheckBoxMenuItem newItem = new JCheckBoxMenuItem(new AbstractAction(wg.getName()) {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    JMenuItem selectedItem = (JMenuItem) e.getSource();
+                    InstanceManager.getDefault(WindowGroupManager.class).select(selectedItem.getText());
+                }
+            });
+            if (wg == selectedWindowGroup) {
+                newItem.setState(true);
+            }
+            add(newItem);
+        }
+        
+/*
+        add(new AbstractAction(Bundle.getMessage("MenuItemMinimize")) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                // the next line works on Java 2, but not 1.1.8
+                if (parentFrame != null) {
+                    parentFrame.setState(Frame.ICONIFIED);
+                }
+            }
+        });
+        add(new JSeparator());
+
+        int framesNumber = framesList.size();
+        for (int i = 0; i < framesNumber; i++) {
+            JmriJFrame iFrame = framesList.get(i);
+            windowName = iFrame.getTitle();
+            if (windowName.equals("")) {
+                windowName = "Untitled";
+            }
+            JCheckBoxMenuItem newItem = new JCheckBoxMenuItem(new AbstractAction(windowName) {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    JMenuItem selectedItem = (JMenuItem) e.getSource();
+                    // Since different windows can have the same name, look for the position of the selected menu item
+                    int itemCount = getItemCount();
+                    // Skip possible other items at the top of the menu (for example, "Minimize")
+                    int firstItem = itemCount - framesList.size();
+                    for (int i = firstItem; i < itemCount; i++) {
+                        if (selectedItem == getItem(i)) {
+                            i -= firstItem;
+                            // Retrieve the corresponding window
+                            if (i < framesList.size()) { // "i" should always be < framesList.size(), but it's better to make sure
+                                framesList.get(i).setVisible(true);
+                                framesList.get(i).setExtendedState(Frame.NORMAL);
+                                return;
+                            }
+                        }
+                    }
+                }
+            });
+            if (iFrame == parentFrame) {
+                newItem.setState(true);
+            }
+            add(newItem);
+        }
+*/
+    }
+
+    @Override
+    public void menuDeselected(MenuEvent e) {
+    }
+
+    @Override
+    public void menuCanceled(MenuEvent e) {
+    }
+
+}

--- a/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
+++ b/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
@@ -55,9 +55,9 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
     public void checkSetEditable() {
         e.setAllEditable(true);
         JMenuBarOperator jmbo = new JMenuBarOperator(jfo);
-        Assertions.assertEquals(4, jmbo.getMenuCount(), "Editable Menu Count: 4");
+        Assertions.assertEquals(5, jmbo.getMenuCount(), "Editable Menu Count: 5");
         e.setAllEditable(false);
-        Assertions.assertEquals(3, jmbo.getMenuCount(), "Non-editable Menu Count: 3");
+        Assertions.assertEquals(4, jmbo.getMenuCount(), "Non-editable Menu Count: 4");
         e.setAllEditable(true); // reset to be able to get to the menuBar to delete e
     }
 


### PR DESCRIPTION
This PR adds a new menu `Window groups`.

1. Create a new window group
2. Arrange the windows as desired
3. Store

Repeat step 1 - 3 to create more window groups.

To update a window group, select it, rearrange the windows and store.

To remove a window group, select the window group you want to remove and select Remove.

The window groups are not yet stored when JMRI quits. This remains to do.