### PR TITLE
Add space between labels in error dialogs

### DIFF
--- a/java/src/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialog.java
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialog.java
@@ -43,7 +43,9 @@ public class ErrorHandlingDialog {
         
         contentPanel.add(new JLabel(Bundle.getMessage(
                 "ErrorHandlingDialog_Name", item.getShortDescription())));
+        contentPanel.add(Box.createVerticalStrut(10));
         contentPanel.add(new JLabel(errorMessage));
+        contentPanel.add(Box.createVerticalStrut(10));
         
         contentPanel.add(_disableConditionalNGCheckBox);
         _disableConditionalNGCheckBox.setAlignmentX(Component.LEFT_ALIGNMENT);

--- a/java/src/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialog_MultiLine.java
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/ErrorHandlingDialog_MultiLine.java
@@ -44,9 +44,12 @@ public class ErrorHandlingDialog_MultiLine {
         
         contentPanel.add(new JLabel(Bundle.getMessage(
                 "ErrorHandlingDialog_Name", item.getShortDescription())));
+        contentPanel.add(Box.createVerticalStrut(10));
         contentPanel.add(new JLabel(errorMessage));
+        contentPanel.add(Box.createVerticalStrut(10));
         String errorMsg = String.join("<br>", errorMessageList);
         contentPanel.add(new JLabel("<html>"+errorMsg+"</html>"));
+        contentPanel.add(Box.createVerticalStrut(10));
         
         contentPanel.add(_disableConditionalNGCheckBox);
         _disableConditionalNGCheckBox.setAlignmentX(Component.LEFT_ALIGNMENT);


### PR DESCRIPTION
This PR adds space in error dialogs in LogixNG as requested by @dsand47 

![ErrorHandling4](https://user-images.githubusercontent.com/20255317/116827773-170de800-ab9b-11eb-9de8-508dbae27ac9.png)

![ErrorHandling3](https://user-images.githubusercontent.com/20255317/116827772-1412f780-ab9b-11eb-9f3c-4cd11ee6bc04.png)
