### PR TITLE
Add support for readCV and confirmCV startVal to loconet

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnDeferProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnDeferProgrammer.java
@@ -39,9 +39,15 @@ public class LnDeferProgrammer implements Programmer {
     /** {@inheritDoc} */
     @Override
     public void readCV(String CV, ProgListener p) throws ProgrammerException {
+        readCV(CV, p, 0);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void readCV(String CV, ProgListener p, int startVal) throws ProgrammerException {
         SlotManager m = memo.getSlotManager();
         if (m!=null) {
-            m.readCV(CV, p);
+            m.readCV(CV, p, startVal);
         } else {
             log.warn("readCV called without a SlotManager");
         }


### PR DESCRIPTION
see #9476 for background.
This PR changes JMRI to include the proper startVal (guess) in the loconet programming messages.
From testing, it does NOT currently have any effect on CV reads via Digitrax hardware. I assume firmware changes would be needed to benefit from this change. This PR is provided to support those (hopefully) future changes.

This PR is a retry of PR #9649 which got gitborked. I will delete #9649 