### PR TITLE
Update logixng FunctionsBundle

### DIFF
--- a/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle.properties
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle.properties
@@ -139,7 +139,7 @@ Example:                                                                        
 <p>                                                                                         \
 <b>readMemory("IM2")</b>                                                                    \
 <p>                                                                                         \
-Reads the memory IM2. If the value of IM2 is a reference, for example {IM41},               \
+Reads the memory IM2. If the value of IM2 is a reference, ( for example IM41 ),               \
 that reference is evaluated, meaning that the value of IM41 is returned, unless             \
 IM41 also is a valid reference, since references are evaluated recursively.                 \
 </html>

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle_cs.properties
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle_cs.properties
@@ -139,7 +139,7 @@ P\u0159\u00edklad:                                                              
 <p>                                                                                         \
 <b>readMemory("IM2")</b>                                                                    \
 <p>                                                                                         \
-P\u0159e\u010dte pam\u011b\u0165 IM2. Pokud je hodnota IM2 odkazem, nap\u0159\u00edklad {IM41},                           \
+P\u0159e\u010dte pam\u011b\u0165 IM2. Pokud je hodnota IM2 odkazem, nap\u0159\u00edklad ( IM41 ),                           \
 potom je odkaz vyhodnocen, to znamen\u00e1 \u017ee je vr\u00e1cena hodnota z IM41, pokud                   \
 IM41 nen\u00ed tak\u00e9 platn\u00fdm odkazem, proto\u017ee odkazy jsou vyhodnocov\u00e1ny rekurzivn\u011b.               \
 </html>


### PR DESCRIPTION
https://jmri-developers.groups.io/g/jmri/message/5428

`[resourceCheck] messageformat check: Unable to create MessageFormat instance can't parse argument number: IM41`

For normal Bundle packs, specific tect can be insterted with the {0}, {1} for 1st and 2nd arguments supplied.
The {IM41} seems to be confusing this process, so changing to ( IM41 ) should resolve,