### PR TITLE
LogixNG error dialog with multiple lines

### DIFF
--- a/java/src/jmri/JmriMultiLineException.java
+++ b/java/src/jmri/JmriMultiLineException.java
@@ -13,6 +13,11 @@ public class JmriMultiLineException extends JmriException {
 
     private final List<String> errors;
 
+    public JmriMultiLineException(String s, List<String> errors) {
+        super(s);
+        this.errors = Collections.unmodifiableList(new ArrayList<>(errors));
+    }
+
     public JmriMultiLineException(String s, List<String> errors, Throwable t) {
         super(s, t);
         this.errors = Collections.unmodifiableList(new ArrayList<>(errors));

--- a/java/src/jmri/JmriMultiLineException.java
+++ b/java/src/jmri/JmriMultiLineException.java
@@ -27,4 +27,16 @@ public class JmriMultiLineException extends JmriException {
         return errors;
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public String getMessage() {
+        return super.getMessage() + ": " + String.join(", ", errors);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getLocalizedMessage() {
+        return super.getLocalizedMessage() + ": " + String.join(", ", errors);
+    }
+
 }

--- a/java/src/jmri/JmriMultiLineException.java
+++ b/java/src/jmri/JmriMultiLineException.java
@@ -1,0 +1,25 @@
+package jmri;
+
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * JMRI exception that can have many error messages.
+ *
+ * @author Daniel Bergqvist Copyright (C) 2021
+ */
+public class JmriMultiLineException extends JmriException {
+
+    private final List<String> errors;
+
+    public JmriMultiLineException(String s, List<String> errors, Throwable t) {
+        super(s, t);
+        this.errors = Collections.unmodifiableList(new ArrayList<>(errors));
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+}

--- a/java/src/jmri/Reference.java
+++ b/java/src/jmri/Reference.java
@@ -1,0 +1,51 @@
+package jmri;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+
+/**
+ * A reference to an object.
+ * It's a faster replacement for AtomicReference when thread safety is not
+ * needed.
+ *
+ * @param <E> the type of the reference
+ *
+ * @author Daniel Bergqvist Copyright (C) 2021
+ */
+public class Reference<E> {
+
+    private E _ref;
+
+    /**
+     * Create an instance of Reference.
+     */
+    public Reference() {
+    }
+
+    /**
+     * Create an instance of Reference.
+     * @param ref the reference
+     */
+    public Reference(@CheckForNull E ref) {
+        this._ref = ref;
+    }
+
+    /**
+     * Set the reference.
+     * @param ref the new reference
+     */
+    public void set(@CheckForNull E ref) {
+        this._ref = ref;
+    }
+
+    /**
+     * Return the reference.
+     * @return the reference
+     */
+    @CheckReturnValue
+    @CheckForNull
+    public E get() {
+        return _ref;
+    }
+
+}

--- a/java/src/jmri/jmrit/logixng/actions/ActionBlock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionBlock.java
@@ -374,7 +374,7 @@ public class ActionBlock extends AbstractDigitalAction implements VetoableChange
             // Variables used in lambda must be effectively final
             DirectOperation theOper = oper;
 
-            ThreadingUtil.runOnLayout(() -> {
+            ThreadingUtil.runOnLayoutWithJmriException(() -> {
                 Sensor sensor;
                 LayoutBlock lblk;
 

--- a/java/src/jmri/jmrit/logixng/actions/ActionClock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionClock.java
@@ -83,7 +83,7 @@ public class ActionClock extends AbstractDigitalAction {
     @Override
     public void execute() throws JmriException {
         ClockState theState = _clockState;
-        ThreadingUtil.runOnLayout(() -> {
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
             switch(theState) {
                 case SetClock:
                     Calendar cal = Calendar.getInstance();

--- a/java/src/jmri/jmrit/logixng/actions/ActionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionEntryExit.java
@@ -320,7 +320,7 @@ public class ActionEntryExit extends AbstractDigitalAction implements VetoableCh
         // Variables used in lambda must be effectively final
         Operation theOper = oper;
 
-        ThreadingUtil.runOnLayout(() -> {
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
             switch (theOper) {
                 case SetNXPairEnabled:
                     entryExit.setEnabled(true);

--- a/java/src/jmri/jmrit/logixng/actions/ActionLight.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionLight.java
@@ -311,7 +311,7 @@ public class ActionLight extends AbstractDigitalAction implements VetoableChange
             state = LightState.valueOf(name);
         }
 
-        ThreadingUtil.runOnLayout(() -> {
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
             if (state == LightState.Toggle) {
                 if (light.getCommandedState() == Turnout.CLOSED) {
                     light.setCommandedState(Turnout.THROWN);

--- a/java/src/jmri/jmrit/logixng/actions/ActionMemory.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionMemory.java
@@ -346,7 +346,7 @@ public class ActionMemory extends AbstractDigitalAction
 
         AtomicReference<JmriException> ref = new AtomicReference<>();
 
-        ThreadingUtil.runOnLayout(() -> {
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
 
             switch (_memoryOperation) {
                 case SetToNull:

--- a/java/src/jmri/jmrit/logixng/actions/ActionOBlock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionOBlock.java
@@ -372,7 +372,7 @@ public class ActionOBlock extends AbstractDigitalAction implements VetoableChang
             // Variables used in lambda must be effectively final
             DirectOperation theOper = oper;
 
-            ThreadingUtil.runOnLayout(() -> {
+            ThreadingUtil.runOnLayoutWithJmriException(() -> {
                 switch (theOper) {
                     case None:
                         break;

--- a/java/src/jmri/jmrit/logixng/actions/ActionPower.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionPower.java
@@ -57,7 +57,7 @@ public class ActionPower extends AbstractDigitalAction {
     @Override
     public void execute() throws JmriException {
         AtomicReference<JmriException> exception = new AtomicReference<>();
-        ThreadingUtil.runOnLayout(() -> {
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
             try {
                 InstanceManager.getDefault(PowerManager.class).setPower(_powerState.getID());
             } catch (JmriException e) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionScript.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionScript.java
@@ -111,7 +111,7 @@ public class ActionScript extends AbstractDigitalAction {
         AtomicReference<RuntimeException> runtimeExceptionRef = new AtomicReference<>();
         
         if (_scriptClass != null) {
-            jmri.util.ThreadingUtil.runOnLayout(() -> {
+            jmri.util.ThreadingUtil.runOnLayoutWithJmriException(() -> {
                 try {
                     _scriptClass.execute();
                 } catch (JmriException e) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionSensor.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSensor.java
@@ -311,7 +311,7 @@ public class ActionSensor extends AbstractDigitalAction implements VetoableChang
             state = SensorState.valueOf(name);
         }
 
-        ThreadingUtil.runOnLayout(() -> {
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
             if (state == SensorState.Toggle) {
                 if (sensor.getCommandedState() == Sensor.INACTIVE) {
                     sensor.setCommandedState(Sensor.ACTIVE);

--- a/java/src/jmri/jmrit/logixng/actions/ActionSignalHead.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSignalHead.java
@@ -475,7 +475,7 @@ public class ActionSignalHead extends AbstractDigitalAction
         OperationType operation = getOperation();
 
         AtomicReference<JmriException> ref = new AtomicReference<>();
-        jmri.util.ThreadingUtil.runOnLayout(() -> {
+        jmri.util.ThreadingUtil.runOnLayoutWithJmriException(() -> {
             try {
                 switch (operation) {
                     case Appearance:

--- a/java/src/jmri/jmrit/logixng/actions/ActionSignalMast.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSignalMast.java
@@ -462,7 +462,7 @@ public class ActionSignalMast extends AbstractDigitalAction
         OperationType operation = getOperation();
 
         AtomicReference<JmriException> ref = new AtomicReference<>();
-        jmri.util.ThreadingUtil.runOnLayout(() -> {
+        jmri.util.ThreadingUtil.runOnLayoutWithJmriException(() -> {
             try {
                 switch (operation) {
                     case Aspect:

--- a/java/src/jmri/jmrit/logixng/actions/ActionSimpleScript.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSimpleScript.java
@@ -276,7 +276,7 @@ public class ActionSimpleScript extends AbstractDigitalAction {
         
         bindings.put("params", params);    // Give the script access to the local variable 'params'
         
-        ThreadingUtil.runOnLayout(() -> {
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
             switch (operation) {
                 case RunScript:
                     try (InputStreamReader reader = new InputStreamReader(

--- a/java/src/jmri/jmrit/logixng/actions/ActionThrottle.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionThrottle.java
@@ -163,7 +163,7 @@ public class ActionThrottle extends AbstractDigitalAction
             DccThrottle throttle = _throttle;
             float spd = (float) speed;
             boolean fwd = isForward;
-            jmri.util.ThreadingUtil.runOnLayout(() -> {
+            jmri.util.ThreadingUtil.runOnLayoutWithJmriException(() -> {
                 throttle.setSpeedSetting(spd);
                 throttle.setIsForward(fwd);
             });

--- a/java/src/jmri/jmrit/logixng/actions/ActionTurnout.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionTurnout.java
@@ -311,7 +311,7 @@ public class ActionTurnout extends AbstractDigitalAction implements VetoableChan
             state = TurnoutState.valueOf(name);
         }
 
-        ThreadingUtil.runOnLayout(() -> {
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
             if (state == TurnoutState.Toggle) {
                 if (turnout.getCommandedState() == Turnout.CLOSED) {
                     turnout.setCommandedState(Turnout.THROWN);

--- a/java/src/jmri/jmrit/logixng/actions/ActionTurnoutLock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionTurnoutLock.java
@@ -322,7 +322,7 @@ public class ActionTurnoutLock extends AbstractDigitalAction implements Vetoable
         // Variables used in lambda must be effectively final
         TurnoutLock theLock = lock;
 
-        ThreadingUtil.runOnLayout(() -> {
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
             if (theLock == TurnoutLock.Lock) {
                 turnout.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, true);
             } else if (theLock == TurnoutLock.Unlock) {

--- a/java/src/jmri/jmrit/logixng/actions/AnalogActionMemory.java
+++ b/java/src/jmri/jmrit/logixng/actions/AnalogActionMemory.java
@@ -74,9 +74,9 @@ public class AnalogActionMemory extends AbstractAnalogAction
 
     /** {@inheritDoc} */
     @Override
-    public void setValue(double value) {
+    public void setValue(double value) throws JmriException {
         if (_memoryHandle != null) {
-            jmri.util.ThreadingUtil.runOnLayout(() -> {
+            jmri.util.ThreadingUtil.runOnLayoutWithJmriException(() -> {
                 _memoryHandle.getBean().setValue(value);
             });
         }

--- a/java/src/jmri/jmrit/logixng/actions/EnableLogix.java
+++ b/java/src/jmri/jmrit/logixng/actions/EnableLogix.java
@@ -315,7 +315,7 @@ public class EnableLogix extends AbstractDigitalAction implements VetoableChange
         // Variables used in lambda must be effectively final
         Operation theLock = lock;
         
-        ThreadingUtil.runOnLayout(() -> {
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
             logix.setEnabled(theLock == Operation.Enable);
         });
     }

--- a/java/src/jmri/jmrit/logixng/actions/TriggerRoute.java
+++ b/java/src/jmri/jmrit/logixng/actions/TriggerRoute.java
@@ -319,7 +319,7 @@ public class TriggerRoute extends AbstractDigitalAction implements VetoableChang
         // Variables used in lambda must be effectively final
         Operation theOper = oper;
 
-        ThreadingUtil.runOnLayout(() -> {
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
             if (theOper == Operation.TriggerRoute) {
                 route.setRoute();
             } else {

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
@@ -11,6 +11,7 @@ import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.SymbolTable.VariableData;
 import jmri.jmrit.logixng.implementation.swing.ErrorHandlingDialog;
+import jmri.jmrit.logixng.implementation.swing.ErrorHandlingDialog_MultiLine;
 import jmri.util.LoggingUtil;
 import jmri.util.ThreadingUtil;
 
@@ -189,10 +190,12 @@ public abstract class AbstractMaleSocket implements MaleSocket {
         _object.setComment(comment);
     }
 
+    @Override
     public boolean getListen() {
         return _listen;
     }
 
+    @Override
     public void setListen(boolean listen)
     {
         _listen = listen;
@@ -550,6 +553,49 @@ public abstract class AbstractMaleSocket implements MaleSocket {
                 boolean abort = ThreadingUtil.runOnGUIwithReturn(() -> {
                     ErrorHandlingDialog dialog = new ErrorHandlingDialog();
                     return dialog.showDialog(item, message);
+                });
+                if (abort) throw new AbortConditionalNGExecutionException();
+                break;
+
+            case LogError:
+                log.error("item {}, {} thrown an exception: {}", item.toString(), getObject().toString(), e, e);
+                break;
+
+            case LogErrorOnce:
+                LoggingUtil.warnOnce(log, "item {}, {} thrown an exception: {}", item.toString(), getObject().toString(), e, e);
+                break;
+
+            case ThrowException:
+                throw e;
+
+            case AbortExecution:
+                log.error("item {}, {} thrown an exception: {}", item.toString(), getObject().toString(), e, e);
+                throw new AbortConditionalNGExecutionException(e);
+
+            default:
+                throw e;
+        }
+    }
+
+    public void handleError(
+            Base item,
+            String message,
+            List<String> messageList,
+            JmriMultiLineException e,
+            Logger log)
+            throws JmriException {
+
+        ErrorHandlingType errorHandlingType = _errorHandlingType;
+        if (errorHandlingType == ErrorHandlingType.Default) {
+            errorHandlingType = InstanceManager.getDefault(LogixNGPreferences.class)
+                    .getErrorHandlingType();
+        }
+
+        switch (errorHandlingType) {
+            case ShowDialogBox:
+                boolean abort = ThreadingUtil.runOnGUIwithReturn(() -> {
+                    ErrorHandlingDialog_MultiLine dialog = new ErrorHandlingDialog_MultiLine();
+                    return dialog.showDialog(item, message, messageList);
                 });
                 if (abort) throw new AbortConditionalNGExecutionException();
                 break;

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocket.java
@@ -62,7 +62,7 @@ public class DefaultMaleAnalogActionSocket extends AbstractMaleSocket implements
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             internalSetValue(value);
         } catch (JmriMultiLineException e) {
-            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
+            handleError(this, Bundle.getMessage("ExceptionExecuteMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionSetValue", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocket.java
@@ -61,6 +61,8 @@ public class DefaultMaleAnalogActionSocket extends AbstractMaleSocket implements
         try {
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             internalSetValue(value);
+        } catch (JmriMultiLineException e) {
+            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionSetValue", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogExpressionSocket.java
@@ -76,6 +76,8 @@ public class DefaultMaleAnalogExpressionSocket extends AbstractMaleSocket implem
         try {
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             result = internalEvaluate();
+        } catch (JmriMultiLineException e) {
+            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionEvaluate", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleAnalogExpressionSocket.java
@@ -77,7 +77,7 @@ public class DefaultMaleAnalogExpressionSocket extends AbstractMaleSocket implem
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             result = internalEvaluate();
         } catch (JmriMultiLineException e) {
-            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
+            handleError(this, Bundle.getMessage("ExceptionEvaluateMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionEvaluate", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalActionSocket.java
@@ -44,7 +44,7 @@ public class DefaultMaleDigitalActionSocket
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             ((DigitalActionBean)getObject()).execute();
         } catch (JmriMultiLineException e) {
-            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
+            handleError(this, Bundle.getMessage("ExceptionExecuteMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionExecuteAction", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalActionSocket.java
@@ -43,6 +43,8 @@ public class DefaultMaleDigitalActionSocket
         try {
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             ((DigitalActionBean)getObject()).execute();
+        } catch (JmriMultiLineException e) {
+            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionExecuteAction", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalBooleanActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalBooleanActionSocket.java
@@ -43,6 +43,8 @@ public class DefaultMaleDigitalBooleanActionSocket
         try {
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             ((DigitalBooleanActionBean)getObject()).execute(hasChangedToTrue, hasChangedToFalse);
+        } catch (JmriMultiLineException e) {
+            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionExecuteBooleanAction", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalBooleanActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalBooleanActionSocket.java
@@ -44,7 +44,7 @@ public class DefaultMaleDigitalBooleanActionSocket
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             ((DigitalBooleanActionBean)getObject()).execute(hasChangedToTrue, hasChangedToFalse);
         } catch (JmriMultiLineException e) {
-            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
+            handleError(this, Bundle.getMessage("ExceptionExecuteMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionExecuteBooleanAction", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocket.java
@@ -71,6 +71,9 @@ public class DefaultMaleDigitalExpressionSocket extends AbstractMaleSocket imple
         try {
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             lastEvaluationResult = ((DigitalExpressionBean)getObject()).evaluate();
+        } catch (JmriMultiLineException e) {
+            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
+            lastEvaluationResult = false;
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionEvaluateExpression", e.getLocalizedMessage()), e, log);
             lastEvaluationResult = false;

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocket.java
@@ -72,7 +72,7 @@ public class DefaultMaleDigitalExpressionSocket extends AbstractMaleSocket imple
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             lastEvaluationResult = ((DigitalExpressionBean)getObject()).evaluate();
         } catch (JmriMultiLineException e) {
-            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
+            handleError(this, Bundle.getMessage("ExceptionEvaluateMulti"), e.getErrors(), e, log);
             lastEvaluationResult = false;
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionEvaluateExpression", e.getLocalizedMessage()), e, log);

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringActionSocket.java
@@ -49,7 +49,7 @@ public class DefaultMaleStringActionSocket extends AbstractMaleSocket implements
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             ((StringActionBean)getObject()).setValue(value);
         } catch (JmriMultiLineException e) {
-            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
+            handleError(this, Bundle.getMessage("ExceptionExecuteMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionSetValue", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringActionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringActionSocket.java
@@ -48,6 +48,8 @@ public class DefaultMaleStringActionSocket extends AbstractMaleSocket implements
         try {
             conditionalNG.getSymbolTable().createSymbols(_localVariables);
             ((StringActionBean)getObject()).setValue(value);
+        } catch (JmriMultiLineException e) {
+            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionSetValue", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringExpressionSocket.java
@@ -56,6 +56,8 @@ public class DefaultMaleStringExpressionSocket extends AbstractMaleSocket
         try {
             currentConditionalNG.getSymbolTable().createSymbols(_localVariables);
             result = ((StringExpressionBean)getObject()).evaluate();
+        } catch (JmriMultiLineException e) {
+            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionEvaluate", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleStringExpressionSocket.java
@@ -57,7 +57,7 @@ public class DefaultMaleStringExpressionSocket extends AbstractMaleSocket
             currentConditionalNG.getSymbolTable().createSymbols(_localVariables);
             result = ((StringExpressionBean)getObject()).evaluate();
         } catch (JmriMultiLineException e) {
-            handleError(this, Bundle.getMessage("ExceptionMulti"), e.getErrors(), e, log);
+            handleError(this, Bundle.getMessage("ExceptionEvaluateMulti"), e.getErrors(), e, log);
         } catch (JmriException e) {
             handleError(this, Bundle.getMessage("ExceptionEvaluate", e.getLocalizedMessage()), e, log);
         } catch (RuntimeException e) {

--- a/java/src/jmri/jmrit/logixng/implementation/ImplementationBundle.properties
+++ b/java/src/jmri/jmrit/logixng/implementation/ImplementationBundle.properties
@@ -33,6 +33,7 @@ ExceptionExecute    = An exception has occured during execute: {0}
 ExceptionExecuteAction          = An exception has occurred during execute: {0}
 ExceptionExecuteBooleanAction   = An exception has occurred during execute: {0}
 ExceptionEvaluateExpression     = An exception has occurred during evaluate: {0}
+ExceptionMulti      = An exception has occurred during evaluate:
 
 FemaleAnalogActionSocket_Descr      = Analog action socket
 FemaleAnalogExpressionSocket_Descr  = Analog expression socket

--- a/java/src/jmri/jmrit/logixng/implementation/ImplementationBundle.properties
+++ b/java/src/jmri/jmrit/logixng/implementation/ImplementationBundle.properties
@@ -33,7 +33,8 @@ ExceptionExecute    = An exception has occured during execute: {0}
 ExceptionExecuteAction          = An exception has occurred during execute: {0}
 ExceptionExecuteBooleanAction   = An exception has occurred during execute: {0}
 ExceptionEvaluateExpression     = An exception has occurred during evaluate: {0}
-ExceptionMulti      = An exception has occurred during evaluate:
+ExceptionExecuteMulti           = An exception has occurred during execute:
+ExceptionEvaluateMulti          = An exception has occurred during evaluate:
 
 FemaleAnalogActionSocket_Descr      = Analog action socket
 FemaleAnalogExpressionSocket_Descr  = Analog expression socket

--- a/java/src/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialog_MultiLine.java
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialog_MultiLine.java
@@ -1,0 +1,141 @@
+package jmri.jmrit.logixng.implementation.swing;
+
+import java.awt.*;
+import java.awt.event.*;
+import java.util.List;
+import javax.swing.*;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.Base;
+import jmri.jmrit.logixng.LogixNG_Manager;
+
+/**
+ *
+ * @author Daniel Bergqvist 2021
+ */
+public class ErrorHandlingDialog_MultiLine {
+    
+    private Base _item;
+    private JDialog _errorDialog;
+    
+    private final JCheckBox _disableConditionalNGCheckBox =
+            new JCheckBox(Bundle.getMessage("ErrorHandlingDialog_DisableConditionalNG"));   // NOI18N
+    
+    private final JCheckBox _disableLogixNGCheckBox =
+            new JCheckBox(Bundle.getMessage("ErrorHandlingDialog_DisableLogixNG"));   // NOI18N
+    
+    private final JCheckBox _stopAllLogixNGCheckBox =
+            new JCheckBox(Bundle.getMessage("ErrorHandlingDialog_StopAllLogixNGs"));   // NOI18N
+    
+    private boolean _abortExecution = false;
+    
+    
+    public boolean showDialog(Base item, String errorMessage, List<String> errorMessageList) {
+        
+        _item = item;
+        
+        _errorDialog = new JDialog(
+                (JDialog)null,
+                Bundle.getMessage("ErrorHandlingDialog_Title"),
+                true);
+        
+        Container contentPanel = _errorDialog.getContentPane();
+        contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
+        
+        contentPanel.add(new JLabel(Bundle.getMessage(
+                "ErrorHandlingDialog_Name", item.getShortDescription())));
+        contentPanel.add(new JLabel(errorMessage));
+        String errorMsg = String.join("<br>", errorMessageList);
+        contentPanel.add(new JLabel("<html>"+errorMsg+"</html>"));
+        
+        contentPanel.add(_disableConditionalNGCheckBox);
+        _disableConditionalNGCheckBox.setAlignmentX(Component.LEFT_ALIGNMENT);
+        contentPanel.add(_disableLogixNGCheckBox);
+        _disableLogixNGCheckBox.setAlignmentX(Component.LEFT_ALIGNMENT);
+        contentPanel.add(_stopAllLogixNGCheckBox);
+        _stopAllLogixNGCheckBox.setAlignmentX(Component.LEFT_ALIGNMENT);
+        
+        // set up message
+        JPanel panel3 = new JPanel();
+        panel3.setLayout(new BoxLayout(panel3, BoxLayout.Y_AXIS));
+        
+        contentPanel.add(panel3);
+        
+        // set up create and cancel buttons
+        JPanel panel5 = new JPanel();
+        panel5.setLayout(new FlowLayout());
+        
+        // Abort
+        JButton abortButton = new JButton(Bundle.getMessage("ErrorHandlingDialog_Abort"));  // NOI18N
+        panel5.add(abortButton);
+        abortButton.addActionListener((ActionEvent e) -> {
+            abortPressed(null);
+        });
+//        cancel.setToolTipText(Bundle.getMessage("CancelLogixButtonHint"));      // NOI18N
+//        abortButton.setToolTipText("CancelLogixButtonHint");      // NOI18N
+        
+        // Continue
+        JButton continueButton = new JButton(Bundle.getMessage("ErrorHandlingDialog_Continue"));    // NOI18N
+        panel5.add(continueButton);
+        continueButton.addActionListener((ActionEvent e) -> {
+            continuePressed(null);
+        });
+//        cancel.setToolTipText(Bundle.getMessage("CancelLogixButtonHint"));      // NOI18N
+//        continueButton.setToolTipText("CancelLogixButtonHint");      // NOI18N
+        
+        _errorDialog.addWindowListener(new java.awt.event.WindowAdapter() {
+            @Override
+            public void windowClosing(java.awt.event.WindowEvent e) {
+                continuePressed(null);
+            }
+        });
+/*        
+        _create = new JButton(Bundle.getMessage("ButtonCreate"));  // NOI18N
+        panel5.add(_create);
+        _create.addActionListener((ActionEvent e) -> {
+            cancelAddPressed(null);
+            
+            SwingConfiguratorInterface swingConfiguratorInterface =
+                    _swingConfiguratorComboBox.getItemAt(_swingConfiguratorComboBox.getSelectedIndex());
+//            System.err.format("swingConfiguratorInterface: %s%n", swingConfiguratorInterface.getClass().getName());
+            createAddFrame(femaleSocket, path, swingConfiguratorInterface);
+        });
+*/        
+        contentPanel.add(panel5);
+        
+//        addLogixNGFrame.setLocationRelativeTo(component);
+        _errorDialog.setLocationRelativeTo(null);
+        _errorDialog.pack();
+        _errorDialog.setVisible(true);
+        
+        return _abortExecution;
+    }
+    
+    private void handleCheckBoxes() {
+        if (_disableConditionalNGCheckBox.isSelected()) {
+            _item.getConditionalNG().setEnabled(false);
+        }
+        if (_disableLogixNGCheckBox.isSelected()) {
+            _item.getLogixNG().setEnabled(false);
+        }
+        if (_stopAllLogixNGCheckBox.isSelected()) {
+            InstanceManager.getDefault(LogixNG_Manager.class).deActivateAllLogixNGs();
+        }
+    }
+    
+    private void abortPressed(ActionEvent e) {
+        _errorDialog.setVisible(false);
+        _errorDialog.dispose();
+        _errorDialog = null;
+        _abortExecution = true;
+        handleCheckBoxes();
+    }
+    
+    private void continuePressed(ActionEvent e) {
+        _errorDialog.setVisible(false);
+        _errorDialog.dispose();
+        _errorDialog = null;
+        handleCheckBoxes();
+    }
+    
+}

--- a/java/test/jmri/JmriMultiLineExceptionTest.java
+++ b/java/test/jmri/JmriMultiLineExceptionTest.java
@@ -1,0 +1,39 @@
+package jmri;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.*;
+
+/**
+ * Test JmriMultiLineException
+ * 
+ * @author Daniel Bergqvist 2021
+ */
+public class JmriMultiLineExceptionTest {
+
+    @Test
+    public void testCtor() {
+        List<String> list = new ArrayList<>();
+        list.add("First row");
+        list.add("Second row");
+        list.add("Third row");
+        list.add("Forth row");
+        JmriMultiLineException obj = new JmriMultiLineException("The error", list);
+        Assert.assertNotNull(obj);
+    }
+    
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+    
+}

--- a/java/test/jmri/jmrit/logixng/actions/AnalogActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AnalogActionMemoryTest.java
@@ -119,7 +119,7 @@ public class AnalogActionMemoryTest extends AbstractAnalogActionTestBase {
     }
     
     @Test
-    public void testAction() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
+    public void testAction() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException, JmriException {
         AnalogActionMemory action = (AnalogActionMemory)_base;
         action.setValue(0.0d);
         Assert.assertTrue("Memory has correct value", 0.0d == (Double)_memory.getValue());

--- a/java/test/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialog_MultiLineTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialog_MultiLineTest.java
@@ -1,0 +1,39 @@
+package jmri.jmrit.logixng.implementation.swing;
+
+import java.io.IOException;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.*;
+
+/**
+ * Test ErrorHandlingDialog_MultiLine
+ * 
+ * @author Daniel Bergqvist 2021
+ */
+public class ErrorHandlingDialog_MultiLineTest {
+
+    @Test
+    public void testCtor() {
+        ErrorHandlingDialog_MultiLine obj = new ErrorHandlingDialog_MultiLine();
+        Assert.assertNotNull(obj);
+    }
+    
+    // The minimal setup for log4J
+    @Before
+    public void setUp() throws IOException {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initLogixNGManager();
+    }
+
+    @After
+    public void tearDown() {
+        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.tearDown();
+    }
+    
+}


### PR DESCRIPTION
This PR adds the option to show multiple error messages in the LogixNG error dialog. A multi line error message is thrown by throwing `jmri.JmriMultiLineException`.

```
List<String> list = new ArrayList<>();
list.add("First error message");
list.add("Second error message");
list.add("Third error message");
list.add("Fourth error message");
throw new jmri.JmriMultiLineException("The error", list);
```