### PR TITLE
Store Item rather than Label in varValue.

### DIFF
--- a/java/src/jmri/jmrit/roster/LocoFile.java
+++ b/java/src/jmri/jmrit/roster/LocoFile.java
@@ -240,7 +240,7 @@ public class LocoFile extends XmlFile {
             if (variableModel != null) {
                 for (int i = 0; i < variableModel.getRowCount(); i++) {
                     decoderDef.addContent(new Element("varValue")
-                            .setAttribute("item", variableModel.getLabel(i))
+                            .setAttribute("item", variableModel.getItem(i))
                             .setAttribute("value", variableModel.getValString(i))
                     );
                 }


### PR DESCRIPTION
Again, follows on from #9495.

Roster entries have been storing the variable `Label` rather than the `Item` `for the item="xxx"` attribute of each `varValue`, causing a match failure on loading when the locale is changed after a roster entry has been changed.