### PR TITLE
Boxing/unboxing to parse a primitive

### DIFF
--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -614,7 +614,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         }
 
         try {
-            return Float.valueOf(speed);
+            return Float.parseFloat(speed);
         } catch (NumberFormatException nx) {
             //considered normal if the speed is not a number.
         }

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -1052,7 +1052,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
             return -1;
         }
         try {
-            return Float.valueOf(speed);
+            return Float.parseFloat(speed);
             //return Integer.parseInt(_blockSpeed);
         } catch (NumberFormatException nx) {
             //considered normal if the speed is not a number.
@@ -1122,7 +1122,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
             return -1;
         }
         try {
-            return Float.valueOf(speed);
+            return Float.parseFloat(speed);
         } catch (NumberFormatException nx) {
             //considered normal if the speed is not a number.
         }

--- a/java/src/jmri/implementation/DefaultSignalMastLogic.java
+++ b/java/src/jmri/implementation/DefaultSignalMastLogic.java
@@ -983,10 +983,10 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
                             log.debug(advancedAspect[i]);
                             if ((divergRoute && (divergFlagsAvailable) && (divergAspects.contains(i))) || ((divergRoute && !divergFlagsAvailable) || (!divergRoute)) && (nonDivergAspects.contains(i))) {
                                 log.debug("In list");
-                                if ((strSpeed != null) && (!strSpeed.equals(""))) {
+                                if ((strSpeed != null) && (!strSpeed.isEmpty())) {
                                     float speed = 0.0f;
                                     try {
-                                        speed = Float.valueOf(strSpeed);
+                                        speed = Float.parseFloat(strSpeed);
                                     } catch (NumberFormatException nx) {
                                         // not a number, perhaps a name?
                                         try {

--- a/java/src/jmri/implementation/DefaultSignalSystem.java
+++ b/java/src/jmri/implementation/DefaultSignalSystem.java
@@ -147,7 +147,7 @@ public class DefaultSignalSystem extends AbstractNamedBean implements SignalSyst
                 if (speed != null) {
                     float aspectSpeed = 0.0f;
                     try {
-                        aspectSpeed = Float.valueOf(speed);
+                        aspectSpeed = Float.parseFloat(speed);
                     } catch (NumberFormatException nx) {
                         try {
                             aspectSpeed = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(speed);

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -978,7 +978,7 @@ public class AutoActiveTrain implements ThrottleListener {
             float speed = -1.0f;
             if (aspectSpeedStr != null) {
                 try {
-                    speed = Float.valueOf(aspectSpeedStr);
+                    speed = Float.parseFloat(aspectSpeedStr);
                 } catch (NumberFormatException nx) {
                     try {
                         speed = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(aspectSpeedStr);
@@ -1137,7 +1137,7 @@ public class AutoActiveTrain implements ThrottleListener {
         float blockSpeed = -1.0f;
         if (!blockSpeedName.isEmpty()) {
             try {
-                blockSpeed = Float.valueOf(blockSpeedName);
+                blockSpeed = Float.parseFloat(blockSpeedName);
             } catch (NumberFormatException nx) {
                 try {
                     blockSpeed = jmri.InstanceManager.getDefault(SignalSpeedMap.class).getSpeed(blockSpeedName);

--- a/java/src/jmri/jmrit/logix/configurexml/OBlockManagerXml.java
+++ b/java/src/jmri/jmrit/logix/configurexml/OBlockManagerXml.java
@@ -279,7 +279,7 @@ public class OBlockManagerXml // extends XmlFile
             block.setMetricUnits(false);
         }
         if (elem.getAttribute("length") != null) {
-            block.setLength(Float.valueOf(elem.getAttribute("length").getValue()).floatValue());
+            block.setLength(Float.parseFloat(elem.getAttribute("length").getValue()));
         }
         if (elem.getAttribute("curve") != null) {
             block.setCurvature(Integer.parseInt((elem.getAttribute("curve")).getValue()));

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -423,14 +423,15 @@ public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListen
      * @return null if the rate could not be parsed, negative, or an unsupported fraction.
      * Otherwise the fraction value.
      */
-    @CheckForNull Double parseRate(String fieldEntry) {
+    @CheckForNull
+    Double parseRate(String fieldEntry) {
         double rate;
         try {
             char decimalSeparator = threeDigits.getDecimalFormatSymbols().getDecimalSeparator() ;
             if (decimalSeparator != '.') {
                 fieldEntry = fieldEntry.replace(decimalSeparator, '.') ;
             }
-            rate = Double.valueOf(fieldEntry);
+            rate = Double.parseDouble(fieldEntry);
         } catch (NumberFormatException e) {
             JOptionPane.showMessageDialog(this, (Bundle.getMessage("ParseRateError") + "\n" + e),
                     Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
@@ -1899,7 +1899,7 @@ public class PaneProgPane extends javax.swing.JPanel
                 case "double": {
                     double attribValue;
                     try {
-                        attribValue = Double.valueOf(attribRawValue);
+                        attribValue = Double.parseDouble(attribRawValue);
                         constraint.set(globs.gridConstraints, attribValue);
                     } catch (IllegalAccessException ey) {
                         log.error("Unable to set constraint \"{}. IllegalAccessException error thrown.", attribName);
@@ -2620,7 +2620,7 @@ public class PaneProgPane extends javax.swing.JPanel
                 // Java 1.5 has a known bug, #6328248, that prevents printing of progress
                 //  bars using old style printing classes.  It results in blank bars on Windows,
                 //  but hangs Macs. The version check is a workaround.
-                float v = Float.valueOf(java.lang.System.getProperty("java.version").substring(0, 3));
+                float v = Float.parseFloat(System.getProperty("java.version").substring(0, 3));
                 if (originalName.equals("Speed Table") && v < 1.5) {
                     // set the height of the speed table graph in lines
                     int speedFrameLineHeight = 11;

--- a/java/src/jmri/jmrix/bachrus/DccSpeedProfile.java
+++ b/java/src/jmri/jmrix/bachrus/DccSpeedProfile.java
@@ -186,7 +186,7 @@ public class DccSpeedProfile {
         for (int i = 2; i < dccProfileData.size(); i++) {
             try {
                 String value = dccProfileData.get(i).get(1);
-                float speed = Float.valueOf(value);
+                float speed = Float.parseFloat(value);
                 // speed values from the speedometer are calc'd and stored in 
                 // the DccSpeedProfile object as KPH so need to convert
                 // if the file was in MPH

--- a/java/src/jmri/jmrix/direct/serial/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/direct/serial/ConnectionConfig.java
@@ -30,7 +30,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     @Override
     public String name() {
         if (SystemType.isMacOSX()
-                || (SystemType.isWindows() && Double.valueOf(System.getProperty("os.version")) >= 6)) {
+                || (SystemType.isWindows() && Double.parseDouble(System.getProperty("os.version")) >= 6)) {
             return Bundle.getMessage("DirectSerialNameNot");
         }
 


### PR DESCRIPTION
Fix Boxing/unboxing to parse a primitive
Float.valueOf(String) > Float.parseFloat(String)
Double.valueOf(String) > Double.parseDouble(String)

See #9681 