### PR TITLE
Edit LogixNG Tables

### DIFF
--- a/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
@@ -756,6 +756,7 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
                     _inEditMode = false;
                     f.setVisible(true);
                 } else if (key.equals("Delete")) {           // NOI18N
+                    _inEditMode = false;
                     deletePressed(value);
                 } else if (key.equals("chgUname")) {         // NOI18N
                     E x = getManager().getBySystemName(lgxName);

--- a/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
@@ -3,12 +3,10 @@ package jmri.jmrit.beantable;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Container;
-import java.awt.FlowLayout;
+import java.awt.Font;
 import java.awt.event.*;
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.*;
 
 import javax.annotation.Nonnull;
@@ -83,6 +81,8 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
     protected abstract E createBean(String systemName, String userName);
 
     protected abstract void deleteBean(E bean);
+
+    protected boolean browseMonoSpace() { return false; }
 
     protected abstract String getBeanText(E bean);
 
@@ -940,6 +940,9 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
 
         // Build the conditionalNGs listing
         _textContent = new JTextArea(this.getBeanText(_curNamedBean));
+        if (browseMonoSpace()) {
+            _textContent.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+        }
         JScrollPane scrollPane = new JScrollPane(_textContent);
         contentPane.add(scrollPane);
 

--- a/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
@@ -1,31 +1,15 @@
 package jmri.jmrit.beantable;
 
-import java.awt.BorderLayout;
-import java.awt.Component;
 import java.awt.Container;
 import java.awt.FlowLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
-import java.awt.event.KeyEvent;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.*;
-import javax.swing.table.TableColumn;
 
 import jmri.InstanceManager;
 import jmri.Manager;
-import jmri.UserPreferencesManager;
-import jmri.util.FileUtil;
 import jmri.util.JmriJFrame;
 
-import java.util.ResourceBundle;
 
 import jmri.jmrit.logixng.NamedTable;
 import jmri.jmrit.logixng.NamedTableManager;
@@ -121,7 +105,7 @@ public class LogixNGTableTableAction extends AbstractLogixNGTableAction<NamedTab
 
     @Override
     protected void deleteBean(NamedTable bean) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        InstanceManager.getDefault(NamedTableManager.class).deleteNamedTable(bean);
     }
 
     @Override

--- a/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
@@ -109,8 +109,50 @@ public class LogixNGTableTableAction extends AbstractLogixNGTableAction<NamedTab
     }
 
     @Override
+    protected boolean browseMonoSpace() {
+        return true;
+    }
+
+    @Override
     protected String getBeanText(NamedTable bean) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        int maxColumnWidth = 0;
+        int columnWidth[] = new int[bean.numColumns()];
+        String[][] cells = new String[bean.numRows()][];
+        for (int row=0; row < bean.numRows(); row++) {
+            cells[row] = new String[bean.numColumns()];
+            for (int col=0; col < bean.numColumns(); col++) {
+                Object value = bean.getCell(row, col);
+                cells[row][col] = value != null ? value.toString() : "<null>";
+                columnWidth[col] = Math.max(columnWidth[col], cells[row][col].length());
+                maxColumnWidth = Math.max(maxColumnWidth, columnWidth[col]);
+            }
+        }
+        String columnLine = "";
+        while (columnLine.length()+2 < maxColumnWidth) columnLine += "----------------------";
+        String columnPadding = String.format("%"+Integer.toString(maxColumnWidth)+"s", "");
+        StringBuilder sb = new StringBuilder();
+        sb.append("+");
+        for (int col=0; col < bean.numColumns(); col++) {
+            sb.append(columnLine.substring(0,columnWidth[col]+2));
+            sb.append("+");
+            if (col+1 == bean.numColumns()) sb.append(String.format("%n"));
+        }
+        for (int row=0; row < bean.numRows(); row++) {
+            sb.append("|");
+            for (int col=0; col < bean.numColumns(); col++) {
+                sb.append(" ");
+                sb.append((cells[row][col]+columnPadding).substring(0,columnWidth[col]));
+                sb.append(" |");
+                if (col+1 == bean.numColumns()) sb.append(String.format("%n"));
+            }
+            sb.append("+");
+            for (int col=0; col < bean.numColumns(); col++) {
+                sb.append(columnLine.substring(0,columnWidth[col]+2));
+                sb.append("+");
+                if (col+1 == bean.numColumns()) sb.append(String.format("%n"));
+            }
+        }
+        return sb.toString();
     }
 
     @Override

--- a/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
@@ -74,7 +74,7 @@ public class LogixNGTableTableAction extends AbstractLogixNGTableAction<NamedTab
 
     @Override
     protected AbstractLogixNGEditor<NamedTable> getEditor(BeanTableFrame<NamedTable> f, BeanTableDataModel<NamedTable> m, String sName) {
-        return null;
+        return new TableEditor(m, sName);
     }
 
     @Override

--- a/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
@@ -127,8 +127,10 @@ public class LogixNGTableTableAction extends AbstractLogixNGTableAction<NamedTab
                 maxColumnWidth = Math.max(maxColumnWidth, columnWidth[col]);
             }
         }
-        String columnLine = "";
-        while (columnLine.length()+2 < maxColumnWidth) columnLine += "----------------------";
+        StringBuilder columnLine = new StringBuilder();
+        while (columnLine.length()+2 < maxColumnWidth) {
+            columnLine.append("----------------------");
+        }
         String columnPadding = String.format("%"+Integer.toString(maxColumnWidth)+"s", "");
         StringBuilder sb = new StringBuilder();
         sb.append("+");

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractNamedTable.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractNamedTable.java
@@ -98,7 +98,8 @@ public abstract class AbstractNamedTable extends AbstractNamedBean implements Na
     private static NamedTable loadFromCSV(
             @CheckForNull String systemName, @CheckForNull String userName,
             @Nonnull String fileName,
-            @Nonnull List<String> lines)
+            @Nonnull List<String> lines,
+            boolean registerInManager)
             throws NamedBean.BadUserNameException, NamedBean.BadSystemNameException {
         
         NamedTableManager manager = InstanceManager.getDefault(NamedTableManager.class);
@@ -142,54 +143,59 @@ public abstract class AbstractNamedTable extends AbstractNamedBean implements Na
         }
         
         NamedTable table = new DefaultCsvNamedTable(systemName, userName, fileName, csvCells);
-        manager.register(table);
+        
+        if (registerInManager) manager.register(table);
         
         return table;
     }
     
     @Nonnull
     public static NamedTable loadTableFromCSV_Text(
-            @Nonnull String fileName, @Nonnull String text)
+            @Nonnull String fileName,
+            @Nonnull String text,
+            boolean registerInManager)
             throws BadUserNameException, BadSystemNameException {
         
         List<String> lines = Arrays.asList(text.split("\\r?\\n",-1));
-        return loadFromCSV(null, null, fileName, lines);
+        return loadFromCSV(null, null, fileName, lines, registerInManager);
     }
     
     @Nonnull
-    public static NamedTable loadTableFromCSV_File(@Nonnull String fileName)
+    public static NamedTable loadTableFromCSV_File(
+            @Nonnull String fileName, boolean registerInManager)
             throws BadUserNameException, BadSystemNameException, IOException {
         
         List<String> lines = Files.readAllLines(FileUtil.getFile(fileName).toPath(), StandardCharsets.UTF_8);
-        return loadFromCSV(null, null, fileName, lines);
+        return loadFromCSV(null, null, fileName, lines, registerInManager);
     }
     
     @Nonnull
-    public static NamedTable loadTableFromCSV_File(@Nonnull File file)
+    public static NamedTable loadTableFromCSV_File(
+            @Nonnull File file, boolean registerInManager)
             throws BadUserNameException, BadSystemNameException, IOException {
         
         List<String> lines = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
-        return loadFromCSV(null, null, file.getPath(), lines);
+        return loadFromCSV(null, null, file.getPath(), lines, registerInManager);
     }
     
     @Nonnull
     public static NamedTable loadTableFromCSV_File(
             @Nonnull String systemName, @CheckForNull String userName,
-            @Nonnull String fileName)
+            @Nonnull String fileName, boolean registerInManager)
             throws NamedBean.BadUserNameException, NamedBean.BadSystemNameException, IOException {
         
         List<String> lines = Files.readAllLines(FileUtil.getFile(fileName).toPath(), StandardCharsets.UTF_8);
-        return loadFromCSV(systemName, userName, fileName, lines);
+        return loadFromCSV(systemName, userName, fileName, lines, registerInManager);
     }
     
     @Nonnull
     public static NamedTable loadTableFromCSV_File(
             @Nonnull String systemName, @CheckForNull String userName,
-            @Nonnull File file)
+            @Nonnull File file, boolean registerInManager)
             throws NamedBean.BadUserNameException, NamedBean.BadSystemNameException, IOException {
         
         List<String> lines = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
-        return loadFromCSV(systemName, userName, file.getPath(), lines);
+        return loadFromCSV(systemName, userName, file.getPath(), lines, registerInManager);
     }
     
     /**

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultCsvNamedTable.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultCsvNamedTable.java
@@ -27,7 +27,8 @@ import jmri.jmrit.logixng.NamedTableManager;
  */
 public class DefaultCsvNamedTable extends AbstractNamedTable {
 
-    private final String _fileName;
+    private String _fileName;
+    
     /**
      * Create a new named table.
      * @param sys the system name
@@ -48,6 +49,10 @@ public class DefaultCsvNamedTable extends AbstractNamedTable {
     
     public String getFileName() {
         return _fileName;
+    }
+    
+    public void setFileName(String fileName) {
+        this._fileName = fileName;
     }
     
 }

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultNamedTableManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultNamedTableManager.java
@@ -81,7 +81,7 @@ public class DefaultNamedTableManager extends AbstractManager<NamedTable>
         }
         try {
             // NamedTable does not exist, create a new NamedTable
-            x = AbstractNamedTable.loadTableFromCSV_File(systemName, userName, fileName);
+            x = AbstractNamedTable.loadTableFromCSV_File(systemName, userName, fileName, true);
         } catch (IOException ex) {
 //            Exceptions.printStackTrace(ex);
             log.error("Cannot load table due to I/O error", ex);
@@ -148,7 +148,7 @@ public class DefaultNamedTableManager extends AbstractManager<NamedTable>
     @Override
     public NamedTable loadTableFromCSV(@Nonnull String fileName)
             throws NamedBean.BadUserNameException, NamedBean.BadSystemNameException, IOException {
-        return AbstractNamedTable.loadTableFromCSV_File(fileName);
+        return AbstractNamedTable.loadTableFromCSV_File(fileName, true);
     }
     
     /**
@@ -157,7 +157,7 @@ public class DefaultNamedTableManager extends AbstractManager<NamedTable>
     @Override
     public NamedTable loadTableFromCSV(@Nonnull String fileName, @Nonnull String text)
             throws NamedBean.BadUserNameException, NamedBean.BadSystemNameException {
-        return AbstractNamedTable.loadTableFromCSV_Text(fileName, text);
+        return AbstractNamedTable.loadTableFromCSV_Text(fileName, text, true);
     }
     
     /**
@@ -166,7 +166,7 @@ public class DefaultNamedTableManager extends AbstractManager<NamedTable>
     @Override
     public NamedTable loadTableFromCSV(@Nonnull File file)
             throws NamedBean.BadUserNameException, NamedBean.BadSystemNameException, IOException {
-        return AbstractNamedTable.loadTableFromCSV_File(file);
+        return AbstractNamedTable.loadTableFromCSV_File(file, true);
     }
     
     /**
@@ -177,7 +177,7 @@ public class DefaultNamedTableManager extends AbstractManager<NamedTable>
             @Nonnull File file,
             @Nonnull String sys, @CheckForNull String user)
             throws NamedBean.BadUserNameException, NamedBean.BadSystemNameException, IOException {
-        return AbstractNamedTable.loadTableFromCSV_File(sys, user, file);
+        return AbstractNamedTable.loadTableFromCSV_File(sys, user, file, true);
     }
     
     /**

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultSymbolTable.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultSymbolTable.java
@@ -26,6 +26,20 @@ public class DefaultSymbolTable implements SymbolTable {
     private final Map<String, Symbol> _symbols = new HashMap<>();
     
     
+    /**
+     * Create a new instance of DefaultSymbolTable with no previous symbol table.
+     */
+    public DefaultSymbolTable() {
+        _prevSymbolTable = null;
+        _stack = new DefaultStack();
+        _firstSymbolIndex = _stack.getCount();
+    }
+    
+    /**
+     * Create a new instance of DefaultSymbolTable with previous symbol table
+     * and the stack from a ConditionalNG.
+     * @param currentConditionalNG the ConditionalNG
+     */
     public DefaultSymbolTable(ConditionalNG currentConditionalNG) {
         _prevSymbolTable = currentConditionalNG.getSymbolTable();
         _stack = currentConditionalNG.getStack();

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
@@ -211,3 +211,5 @@ LogixNG_Initialization_ButtonAddLogixNG         = Add initialization LogixNG
 LogixNG_Initialization_ErrorTitle               = Error
 LogixNG_Initialization_ErrorLogixNG_Exists      = The LogixNG is already in the initialization table
 LogixNG_Initialization_ErrorNoLogixNG_Selected  = No LogixNG is selected
+
+TableEditor_CopyToClipboard     = Copy to clipboard

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
@@ -217,3 +217,5 @@ TableEditor_CsvFile             = CSV table
 TableEditor_UnknownTableType    = Unknown table type
 TableEditor_FileName            = File name
 TableEditor_CopyToClipboard     = Copy to clipboard
+
+TableEditor_Error_FileNotFound  = File not found: {0}

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGSwingBundle.properties
@@ -212,4 +212,8 @@ LogixNG_Initialization_ErrorTitle               = Error
 LogixNG_Initialization_ErrorLogixNG_Exists      = The LogixNG is already in the initialization table
 LogixNG_Initialization_ErrorNoLogixNG_Selected  = No LogixNG is selected
 
+TableEditor_TableType           = Table type
+TableEditor_CsvFile             = CSV table
+TableEditor_UnknownTableType    = Unknown table type
+TableEditor_FileName            = File name
 TableEditor_CopyToClipboard     = Copy to clipboard

--- a/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
@@ -1,8 +1,11 @@
 package jmri.jmrit.logixng.tools.swing;
 
+import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
 import java.beans.PropertyChangeListener;
@@ -15,7 +18,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.*;
 import javax.swing.border.Border;
+import javax.swing.event.ListSelectionListener;
 import javax.swing.table.AbstractTableModel;
+import javax.swing.table.JTableHeader;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
@@ -23,12 +28,14 @@ import javax.swing.table.TableColumnModel;
 import jmri.InstanceManager;
 import jmri.UserPreferencesManager;
 import jmri.jmrit.beantable.BeanTableDataModel;
-import jmri.jmrit.beantable.BeanTableFrame;
 import jmri.jmrit.logixng.*;
-import jmri.util.JmriJFrame;
+import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
+import jmri.jmrit.logixng.util.ReferenceUtil;
 import jmri.swing.NamedBeanComboBox;
+import jmri.util.JmriJFrame;
 import jmri.util.table.ButtonEditor;
 import jmri.util.table.ButtonRenderer;
+import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
 
 /**
  * Editor for LogixNG Tables
@@ -39,22 +46,21 @@ import jmri.util.table.ButtonRenderer;
  * @author Dave Sand copyright (c) 2017  (ConditionalListEdit)
  * @author Daniel Bergqvist (c) 2019
  */
-public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
+    public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
 
-//    BeanTableFrame<NamedTable> beanTableFrame;
-    BeanTableDataModel<NamedTable> beanTableDataModel;
+    private final BeanTableDataModel<NamedTable> beanTableDataModel;
 
-    NamedTableManager _tableManager = null;
-    NamedTable _curTable = null;
+    private NamedTableManager _tableManager = null;
+    private NamedTable _curTable = null;
 
-//    ConditionalNGEditor _treeEdit = null;
+//    private ConditionalNGEditor _treeEdit = null;
 
-//    int _numConditionalNGs = 0;
-    boolean _inEditMode = false;
+//    private int _numConditionalNGs = 0;
+    private boolean _inEditMode = false;
 
-    boolean _showReminder = false;
-    boolean _suppressReminder = false;
-    boolean _suppressIndirectRef = false;
+    private boolean _showReminder = false;
+    
+    private final SymbolTable symbolTable = new DefaultSymbolTable();
 
 //    private final JCheckBox _autoSystemName = new JCheckBox(Bundle.getMessage("LabelAutoSysName"));   // NOI18N
 //    private final JLabel _sysNameLabel = new JLabel(Bundle.getMessage("SystemName") + ":");  // NOI18N
@@ -72,54 +78,51 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
      * @param m the bean table model
      * @param sName name of the NamedTable being edited
      */
-//     * @param f the bean table frame
-//    public TableEditor(BeanTableFrame<NamedTable> f, BeanTableDataModel<NamedTable> m, String sName) {
     public TableEditor(BeanTableDataModel<NamedTable> m, String sName) {
-//        this.beanTableFrame = f;
         this.beanTableDataModel = m;
         _tableManager = InstanceManager.getDefault(jmri.jmrit.logixng.NamedTableManager.class);
         _curTable = _tableManager.getBySystemName(sName);
-        makeEditLogixNGWindow();
+        makeEditTableWindow();
     }
 
     // ------------ NamedTable Variables ------------
-    JmriJFrame _editLogixNGFrame = null;
-    JTextField editUserName = new JTextField(20);
-    JLabel status = new JLabel(" ");
+    private JmriJFrame _editLogixNGFrame = null;
+    private final JTextField editUserName = new JTextField(20);
+//    private JLabel status = new JLabel(" ");
 
     // ------------ ConditionalNG Variables ------------
-    ConditionalNGTableModel conditionalNGTableModel = null;
-    ConditionalNG _curConditionalNG = null;
-    int _conditionalRowNumber = 0;
-    boolean _inReorderMode = false;
-    boolean _inActReorder = false;
-    boolean _inVarReorder = false;
-    int _nextInOrder = 0;
+    private TableTableModel tableTableModel = null;
+//    private ConditionalNG _curConditionalNG = null;
+//    private int _conditionalRowNumber = 0;
+//    private boolean _inReorderMode = false;
+//    private boolean _inActReorder = false;
+//    private boolean _inVarReorder = false;
+//    private int _nextInOrder = 0;
 
     // ------------ Select NamedTable/ConditionalNG Variables ------------
-    JPanel _selectLogixNGPanel = null;
-    JPanel _selectConditionalNGPanel = null;
+//    private JPanel _selectLogixNGPanel = null;
+//    private JPanel _selectConditionalNGPanel = null;
 //    private JComboBox<String> _selectLogixNGComboBox = new JComboBox<>();
 //    private JComboBox<String> _selectConditionalNGComboBox = new JComboBox<>();
-    TreeMap<String, String> _selectLogixNGMap = new TreeMap<>();
-    ArrayList<String> _selectConditionalNGList = new ArrayList<>();
+//    private TreeMap<String, String> _selectLogixNGMap = new TreeMap<>();
+//    private ArrayList<String> _selectConditionalNGList = new ArrayList<>();
 
     // ------------ Edit ConditionalNG Variables ------------
-    boolean _inEditConditionalNGMode = false;
-    JmriJFrame _editConditionalNGFrame = null;
-    JTextField _conditionalUserName = new JTextField(22);
-    JRadioButton _triggerOnChangeButton;
+//    private boolean _inEditConditionalNGMode = false;
+//    private JmriJFrame _editConditionalNGFrame = null;
+//    private JTextField _conditionalUserName = new JTextField(22);
+//    private JRadioButton _triggerOnChangeButton;
 
     // ------------ Methods for Edit NamedTable Pane ------------
 
     /**
      * Create and/or initialize the Edit NamedTable pane.
      */
-    void makeEditLogixNGWindow() {
+    private void makeEditTableWindow() {
         editUserName.setText(_curTable.getUserName());
         // clear conditional table if needed
-        if (conditionalNGTableModel != null) {
-            conditionalNGTableModel.fireTableStructureChanged();
+        if (tableTableModel != null) {
+            tableTableModel.fireTableStructureChanged();
         }
         _inEditMode = true;
         if (_editLogixNGFrame == null) {
@@ -155,7 +158,29 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
             panel2.add(editUserName);
             editUserName.setToolTipText(Bundle.getMessage("LogixNGUserNameHint2"));  // NOI18N
             contentPane.add(panel2);
-            // add table of ConditionalNGs
+            
+            boolean isCsvTable = _curTable instanceof DefaultCsvNamedTable;
+            
+            JPanel panel3 = new JPanel();
+            panel3.setLayout(new FlowLayout());
+            JLabel tableTypeLabel = new JLabel("Table type: ");  // NOI18N
+//            JLabel tableTypeLabel = new JLabel(Bundle.getMessage("TableType") + ": ");  // NOI18N
+            panel3.add(tableTypeLabel);
+            panel3.add(new JLabel(isCsvTable ? "CSV table" : "Unknown table type"));
+            contentPane.add(panel3);
+            
+            if (isCsvTable) {
+                JPanel panel4 = new JPanel();
+                panel4.setLayout(new FlowLayout());
+                JLabel tableFileNameLabel = new JLabel("File name: ");  // NOI18N
+//                JLabel tableTypeLabel = new JLabel(Bundle.getMessage("FileName") + ": ");  // NOI18N
+                panel4.add(tableFileNameLabel);
+                panel4.add(new JLabel(((DefaultCsvNamedTable)_curTable).getFileName()));
+                contentPane.add(panel4);
+            }
+            
+            
+            // add table of Tables
             JPanel pctSpace = new JPanel();
             pctSpace.setLayout(new FlowLayout());
             pctSpace.add(new JLabel("   "));
@@ -165,93 +190,149 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
             pTitle.add(new JLabel(Bundle.getMessage("ConditionalNGTableTitle")));  // NOI18N
             contentPane.add(pTitle);
             // initialize table of conditionals
-            conditionalNGTableModel = new ConditionalNGTableModel();
-            JTable conditionalTable = new JTable(conditionalNGTableModel);
-            conditionalTable.setRowSelectionAllowed(false);
-            TableColumnModel conditionalColumnModel = conditionalTable
-                    .getColumnModel();
-            TableColumn sNameColumn = conditionalColumnModel
-                    .getColumn(ConditionalNGTableModel.SNAME_COLUMN);
-            sNameColumn.setResizable(true);
-            sNameColumn.setMinWidth(100);
-            sNameColumn.setPreferredWidth(130);
-            TableColumn uNameColumn = conditionalColumnModel
-                    .getColumn(ConditionalNGTableModel.UNAME_COLUMN);
-            uNameColumn.setResizable(true);
-            uNameColumn.setMinWidth(210);
-            uNameColumn.setPreferredWidth(260);
-            TableColumn buttonColumn = conditionalColumnModel
-                    .getColumn(ConditionalNGTableModel.BUTTON_COLUMN);
-
-            // install button renderer and editor
-            ButtonRenderer buttonRenderer = new ButtonRenderer();
-            conditionalTable.setDefaultRenderer(JButton.class, buttonRenderer);
-            TableCellEditor buttonEditor = new ButtonEditor(new JButton());
-            conditionalTable.setDefaultEditor(JButton.class, buttonEditor);
-            JButton testButton = new JButton("XXXXXX");  // NOI18N
-            conditionalTable.setRowHeight(testButton.getPreferredSize().height);
-            buttonColumn.setMinWidth(testButton.getPreferredSize().width);
-            buttonColumn.setMaxWidth(testButton.getPreferredSize().width);
-            buttonColumn.setResizable(false);
-
-            JScrollPane conditionalTableScrollPane = new JScrollPane(conditionalTable);
-            Dimension dim = conditionalTable.getPreferredSize();
+            tableTableModel = new TableTableModel();
+            JTable tableTable = new JTable(tableTableModel);
+            tableTable.setCellSelectionEnabled(true);
+            tableTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+            tableTable.setAutoResizeMode( JTable.AUTO_RESIZE_OFF );
+            tableTable.getTableHeader().setReorderingAllowed(false);
+            
+            JButton cellRefByIndexButton = new JButton(Bundle.getMessage("TableEditor_CopyToClipboard"));  // NOI18N
+            JLabel cellRefByIndexLabel = new JLabel();  // NOI18N
+            JTextField cellRefByIndex = new JTextField();
+            cellRefByIndex.setEditable(false);
+            
+            JButton cellRefByHeaderButton = new JButton(Bundle.getMessage("TableEditor_CopyToClipboard"));  // NOI18N
+            JLabel cellRefByHeaderLabel = new JLabel();  // NOI18N
+            JTextField cellRefByHeader = new JTextField();
+            cellRefByHeader.setEditable(false);
+            
+            java.awt.datatransfer.Clipboard clipboard =
+                    Toolkit.getDefaultToolkit().getSystemClipboard();
+            
+            cellRefByIndexButton.addActionListener(
+                    (evt) -> { clipboard.setContents(new StringSelection(cellRefByIndexLabel.getText()), null);});
+            
+            cellRefByHeaderButton.addActionListener(
+                    (evt) -> { clipboard.setContents(new StringSelection(cellRefByHeaderLabel.getText()), null);});
+            
+            ListSelectionListener selectCellListener = (evt) -> {
+                String refByIndex = String.format("{%s[%d,%d]}", _curTable.getDisplayName(), tableTable.getSelectedRow()+1, tableTable.getSelectedColumn()+1);
+                cellRefByIndexLabel.setText(refByIndex);  // NOI18N
+                cellRefByIndex.setText(ReferenceUtil.getReference(symbolTable, refByIndex));  // NOI18N
+                
+                Object rowHeaderObj = _curTable.getCell(tableTable.getSelectedRow()+1, 0);
+                Object columnHeaderObj = _curTable.getCell(0, tableTable.getSelectedColumn()+1);
+                String rowHeader = rowHeaderObj != null ? rowHeaderObj.toString() : "";
+                String columnHeader = columnHeaderObj != null ? columnHeaderObj.toString() : "";
+                if (!rowHeader.isEmpty() && !columnHeader.isEmpty()) {
+                    cellRefByHeaderButton.setEnabled(true);
+                    String refByHeader = String.format("{%s[%s,%s]}", _curTable.getDisplayName(), _curTable.getCell(tableTable.getSelectedRow()+1,0), _curTable.getCell(0,tableTable.getSelectedColumn()+1));
+                    cellRefByHeaderLabel.setText(refByHeader);  // NOI18N
+                    cellRefByHeader.setText(ReferenceUtil.getReference(symbolTable, refByIndex));  // NOI18N
+                } else {
+                    cellRefByHeaderButton.setEnabled(false);
+                    cellRefByHeaderLabel.setText("");    // NOI18N
+                    cellRefByHeader.setText("");        // NOI18N
+                }
+            };
+            tableTable.getSelectionModel().addListSelectionListener(selectCellListener);
+            tableTable.getColumnModel().getSelectionModel().addListSelectionListener(selectCellListener);
+            
+            ListModel lm = new AbstractListModel() {
+                @Override
+                public int getSize() {
+                    return _curTable.numRows()-1;
+                }
+                
+                @Override
+                public Object getElementAt(int index) {
+                    return _curTable.getCell(index+1, 0);
+                }
+            };
+            
+            JList rowHeader = new JList(lm);
+            rowHeader.setFixedCellHeight(
+                    tableTable.getRowHeight()
+//                    tableTable.getRowHeight() + tableTable.getRowMargin()
+//                    + table.getIntercellSpacing().height
+            );
+            rowHeader.setCellRenderer(new RowHeaderRenderer(tableTable));
+            
+            JScrollPane tableTableScrollPane = new JScrollPane(tableTable);
+            tableTableScrollPane.setRowHeaderView(rowHeader);
+            Dimension dim = tableTable.getPreferredSize();
             dim.height = 450;
-            conditionalTableScrollPane.getViewport().setPreferredSize(dim);
-            contentPane.add(conditionalTableScrollPane);
-
-            // add message area between table and buttons
+            tableTableScrollPane.setPreferredSize(dim);
+//            tableTableScrollPane.getViewport().setPreferredSize(dim);
+            contentPane.add(tableTableScrollPane);
+            
             JPanel panel4 = new JPanel();
-            panel4.setLayout(new BoxLayout(panel4, BoxLayout.Y_AXIS));
-            JPanel panel41 = new JPanel();
-            panel41.setLayout(new FlowLayout());
-            panel41.add(status);
-            panel4.add(panel41);
-            JPanel panel42 = new JPanel();
-            panel42.setLayout(new FlowLayout());
+            panel4.setLayout(new FlowLayout());
+            panel4.add(cellRefByIndexButton);
+            panel4.add(cellRefByIndexLabel);
+            panel4.add(cellRefByIndex);
+            contentPane.add(panel4);
+            
+            JPanel panel5 = new JPanel();
+            panel5.setLayout(new FlowLayout());
+            panel5.add(cellRefByHeaderButton);
+            panel5.add(cellRefByHeaderLabel);
+            panel5.add(cellRefByHeader);
+            contentPane.add(panel5);
+            
+            // add message area between table and buttons
+//            JPanel panel4 = new JPanel();
+//            panel4.setLayout(new BoxLayout(panel4, BoxLayout.Y_AXIS));
+//            JPanel panel41 = new JPanel();
+//            panel41.setLayout(new FlowLayout());
+//            panel41.add(status);
+//            panel4.add(panel41);
+//            JPanel panel42 = new JPanel();
+//            panel42.setLayout(new FlowLayout());
             // ConditionalNG panel buttons - New ConditionalNG
-            JButton newConditionalNGButton = new JButton(Bundle.getMessage("NewConditionalNGButton"));  // NOI18N
-            panel42.add(newConditionalNGButton);
+//            JButton newConditionalNGButton = new JButton(Bundle.getMessage("NewConditionalNGButton"));  // NOI18N
+//            panel42.add(newConditionalNGButton);
 //            newConditionalNGButton.addActionListener((e) -> {
 //                newConditionalNGPressed(e);
 //            });
-            newConditionalNGButton.setToolTipText(Bundle.getMessage("NewConditionalNGButtonHint"));  // NOI18N
+//            newConditionalNGButton.setToolTipText(Bundle.getMessage("NewConditionalNGButtonHint"));  // NOI18N
             // ConditionalNG panel buttons - Reorder
-            JButton reorderButton = new JButton(Bundle.getMessage("ReorderButton"));  // NOI18N
-            panel42.add(reorderButton);
+//            JButton reorderButton = new JButton(Bundle.getMessage("ReorderButton"));  // NOI18N
+//            panel42.add(reorderButton);
 //            reorderButton.addActionListener((e) -> {
 //                reorderPressed(e);
 //            });
-            reorderButton.setToolTipText(Bundle.getMessage("ReorderButtonHint"));  // NOI18N
+//            reorderButton.setToolTipText(Bundle.getMessage("ReorderButtonHint"));  // NOI18N
             // ConditionalNG panel buttons - Calculate
-            JButton executeButton = new JButton(Bundle.getMessage("ExecuteButton"));  // NOI18N
-            panel42.add(executeButton);
+//            JButton executeButton = new JButton(Bundle.getMessage("ExecuteButton"));  // NOI18N
+//            panel42.add(executeButton);
 //            executeButton.addActionListener((e) -> {
 //                executePressed(e);
 //            });
-            executeButton.setToolTipText(Bundle.getMessage("ExecuteButtonHint"));  // NOI18N
-            panel4.add(panel42);
-            Border panel4Border = BorderFactory.createEtchedBorder();
-            panel4.setBorder(panel4Border);
-            contentPane.add(panel4);
+//            executeButton.setToolTipText(Bundle.getMessage("ExecuteButtonHint"));  // NOI18N
+//            panel4.add(panel42);
+//            Border panel4Border = BorderFactory.createEtchedBorder();
+//            panel4.setBorder(panel4Border);
+//            contentPane.add(panel4);
             // add buttons at bottom of window
-            JPanel panel5 = new JPanel();
-            panel5.setLayout(new FlowLayout());
+            JPanel panel6 = new JPanel();
+            panel6.setLayout(new FlowLayout());
             // Bottom Buttons - Done NamedTable
             JButton done = new JButton(Bundle.getMessage("ButtonDone"));  // NOI18N
-            panel5.add(done);
+            panel6.add(done);
             done.addActionListener((e) -> {
                 donePressed(e);
             });
             done.setToolTipText(Bundle.getMessage("DoneButtonHint"));  // NOI18N
             // Delete NamedTable
             JButton delete = new JButton(Bundle.getMessage("ButtonDelete"));  // NOI18N
-            panel5.add(delete);
+            panel6.add(delete);
             delete.addActionListener((e) -> {
                 deletePressed();
             });
             delete.setToolTipText(Bundle.getMessage("DeleteLogixNGButtonHint"));  // NOI18N
-            contentPane.add(panel5);
+            contentPane.add(panel6);
         }
 
         _editLogixNGFrame.addWindowListener(new java.awt.event.WindowAdapter() {
@@ -622,11 +703,11 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
 
     // ------------ Methods for Edit ConditionalNG Pane ------------
 
-    /**
+    /*.*
      * Respond to Edit Button in the ConditionalNG table of the Edit NamedTable Window.
      *
      * @param rx index (row number) of ConditionalNG to be edited
-     */
+     *./
     void editConditionalNGPressed(int rx) {
 /*
         if (_inEditConditionalNGMode) {
@@ -646,7 +727,7 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
         _conditionalRowNumber = rx;
         // get action variables
         makeEditConditionalNGWindow();
-*/
+*./
     }
 
     /*.*
@@ -706,18 +787,12 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
     // ------------ Table Models ------------
 
     /**
-     * Table model for ConditionalNGs in the Edit NamedTable pane.
+     * Table model for Tables in the Edit NamedTable pane.
      */
-    public final class ConditionalNGTableModel extends AbstractTableModel implements
-            PropertyChangeListener {
+    public final class TableTableModel extends AbstractTableModel {
+//            implements PropertyChangeListener {
 
-        public static final int SNAME_COLUMN = 0;
-
-        public static final int UNAME_COLUMN = 1;
-
-        public static final int BUTTON_COLUMN = 2;
-
-        public ConditionalNGTableModel() {
+        public TableTableModel() {
             super();
 //            updateConditionalNGListeners();
         }
@@ -741,7 +816,7 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
                 }
             }
         }
-*/
+*./
         @Override
         public void propertyChange(java.beans.PropertyChangeEvent e) {
             if (e.getPropertyName().equals("length")) {  // NOI18N
@@ -754,7 +829,7 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
             }
         }
 
-        /**
+        /*.*
          * Check if this property event is announcing a change this table should
          * display.
          * <p>
@@ -763,12 +838,12 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
          *
          * @param e the event heard
          * @return true if a change in State or Appearance was heard
-         */
+         *./
         boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
             return (e.getPropertyName().contains("State") ||      // NOI18N
                     e.getPropertyName().contains("Appearance"));  // NOI18N
         }
-
+/*
         @Override
         public Class<?> getColumnClass(int c) {
             if (c == BUTTON_COLUMN) {
@@ -776,18 +851,17 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
             }
             return String.class;
         }
-
+*/
         @Override
         public int getColumnCount() {
-            return 4;
+            return _curTable.numColumns()-1;    // Don't show row headers
         }
 
         @Override
         public int getRowCount() {
-            return 5;   // For test only
-//            return (_numConditionalNGs);
+            return _curTable.numRows()-1;
         }
-
+/*
         @Override
         public boolean isCellEditable(int r, int c) {
             if (!_inReorderMode) {
@@ -799,9 +873,17 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
             }
             return (false);
         }
-
+*/
+//        @Override
+//        public String getRowName(int row) {
+//            return _curTable.getCell(row, 0);
+//        }
+        
         @Override
         public String getColumnName(int col) {
+            Object data = _curTable.getCell(0, col+1);
+            return data != null ? data.toString() : "<null>";
+/*            
             switch (col) {
                 case SNAME_COLUMN:
                     return Bundle.getMessage("ColumnSystemName");  // NOI18N
@@ -812,8 +894,9 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
                 default:
                     return "";
             }
+*/            
         }
-
+/*
         @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "DB_DUPLICATE_SWITCH_CLAUSES",
                 justification = "better to keep cases in column order rather than to combine")
         public int getPreferredWidth(int col) {
@@ -828,7 +911,12 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
                     return new JTextField(5).getPreferredSize().width;
             }
         }
-
+*/
+        @Override
+        public Object getValueAt(int row, int col) {
+            return _curTable.getCell(row+1, col+1);
+        }
+/*        
         @Override
         public Object getValueAt(int r, int col) {
             int rx = r;
@@ -860,7 +948,7 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
                     return Bundle.getMessage("BeanStateUnknown");  // NOI18N
             }
         }
-
+/*
         @Override
         public void setValueAt(Object value, int row, int col) {
             int rx = row;
@@ -924,11 +1012,32 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
                         messageDuplicateConditionalNGUserName(cn.getSystemName());
                     }
                 }
-*/
+*./
             }
         }
+*/        
     }
 
+    private static final class RowHeaderRenderer extends JLabel implements ListCellRenderer {
+        
+        RowHeaderRenderer(JTable table) {
+            JTableHeader header = table.getTableHeader();
+            setOpaque(true);
+            setBorder(UIManager.getBorder("TableHeader.cellBorder"));
+            setHorizontalAlignment(CENTER);
+            setForeground(header.getForeground());
+            setBackground(header.getBackground());
+            setFont(header.getFont());
+        }
+        
+        @Override
+        public Component getListCellRendererComponent(JList list, Object value,
+                int index, boolean isSelected, boolean cellHasFocus) {
+            setText((value == null) ? "" : value.toString());
+            return this;
+        }
+    }
+    
     /*.*
      * Send a duplicate Conditional user name message for Edit Logix pane.
      *
@@ -972,7 +1081,7 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
      * This contains a list of commands to be processed by the listener
      * recipient.
      */
-    private HashMap<String, String> tableData = new HashMap<>();
+    private final HashMap<String, String> tableData = new HashMap<>();
 
     /**
      * Add a listener.
@@ -1039,4 +1148,4 @@ public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
         }
     }
 */
-}
+    }

--- a/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
@@ -242,7 +242,7 @@ import jmri.jmrit.logixng.tools.swing.Bundle;
             tableTable.getSelectionModel().addListSelectionListener(selectCellListener);
             tableTable.getColumnModel().getSelectionModel().addListSelectionListener(selectCellListener);
             
-            ListModel lm = new RowHeaderListModel();
+            ListModel<Object> lm = new RowHeaderListModel();
             
             JList<Object> rowHeader = new JList<>(lm);
             rowHeader.setFixedCellHeight(

--- a/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
@@ -82,6 +82,7 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
     // ------------ NamedTable Variables ------------
     private JmriJFrame _editLogixNGFrame = null;
     private final JTextField editUserName = new JTextField(20);
+    private final JTextField editCsvTableName = new JTextField(40);
 //    private JLabel status = new JLabel(" ");
 
     // ------------ ConditionalNG Variables ------------
@@ -170,7 +171,10 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
                 panel4.setLayout(new FlowLayout());
                 JLabel tableFileNameLabel = new JLabel(Bundle.getMessage("TableEditor_FileName") + ": ");  // NOI18N
                 panel4.add(tableFileNameLabel);
-                panel4.add(new JLabel(((DefaultCsvNamedTable)_curTable).getFileName()));
+//                panel4.add(new JLabel(((DefaultCsvNamedTable)_curTable).getFileName()));
+                editCsvTableName.setText(((DefaultCsvNamedTable)_curTable).getFileName());
+                panel4.add(editCsvTableName);
+//                editCsvTableName.setToolTipText(Bundle.getMessage("LogixNGUserNameHint2"));  // NOI18N
                 contentPane.add(panel4);
             }
             
@@ -368,6 +372,11 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
             tableData.clear();
             tableData.put("chgUname", uName);  // NOI18N
             fireEditorEvent();
+        }
+        if (_curTable instanceof DefaultCsvNamedTable) {
+            // Check if the User Name has been changed
+            String csvFileName = editCsvTableName.getText().trim();
+            ((DefaultCsvNamedTable)_curTable).setFileName(csvFileName);
         }
         // complete update and activate NamedTable
         finishDone();

--- a/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
@@ -242,19 +242,9 @@ import jmri.jmrit.logixng.tools.swing.Bundle;
             tableTable.getSelectionModel().addListSelectionListener(selectCellListener);
             tableTable.getColumnModel().getSelectionModel().addListSelectionListener(selectCellListener);
             
-            ListModel lm = new AbstractListModel() {
-                @Override
-                public int getSize() {
-                    return _curTable.numRows()-1;
-                }
-                
-                @Override
-                public Object getElementAt(int index) {
-                    return _curTable.getCell(index+1, 0);
-                }
-            };
+            ListModel lm = new RowHeaderListModel();
             
-            JList<Object> rowHeader = new JList<>((ListModel<Object>)lm);
+            JList<Object> rowHeader = new JList<>(lm);
             rowHeader.setFixedCellHeight(
                     tableTable.getRowHeight()
 //                    tableTable.getRowHeight() + tableTable.getRowMargin()
@@ -479,7 +469,19 @@ import jmri.jmrit.logixng.tools.swing.Bundle;
         }
     }
 
-    private static final class RowHeaderRenderer extends JLabel implements ListCellRenderer {
+    private class RowHeaderListModel extends AbstractListModel<Object> {
+        @Override
+        public int getSize() {
+            return _curTable.numRows()-1;
+        }
+
+        @Override
+        public Object getElementAt(int index) {
+            return _curTable.getCell(index+1, 0);
+        }
+    }
+    
+    private static final class RowHeaderRenderer extends JLabel implements ListCellRenderer<Object> {
         
         RowHeaderRenderer(JTable table) {
             JTableHeader header = table.getTableHeader();

--- a/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
@@ -254,7 +254,7 @@ import jmri.jmrit.logixng.tools.swing.Bundle;
                 }
             };
             
-            JList<Object> rowHeader = new JList<>(lm);
+            JList<Object> rowHeader = new JList<>((ListModel<Object>)lm);
             rowHeader.setFixedCellHeight(
                     tableTable.getRowHeight()
 //                    tableTable.getRowHeight() + tableTable.getRowMargin()

--- a/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
@@ -48,14 +48,9 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
  */
     public final class TableEditor implements AbstractLogixNGEditor<NamedTable> {
 
-    private final BeanTableDataModel<NamedTable> beanTableDataModel;
-
     private NamedTableManager _tableManager = null;
     private NamedTable _curTable = null;
 
-//    private ConditionalNGEditor _treeEdit = null;
-
-//    private int _numConditionalNGs = 0;
     private boolean _inEditMode = false;
 
     private boolean _showReminder = false;
@@ -79,7 +74,6 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
      * @param sName name of the NamedTable being edited
      */
     public TableEditor(BeanTableDataModel<NamedTable> m, String sName) {
-        this.beanTableDataModel = m;
         _tableManager = InstanceManager.getDefault(jmri.jmrit.logixng.NamedTableManager.class);
         _curTable = _tableManager.getBySystemName(sName);
         makeEditTableWindow();
@@ -163,17 +157,18 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
             
             JPanel panel3 = new JPanel();
             panel3.setLayout(new FlowLayout());
-            JLabel tableTypeLabel = new JLabel("Table type: ");  // NOI18N
-//            JLabel tableTypeLabel = new JLabel(Bundle.getMessage("TableType") + ": ");  // NOI18N
+            JLabel tableTypeLabel = new JLabel(Bundle.getMessage("TableEditor_TableType") + ": ");  // NOI18N
             panel3.add(tableTypeLabel);
-            panel3.add(new JLabel(isCsvTable ? "CSV table" : "Unknown table type"));
+            panel3.add(new JLabel(
+                    isCsvTable
+                            ? Bundle.getMessage("TableEditor_CsvFile")
+                            : Bundle.getMessage("TableEditor_UnknownTableType")));
             contentPane.add(panel3);
             
             if (isCsvTable) {
                 JPanel panel4 = new JPanel();
                 panel4.setLayout(new FlowLayout());
-                JLabel tableFileNameLabel = new JLabel("File name: ");  // NOI18N
-//                JLabel tableTypeLabel = new JLabel(Bundle.getMessage("FileName") + ": ");  // NOI18N
+                JLabel tableFileNameLabel = new JLabel(Bundle.getMessage("TableEditor_FileName") + ": ");  // NOI18N
                 panel4.add(tableFileNameLabel);
                 panel4.add(new JLabel(((DefaultCsvNamedTable)_curTable).getFileName()));
                 contentPane.add(panel4);
@@ -187,7 +182,7 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
             contentPane.add(pctSpace);
             JPanel pTitle = new JPanel();
             pTitle.setLayout(new FlowLayout());
-            pTitle.add(new JLabel(Bundle.getMessage("ConditionalNGTableTitle")));  // NOI18N
+//            pTitle.add(new JLabel(Bundle.getMessage("ConditionalNGTableTitle")));  // NOI18N
             contentPane.add(pTitle);
             // initialize table of conditionals
             tableTableModel = new TableTableModel();
@@ -263,8 +258,8 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
             tableTableScrollPane.setRowHeaderView(rowHeader);
             Dimension dim = tableTable.getPreferredSize();
             dim.height = 450;
-            tableTableScrollPane.setPreferredSize(dim);
-//            tableTableScrollPane.getViewport().setPreferredSize(dim);
+//            tableTableScrollPane.setPreferredSize(dim);
+            tableTableScrollPane.getViewport().setPreferredSize(dim);
             contentPane.add(tableTableScrollPane);
             
             JPanel panel4 = new JPanel();
@@ -281,40 +276,6 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
             panel5.add(cellRefByHeader);
             contentPane.add(panel5);
             
-            // add message area between table and buttons
-//            JPanel panel4 = new JPanel();
-//            panel4.setLayout(new BoxLayout(panel4, BoxLayout.Y_AXIS));
-//            JPanel panel41 = new JPanel();
-//            panel41.setLayout(new FlowLayout());
-//            panel41.add(status);
-//            panel4.add(panel41);
-//            JPanel panel42 = new JPanel();
-//            panel42.setLayout(new FlowLayout());
-            // ConditionalNG panel buttons - New ConditionalNG
-//            JButton newConditionalNGButton = new JButton(Bundle.getMessage("NewConditionalNGButton"));  // NOI18N
-//            panel42.add(newConditionalNGButton);
-//            newConditionalNGButton.addActionListener((e) -> {
-//                newConditionalNGPressed(e);
-//            });
-//            newConditionalNGButton.setToolTipText(Bundle.getMessage("NewConditionalNGButtonHint"));  // NOI18N
-            // ConditionalNG panel buttons - Reorder
-//            JButton reorderButton = new JButton(Bundle.getMessage("ReorderButton"));  // NOI18N
-//            panel42.add(reorderButton);
-//            reorderButton.addActionListener((e) -> {
-//                reorderPressed(e);
-//            });
-//            reorderButton.setToolTipText(Bundle.getMessage("ReorderButtonHint"));  // NOI18N
-            // ConditionalNG panel buttons - Calculate
-//            JButton executeButton = new JButton(Bundle.getMessage("ExecuteButton"));  // NOI18N
-//            panel42.add(executeButton);
-//            executeButton.addActionListener((e) -> {
-//                executePressed(e);
-//            });
-//            executeButton.setToolTipText(Bundle.getMessage("ExecuteButtonHint"));  // NOI18N
-//            panel4.add(panel42);
-//            Border panel4Border = BorderFactory.createEtchedBorder();
-//            panel4.setBorder(panel4Border);
-//            contentPane.add(panel4);
             // add buttons at bottom of window
             JPanel panel6 = new JPanel();
             panel6.setLayout(new FlowLayout());
@@ -372,66 +333,6 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
         }
     }
 
-    /*.*
-     * Respond to the Reorder Button in the Edit NamedTable pane.
-     *
-     * @param e The event heard
-     *./
-    void reorderPressed(ActionEvent e) {
-        if (checkEditConditionalNG()) {
-            return;
-        }
-        // Check if reorder is reasonable
-        _showReminder = true;
-        _nextInOrder = 0;
-        _inReorderMode = true;
-        status.setText(Bundle.getMessage("ReorderMessage"));  // NOI18N
-        conditionalNGTableModel.fireTableDataChanged();
-    }
-
-    /*.*
-     * Respond to the First/Next (Delete) Button in the Edit NamedTable window.
-     *
-     * @param row index of the row to put as next in line (instead of the one
-     *            that was supposed to be next)
-     *./
-    void swapConditionalNG(int row) {
-        _curTable.swapConditionalNG(_nextInOrder, row);
-        _nextInOrder++;
-        if (_nextInOrder >= _numConditionalNGs) {
-            _inReorderMode = false;
-        }
-        //status.setText("");
-        conditionalNGTableModel.fireTableDataChanged();
-    }
-
-    /*.*
-     * Responds to the Execute Button in the Edit NamedTable window.
-     *
-     * @param e The event heard
-     *./
-    void executePressed(ActionEvent e) {
-        if (checkEditConditionalNG()) {
-            return;
-        }
-        // are there ConditionalNGs to calculate?
-        if (_numConditionalNGs > 0) {
-            // There are conditionals to calculate
-            for (int i = 0; i < _numConditionalNGs; i++) {
-                ConditionalNG c = _curTable.getConditionalNG(i);
-                if (c == null) {
-                    log.error("Invalid conditional system name when calculating"); // NOI18N
-                } else {
-                    c.execute();
-                    // calculate without taking any action
-//                    c.calculate(false, null);
-                }
-            }
-            // force the table to update
-            conditionalNGTableModel.fireTableDataChanged();
-        }
-    }
-*/
     /**
      * Respond to the Done button in the Edit NamedTable window.
      * <p>
@@ -489,9 +390,6 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
      * Respond to the Delete button in the Edit NamedTable window.
      */
     void deletePressed() {
-//        if (checkEditConditionalNG()) {
-//            return;
-//        }
 /*
         if (!checkConditionalNGReferences(_curLogixNG.getSystemName())) {
             return;
@@ -504,354 +402,13 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
         finishDone();
     }
 
-    /*.*
-     * Respond to the New ConditionalNG Button in Edit NamedTable Window.
-     *
-     * @param e The event heard
-     *./
-    void newConditionalNGPressed(ActionEvent e) {
-        if (checkEditConditionalNG()) {
-            return;
-        }
-
-        // make an Add Item Frame
-        if (showAddLogixNGFrame()) {
-            if (_systemName.getText().isEmpty() && _autoSystemName.isSelected()) {
-                _systemName.setText(InstanceManager.getDefault(ConditionalNG_Manager.class).getAutoSystemName());
-            }
-
-            // Create ConditionalNG
-            _curConditionalNG =
-                    InstanceManager.getDefault(ConditionalNG_Manager.class)
-                            .createConditionalNG(_systemName.getText(), _addUserName.getText());
-
-            if (_curConditionalNG == null) {
-                // should never get here unless there is an assignment conflict
-                log.error("Failure to create ConditionalNG"); // NOI18N
-                return;
-            }
-            // add to NamedTable at the end of the calculate order
-            _curTable.addConditionalNG(_curConditionalNG);
-            conditionalNGTableModel.fireTableRowsInserted(_numConditionalNGs, _numConditionalNGs);
-            _conditionalRowNumber = _numConditionalNGs;
-            _numConditionalNGs++;
-            _showReminder = true;
-            makeEditConditionalNGWindow();
-        }
-    }
-
-    /*.*
-     * Create or edit action/expression dialog.
-     *./
-    private boolean showAddLogixNGFrame() {
-
-        AtomicBoolean result = new AtomicBoolean(false);
-
-        JDialog dialog  = new JDialog(
-                _editLogixNGFrame,
-                Bundle.getMessage("AddConditionalNGDialogTitle"),
-                true);
-//        frame.addHelpMenu(
-//                "package.jmri.jmrit.logixng.tools.swing.ConditionalNGAddEdit", true);     // NOI18N
-        Container contentPanel = dialog.getContentPane();
-        contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
-
-        JPanel p;
-        p = new JPanel();
-//        p.setLayout(new FlowLayout());
-        p.setLayout(new java.awt.GridBagLayout());
-        java.awt.GridBagConstraints c = new java.awt.GridBagConstraints();
-        c.gridwidth = 1;
-        c.gridheight = 1;
-        c.gridx = 0;
-        c.gridy = 0;
-        c.anchor = java.awt.GridBagConstraints.EAST;
-        p.add(_sysNameLabel, c);
-        c.gridy = 1;
-        p.add(_userNameLabel, c);
-        c.gridx = 1;
-        c.gridy = 0;
-        c.anchor = java.awt.GridBagConstraints.WEST;
-        c.weightx = 1.0;
-        c.fill = java.awt.GridBagConstraints.HORIZONTAL;  // text field will expand
-        p.add(_systemName, c);
-        c.gridy = 1;
-        p.add(_addUserName, c);
-        c.gridx = 2;
-        c.gridy = 1;
-        c.anchor = java.awt.GridBagConstraints.WEST;
-        c.weightx = 1.0;
-        c.fill = java.awt.GridBagConstraints.HORIZONTAL;  // text field will expand
-        c.gridy = 0;
-        p.add(_autoSystemName, c);
-
-        _systemName.setText("");
-        _systemName.setEnabled(true);
-        _addUserName.setText("");
-
-        _addUserName.setToolTipText(Bundle.getMessage("UserNameHint"));    // NOI18N
-//        _addUserName.setToolTipText("LogixNGUserNameHint");    // NOI18N
-        _systemName.setToolTipText(Bundle.getMessage("LogixNGSystemNameHint"));   // NOI18N
-//        _systemName.setToolTipText("LogixNGSystemNameHint");   // NOI18N
-        contentPanel.add(p);
-        // set up message
-        JPanel panel3 = new JPanel();
-        panel3.setLayout(new BoxLayout(panel3, BoxLayout.Y_AXIS));
-        JPanel panel31 = new JPanel();
-//        panel31.setLayout(new FlowLayout());
-        JPanel panel32 = new JPanel();
-        JLabel message1 = new JLabel(Bundle.getMessage("AddMessage1"));  // NOI18N
-        panel31.add(message1);
-        JLabel message2 = new JLabel(Bundle.getMessage("AddMessage2"));  // NOI18N
-        panel32.add(message2);
-
-        // set up create and cancel buttons
-        JPanel panel5 = new JPanel();
-        panel5.setLayout(new FlowLayout());
-
-        // Get panel for the item
-        panel3.add(panel31);
-        panel3.add(panel32);
-        contentPanel.add(panel3);
-
-        // Cancel
-        JButton cancel = new JButton(Bundle.getMessage("ButtonCancel"));    // NOI18N
-        panel5.add(cancel);
-        cancel.addActionListener((ActionEvent e) -> {
-            dialog.dispose();
-        });
-//        cancel.setToolTipText(Bundle.getMessage("CancelLogixButtonHint"));      // NOI18N
-        cancel.setToolTipText("CancelLogixButtonHint");      // NOI18N
-
-        JButton create = new JButton(Bundle.getMessage("ButtonCreate"));  // NOI18N
-        create.addActionListener((ActionEvent e2) -> {
-            InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent((prefMgr) -> {
-                prefMgr.setCheckboxPreferenceState(systemNameAuto, _autoSystemName.isSelected());
-            });
-            result.set(true);
-            dialog.dispose();
-        });
-        create.setToolTipText(Bundle.getMessage("CreateButtonHint"));  // NOI18N
-
-        panel5.add(create);
-
-        dialog.addWindowListener(new java.awt.event.WindowAdapter() {
-            @Override
-            public void windowClosing(java.awt.event.WindowEvent e) {
-                dialog.dispose();
-            }
-        });
-
-        contentPanel.add(panel5);
-
-        _autoSystemName.addItemListener((ItemEvent e) -> {
-            autoSystemName();
-        });
-//        addLogixNGFrame.setLocationRelativeTo(component);
-        dialog.pack();
-        dialog.setLocationRelativeTo(null);
-
-        _autoSystemName.setSelected(true);
-        InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent((prefMgr) -> {
-            _autoSystemName.setSelected(prefMgr.getCheckboxPreferenceState(systemNameAuto, true));
-        });
-
-        dialog.setVisible(true);
-
-        return result.get();
-    }
-
-    /*.*
-     * Enable/disable fields for data entry when user selects to have system
-     * name automatically generated.
-     *./
-    void autoSystemName() {
-        if (_autoSystemName.isSelected()) {
-            _systemName.setEnabled(false);
-            _sysNameLabel.setEnabled(false);
-        } else {
-            _systemName.setEnabled(true);
-            _sysNameLabel.setEnabled(true);
-        }
-    }
-*/
-    // ============ Edit Conditional Window and Methods ============
-
-    /*.*
-     * Create and/or initialize the Edit Conditional window.
-     * <p>
-     * Note: you can get here via the New Conditional button
-     * (newConditionalPressed) or via an Edit button in the Conditional table of
-     * the Edit Logix window.
-     *./
-    void makeEditConditionalNGWindow() {
-        // deactivate this Logix
-        _curTable.deActivateLogixNG();
-        _conditionalUserName.setText(_curConditionalNG.getUserName());
-
-        // Create a new NamedTable edit view, add the listener.
-//        if (_editMode == LogixNGTableAction.EditMode.TREEEDIT) {
-            _treeEdit = new ConditionalNGEditor(_curConditionalNG);
-            _treeEdit.initComponents();
-            _treeEdit.setVisible(true);
-            _inEditMode = true;
-
-            final TableEditor logixNGEditor = this;
-            _treeEdit.addLogixNGEventListener(new LogixNGEventListenerImpl(logixNGEditor));
-//        }
-    }
-
-    // ------------ Methods for Edit ConditionalNG Pane ------------
-
-    /*.*
-     * Respond to Edit Button in the ConditionalNG table of the Edit NamedTable Window.
-     *
-     * @param rx index (row number) of ConditionalNG to be edited
-     *./
-    void editConditionalNGPressed(int rx) {
-/*
-        if (_inEditConditionalNGMode) {
-            // Already editing a ConditionalNG, ask for completion of that edit
-            JOptionPane.showMessageDialog(_editConditionalNGFrame,
-                    Bundle.getMessage("Error34", _curConditionalNG.getSystemName()),
-                    Bundle.getMessage("ErrorTitle"), // NOI18N
-                    JOptionPane.ERROR_MESSAGE);
-            return;
-        }
-        // get ConditionalNG to edit
-        _curConditionalNG = _curTable.getConditionalNG(rx);
-        if (_curConditionalNG == null) {
-            log.error("Attempted edit of non-existant conditional.");  // NOI18N
-            return;
-        }
-        _conditionalRowNumber = rx;
-        // get action variables
-        makeEditConditionalNGWindow();
-*./
-    }
-
-    /*.*
-     * Check if edit of a conditional is in progress.
-     *
-     * @return true if this is the case, after showing dialog to user
-     *./
-    boolean checkEditConditionalNG() {
-        if (_inEditConditionalNGMode) {
-            // Already editing a ConditionalNG, ask for completion of that edit
-            JOptionPane.showMessageDialog(_editConditionalNGFrame,
-                    Bundle.getMessage("Error35", _curConditionalNG.getSystemName()), // NOI18N
-                    Bundle.getMessage("ErrorTitle"), // NOI18N
-                    JOptionPane.ERROR_MESSAGE);
-            return true;
-        }
-        return false;
-    }
-
-    boolean checkConditionalNGUserName(String uName, NamedTable logixNG) {
-        if ((uName != null) && (!(uName.equals("")))) {
-            for (int i=0; i < logixNG.getNumConditionalNGs(); i++) {
-                ConditionalNG p = logixNG.getConditionalNG(i);
-                if (uName.equals(p.getUserName())) {
-                    // ConditionalNG with this user name already exists
-                    log.error("Failure to update ConditionalNG with Duplicate User Name: " // NOI18N
-                            + uName);
-                    JOptionPane.showMessageDialog(_editConditionalNGFrame,
-                            Bundle.getMessage("Error10"),    // NOI18N
-                            Bundle.getMessage("ErrorTitle"), // NOI18N
-                            JOptionPane.ERROR_MESSAGE);
-                    return false;
-                }
-            }
-        } // else return false;
-        return true;
-    }
-
-    /*.*
-     * Check form of ConditionalNG systemName.
-     *
-     * @param sName system name of bean to be checked
-     * @return false if sName is empty string or null
-     *./
-    boolean checkConditionalNGSystemName(String sName) {
-        if ((sName != null) && (!(sName.equals("")))) {
-            ConditionalNG p = _curTable.getConditionalNG(sName);
-            if (p != null) {
-                return false;
-            }
-        } else {
-            return false;
-        }
-        return true;
-    }
-*/
     // ------------ Table Models ------------
 
     /**
      * Table model for Tables in the Edit NamedTable pane.
      */
     public final class TableTableModel extends AbstractTableModel {
-//            implements PropertyChangeListener {
 
-        public TableTableModel() {
-            super();
-//            updateConditionalNGListeners();
-        }
-/*
-        synchronized void updateConditionalNGListeners() {
-            // first, remove listeners from the individual objects
-            ConditionalNG c;
-            _numConditionalNGs = _curTable.getNumConditionalNGs();
-            for (int i = 0; i < _numConditionalNGs; i++) {
-                // if object has been deleted, it's not here; ignore it
-                c = _curTable.getConditionalNG(i);
-                if (c != null) {
-                    c.removePropertyChangeListener(this);
-                }
-            }
-            // and add them back in
-            for (int i = 0; i < _numConditionalNGs; i++) {
-                c = _curTable.getConditionalNG(i);
-                if (c != null) {
-                    c.addPropertyChangeListener(this);
-                }
-            }
-        }
-*./
-        @Override
-        public void propertyChange(java.beans.PropertyChangeEvent e) {
-            if (e.getPropertyName().equals("length")) {  // NOI18N
-                // a new NamedBean is available in the manager
-//                updateConditionalNGListeners();
-                fireTableDataChanged();
-            } else if (matchPropertyName(e)) {
-                // a value changed.
-                fireTableDataChanged();
-            }
-        }
-
-        /*.*
-         * Check if this property event is announcing a change this table should
-         * display.
-         * <p>
-         * Note that events will come both from the NamedBeans and from the
-         * manager.
-         *
-         * @param e the event heard
-         * @return true if a change in State or Appearance was heard
-         *./
-        boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
-            return (e.getPropertyName().contains("State") ||      // NOI18N
-                    e.getPropertyName().contains("Appearance"));  // NOI18N
-        }
-/*
-        @Override
-        public Class<?> getColumnClass(int c) {
-            if (c == BUTTON_COLUMN) {
-                return JButton.class;
-            }
-            return String.class;
-        }
-*/
         @Override
         public int getColumnCount() {
             return _curTable.numColumns()-1;    // Don't show row headers
@@ -861,161 +418,17 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
         public int getRowCount() {
             return _curTable.numRows()-1;
         }
-/*
-        @Override
-        public boolean isCellEditable(int r, int c) {
-            if (!_inReorderMode) {
-                return ((c == UNAME_COLUMN) || (c == BUTTON_COLUMN));
-            } else if (c == BUTTON_COLUMN) {
-                if (r >= _nextInOrder) {
-                    return (true);
-                }
-            }
-            return (false);
-        }
-*/
-//        @Override
-//        public String getRowName(int row) {
-//            return _curTable.getCell(row, 0);
-//        }
         
         @Override
         public String getColumnName(int col) {
             Object data = _curTable.getCell(0, col+1);
             return data != null ? data.toString() : "<null>";
-/*            
-            switch (col) {
-                case SNAME_COLUMN:
-                    return Bundle.getMessage("ColumnSystemName");  // NOI18N
-                case UNAME_COLUMN:
-                    return Bundle.getMessage("ColumnUserName");  // NOI18N
-                case BUTTON_COLUMN:
-                    return ""; // no label
-                default:
-                    return "";
-            }
-*/            
         }
-/*
-        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "DB_DUPLICATE_SWITCH_CLAUSES",
-                justification = "better to keep cases in column order rather than to combine")
-        public int getPreferredWidth(int col) {
-            switch (col) {
-                case SNAME_COLUMN:
-                    return new JTextField(6).getPreferredSize().width;
-                case UNAME_COLUMN:
-                    return new JTextField(17).getPreferredSize().width;
-                case BUTTON_COLUMN:
-                    return new JTextField(6).getPreferredSize().width;
-                default:
-                    return new JTextField(5).getPreferredSize().width;
-            }
-        }
-*/
+        
         @Override
         public Object getValueAt(int row, int col) {
             return _curTable.getCell(row+1, col+1);
         }
-/*        
-        @Override
-        public Object getValueAt(int r, int col) {
-            int rx = r;
-//            if ((rx > _numConditionalNGs) || (_curTable == null)) {
-//                return null;
-//            }
-            switch (col) {
-                case BUTTON_COLUMN:
-                    if (!_inReorderMode) {
-                        return Bundle.getMessage("ButtonEdit");  // NOI18N
-                    } else if (_nextInOrder == 0) {
-                        return Bundle.getMessage("ButtonFirst");  // NOI18N
-                    } else if (_nextInOrder <= r) {
-                        return Bundle.getMessage("ButtonNext");  // NOI18N
-                    } else {
-                        return Integer.toString(rx + 1);
-                    }
-                case SNAME_COLUMN:
-//                    return _curTable.getConditionalNG(rx);
-                case UNAME_COLUMN: {
-                    //log.debug("ConditionalNGTableModel: {}", _curLogixNG.getConditionalNGByNumberOrder(rx));  // NOI18N
-//                    ConditionalNG c = _curTable.getConditionalNG(rx);
-//                    if (c != null) {
-//                        return c.getUserName();
-//                    }
-                    return "";
-                }
-                default:
-                    return Bundle.getMessage("BeanStateUnknown");  // NOI18N
-            }
-        }
-/*
-        @Override
-        public void setValueAt(Object value, int row, int col) {
-            int rx = row;
-//            if ((rx > _numConditionalNGs) || (_curTable == null)) {
-//                return;
-//            }
-            if (col == BUTTON_COLUMN) {
-                if (_inReorderMode) {
-//                    swapConditionalNG(row);
-                } else {
-                    // Use separate Runnable so window is created on top
-                    class WindowMaker implements Runnable {
-
-                        int row;
-
-                        WindowMaker(int r) {
-                            row = r;
-                        }
-
-                        @Override
-                        public void run() {
-                            editConditionalNGPressed(row);
-                        }
-                    }
-                    WindowMaker t = new WindowMaker(rx);
-                    javax.swing.SwingUtilities.invokeLater(t);
-                }
-            } else if (col == UNAME_COLUMN) {
-                throw new UnsupportedOperationException("Not implemented yet");
-/*
-                String uName = (String) value;
-                ConditionalNG cn = _curTable.getConditionalNGByUserName(uName);
-                if (cn == null) {
-                    ConditionalNG cdl = _curTable.getConditionalNG(rx);
-                    cdl.setUserName(uName.trim()); // N11N
-                    fireTableRowsUpdated(rx, rx);
-/*
-                    // Update any conditional references
-                    ArrayList<String> refList = InstanceManager.getDefault(jmri.ConditionalNGManager.class).getWhereUsed(sName);
-                    if (refList != null) {
-                        for (String ref : refList) {
-                            ConditionalNG cRef = _conditionalManager.getBySystemName(ref);
-                            List<ConditionalNGVariable> varList = cRef.getCopyOfStateVariables();
-                            for (ConditionalNGVariable var : varList) {
-                                // Find the affected conditional variable
-                                if (var.getName().equals(sName)) {
-                                    if (uName.length() > 0) {
-                                        var.setGuiName(uName);
-                                    } else {
-                                        var.setGuiName(sName);
-                                    }
-                                }
-                            }
-                            cRef.setStateVariables(varList);
-                        }
-                    }
-*./
-                } else {
-                    // Duplicate user name
-                    if (cn != _curTable.getConditionalNG(rx)) {
-                        messageDuplicateConditionalNGUserName(cn.getSystemName());
-                    }
-                }
-*./
-            }
-        }
-*/        
     }
 
     private static final class RowHeaderRenderer extends JLabel implements ListCellRenderer {
@@ -1038,31 +451,19 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
         }
     }
     
-    /*.*
-     * Send a duplicate Conditional user name message for Edit Logix pane.
-     *
-     * @param svName proposed name that duplicates an existing name
-     *./
-    void messageDuplicateConditionalNGUserName(String svName) {
-        JOptionPane.showMessageDialog(null,
-                Bundle.getMessage("Error30", svName),
-                Bundle.getMessage("ErrorTitle"), // NOI18N
-                JOptionPane.ERROR_MESSAGE);
-    }
-*/
     protected String getClassName() {
         return TableEditor.class.getName();
     }
 
 
     // ------------ NamedTable Notifications ------------
-    // The ConditionalNG views support some direct changes to the parent logix.
+    // The Table views support some direct changes to the parent logix.
     // This custom event is used to notify the parent NamedTable that changes are requested.
     // When the event occurs, the parent NamedTable can retrieve the necessary information
     // to carry out the actions.
     //
     // 1) Notify the calling NamedTable that the NamedTable user name has been changed.
-    // 2) Notify the calling NamedTable that the conditional view is closing
+    // 2) Notify the calling NamedTable that the table view is closing
     // 3) Notify the calling NamedTable that it is to be deleted
     /**
      * Create a custom listener event.
@@ -1114,38 +515,5 @@ import jmri.jmrit.logixng.implementation.DefaultCsvNamedTable;
 
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TableEditor.class);
-/*
-    private class LogixNGEventListenerImpl implements ConditionalNGEditor.LogixNGEventListener {
-
-        private final TableEditor _logixNGEditor;
-
-        public LogixNGEventListenerImpl(TableEditor logixNGEditor) {
-            this._logixNGEditor = logixNGEditor;
-        }
-
-        @Override
-        public void logixNGEventOccurred() {
-            String lgxName = _curTable.getSystemName();
-            _treeEdit.logixNGData.forEach((key, value) -> {
-                if (key.equals("Finish")) {                  // NOI18N
-                    _treeEdit = null;
-                    _inEditMode = false;
-                    _curTable.setEnabled(true);
-                    _logixNGEditor.bringToFront();
-                    if (_curTable.isEnabled()) _curTable.activateLogixNG();
-                } else if (key.equals("Delete")) {           // NOI18N
-                    deletePressed();
-                } else if (key.equals("chgUname")) {         // NOI18N
-                    NamedTable x = _tableManager.getBySystemName(lgxName);
-                    if (x == null) {
-                        log.error("Found no logixNG for name {} when changing user name (2)", lgxName);
-                        return;
-                    }
-                    x.setUserName(value);
-                    beanTableDataModel.fireTableDataChanged();
-                }
-            });
-        }
-    }
-*/
-    }
+    
+}

--- a/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
@@ -7,36 +7,23 @@ import java.awt.FlowLayout;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
-import java.awt.event.ItemEvent;
-import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.List;
-import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.*;
-import javax.swing.border.Border;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.JTableHeader;
-import javax.swing.table.TableCellEditor;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableColumnModel;
 
 import jmri.InstanceManager;
-import jmri.UserPreferencesManager;
 import jmri.jmrit.beantable.BeanTableDataModel;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.implementation.*;
 import jmri.jmrit.logixng.util.ReferenceUtil;
-import jmri.swing.NamedBeanComboBox;
 import jmri.util.JmriJFrame;
-import jmri.util.table.ButtonEditor;
-import jmri.util.table.ButtonRenderer;
-import jmri.jmrit.logixng.tools.swing.Bundle;
 
 /**
  * Editor for LogixNG Tables

--- a/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TableEditor.java
@@ -254,7 +254,7 @@ import jmri.jmrit.logixng.tools.swing.Bundle;
                 }
             };
             
-            JList<String> rowHeader = new JList<>(lm);
+            JList<Object> rowHeader = new JList<>(lm);
             rowHeader.setFixedCellHeight(
                     tableTable.getRowHeight()
 //                    tableTable.getRowHeight() + tableTable.getRowMargin()

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultNamedTableTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultNamedTableTest.java
@@ -25,7 +25,8 @@ public class DefaultNamedTableTest {
     @Test
     public void testCSVFile() throws IOException {
         NamedTable table = AbstractNamedTable.loadTableFromCSV_File(
-                new File("java/test/jmri/jmrit/logixng/panel_and_data_files/turnout_and_signals.csv"));
+                new File("java/test/jmri/jmrit/logixng/panel_and_data_files/turnout_and_signals.csv"),
+                true);
         
         FileUtil.createDirectory(FileUtil.getUserFilesPath() + "temp");
         File file = new File(FileUtil.getUserFilesPath() + "temp/" + "turnout_and_signals.csv");

--- a/java/test/jmri/jmrit/logixng/tools/swing/TableEditorTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/swing/TableEditorTest.java
@@ -13,7 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Test TimeDiagram
+ * Test TableEditor
  * 
  * @author Daniel Bergqvist Copyright (C) 2018
  */


### PR DESCRIPTION
This PR is by request by David Parks.

The PR implements `Edit` of LogixNG Table tables.

---

**Edit LogixNG table**

When Edit is selected, a dialog is shown which shows the LogixNG table with its system name, user name, table type, file name and table contents.

If the user selects a cell in the table, a reference to that cell is shown below the table using the row and column indexes. If that cell has both a row header and a column header, a reference to that cell using the row header and column header is also shown.

The buttons "Copy to clipboard" copies the reference to the clipboard.

![LogixNG_Table](https://user-images.githubusercontent.com/20255317/120240640-63634b00-c261-11eb-859b-7ec005c39d27.png)
