### PR TITLE
Proposed exception to “stale issue” processing

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ daysUntilStale: 45
 daysUntilClose: 15
 
 # Issues with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels: "Bug"
+exemptLabels: ["Bug"]
 
 # exemptLabels:
 #  - "status: accepted"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ daysUntilStale: 45
 daysUntilClose: 15
 
 # Issues with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels: []
+exemptLabels: "Bug"
 
 # exemptLabels:
 #  - "status: accepted"


### PR DESCRIPTION
Proposal:  if an issue has been explicitly labeled “Bug,” I think it should be exempt from the stale issue processing.  If someone went to the trouble of identifying a verifiable bug, and actually labeling it as such, shouldn’t we at least keep the issue open to give a developer the opportunity to clear it?  Of course, if the label was never applied or is removed, then the issue becomes subject to being closed when stale.

[If there is significant disagreement with this proposal, I will withdraw the PR.]