### PR TITLE
Fix bug in the LogixNG Clipboard

### DIFF
--- a/java/src/jmri/jmrit/logixng/MaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/MaleSocket.java
@@ -47,7 +47,8 @@ public interface MaleSocket extends Debugable {
     
     /**
      * Set whenether this male socket is enabled or disabled, without activating
-     * the male socket. This is used when loading the xml file.
+     * the male socket. This is used when loading the xml file and when copying
+     * an item.
      * <P>
      * This method must call registerListeners() / unregisterListeners().
      * 

--- a/java/src/jmri/jmrit/logixng/expressions/TimeSinceMidnight.java
+++ b/java/src/jmri/jmrit/logixng/expressions/TimeSinceMidnight.java
@@ -21,7 +21,7 @@ public class TimeSinceMidnight extends AbstractAnalogExpression implements Prope
     private Timebase _fastClock;
 
     TimerTask timerTask = null;
-    private int milisInAMinute = 60000;
+    private final int millisInAMinute = 60000;
 
 
     public TimeSinceMidnight(String sys, String user) {
@@ -180,7 +180,7 @@ public class TimeSinceMidnight extends AbstractAnalogExpression implements Prope
                 propertyChange(null);
             }
         };
-        TimerUtil.schedule(timerTask, System.currentTimeMillis() % milisInAMinute, milisInAMinute);
+        TimerUtil.schedule(timerTask, System.currentTimeMillis() % millisInAMinute, millisInAMinute);
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
@@ -553,7 +553,7 @@ public abstract class AbstractMaleSocket implements MaleSocket {
         if (maleSocket.getDebugConfig() != null) {
             maleSocket.setDebugConfig(maleSocket.getDebugConfig().getCopy());
         }
-        maleSocket.setEnabled(isEnabled());
+        maleSocket.setEnabledFlag(isEnabled());
         maleSocket.setListen(getListen());
         maleSocket.setErrorHandlingType(getErrorHandlingType());
         maleSocket.setLocked(isLocked());

--- a/java/src/jmri/jmrit/logixng/tools/debugger/AbstractDebuggerMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/tools/debugger/AbstractDebuggerMaleSocket.java
@@ -104,7 +104,7 @@ public abstract class AbstractDebuggerMaleSocket extends AbstractMaleSocket {
 
     @Override
     public void setEnabledFlag(boolean enable) {
-        throw new UnsupportedOperationException("Not supported");
+        ((MaleSocket)getObject()).setEnabledFlag(enable);
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
@@ -1571,13 +1571,14 @@ public class TreeEditor extends TreeViewer {
                             Clipboard clipboard =
                                     InstanceManager.getDefault(LogixNG_Manager.class).getClipboard();
                             List<String> errors = new ArrayList<>();
-                            if (!clipboard.add(_currentFemaleSocket.getConnectedSocket(), errors)) {
+                            MaleSocket maleSocket = _currentFemaleSocket.getConnectedSocket();
+                            _currentFemaleSocket.disconnect();
+                            if (!clipboard.add(maleSocket, errors)) {
                                 JOptionPane.showMessageDialog(this,
                                         String.join("<br>", errors),
                                         Bundle.getMessage("TitleError"),
                                         JOptionPane.ERROR_MESSAGE);
                             }
-                            _currentFemaleSocket.disconnect();
                             ThreadingUtil.runOnGUIEventually(() -> {
                                 _treePane._femaleRootSocket.registerListeners();
                                 _treePane.updateTree(_currentFemaleSocket, _currentPath.getPath());


### PR DESCRIPTION
There is a small bug in the LogixNG clipboard. If the user cuts an item on the clipboard itself, he will get an error message. Everything works, but the error message is annoying and gives the user a sense that something is wrong.

![Clipboard_bug](https://user-images.githubusercontent.com/20255317/122659772-6b851b00-d17b-11eb-966e-e951a2259ec9.png)
