### PR TITLE
Update QuadLN_S template to support Midpoint/Oscillate Mode

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -294,6 +294,11 @@
                 <li></li>
             </ul>
 
+        <h4>Tam Valley Depot</h4>
+            <ul>
+                <li>Added support for new QuadLN_S Midpoint/Oscillate mode</li>
+            </ul>
+
         <h4>TCS</h4>
             <ul>
                 <li></li>

--- a/xml/decoders/tvd/ServoLock.xml
+++ b/xml/decoders/tvd/ServoLock.xml
@@ -18,4 +18,5 @@
     <enumChoice choice="None"/>
     <enumChoice choice="Local Lockout"/>
     <enumChoice choice="Midpoint"/>
+    <enumChoice choice="Midpoint/Oscillate"/>
 </enumVal>


### PR DESCRIPTION
QuadLN_S firmware version 3.0.6 adds a new Lock mode called "Midpoint/Oscillate" for use with wig-wag signals, oil pumps and other animations.  This PR updates the decoder template to support the new mode.