### PR TITLE
Update to Spotbugs 4.2.3

### DIFF
--- a/.spotbugs-check.xml
+++ b/.spotbugs-check.xml
@@ -18,6 +18,7 @@
         <Confidence value="2" /> <!-- 3 is low priority, 2 is medium priority, 1 is high priority -->
         <Or>
            <Bug pattern="IS2_INCONSISTENT_SYNC" />
+           <Bug pattern="OVERRIDING_METHODS_MUST_INVOKE_SUPER" />
         </Or>
      </Match>
 

--- a/help/en/html/doc/Technical/IntelliJ.shtml
+++ b/help/en/html/doc/Technical/IntelliJ.shtml
@@ -670,7 +670,7 @@
           To add the path to SpotBugs for Ant in your <code>local.properties</code> file to match the place where the
           SpotBugs application is located on your computer add these lines:<br>
           <code># configure SpotBugs<br>
-            spotbugs.home=/Users/you/Apps/spotbugs-3.1.12</code><br>
+            spotbugs.home=/Users/you/Apps/spotbugs-4.2.3</code><br>
           See the <a href="SpotBugs.shtml">JMRI SpotBugs help</a>.
         </li>
         <li>Next, from the <b>Ant Build</b> tab select the <b>spotbugs</b> ant task, wait for

--- a/help/en/html/doc/Technical/SpotBugs.shtml
+++ b/help/en/html/doc/Technical/SpotBugs.shtml
@@ -260,7 +260,7 @@ scanning through the code.
         following to your 
         <a href="StartUpScripts.shtml">local.properties</a> file:
     <pre style="font-family: monospace;">
-    spotbugs.home = /Users/jake/.spotbugs/spotbugs-3.1.7
+    spotbugs.home = /Users/jake/.spotbugs/spotbugs-4.2.3
     </pre>
         <li>In order to check for spotbugs issues in logging statements, we use the <a
             href="https://www.kengo-toda.jp/findbugs-slf4j/">Findbugs-slf4j</a> plugin by KengoTODA. To use this

--- a/help/fr/html/doc/Technical/FindBugs.shtml
+++ b/help/fr/html/doc/Technical/FindBugs.shtml
@@ -202,7 +202,7 @@ Pour ex&#233;cuter la t&#226;che:
     <li> soit ex&#233;cuter
  
 <code>
-ant-Dspotbugs.home=C:/SpotBugs-3.1.1 spotbugs ( rempla&#233;ant le param&#232;tre de votre emplacement d'installation )
+ant-Dspotbugs.home=C:/SpotBugs-4.2.3 spotbugs ( rempla&#233;ant le param&#232;tre de votre emplacement d'installation )
 </code>
 
 ou modifier le build.xml et modifier le param&#232;tre comment&#233;

--- a/help/fr/html/doc/Technical/NetBeans.shtml
+++ b/help/fr/html/doc/Technical/NetBeans.shtml
@@ -302,9 +302,9 @@
         Si n&#233;cessaire, cr&#233;ez le fichier local.properties dans le m&#234;me r&#233;pertoire que
         le fichier JMRI build.xml. Dans le fichier local.properties, ajouter la variable
         spotbugs.home avec un chemin vers l'ex&#233;cutable spotbugs, tels que: </p>
-		<p style="font-family: monospace"> spotbugs.home=C:/spotbugs-3.1.1</p>
+		<p style="font-family: monospace"> spotbugs.home=C:/spotbugs-4.2.3</p>
 		<p>ou</p>
-		<p style="font-family: monospace">spotbugs.home =/opt/spotbugs-3.1.1</p>
+		<p style="font-family: monospace">spotbugs.home =/opt/spotbugs-4.2.3</p>
 		<p>Pour ex&#233;cuter l'outil SpotBugs sur le code JMRI,ex&#233;cutez la cible ant "spotbugs"
 		qui est d&#233;fini dans build.xml. Dans NetBeans cela peut &#234;tre accompli
 		par un clic droit sur le fichier build.xml  dans le volet "Files" et " Run"ing La cible "SpotBugs".

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
                     <plugin>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
-                        <version>3.1.12</version>
+                        <version>4.2.2</version>
                         <configuration>
                             <plugins>
                                 <plugin>
@@ -474,7 +474,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.12</version>
+                <version>4.2.2</version>
                 <!-- configured to fail on medium priority bugs (needs to be done two places)-->
                 <configuration>
                     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
                     <plugin>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
-                        <version>4.2.2</version>
+                        <version>4.2.3</version>
                         <configuration>
                             <plugins>
                                 <plugin>
@@ -474,7 +474,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.2.2</version>
+                <version>4.2.3</version>
                 <!-- configured to fail on medium priority bugs (needs to be done two places)-->
                 <configuration>
                     <plugins>


### PR DESCRIPTION
New Performance Warning (13) - Boxing/unboxing to parse a primitive Float.floatValue() Should call Float.parseFloat(String) instead - fixed by #9684 
New Correctness Warning (28) - Super method is annotated with @OverridingMethodsMustInvokeSuper, but XXXX isn't calling the super method - added to ignore list until fixed.

DMI_RANDOM_USED_ONLY_ONCE Warning (6) - fixed by #9709 

eg. html report for 4.2.2
[spotbugs-4.2.2-hom-12-04-2021.zip](https://github.com/JMRI/JMRI/files/6302693/spotbugs-4.2.2-hom-12-04-2021.zip)