### PR TITLE
Add RetryRule

### DIFF
--- a/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
+++ b/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
@@ -5,11 +5,11 @@ import java.util.HashMap;
 
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import jmri.util.JUnitUtil;
-import org.junit.jupiter.api.AfterAll;
+import jmri.util.junit.rules.RetryRule;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.junit.Assume;
-import org.junit.jupiter.api.BeforeAll;
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JComboBoxOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
@@ -25,6 +25,9 @@ public class AddEntryExitPairPanelTest {
     static EntryExitTestTools tools;
     static HashMap<String, LayoutEditor> panels = new HashMap<>();
     static EntryExitPairs eep;
+
+    //@Rule
+    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     @Test
     public void testCTor() {


### PR DESCRIPTION
This PR tries to fix this problem with CI:
```
[INFO] Running jmri.jmrit.entryexit.AddEntryExitPairPanelTest
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 235.53 s <<< FAILURE! - in jmri.jmrit.entryexit.AddEntryExitPairPanelTest
[ERROR] testPanelActions  Time elapsed: 232.358 s  <<< ERROR!
org.netbeans.jemmy.TimeoutExpiredException: Wait event queue staying empty for 10 (QueueTool.WaitQueueEmptyTimeout)
	at org.netbeans.jemmy.Waiter.waitAction(Waiter.java:210)
	at org.netbeans.jemmy.QueueTool.waitEmpty(QueueTool.java:307)
	at org.netbeans.jemmy.drivers.lists.JComboMouseDriver.selectItem(JComboMouseDriver.java:62)
	at org.netbeans.jemmy.operators.JComboBoxOperator.selectItem(JComboBoxOperator.java:612)
	at org.netbeans.jemmy.operators.JComboBoxOperator.selectItem(JComboBoxOperator.java:566)
	at org.netbeans.jemmy.operators.JComboBoxOperator.selectItem(JComboBoxOperator.java:592)
	at jmri.jmrit.entryexit.AddEntryExitPairPanelTest.testPanelActions(AddEntryExitPairPanelTest.java:51)
```