### PR TITLE
Logixng xml

### DIFF
--- a/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
@@ -530,13 +530,21 @@ public abstract class AbstractMaleSocket implements MaleSocket {
 
     @Override
     public ErrorHandlingType getErrorHandlingType() {
-        return _errorHandlingType;
+        if (getObject() instanceof MaleSocket) {
+            return ((MaleSocket)getObject()).getErrorHandlingType();
+        } else {
+            return _errorHandlingType;
+        }
     }
 
     @Override
     public void setErrorHandlingType(ErrorHandlingType errorHandlingType)
     {
-        _errorHandlingType = errorHandlingType;
+        if (getObject() instanceof MaleSocket) {
+            ((MaleSocket)getObject()).setErrorHandlingType(errorHandlingType);
+        } else {
+            _errorHandlingType = errorHandlingType;
+        }
     }
 
     public void handleError(Base item, String message, JmriException e, Logger log) throws JmriException {
@@ -544,7 +552,7 @@ public abstract class AbstractMaleSocket implements MaleSocket {
         // Always throw AbortConditionalNGExecutionException exceptions
         if (!_catchAbortExecution && (e instanceof AbortConditionalNGExecutionException)) throw e;
 
-        ErrorHandlingType errorHandlingType = _errorHandlingType;
+        ErrorHandlingType errorHandlingType = getErrorHandlingType();
         if (errorHandlingType == ErrorHandlingType.Default) {
             errorHandlingType = InstanceManager.getDefault(LogixNGPreferences.class)
                     .getErrorHandlingType();
@@ -587,7 +595,7 @@ public abstract class AbstractMaleSocket implements MaleSocket {
             Logger log)
             throws JmriException {
 
-        ErrorHandlingType errorHandlingType = _errorHandlingType;
+        ErrorHandlingType errorHandlingType = getErrorHandlingType();
         if (errorHandlingType == ErrorHandlingType.Default) {
             errorHandlingType = InstanceManager.getDefault(LogixNGPreferences.class)
                     .getErrorHandlingType();
@@ -624,7 +632,7 @@ public abstract class AbstractMaleSocket implements MaleSocket {
 
     public void handleError(Base item, String message, RuntimeException e, Logger log) throws JmriException {
 
-        ErrorHandlingType errorHandlingType = _errorHandlingType;
+        ErrorHandlingType errorHandlingType = getErrorHandlingType();
         if (errorHandlingType == ErrorHandlingType.Default) {
             errorHandlingType = InstanceManager.getDefault(LogixNGPreferences.class)
                     .getErrorHandlingType();

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/AbstractMaleSocketXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/AbstractMaleSocketXml.java
@@ -38,7 +38,10 @@ public class AbstractMaleSocketXml
         element.setAttribute("catchAbortExecution", maleSocket.getCatchAbortExecution()? "yes" : "no");  // NOI18N
         element.setAttribute("class", this.getClass().getName());
         
-        element.addContent(new Element("errorHandling").addContent(maleSocket.getErrorHandlingType().name()));
+        // Only store error handling type of the inner most socket
+        if (!(maleSocket.getObject() instanceof MaleSocket)) {
+            element.addContent(new Element("errorHandling").addContent(maleSocket.getErrorHandlingType().name()));
+        }
         
         for (SymbolTable.VariableData data : maleSocket.getLocalVariables()) {
             Element elementVariable = new Element("LocalVariable");

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogActionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogActionManagerXml.java
@@ -41,9 +41,9 @@ public class DefaultAnalogActionManagerXml extends AbstractManagerXml {
         setStoreElementClass(actions);
         AnalogActionManager tm = (AnalogActionManager) o;
         if (tm != null) {
+            if (tm.getNamedBeanSet().isEmpty()) return null;
             for (MaleAnalogActionSocket action : tm.getNamedBeanSet()) {
                 log.debug("action system name is " + action.getSystemName());  // NOI18N
-//                log.error("action system name is " + action.getSystemName() + ", " + action.getLongDescription());  // NOI18N
                 try {
                     List<Element> elements = new ArrayList<>();
                     // The male socket may be embedded in other male sockets
@@ -55,7 +55,6 @@ public class DefaultAnalogActionManagerXml extends AbstractManagerXml {
                     Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
-//                        e.addContent(storeMaleSocket(a));
                         actions.addContent(e);
                     } else {
                         throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogExpressionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogExpressionManagerXml.java
@@ -41,9 +41,9 @@ public class DefaultAnalogExpressionManagerXml extends AbstractManagerXml {
         setStoreElementClass(expressions);
         AnalogExpressionManager tm = (AnalogExpressionManager) o;
         if (tm != null) {
+            if (tm.getNamedBeanSet().isEmpty()) return null;
             for (MaleAnalogExpressionSocket expression : tm.getNamedBeanSet()) {
                 log.debug("expression system name is " + expression.getSystemName());  // NOI18N
-//                log.error("expression system name is " + expression.getSystemName() + ", " + expression.getLongDescription());  // NOI18N
                 try {
                     List<Element> elements = new ArrayList<>();
                     // The male socket may be embedded in other male sockets
@@ -55,7 +55,6 @@ public class DefaultAnalogExpressionManagerXml extends AbstractManagerXml {
                     Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
-//                        e.addContent(storeMaleSocket(expression));
                         expressions.addContent(e);
                     } else {
                         throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultConditionalNGManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultConditionalNGManagerXml.java
@@ -42,6 +42,7 @@ public class DefaultConditionalNGManagerXml extends jmri.managers.configurexml.A
         ConditionalNG_Manager tm = (ConditionalNG_Manager) o;
         LogixNG_Manager lm = InstanceManager.getDefault(LogixNG_Manager.class);
         if (tm != null) {
+            if (lm.getNamedBeanSet().isEmpty()) return null;
             for (LogixNG logixNG : lm.getNamedBeanSet()) {
                 for (int i=0; i < logixNG.getNumConditionalNGs(); i++) {
                     ConditionalNG conditionalNG = logixNG.getConditionalNG(i);

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalActionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalActionManagerXml.java
@@ -40,11 +40,10 @@ public class DefaultDigitalActionManagerXml extends AbstractManagerXml {
         Element actions = new Element("LogixNGDigitalActions");
         setStoreElementClass(actions);
         DigitalActionManager tm = (DigitalActionManager) o;
-//        System.out.format("DefaultDigitalActionManagerXml: manager: %s%n", tm);
         if (tm != null) {
+            if (tm.getNamedBeanSet().isEmpty()) return null;
             for (MaleDigitalActionSocket action : tm.getNamedBeanSet()) {
                 log.debug("action system name is " + action.getSystemName());  // NOI18N
-//                log.error("action system name is " + action.getSystemName() + ", " + action.getLongDescription());  // NOI18N
                 try {
                     List<Element> elements = new ArrayList<>();
                     // The male socket may be embedded in other male sockets
@@ -53,11 +52,9 @@ public class DefaultDigitalActionManagerXml extends AbstractManagerXml {
                         elements.add(storeMaleSocket(a));
                         a = (MaleDigitalActionSocket) a.getObject();
                     }
-//                    Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(getAction(a));
                     Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
-//                        e.addContent(storeMaleSocket(a));
                         actions.addContent(e);
                     } else {
                         throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalBooleanActionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalBooleanActionManagerXml.java
@@ -40,11 +40,10 @@ public class DefaultDigitalBooleanActionManagerXml extends AbstractManagerXml {
         Element actions = new Element("LogixNGDigitalBooleanActions");
         setStoreElementClass(actions);
         DigitalBooleanActionManager tm = (DigitalBooleanActionManager) o;
-//        System.out.format("DefaultDigitalBooleanActionManagerXml: manager: %s%n", tm);
         if (tm != null) {
+            if (tm.getNamedBeanSet().isEmpty()) return null;
             for (MaleDigitalBooleanActionSocket action : tm.getNamedBeanSet()) {
                 log.debug("action system name is " + action.getSystemName());  // NOI18N
-//                log.error("action system name is " + action.getSystemName() + ", " + action.getLongDescription());  // NOI18N
                 try {
                     List<Element> elements = new ArrayList<>();
                     // The male socket may be embedded in other male sockets
@@ -56,7 +55,6 @@ public class DefaultDigitalBooleanActionManagerXml extends AbstractManagerXml {
                     Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
-//                        e.addContent(storeMaleSocket(a));
                         actions.addContent(e);
                     } else {
                         throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalExpressionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultDigitalExpressionManagerXml.java
@@ -43,11 +43,10 @@ public class DefaultDigitalExpressionManagerXml extends AbstractManagerXml {
         Element expressions = new Element("LogixNGDigitalExpressions");
         setStoreElementClass(expressions);
         DigitalExpressionManager tm = (DigitalExpressionManager) o;
-//        System.out.format("DefaultDigitalExpressionManagerXml: manager: %s%n", tm);
         if (tm != null) {
+            if (tm.getNamedBeanSet().isEmpty()) return null;
             for (MaleDigitalExpressionSocket expression : tm.getNamedBeanSet()) {
                 log.debug("action system name is " + expression.getSystemName());  // NOI18N
-//                log.error("action system name is " + action.getSystemName() + ", " + action.getLongDescription());  // NOI18N
                 try {
                     List<Element> elements = new ArrayList<>();
                     // The male socket may be embedded in other male sockets
@@ -59,7 +58,6 @@ public class DefaultDigitalExpressionManagerXml extends AbstractManagerXml {
                     Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(a.getObject());
                     if (e != null) {
                         for (Element ee : elements) e.addContent(ee);
-//                        e.addContent(storeMaleSocket(a));
                         expressions.addContent(e);
                     } else {
                         throw new RuntimeException("Cannot load xml configurator for " + a.getObject().getClass().getName());

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultLogixNGManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultLogixNGManagerXml.java
@@ -38,6 +38,8 @@ public class DefaultLogixNGManagerXml extends jmri.managers.configurexml.Abstrac
      */
     @Override
     public Element store(Object o) {
+        boolean hasData = false;
+        
         Element logixNGs = new Element("LogixNGs");
         setStoreElementClass(logixNGs);
         LogixNG_Manager tm = (LogixNG_Manager) o;
@@ -67,6 +69,7 @@ public class DefaultLogixNGManagerXml extends jmri.managers.configurexml.Abstrac
                 elem.setAttribute("enabled", enabled ? "yes" : "no");  // NOI18N
 
                 logixNGs.addContent(elem);
+                hasData = true;
             }
 
             Element elemInitializationTable = new Element("InitializationTable");  // NOI18N
@@ -92,7 +95,7 @@ public class DefaultLogixNGManagerXml extends jmri.managers.configurexml.Abstrac
             }
             logixNGs.addContent(elemClipboard);
         }
-        return (logixNGs);
+        return hasData ? logixNGs : null;
     }
 
     /**

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultModuleManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultModuleManagerXml.java
@@ -31,7 +31,7 @@ public class DefaultModuleManagerXml extends AbstractManagerXml {
     }
 
     /**
-     * Default implementation for storing the contents of a LogixManager
+     * Default implementation for storing the contents of a ModuleManager
      *
      * @param o Object to store, of type LogixManager
      * @return Element containing the complete info
@@ -42,7 +42,8 @@ public class DefaultModuleManagerXml extends AbstractManagerXml {
         setStoreElementClass(expressions);
         DefaultModuleManager tm = (DefaultModuleManager) o;
         if (tm != null) {
-            for (Module module:  tm.getNamedBeanSet()) {
+            if (tm.getNamedBeanSet().isEmpty()) return null;
+            for (Module module : tm.getNamedBeanSet()) {
                 try {
                     Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(module);
                     if (e != null) {
@@ -53,7 +54,7 @@ public class DefaultModuleManagerXml extends AbstractManagerXml {
                 }
             }
         }
-        return (expressions);
+        return expressions;
     }
 
     /**

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultNamedTableManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultNamedTableManagerXml.java
@@ -30,30 +30,31 @@ public class DefaultNamedTableManagerXml extends AbstractManagerXml {
     }
 
     /**
-     * Default implementation for storing the contents of a LogixManager
+     * Default implementation for storing the contents of a NamedTableManager
      *
      * @param o Object to store, of type LogixManager
      * @return Element containing the complete info
      */
     @Override
     public Element store(Object o) {
-        Element expressions = new Element("LogixNGTables");
-        setStoreElementClass(expressions);
+        Element tables = new Element("LogixNGTables");
+        setStoreElementClass(tables);
         DefaultNamedTableManager tm = (DefaultNamedTableManager) o;
         if (tm != null) {
-            for (NamedTable table:  tm.getNamedBeanSet()) {
-                log.debug("expression system name is " + table.getSystemName());  // NOI18N
+            if (tm.getNamedBeanSet().isEmpty()) return null;
+            for (NamedTable table : tm.getNamedBeanSet()) {
+                log.debug("table system name is " + table.getSystemName());  // NOI18N
                 try {
                     Element e = jmri.configurexml.ConfigXmlManager.elementFromObject(table);
                     if (e != null) {
-                        expressions.addContent(e);
+                        tables.addContent(e);
                     }
                 } catch (RuntimeException e) {
-                    log.error("Error storing action: {}", e, e);
+                    log.error("Error storing table: {}", e, e);
                 }
             }
         }
-        return (expressions);
+        return (tables);
     }
 
     /**

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultStringActionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultStringActionManagerXml.java
@@ -41,6 +41,7 @@ public class DefaultStringActionManagerXml extends AbstractManagerXml {
         setStoreElementClass(actions);
         StringActionManager tm = (StringActionManager) o;
         if (tm != null) {
+            if (tm.getNamedBeanSet().isEmpty()) return null;
             for (MaleStringActionSocket action : tm.getNamedBeanSet()) {
                 log.debug("action system name is " + action.getSystemName());  // NOI18N
 //                log.error("action system name is " + action.getSystemName() + ", " + action.getLongDescription());  // NOI18N

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultStringExpressionManagerXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultStringExpressionManagerXml.java
@@ -41,6 +41,7 @@ public class DefaultStringExpressionManagerXml extends AbstractManagerXml {
         setStoreElementClass(expressions);
         StringExpressionManager tm = (StringExpressionManager) o;
         if (tm != null) {
+            if (tm.getNamedBeanSet().isEmpty()) return null;
             for (MaleStringExpressionSocket expression : tm.getNamedBeanSet()) {
                 log.debug("expression system name is " + expression.getSystemName());  // NOI18N
 //                log.error("expression system name is " + expression.getSystemName() + ", " + expression.getLongDescription());  // NOI18N

--- a/java/src/jmri/jmrit/logixng/implementation/swing/AbstractMaleSocketSwing.java
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/AbstractMaleSocketSwing.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 import javax.swing.*;
 
 import jmri.*;
@@ -119,6 +120,7 @@ public abstract class AbstractMaleSocketSwing extends AbstractSwingConfigurator 
     }
     
     /** {@inheritDoc} */
+    @OverridingMethodsMustInvokeSuper
     @Override
     public void updateObject(@Nonnull Base object) {
         if (! (object instanceof AbstractMaleSocket)) {

--- a/java/src/jmri/jmrit/logixng/implementation/swing/AbstractMaleSocketSwing.java
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/AbstractMaleSocketSwing.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.annotation.OverridingMethodsMustInvokeSuper;
 import javax.swing.*;
 
 import jmri.*;
@@ -119,10 +118,13 @@ public abstract class AbstractMaleSocketSwing extends AbstractSwingConfigurator 
         throw new UnsupportedOperationException("Not supported");
     }
     
+    protected void updateObjectForSubPanel(@Nonnull Base object) {
+        // Do nothing
+    }
+    
     /** {@inheritDoc} */
-    @OverridingMethodsMustInvokeSuper
     @Override
-    public void updateObject(@Nonnull Base object) {
+    public final void updateObject(@Nonnull Base object) {
         if (! (object instanceof AbstractMaleSocket)) {
             throw new IllegalArgumentException("object is not an AbstractMaleSocket: " + object.getClass().getName());
         }
@@ -130,6 +132,8 @@ public abstract class AbstractMaleSocketSwing extends AbstractSwingConfigurator 
         AbstractMaleSocket maleSocket = (AbstractMaleSocket)object;
         maleSocket.setErrorHandlingType(errorHandlingComboBox.getItemAt(errorHandlingComboBox.getSelectedIndex()));
         maleSocket.setCatchAbortExecution(catchAbortExecutionCheckBox.isSelected());
+        
+        updateObjectForSubPanel(object);
     }
     
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/implementation/swing/DefaultMaleDigitalExpressionSocketSwing.java
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/DefaultMaleDigitalExpressionSocketSwing.java
@@ -41,6 +41,8 @@ public class DefaultMaleDigitalExpressionSocketSwing extends AbstractMaleSocketS
     /** {@inheritDoc} */
     @Override
     public void updateObject(@Nonnull Base object) {
+        super.updateObject(object);
+
         Base obj = object;
         while (((obj instanceof MaleSocket)) && (! (obj instanceof DefaultMaleDigitalExpressionSocket))) {
             obj = ((MaleSocket)obj).getObject();

--- a/java/src/jmri/jmrit/logixng/implementation/swing/DefaultMaleDigitalExpressionSocketSwing.java
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/DefaultMaleDigitalExpressionSocketSwing.java
@@ -40,9 +40,7 @@ public class DefaultMaleDigitalExpressionSocketSwing extends AbstractMaleSocketS
 
     /** {@inheritDoc} */
     @Override
-    public void updateObject(@Nonnull Base object) {
-        super.updateObject(object);
-
+    public void updateObjectForSubPanel(@Nonnull Base object) {
         Base obj = object;
         while (((obj instanceof MaleSocket)) && (! (obj instanceof DefaultMaleDigitalExpressionSocket))) {
             obj = ((MaleSocket)obj).getObject();

--- a/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
@@ -18,7 +18,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
   <jmriversion>
     <major>4</major>
     <minor>23</minor>
-    <test>5</test>
+    <test>7</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -77,7 +77,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <memory>
       <systemName>IM3</systemName>
     </memory>
-    <memory value="3:02 PM">
+    <memory value="3:37 AM">
       <systemName>IMCURRENTTIME</systemName>
     </memory>
     <memory value="1.0">
@@ -147,7 +147,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <userName>First conditional</userName>
     </conditional>
   </conditionals>
-  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Thu May 13 15:02:20 CDT 2021" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri May 28 03:37:54 CEST 2021" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <LogixNGs class="jmri.jmrit.logixng.implementation.configurexml.DefaultLogixNGManagerXml">
     <Thread>
       <id>0</id>
@@ -1251,7 +1251,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -1362,7 +1362,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>LogError</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -1417,7 +1417,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>LogErrorOnce</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -1472,7 +1472,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>ShowDialogBox</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -1527,7 +1527,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>ThrowException</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -7724,7 +7724,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>ThrowException</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -7789,7 +7789,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -7854,7 +7854,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -7919,7 +7919,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -7983,7 +7983,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8047,7 +8047,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8111,7 +8111,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8492,7 +8492,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8552,7 +8552,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>LogError</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8612,7 +8612,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>LogErrorOnce</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8672,7 +8672,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>ShowDialogBox</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8730,7 +8730,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>ThrowException</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10107,7 +10107,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>ThrowException</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10172,7 +10172,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10237,7 +10237,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10302,7 +10302,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10366,7 +10366,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>LogError</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10430,7 +10430,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>LogErrorOnce</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10494,7 +10494,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>ShowDialogBox</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -12813,7 +12813,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>ThrowException</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -12879,7 +12879,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -12945,7 +12945,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -13011,7 +13011,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -13077,7 +13077,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -13142,7 +13142,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -13207,7 +13207,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -13272,7 +13272,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>AbortExecution</errorHandling>
+          <errorHandling>Default</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -18303,9 +18303,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
   <filehistory>
     <operation>
       <type>Store</type>
-      <date>Thu May 13 15:02:22 CDT 2021</date>
+      <date>Fri May 28 03:37:57 CEST 2021</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.23.5ish+das+20210513T1958Z+R40a1df59ba on Thu May 13 15:02:22 CDT 2021-->
+  <!--Written by JMRI version 4.23.7ish+daniel+2021-05-28T01:35:03Z+R1f82f90 on Fri May 28 03:37:57 CEST 2021-->
 </layout-config>

--- a/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
@@ -77,7 +77,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <memory>
       <systemName>IM3</systemName>
     </memory>
-    <memory value="3:37 AM">
+    <memory value="5:23 AM">
       <systemName>IMCURRENTTIME</systemName>
     </memory>
     <memory value="1.0">
@@ -147,7 +147,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <userName>First conditional</userName>
     </conditional>
   </conditionals>
-  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri May 28 03:37:54 CEST 2021" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri May 28 05:23:02 CEST 2021" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <LogixNGs class="jmri.jmrit.logixng.implementation.configurexml.DefaultLogixNGManagerXml">
     <Thread>
       <id>0</id>
@@ -1251,7 +1251,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="no" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -1362,7 +1362,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -1417,7 +1417,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>LogErrorOnce</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -1472,7 +1472,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>ShowDialogBox</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -1527,7 +1527,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalExpressionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalExpressionSocketXml" DefaultMaleDigitalExpressionSocketListen="yes">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>ThrowException</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -7724,7 +7724,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>ThrowException</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -7789,7 +7789,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -7854,7 +7854,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -7919,7 +7919,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -7983,7 +7983,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8047,7 +8047,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8111,7 +8111,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8492,7 +8492,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8552,7 +8552,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8612,7 +8612,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>LogErrorOnce</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8672,7 +8672,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>ShowDialogBox</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -8730,7 +8730,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>ThrowException</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10107,7 +10107,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>ThrowException</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10172,7 +10172,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10237,7 +10237,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10302,7 +10302,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10366,7 +10366,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>LogError</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10430,7 +10430,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>LogErrorOnce</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -10494,7 +10494,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>ShowDialogBox</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -12813,7 +12813,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>ThrowException</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -12879,7 +12879,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -12945,7 +12945,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -13011,7 +13011,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -13077,7 +13077,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -13142,7 +13142,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -13207,7 +13207,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -13272,7 +13272,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
         <AbstractMaleSocket enabled="yes" catchAbortExecution="no" class="jmri.jmrit.logixng.implementation.configurexml.DefaultMaleDigitalActionSocketXml">
-          <errorHandling>Default</errorHandling>
+          <errorHandling>AbortExecution</errorHandling>
           <LocalVariable>
             <name>A1</name>
             <type>None</type>
@@ -18303,9 +18303,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
   <filehistory>
     <operation>
       <type>Store</type>
-      <date>Fri May 28 03:37:57 CEST 2021</date>
+      <date>Fri May 28 05:23:05 CEST 2021</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.23.7ish+daniel+2021-05-28T01:35:03Z+R1f82f90 on Fri May 28 03:37:57 CEST 2021-->
+  <!--Written by JMRI version 4.23.7ish+daniel+2021-05-28T03:20:01Z+R20acf88 on Fri May 28 05:23:05 CEST 2021-->
 </layout-config>


### PR DESCRIPTION
Don't add the top elements for LogixNG managers if the managers have nothing to store.

If a user doesn't use LogixNG, he might store the panel file with the latest JMRI release and then open the panel file in a previous release that doesn't know about LogixNG.