### PR TITLE
Log warning when findVar matches by Label rather than Item.

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -54,11 +54,11 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
      * Define the columns.
      * <p>
      * Values understood are: "Name", "Value", "Range",
-     * "Read", "Write", "Comment", "CV", "Mask", "State". 
+     * "Read", "Write", "Comment", "CV", "Mask", "State".
      * <p>
      * For each, a property
      * key in SymbolicProgBundle by the same name allows i18n.
-     * 
+     *
      * @param status variable status.
      * @param h values headers array.
      * @param cvModel cv table model to use.
@@ -1079,13 +1079,13 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
     public VariableValue findVar(String name) {
         for (int i = 0; i < getRowCount(); i++) {
             if (name.equals(getItem(i))) {
-            log.debug("findVar matched '{}' by Item", name);
+                log.debug("findVar matched '{}' by Item", name);
                 return getVariable(i);
             }
         }
         for (int i = 0; i < getRowCount(); i++) {
             if (name.equals(getLabel(i))) {
-            log.warn("findVar matched '{}' by Label rather than Item", name);
+                log.warn("findVar matched '{}' by Label rather than Item", name);
                 return getVariable(i);
             }
         }

--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -1079,9 +1079,13 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
     public VariableValue findVar(String name) {
         for (int i = 0; i < getRowCount(); i++) {
             if (name.equals(getItem(i))) {
+            log.debug("findVar matched '{}' by Item", name);
                 return getVariable(i);
             }
+        }
+        for (int i = 0; i < getRowCount(); i++) {
             if (name.equals(getLabel(i))) {
+            log.warn("findVar matched '{}' by Label rather than Item", name);
                 return getVariable(i);
             }
         }

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/pass/DecoderWithQualifier.xml
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/pass/DecoderWithQualifier.xml
@@ -13,6 +13,7 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
     <version author="Bob Jacobsen" version="1" lastUpdated="20100119"/>
+    <version author="Dave Heap" version="2" lastUpdated="20210505"/>
 
     <decoder>
 
@@ -56,10 +57,10 @@
             <label>Acceleration Rate</label>
           </variable>
 
-            <variable label="Minor Version Number" CV="56.254.5" readOnly="yes" item="CV56.254.5">
+            <variable label="Minor Version Number" CV="56.254.5" readOnly="yes" item="Minor Version">
               <decVal/>
             </variable>
-            <variable label="Major Version Number" CV="56.254.6" readOnly="yes" item="CV56.254.6">
+            <variable label="Major Version Number" CV="56.254.6" readOnly="yes" item="Major Version">
               <decVal/>
             </variable>
 
@@ -78,7 +79,7 @@
 
             <variable label="CV55.92.0 qual minor gt 100" CV="55.92.0" mask="XXXXXXXV" default="1" item="iCV55.92.0">
                 <qualifier>
-                    <variableref>Minor Version Number</variableref>
+                    <variableref>Minor Version</variableref>
                     <relation>ge</relation>
                     <value>100</value>
                 </qualifier>
@@ -90,12 +91,12 @@
 
             <variable label="CV55.92.1 qual minor, major gt 100" CV="55.92.1" mask="XXXXXXXV" default="1" item="iCV55.92.1">
                 <qualifier>
-                    <variableref>Minor Version Number</variableref>
+                    <variableref>Minor Version</variableref>
                     <relation>ge</relation>
                     <value>100</value>
                 </qualifier>
                 <qualifier>
-                    <variableref>Major Version Number</variableref>
+                    <variableref>Major Version</variableref>
                     <relation>ge</relation>
                     <value>100</value>
                 </qualifier>


### PR DESCRIPTION
Follows on from #9495.

Logs a warning if findVar can't find a match by `Item` and has to fall back to a match by `Label`.

Matching by `Label` is likely to fail for non-default languages. This PR is an aid to locating decoder definitions that need to be updated to use Item in all qualifier variablerefs.