### PR TITLE
Logixng unselect bean

### DIFF
--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionBlockSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionBlockSwing.java
@@ -260,7 +260,7 @@ public class ActionBlockSwing extends AbstractDigitalActionSwing {
         }
 
         if (_tabbedPaneBlock.getSelectedComponent() == _panelBlockDirect) {
-            if (_blockBeanPanel == null || _blockBeanPanel.getNamedBean() == null) {
+            if (_blockBeanPanel.getNamedBean() == null) {
                 errorMessages.add(Bundle.getMessage("ActionBlock_ErrorBlock"));
             }
         }
@@ -353,14 +353,18 @@ public class ActionBlockSwing extends AbstractDigitalActionSwing {
         }
         ActionBlock action = (ActionBlock) object;
 
-        if (_blockBeanPanel != null && !_blockBeanPanel.isEmpty() && (_tabbedPaneBlock.getSelectedComponent() == _panelBlockDirect)) {
+        if (_tabbedPaneBlock.getSelectedComponent() == _panelBlockDirect) {
             Block block = _blockBeanPanel.getNamedBean();
             if (block != null) {
                 NamedBeanHandle<Block> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(block.getDisplayName(), block);
                 action.setBlock(handle);
+            } else {
+                action.removeBlock();
             }
+        } else {
+            action.removeBlock();
         }
 
         try {

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionEntryExitSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionEntryExitSwing.java
@@ -207,14 +207,18 @@ public class ActionEntryExitSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object must be an TriggerEntryExit but is a: "+object.getClass().getName());
         }
         ActionEntryExit action = (ActionEntryExit)object;
-        if (!entryExitBeanPanel.isEmpty() && (_tabbedPaneEntryExit.getSelectedComponent() == _panelEntryExitDirect)) {
+        if (_tabbedPaneEntryExit.getSelectedComponent() == _panelEntryExitDirect) {
             DestinationPoints entryExit = entryExitBeanPanel.getNamedBean();
             if (entryExit != null) {
                 NamedBeanHandle<DestinationPoints> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(entryExit.getDisplayName(), entryExit);
                 action.setDestinationPoints(handle);
+            } else {
+                action.removeDestinationPoints();
             }
+        } else {
+            action.removeDestinationPoints();
         }
         try {
             if (_tabbedPaneEntryExit.getSelectedComponent() == _panelEntryExitDirect) {

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionLightSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionLightSwing.java
@@ -208,14 +208,18 @@ public class ActionLightSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object must be an ActionLight but is a: "+object.getClass().getName());
         }
         ActionLight action = (ActionLight)object;
-        if (!lightBeanPanel.isEmpty() && (_tabbedPaneLight.getSelectedComponent() == _panelLightDirect)) {
+        if (_tabbedPaneLight.getSelectedComponent() == _panelLightDirect) {
             Light light = lightBeanPanel.getNamedBean();
             if (light != null) {
                 NamedBeanHandle<Light> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(light.getDisplayName(), light);
                 action.setLight(handle);
+            } else {
+                action.removeLight();
             }
+        } else {
+            action.removeLight();
         }
         try {
             if (_tabbedPaneLight.getSelectedComponent() == _panelLightDirect) {

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionMemorySwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionMemorySwing.java
@@ -196,25 +196,28 @@ public class ActionMemorySwing extends AbstractDigitalActionSwing {
         }
         ActionMemory action = (ActionMemory)object;
         
-        if (!_memoryBeanPanel.isEmpty()) {
-            Memory memory = _memoryBeanPanel.getNamedBean();
-            if (memory != null) {
-                NamedBeanHandle<Memory> handle
-                        = InstanceManager.getDefault(NamedBeanHandleManager.class)
-                                .getNamedBeanHandle(memory.getDisplayName(), memory);
-                action.setMemory(handle);
-            }
+        Memory memory = _memoryBeanPanel.getNamedBean();
+        if (memory != null) {
+            NamedBeanHandle<Memory> handle
+                    = InstanceManager.getDefault(NamedBeanHandleManager.class)
+                            .getNamedBeanHandle(memory.getDisplayName(), memory);
+            action.setMemory(handle);
+        } else {
+            action.removeMemory();
         }
         
-        if (!_copyMemoryBeanPanel.isEmpty()
-                && (_tabbedPaneMemoryOperation.getSelectedComponent() == _copyMemory)) {
+        if (_tabbedPaneMemoryOperation.getSelectedComponent() == _copyMemory) {
             Memory otherMemory = _copyMemoryBeanPanel.getNamedBean();
             if (otherMemory != null) {
                 NamedBeanHandle<Memory> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(otherMemory.getDisplayName(), otherMemory);
                 action.setOtherMemory(handle);
+            } else {
+                action.removeOtherMemory();
             }
+        } else {
+            action.removeOtherMemory();
         }
         
         try {

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionOBlockSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionOBlockSwing.java
@@ -351,14 +351,18 @@ public class ActionOBlockSwing extends AbstractDigitalActionSwing {
         }
         ActionOBlock action = (ActionOBlock) object;
 
-        if (_oblockBeanPanel != null && !_oblockBeanPanel.isEmpty() && (_tabbedPaneOBlock.getSelectedComponent() == _panelOBlockDirect)) {
+        if (_tabbedPaneOBlock.getSelectedComponent() == _panelOBlockDirect) {
             OBlock oblock = _oblockBeanPanel.getNamedBean();
             if (oblock != null) {
                 NamedBeanHandle<OBlock> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(oblock.getDisplayName(), oblock);
                 action.setOBlock(handle);
+            } else {
+                action.removeOBlock();
             }
+        } else {
+            action.removeOBlock();
         }
 
         try {

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionSensorSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionSensorSwing.java
@@ -214,14 +214,18 @@ public class ActionSensorSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object must be an ActionSensor but is a: "+object.getClass().getName());
         }
         ActionSensor action = (ActionSensor)object;
-        if (!sensorBeanPanel.isEmpty() && (_tabbedPaneSensor.getSelectedComponent() == _panelSensorDirect)) {
+        if (_tabbedPaneSensor.getSelectedComponent() == _panelSensorDirect) {
             Sensor sensor = sensorBeanPanel.getNamedBean();
             if (sensor != null) {
                 NamedBeanHandle<Sensor> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(sensor.getDisplayName(), sensor);
                 action.setSensor(handle);
+            } else {
+                action.removeSensor();
             }
+        } else {
+            action.removeSensor();
         }
         try {
             if (_tabbedPaneSensor.getSelectedComponent() == _panelSensorDirect) {

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionSignalHeadSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionSignalHeadSwing.java
@@ -325,7 +325,7 @@ public class ActionSignalHeadSwing extends AbstractDigitalActionSwing {
     }
 
     private void setAppearanceComboBox(ActionSignalHead action) {
-        SignalHead sh = null;
+        SignalHead sh;
         if (_tabbedPaneSignalHead.getSelectedComponent() == _panelSignalHeadDirect) {
             sh = (SignalHead) _signalHeadBeanPanel.getBeanCombo().getSelectedItem();
         } else {
@@ -407,13 +407,15 @@ public class ActionSignalHeadSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object must be an ActionSignalHead but is a: "+object.getClass().getName());
         }
         ActionSignalHead action = (ActionSignalHead)object;
-        if (!_signalHeadBeanPanel.isEmpty() && (_tabbedPaneSignalHead.getSelectedComponent() == _panelSignalHeadDirect)) {
+        if (_tabbedPaneSignalHead.getSelectedComponent() == _panelSignalHeadDirect) {
             SignalHead signalHead = _signalHeadBeanPanel.getNamedBean();
             if (signalHead != null) {
                 NamedBeanHandle<SignalHead> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(signalHead.getDisplayName(), signalHead);
                 action.setSignalHead(handle);
+            } else {
+                action.removeSignalHead();
             }
         } else {
             action.removeSignalHead();

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionSignalMastSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionSignalMastSwing.java
@@ -323,7 +323,7 @@ public class ActionSignalMastSwing extends AbstractDigitalActionSwing {
     }
 
     private void setAspectComboBox(ActionSignalMast action) {
-        SignalMast sm = null;
+        SignalMast sm;
         if (_tabbedPaneSignalMast.getSelectedComponent() == _panelSignalMastDirect) {
             sm = (SignalMast) _signalMastBeanPanel.getBeanCombo().getSelectedItem();
         } else {
@@ -401,13 +401,15 @@ public class ActionSignalMastSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object must be an ActionSignalMast but is a: "+object.getClass().getName());
         }
         ActionSignalMast action = (ActionSignalMast)object;
-        if (!_signalMastBeanPanel.isEmpty() && (_tabbedPaneSignalMast.getSelectedComponent() == _panelSignalMastDirect)) {
+        if (_tabbedPaneSignalMast.getSelectedComponent() == _panelSignalMastDirect) {
             SignalMast signalMast = _signalMastBeanPanel.getNamedBean();
             if (signalMast != null) {
                 NamedBeanHandle<SignalMast> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(signalMast.getDisplayName(), signalMast);
                 action.setSignalMast(handle);
+            } else {
+                action.removeSignalMast();
             }
         } else {
             action.removeSignalMast();

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionTurnoutLockSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionTurnoutLockSwing.java
@@ -208,14 +208,18 @@ public class ActionTurnoutLockSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object must be an ActionTurnoutLock but is a: "+object.getClass().getName());
         }
         ActionTurnoutLock action = (ActionTurnoutLock)object;
-        if (!turnoutBeanPanel.isEmpty() && (_tabbedPaneTurnout.getSelectedComponent() == _panelTurnoutDirect)) {
+        if (_tabbedPaneTurnout.getSelectedComponent() == _panelTurnoutDirect) {
             Turnout turnout = turnoutBeanPanel.getNamedBean();
             if (turnout != null) {
                 NamedBeanHandle<Turnout> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(turnout.getDisplayName(), turnout);
                 action.setTurnout(handle);
+            } else {
+                action.removeTurnout();
             }
+        } else {
+            action.removeTurnout();
         }
         try {
             if (_tabbedPaneTurnout.getSelectedComponent() == _panelTurnoutDirect) {

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionTurnoutSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionTurnoutSwing.java
@@ -208,14 +208,18 @@ public class ActionTurnoutSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object must be an ActionTurnout but is a: "+object.getClass().getName());
         }
         ActionTurnout action = (ActionTurnout)object;
-        if (!turnoutBeanPanel.isEmpty() && (_tabbedPaneTurnout.getSelectedComponent() == _panelTurnoutDirect)) {
+        if (_tabbedPaneTurnout.getSelectedComponent() == _panelTurnoutDirect) {
             Turnout turnout = turnoutBeanPanel.getNamedBean();
             if (turnout != null) {
                 NamedBeanHandle<Turnout> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(turnout.getDisplayName(), turnout);
                 action.setTurnout(handle);
+            } else {
+                action.removeTurnout();
             }
+        } else {
+            action.removeTurnout();
         }
         try {
             if (_tabbedPaneTurnout.getSelectedComponent() == _panelTurnoutDirect) {

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionWarrantSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionWarrantSwing.java
@@ -380,14 +380,18 @@ public class ActionWarrantSwing extends AbstractDigitalActionSwing {
         }
         ActionWarrant action = (ActionWarrant) object;
 
-        if (_warrantBeanPanel != null && !_warrantBeanPanel.isEmpty() && (_tabbedPaneWarrant.getSelectedComponent() == _panelWarrantDirect)) {
+        if (_tabbedPaneWarrant.getSelectedComponent() == _panelWarrantDirect) {
             Warrant warrant = _warrantBeanPanel.getNamedBean();
             if (warrant != null) {
                 NamedBeanHandle<Warrant> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(warrant.getDisplayName(), warrant);
                 action.setWarrant(handle);
+            } else {
+                action.removeWarrant();
             }
+        } else {
+            action.removeWarrant();
         }
 
         try {

--- a/java/src/jmri/jmrit/logixng/actions/swing/AnalogActionMemorySwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/AnalogActionMemorySwing.java
@@ -67,14 +67,14 @@ public class AnalogActionMemorySwing extends AbstractAnalogActionSwing {
     @Override
     public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
         AnalogActionMemory action = new AnalogActionMemory(systemName, userName);
-        if (!memoryBeanPanel.isEmpty()) {
-            Memory memory = memoryBeanPanel.getNamedBean();
-            if (memory != null) {
-                NamedBeanHandle<Memory> handle
-                        = InstanceManager.getDefault(NamedBeanHandleManager.class)
-                                .getNamedBeanHandle(memory.getDisplayName(), memory);
-                action.setMemory(handle);
-            }
+        Memory memory = memoryBeanPanel.getNamedBean();
+        if (memory != null) {
+            NamedBeanHandle<Memory> handle
+                    = InstanceManager.getDefault(NamedBeanHandleManager.class)
+                            .getNamedBeanHandle(memory.getDisplayName(), memory);
+            action.setMemory(handle);
+        } else {
+            action.removeMemory();
         }
         return InstanceManager.getDefault(AnalogActionManager.class).registerAction(action);
     }

--- a/java/src/jmri/jmrit/logixng/actions/swing/EnableLogixSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/EnableLogixSwing.java
@@ -208,14 +208,18 @@ public class EnableLogixSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object must be an EnableLogix but is a: "+object.getClass().getName());
         }
         EnableLogix action = (EnableLogix)object;
-        if (!logixBeanPanel.isEmpty() && (_tabbedPaneLogix.getSelectedComponent() == _panelLogixDirect)) {
+        if (_tabbedPaneLogix.getSelectedComponent() == _panelLogixDirect) {
             Logix logix = logixBeanPanel.getNamedBean();
             if (logix != null) {
                 NamedBeanHandle<Logix> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(logix.getDisplayName(), logix);
                 action.setLogix(handle);
+            } else {
+                action.removeLogix();
             }
+        } else {
+            action.removeLogix();
         }
         try {
             if (_tabbedPaneLogix.getSelectedComponent() == _panelLogixDirect) {

--- a/java/src/jmri/jmrit/logixng/actions/swing/TableForEachSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/TableForEachSwing.java
@@ -118,14 +118,14 @@ public class TableForEachSwing extends AbstractDigitalActionSwing {
         
         // Create a temporary action in case we don't have one.
         TableForEach action = (TableForEach)object;
-        if (!tableBeanPanel.isEmpty()) {
-            NamedTable table = tableBeanPanel.getNamedBean();
-            if (table != null) {
-                NamedBeanHandle<NamedTable> handle
-                        = InstanceManager.getDefault(NamedBeanHandleManager.class)
-                                .getNamedBeanHandle(table.getDisplayName(), table);
-                action.setTable(handle);
-            }
+        NamedTable table = tableBeanPanel.getNamedBean();
+        if (table != null) {
+            NamedBeanHandle<NamedTable> handle
+                    = InstanceManager.getDefault(NamedBeanHandleManager.class)
+                            .getNamedBeanHandle(table.getDisplayName(), table);
+            action.setTable(handle);
+        } else {
+            action.removeTable();
         }
         action.setTableRowOrColumn((TableForEach.TableRowOrColumn)_tableRowOrColumnComboBox.getSelectedItem());
         action.setRowOrColumnName(_rowOrColumnName.getText());

--- a/java/src/jmri/jmrit/logixng/actions/swing/TriggerRouteSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/TriggerRouteSwing.java
@@ -208,14 +208,18 @@ public class TriggerRouteSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object must be an TriggerRoute but is a: "+object.getClass().getName());
         }
         TriggerRoute action = (TriggerRoute)object;
-        if (!routeBeanPanel.isEmpty() && (_tabbedPaneRoute.getSelectedComponent() == _panelRouteDirect)) {
+        if (_tabbedPaneRoute.getSelectedComponent() == _panelRouteDirect) {
             Route route = routeBeanPanel.getNamedBean();
             if (route != null) {
                 NamedBeanHandle<Route> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(route.getDisplayName(), route);
                 action.setRoute(handle);
+            } else {
+                action.removeRoute();
             }
+        } else {
+            action.removeRoute();
         }
         try {
             if (_tabbedPaneRoute.getSelectedComponent() == _panelRouteDirect) {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionBlockSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionBlockSwing.java
@@ -9,8 +9,6 @@ import javax.swing.*;
 import jmri.Block;
 import jmri.BlockManager;
 import jmri.InstanceManager;
-import jmri.Memory;
-import jmri.MemoryManager;
 import jmri.NamedBeanHandle;
 import jmri.NamedBeanHandleManager;
 import jmri.jmrit.logixng.*;
@@ -271,7 +269,7 @@ public class ExpressionBlockSwing extends AbstractDigitalExpressionSwing {
         }
 
         if (_tabbedPaneBlock.getSelectedComponent() == _panelBlockDirect) {
-            if (_blockBeanPanel == null || _blockBeanPanel.getNamedBean() == null) {
+            if (_blockBeanPanel.getNamedBean() == null) {
                 errorMessages.add(Bundle.getMessage("Block_ErrorBlock"));
             }
         }
@@ -371,14 +369,18 @@ public class ExpressionBlockSwing extends AbstractDigitalExpressionSwing {
         }
 
         ExpressionBlock expression = (ExpressionBlock) object;
-        if (_blockBeanPanel != null && !_blockBeanPanel.isEmpty() && (_tabbedPaneBlock.getSelectedComponent() == _panelBlockDirect)) {
+        if (_tabbedPaneBlock.getSelectedComponent() == _panelBlockDirect) {
             Block block = _blockBeanPanel.getNamedBean();
             if (block != null) {
                 NamedBeanHandle<Block> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(block.getDisplayName(), block);
                 expression.setBlock(handle);
+            } else {
+                expression.removeBlock();
             }
+        } else {
+            expression.removeBlock();
         }
 
         try {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionConditionalSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionConditionalSwing.java
@@ -215,14 +215,18 @@ public class ExpressionConditionalSwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object must be an ExpressionConditional but is a: "+object.getClass().getName());
         }
         ExpressionConditional expression = (ExpressionConditional)object;
-        if (!_conditionalBeanPanel.isEmpty() && (_tabbedPaneConditional.getSelectedComponent() == _panelConditionalDirect)) {
+        if (_tabbedPaneConditional.getSelectedComponent() == _panelConditionalDirect) {
             Conditional conditional = _conditionalBeanPanel.getNamedBean();
             if (conditional != null) {
                 NamedBeanHandle<Conditional> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(conditional.getDisplayName(), conditional);
                 expression.setConditional(handle);
+            } else {
+                expression.removeConditional();
             }
+        } else {
+            expression.removeConditional();
         }
         try {
             if (_tabbedPaneConditional.getSelectedComponent() == _panelConditionalDirect) {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionEntryExitSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionEntryExitSwing.java
@@ -226,14 +226,18 @@ public class ExpressionEntryExitSwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object must be an ExpressionEntryExit but is a: "+object.getClass().getName());
         }
         ExpressionEntryExit expression = (ExpressionEntryExit)object;
-        if (!destinationPointsBeanPanel.isEmpty() && (_tabbedPaneEntryExit.getSelectedComponent() == _panelEntryExitDirect)) {
+        if (_tabbedPaneEntryExit.getSelectedComponent() == _panelEntryExitDirect) {
             DestinationPoints entryExit = destinationPointsBeanPanel.getNamedBean();
             if (entryExit != null) {
                 NamedBeanHandle<DestinationPoints> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(entryExit.getDisplayName(), entryExit);
                 expression.setDestinationPoints(handle);
+            } else {
+                expression.removeDestinationPoints();
             }
+        } else {
+            expression.removeDestinationPoints();
         }
         try {
             if (_tabbedPaneEntryExit.getSelectedComponent() == _panelEntryExitDirect) {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionLightSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionLightSwing.java
@@ -216,14 +216,18 @@ public class ExpressionLightSwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object must be an ExpressionLight but is a: "+object.getClass().getName());
         }
         ExpressionLight expression = (ExpressionLight)object;
-        if (!_lightBeanPanel.isEmpty() && (_tabbedPaneLight.getSelectedComponent() == _panelLightDirect)) {
+        if (_tabbedPaneLight.getSelectedComponent() == _panelLightDirect) {
             Light light = _lightBeanPanel.getNamedBean();
             if (light != null) {
                 NamedBeanHandle<Light> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(light.getDisplayName(), light);
                 expression.setLight(handle);
+            } else {
+                expression.removeLight();
             }
+        } else {
+            expression.removeLight();
         }
         try {
             if (_tabbedPaneLight.getSelectedComponent() == _panelLightDirect) {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionLocalVariableSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionLocalVariableSwing.java
@@ -177,7 +177,11 @@ public class ExpressionLocalVariableSwing extends AbstractDigitalExpressionSwing
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(otherMemory.getDisplayName(), otherMemory);
                 expression.setMemory(handle);
+            } else {
+                expression.removeMemory();
             }
+        } else {
+            expression.removeMemory();
         }
         
         if (_tabbedPane.getSelectedComponent() == _tabbedPaneCompareTo) {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionMemorySwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionMemorySwing.java
@@ -162,14 +162,14 @@ public class ExpressionMemorySwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object must be an ExpressionMemory but is a: "+object.getClass().getName());
         }
         ExpressionMemory expression = (ExpressionMemory)object;
-        if (!_memoryBeanPanel.isEmpty()) {
-            Memory memory = _memoryBeanPanel.getNamedBean();
-            if (memory != null) {
-                NamedBeanHandle<Memory> handle
-                        = InstanceManager.getDefault(NamedBeanHandleManager.class)
-                                .getNamedBeanHandle(memory.getDisplayName(), memory);
-                expression.setMemory(handle);
-            }
+        Memory memory = _memoryBeanPanel.getNamedBean();
+        if (memory != null) {
+            NamedBeanHandle<Memory> handle
+                    = InstanceManager.getDefault(NamedBeanHandleManager.class)
+                            .getNamedBeanHandle(memory.getDisplayName(), memory);
+            expression.setMemory(handle);
+        } else {
+            expression.removeMemory();
         }
         expression.setMemoryOperation(_memoryOperationComboBox.getItemAt(_memoryOperationComboBox.getSelectedIndex()));
         expression.setCaseInsensitive(_caseInsensitiveCheckBox.isSelected());
@@ -184,7 +184,11 @@ public class ExpressionMemorySwing extends AbstractDigitalExpressionSwing {
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(otherMemory.getDisplayName(), otherMemory);
                 expression.setOtherMemory(handle);
+            } else {
+                expression.removeOtherMemory();
             }
+        } else {
+            expression.removeOtherMemory();
         }
         
         if (_tabbedPane.getSelectedComponent() == _tabbedPaneCompareTo) {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionOBlockSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionOBlockSwing.java
@@ -225,14 +225,18 @@ public class ExpressionOBlockSwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object must be an ExpressionOBlock but is a: "+object.getClass().getName());
         }
         ExpressionOBlock expression = (ExpressionOBlock)object;
-        if (!oblockBeanPanel.isEmpty() && (_tabbedPaneOBlock.getSelectedComponent() == _panelOBlockDirect)) {
+        if (_tabbedPaneOBlock.getSelectedComponent() == _panelOBlockDirect) {
             OBlock oblock = oblockBeanPanel.getNamedBean();
             if (oblock != null) {
                 NamedBeanHandle<OBlock> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(oblock.getDisplayName(), oblock);
                 expression.setOBlock(handle);
+            } else {
+                expression.removeOBlock();
             }
+        } else {
+            expression.removeOBlock();
         }
         try {
             if (_tabbedPaneOBlock.getSelectedComponent() == _panelOBlockDirect) {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionSensorSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionSensorSwing.java
@@ -226,14 +226,18 @@ public class ExpressionSensorSwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object must be an ExpressionSensor but is a: "+object.getClass().getName());
         }
         ExpressionSensor expression = (ExpressionSensor)object;
-        if (!sensorBeanPanel.isEmpty() && (_tabbedPaneSensor.getSelectedComponent() == _panelSensorDirect)) {
+        if (_tabbedPaneSensor.getSelectedComponent() == _panelSensorDirect) {
             Sensor sensor = sensorBeanPanel.getNamedBean();
             if (sensor != null) {
                 NamedBeanHandle<Sensor> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(sensor.getDisplayName(), sensor);
                 expression.setSensor(handle);
+            } else {
+                expression.removeSensor();
             }
+        } else {
+            expression.removeSensor();
         }
         try {
             if (_tabbedPaneSensor.getSelectedComponent() == _panelSensorDirect) {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionSignalHeadSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionSignalHeadSwing.java
@@ -326,7 +326,7 @@ public class ExpressionSignalHeadSwing extends AbstractDigitalExpressionSwing {
     }
 
     private void setAppearanceComboBox(ExpressionSignalHead expression) {
-        SignalHead sh = null;
+        SignalHead sh;
         if (_tabbedPaneSignalHead.getSelectedComponent() == _panelSignalHeadDirect) {
             sh = (SignalHead) _signalHeadBeanPanel.getBeanCombo().getSelectedItem();
         } else {
@@ -408,13 +408,15 @@ public class ExpressionSignalHeadSwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object must be an ExpressionSignalHead but is a: "+object.getClass().getName());
         }
         ExpressionSignalHead expression = (ExpressionSignalHead)object;
-        if (!_signalHeadBeanPanel.isEmpty() && (_tabbedPaneSignalHead.getSelectedComponent() == _panelSignalHeadDirect)) {
+        if (_tabbedPaneSignalHead.getSelectedComponent() == _panelSignalHeadDirect) {
             SignalHead signalHead = _signalHeadBeanPanel.getNamedBean();
             if (signalHead != null) {
                 NamedBeanHandle<SignalHead> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(signalHead.getDisplayName(), signalHead);
                 expression.setSignalHead(handle);
+            } else {
+                expression.removeSignalHead();
             }
         } else {
             expression.removeSignalHead();

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionSignalMastSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionSignalMastSwing.java
@@ -326,7 +326,7 @@ public class ExpressionSignalMastSwing extends AbstractDigitalExpressionSwing {
     }
 
     private void setAspectComboBox(ExpressionSignalMast expression) {
-        SignalMast sm = null;
+        SignalMast sm;
         if (_tabbedPaneSignalMast.getSelectedComponent() == _panelSignalMastDirect) {
             sm = (SignalMast) _signalMastBeanPanel.getBeanCombo().getSelectedItem();
         } else {
@@ -404,13 +404,15 @@ public class ExpressionSignalMastSwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object must be an ExpressionSignalMast but is a: "+object.getClass().getName());
         }
         ExpressionSignalMast expression = (ExpressionSignalMast)object;
-        if (!_signalMastBeanPanel.isEmpty() && (_tabbedPaneSignalMast.getSelectedComponent() == _panelSignalMastDirect)) {
+        if (_tabbedPaneSignalMast.getSelectedComponent() == _panelSignalMastDirect) {
             SignalMast signalMast = _signalMastBeanPanel.getNamedBean();
             if (signalMast != null) {
                 NamedBeanHandle<SignalMast> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(signalMast.getDisplayName(), signalMast);
                 expression.setSignalMast(handle);
+            } else {
+                expression.removeSignalMast();
             }
         } else {
             expression.removeSignalMast();

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionTurnoutSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionTurnoutSwing.java
@@ -220,14 +220,18 @@ public class ExpressionTurnoutSwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object must be an ExpressionTurnout but is a: "+object.getClass().getName());
         }
         ExpressionTurnout expression = (ExpressionTurnout)object;
-        if (!turnoutBeanPanel.isEmpty() && (_tabbedPaneTurnout.getSelectedComponent() == _panelTurnoutDirect)) {
+        if (_tabbedPaneTurnout.getSelectedComponent() == _panelTurnoutDirect) {
             Turnout turnout = turnoutBeanPanel.getNamedBean();
             if (turnout != null) {
                 NamedBeanHandle<Turnout> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(turnout.getDisplayName(), turnout);
                 expression.setTurnout(handle);
+            } else {
+                expression.removeTurnout();
             }
+        } else {
+            expression.removeTurnout();
         }
         try {
             if (_tabbedPaneTurnout.getSelectedComponent() == _panelTurnoutDirect) {

--- a/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionWarrantSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/ExpressionWarrantSwing.java
@@ -226,14 +226,18 @@ public class ExpressionWarrantSwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object must be an ExpressionWarrant but is a: "+object.getClass().getName());
         }
         ExpressionWarrant expression = (ExpressionWarrant)object;
-        if (!warrantBeanPanel.isEmpty() && (_tabbedPaneWarrant.getSelectedComponent() == _panelWarrantDirect)) {
+        if (_tabbedPaneWarrant.getSelectedComponent() == _panelWarrantDirect) {
             Warrant warrant = warrantBeanPanel.getNamedBean();
             if (warrant != null) {
                 NamedBeanHandle<Warrant> handle
                         = InstanceManager.getDefault(NamedBeanHandleManager.class)
                                 .getNamedBeanHandle(warrant.getDisplayName(), warrant);
                 expression.setWarrant(handle);
+            } else {
+                expression.removeWarrant();
             }
+        } else {
+            expression.removeWarrant();
         }
         try {
             if (_tabbedPaneWarrant.getSelectedComponent() == _panelWarrantDirect) {


### PR DESCRIPTION
@dsand47 
If the user edits an action or expression and either unselect the bean or selects one of the other tabbed panes Reference, Local variable or Formula, the bean is removed from the action/expression.

This means two things: The expression doesn't listen to the bean anymore. And the bean can be removed from JMRI without the action/expression complaining about it being used.

I discovered that if I created the expression Sensor and selected the sensor IS1, but then edited the expression and changed it to use a formula instead, the expression still listened to the sensor IS1. This PR resolves that.