### PR TITLE
Remove TriggerOnChange

### DIFF
--- a/java/src/jmri/jmrit/logixng/DigitalExpression.java
+++ b/java/src/jmri/jmrit/logixng/DigitalExpression.java
@@ -18,18 +18,4 @@ public interface DigitalExpression extends Base {
      */
     public boolean evaluate() throws JmriException;
     
-    /**
-     * Set whenether this expression should trigger the ConditionalNG if the
-     * named beans it listens to changes state.
-     * @param triggerOnChange true if trigger on change, false otherwise
-     */
-    public void setTriggerOnChange(boolean triggerOnChange);
-    
-    /**
-     * Get whenether this expression should trigger the ConditionalNG if the
-     * named beans it listens to changes state.
-     * @return true if trigger on change, false otherwise
-     */
-    public boolean getTriggerOnChange();
-    
 }

--- a/java/src/jmri/jmrit/logixng/expressions/AbstractDigitalExpression.java
+++ b/java/src/jmri/jmrit/logixng/expressions/AbstractDigitalExpression.java
@@ -17,7 +17,6 @@ public abstract class AbstractDigitalExpression extends AbstractBase
     private Base _parent = null;
     private Lock _lock = Lock.NONE;
     private int _state = DigitalExpressionBean.UNKNOWN;
-    boolean _triggerOnChange = true;    // By default, trigger on change
     
     
     public AbstractDigitalExpression(String sys, String user)
@@ -80,18 +79,6 @@ public abstract class AbstractDigitalExpression extends AbstractBase
     @Override
     public void setLock(Lock lock) {
         _lock = lock;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public void setTriggerOnChange(boolean triggerOnChange) {
-        _triggerOnChange = triggerOnChange;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public boolean getTriggerOnChange() {
-        return _triggerOnChange;
     }
     
     public String getNewSocketName() {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBlock.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBlock.java
@@ -595,9 +595,7 @@ public class ExpressionBlock extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionClock.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionClock.java
@@ -248,9 +248,7 @@ public class ExpressionClock extends AbstractDigitalExpression implements Proper
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionConditional.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionConditional.java
@@ -418,9 +418,7 @@ public class ExpressionConditional extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
@@ -428,9 +428,7 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionLight.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionLight.java
@@ -423,9 +423,7 @@ public class ExpressionLight extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionLocalVariable.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionLocalVariable.java
@@ -496,9 +496,7 @@ public class ExpressionLocalVariable extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionMemory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionMemory.java
@@ -527,9 +527,7 @@ public class ExpressionMemory extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionOBlock.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionOBlock.java
@@ -424,9 +424,7 @@ public class ExpressionOBlock extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionPower.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionPower.java
@@ -130,9 +130,7 @@ public class ExpressionPower extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
     
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionReference.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionReference.java
@@ -220,9 +220,7 @@ public class ExpressionReference extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
     
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionScript.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionScript.java
@@ -491,9 +491,7 @@ public class ExpressionScript extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSensor.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSensor.java
@@ -423,9 +423,7 @@ public class ExpressionSensor extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalHead.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalHead.java
@@ -678,9 +678,7 @@ public class ExpressionSignalHead extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalMast.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalMast.java
@@ -676,9 +676,7 @@ public class ExpressionSignalMast extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionTurnout.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionTurnout.java
@@ -423,9 +423,7 @@ public class ExpressionTurnout extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionWarrant.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionWarrant.java
@@ -445,9 +445,7 @@ public class ExpressionWarrant extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/expressions/LastResultOfDigitalExpression.java
+++ b/java/src/jmri/jmrit/logixng/expressions/LastResultOfDigitalExpression.java
@@ -176,9 +176,7 @@ public class LastResultOfDigitalExpression extends AbstractDigitalExpression
     /** {@inheritDoc} */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (getTriggerOnChange()) {
-            getConditionalNG().execute();
-        }
+        getConditionalNG().execute();
     }
     
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
@@ -192,12 +192,18 @@ public abstract class AbstractMaleSocket implements MaleSocket {
 
     @Override
     public boolean getListen() {
+        if (getObject() instanceof MaleSocket) {
+            return ((MaleSocket)getObject()).getListen();
+        }
         return _listen;
     }
 
     @Override
     public void setListen(boolean listen)
     {
+        if (getObject() instanceof MaleSocket) {
+            ((MaleSocket)getObject()).setListen(listen);
+        }
         _listen = listen;
     }
 

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultFemaleDigitalExpressionSocket.java
@@ -43,18 +43,6 @@ public class DefaultFemaleDigitalExpressionSocket extends AbstractFemaleSocket
 
     /** {@inheritDoc} */
     @Override
-    public boolean getTriggerOnChange() {
-        throw new UnsupportedOperationException("Not supported");
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public void setTriggerOnChange(boolean triggerOnChange) {
-        throw new UnsupportedOperationException("Not supported");
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public String getShortDescription(Locale locale) {
         return Bundle.getMessage(locale, "DefaultFemaleDigitalExpressionSocket_Short");
     }

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocket.java
@@ -28,18 +28,6 @@ public class DefaultMaleDigitalExpressionSocket extends AbstractMaleSocket imple
         ((DigitalExpressionBean)getObject()).notifyChangedResult(oldResult, newResult);
     }
     
-    /** {@inheritDoc} */
-    @Override
-    public boolean getTriggerOnChange() {
-        return ((DigitalExpressionBean)getObject()).getTriggerOnChange();
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public void setTriggerOnChange(boolean triggerOnChange) {
-        ((DigitalExpressionBean)getObject()).setTriggerOnChange(triggerOnChange);
-    }
-    
     private void checkChangedLastResult(boolean savedLastResult) {
         if (savedLastResult != lastEvaluationResult) {
             ((DigitalExpressionBean)getObject())

--- a/java/src/jmri/jmrit/logixng/tools/ImportConditional.java
+++ b/java/src/jmri/jmrit/logixng/tools/ImportConditional.java
@@ -411,8 +411,6 @@ public class ImportConditional {
                         Bundle.getMessage("ConditionalBadSensorType", cv.getType().toString()));
         }
 
-        expression.setTriggerOnChange(cv.doTriggerActions());
-
         return expression;
     }
 
@@ -445,8 +443,6 @@ public class ImportConditional {
                 throw new InvalidConditionalVariableException(
                         Bundle.getMessage("ConditionalBadTurnoutType", cv.getType().toString()));
         }
-
-        expression.setTriggerOnChange(cv.doTriggerActions());
 
         return expression;
     }
@@ -521,7 +517,6 @@ public class ImportConditional {
         }
 
         expression.setListenToOtherMemory(false);
-        expression.setTriggerOnChange(cv.doTriggerActions());
 
         return expression;
     }
@@ -555,8 +550,6 @@ public class ImportConditional {
                 throw new InvalidConditionalVariableException(
                         Bundle.getMessage("ConditionalBadLightType", cv.getType().toString()));
         }
-
-        expression.setTriggerOnChange(cv.doTriggerActions());
 
         return expression;
     }
@@ -626,8 +619,6 @@ public class ImportConditional {
                         Bundle.getMessage("ConditionalBadSignalHeadType", cv.getType().toString()));
         }
 
-        expression.setTriggerOnChange(cv.doTriggerActions());
-
         isNegated.set(false);   // We have already handled this
 
         return expression;
@@ -666,8 +657,6 @@ public class ImportConditional {
                         Bundle.getMessage("ConditionalBadSignalMastType", cv.getType().toString()));
         }
 
-        expression.setTriggerOnChange(cv.doTriggerActions());
-
         isNegated.set(false);   // We have already handled this
 
         return expression;
@@ -703,8 +692,6 @@ public class ImportConditional {
                         Bundle.getMessage("ConditionalBadEntryExitType", cv.getType().toString()));
         }
 
-        expression.setTriggerOnChange(cv.doTriggerActions());
-
         return expression;
     }
 
@@ -738,8 +725,6 @@ public class ImportConditional {
                         Bundle.getMessage("ConditionalBadConditionalType", cv.getType().toString()));
         }
 
-        expression.setTriggerOnChange(cv.doTriggerActions());
-
         return expression;
     }
 
@@ -766,8 +751,6 @@ public class ImportConditional {
 
         expression.setType(ExpressionClock.Type.FastClock);
         expression.setRange(ConditionalVariable.fixMidnight(cv.getNum1()), ConditionalVariable.fixMidnight(cv.getNum2()));
-
-        expression.setTriggerOnChange(cv.doTriggerActions());
 
         return expression;
     }
@@ -811,8 +794,6 @@ public class ImportConditional {
                         Bundle.getMessage("ConditionalBadWarrantType", cv.getType().toString()));
         }
 
-        expression.setTriggerOnChange(cv.doTriggerActions());
-
         return expression;
     }
 
@@ -841,7 +822,6 @@ public class ImportConditional {
 
         expression.setOBlock(b);
         expression.setBeanState(oblockStatus);
-        expression.setTriggerOnChange(cv.doTriggerActions());
 
         return expression;
     }
@@ -1050,9 +1030,6 @@ public class ImportConditional {
                 throw new InvalidConditionalVariableException(
                         Bundle.getMessage("ActionBadTurnoutType", ca.getType().toString()));
         }
-
-//        ca.getActionData();
-//        action.setTriggerOnChange(ca.doTriggerActions());
 
         return action;
     }

--- a/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleDigitalExpressionSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/DebuggerMaleDigitalExpressionSocket.java
@@ -95,14 +95,4 @@ public class DebuggerMaleDigitalExpressionSocket extends AbstractDebuggerMaleSoc
         return ((MaleDigitalExpressionSocket)getObject()).compareSystemNameSuffix(suffix1, suffix2, n2);
     }
 
-    @Override
-    public void setTriggerOnChange(boolean triggerOnChange) {
-        ((MaleDigitalExpressionSocket)getObject()).setTriggerOnChange(triggerOnChange);
-    }
-
-    @Override
-    public boolean getTriggerOnChange() {
-        return ((MaleDigitalExpressionSocket)getObject()).getTriggerOnChange();
-    }
-    
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DigitalExpressionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DigitalExpressionManagerTest.java
@@ -209,16 +209,6 @@ public class DigitalExpressionManagerTest extends AbstractManagerTestBase {
         }
 
         @Override
-        public void setTriggerOnChange(boolean triggerOnChange) {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
-        public boolean getTriggerOnChange() {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
         public Base getDeepCopy(Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }


### PR DESCRIPTION
David Parks discovered a bug which this PR solves.

The PR removes the methods `setTriggerOnChange()` and `getTriggerOnChange()` from `DigitalExpression` since that feature is implemented with `setListen()` and `getListen()` in `MaleSocket` instead.