### PR TITLE
Sensor Table - Use correct Manager, fix Active / InActive delay exception on sort

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -452,7 +452,8 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li></li>
+            <li>Fixed Duplication of Sensors in Sensor Table views. Bug introduced in 4.23.3</li>
+            <li>Fixed Sensor Table sort issues with Delay to Active, Delay to InActive columns.</li>
         </ul>
 
     <h3>Scripting</h3>

--- a/java/src/jmri/implementation/AbstractSensor.java
+++ b/java/src/jmri/implementation/AbstractSensor.java
@@ -47,6 +47,9 @@ public abstract class AbstractSensor extends AbstractNamedBean implements Sensor
     protected long sensorDebounceGoingInActive = 0L;
     protected boolean useDefaultTimerSettings = false;
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setSensorDebounceGoingActiveTimer(long time) {
         if (sensorDebounceGoingActive == time) {
@@ -57,11 +60,17 @@ public abstract class AbstractSensor extends AbstractNamedBean implements Sensor
         firePropertyChange("ActiveTimer", oldValue, sensorDebounceGoingActive);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public long getSensorDebounceGoingActiveTimer() {
         return sensorDebounceGoingActive;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setSensorDebounceGoingInActiveTimer(long time) {
         if (sensorDebounceGoingInActive == time) {
@@ -72,6 +81,9 @@ public abstract class AbstractSensor extends AbstractNamedBean implements Sensor
         firePropertyChange("InActiveTimer", oldValue, sensorDebounceGoingInActive);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public long getSensorDebounceGoingInActiveTimer() {
         return sensorDebounceGoingInActive;

--- a/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
@@ -247,10 +247,11 @@ abstract public class AbstractTableTabAction<E extends NamedBean> extends Abstra
             if (model instanceof XTableColumnModel) {
                 Enumeration<TableColumn> e = ((XTableColumnModel) model).getColumns(false);
                 int numCols = ((XTableColumnModel) model).getColumnCount(false);
-                // XTableColumnModel has been spotted to return a fleeting incorrect
-                // column count, possibly when manager is changed at startup
+                // XTableColumnModel has been spotted to return a fleeting different
+                // column count to actual model, generally if manager is changed at startup
                 // so we do a sanity check to make sure the models are in synch.
                 if (numCols != dataModel.getColumnCount()){
+                    log.debug("Difference with Xtable cols: {} Model cols: {}",numCols,dataModel.getColumnCount());
                     return;
                 }
                 boolean[] colsVisible = new boolean[numCols];

--- a/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
@@ -247,6 +247,13 @@ abstract public class AbstractTableTabAction<E extends NamedBean> extends Abstra
             if (model instanceof XTableColumnModel) {
                 Enumeration<TableColumn> e = ((XTableColumnModel) model).getColumns(false);
                 int numCols = ((XTableColumnModel) model).getColumnCount(false);
+                // XTableColumnModel has been spotted to return a fleeting incorrect
+                // column count, possibly when manager is changed at startup
+                // so we do a sanity check to make sure the models are in synch.
+                if (numCols != dataModel.getColumnCount()){
+                    log.debug("Xtable cols: {} Model cols: {}",numCols,dataModel.getColumnCount());
+                    return;
+                }
                 boolean[] colsVisible = new boolean[numCols];
                 while (e.hasMoreElements()) {
                     TableColumn column = e.nextElement();

--- a/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
@@ -251,7 +251,6 @@ abstract public class AbstractTableTabAction<E extends NamedBean> extends Abstra
                 // column count, possibly when manager is changed at startup
                 // so we do a sanity check to make sure the models are in synch.
                 if (numCols != dataModel.getColumnCount()){
-                    log.debug("Xtable cols: {} Model cols: {}",numCols,dataModel.getColumnCount());
                     return;
                 }
                 boolean[] colsVisible = new boolean[numCols];

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -60,33 +60,18 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
 
     /**
      * Create a new Bean Table Data Model.
-     * The default Manager for the bean type will be a Proxy Manager.
+     * The default Manager for the bean type may well be a Proxy Manager.
      */
     public BeanTableDataModel() {
         super();
-        initModel(null);
-    }
-    
-    /**
-     * Create a new Bean Table Data Model.
-     * The Manager for the bean type will be the one provided.
-     * @param beanManager the Bean Manager for the Table Model, 
-     *                  null will default to a Proxy Manager.
-     */
-    public BeanTableDataModel(Manager<T> beanManager) {
-        super();
-        initModel(beanManager);
+        initModel();
     }
     
     /**
      * Internal routine to avoid over ride method call in constructor.
-     * @param beanManager Bean Manager, can be null.
      */
-    private void initModel(Manager<T> beanManager){
+    private void initModel(){
         nbMan = InstanceManager.getDefault(NamedBeanHandleManager.class);
-        if (beanManager!=null){
-            setManager(beanManager);
-        }
         // log.error("get mgr is: {}",this.getManager());
         getManager().addPropertyChangeListener(this);
         updateNameList();

--- a/java/src/jmri/jmrit/beantable/BlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/BlockTableAction.java
@@ -9,9 +9,11 @@ import javax.swing.*;
 
 import jmri.Block;
 import jmri.InstanceManager;
+import jmri.Manager;
 import jmri.NamedBean;
 import jmri.UserPreferencesManager;
 import jmri.jmrit.beantable.block.BlockTableDataModel;
+import jmri.BlockManager;
 import jmri.util.JmriJFrame;
 
 import org.slf4j.Logger;
@@ -53,6 +55,12 @@ public class BlockTableAction extends AbstractTableAction<Block> {
     @Override
     protected void createModel() {
         m = new BlockTableDataModel(getManager());
+    }
+    
+    @Nonnull
+    @Override
+    protected Manager<Block> getManager() {
+        return InstanceManager.getDefault(BlockManager.class);
     }
 
     @Override

--- a/java/src/jmri/jmrit/beantable/block/BlockTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/block/BlockTableDataModel.java
@@ -65,7 +65,7 @@ public class BlockTableDataModel extends BeanTableDataModel<Block> {
     
     public BlockTableDataModel(Manager<Block> mgr){
         super();
-        setManager(mgr); // for consistency, no local method as 
+        setManager(mgr); // for consistency with other BeanTableModels, default BlockManager always used.
         
         defaultBlockSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + InstanceManager.getDefault(BlockManager.class).getDefaultSpeed()); // first entry in drop down list
         speedList.add(defaultBlockSpeedText);

--- a/java/src/jmri/jmrit/beantable/block/BlockTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/block/BlockTableDataModel.java
@@ -64,7 +64,8 @@ public class BlockTableDataModel extends BeanTableDataModel<Block> {
     String defaultBlockSpeedText;
     
     public BlockTableDataModel(Manager<Block> mgr){
-        super(mgr);
+        super();
+        setManager(mgr); // for consistency, no local method as 
         
         defaultBlockSpeedText = (Bundle.getMessage("UseGlobal", "Global") + " " + InstanceManager.getDefault(BlockManager.class).getDefaultSpeed()); // first entry in drop down list
         speedList.add(defaultBlockSpeedText);

--- a/java/src/jmri/jmrit/beantable/light/LightTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/light/LightTableDataModel.java
@@ -44,7 +44,8 @@ public class LightTableDataModel extends BeanTableDataModel<Light> {
     }
 
     public LightTableDataModel(Manager<Light> mgr){
-        super(mgr);
+        super();
+        setManager(mgr);
         initTable();
     }
     

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -7,6 +7,7 @@ import java.awt.Image;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeEvent;
 import java.io.File;
 import java.io.IOException;
 import java.util.Enumeration;
@@ -54,6 +55,7 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      */
     public SensorTableDataModel() {
         super();
+        _graphicState = InstanceManager.getDefault(GuiLafPreferencesManager.class).isGraphicTableState();
     }
 
     /**
@@ -63,8 +65,8 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      * @param manager Bean Manager.
      */
     public SensorTableDataModel(Manager<Sensor> manager) {
-        super(manager);
-        updateNameList();
+        super();
+        setManager(manager); // updates name list
         // load graphic state column display preference
         _graphicState = InstanceManager.getDefault(GuiLafPreferencesManager.class).isGraphicTableState();
     }
@@ -197,7 +199,7 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
                 return Boolean.class;
             case ACTIVEDELAY:
             case INACTIVEDELAY:
-                return String.class;
+                return Long.class; // if long.class (lowercase) is returned here, cell is NOT editable.
             case PULLUPCOL:
                 return JComboBox.class;
             case EDITCOL:
@@ -332,33 +334,37 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
         }
         switch (col) {
             case INVERTCOL:
-                s.setInverted(((Boolean) value));
+                s.setInverted(((boolean) value));
                 break;
             case USEGLOBALDELAY:
-                s.setUseDefaultTimerSettings(((Boolean) value));
+                s.setUseDefaultTimerSettings(((boolean) value));
                 break;
             case ACTIVEDELAY:
                 try {
-                    Long activeDeBounce = Long.parseLong((String) value);
+                    long activeDeBounce = (long) value;
                     if (activeDeBounce < 0 || activeDeBounce > Sensor.MAX_DEBOUNCE) {
-                        JOptionPane.showMessageDialog(null, Bundle.getMessage("SensorDebounceActOutOfRange") + "\n\"" + (String) value + "\"", "Input Error", JOptionPane.ERROR_MESSAGE);
+                        JOptionPane.showMessageDialog(null, Bundle.getMessage("SensorDebounceActOutOfRange")
+                            + "\n\"" + Sensor.MAX_DEBOUNCE + "\"", Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
                     } else {
-                        s.setSensorDebounceGoingActiveTimer(Long.parseLong((String) value));
+                        s.setSensorDebounceGoingActiveTimer(activeDeBounce);
                     }
                 } catch (NumberFormatException exActiveDeBounce) {
-                    JOptionPane.showMessageDialog(null, Bundle.getMessage("SensorDebounceActError") + "\n\"" + Long.toString(Sensor.MAX_DEBOUNCE) + "\"", "Input Error", JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.showMessageDialog(null, Bundle.getMessage("SensorDebounceActError")
+                        + "\n\"" + value  + "\"" + exActiveDeBounce.getLocalizedMessage(), Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
                 }
                 break;
             case INACTIVEDELAY:
                 try {
-                    Long inactiveDeBounce = Long.parseLong((String) value);
+                    long inactiveDeBounce = (long) value;
                     if (inactiveDeBounce < 0 || inactiveDeBounce > Sensor.MAX_DEBOUNCE) {
-                        JOptionPane.showMessageDialog(null, Bundle.getMessage("SensorDebounceInActOutOfRange") + "\n\"" + Long.toString(Sensor.MAX_DEBOUNCE) + "\"", "Input Error", JOptionPane.ERROR_MESSAGE);
+                        JOptionPane.showMessageDialog(null, Bundle.getMessage("SensorDebounceInActOutOfRange") 
+                            + "\n\"" + Sensor.MAX_DEBOUNCE + "\"", Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
                     } else {
-                        s.setSensorDebounceGoingInActiveTimer(Long.parseLong((String) value));
+                        s.setSensorDebounceGoingInActiveTimer(inactiveDeBounce);
                     }
                 } catch (NumberFormatException exActiveDeBounce) {
-                    JOptionPane.showMessageDialog(null, Bundle.getMessage("SensorDebounceInActError") + "\n\"" + (String) value + "\"", "Input Error", JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.showMessageDialog(null, Bundle.getMessage("SensorDebounceInActError")
+                        + "\n\"" + value + "\"" + exActiveDeBounce.getLocalizedMessage(), Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
                 }
                 break;
             case EDITCOL:
@@ -403,12 +409,15 @@ public class SensorTableDataModel extends BeanTableDataModel<Sensor> {
      * {@inheritDoc}
      */
     @Override
-    protected boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
-        if ((e.getPropertyName().contains("inverted")) || (e.getPropertyName().contains("GlobalTimer"))
-                || (e.getPropertyName().contains("ActiveTimer")) || (e.getPropertyName().contains("InActiveTimer"))) {
-            return true;
-        } else {
-            return super.matchPropertyName(e);
+    protected boolean matchPropertyName(PropertyChangeEvent e) {
+        switch (e.getPropertyName()) {
+            case "inverted":
+            case "GlobalTimer":
+            case "ActiveTimer":
+            case "InActiveTimer":
+                return true;
+            default:
+                return super.matchPropertyName(e);
         }
     }
 

--- a/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/turnout/TurnoutTableDataModel.java
@@ -76,7 +76,8 @@ public class TurnoutTableDataModel extends BeanTableDataModel<Turnout>{
     }
     
     public TurnoutTableDataModel(Manager<Turnout> mgr){
-        super(mgr);
+        super();
+        setManager(mgr);
         initTable();
     }
     

--- a/java/test/jmri/jmrit/beantable/sensor/SensorTableDataModelTest.java
+++ b/java/test/jmri/jmrit/beantable/sensor/SensorTableDataModelTest.java
@@ -1,5 +1,8 @@
 package jmri.jmrit.beantable.sensor;
 
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+
 import jmri.Sensor;
 import jmri.util.JUnitUtil;
 
@@ -41,6 +44,18 @@ public class SensorTableDataModelTest extends jmri.jmrit.beantable.AbstractBeanT
             t.getColumnName(SensorTableDataModel.FORGETCOL));
         assertEquals("Column12 - QUERYCOL",Bundle.getMessage("StateQueryHeader"),
             t.getColumnName(SensorTableDataModel.QUERYCOL));
+    }
+    
+    @Test
+    public void testGetColumnClasses() {
+        assertEquals("INVERTCOL ",Boolean.class,t.getColumnClass(SensorTableDataModel.INVERTCOL) );
+        assertEquals("EDITCOL ",JButton.class,t.getColumnClass(SensorTableDataModel.EDITCOL) );
+        assertEquals("USEGLOBALDELAY ",Boolean.class,t.getColumnClass(SensorTableDataModel.USEGLOBALDELAY) );
+        assertEquals("ACTIVEDELAY Long not long",Long.class,t.getColumnClass(SensorTableDataModel.ACTIVEDELAY) );
+        assertEquals("INACTIVEDELAY Long not long",Long.class,t.getColumnClass(SensorTableDataModel.INACTIVEDELAY) );
+        assertEquals("PULLUPCOL ",JComboBox.class,t.getColumnClass(SensorTableDataModel.PULLUPCOL) );
+        assertEquals("FORGETCOL ",JButton.class,t.getColumnClass(SensorTableDataModel.FORGETCOL) );
+        assertEquals("QUERYCOL ",JButton.class,t.getColumnClass(SensorTableDataModel.QUERYCOL) );
     }
 
     @BeforeEach


### PR DESCRIPTION
Removes recently introduced constructor BeanTableDataModel(Manager<T> beanManager) as not setting Manager properly in Sensor Tables.
Update implementing classes to setManager outside of constructor.

use Long.class for SensorTableDataModel ACTIVEDELAY / INACTIVEDELAY

Sanity check on number of columns before updating checkboxes.

Fixes #9645
Fixes #9646