### PR TITLE
use ThreadLocalRandom not Random

### DIFF
--- a/java/src/jmri/jmrit/audio/AbstractAudioSource.java
+++ b/java/src/jmri/jmrit/audio/AbstractAudioSource.java
@@ -2,7 +2,7 @@ package jmri.jmrit.audio;
 
 import java.util.LinkedList;
 import java.util.Queue;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nonnull;
 import javax.vecmath.Vector3f;
 import jmri.Audio;
@@ -446,8 +446,7 @@ public abstract class AbstractAudioSource extends AbstractAudio implements Audio
      */
     protected void calculateLoops() {
         if (this.minLoops != this.maxLoops) {
-            Random r = new Random();
-            this.numLoops = this.minLoops + r.nextInt(this.maxLoops - this.minLoops);
+            this.numLoops = this.minLoops + ThreadLocalRandom.current().nextInt(this.maxLoops - this.minLoops);
         } else {
             this.numLoops = this.minLoops;
         }

--- a/java/src/jmri/jmrix/can/cbus/simulator/CbusEventResponder.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/CbusEventResponder.java
@@ -1,7 +1,8 @@
 package jmri.jmrix.can.cbus.simulator;
 
 import java.util.ArrayList;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
 import jmri.jmrix.AbstractMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
@@ -23,14 +24,12 @@ public class CbusEventResponder extends CbusSimCanListener {
     
     private int _node;
     private int _mode;
-    private final Random _random;
     
     public ArrayList<String> evModes;
     public ArrayList<String> evModesTip;
     
     public CbusEventResponder( CanSystemConnectionMemo memod ){
         super(memod,null);
-        _random = new Random();
         init();
     }
     
@@ -113,7 +112,7 @@ public class CbusEventResponder extends CbusSimCanListener {
         boolean sendOn = false;
         switch (_mode) {
             case 1: // random
-                sendOn = _random.nextBoolean();
+                sendOn = ThreadLocalRandom.current().nextBoolean();
                 break;
             case 2: // Odd On / Even Off
                 sendOn = m.getElement(4) % 2 != 0;

--- a/java/src/jmri/jmrix/dccpp/simulator/DCCppSimulatorAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/simulator/DCCppSimulatorAdapter.java
@@ -5,7 +5,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.util.Random;
+
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -54,8 +55,6 @@ public class DCCppSimulatorAdapter extends DCCppSimulatorPortController implemen
 
     private java.util.TimerTask keepAliveTimer; // Timer used to periodically
     private static final long keepAliveTimeoutValue = 30000; // Interval 
-    
-    private Random rgen = null;
 
     public DCCppSimulatorAdapter() {
         setPort(Bundle.getMessage("None"));
@@ -74,8 +73,6 @@ public class DCCppSimulatorAdapter extends DCCppSimulatorPortController implemen
         for (int i = 0; i < DCCppConstants.MAX_DIRECT_CV + 1; i++) {
             CVs[i] = 0;
         }
-
-        rgen = new Random(); // used to generate randomized output for current meter
     }
 
     @Override
@@ -223,8 +220,6 @@ public class DCCppSimulatorAdapter extends DCCppSimulatorPortController implemen
         // of the command station simulation.
         log.debug("Simulator Thread Started");
 
-        rgen = new Random();
-
         keepAliveTimer();
 
         ConnectionStatus.instance().setConnectionState(getUserName(), getCurrentPortName(), ConnectionStatus.CONNECTION_UP);
@@ -238,7 +233,7 @@ public class DCCppSimulatorAdapter extends DCCppSimulatorPortController implemen
             }
 
             // Once every SENSOR_MSG_RATE loops, generate a random Sensor message.
-            int rand = rgen.nextInt(SENSOR_MSG_RATE);
+            int rand = ThreadLocalRandom.current().nextInt(SENSOR_MSG_RATE);
             if (rand == 1) {
                 generateRandomSensorReply();
             }
@@ -551,8 +546,8 @@ public class DCCppSimulatorAdapter extends DCCppSimulatorPortController implemen
 
     /* 'c' current request message gets multiple reply messages */
     private void generateMeterReplies() {
-        int currentmA = 1100 + rgen.nextInt(64);
-        double voltageV = 14.5 + rgen.nextInt(10)/10.0; 
+        int currentmA = 1100 + ThreadLocalRandom.current().nextInt(64);
+        double voltageV = 14.5 + ThreadLocalRandom.current().nextInt(10)/10.0; 
         String rs = "c CurrentMAIN " + (trackPowerState ? Double.toString(currentmA) : "0") + " C Milli 0 1997 1 1997";
         DCCppReply r = new DCCppReply(rs);
         writeReply(r);       
@@ -565,10 +560,8 @@ public class DCCppSimulatorAdapter extends DCCppSimulatorPortController implemen
 
     private void generateRandomSensorReply() {
         // Pick a random sensor number between 0 and 10;
-        Random sNumGenerator = new Random();
-        int sensorNum = sNumGenerator.nextInt(10)+1; // Generate a random sensor number between 1 and 10
-        Random valueGenerator = new Random();
-        int value = valueGenerator.nextInt(2); // Generate state value between 0 and 1
+        int sensorNum = ThreadLocalRandom.current().nextInt(10)+1; // Generate a random sensor number between 1 and 10
+        int value = ThreadLocalRandom.current().nextInt(2); // Generate state value between 0 and 1
 
         String reply = (value == 1 ? "Q " : "q ") + sensorNum;
 

--- a/java/src/jmri/util/node/NodeIdentity.java
+++ b/java/src/jmri/util/node/NodeIdentity.java
@@ -16,9 +16,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
 import jmri.profile.Profile;
 import jmri.profile.ProfileManager;
 import jmri.util.FileUtil;
@@ -52,7 +53,6 @@ public class NodeIdentity {
     private UUID uuid = null;
     private String networkIdentity = null;
     private String storageIdentity = null;
-    private Random random = null;
     private final Map<Profile, String> profileStorageIdentities = new HashMap<>();
 
     private static NodeIdentity instance = null;
@@ -321,10 +321,7 @@ public class NodeIdentity {
         if (this.networkIdentity == null) {
             log.info("No MAC addresses found, generating a random multicast MAC address as per RFC 4122.");
             byte[] randBytes = new byte[6];
-            if (random == null) {
-                random = new Random();
-            }
-            random.nextBytes(randBytes);
+            ThreadLocalRandom.current().nextBytes(randBytes);
             // set multicast bit in first octet
             randBytes[0] = (byte) (randBytes[0] | 0x01);
             this.networkIdentity = this.createNetworkIdentity(randBytes);


### PR DESCRIPTION
Resolves warnings from Spotbugs 4.2.2 to 4.2.3 DMI_RANDOM_USED_ONLY_ONCE
eg https://github.com/JMRI/JMRI/pull/9681/checks?check_run_id=2400170818