### PR TITLE
Modify Power Manager Behaviour on ARST

### DIFF
--- a/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
@@ -54,8 +54,9 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
     protected String _protocol = ConfigurationManager.MERGCBUS;
     protected SubProtocol _subProtocol = SubProtocol.CBUS;
     protected ProgModeSwitch _progModeSwitch = ProgModeSwitch.NONE;
-    protected boolean _supportsCVHints = false;
-    private boolean _multipleThrottles = true;
+    protected boolean _supportsCVHints = false; // Support for CV read hint values
+    private boolean _multipleThrottles = true;  // Support for multiple throttles 
+    private boolean _powerOnArst = true;        // Turn power on if ARST opcode received
     
     jmri.jmrix.swing.ComponentFactory cf = null;
 
@@ -205,6 +206,18 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
     
     public void setSupportsCVHints(boolean b) {
         _supportsCVHints = b;
+    }
+    
+    /**
+     * 
+     * @return 
+     */
+    public boolean powerOnArst() {
+        return _powerOnArst;
+    }
+    
+    public void setPowerOnArst(boolean b) {
+        _powerOnArst = b;
     }
     
     /**

--- a/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
@@ -209,8 +209,9 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
     }
     
     /**
+     * Get the behaviour on ARST opcode
      * 
-     * @return 
+     * @return true if track power is on after ARST
      */
     public boolean powerOnArst() {
         return _powerOnArst;

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/sproggen5/serialdriver/Sprog3PlusSerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/sproggen5/serialdriver/Sprog3PlusSerialDriverAdapter.java
@@ -55,7 +55,8 @@ public class Sprog3PlusSerialDriverAdapter extends GcSerialDriverAdapter {
         this.getSystemConnectionMemo().setSubProtocol(ConfigurationManager.SubProtocol.NONE);
         this.getSystemConnectionMemo().setProgModeSwitch(_progMode);
         this.getSystemConnectionMemo().setSupportsCVHints(true);
-
+        this.getSystemConnectionMemo().setPowerOnArst(false);
+        
         // do central protocol-specific configuration    
         //jmri.jmrix.can.ConfigurationManager.configure(getOptionState(option1Name));
         this.getSystemConnectionMemo().configureManagers();

--- a/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
@@ -12,14 +12,16 @@ import jmri.managers.AbstractPowerManager;
  * PowerManager implementation for controlling CBUS layout power.
  *
  * @author Bob Jacobsen Copyright (C) 2001
- * @author Andrew CRosland Copyright (C) 2009
+ * @author Andrew Crosland Copyright (C) 2009, 2021
  */
 public class CbusPowerManager extends AbstractPowerManager<CanSystemConnectionMemo> implements CanListener {
 
     private TrafficController tc;
+    private CanSystemConnectionMemo _memo;
 
     public CbusPowerManager(CanSystemConnectionMemo memo) {
         super(memo);
+        _memo = memo;
         // connect to the TrafficManager
         tc = memo.getTrafficController();
         addTc(tc);
@@ -83,7 +85,11 @@ public class CbusPowerManager extends AbstractPowerManager<CanSystemConnectionMe
         } else if (CbusMessage.isTrackOn(m)) {
             power = ON;
         } else if (CbusMessage.isArst(m)) {
-            power = ON;
+            // Some CBUS command stations (e.g. CANCMD) will turn on the track
+            // power before sending ARST, so we log it here
+            if (_memo.powerOnArst()) {
+                power = ON;
+            }
         }
         firePowerPropertyChange(old, power);
     }

--- a/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
@@ -84,7 +84,9 @@ public class CbusPowerManager extends AbstractPowerManager<CanSystemConnectionMe
             power = ON;
         } else if (CbusMessage.isArst(m)) {
             // Some CBUS command stations (e.g. CANCMD) will turn on the track
-            // power before sending ARST, so we log it here
+            // power at start up, before sending ARST (System reset). Others,
+            // e.g., SPROG CBUS hardware can selectively turn on the track power
+            // so we selectively check for ARST here, based on connection settings.
             if (memo.powerOnArst()) {
                 power = ON;
             }

--- a/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
@@ -17,11 +17,9 @@ import jmri.managers.AbstractPowerManager;
 public class CbusPowerManager extends AbstractPowerManager<CanSystemConnectionMemo> implements CanListener {
 
     private TrafficController tc;
-    private CanSystemConnectionMemo _memo;
 
     public CbusPowerManager(CanSystemConnectionMemo memo) {
         super(memo);
-        _memo = memo;
         // connect to the TrafficManager
         tc = memo.getTrafficController();
         addTc(tc);
@@ -87,7 +85,7 @@ public class CbusPowerManager extends AbstractPowerManager<CanSystemConnectionMe
         } else if (CbusMessage.isArst(m)) {
             // Some CBUS command stations (e.g. CANCMD) will turn on the track
             // power before sending ARST, so we log it here
-            if (_memo.powerOnArst()) {
+            if (memo.powerOnArst()) {
                 power = ON;
             }
         }

--- a/java/test/jmri/jmrix/can/cbus/CbusPowerManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusPowerManagerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.*;
  *
  * @author Paul Bender Copyright (C) 2017
  * @author Steve Young Copyright (c) 2019
+ * @author Andrew Crosland Copyright (c) 2021
  */
 public class CbusPowerManagerTest extends AbstractPowerManagerTestBase {
 
@@ -111,6 +112,31 @@ public class CbusPowerManagerTest extends AbstractPowerManagerTestBase {
         pwr.reply(r);
         Assert.assertEquals("on", PowerManager.ON, p.getPower());
         Assert.assertEquals(0, controller.outbound.size());
+        
+    }
+    
+    @Test
+    public void checkArstBehaviour () throws jmri.JmriException {
+        
+        // Test effect of ARST on power state
+        CanReply r = new CanReply( new int[]{CbusConstants.CBUS_TOF},0x12);
+        pwr.reply(r);
+        Assert.assertEquals("set off before ARST", PowerManager.OFF, p.getPower());
+        
+        r = new CanReply( new int[]{CbusConstants.CBUS_ARST},0x12);
+        pwr.reply(r);
+        Assert.assertEquals("on after ARST", PowerManager.ON, p.getPower());
+        
+        // Change from default behaviour
+        memo.setPowerOnArst(false);
+        
+        r = new CanReply( new int[]{CbusConstants.CBUS_TOF},0x12);
+        pwr.reply(r);
+        Assert.assertEquals("set off before ARST", PowerManager.OFF, p.getPower());
+        
+        r = new CanReply( new int[]{CbusConstants.CBUS_ARST},0x12);
+        pwr.reply(r);
+        Assert.assertEquals("still off after ARST", PowerManager.OFF, p.getPower());
         
     }
     


### PR DESCRIPTION
Some CBUS command stations (e.g. CANCMD) will turn on the track power before sending ARST (System reset op code) on start-up.

SPROG CBUS command stations will selectively turn on track power before sending ARST.

JMRI currently shows track power ON after receiving ARST so the power can be out of synch between JMRI and SPROG hardware.

Add a new flag to the CanSystemConnectionMemo and modify CbusPowerManager to ignore the ARST if the command station is known to send an explicit TON or TOF at start-up.