### PR TITLE
Fix SPROG Gen 5 connection type list

### DIFF
--- a/java/src/jmri/jmrix/can/adapters/gridconnect/sproggen5/Bundle.properties
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/sproggen5/Bundle.properties
@@ -2,7 +2,6 @@
 #
 # Default properties for the jmri.jmrix.can.adapters.sprogconnect classes
 
-CanSprogTitle = CAN SPROG Command Station
 CanisbTitle = CANISB Isolated USB-CAN Adapter
 PiSprog3Title = Pi-SPROG 3
 Sprog3PlusTitle = SPROG 3 Plus

--- a/java/src/jmri/jmrix/sproggen5/SprogGen5ConnectionTypeList.java
+++ b/java/src/jmri/jmrix/sproggen5/SprogGen5ConnectionTypeList.java
@@ -25,7 +25,6 @@ public class SprogGen5ConnectionTypeList implements jmri.jmrix.ConnectionTypeLis
             "jmri.jmrix.can.adapters.gridconnect.sproggen5.serialdriver.PiSprog3PlusConnectionConfig",
             "jmri.jmrix.can.adapters.gridconnect.sproggen5.serialdriver.PiSprog3v2ConnectionConfig",
             "jmri.jmrix.can.adapters.gridconnect.sproggen5.serialdriver.PiSprog3ConnectionConfig",
-            "jmri.jmrix.can.adapters.gridconnect.sproggen5.serialdriver.CanSprogConnectionConfig",
         };
     }
 

--- a/java/test/jmri/jmrix/sproggen5/SprogGen5ConnectionTypeListTest.java
+++ b/java/test/jmri/jmrix/sproggen5/SprogGen5ConnectionTypeListTest.java
@@ -1,0 +1,49 @@
+package jmri.jmrix.sproggen5;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+
+/**
+ * Tests for SprogConnectionTypeList.
+ *
+ * @author Paul Bender Copyright (C) 2016
+ */
+public class SprogGen5ConnectionTypeListTest {
+
+   @Test
+   public void ConstructorTest(){
+       SprogGen5ConnectionTypeList ct = new SprogGen5ConnectionTypeList();
+       Assert.assertNotNull(ct);
+   }
+
+   @Test
+   public void ManfacturerString(){
+       SprogGen5ConnectionTypeList ct = new SprogGen5ConnectionTypeList();
+       Assert.assertEquals("Manufacturers",new String[]{"SPROG DCC Generation 5"}, ct.getManufacturers());
+   }
+
+   @Test
+   public void ProtocolClassList(){
+       SprogGen5ConnectionTypeList ct = new SprogGen5ConnectionTypeList();
+       Assert.assertEquals("Protocol Class List", new String[]{
+            "jmri.jmrix.can.adapters.gridconnect.sproggen5.serialdriver.CanisbConnectionConfig",
+            "jmri.jmrix.can.adapters.gridconnect.sproggen5.serialdriver.Sprog3PlusConnectionConfig",
+            "jmri.jmrix.can.adapters.gridconnect.sproggen5.serialdriver.PiSprog3PlusConnectionConfig",
+            "jmri.jmrix.can.adapters.gridconnect.sproggen5.serialdriver.PiSprog3v2ConnectionConfig",
+            "jmri.jmrix.can.adapters.gridconnect.sproggen5.serialdriver.PiSprog3ConnectionConfig"},
+            ct.getAvailableProtocolClasses());
+   }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+}


### PR DESCRIPTION
Obsolete connection type was causing ClassNotFoundException when creating a new connection