### PR TITLE
Support new NCE Power Pro firmware.

### DIFF
--- a/java/src/jmri/jmrix/nce/NceBundle.properties
+++ b/java/src/jmri/jmrix/nce/NceBundle.properties
@@ -31,3 +31,5 @@ InvalidSystemNameBadAIUPin     = "{0}" must use an AIU pin from 1 to 14
 SystemLabel = System:
 UsbVersionLabel = USB Version:
 
+# Nce simulator items
+EpromLabel = Command Station EPROM:

--- a/java/src/jmri/jmrix/nce/NceConnectionStatus.java
+++ b/java/src/jmri/jmrix/nce/NceConnectionStatus.java
@@ -64,6 +64,7 @@ public class NceConnectionStatus implements NceListener {
 
     private static final int mm_2007a = 1; // Revision of May 2007 EPROM VV.MM.mm = 6.2.1
     private static final int mm_2008 = 2; // Revision of 2008 EPROM VV.MM.mm = 6.2.2
+    private static final int mm_2021 = 3; // Revision of 2021 EPROM VV.MM.mm = 6.2.3
 
     private static final int VV_2012 = 7; // Revision 2012 EPROM VV.MM.mm = 7.2.0
     private static final int MM_2012 = 2;
@@ -289,6 +290,11 @@ public class NceConnectionStatus implements NceListener {
             if (VV == VV_2007 && MM == MM_2007 && mm == mm_2007) {
                 setNceEpromMarch2007(true);
                 epromState = WARN2_STATE;
+            }
+
+            // check for Power Pro 2021 or later 
+            if (VV == VV_2007 && MM == MM_2007 && mm >= mm_2021) {
+                tc.setPwrProVer060203orLater(true);
             }
 
             // Confirm that user selected correct revision of EPROM, check for old EPROM installed, new EPROM

--- a/java/src/jmri/jmrix/nce/NceProgrammer.java
+++ b/java/src/jmri/jmrix/nce/NceProgrammer.java
@@ -103,7 +103,8 @@ public class NceProgrammer extends AbstractProgrammer implements NceListener {
                 && ((tc != null)
                 && ((tc.getCommandOptions() == NceTrafficController.OPTION_1999)
                 || (tc.getCommandOptions() == NceTrafficController.OPTION_2004)
-                || (tc.getCommandOptions() == NceTrafficController.OPTION_2006))));
+                || (tc.getCommandOptions() == NceTrafficController.OPTION_2006)))
+                && (!tc.isPwrProVer060203orLater()));
     }
 
     // members for handling the programmer interface

--- a/java/src/jmri/jmrix/nce/NceTrafficController.java
+++ b/java/src/jmri/jmrix/nce/NceTrafficController.java
@@ -62,10 +62,10 @@ public class NceTrafficController extends AbstractMRTrafficController implements
                 || getUsbSystem() == NceTrafficController.USB_SYSTEM_SB5
                 || getUsbSystem() == NceTrafficController.USB_SYSTEM_TWIN));
 
-        if (NmraPacket.isAccSignalDecoderPkt(packet)
+        if (isUsb && NmraPacket.isAccSignalDecoderPkt(packet)
                 && (NmraPacket.getAccSignalDecoderPktAddress(packet) > 0)
-                && (NmraPacket.getAccSignalDecoderPktAddress(packet) < 2048)) {
-            // intercept only those NMRA signal cmds we can handle with NCE binary commands
+                && (NmraPacket.getAccSignalDecoderPktAddress(packet) <= 2044)) {
+            // intercept NMRA signal cmds to USB systems
             int addr = NmraPacket.getAccSignalDecoderPktAddress(packet);
             int aspect = packet[2];
             log.debug("isAccSignalDecoderPkt(packet) sigAddr ={}, aspect ={}", addr, aspect);
@@ -164,6 +164,25 @@ public class NceTrafficController extends AbstractMRTrafficController implements
 
     private int commandOptions = OPTION_2006;
     public boolean commandOptionSet = false;
+    private boolean pwrProVer060203orLater = false;
+
+    /**
+     * Ask whether Power Pro firmware version is 6.2.3 or later.
+     *
+     * @return {@code true} if it does, otherwise {@code false}
+     */
+    public boolean isPwrProVer060203orLater() {
+        return pwrProVer060203orLater;
+    }
+
+    /**
+     * Specify whether Power Pro firmware version is 6.2.3 or later.
+     *
+     * @param isTrue {@code true} if it does, otherwise {@code false}
+     */
+    public void setPwrProVer060203orLater(boolean isTrue) {
+        pwrProVer060203orLater = isTrue;
+    }
 
     /**
      * Control which command format should be used for various commands: ASCII

--- a/java/src/jmri/jmrix/nce/simulator/Bundle.java
+++ b/java/src/jmri/jmrix/nce/simulator/Bundle.java
@@ -1,0 +1,98 @@
+package jmri.jmrix.nce.simulator;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Locale;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.jmrix.nce.Bundle {
+
+    @CheckForNull
+    private static final String name = null; // No local resources
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    @CheckForNull
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/test/jmri/jmrix/nce/NceConnectionStatusTest.java
+++ b/java/test/jmri/jmrix/nce/NceConnectionStatusTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.*;
 /**
  *
  * @author Paul Bender Copyright (C) 2017
+ * @author Dave Heap Copyright (C) 2021
  */
 public class NceConnectionStatusTest {
 
@@ -16,7 +17,59 @@ public class NceConnectionStatusTest {
     @Test
     public void testCTor() {
         NceConnectionStatus t = new NceConnectionStatus(tcis);
-        Assert.assertNotNull("exists",t);
+        Assert.assertNotNull("exists", t);
+    }
+
+    @Test
+    public void testPowerProVer2007() {
+        NceConnectionStatus t = new NceConnectionStatus(tcis);
+        Assert.assertNotNull("exists", t);
+        NceReply x = new NceReply(tcis);
+        x.setBinary(true);
+        x.setElement(0, 6);
+        x.setElement(1, 2);
+        x.setElement(2, 0);
+        t.reply(x);
+        Assert.assertFalse("Expected isPwrProVer060203orLater to be false", tcis.isPwrProVer060203orLater());
+    }
+
+    @Test
+    public void testPowerProVer2007a() {
+        NceConnectionStatus t = new NceConnectionStatus(tcis);
+        Assert.assertNotNull("exists", t);
+        NceReply x = new NceReply(tcis);
+        x.setBinary(true);
+        x.setElement(0, 6);
+        x.setElement(1, 2);
+        x.setElement(2, 1);
+        t.reply(x);
+        Assert.assertFalse("Expected isPwrProVer060203orLater to be false", tcis.isPwrProVer060203orLater());
+    }
+
+    @Test
+    public void testPowerProVer2008to2011() {
+        NceConnectionStatus t = new NceConnectionStatus(tcis);
+        Assert.assertNotNull("exists", t);
+        NceReply x = new NceReply(tcis);
+        x.setBinary(true);
+        x.setElement(0, 6);
+        x.setElement(1, 2);
+        x.setElement(2, 2);
+        t.reply(x);
+        Assert.assertFalse("Expected isPwrProVer060203orLater to be false", tcis.isPwrProVer060203orLater());
+    }
+
+    @Test
+    public void testPowerProVer2021() {
+        NceConnectionStatus t = new NceConnectionStatus(tcis);
+        Assert.assertNotNull("exists", t);
+        NceReply x = new NceReply(tcis);
+        x.setBinary(true);
+        x.setElement(0, 6);
+        x.setElement(1, 2);
+        x.setElement(2, 3);
+        t.reply(x);
+        Assert.assertTrue("Expected isPwrProVer060203orLater to be true", tcis.isPwrProVer060203orLater());
     }
 
     @BeforeEach
@@ -32,5 +85,4 @@ public class NceConnectionStatusTest {
     }
 
     // private final static Logger log = LoggerFactory.getLogger(NceConnectionStatusTest.class);
-
 }


### PR DESCRIPTION
- Detects new NCE Power Pro firmware and if fitted enables Program Track Writes for CVs>256.
- New Simulator option to emulate various firmware versions.

Branched from [release-4.23.5](https://github.com/JMRI/JMRI/tree/release-4.23.5)