### PR TITLE
createNewTurnout to throw IAE, not return null

### DIFF
--- a/java/src/jmri/TurnoutManager.java
+++ b/java/src/jmri/TurnoutManager.java
@@ -104,7 +104,7 @@ public interface TurnoutManager extends ProvidingManager<Turnout> {
 
     /**
      * Return a Turnout with the specified system and user names.
-     * Provide by UserName then System Name.
+     * Lookup by UserName then provide by System Name.
      * <p>
      * Note that
      * two calls with the same arguments will get the same instance; there is

--- a/java/src/jmri/jmrix/acela/AcelaTurnoutManager.java
+++ b/java/src/jmri/jmrix/acela/AcelaTurnoutManager.java
@@ -37,23 +37,20 @@ public class AcelaTurnoutManager extends AbstractTurnoutManager {
      * <p>
      * Assumes calling method has checked that a Turnout with this
      * system name does not already exist.
-     *
-     * @param systemName turnout system name
-     * @param userName turnout user name
-     * @return null if the system name is not in a valid format
+     * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Turnout trn = null;
         // check if the output bit is available
-        int nAddress = -1;
-        nAddress = AcelaAddress.getNodeAddressFromSystemName(systemName, getMemo());
+        int nAddress = AcelaAddress.getNodeAddressFromSystemName(systemName, getMemo());
         if (nAddress == -1) {
-            return (null);
+            throw new IllegalArgumentException("Cannot get Node Address from System Name " + systemName);
         }
         int bitNum = AcelaAddress.getBitFromSystemName(systemName, getSystemPrefix());
         if (bitNum == -1) {
-            return (null);
+            throw new IllegalArgumentException("Cannot get Bit Number from System Name " + systemName);
         }
 
         // Validate the systemName

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
@@ -34,8 +34,9 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
     /**
      * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         String addr = systemName.substring(getSystemPrefix().length() + 1);
         // first, check validity
         String newAddress;

--- a/java/src/jmri/jmrix/cmri/serial/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialTurnoutManager.java
@@ -38,14 +38,14 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
     /**
      * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // validate the system name, and normalize it
-        String sName = "";
-        sName = getMemo().normalizeSystemName(systemName);
-        if (sName.equals("")) {
+        String sName = getMemo().normalizeSystemName(systemName);
+        if (sName.isEmpty()) {
             // system name is not valid
-            return null;
+            throw new IllegalArgumentException("Cannot create System Name from " + systemName);
         }
         // does this turnout already exist
         Turnout t = getBySystemName(sName);
@@ -62,17 +62,16 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
         // check if the addressed output bit is available
         int nAddress = getMemo().getNodeAddressFromSystemName(sName);
         if (nAddress == -1) {
-            return null;
+            throw new IllegalArgumentException("Cannot get Node Address from System Name " + systemName + " " + sName);
         }
         int bitNum = getMemo().getBitFromSystemName(sName);
         if (bitNum == 0) {
-            return null;
+            throw new IllegalArgumentException("Cannot get Bit from System Name " + systemName + " " + sName);
         }
         String conflict = getMemo().isOutputBitFree(nAddress, bitNum);
-        if ((!conflict.equals("")) && (!conflict.equals(sName))) {
+        if ((!conflict.isEmpty()) && (!conflict.equals(sName))) {
             log.error("{} assignment conflict with {}.", sName, conflict);
-            notifyTurnoutCreationError(conflict, bitNum);
-            return null;
+            throw new IllegalArgumentException(Bundle.getMessage("ErrorAssignDialog", bitNum, conflict));
         }
 
         // create the turnout
@@ -90,7 +89,9 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
      * Public method to notify user of Turnout creation error.
      * @param conflict human readable name of turnout with conflict.
      * @param bitNum conflict bit number.
+     * @deprecated  since 4.23.4;
      */
+    @Deprecated
     public void notifyTurnoutCreationError(String conflict, int bitNum) {
         JOptionPane.showMessageDialog(null, Bundle.getMessage("ErrorAssignDialog", bitNum, conflict) + "\n" +
                 Bundle.getMessage("ErrorAssignLine2T"),

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
@@ -52,16 +52,16 @@ public class DCCppTurnoutManager extends jmri.managers.AbstractTurnoutManager im
     /**
      * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-        Turnout t = null;
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // check if the output bit is available
         int bitNum = getBitFromSystemName(systemName);
         if (bitNum < 0) {
-            return null;
+            throw new IllegalArgumentException("Cannot get Bit from System Name " + systemName);
         }
         // make the new Turnout object
-        t = new DCCppTurnout(getSystemPrefix(), bitNum, tc);
+        Turnout t = new DCCppTurnout(getSystemPrefix(), bitNum, tc);
         t.setUserName(userName);
         return t;
     }

--- a/java/src/jmri/jmrix/easydcc/EasyDccTurnoutManager.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccTurnoutManager.java
@@ -42,13 +42,20 @@ public class EasyDccTurnoutManager extends jmri.managers.AbstractTurnoutManager 
         return (EasyDccSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-        Turnout t;
-        int addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
-        t = new EasyDccTurnout(getSystemPrefix(), addr, getMemo());
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        int addr;
+        try {
+            addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Could not create EasyDCC Turnout Systemname '"+systemName+"' .");
+        }
+        Turnout t = new EasyDccTurnout(getSystemPrefix(), addr, getMemo());
         t.setUserName(userName);
-
         return t;
     }
 

--- a/java/src/jmri/jmrix/ecos/EcosTurnoutManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosTurnoutManager.java
@@ -66,12 +66,16 @@ public class EcosTurnoutManager extends jmri.managers.AbstractTurnoutManager
         return (EcosSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         int addr;
         try {
             addr = Integer.parseInt(systemName.substring(getSystemNamePrefix().length()));
-        } catch (java.lang.NumberFormatException e) {
+        } catch (NumberFormatException e) {
             throw new IllegalArgumentException("failed to convert systemName '"+systemName+"' to an Ecos turnout address");
         }
         Turnout t = new EcosTurnout(addr, getSystemPrefix(), tc, this);

--- a/java/src/jmri/jmrix/grapevine/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialTurnoutManager.java
@@ -31,25 +31,29 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
         return (GrapevineSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         String prefix = getSystemPrefix();
         // validate the system name, and normalize it
         String sName = SerialAddress.normalizeSystemName(systemName, prefix);
-        if (sName.equals("")) {
+        if (sName.isEmpty()) {
             // system name is not valid
-            return null;
+            throw new IllegalArgumentException("Cannot create System Name from " + systemName);
         }
         // does this turnout already exist
         Turnout t = getBySystemName(sName);
         if (t != null) {
-            return null;
+            return t;
         }
         // check under alternate name
         String altName = SerialAddress.convertSystemNameToAlternate(sName, prefix);
         t = getBySystemName(altName);
         if (t != null) {
-            return null;
+            return t;
         }
         // create the turnout
         t = new SerialTurnout(sName, userName, getMemo());

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManager.java
@@ -39,9 +39,13 @@ public class XBeeTurnoutManager extends AbstractTurnoutManager {
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-        XBeeNode curNode = null;
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        XBeeNode curNode;
         String name = addressFromSystemName(systemName);
         if ((curNode = (XBeeNode) tc.getNodeFromName(name)) == null) {
             if ((curNode = (XBeeNode) tc.getNodeFromAddress(name)) == null) {
@@ -50,9 +54,8 @@ public class XBeeTurnoutManager extends AbstractTurnoutManager {
                 } catch (java.lang.NumberFormatException nfe) {
                     // if there was a number format exception, we couldn't
                     // find the node.
-                    curNode = null;
                     log.debug("failed to create turnout {}", systemName);
-                    return null;
+                    throw new IllegalArgumentException("Cannot find Node, check Turnout System Name " + systemName);
                 }
             }
         }
@@ -68,7 +71,7 @@ public class XBeeTurnoutManager extends AbstractTurnoutManager {
             return (XBeeTurnout) curNode.getPinBean(pin);
         } else {
             log.debug("failed to create turnout {}", systemName);
-            return null;
+            throw new IllegalArgumentException("Cannot create Turnout " + systemName + ", check pins.");
         }
     }
 

--- a/java/src/jmri/jmrix/internal/InternalTurnoutManager.java
+++ b/java/src/jmri/jmrix/internal/InternalTurnoutManager.java
@@ -28,10 +28,12 @@ public class InternalTurnoutManager extends AbstractTurnoutManager {
     }
 
     /**
-     * Create and return an internal (no layout connection) turnout
+     * Create and return an internal (no layout connection) Turnout.
+     * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         return new AbstractTurnout(systemName, userName) {
 
             @Override

--- a/java/src/jmri/jmrix/ipocs/IpocsTurnoutManager.java
+++ b/java/src/jmri/jmrix/ipocs/IpocsTurnoutManager.java
@@ -13,16 +13,20 @@ import javax.annotation.Nonnull;
  */
 public class IpocsTurnoutManager extends AbstractTurnoutManager {
 
-  public IpocsTurnoutManager(SystemConnectionMemo memo) {
-    super(memo);
-  }
+    public IpocsTurnoutManager(SystemConnectionMemo memo) {
+        super(memo);
+    }
 
-  private IpocsPortController getPortController() {
-    return ((IpocsSystemConnectionMemo)memo).getPortController();
-  }
+    private IpocsPortController getPortController() {
+        return ((IpocsSystemConnectionMemo)memo).getPortController();
+    }
 
-  @Override
-  protected Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-    return new IpocsTurnout(getPortController(), systemName, userName);
-  }
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
+    @Override
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+      return new IpocsTurnout(getPortController(), systemName, userName);
+    }
 }

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientTurnoutManager.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientTurnoutManager.java
@@ -26,11 +26,19 @@ public class JMRIClientTurnoutManager extends jmri.managers.AbstractTurnoutManag
         return (JMRIClientSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-        Turnout t;
-        int addr = Integer.parseInt(systemName.substring(getSystemNamePrefix().length()));
-        t = new JMRIClientTurnout(addr, getMemo());
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        int addr;
+        try {
+            addr = Integer.parseInt(systemName.substring(getSystemNamePrefix().length()));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to convert systemName '"+systemName+"' to a Turnout.");
+        }
+        Turnout t = new JMRIClientTurnout(addr, getMemo());
         t.setUserName(userName);
         return t;
     }

--- a/java/src/jmri/jmrix/lenz/XNetTurnoutManager.java
+++ b/java/src/jmri/jmrix/lenz/XNetTurnoutManager.java
@@ -45,15 +45,15 @@ public class XNetTurnoutManager extends jmri.managers.AbstractTurnoutManager imp
      * Create a new Turnout based on the system name.
      * Assumes calling method has checked that a Turnout with this
      * system name does not already exist.
-     *
-     * @return null if the system name is not in a valid format
+     * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // check if the output bit is available
         int bitNum = XNetAddress.getBitFromSystemName(systemName, getSystemPrefix());
         if (bitNum == -1) {
-            return (null);
+            throw new IllegalArgumentException("Cannot get Bit from System Name " + systemName);
         }
         // create the new Turnout object
         Turnout t = new XNetTurnout(getSystemPrefix(), bitNum, tc);

--- a/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutManager.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutManager.java
@@ -22,13 +22,17 @@ public class EliteXNetTurnoutManager extends jmri.jmrix.lenz.XNetTurnoutManager 
     }
 
     // XNet-specific methods
-
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // check if the output bit is available
         int bitNum = XNetAddress.getBitFromSystemName(systemName, getSystemPrefix());
         if (bitNum == -1) {
-            return (null);
+            throw new IllegalArgumentException("Cannot get Bit from System Name " + systemName);
         }
         // create the new Turnout object
         Turnout t = new EliteXNetTurnout(getSystemPrefix(), bitNum, tc);

--- a/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
+++ b/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
@@ -93,8 +93,9 @@ public class LnTurnoutManager extends AbstractTurnoutManager implements LocoNetL
     /**
      * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         String prefix = getSystemPrefix();
         int addr;
         try {

--- a/java/src/jmri/jmrix/maple/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/maple/SerialTurnoutManager.java
@@ -30,14 +30,17 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
         return (MapleSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // validate the system name, and normalize it
-        String sName = "";
-        sName = SerialAddress.normalizeSystemName(systemName, getSystemPrefix());
-        if (sName.equals("")) {
+        String sName = SerialAddress.normalizeSystemName(systemName, getSystemPrefix());
+        if (sName.isEmpty()) {
             // system name is not valid
-            return null;
+            throw new IllegalArgumentException("Cannot create System Name from " + systemName);
         }
         // does this turnout already exist
         Turnout t = getBySystemName(sName);
@@ -48,14 +51,12 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
         // check if the addressed output bit is available
         int bitNum = SerialAddress.getBitFromSystemName(sName, getSystemPrefix());
         if (bitNum == 0) {
-            return (null);
+            throw new IllegalArgumentException("Cannot get Bit from System Name " + systemName + " " + sName);
         }
-        String conflict = "";
-        conflict = SerialAddress.isOutputBitFree(bitNum, getSystemPrefix());
-        if ((!conflict.equals("")) && (!conflict.equals(sName))) {
+        String conflict = SerialAddress.isOutputBitFree(bitNum, getSystemPrefix());
+        if ((!conflict.isEmpty()) && (!conflict.equals(sName))) {
             log.error("{} assignment conflict with {}.", sName, conflict);
-            notifyTurnoutCreationError(conflict, bitNum);
-            return (null);
+            throw new IllegalArgumentException("The output bit " + bitNum + ", is currently assigned to " + conflict + ".");
         }
 
         // create the turnout
@@ -81,7 +82,9 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
      * Public method to notify user of Turnout creation error.
      * @param conflict string of the turnout which is in conflict.
      * @param bitNum the bit number in conflict.
+     * @deprecated  since 4.23.4;
      */
+    @Deprecated
     public void notifyTurnoutCreationError(String conflict, int bitNum) {
         javax.swing.JOptionPane.showMessageDialog(null, "ERROR - The output bit, "
                 + bitNum + ", is currently assigned to " + conflict + ". Turnout can not be "

--- a/java/src/jmri/jmrix/marklin/MarklinTurnoutManager.java
+++ b/java/src/jmri/jmrix/marklin/MarklinTurnoutManager.java
@@ -30,14 +30,18 @@ public class MarklinTurnoutManager extends jmri.managers.AbstractTurnoutManager 
         return (MarklinSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         int addr;
         try {
             addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
-        } catch (java.lang.NumberFormatException e) {
-            log.error("failed to convert systemName {} to a turnout address", systemName);
-            return null;
+        } catch (NumberFormatException e) {
+            log.error("Failed to convert systemName {} to a turnout address", systemName);
+            throw new IllegalArgumentException("failed to convert systemName '"+systemName+"' to a Turnout address");
         }
         Turnout t = new MarklinTurnout(addr, getSystemPrefix(), tc);
         t.setUserName(userName);

--- a/java/src/jmri/jmrix/mqtt/MqttTurnoutManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnoutManager.java
@@ -60,8 +60,12 @@ public class MqttTurnoutManager extends jmri.managers.AbstractTurnoutManager {
         return prefix + typeLetter() + topicSuffix;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         MqttTurnout t;
         String suffix = systemName.substring(getSystemNamePrefix().length());
 

--- a/java/src/jmri/jmrix/mrc/MrcTurnoutManager.java
+++ b/java/src/jmri/jmrix/mrc/MrcTurnoutManager.java
@@ -27,9 +27,18 @@ public class MrcTurnoutManager extends jmri.managers.AbstractTurnoutManager {
         return (MrcSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-        int addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        int addr;
+        try {
+            addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to convert systemName '"+systemName+"' to a Turnout address");
+        }
         Turnout t = new MrcTurnout(addr, tc, getSystemPrefix());
         t.setUserName(userName);
         return t;

--- a/java/src/jmri/jmrix/nce/NceTurnoutManager.java
+++ b/java/src/jmri/jmrix/nce/NceTurnoutManager.java
@@ -29,9 +29,18 @@ public class NceTurnoutManager extends jmri.managers.AbstractTurnoutManager impl
         return (NceSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-        int addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        int addr;
+        try {
+            addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to convert systemName '"+systemName+"' to a Turnout address");
+        }
         Turnout t = new NceTurnout(getMemo().getNceTrafficController(), getSystemPrefix(), addr);
         t.setUserName(userName);
 

--- a/java/src/jmri/jmrix/oaktree/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/oaktree/SerialTurnoutManager.java
@@ -30,24 +30,28 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
         return (OakTreeSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // validate the system name, and normalize it
         String sName = SerialAddress.normalizeSystemName(systemName, getSystemPrefix());
-        if (sName.equals("")) {
+        if (sName.isEmpty()) {
             // system name is not valid
-            return null;
+            throw new IllegalArgumentException("Cannot create System Name from " + systemName);
         }
         // does this turnout already exist
         Turnout t = getBySystemName(sName);
         if (t != null) {
-            return null;
+            return t;
         }
         // check under alternate name
         String altName = SerialAddress.convertSystemNameToAlternate(sName, getSystemPrefix());
         t = getBySystemName(altName);
         if (t != null) {
-            return null;
+            return t;
         }
         // create the turnout
         t = new SerialTurnout(sName, userName, getMemo());

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnoutManager.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnoutManager.java
@@ -76,9 +76,11 @@ public class OlcbTurnoutManager extends AbstractTurnoutManager {
      * an existing method has been invoked.
      *
      * @return never null
+     * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         String addr = systemName.substring(getSystemPrefix().length() + 1);
         OlcbTurnout t = new OlcbTurnout(getSystemPrefix(), addr, memo.get(OlcbInterface.class));
         t.setUserName(userName);

--- a/java/src/jmri/jmrix/pi/RaspberryPiTurnoutManager.java
+++ b/java/src/jmri/jmrix/pi/RaspberryPiTurnoutManager.java
@@ -27,8 +27,12 @@ public class RaspberryPiTurnoutManager extends jmri.managers.AbstractTurnoutMana
         return (RaspberryPiSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Turnout t = new RaspberryPiTurnout(systemName, userName);
         return t;
     }

--- a/java/src/jmri/jmrix/powerline/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/powerline/SerialTurnoutManager.java
@@ -84,18 +84,22 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // validate the system name, and normalize it
         String sName = tc.getAdapterMemo().getSerialAddress().normalizeSystemName(systemName);
-        if (sName.equals("")) {
+        if (sName.isEmpty()) {
             // system name is not valid
-            return null;
+            throw new IllegalArgumentException("Cannot create Turnout System Name from " + systemName);
         }
         // does this turnout already exist
         Turnout t = getBySystemName(sName);
         if (t != null) {
-            return null;
+            return t;
         }
 
         // create the turnout

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetTurnoutManager.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetTurnoutManager.java
@@ -23,9 +23,19 @@ public class Z21XNetTurnoutManager extends XNetTurnoutManager {
     }
 
     // XNet-specific methods
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-        int addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        int addr;
+        try {
+            addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to convert systemName '"+systemName+"' to a numeric Turnout address");
+        }
         Turnout t = new Z21XNetTurnout(getSystemPrefix(), addr, tc);
         t.setUserName(userName);
         return t;

--- a/java/src/jmri/jmrix/secsi/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/secsi/SerialTurnoutManager.java
@@ -30,24 +30,28 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
         return (SecsiSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // validate the system name, and normalize it
         String sName = SerialAddress.normalizeSystemName(systemName, getSystemPrefix());
-        if (sName.equals("")) {
+        if (sName.isEmpty()) {
             // system name is not valid
-            return null;
+            throw new IllegalArgumentException("Cannot create System Name from " + systemName);
         }
         // does this turnout already exist
         Turnout t = getBySystemName(sName);
         if (t != null) {
-            return null;
+            return t;
         }
         // check under alternate name
         String altName = SerialAddress.convertSystemNameToAlternate(sName, getSystemPrefix());
         t = getBySystemName(altName);
         if (t != null) {
-            return null;
+            return t;
         }
         // create the turnout
         t = new SerialTurnout(sName, userName, getMemo());

--- a/java/src/jmri/jmrix/sprog/SprogTurnoutManager.java
+++ b/java/src/jmri/jmrix/sprog/SprogTurnoutManager.java
@@ -29,9 +29,18 @@ public class SprogTurnoutManager extends jmri.managers.AbstractTurnoutManager {
 
     // Sprog-specific methods
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-        int addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1)); // multi char prefix
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        int addr;
+        try {
+            addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1)); // multi char prefix
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to convert systemName '"+systemName+"' to a Turnout address");
+        }
         Turnout t;
         if (getMemo().getSprogMode() == SprogConstants.SprogMode.OPS ) {
             t = new SprogCSTurnout(addr, getMemo());

--- a/java/src/jmri/jmrix/srcp/SRCPTurnoutManager.java
+++ b/java/src/jmri/jmrix/srcp/SRCPTurnoutManager.java
@@ -37,13 +37,20 @@ public class SRCPTurnoutManager extends jmri.managers.AbstractTurnoutManager {
         return (SRCPBusConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-        Turnout t;
-        int addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
-        t = new SRCPTurnout(addr, getMemo());
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        int addr;
+        try {
+            addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to convert systemName '"+systemName+"' to a Turnout address");
+        }
+        Turnout t = new SRCPTurnout(addr, getMemo());
         t.setUserName(userName);
-
         return t;
     }
 

--- a/java/src/jmri/jmrix/tams/TamsTurnoutManager.java
+++ b/java/src/jmri/jmrix/tams/TamsTurnoutManager.java
@@ -35,14 +35,15 @@ public class TamsTurnoutManager extends jmri.managers.AbstractTurnoutManager imp
     /**
      * {@inheritDoc}
      */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         int addr;
         try {
             addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
-        } catch (java.lang.NumberFormatException e) {
+        } catch (NumberFormatException e) {
             log.error("failed to convert systemName {} to a turnout address", systemName);
-            return null;
+            throw new IllegalArgumentException("Failed to convert systemName '"+systemName+"' to a Turnout address");
         }
         Turnout t = new TamsTurnout(addr, getSystemPrefix(), getMemo().getTrafficController());
         t.setUserName(userName);

--- a/java/src/jmri/jmrix/tmcc/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/tmcc/SerialTurnoutManager.java
@@ -35,15 +35,19 @@ public class SerialTurnoutManager extends AbstractTurnoutManager implements Seri
         return (TmccSystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // validate the system name
         String sName = validateSystemNameFormat(systemName);
         // does this turnout already exist?
         Turnout t = getBySystemName(sName);
         if (t != null) {
             log.debug("Turnout already exists");
-            return null;
+            return t;
         }
         // create the turnout
         log.debug("new SerialTurnout with addr = {}", systemName.substring(getSystemPrefix().length() + 1));

--- a/java/src/jmri/jmrix/xpa/XpaTurnoutManager.java
+++ b/java/src/jmri/jmrix/xpa/XpaTurnoutManager.java
@@ -27,10 +27,18 @@ public class XpaTurnoutManager extends jmri.managers.AbstractTurnoutManager {
         return (XpaSystemConnectionMemo) memo;
     }
 
-    // Xpa-specific methods
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-        int addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        int addr;
+        try {
+            addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to convert systemName '"+systemName+"' to a Turnout address");
+        }
         Turnout t = new XpaTurnout(addr, getMemo());
         t.setUserName(userName);
         return t;

--- a/java/src/jmri/jmrix/zimo/Mx1TurnoutManager.java
+++ b/java/src/jmri/jmrix/zimo/Mx1TurnoutManager.java
@@ -26,9 +26,18 @@ public class Mx1TurnoutManager extends jmri.managers.AbstractTurnoutManager {
         return (Mx1SystemConnectionMemo) memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
-        int addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        int addr;
+        try {
+            addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
+        } catch (java.lang.NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to convert systemName '"+systemName+"' to a Turnout address");
+        }
         Turnout t = new Mx1Turnout(addr, getMemo().getMx1TrafficController(), getSystemPrefix());
         t.setUserName(userName);
         return t;

--- a/java/src/jmri/jmrix/ztc/ztc611/ZTC611XNetTurnoutManager.java
+++ b/java/src/jmri/jmrix/ztc/ztc611/ZTC611XNetTurnoutManager.java
@@ -20,12 +20,17 @@ public class ZTC611XNetTurnoutManager extends jmri.jmrix.lenz.XNetTurnoutManager
     }
 
     // XNet-specific methods
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
     @Override
-    public Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // check if the output bit is available
         int bitNum = XNetAddress.getBitFromSystemName(systemName, getSystemPrefix());
         if (bitNum == -1) {
-            return (null);
+            throw new IllegalArgumentException("Cannot get Bit from System Name " + systemName);
         }
         Turnout t = new ZTC611XNetTurnout(getSystemPrefix(), bitNum, tc);
         t.setUserName(userName);

--- a/java/src/jmri/managers/AbstractProvidingProxyManager.java
+++ b/java/src/jmri/managers/AbstractProvidingProxyManager.java
@@ -92,7 +92,7 @@ abstract public class AbstractProvidingProxyManager<E extends NamedBean> extends
      * @return requested NamedBean object (never null)
      */
     @Nonnull
-    public E newNamedBean(String systemName, String userName) throws IllegalArgumentException {
+    public E newNamedBean(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         // make sure internal present
         initInternal();
 
@@ -117,7 +117,7 @@ abstract public class AbstractProvidingProxyManager<E extends NamedBean> extends
      * @return a bean
      */
     @Nonnull
-    abstract protected E makeBean(Manager<E> manager, String systemName, String userName) throws IllegalArgumentException;
+    abstract protected E makeBean(Manager<E> manager,@Nonnull String systemName, String userName) throws IllegalArgumentException;
 
     // initialize logging
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractProvidingProxyManager.class);

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -46,11 +46,18 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
         return super.getNamedBean(name);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    protected Turnout makeBean(Manager<Turnout> manager, String systemName, String userName) {
+    @Nonnull
+    protected Turnout makeBean(Manager<Turnout> manager, String systemName, String userName) throws IllegalArgumentException {
         return ((TurnoutManager) manager).newTurnout(systemName, userName);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     @Nonnull
     public Turnout provideTurnout(@Nonnull String name) throws IllegalArgumentException {
@@ -93,7 +100,7 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
      */
     @Override
     @Nonnull
-    public Turnout newTurnout(@Nonnull String systemName, String userName) {
+    public Turnout newTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         return newNamedBean(systemName, userName);
     }
 
@@ -156,11 +163,17 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
         return ((TurnoutManager) getManagerOrDefault(systemName)).askControlType(systemName);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isControlTypeSupported(@Nonnull String systemName) {
         return ((TurnoutManager) getManagerOrDefault(systemName)).isControlTypeSupported(systemName);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isNumControlBitsSupported(@Nonnull String systemName) {
         return ((TurnoutManager) getManagerOrDefault(systemName)).isNumControlBitsSupported(systemName);
@@ -175,6 +188,9 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
         return TurnoutOperationManager.concatenateTypeLists(typeList.toArray(new String[0]));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean allowMultipleAdditions(@Nonnull String systemName) {
         return ((TurnoutManager) getManagerOrDefault(systemName)).allowMultipleAdditions(systemName);
@@ -191,6 +207,9 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
         return getNextValidAddress(curAddress, prefix, ignoreInitialExisting, typeLetter());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setDefaultClosedSpeed(@Nonnull String speed) throws jmri.JmriException {
         for (Manager<Turnout> m : getManagerList()) {
@@ -203,6 +222,9 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setDefaultThrownSpeed(@Nonnull String speed) throws jmri.JmriException {
         for (Manager<Turnout> m : getManagerList()) {
@@ -215,11 +237,17 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getDefaultThrownSpeed() {
         return ((TurnoutManager) getDefaultManager()).getDefaultThrownSpeed();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getDefaultClosedSpeed() {
         return ((TurnoutManager) getDefaultManager()).getDefaultClosedSpeed();
@@ -258,11 +286,17 @@ public class ProxyTurnoutManager extends AbstractProvidingProxyManager<Turnout> 
         return ((TurnoutManager) getDefaultManager()).outputIntervalEnds();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getXMLOrder() {
         return jmri.Manager.TURNOUTS;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     @Nonnull
     public String getBeanTypeHandled(boolean plural) {

--- a/java/test/jmri/util/managers/TurnoutManagerThrowExceptionScaffold.java
+++ b/java/test/jmri/util/managers/TurnoutManagerThrowExceptionScaffold.java
@@ -22,7 +22,7 @@ public class TurnoutManagerThrowExceptionScaffold extends InternalTurnoutManager
     
     /** {@inheritDoc} */
     @Override
-    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) {
+    protected Turnout createNewTurnout(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         throw new IllegalArgumentException("Illegal argument");
     }
     


### PR DESCRIPTION
See #7661 though further dev. required before this can be closed.

Lint TurnoutManager createNewSensor methods.
All annotated Nonnull / IllegalArgumentException
All moved to protected to prevent duplicates.