### PR TITLE
Convert ActivateTrainFrame to JmriJFrame base

### DIFF
--- a/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.dispatcher;
 
+import java.awt.Container;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -17,6 +18,7 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import javax.swing.JMenuBar;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
@@ -63,9 +65,10 @@ import jmri.util.swing.JComboBoxUtil;
  *
  * @author Dave Duchamp Copyright (C) 2009
  */
-public class ActivateTrainFrame {
+public class ActivateTrainFrame extends JmriJFrame {
 
     public ActivateTrainFrame(DispatcherFrame d) {
+        super(true,true);
         _dispatcher = d;
         _tiFile = new TrainInfoFile();
     }
@@ -82,7 +85,7 @@ public class ActivateTrainFrame {
     private Transit selectedTransit = null;
     //private String selectedTrain = "";
     private JmriJFrame initiateFrame = null;
-    private JPanel initiatePane = null;
+    private Container initiatePane = null;
     private final jmri.swing.NamedBeanComboBox<Transit> transitSelectBox = new jmri.swing.NamedBeanComboBox<>(_TransitManager);
     private final JLabel trainBoxLabel = new JLabel("     " + Bundle.getMessage("TrainBoxLabel") + ":");
     private final JComboBox<Object> trainSelectBox = new JComboBox<>();
@@ -200,10 +203,10 @@ public class ActivateTrainFrame {
         _ActiveTrainsList = _dispatcher.getActiveTrainsList();
         // create window if needed
         if (initiateFrame == null) {
-            initiateFrame = new JmriJFrame(Bundle.getMessage("AddTrainTitle"), false, true);
+            initiateFrame = this;
+            initiateFrame.setTitle(Bundle.getMessage("AddTrainTitle"));
             initiateFrame.addHelpMenu("package.jmri.jmrit.dispatcher.NewTrain", true);
-
-            initiatePane = new JPanel();
+            initiatePane = initiateFrame.getContentPane();
             initiatePane.setLayout(new BoxLayout(initiatePane, BoxLayout.Y_AXIS));
 
             // add buttons to load and save train information
@@ -766,9 +769,6 @@ public class ActivateTrainFrame {
     }
 
     private void cancelInitiateTrain(ActionEvent e) {
-        initiateFrame.setVisible(false);
-        initiateFrame.dispose();  // prevent this window from being listed in the Window menu.
-        initiateFrame = null;
         _dispatcher.newTrainDone(null);
     }
 
@@ -943,9 +943,6 @@ public class ActivateTrainFrame {
             _dispatcher.getAutoTrainsFrame().addAutoActiveTrain(aat);
         }
         _dispatcher.allocateNewActiveTrain(at);
-        initiateFrame.setVisible(false);
-        initiateFrame.dispose();  // prevent this window from being listed in the Window menu.
-        initiateFrame = null;
         _dispatcher.newTrainDone(at);
     }
 

--- a/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.dispatcher;
 
-import java.beans.PropertyChangeEvent;
 import java.util.ArrayList;
 import java.util.List;
 import jmri.Block;

--- a/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
@@ -482,10 +482,10 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
                 @Override
                 public void actionPerformed(ActionEvent e) {
                     if (!newTrainActive) {
-                        atFrame.initiateTrain(e);
+                        getActiveTrainFrame().initiateTrain(e);
                         newTrainActive = true;
                     } else {
-                        atFrame.showActivateFrame();
+                        getActiveTrainFrame().showActivateFrame();
                     }
                 }
             });
@@ -508,11 +508,11 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
                     if (!newTrainActive) {
                         cancelRestart(e);
                     } else if (restartingTrainsList.size() > 0) {
-                        atFrame.showActivateFrame();
+                        getActiveTrainFrame().showActivateFrame();
                         JOptionPane.showMessageDialog(dispatcherFrame, Bundle.getMessage("Message2"),
                                 Bundle.getMessage("MessageTitle"), JOptionPane.INFORMATION_MESSAGE);
                     } else {
-                        atFrame.showActivateFrame();
+                        getActiveTrainFrame().showActivateFrame();
                     }
                 }
             });
@@ -525,11 +525,11 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
                     if (!newTrainActive) {
                         terminateTrain(e);
                     } else if (activeTrainsList.size() > 0) {
-                        atFrame.showActivateFrame();
+                        getActiveTrainFrame().showActivateFrame();
                         JOptionPane.showMessageDialog(dispatcherFrame, Bundle.getMessage("Message1"),
                                 Bundle.getMessage("MessageTitle"), JOptionPane.INFORMATION_MESSAGE);
                     } else {
-                        atFrame.showActivateFrame();
+                        getActiveTrainFrame().showActivateFrame();
                     }
                 }
             });
@@ -2716,6 +2716,11 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
             else if (at.getDelayedRestart() == ActiveTrain.TIMEDDELAY) {
                 fastClockWarn(false);
             }
+        }
+        if (atFrame != null) {
+            atFrame.setVisible(false);
+            atFrame.dispose();
+            atFrame = null;
         }
         newTrainActive = false;
     }

--- a/java/src/jmri/jmrit/dispatcher/OptionsFile.java
+++ b/java/src/jmri/jmrit/dispatcher/OptionsFile.java
@@ -10,7 +10,6 @@ import jmri.configurexml.AbstractXmlAdapter.EnumIoNamesNumbers;
 import jmri.jmrit.dispatcher.DispatcherFrame.TrainsFrom;
 import jmri.jmrit.display.EditorManager;
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
-import jmri.jmrit.display.layoutEditor.LayoutTurnout;
 import jmri.util.FileUtil;
 import org.jdom2.Document;
 import org.jdom2.Element;


### PR DESCRIPTION
And remove unused imports.
This fixes the issue reported in jmri-users concerning multiple error messages.
