### PR TITLE
WIP: Show speed step on speed table pane

### DIFF
--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -229,6 +229,8 @@ SpeedStep32TMCC         = 32 SS (TMCC)
 SpeedStep28Motorola     = 28 SS (Motorola)
 SpeedStepIncremental    = Incremental
 
+SpeedStepNumber         = Speed Step {0}
+
 # Protocol names
 ProtocolDCC                      = DCC
 ProtocolDCC_Long                 = DCC Long

--- a/java/src/jmri/jmrit/symbolicprog/SpeedTableVarValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SpeedTableVarValue.java
@@ -466,12 +466,15 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
             j.add(b, cs);
 
             cs.gridy++;
-            JLabel num = new JLabel(""+(i+1));
-            num.setToolTipText("Step Number");
+            JLabel num;
+            // every 3rd step
+            if ( (i == 0) || ( (i+1)%3 == 1) )  num = new JLabel(""+(i+1));
+            else num = new JLabel("");
+            num.setToolTipText(Bundle.getMessage("SpeedStepNumber", (i+1) ) );
 
             g.setConstraints(num, cs);
             j.add(num, cs);
-  }
+        }
 
         // add control buttons
         JPanel k = new JPanel();

--- a/java/src/jmri/jmrit/symbolicprog/SpeedTableVarValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SpeedTableVarValue.java
@@ -257,7 +257,7 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
         }
 
         // don't do the match if this step isn't checked,
-        // which is necessary to keep from an infinite 
+        // which is necessary to keep from an infinite
         // recursion
         if (!stepCheckBoxes.get(modifiedStepIndex).isSelected()) {
             return;
@@ -360,7 +360,7 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
         return buf.toString();
     }
 
-    /** 
+    /**
      * Set value from a String value.
      * <p>
      * Requires the format written by getValueString, not implemented yet
@@ -465,7 +465,13 @@ public class SpeedTableVarValue extends VariableValue implements ChangeListener 
             g.setConstraints(b, cs);
             j.add(b, cs);
 
-        }
+            cs.gridy++;
+            JLabel num = new JLabel(""+(i+1));
+            num.setToolTipText("Step Number");
+
+            g.setConstraints(num, cs);
+            j.add(num, cs);
+  }
 
         // add control buttons
         JPanel k = new JPanel();


### PR DESCRIPTION
At user suggestion, shows the speed step on the Speed Table pane.  See the area highlighted with the (added in post) blue arrows below:

![image](https://user-images.githubusercontent.com/2774117/118157919-1ff78880-b3e9-11eb-8f5a-d7961324d279.png)

Not sure if this is an improvement or not, as the tooltip for each column was already making this available.

