### PR TITLE
Bean Tables - Update ListedTableFrame

### DIFF
--- a/java/src/jmri/jmrit/beantable/ListedTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ListedTableAction.java
@@ -64,7 +64,8 @@ public class ListedTableAction extends AbstractAction {
         Runnable r = new Runnable() {
             @Override
             public void run() {
-                f = new ListedTableFrame(title) {};
+                f = new ListedTableFrame<>(title);
+                f.initTables();
                 f.initComponents();
                 addToFrame(f);
 

--- a/java/src/jmri/jmrit/beantable/ListedTableFrame.java
+++ b/java/src/jmri/jmrit/beantable/ListedTableFrame.java
@@ -25,7 +25,6 @@ import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.SortOrder;
-import javax.swing.Timer;
 import javax.swing.table.TableRowSorter;
 import jmri.*;
 import jmri.swing.RowSorterUtil;
@@ -59,19 +58,34 @@ public class ListedTableFrame<E extends NamedBean> extends BeanTableFrame<E> {
     JScrollPane listScroller;
     JPanel listPanel;
     JPanel detailPanel;
-    TabbedTableItem<E> itemBeingAdded = null;
     static boolean init = false;
 
+    /**
+     * Create a new Listed Table Frame.
+     * Call initTables() before initComponents()
+     */
     public ListedTableFrame() {
         this(Bundle.getMessage("TitleListedTable"));
     }
 
+    /**
+     * Create a new Listed Table Frame.
+     * Call initTables() before initComponents()
+     * @param s Initial Frame Title
+     */
     public ListedTableFrame(String s) {
         super(s);
-        if (jmri.InstanceManager.getNullableDefault(jmri.jmrit.beantable.ListedTableFrame.class) == null) {
+        if (InstanceManager.getNullableDefault(jmri.jmrit.beantable.ListedTableFrame.class) == null) {
             // We add this to the InstanceManager so that other components can add to the table
-            jmri.InstanceManager.store(this, jmri.jmrit.beantable.ListedTableFrame.class);
+            InstanceManager.store(ListedTableFrame.this, jmri.jmrit.beantable.ListedTableFrame.class);
         }
+    }
+    
+    /**
+     * Initialise all tables to be added to Frame.
+     * Should be called after ListedTableFrame construction and before initComponents()
+     */
+    public void initTables() {
         if (!init) {
             // Add the default tables to the static list array,
             // this should only be done once on first loading
@@ -115,10 +129,9 @@ public class ListedTableFrame<E extends NamedBean> extends BeanTableFrame<E> {
             // Here we add all the tables into the panel
             try {
                 TabbedTableItem<E> itemModel = new TabbedTableItem<>(item.getClassAsString(), item.getItemString(), item.getStandardTableModel());
-                itemBeingAdded = itemModel;
                 detailPanel.add(itemModel.getPanel(), itemModel.getClassAsString());
                 tabbedTableArray.add(itemModel);
-                itemBeingAdded.getAAClass().addToFrame(this);
+                itemModel.getAAClass().addToFrame(this);
             } catch (Exception ex) {
                 detailPanel.add(errorPanel(item.getItemString()), item.getClassAsString());
                 log.error("Error when adding {} to display", item.getClassAsString(), ex);
@@ -183,7 +196,7 @@ public class ListedTableFrame<E extends NamedBean> extends BeanTableFrame<E> {
                     return;
                 }
             } catch (Exception ex) {
-                log.error("An error occurred in the goto list for {}", selection);
+                log.error("An error occurred in the goto list for {}, {}", selection,ex.getMessage());
             }
         }
     }
@@ -307,6 +320,10 @@ public class ListedTableFrame<E extends NamedBean> extends BeanTableFrame<E> {
         }
     }
 
+    /**
+     * Flag Table initialisation started
+     * @param newVal true when started
+     */
     private synchronized static void setInit(boolean newVal) {
         init = newVal;
     }
@@ -514,19 +531,10 @@ public class ListedTableFrame<E extends NamedBean> extends BeanTableFrame<E> {
             menuItem = new JMenuItem("Open in New Window"); // TODO I18N
             popUp.add(menuItem);
             menuItem.addActionListener((ActionEvent e) -> openNewTableWindow(mouseItem));
-            try {
-                Object p2 = Toolkit.getDefaultToolkit().getDesktopProperty("awt.multiClickInterval");
-                if (p2 != null) {
-                    clickDelay = ((Integer) p2);
-                }
-            } catch (Exception e1) {
-                log.debug("Cannot parse DesktopProperty awt.multiClickInterval to set double click interval {}", e1.getMessage());
-            }
             currentItemSelected = 0;
         }
 
-        int clickDelay = 500;
-        int currentItemSelected;
+        private int currentItemSelected;
 
         @Override
         public void mousePressed(MouseEvent e) {
@@ -542,10 +550,11 @@ public class ListedTableFrame<E extends NamedBean> extends BeanTableFrame<E> {
             }
         }
 
-        javax.swing.Timer clickTimer = null;
-
+        // records the original pre-click index
+        private int beforeClickIndex;
+        
         //Records the item index that the mouse is currently over
-        int mouseItem;
+        private int mouseItem;        
 
         void showPopup(MouseEvent e) {
             popUp.show(e.getComponent(), e.getX(), e.getY());
@@ -567,16 +576,13 @@ public class ListedTableFrame<E extends NamedBean> extends BeanTableFrame<E> {
                 showPopup(e);
                 return;
             }
-            if (clickTimer == null) {
-                clickTimer = new Timer(clickDelay, (ActionEvent e1) -> selectListItem(mouseItem));
-                clickTimer.setRepeats(false);
-            }
             if (e.getClickCount() == 1) {
-                clickTimer.start();
+                beforeClickIndex = currentItemSelected;
+                selectListItem(mouseItem);
             } else if (e.getClickCount() == 2) {
-                clickTimer.stop();
+                list.setSelectedIndex(beforeClickIndex);
+                selectListItem(beforeClickIndex);
                 openNewTableWindow(mouseItem);
-                list.setSelectedIndex(currentItemSelected);
             }
         }
 

--- a/java/test/jmri/jmrit/beantable/IdTagTableTabActionTest.java
+++ b/java/test/jmri/jmrit/beantable/IdTagTableTabActionTest.java
@@ -1,9 +1,23 @@
 package jmri.jmrit.beantable;
 
+import java.awt.GraphicsEnvironment;
+
+import javax.swing.JFrame;
+
+import jmri.IdTag;
+import jmri.IdTagManager;
+import jmri.InstanceManager;
+import jmri.jmrix.internal.InternalSystemConnectionMemo;
+import jmri.managers.AbstractProxyManager;
+import jmri.managers.DefaultIdTagManager;
+import jmri.managers.ProxyIdTagManager;
+
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.netbeans.jemmy.operators.*;
 
 /**
  *
@@ -36,6 +50,103 @@ public class IdTagTableTabActionTest extends AbstractTableTabActionBase {
     @Override
     @Disabled("parent class test causes an NPE; need to investigate cause")
     public void testGetPanel() {
+    }
+    
+    @Disabled("v4.23.4ish Proxy returning 3 IdTag Managers, not the 2 created")
+    @Test
+    public void testMultiSystemTabs(){
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
+        JUnitUtil.resetInstanceManager();
+        // Not returning null v4.23.4ish
+        // Assert.assertNull("Null Manager at start",InstanceManager.getNullableDefault(IdTagManager.class));
+    
+        ProxyIdTagManager l = new ProxyIdTagManager(); // has 2 systems: ID, JD
+        l.addManager(
+            new DefaultIdTagManager(new InternalSystemConnectionMemo("J", "Juliet")) {
+                @Override
+                public void init() {} // init override to prevent loading xml data and registering shutdown task.
+            });
+        l.addManager(
+            new DefaultIdTagManager(new InternalSystemConnectionMemo("I", "India")) {
+                @Override
+                public void init() {} // init override to prevent loading xml data and registering shutdown task.
+            });
+        InstanceManager.setIdTagManager(l);
+        
+        // Test that Proxy IdTag Manager has Juliet, India, and nothing else.
+        IdTagManager plm = InstanceManager.getDefault(IdTagManager.class);
+        if (!(plm instanceof AbstractProxyManager)) {
+            Assert.fail("Instance IdTagManager Not a proxy IdTag Manager");
+        }
+        
+        try {
+            @SuppressWarnings("unchecked")
+            AbstractProxyManager<IdTag> proxy = (AbstractProxyManager<IdTag>) plm;
+            int numLm = proxy.getDisplayOrderManagerList().size();
+            Assert.assertEquals("2 IdTag Managers, Juliet, India",2, numLm);
+            
+            String s = proxy.getDisplayOrderManagerList().get(0).getMemo().getUserName();
+            Assert.assertEquals("IdTag Manager 0 , Juliet","Juliet", s);
+            
+            s = proxy.getDisplayOrderManagerList().get(1).getMemo().getUserName();
+            Assert.assertEquals("IdTag Manager 1, India","India", s);
+        } catch (ClassCastException e){
+            Assert.fail("catch Instance IdTagManager Not a proxy IdTag Manager");
+        }
+        
+        
+        InstanceManager.getDefault(IdTagManager.class).provideIdTag("ID1");
+        InstanceManager.getDefault(IdTagManager.class).provideIdTag("ID2");
+        InstanceManager.getDefault(IdTagManager.class).provideIdTag("ID3");
+        InstanceManager.getDefault(IdTagManager.class).provideIdTag("ID4");
+        InstanceManager.getDefault(IdTagManager.class).provideIdTag("ID5");
+        
+        InstanceManager.getDefault(IdTagManager.class).provideIdTag("JD8");
+        InstanceManager.getDefault(IdTagManager.class).provideIdTag("JD9");
+        
+        TabbedIdTagTableFrame sf = new TabbedIdTagTableFrame();
+        sf.initTables();
+        sf.initComponents();
+        sf.pack();
+        sf.setVisible(true);
+        
+        JFrame f = JFrameOperator.waitJFrame(sf.getTitle(), true, true);
+        JFrameOperator jfo = new JFrameOperator(f);
+        JTabbedPaneOperator tabOperator = new JTabbedPaneOperator(jfo);
+        Assert.assertEquals("3 manager tabs",3, tabOperator.getTabCount());
+        
+        tabOperator.selectPage("All");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        JTableOperator controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("All tab 7 IdTag",7, controltbl.getRowCount());
+        
+        tabOperator.selectPage("Juliet");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("Juliet tab 2 IdTag",2, controltbl.getRowCount());
+        
+        tabOperator.selectPage("India");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("India tab 5 IdTag",5, controltbl.getRowCount());
+        
+        // jmri.util.swing.JemmyUtil.pressButton(jfo, "Not a Button, pause test");
+        jfo.requestClose();
+    
+    }
+    
+    private static class TabbedIdTagTableFrame extends ListedTableFrame<IdTag> {
+        
+        public TabbedIdTagTableFrame(){
+            super();
+            tabbedTableItemListArrayArray.clear(); // reset static BeanTable list
+        }
+        
+        @Override
+        public void initTables() {
+            addTable("jmri.jmrit.beantable.IdTagTableTabAction", Bundle.getMessage("MenuItemIdTagTable"), false);
+        }
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/beantable/LightTableTabActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LightTableTabActionTest.java
@@ -1,9 +1,22 @@
 package jmri.jmrit.beantable;
 
+import java.awt.GraphicsEnvironment;
+
+import javax.swing.JFrame;
+
+import jmri.InstanceManager;
+import jmri.Light;
+import jmri.LightManager;
+import jmri.jmrix.internal.InternalLightManager;
+import jmri.jmrix.internal.InternalSystemConnectionMemo;
+import jmri.managers.AbstractProxyManager;
+import jmri.managers.ProxyLightManager;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.netbeans.jemmy.operators.*;
 
 /**
  *
@@ -30,6 +43,94 @@ public class LightTableTabActionTest extends AbstractTableTabActionBase {
     @Test
     public void testIncludeAddButton() {
         Assert.assertTrue("Default include add button", a.includeAddButton());
+    }
+    
+    @Test
+    public void testMultiSystemTabs(){
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
+        JUnitUtil.resetInstanceManager();
+        // Not returning null v4.23.4ish
+        // Assert.assertNull("No Manager at start",InstanceManager.getNullableDefault(LightManager.class));
+    
+        ProxyLightManager l = new ProxyLightManager(); // has 2 systems: JL, IL
+        l.addManager(new InternalLightManager(new InternalSystemConnectionMemo("J", "Juliet")));
+        l.addManager(new InternalLightManager(new InternalSystemConnectionMemo("I", "India")));
+        InstanceManager.setLightManager(l);
+        
+        // Test that Proxy Light Manager has Juliet, India, and nothing else.
+        LightManager plm = InstanceManager.getDefault(LightManager.class);
+        if (!(plm instanceof AbstractProxyManager)) {
+            Assert.fail("Instance LightManager Not a proxy Light Manager");
+        }
+        
+        try {
+            @SuppressWarnings("unchecked")
+            AbstractProxyManager<Light> proxy = (AbstractProxyManager<Light>) plm;
+            int numLm = proxy.getDisplayOrderManagerList().size();
+            Assert.assertEquals("2 Light Managers, Juliet, India",2, numLm);
+            
+            String s = proxy.getDisplayOrderManagerList().get(0).getMemo().getUserName();
+            Assert.assertEquals("Light Manager 0 , Juliet","Juliet", s);
+            
+            s = proxy.getDisplayOrderManagerList().get(1).getMemo().getUserName();
+            Assert.assertEquals("Light Manager 1, India","India", s);
+        } catch (ClassCastException e){
+            Assert.fail("catch Instance LightManager Not a proxy Light Manager");
+        }
+        
+        
+        InstanceManager.getDefault(LightManager.class).provideLight("IL1");
+        InstanceManager.getDefault(LightManager.class).provideLight("IL2");
+        InstanceManager.getDefault(LightManager.class).provideLight("IL3");
+        InstanceManager.getDefault(LightManager.class).provideLight("IL4");
+        InstanceManager.getDefault(LightManager.class).provideLight("IL5");
+        
+        InstanceManager.getDefault(LightManager.class).provideLight("JL8");
+        InstanceManager.getDefault(LightManager.class).provideLight("JL9");
+        
+        TabbedLightTableFrame sf = new TabbedLightTableFrame();
+        sf.initTables();
+        sf.initComponents();
+        sf.pack();
+        sf.setVisible(true);
+        
+        JFrame f = JFrameOperator.waitJFrame(sf.getTitle(), true, true);
+        JFrameOperator jfo = new JFrameOperator(f);
+        JTabbedPaneOperator tabOperator = new JTabbedPaneOperator(jfo);
+        Assert.assertEquals("3 manager tabs",3, tabOperator.getTabCount());
+        
+        tabOperator.selectPage("All");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        JTableOperator controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("All tab 7 Lights",7, controltbl.getRowCount());
+        
+        tabOperator.selectPage("Juliet");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("Juliet tab 2 Lights",2, controltbl.getRowCount());
+        
+        tabOperator.selectPage("India");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("India tab 5 Lights",5, controltbl.getRowCount());
+        
+        // jmri.util.swing.JemmyUtil.pressButton(jfo, "Not a Button, pause test");
+        jfo.requestClose();
+    
+    }
+    
+    private static class TabbedLightTableFrame extends ListedTableFrame<Light> {
+        
+        public TabbedLightTableFrame(){
+            super();
+            tabbedTableItemListArrayArray.clear(); // reset static BeanTable list
+        }
+        
+        @Override
+        public void initTables() {
+            addTable("jmri.jmrit.beantable.LightTableTabAction", Bundle.getMessage("MenuItemLightTable"), false);
+        }
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/beantable/ReporterTableTabActionTest.java
+++ b/java/test/jmri/jmrit/beantable/ReporterTableTabActionTest.java
@@ -1,9 +1,23 @@
 package jmri.jmrit.beantable;
 
+import java.awt.GraphicsEnvironment;
+
+import javax.swing.JFrame;
+
+import jmri.InstanceManager;
+
+import jmri.Reporter;
+import jmri.ReporterManager;
+import jmri.jmrix.internal.InternalReporterManager;
+import jmri.jmrix.internal.InternalSystemConnectionMemo;
+import jmri.managers.AbstractProxyManager;
+import jmri.managers.ProxyReporterManager;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.netbeans.jemmy.operators.*;
 
 /**
  *
@@ -30,6 +44,95 @@ public class ReporterTableTabActionTest extends AbstractTableTabActionBase {
     @Test
     public void testIncludeAddButton() {
         Assert.assertTrue("Default include add button", a.includeAddButton());
+    }
+    
+    @Test
+    public void testMultiSystemTabs(){
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
+        JUnitUtil.resetInstanceManager();
+        // Not returning null v4.23.4ish
+        // Assert.assertNull("No Manager at start",InstanceManager.getNullableDefault(ReporterManager.class));
+    
+        ProxyReporterManager l = new ProxyReporterManager(); // has 2 systems: IR, JR
+        l.addManager(new InternalReporterManager(new InternalSystemConnectionMemo("J", "Juliet")));
+        l.addManager(new InternalReporterManager(new InternalSystemConnectionMemo("I", "India")));
+        InstanceManager.setReporterManager(l);
+        
+        // Test that Proxy Reporter Manager has Juliet, India, and nothing else.
+        ReporterManager plm = InstanceManager.getDefault(ReporterManager.class);
+        if (!(plm instanceof AbstractProxyManager)) {
+            Assert.fail("Instance ReporterManager Not a proxy Reporter Manager");
+        }
+        
+        try {
+            @SuppressWarnings("unchecked")
+            AbstractProxyManager<Reporter> proxy = (AbstractProxyManager<Reporter>) plm;
+            int numLm = proxy.getDisplayOrderManagerList().size();
+            Assert.assertEquals("2 Reporter Managers, Juliet, India",2, numLm);
+            
+            String s = proxy.getDisplayOrderManagerList().get(0).getMemo().getUserName();
+            Assert.assertEquals("Reporter Manager 0 , Juliet","Juliet", s);
+            
+            s = proxy.getDisplayOrderManagerList().get(1).getMemo().getUserName();
+            Assert.assertEquals("Reporter Manager 1, India","India", s);
+        } catch (ClassCastException e){
+            Assert.fail("catch Instance SensorManager Not a proxy Reporter Manager");
+        }
+        
+        
+        
+        InstanceManager.getDefault(ReporterManager.class).provideReporter("IR1");
+        InstanceManager.getDefault(ReporterManager.class).provideReporter("IR2");
+        InstanceManager.getDefault(ReporterManager.class).provideReporter("IR3");
+        InstanceManager.getDefault(ReporterManager.class).provideReporter("IR4");
+        InstanceManager.getDefault(ReporterManager.class).provideReporter("IR5");
+        
+        InstanceManager.getDefault(ReporterManager.class).provideReporter("JR8");
+        InstanceManager.getDefault(ReporterManager.class).provideReporter("JR9");
+        
+        TabbedReporterTableFrame sf = new TabbedReporterTableFrame();
+        sf.initTables();
+        sf.initComponents();
+        sf.pack();
+        sf.setVisible(true);
+        
+        JFrame f = JFrameOperator.waitJFrame(sf.getTitle(), true, true);
+        JFrameOperator jfo = new JFrameOperator(f);
+        JTabbedPaneOperator tabOperator = new JTabbedPaneOperator(jfo);
+        Assert.assertEquals("3 manager tabs",3, tabOperator.getTabCount());
+        
+        tabOperator.selectPage("All");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        JTableOperator controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("All tab 7 Reporters",7, controltbl.getRowCount());
+        
+        tabOperator.selectPage("Juliet");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("Juliet tab 2 Reporters",2, controltbl.getRowCount());
+        
+        tabOperator.selectPage("India");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("India tab 5 Reporters",5, controltbl.getRowCount());
+        
+        // jmri.util.swing.JemmyUtil.pressButton(jfo, "Not a Button, pause test");
+        jfo.requestClose();
+    
+    }
+    
+    private static class TabbedReporterTableFrame extends ListedTableFrame<Reporter> {
+        
+        public TabbedReporterTableFrame(){
+            super();
+            tabbedTableItemListArrayArray.clear(); // reset static BeanTable list
+        }
+        
+        @Override
+        public void initTables() {
+            addTable("jmri.jmrit.beantable.ReporterTableTabAction", Bundle.getMessage("MenuItemReporterTable"), false);
+        }
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/beantable/ReporterTableTabActionTest.java
+++ b/java/test/jmri/jmrit/beantable/ReporterTableTabActionTest.java
@@ -77,9 +77,8 @@ public class ReporterTableTabActionTest extends AbstractTableTabActionBase {
             s = proxy.getDisplayOrderManagerList().get(1).getMemo().getUserName();
             Assert.assertEquals("Reporter Manager 1, India","India", s);
         } catch (ClassCastException e){
-            Assert.fail("catch Instance SensorManager Not a proxy Reporter Manager");
+            Assert.fail("catch Instance Reporter Manager Not a proxy Reporter Manager");
         }
-        
         
         
         InstanceManager.getDefault(ReporterManager.class).provideReporter("IR1");

--- a/java/test/jmri/jmrit/beantable/TurnoutTableTabActionTest.java
+++ b/java/test/jmri/jmrit/beantable/TurnoutTableTabActionTest.java
@@ -1,9 +1,22 @@
 package jmri.jmrit.beantable;
 
+import java.awt.GraphicsEnvironment;
+
+import javax.swing.JFrame;
+
+import jmri.InstanceManager;
+import jmri.Turnout;
+import jmri.TurnoutManager;
 import jmri.util.JUnitUtil;
+import jmri.jmrix.internal.InternalTurnoutManager;
+import jmri.jmrix.internal.InternalSystemConnectionMemo;
+import jmri.managers.AbstractProxyManager;
+import jmri.managers.ProxyTurnoutManager;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.netbeans.jemmy.operators.*;
 
 /**
  *
@@ -30,6 +43,114 @@ public class TurnoutTableTabActionTest extends AbstractTableTabActionBase {
     @Test
     public void testIncludeAddButton() {
         Assert.assertTrue("Default include add button", a.includeAddButton());
+    }
+    
+    /**
+     * Tests working in matching form for 
+     * ReporterTableTabActionTest
+     * SensorTableTabActionTest
+     * LightTableTabAtionTest
+     * 
+     * Issue with Proxy Manager?, only creates 1 Manager
+     * 
+     */
+    @Disabled("4.23.4ish Only 1 Manager visible to proxy, not 2?")
+    @Test
+    public void testMultiSystemTabs(){
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
+        JUnitUtil.resetInstanceManager();
+        // Not returning null v4.23.4ish
+        Assert.assertNull("No Manager at start",InstanceManager.getNullableDefault(TurnoutManager.class));
+        
+        ProxyTurnoutManager l = new ProxyTurnoutManager(); // has 2 systems: IT, JT
+        l.addManager(new InternalTurnoutManager(new InternalSystemConnectionMemo("J", "Juliet")));
+        l.addManager(new InternalTurnoutManager(new InternalSystemConnectionMemo("I", "India")));
+        InstanceManager.setTurnoutManager(l);
+        
+        // Test that Proxy TurnoutManager Manager has Juliet, India, and nothing else.
+        TurnoutManager plm = InstanceManager.getDefault(TurnoutManager.class);
+        if (!(plm instanceof AbstractProxyManager)) {
+            Assert.fail("Instance TurnoutManager Not a proxy Turnout Manager");
+        }
+        
+        try {
+            @SuppressWarnings("unchecked")
+            AbstractProxyManager<Turnout> proxy = (AbstractProxyManager<Turnout>) plm;
+            int numLm = proxy.getDisplayOrderManagerList().size();
+            Assert.assertEquals("2 Turnout Managers, Juliet, India",2, numLm);
+            
+            String s = proxy.getDisplayOrderManagerList().get(0).getMemo().getUserName();
+            Assert.assertEquals("Turnout Manager 0 , Juliet","Juliet", s);
+            
+            s = proxy.getDisplayOrderManagerList().get(1).getMemo().getUserName();
+            Assert.assertEquals("Turnout Manager 1, India","India", s);
+        } catch (ClassCastException e){
+            Assert.fail("catch Instance TurnoutManager Not a proxy Turnout Manager");
+        }
+        
+        
+        InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
+        InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT2");
+        InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT3");
+        InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT4");
+        InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT5");
+        
+        InstanceManager.getDefault(TurnoutManager.class).provideTurnout("JT8");
+        InstanceManager.getDefault(TurnoutManager.class).provideTurnout("JT9");
+        
+        TabbedTurnoutTableFrame sf = new TabbedTurnoutTableFrame();
+        sf.initTables();
+        sf.initComponents();
+        sf.pack();
+        sf.setVisible(true);
+        
+        JFrame f = JFrameOperator.waitJFrame(sf.getTitle(), true, true);
+        JFrameOperator jfo = new JFrameOperator(f);
+        JTabbedPaneOperator tabOperator = new JTabbedPaneOperator(jfo);
+        
+        
+        // will fail here as only 2 tabs present.
+        Assert.assertEquals("3 manager tabs",3, tabOperator.getTabCount());
+        
+        
+        
+        jmri.util.swing.JemmyUtil.pressButton(jfo, "Not a Button, pause test");
+        
+        
+        
+        tabOperator.selectPage("All");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        JTableOperator controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("All tab 7 Turnouts",7, controltbl.getRowCount());
+        
+        tabOperator.selectPage("Juliet");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("Juliet tab 2 Turnouts",2, controltbl.getRowCount());
+        
+        tabOperator.selectPage("India");
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+        controltbl = new JTableOperator(jfo, 0);
+        Assert.assertEquals("India tab 5 Turnouts",5, controltbl.getRowCount());
+        
+        jmri.util.swing.JemmyUtil.pressButton(jfo, "Not a Button, pause test");
+        jfo.requestClose();
+    
+    }
+    
+    
+    private static class TabbedTurnoutTableFrame extends ListedTableFrame<Turnout> {
+        
+        public TabbedTurnoutTableFrame(){
+            super();
+            tabbedTableItemListArrayArray.clear(); // reset static BeanTable list
+        }
+        
+        @Override
+        public void initTables() {
+            addTable("jmri.jmrit.beantable.TurnoutTableTabAction", Bundle.getMessage("MenuItemTurnoutTable"), false);
+        }
     }
 
     @BeforeEach


### PR DESCRIPTION
Moves core Bean Table creation from ListedTableFrame constructor to new method initTables()

Removes single click delay on selecting tables from list, double click still opens new Table Frame.

Adds TableTabAction rowCount Tests for each Manager Tab.

SensorTableTabAction
LightTableTabAction
ReporterTableTabAction
TurnoutTableTabAction - Disabled while investigating ProxyTurnoutManager discrepancy
IdTagTableAction - Disabled while investigating ProxyIdTagManager discrepancy

Until #9656 was merged failed SensorTableTabActionTest due to incorrect row count.