### PR TITLE
Add check to ensure an action/expression doesn't belong to two different ConditionalNGs.

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -362,6 +362,7 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
                 InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class);
         java.util.List<String> errors = new ArrayList<>();
         if (!logixNG_Manager.setupAllLogixNGs(errors)) {
+            for (String s : errors) log.error(s);
             JOptionPane.showMessageDialog(this,
                     String.join("<br>", errors),
                     Bundle.getMessage("TitleError"),

--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -364,7 +364,7 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         if (!logixNG_Manager.setupAllLogixNGs(errors)) {
             for (String s : errors) log.error(s);
             JOptionPane.showMessageDialog(this,
-                    String.join("<br>", errors),
+                    "<html>"+String.join("<br>", errors)+"</html>",
                     Bundle.getMessage("TitleError"),
                     JOptionPane.ERROR_MESSAGE);
         }

--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -3,14 +3,14 @@ package apps;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.awt.*;
+import java.awt.List;
 import java.awt.event.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.net.*;
-import java.util.EventObject;
-import java.util.Locale;
+import java.util.*;
 
 import javax.swing.*;
 import javax.swing.text.DefaultEditorKit;
@@ -360,7 +360,13 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         
         jmri.jmrit.logixng.LogixNG_Manager logixNG_Manager =
                 InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class);
-        logixNG_Manager.setupAllLogixNGs();
+        java.util.List<String> errors = new ArrayList<>();
+        if (!logixNG_Manager.setupAllLogixNGs(errors)) {
+            JOptionPane.showMessageDialog(this,
+                    String.join("<br>", errors),
+                    Bundle.getMessage("TitleError"),
+                    JOptionPane.ERROR_MESSAGE);
+        }
         if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()) {
             logixNG_Manager.activateAllLogixNGs();
         }

--- a/java/src/apps/AppsBase.java
+++ b/java/src/apps/AppsBase.java
@@ -6,7 +6,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 
+import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
 import jmri.*;
@@ -116,7 +118,13 @@ public abstract class AppsBase {
         
         jmri.jmrit.logixng.LogixNG_Manager logixNG_Manager =
                 InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class);
-        logixNG_Manager.setupAllLogixNGs();
+        java.util.List<String> errors = new ArrayList<>();
+        if (!logixNG_Manager.setupAllLogixNGs(errors)) {
+            JOptionPane.showMessageDialog(null,
+                    String.join("<br>", errors),
+                    Bundle.getMessage("TitleError"),
+                    JOptionPane.ERROR_MESSAGE);
+        }
         if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()) {
             logixNG_Manager.activateAllLogixNGs();
         }

--- a/java/src/apps/AppsBase.java
+++ b/java/src/apps/AppsBase.java
@@ -120,6 +120,7 @@ public abstract class AppsBase {
                 InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class);
         java.util.List<String> errors = new ArrayList<>();
         if (!logixNG_Manager.setupAllLogixNGs(errors)) {
+            for (String s : errors) log.error(s);
             JOptionPane.showMessageDialog(null,
                     String.join("<br>", errors),
                     Bundle.getMessage("TitleError"),

--- a/java/src/apps/AppsBase.java
+++ b/java/src/apps/AppsBase.java
@@ -122,7 +122,7 @@ public abstract class AppsBase {
         if (!logixNG_Manager.setupAllLogixNGs(errors)) {
             for (String s : errors) log.error(s);
             JOptionPane.showMessageDialog(null,
-                    String.join("<br>", errors),
+                    "<html>"+String.join("<br>", errors)+"</html>",
                     Bundle.getMessage("TitleError"),
                     JOptionPane.ERROR_MESSAGE);
         }

--- a/java/src/apps/AppsBundle.properties
+++ b/java/src/apps/AppsBundle.properties
@@ -38,6 +38,8 @@ TitleContext = JMRI Context
 TitleUpdate = Check for Updates
 TitleConsole = JMRI System Console
 
+TitleError   = Error
+
 ButtonQuit = Quit
 ButtonCopyClip = Copy to clipboard
 ButtonClose = Close

--- a/java/src/jmri/configurexml/LoadXmlConfigAction.java
+++ b/java/src/jmri/configurexml/LoadXmlConfigAction.java
@@ -1,5 +1,7 @@
 package jmri.configurexml;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.awt.event.ActionEvent;
 
@@ -74,7 +76,10 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
                         
                         jmri.jmrit.logixng.LogixNG_Manager logixNG_Manager =
                                 InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class);
-                        logixNG_Manager.setupAllLogixNGs();
+                        List<String> errors = new ArrayList<>();
+                        if (! logixNG_Manager.setupAllLogixNGs(errors)) {
+                            for (String s : errors) log.error(s);
+                        }
                         if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()) {
                             logixNG_Manager.activateAllLogixNGs();
                         }

--- a/java/src/jmri/configurexml/LoadXmlConfigAction.java
+++ b/java/src/jmri/configurexml/LoadXmlConfigAction.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.awt.event.ActionEvent;
 
 import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
 
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
@@ -79,6 +80,10 @@ public class LoadXmlConfigAction extends LoadStoreBaseAction {
                         List<String> errors = new ArrayList<>();
                         if (! logixNG_Manager.setupAllLogixNGs(errors)) {
                             for (String s : errors) log.error(s);
+                            JOptionPane.showMessageDialog(null,
+                                    String.join("<br>", errors),
+                                    Bundle.getMessage("TitleError"),
+                                    JOptionPane.ERROR_MESSAGE);
                         }
                         if (InstanceManager.getDefault(LogixNGPreferences.class).getStartLogixNGOnStartup()) {
                             logixNG_Manager.activateAllLogixNGs();

--- a/java/src/jmri/jmrit/logixng/Base.java
+++ b/java/src/jmri/jmrit/logixng/Base.java
@@ -282,8 +282,10 @@ public interface Base extends PropertyChangeProvider {
 
     /**
      * Set the parent for all the children.
+     * @param errors a list of potential errors
+     * @return true if success, false otherwise
      */
-    public void setParentForAllChildren();
+    public boolean setParentForAllChildren(List<String> errors);
 
     /**
      * Get a child of this item

--- a/java/src/jmri/jmrit/logixng/Base.java
+++ b/java/src/jmri/jmrit/logixng/Base.java
@@ -282,6 +282,7 @@ public interface Base extends PropertyChangeProvider {
 
     /**
      * Set the parent for all the children.
+     * 
      * @param errors a list of potential errors
      * @return true if success, false otherwise
      */

--- a/java/src/jmri/jmrit/logixng/Clipboard.java
+++ b/java/src/jmri/jmrit/logixng/Clipboard.java
@@ -22,6 +22,8 @@ public interface Clipboard {
      * The last added item is on the top of the clipboard.
      * 
      * @param maleSocket the item to add on the clipboard
+     * @param errors a list of potential errors
+     * @return true if success, false otherwise
      */
     public boolean add(MaleSocket maleSocket, List<String> errors);
     

--- a/java/src/jmri/jmrit/logixng/Clipboard.java
+++ b/java/src/jmri/jmrit/logixng/Clipboard.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng;
 
+import java.util.List;
+
 /**
  * The clipboard with actions and expressions
  * 
@@ -21,7 +23,7 @@ public interface Clipboard {
      * 
      * @param maleSocket the item to add on the clipboard
      */
-    public void add(MaleSocket maleSocket);
+    public boolean add(MaleSocket maleSocket, List<String> errors);
     
     /**
      * Get the top item on the clipboard and remove it from the clipboard.

--- a/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
+++ b/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
@@ -65,12 +65,18 @@ public interface LogixNG_Manager extends Manager<LogixNG> {
      * <P>
      * This method ensures that everything in the LogixNG tree has a pointer
      * to its parent.
+     * 
+     * @param errors a list of potential errors
+     * @return true if success, false otherwise
      */
     public boolean resolveAllTrees(List<String> errors);
 
     /**
      * Setup all LogixNGs. This method is called after a configuration file is
      * loaded.
+     * 
+     * @param errors a list of potential errors
+     * @return true if success, false otherwise
      */
     public boolean setupAllLogixNGs(List<String> errors);
 

--- a/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
+++ b/java/src/jmri/jmrit/logixng/LogixNG_Manager.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.logixng;
 
 import java.io.PrintWriter;
+import java.util.List;
 import java.util.Locale;
 
 import jmri.Manager;
@@ -65,13 +66,13 @@ public interface LogixNG_Manager extends Manager<LogixNG> {
      * This method ensures that everything in the LogixNG tree has a pointer
      * to its parent.
      */
-    public void resolveAllTrees();
+    public boolean resolveAllTrees(List<String> errors);
 
     /**
      * Setup all LogixNGs. This method is called after a configuration file is
      * loaded.
      */
-    public void setupAllLogixNGs();
+    public boolean setupAllLogixNGs(List<String> errors);
 
     /**
      * Activate all LogixNGs, starts LogixNG processing by connecting all

--- a/java/src/jmri/jmrit/logixng/ModuleManager.java
+++ b/java/src/jmri/jmrit/logixng/ModuleManager.java
@@ -68,6 +68,9 @@ public interface ModuleManager extends Manager<Module> {
      * <P>
      * This method ensures that everything in the Module tree has a pointer
      * to its parent.
+     * 
+     * @param errors a list of potential errors
+     * @return true if success, false otherwise
      */
     public boolean resolveAllTrees(List<String> errors);
 

--- a/java/src/jmri/jmrit/logixng/ModuleManager.java
+++ b/java/src/jmri/jmrit/logixng/ModuleManager.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.logixng;
 
 import java.io.PrintWriter;
+import java.util.List;
 import java.util.Locale;
 
 import jmri.Manager;
@@ -68,7 +69,7 @@ public interface ModuleManager extends Manager<Module> {
      * This method ensures that everything in the Module tree has a pointer
      * to its parent.
      */
-    public void resolveAllTrees();
+    public boolean resolveAllTrees(List<String> errors);
 
     /**
      * Setup all Modules. This method is called after a configuration file is

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractBase.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractBase.java
@@ -87,12 +87,17 @@ public abstract class AbstractBase
                 MaleSocket connectedSocket = femaleSocket.getConnectedSocket();
                 if ((connectedSocket.getParent() != null)
                         && (connectedSocket.getParent() != femaleSocket)) {
+                    errors.add(String.format(
+                            "The child %s already has the parent %s so it cannot be added to %s",
+                            connectedSocket.getSystemName(),
+                            connectedSocket.getParent().getSystemName(),
+                            getSystemName()));
                     log.error("The child {} already has the parent {} so it cannot be added to {}",
                             connectedSocket.getSystemName(),
                             connectedSocket.getParent().getSystemName(),
                             getSystemName());
                     femaleSocket.disconnect();
-                    throw new RuntimeException("Child already has a parent: "+connectedSocket.getLongDescription());
+                    result = false;
                 } else {
                     connectedSocket.setParent(femaleSocket);
                     result = result && connectedSocket.setParentForAllChildren(errors);

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractFemaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractFemaleSocket.java
@@ -63,11 +63,12 @@ public abstract class AbstractFemaleSocket implements FemaleSocket {
 
     /** {@inheritDoc} */
     @Override
-    public void setParentForAllChildren() {
+    public boolean setParentForAllChildren(List<String> errors) {
         if (isConnected()) {
             getConnectedSocket().setParent(this);
-            getConnectedSocket().setParentForAllChildren();
+            return getConnectedSocket().setParentForAllChildren(errors);
         }
+        return true;
     }
 
     /** {@inheritDoc} */
@@ -300,7 +301,7 @@ public abstract class AbstractFemaleSocket implements FemaleSocket {
     /** {@inheritDoc} */
     @Override
     public String getSystemName() {
-        throw new UnsupportedOperationException("Not supported.");
+        return getParent().getSystemName();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
@@ -275,16 +275,18 @@ public abstract class AbstractMaleSocket implements MaleSocket {
 
     /** {@inheritDoc} */
     @Override
-    public final void setParentForAllChildren() {
+    public final boolean setParentForAllChildren(List<String> errors) {
+        boolean result = true;
         for (int i=0; i < getChildCount(); i++) {
             FemaleSocket femaleSocket = getChild(i);
             femaleSocket.setParent(this);
             if (femaleSocket.isConnected()) {
                 MaleSocket connectedSocket = femaleSocket.getConnectedSocket();
                 connectedSocket.setParent(femaleSocket);
-                connectedSocket.setParentForAllChildren();
+                result = result && connectedSocket.setParentForAllChildren(errors);
             }
         }
+        return result;
     }
 
     /**

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
@@ -39,7 +39,9 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
             // This should never happen
             throw new RuntimeException("Program error", ex);
         }
-        _femaleSocket.setParentForAllChildren();
+        if (!_femaleSocket.setParentForAllChildren(new ArrayList<>())) {
+            throw new RuntimeException("Failed to set parent for all children");
+        }
         _clipboardItems.setParent(_femaleSocket.getConnectedSocket());
     }
     
@@ -49,11 +51,11 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
     }
 
     @Override
-    public void add(MaleSocket maleSocket) {
+    public boolean add(MaleSocket maleSocket, List<String> errors) {
         _clipboardItems.ensureFreeSocketAtTop();
         try {
             _clipboardItems.getChild(0).connect(maleSocket);
-            _clipboardItems.setParentForAllChildren();
+            return _clipboardItems.setParentForAllChildren(errors);
         } catch (SocketAlreadyConnectedException ex) {
             throw new RuntimeException("Cannot add socket", ex);
         }
@@ -105,7 +107,7 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
         _clipboardItems.setup();
     }
     
-    public void replaceClipboardItems(ClipboardMany clipboardItems) {
+    public boolean replaceClipboardItems(ClipboardMany clipboardItems, List<String> errors) {
         _clipboardItems = clipboardItems;
         
         _femaleSocket.disconnect();
@@ -116,8 +118,9 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
             // This should never happen
             throw new RuntimeException("Program error", ex);
         }
-        _femaleSocket.setParentForAllChildren();
+        boolean result = _femaleSocket.setParentForAllChildren(errors);
         _clipboardItems.setParent(_femaleSocket.getConnectedSocket());
+        return result;
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNG.java
@@ -314,13 +314,15 @@ public class DefaultLogixNG extends AbstractNamedBean
 
     /** {@inheritDoc} */
     @Override
-    public void setParentForAllChildren() {
+    public boolean setParentForAllChildren(List<String> errors) {
+        boolean result = true;
         for (ConditionalNG_Entry entry : _conditionalNG_Entries) {
             if (entry._conditionalNG != null) {
                 entry._conditionalNG.setParent(this);
-                entry._conditionalNG.setParentForAllChildren();
+                result = result && entry._conditionalNG.setParentForAllChildren(errors);
             }
         }
+        return result;
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
@@ -132,24 +132,28 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
 
     /** {@inheritDoc} */
     @Override
-    public void resolveAllTrees() {
+    public boolean resolveAllTrees(List<String> errors) {
+        boolean result = true;
         for (LogixNG logixNG : _tsys.values()) {
-            logixNG.setParentForAllChildren();
+            result = result && logixNG.setParentForAllChildren(errors);
         }
+        return result;
     }
     
     /** {@inheritDoc} */
     @Override
-    public void setupAllLogixNGs() {
+    public boolean setupAllLogixNGs(List<String> errors) {
+        boolean result = true;
         for (LogixNG logixNG : _tsys.values()) {
             logixNG.setup();
-            logixNG.setParentForAllChildren();
+            result = result && logixNG.setParentForAllChildren(errors);
         }
         for (Module module : InstanceManager.getDefault(ModuleManager.class).getNamedBeanSet()) {
             module.setup();
-            module.setParentForAllChildren();
+            result = result && module.setParentForAllChildren(errors);
         }
         _clipboard.setup();
+        return result;
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultModuleManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultModuleManager.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.logixng.implementation;
 
 import java.io.PrintWriter;
+import java.util.List;
 import java.util.Locale;
 
 import jmri.InstanceManager;
@@ -118,10 +119,12 @@ public class DefaultModuleManager extends AbstractManager<Module>
 
     /** {@inheritDoc} */
     @Override
-    public void resolveAllTrees() {
+    public boolean resolveAllTrees(List<String> errors) {
+        boolean result = true;
         for (Module logixNG_Module : _tsys.values()) {
-            logixNG_Module.setParentForAllChildren();
+            result = result && logixNG_Module.setParentForAllChildren(errors);
         }
+        return result;
     }
     
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultLogixNGManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultLogixNGManagerXml.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.implementation.configurexml;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.List;
 
 import jmri.ConfigureManager;
@@ -270,7 +271,10 @@ public class DefaultLogixNGManagerXml extends jmri.managers.configurexml.Abstrac
 
             LogixNG_Manager tm = InstanceManager.getDefault(jmri.jmrit.logixng.LogixNG_Manager.class);
             ClipboardMany anyMany = ((ClipboardManyXml)o).loadItem(clipboardList.get(0));
-            ((DefaultClipboard)tm.getClipboard()).replaceClipboardItems(anyMany);
+            List<String> errors = new ArrayList<>();
+            if (! ((DefaultClipboard)tm.getClipboard()).replaceClipboardItems(anyMany, errors)) {
+                for (String s : errors) log.error(s);
+            }
         } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
             log.error("cannot create object", ex);
         }

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
@@ -19,6 +19,7 @@ ButtonFirst = First
 ButtonNext = Next
 ReorderMessage = Please press First, then Next, Next, ... in desired order.
 
+TitleError                  = Error
 TitleStartupSettingsPanel   = Startup
 TitlePluginClassesPanel     = Plugin Classes
 TitleTimeDiagramColorsPanel = Time Diagram Colors

--- a/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
@@ -1494,7 +1494,13 @@ public class TreeEditor extends TreeViewer {
                                 () -> {
                             Clipboard clipboard =
                                     InstanceManager.getDefault(LogixNG_Manager.class).getClipboard();
-                            clipboard.add(_currentFemaleSocket.getConnectedSocket());
+                            List<String> errors = new ArrayList<>();
+                            if (!clipboard.add(_currentFemaleSocket.getConnectedSocket(), errors)) {
+                                JOptionPane.showMessageDialog(this,
+                                        String.join("<br>", errors),
+                                        Bundle.getMessage("TitleError"),
+                                        JOptionPane.ERROR_MESSAGE);
+                            }
                             _currentFemaleSocket.disconnect();
                             ThreadingUtil.runOnGUIEventually(() -> {
                                 _treePane._femaleRootSocket.registerListeners();
@@ -1518,7 +1524,15 @@ public class TreeEditor extends TreeViewer {
                             Map<String, String> systemNames = new HashMap<>();
                             Map<String, String> userNames = new HashMap<>();
                             try {
-                                clipboard.add((MaleSocket) _currentFemaleSocket.getConnectedSocket().getDeepCopy(systemNames, userNames));
+                                List<String> errors = new ArrayList<>();
+                                if (!clipboard.add(
+                                        (MaleSocket) _currentFemaleSocket.getConnectedSocket().getDeepCopy(systemNames, userNames),
+                                        errors)) {
+                                    JOptionPane.showMessageDialog(this,
+                                            String.join("<br>", errors),
+                                            Bundle.getMessage("TitleError"),
+                                            JOptionPane.ERROR_MESSAGE);
+                                }
                             } catch (JmriException ex) {
                                 log.error("getDeepCopy thrown exception: {}", ex, ex);
                                 ThreadingUtil.runOnGUIEventually(() -> {
@@ -1547,7 +1561,13 @@ public class TreeEditor extends TreeViewer {
                                     InstanceManager.getDefault(LogixNG_Manager.class).getClipboard();
                             try {
                                 _currentFemaleSocket.connect(clipboard.fetchTopItem());
-                                _currentFemaleSocket.setParentForAllChildren();
+                                List<String> errors = new ArrayList<>();
+                                if (!_currentFemaleSocket.setParentForAllChildren(errors)) {
+                                    JOptionPane.showMessageDialog(this,
+                                            String.join("<br>", errors),
+                                            Bundle.getMessage("TitleError"),
+                                            JOptionPane.ERROR_MESSAGE);
+                                }
                             } catch (SocketAlreadyConnectedException ex) {
                                 log.error("item cannot be connected", ex);
                             }

--- a/java/test/jmri/jmrit/display/logixng/ActionPositionableTest.java
+++ b/java/test/jmri/jmrit/display/logixng/ActionPositionableTest.java
@@ -554,7 +554,7 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         _base = actionPositionable;
         _baseMaleSocket = socket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/display/logixng/ActionPositionableTest.java
+++ b/java/test/jmri/jmrit/display/logixng/ActionPositionableTest.java
@@ -6,6 +6,7 @@ import jmri.jmrit.logixng.actions.*;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 
 import jmri.*;
 import jmri.jmrit.display.*;
@@ -553,7 +554,7 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         _base = actionPositionable;
         _baseMaleSocket = socket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/display/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrit/display/logixng/configurexml/StoreAndLoadTest.java
@@ -219,8 +219,8 @@ public class StoreAndLoadTest {
             results = cm.load(secondFile);
             log.debug(results ? "load was successful" : "store failed");
             if (results) {
-                logixNG_Manager.resolveAllTrees();
-                logixNG_Manager.setupAllLogixNGs();
+                if (! logixNG_Manager.resolveAllTrees(new ArrayList())) throw new RuntimeException();
+                if (! logixNG_Manager.setupAllLogixNGs(new ArrayList())) throw new RuntimeException();
 
                 stringWriter = new StringWriter();
                 printWriter = new PrintWriter(stringWriter);

--- a/java/test/jmri/jmrit/display/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrit/display/logixng/configurexml/StoreAndLoadTest.java
@@ -219,8 +219,8 @@ public class StoreAndLoadTest {
             results = cm.load(secondFile);
             log.debug(results ? "load was successful" : "store failed");
             if (results) {
-                if (! logixNG_Manager.resolveAllTrees(new ArrayList())) throw new RuntimeException();
-                if (! logixNG_Manager.setupAllLogixNGs(new ArrayList())) throw new RuntimeException();
+                if (! logixNG_Manager.resolveAllTrees(new ArrayList<>())) throw new RuntimeException();
+                if (! logixNG_Manager.setupAllLogixNGs(new ArrayList<>())) throw new RuntimeException();
 
                 stringWriter = new StringWriter();
                 printWriter = new PrintWriter(stringWriter);

--- a/java/test/jmri/jmrit/logixng/AbstractBaseTestBase.java
+++ b/java/test/jmri/jmrit/logixng/AbstractBaseTestBase.java
@@ -136,6 +136,13 @@ public abstract class AbstractBaseTestBase {
         Assert.assertTrue("Parent of _base is _baseMaleSocket", _base.getParent() == getLastMaleSocket(_baseMaleSocket));
     }
     
+    @Test
+    public void testFemaleSocketSystemName() {
+        for (int i=0; i < _base.getChildCount(); i++) {
+            Assert.assertEquals(_base.getSystemName(), _base.getChild(i).getSystemName());
+        }
+    }
+    
     /*.*
      * Set parent to null for all children to item, and their children.
      *./

--- a/java/test/jmri/jmrit/logixng/FemaleSocketTestBase.java
+++ b/java/test/jmri/jmrit/logixng/FemaleSocketTestBase.java
@@ -255,10 +255,10 @@ public abstract class FemaleSocketTestBase {
     @Test
     public void testSetParentForAllChildren() throws SocketAlreadyConnectedException {
         Assert.assertFalse("femaleSocket is not connected", _femaleSocket.isConnected());
-        if (! _femaleSocket.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! _femaleSocket.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         Assert.assertNull("malesocket.getParent() is null", maleSocket.getParent());
         _femaleSocket.connect(maleSocket);
-        if (! _femaleSocket.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! _femaleSocket.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         Assert.assertEquals("malesocket.getParent() is femaleSocket", _femaleSocket, maleSocket.getParent());
     }
 

--- a/java/test/jmri/jmrit/logixng/FemaleSocketTestBase.java
+++ b/java/test/jmri/jmrit/logixng/FemaleSocketTestBase.java
@@ -255,10 +255,10 @@ public abstract class FemaleSocketTestBase {
     @Test
     public void testSetParentForAllChildren() throws SocketAlreadyConnectedException {
         Assert.assertFalse("femaleSocket is not connected", _femaleSocket.isConnected());
-        _femaleSocket.setParentForAllChildren();
+        if (! _femaleSocket.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         Assert.assertNull("malesocket.getParent() is null", maleSocket.getParent());
         _femaleSocket.connect(maleSocket);
-        _femaleSocket.setParentForAllChildren();
+        if (! _femaleSocket.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         Assert.assertEquals("malesocket.getParent() is femaleSocket", _femaleSocket, maleSocket.getParent());
     }
 
@@ -446,15 +446,6 @@ public abstract class FemaleSocketTestBase {
             errorFlag.set(true);
         }
         Assert.assertTrue("method not supported", errorFlag.get());
-
-        errorFlag.set(false);
-        try {
-            _femaleSocket.getSystemName();
-        } catch (UnsupportedOperationException ex) {
-            errorFlag.set(true);
-        }
-        Assert.assertTrue("method not supported", errorFlag.get());
-
     }
 
     @Test
@@ -595,7 +586,7 @@ public abstract class FemaleSocketTestBase {
         }
 
         @Override
-        public void setParentForAllChildren() {
+        public boolean setParentForAllChildren(List<String> errors) {
             throw new UnsupportedOperationException("Not supported.");
         }
 

--- a/java/test/jmri/jmrit/logixng/LogixNGTest.java
+++ b/java/test/jmri/jmrit/logixng/LogixNGTest.java
@@ -6,6 +6,7 @@ import jmri.jmrit.logixng.actions.DigitalMany;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Locale;
 
 import jmri.InstanceManager;
@@ -304,7 +305,7 @@ public class LogixNGTest {
         MyConditionalNG conditionalNG_3 = new MyConditionalNG("IQC3", null);
         logixNG.addConditionalNG(conditionalNG_3);
         conditionalNG_3.setEnabled(false);
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
 
         Assert.assertFalse("listeners for conditionalNG_1 are not registered", conditionalNG_1.listenersAreRegistered);
         Assert.assertFalse("listeners for conditionalNG_2 are not registered", conditionalNG_2.listenersAreRegistered);
@@ -465,7 +466,7 @@ public class LogixNGTest {
         MaleSocket digitalActionBean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
         ifThen.getChild(1).connect(digitalActionBean);
 
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
 
         Assert.assertTrue("conditionalng is correct", conditionalNG == digitalActionBean.getConditionalNG());
         Assert.assertTrue("conditionalng is correct", conditionalNG == conditionalNG.getConditionalNG());
@@ -489,7 +490,7 @@ public class LogixNGTest {
         conditionalNG.setSocketSystemName(systemName);
         logixNG.setup();
 
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
 
         Assert.assertTrue("conditionalng child is correct",
                 "Set turnout '' to state Thrown"

--- a/java/test/jmri/jmrit/logixng/LogixNGTest.java
+++ b/java/test/jmri/jmrit/logixng/LogixNGTest.java
@@ -305,7 +305,7 @@ public class LogixNGTest {
         MyConditionalNG conditionalNG_3 = new MyConditionalNG("IQC3", null);
         logixNG.addConditionalNG(conditionalNG_3);
         conditionalNG_3.setEnabled(false);
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
 
         Assert.assertFalse("listeners for conditionalNG_1 are not registered", conditionalNG_1.listenersAreRegistered);
         Assert.assertFalse("listeners for conditionalNG_2 are not registered", conditionalNG_2.listenersAreRegistered);
@@ -466,7 +466,7 @@ public class LogixNGTest {
         MaleSocket digitalActionBean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
         ifThen.getChild(1).connect(digitalActionBean);
 
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
 
         Assert.assertTrue("conditionalng is correct", conditionalNG == digitalActionBean.getConditionalNG());
         Assert.assertTrue("conditionalng is correct", conditionalNG == conditionalNG.getConditionalNG());
@@ -490,7 +490,7 @@ public class LogixNGTest {
         conditionalNG.setSocketSystemName(systemName);
         logixNG.setup();
 
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
 
         Assert.assertTrue("conditionalng child is correct",
                 "Set turnout '' to state Thrown"

--- a/java/test/jmri/jmrit/logixng/RecursiveModuleTest.java
+++ b/java/test/jmri/jmrit/logixng/RecursiveModuleTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng;
 
+import java.util.ArrayList;
+
 import jmri.*;
 import jmri.jmrit.logixng.actions.ActionLocalVariable;
 import jmri.jmrit.logixng.actions.DigitalCallModule;
@@ -239,7 +241,7 @@ public class RecursiveModuleTest {
         System.out.println();
 */        
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
     

--- a/java/test/jmri/jmrit/logixng/RecursiveModuleTest.java
+++ b/java/test/jmri/jmrit/logixng/RecursiveModuleTest.java
@@ -241,7 +241,7 @@ public class RecursiveModuleTest {
         System.out.println();
 */        
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
     

--- a/java/test/jmri/jmrit/logixng/actions/ActionAtomicBooleanTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionAtomicBooleanTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.InstanceManager;
@@ -220,7 +221,7 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
         _base = actionAtomicBoolean;
         _baseMaleSocket = socket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionAtomicBooleanTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionAtomicBooleanTest.java
@@ -221,7 +221,7 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
         _base = actionAtomicBoolean;
         _baseMaleSocket = socket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.actions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 
 import jmri.*;
 import jmri.jmrit.logixng.*;
@@ -544,7 +545,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         _base = actionLight;
         _baseMaleSocket = socket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
@@ -545,7 +545,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         _base = actionLight;
         _baseMaleSocket = socket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
@@ -133,7 +133,7 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
         _base = actionListenOnBeans;
         _baseMaleSocket = socket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
+
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
@@ -131,7 +133,7 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
         _base = actionListenOnBeans;
         _baseMaleSocket = socket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.actions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 
 import jmri.InstanceManager;
 import jmri.JmriException;
@@ -333,7 +334,7 @@ public class ActionMemoryTest extends AbstractDigitalActionTestBase {
         _base = actionMemory;
         _baseMaleSocket = socket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
@@ -334,7 +334,7 @@ public class ActionMemoryTest extends AbstractDigitalActionTestBase {
         _base = actionMemory;
         _baseMaleSocket = socket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
+
 import jmri.InstanceManager;
 import jmri.*;
 import jmri.jmrit.logixng.*;
@@ -337,7 +339,7 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         _base = actionScript;
         _baseMaleSocket = socketActionSimpleScript;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
@@ -339,7 +339,7 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         _base = actionScript;
         _baseMaleSocket = socketActionSimpleScript;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.actions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 
 import jmri.*;
 import jmri.jmrit.logixng.*;
@@ -543,7 +544,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         _base = actionSensor;
         _baseMaleSocket = socket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
@@ -544,7 +544,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         _base = actionSensor;
         _baseMaleSocket = socket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionThrottleTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionThrottleTest.java
@@ -448,7 +448,7 @@ public class ActionThrottleTest extends AbstractDigitalActionTestBase {
         conditionalNG_2.getChild(0).connect(maleSocket2);
 
         logixNG.setEnabled(true);
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
 
         // Test execute when no children are connected
         actionThrottle2.execute();
@@ -589,7 +589,7 @@ public class ActionThrottleTest extends AbstractDigitalActionTestBase {
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionThrottle2);
         conditionalNG_2.getChild(0).connect(maleSocket2);
 
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
 
         int locoAddress = 1234;
         AtomicReference<DccThrottle> myThrottleRef = new AtomicReference<>();
@@ -731,7 +731,7 @@ public class ActionThrottleTest extends AbstractDigitalActionTestBase {
         _base = actionThrottle;
         _baseMaleSocket = maleSocket;
 
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionThrottleTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionThrottleTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
 import jmri.DccThrottle;
@@ -447,7 +448,7 @@ public class ActionThrottleTest extends AbstractDigitalActionTestBase {
         conditionalNG_2.getChild(0).connect(maleSocket2);
 
         logixNG.setEnabled(true);
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
 
         // Test execute when no children are connected
         actionThrottle2.execute();
@@ -588,7 +589,7 @@ public class ActionThrottleTest extends AbstractDigitalActionTestBase {
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionThrottle2);
         conditionalNG_2.getChild(0).connect(maleSocket2);
 
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
 
         int locoAddress = 1234;
         AtomicReference<DccThrottle> myThrottleRef = new AtomicReference<>();
@@ -730,7 +731,7 @@ public class ActionThrottleTest extends AbstractDigitalActionTestBase {
         _base = actionThrottle;
         _baseMaleSocket = maleSocket;
 
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionTimerTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTimerTest.java
@@ -318,7 +318,7 @@ public class ActionTimerTest extends AbstractDigitalActionTestBase {
         _base = _actionTimer;
         _baseMaleSocket = maleSocket;
         
-        if (! _logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! _logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         _logixNG.setEnabled(false);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionTimerTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTimerTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
+
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
@@ -316,7 +318,7 @@ public class ActionTimerTest extends AbstractDigitalActionTestBase {
         _base = _actionTimer;
         _baseMaleSocket = maleSocket;
         
-        _logixNG.setParentForAllChildren();
+        if (! _logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         _logixNG.setEnabled(false);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionTurnoutLockTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTurnoutLockTest.java
@@ -534,7 +534,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         _base = actionTurnoutLock;
         _baseMaleSocket = socket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionTurnoutLockTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTurnoutLockTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.actions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 
 import javax.annotation.Nonnull;
 
@@ -533,7 +534,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         _base = actionTurnoutLock;
         _baseMaleSocket = socket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionTurnoutTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTurnoutTest.java
@@ -544,7 +544,7 @@ public class ActionTurnoutTest extends AbstractDigitalActionTestBase {
         _base = actionTurnout;
         _baseMaleSocket = socket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionTurnoutTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTurnoutTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.actions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 
 import jmri.*;
 import jmri.jmrit.logixng.*;
@@ -543,7 +544,7 @@ public class ActionTurnoutTest extends AbstractDigitalActionTestBase {
         _base = actionTurnout;
         _baseMaleSocket = socket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/AnalogActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AnalogActionMemoryTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.actions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 
 import jmri.*;
 import jmri.jmrit.logixng.*;
@@ -270,7 +271,7 @@ public class AnalogActionMemoryTest extends AbstractAnalogActionTestBase {
         _base = analogActionMemory;
         _baseMaleSocket = maleSocketAnalogActionMemory;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
         
         InstanceManager.getDefault(LogixNG_Manager.class)

--- a/java/test/jmri/jmrit/logixng/actions/AnalogActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AnalogActionMemoryTest.java
@@ -271,7 +271,7 @@ public class AnalogActionMemoryTest extends AbstractAnalogActionTestBase {
         _base = analogActionMemory;
         _baseMaleSocket = maleSocketAnalogActionMemory;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
         
         InstanceManager.getDefault(LogixNG_Manager.class)

--- a/java/test/jmri/jmrit/logixng/actions/AnalogManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AnalogManyTest.java
@@ -351,7 +351,7 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
         _base = action;
         _baseMaleSocket = maleSocket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/AnalogManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AnalogManyTest.java
@@ -351,7 +351,7 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
         _base = action;
         _baseMaleSocket = maleSocket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DigitalBooleanOnChangeTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DigitalBooleanOnChangeTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
+
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.expressions.ExpressionSensor;
@@ -339,7 +341,7 @@ public class DigitalBooleanOnChangeTest extends AbstractDigitalBooleanActionTest
         _base = _actionOnChange;
         _baseMaleSocket = maleSocketActionOnChange;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DigitalBooleanOnChangeTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DigitalBooleanOnChangeTest.java
@@ -341,7 +341,7 @@ public class DigitalBooleanOnChangeTest extends AbstractDigitalBooleanActionTest
         _base = _actionOnChange;
         _baseMaleSocket = maleSocketActionOnChange;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DigitalManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DigitalManyTest.java
@@ -339,7 +339,7 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
         _base = action;
         _baseMaleSocket = maleSocket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DigitalManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DigitalManyTest.java
@@ -339,7 +339,7 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
         _base = action;
         _baseMaleSocket = maleSocket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DoAnalogActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DoAnalogActionTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
+
 import jmri.InstanceManager;
 import jmri.NamedBean;
 import jmri.jmrit.logixng.*;
@@ -296,7 +298,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
         _base = actionDoAnalogAction;
         _baseMaleSocket = maleSocket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DoAnalogActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DoAnalogActionTest.java
@@ -298,7 +298,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
         _base = actionDoAnalogAction;
         _baseMaleSocket = maleSocket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DoStringActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DoStringActionTest.java
@@ -298,7 +298,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
         _base = actionDoStringAction;
         _baseMaleSocket = maleSocket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DoStringActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DoStringActionTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
+
 import jmri.InstanceManager;
 import jmri.NamedBean;
 import jmri.jmrit.logixng.*;
@@ -296,7 +298,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
         _base = actionDoStringAction;
         _baseMaleSocket = maleSocket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
@@ -214,7 +214,7 @@ public class ExecuteDelayedTest extends AbstractDigitalActionTestBase {
         _base = _executeDelayed;
         _baseMaleSocket = maleSocket;
         
-        if (! _logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! _logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         _logixNG.setEnabled(false);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
+
 import jmri.jmrit.logixng.util.TimerUnit;
 import jmri.*;
 import jmri.jmrit.logixng.*;
@@ -212,7 +214,7 @@ public class ExecuteDelayedTest extends AbstractDigitalActionTestBase {
         _base = _executeDelayed;
         _baseMaleSocket = maleSocket;
         
-        _logixNG.setParentForAllChildren();
+        if (! _logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         _logixNG.setEnabled(false);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ForTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ForTest.java
@@ -424,7 +424,7 @@ public class ForTest extends AbstractDigitalActionTestBase {
                 .registerAction(new DigitalMany(
                         InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null)));
         
-        if (! _logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! _logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         _logixNG.setEnabled(false);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ForTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ForTest.java
@@ -424,7 +424,7 @@ public class ForTest extends AbstractDigitalActionTestBase {
                 .registerAction(new DigitalMany(
                         InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null)));
         
-        _logixNG.setParentForAllChildren();
+        if (! _logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         _logixNG.setEnabled(false);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/IfThenElseTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/IfThenElseTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
+
 import jmri.InstanceManager;
 import jmri.NamedBean;
 import jmri.jmrit.logixng.*;
@@ -390,7 +392,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
         _base = actionIfThenElse;
         _baseMaleSocket = maleSocket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/IfThenElseTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/IfThenElseTest.java
@@ -392,7 +392,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
         _base = actionIfThenElse;
         _baseMaleSocket = maleSocket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/LogixTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/LogixTest.java
@@ -324,7 +324,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         _base = actionLogix;
         _baseMaleSocket = maleSocket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/LogixTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/LogixTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
+
 import jmri.jmrit.logixng.expressions.ExpressionSensor;
 import jmri.jmrit.logixng.expressions.ExpressionMemory;
 import jmri.jmrit.logixng.expressions.True;
@@ -322,7 +324,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         _base = actionLogix;
         _baseMaleSocket = maleSocket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ShutdownComputerTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ShutdownComputerTest.java
@@ -166,7 +166,7 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
         _base = actionShutdownComputer;
         _baseMaleSocket = maleSocket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
     

--- a/java/test/jmri/jmrit/logixng/actions/ShutdownComputerTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ShutdownComputerTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions;
 
+import java.util.ArrayList;
+
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
@@ -164,7 +166,7 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
         _base = actionShutdownComputer;
         _baseMaleSocket = maleSocket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
     

--- a/java/test/jmri/jmrit/logixng/actions/StringActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/StringActionMemoryTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.actions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 
 import jmri.InstanceManager;
 import jmri.Memory;
@@ -270,7 +271,7 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
         _base = stringActionMemory;
         _baseMaleSocket = maleSocketStringActionMemory;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/StringActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/StringActionMemoryTest.java
@@ -271,7 +271,7 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
         _base = stringActionMemory;
         _baseMaleSocket = maleSocketStringActionMemory;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/StringManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/StringManyTest.java
@@ -348,7 +348,7 @@ public class StringManyTest extends AbstractStringActionTestBase {
         _base = action;
         _baseMaleSocket = maleSocket;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/StringManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/StringManyTest.java
@@ -348,7 +348,7 @@ public class StringManyTest extends AbstractStringActionTestBase {
         _base = action;
         _baseMaleSocket = maleSocket;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
@@ -291,7 +291,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         _tableForEach.getChild(0).connect(InstanceManager.getDefault(DigitalActionManager.class)
                 .registerAction(new MyAction("IQDA999", null)));
         
-        if (! _logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! _logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         _logixNG.setEnabled(false);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
@@ -291,7 +291,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         _tableForEach.getChild(0).connect(InstanceManager.getDefault(DigitalActionManager.class)
                 .registerAction(new MyAction("IQDA999", null)));
         
-        _logixNG.setParentForAllChildren();
+        if (! _logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         _logixNG.setEnabled(false);
     }
 

--- a/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
@@ -3178,8 +3178,8 @@ public class StoreAndLoadTest {
             results = cm.load(secondFile);
             log.debug(results ? "load was successful" : "store failed");
             if (results) {
-                logixNG_Manager.resolveAllTrees();
-                logixNG_Manager.setupAllLogixNGs();
+                if (! logixNG_Manager.resolveAllTrees(new ArrayList())) throw new RuntimeException();
+                if (! logixNG_Manager.setupAllLogixNGs(new ArrayList())) throw new RuntimeException();
 
                 stringWriter = new StringWriter();
                 printWriter = new PrintWriter(stringWriter);

--- a/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
@@ -3178,8 +3178,8 @@ public class StoreAndLoadTest {
             results = cm.load(secondFile);
             log.debug(results ? "load was successful" : "store failed");
             if (results) {
-                if (! logixNG_Manager.resolveAllTrees(new ArrayList())) throw new RuntimeException();
-                if (! logixNG_Manager.setupAllLogixNGs(new ArrayList())) throw new RuntimeException();
+                if (! logixNG_Manager.resolveAllTrees(new ArrayList<>())) throw new RuntimeException();
+                if (! logixNG_Manager.setupAllLogixNGs(new ArrayList<>())) throw new RuntimeException();
 
                 stringWriter = new StringWriter();
                 printWriter = new PrintWriter(stringWriter);

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionConstantTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionConstantTest.java
@@ -254,7 +254,7 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
         _base = expressionConstant;
         _baseMaleSocket = socketExpression;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionConstantTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionConstantTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.expressions;
 
+import java.util.ArrayList;
 import java.util.Locale;
 
 import jmri.InstanceManager;
@@ -253,7 +254,7 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
         _base = expressionConstant;
         _baseMaleSocket = socketExpression;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionMemoryTest.java
@@ -386,7 +386,7 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         _base = expressionMemory;
         _baseMaleSocket = socketExpression;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionMemoryTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.expressions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 
 import jmri.InstanceManager;
 import jmri.Memory;
@@ -385,7 +386,7 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         _base = expressionMemory;
         _baseMaleSocket = socketExpression;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogFormulaTest.java
@@ -732,7 +732,7 @@ public class AnalogFormulaTest extends AbstractAnalogExpressionTestBase {
         MaleSocket socketAnalogActionMemory = InstanceManager.getDefault(AnalogActionManager.class).registerAction(analogActionMemory);
         doAnalogAction.getChild(1).connect(socketAnalogActionMemory);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogFormulaTest.java
@@ -732,7 +732,7 @@ public class AnalogFormulaTest extends AbstractAnalogExpressionTestBase {
         MaleSocket socketAnalogActionMemory = InstanceManager.getDefault(AnalogActionManager.class).registerAction(analogActionMemory);
         doAnalogAction.getChild(1).connect(socketAnalogActionMemory);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AndTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AndTest.java
@@ -386,7 +386,7 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         _base = expression;
         _baseMaleSocket = maleSocket2;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AndTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AndTest.java
@@ -386,7 +386,7 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         _base = expression;
         _baseMaleSocket = maleSocket2;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AntecedentTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AntecedentTest.java
@@ -708,7 +708,7 @@ public class AntecedentTest extends AbstractDigitalExpressionTestBase implements
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AntecedentTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AntecedentTest.java
@@ -708,7 +708,7 @@ public class AntecedentTest extends AbstractDigitalExpressionTestBase implements
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/DigitalFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/DigitalFormulaTest.java
@@ -732,7 +732,7 @@ public class DigitalFormulaTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/DigitalFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/DigitalFormulaTest.java
@@ -732,7 +732,7 @@ public class DigitalFormulaTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionLightTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionLightTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.expressions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.InstanceManager;
@@ -432,7 +433,7 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         expressionLight.setLight(light);
         light.setCommandedState(Light.ON);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionLightTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionLightTest.java
@@ -433,7 +433,7 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         expressionLight.setLight(light);
         light.setCommandedState(Light.ON);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionLocalVariableTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionLocalVariableTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.expressions;
 
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.*;
@@ -488,7 +489,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         
         expressionLocalVariable.setLocalVariable("myVar");
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionLocalVariableTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionLocalVariableTest.java
@@ -489,7 +489,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         
         expressionLocalVariable.setLocalVariable("myVar");
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
@@ -492,7 +492,7 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         expressionMemory.setMemory(memory);
         memory.setValue("");
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.expressions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.InstanceManager;
@@ -491,7 +492,7 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         expressionMemory.setMemory(memory);
         memory.setValue("");
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionScriptTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionScriptTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.expressions;
 
+import java.util.ArrayList;
+
 import jmri.jmrit.logixng.actions.*;
 import jmri.InstanceManager;
 import jmri.*;
@@ -301,7 +303,7 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         _base = expressionScript;
         _baseMaleSocket = socketExpressionScript;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionScriptTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionScriptTest.java
@@ -303,7 +303,7 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         _base = expressionScript;
         _baseMaleSocket = socketExpressionScript;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionSensorTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionSensorTest.java
@@ -438,7 +438,7 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         expressionSensor.setSensor(sensor);
         sensor.setCommandedState(Sensor.ACTIVE);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionSensorTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionSensorTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.expressions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.InstanceManager;
@@ -437,7 +438,7 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         expressionSensor.setSensor(sensor);
         sensor.setCommandedState(Sensor.ACTIVE);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionTurnoutTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionTurnoutTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.expressions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.InstanceManager;
@@ -437,7 +438,7 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         expressionTurnout.setTurnout(turnout);
         turnout.setCommandedState(Turnout.THROWN);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionTurnoutTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionTurnoutTest.java
@@ -438,7 +438,7 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         expressionTurnout.setTurnout(turnout);
         turnout.setCommandedState(Turnout.THROWN);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/FalseTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/FalseTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.expressions;
 
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.InstanceManager;
@@ -210,7 +211,7 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/FalseTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/FalseTest.java
@@ -211,7 +211,7 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/HoldTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/HoldTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.expressions;
 
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.InstanceManager;
@@ -377,7 +378,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/HoldTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/HoldTest.java
@@ -378,7 +378,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/NotTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/NotTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.expressions;
 
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.InstanceManager;
@@ -312,7 +313,7 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/NotTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/NotTest.java
@@ -313,7 +313,7 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/OrTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/OrTest.java
@@ -387,7 +387,7 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         _base = expressionOr;
         _baseMaleSocket = maleSocket2;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/OrTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/OrTest.java
@@ -387,7 +387,7 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         _base = expressionOr;
         _baseMaleSocket = maleSocket2;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/StringExpressionConstantTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringExpressionConstantTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.expressions;
 
+import java.util.ArrayList;
 import java.util.Locale;
 
 import jmri.InstanceManager;
@@ -268,7 +269,7 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
         _base = expressionConstant;
         _baseMaleSocket = socketExpression;
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/StringExpressionConstantTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringExpressionConstantTest.java
@@ -269,7 +269,7 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
         _base = expressionConstant;
         _baseMaleSocket = socketExpression;
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/StringExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringExpressionMemoryTest.java
@@ -386,7 +386,7 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         MaleSocket socketAction = InstanceManager.getDefault(StringActionManager.class).registerAction(actionMemory);
         maleSocketDoStringAction.getChild(1).connect(socketAction);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/StringExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringExpressionMemoryTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.expressions;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
+import java.util.ArrayList;
 
 import jmri.InstanceManager;
 import jmri.Memory;
@@ -385,7 +386,7 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         MaleSocket socketAction = InstanceManager.getDefault(StringActionManager.class).registerAction(actionMemory);
         maleSocketDoStringAction.getChild(1).connect(socketAction);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/StringFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringFormulaTest.java
@@ -737,7 +737,7 @@ public class StringFormulaTest extends AbstractStringExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(StringActionManager.class).registerAction(stringActionMemory);
         doStringAction.getChild(1).connect(socketAtomicBoolean);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/StringFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringFormulaTest.java
@@ -737,7 +737,7 @@ public class StringFormulaTest extends AbstractStringExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(StringActionManager.class).registerAction(stringActionMemory);
         doStringAction.getChild(1).connect(socketAtomicBoolean);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/TriggerOnceTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/TriggerOnceTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.expressions;
 
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.*;
@@ -321,7 +322,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/TriggerOnceTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/TriggerOnceTest.java
@@ -322,7 +322,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/TrueTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/TrueTest.java
@@ -193,7 +193,7 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/TrueTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/TrueTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logixng.expressions;
 
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.InstanceManager;
@@ -192,7 +193,7 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
         
-        logixNG.setParentForAllChildren();
+        if (! logixNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/implementation/AbstractFemaleSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/AbstractFemaleSocketTest.java
@@ -331,7 +331,7 @@ public class AbstractFemaleSocketTest {
         }
 
         @Override
-        public void setParentForAllChildren() {
+        public boolean setParentForAllChildren(List<String> errors) {
             throw new UnsupportedOperationException("Not supported");
         }
 

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultConditionalNGTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultConditionalNGTest.java
@@ -69,7 +69,7 @@ public class DefaultConditionalNGTest {
         MaleSocket socket = InstanceManager.getDefault(DigitalActionManager.class)
                 .registerAction(action);
         conditionalNG.getChild(0).connect(socket);
-        conditionalNG.setParentForAllChildren();
+        if (! conditionalNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         
         socket.setErrorHandlingType(MaleSocket.ErrorHandlingType.ThrowException);
         

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultConditionalNGTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultConditionalNGTest.java
@@ -69,7 +69,7 @@ public class DefaultConditionalNGTest {
         MaleSocket socket = InstanceManager.getDefault(DigitalActionManager.class)
                 .registerAction(action);
         conditionalNG.getChild(0).connect(socket);
-        if (! conditionalNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! conditionalNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         
         socket.setErrorHandlingType(MaleSocket.ErrorHandlingType.ThrowException);
         

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
@@ -75,7 +75,7 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
         Assert.assertFalse("result is false", ((DefaultFemaleDigitalExpressionSocket)_femaleSocket).evaluate());
         // Test evaluate() when connected
         _femaleSocket.connect(maleSocket);
-        _conditionalNG.setParentForAllChildren();
+        if (! _conditionalNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         Turnout t = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
         _expression.setTurnout(t);
         _expression.setBeanState(ExpressionTurnout.TurnoutState.Thrown);

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocketTest.java
@@ -75,7 +75,7 @@ public class DefaultFemaleDigitalExpressionSocketTest extends FemaleSocketTestBa
         Assert.assertFalse("result is false", ((DefaultFemaleDigitalExpressionSocket)_femaleSocket).evaluate());
         // Test evaluate() when connected
         _femaleSocket.connect(maleSocket);
-        if (! _conditionalNG.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! _conditionalNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         Turnout t = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
         _expression.setTurnout(t);
         _expression.setBeanState(ExpressionTurnout.TurnoutState.Thrown);

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleGenericExpressionSocket1_Test.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleGenericExpressionSocket1_Test.java
@@ -1,7 +1,8 @@
 package jmri.jmrit.logixng.implementation;
 
-import java.util.Map;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.*;
@@ -49,10 +50,10 @@ public class DefaultFemaleGenericExpressionSocket1_Test extends FemaleSocketTest
     public void testSetParentForAllChildren() throws SocketAlreadyConnectedException {
         // This female socket has child female sockets, which requires special treatment
         Assert.assertFalse("femaleSocket is not connected", _femaleSocket.isConnected());
-        _femaleSocket.setParentForAllChildren();
+        if (! _femaleSocket.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         Assert.assertNull("malesocket.getParent() is null", maleSocket.getParent());
         _femaleSocket.connect(maleSocket);
-        _femaleSocket.setParentForAllChildren();
+        if (! _femaleSocket.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
         Assert.assertEquals("malesocket.getParent() is femaleSocket",
                 _femaleGenericSocket,
                 maleSocket.getParent());

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleGenericExpressionSocket1_Test.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultFemaleGenericExpressionSocket1_Test.java
@@ -50,10 +50,10 @@ public class DefaultFemaleGenericExpressionSocket1_Test extends FemaleSocketTest
     public void testSetParentForAllChildren() throws SocketAlreadyConnectedException {
         // This female socket has child female sockets, which requires special treatment
         Assert.assertFalse("femaleSocket is not connected", _femaleSocket.isConnected());
-        if (! _femaleSocket.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! _femaleSocket.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         Assert.assertNull("malesocket.getParent() is null", maleSocket.getParent());
         _femaleSocket.connect(maleSocket);
-        if (! _femaleSocket.setParentForAllChildren(new ArrayList())) throw new RuntimeException();
+        if (! _femaleSocket.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         Assert.assertEquals("malesocket.getParent() is femaleSocket",
                 _femaleGenericSocket,
                 maleSocket.getParent());

--- a/java/test/jmri/jmrix/loconet/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrix/loconet/logixng/configurexml/StoreAndLoadTest.java
@@ -238,8 +238,8 @@ public class StoreAndLoadTest {
             results = cm.load(secondFile);
             log.debug(results ? "load was successful" : "store failed");
             if (results) {
-                if (! logixNG_Manager.resolveAllTrees(new ArrayList())) throw new RuntimeException();
-                if (! logixNG_Manager.setupAllLogixNGs(new ArrayList())) throw new RuntimeException();
+                if (! logixNG_Manager.resolveAllTrees(new ArrayList<>())) throw new RuntimeException();
+                if (! logixNG_Manager.setupAllLogixNGs(new ArrayList<>())) throw new RuntimeException();
 
                 stringWriter = new StringWriter();
                 printWriter = new PrintWriter(stringWriter);

--- a/java/test/jmri/jmrix/loconet/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrix/loconet/logixng/configurexml/StoreAndLoadTest.java
@@ -238,8 +238,8 @@ public class StoreAndLoadTest {
             results = cm.load(secondFile);
             log.debug(results ? "load was successful" : "store failed");
             if (results) {
-                logixNG_Manager.resolveAllTrees();
-                logixNG_Manager.setupAllLogixNGs();
+                if (! logixNG_Manager.resolveAllTrees(new ArrayList())) throw new RuntimeException();
+                if (! logixNG_Manager.setupAllLogixNGs(new ArrayList())) throw new RuntimeException();
 
                 stringWriter = new StringWriter();
                 printWriter = new PrintWriter(stringWriter);


### PR DESCRIPTION
@dsand47 

It seems that I have a bug in LogixNG. For some unknown reason, it seems that an action or expression under some strange condition can end up in two different ConditionalNGs. Then that happens, a runtime exception will occur when one of these ConditionalNGs is executed.

This PR does not resolve that issue. But it adds protection against this so hopefully the user will be notified much earlier when this occurs.