### PR TITLE
Clear any selection group before the panel refreshes

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePointView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePointView.java
@@ -1179,7 +1179,7 @@ public class PositionablePointView extends LayoutTrackView {
                             if (layoutEditor.prevSelectedObject == pp_this) {
                                 layoutEditor.prevSelectedObject = null;
                             }
-                            layoutEditor.clearSelectionGroups();
+                            clearPossibleSelection();
 
                             // remove this PositionablePoint and PositionablePointView from the layoutEditor's list of layout tracks
                             layoutEditor.removeLayoutTrackAndRedraw(pp_this);
@@ -1203,7 +1203,7 @@ public class PositionablePointView extends LayoutTrackView {
             ) {
                 if (canRemove() && layoutEditor.removePositionablePoint(positionablePoint)) {
                     // user is serious about removing this point from the panel
-                    layoutEditor.clearSelectionGroups();
+                    clearPossibleSelection();
                     remove();
                     dispose();
                 }
@@ -1320,6 +1320,19 @@ public class PositionablePointView extends LayoutTrackView {
 
         return popup;
     }   // showPopup
+
+    /**
+     * If an anchor point is selected via a track segment connection, it will be
+     * in the track selection list.  When the merge or delete finishes, draw
+     * can no longer find the object resulting in a Java exception.
+     * <p>
+     * If the anchor point is in the track selection list, the selection groups are cleared.
+     */
+    private void clearPossibleSelection() {
+        if (layoutEditor.getLayoutTrackSelection().contains(positionablePoint)) {
+            layoutEditor.clearSelectionGroups();
+        }
+    }
 
     /**
      * {@inheritDoc}

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePointView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePointView.java
@@ -1179,6 +1179,7 @@ public class PositionablePointView extends LayoutTrackView {
                             if (layoutEditor.prevSelectedObject == pp_this) {
                                 layoutEditor.prevSelectedObject = null;
                             }
+                            layoutEditor.clearSelectionGroups();
 
                             // remove this PositionablePoint and PositionablePointView from the layoutEditor's list of layout tracks
                             layoutEditor.removeLayoutTrackAndRedraw(pp_this);
@@ -1202,6 +1203,7 @@ public class PositionablePointView extends LayoutTrackView {
             ) {
                 if (canRemove() && layoutEditor.removePositionablePoint(positionablePoint)) {
                     // user is serious about removing this point from the panel
+                    layoutEditor.clearSelectionGroups();
                     remove();
                     dispose();
                 }


### PR DESCRIPTION
See the user group thread at https://groups.io/g/jmriusers/message/191030

Reaching a positional point via a track segment connection results in a selection box for the point.  If the point is removed via merge or delete, a Java exception occurs when attempting to draw the point that no longer exists.