### PR TITLE
Fix on change swing classs

### DIFF
--- a/java/src/jmri/jmrit/logixng/actions/ActionBundle.properties
+++ b/java/src/jmri/jmrit/logixng/actions/ActionBundle.properties
@@ -174,9 +174,10 @@ DigitalBooleanMany_Short            = Many
 DigitalBooleanMany_Long             = Many
 
 DigitalBooleanOnChange_Short                  = On change
-DigitalBooleanOnChange_Long_ChangeToTrue      = On change to true
-DigitalBooleanOnChange_Long_ChangeToFalse     = On change to false
-DigitalBooleanOnChange_Long_Change            = On change
+DigitalBooleanOnChange_Long                   = {0}
+DigitalBooleanOnChange_Trigger_ChangeToTrue   = On change to true
+DigitalBooleanOnChange_Trigger_ChangeToFalse  = On change to false
+DigitalBooleanOnChange_Trigger_Change         = On change
 
 DoAnalogAction_Short    = Read analog and set analog
 DoAnalogAction_Long     = Read analog {0} and set analog {1}

--- a/java/src/jmri/jmrit/logixng/actions/ActionBundle_cs.properties
+++ b/java/src/jmri/jmrit/logixng/actions/ActionBundle_cs.properties
@@ -152,9 +152,10 @@ DigitalBooleanMany_Short        = Mnoho
 DigitalBooleanMany_Long         = Mnoho
 
 DigitalBooleanOnChange_Short                  = P\u0159i zm\u011bn\u011b
-DigitalBooleanOnChange_Long_ChangeToTrue      = P\u0159i zm\u011bn\u011b na Pravda
-DigitalBooleanOnChange_Long_ChangeToFalse     = P\u0159i zm\u011bn\u011b na Nepravda
-DigitalBooleanOnChange_Long_Change            = P\u0159i zm\u011bn\u011b
+DigitalBooleanOnChange_Long_Change            = {0}
+DigitalBooleanOnChange_Trigger_ChangeToTrue   = P\u0159i zm\u011bn\u011b na Pravda
+DigitalBooleanOnChange_Trigger_ChangeToFalse  = P\u0159i zm\u011bn\u011b na Nepravda
+DigitalBooleanOnChange_Trigger_Change         = P\u0159i zm\u011bn\u011b
 
 DoAnalogAction_Short    = \u010c\u00edst analog a nastavit analog
 DoAnalogAction_Long     = \u010c\u00edst analog {0} a nastavit analog {1}

--- a/java/src/jmri/jmrit/logixng/actions/DigitalBooleanOnChange.java
+++ b/java/src/jmri/jmrit/logixng/actions/DigitalBooleanOnChange.java
@@ -19,9 +19,20 @@ public class DigitalBooleanOnChange extends AbstractDigitalBooleanAction
      * The trigger of Action.
      */
     public enum Trigger {
-        CHANGE_TO_TRUE,
-        CHANGE_TO_FALSE,
-        CHANGE,
+        CHANGE_TO_TRUE(Bundle.getMessage("DigitalBooleanOnChange_Trigger_ChangeToTrue")),
+        CHANGE_TO_FALSE(Bundle.getMessage("DigitalBooleanOnChange_Trigger_ChangeToFalse")),
+        CHANGE(Bundle.getMessage("DigitalBooleanOnChange_Trigger_Change"));
+
+        private final String _text;
+
+        private Trigger(String text) {
+            this._text = text;
+        }
+
+        @Override
+        public String toString() {
+            return _text;
+        }
     }
 
     private String _socketSystemName;
@@ -143,19 +154,7 @@ public class DigitalBooleanOnChange extends AbstractDigitalBooleanAction
 
     @Override
     public String getLongDescription(Locale locale) {
-        switch (_trigger) {
-            case CHANGE_TO_TRUE:
-                return Bundle.getMessage(locale, "DigitalBooleanOnChange_Long_ChangeToTrue");
-                
-            case CHANGE_TO_FALSE:
-                return Bundle.getMessage(locale, "DigitalBooleanOnChange_Long_ChangeToFalse");
-                
-            case CHANGE:
-                return Bundle.getMessage(locale, "DigitalBooleanOnChange_Long_Change");
-                
-            default:
-                throw new UnsupportedOperationException("_whichChange has unknown value: "+_trigger);
-        }
+        return Bundle.getMessage(locale, "DigitalBooleanOnChange_Long", _trigger.toString());
     }
 
     public FemaleDigitalActionSocket getSocket() {

--- a/java/src/jmri/jmrit/logixng/actions/swing/DigitalBooleanOnChangeSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/DigitalBooleanOnChangeSwing.java
@@ -4,13 +4,16 @@ import java.util.List;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.swing.JComboBox;
 import javax.swing.JPanel;
 
 import jmri.InstanceManager;
 import jmri.jmrit.logixng.Base;
+import jmri.jmrit.logixng.DigitalBooleanActionManager;
 import jmri.jmrit.logixng.MaleSocket;
 import jmri.jmrit.logixng.actions.DigitalBooleanOnChange;
-import jmri.jmrit.logixng.DigitalBooleanActionManager;
+import jmri.jmrit.logixng.actions.DigitalBooleanOnChange.Trigger;
+import jmri.util.swing.JComboBoxUtil;
 
 /**
  * Configures an ActionTurnout object with a Swing JPanel.
@@ -20,11 +23,22 @@ import jmri.jmrit.logixng.DigitalBooleanActionManager;
 public class DigitalBooleanOnChangeSwing extends AbstractBooleanActionSwing {
 
     DigitalBooleanOnChange.Trigger type = DigitalBooleanOnChange.Trigger.CHANGE;
-    
+    private JComboBox<DigitalBooleanOnChange.Trigger> _triggerComboBox;
     
     @Override
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        DigitalBooleanOnChange action = (DigitalBooleanOnChange)object;
+        
         panel = new JPanel();
+        _triggerComboBox = new JComboBox<>();
+        for (Trigger e : Trigger.values()) {
+            _triggerComboBox.addItem(e);
+        }
+        JComboBoxUtil.setupComboBoxMaxRows(_triggerComboBox);
+        panel.add(_triggerComboBox);
+        if (action != null) {
+            _triggerComboBox.setSelectedItem(action.getTrigger());
+        }
     }
     
     /** {@inheritDoc} */
@@ -37,13 +51,18 @@ public class DigitalBooleanOnChangeSwing extends AbstractBooleanActionSwing {
     @Override
     public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
         DigitalBooleanOnChange action = new DigitalBooleanOnChange(systemName, userName, type);
+        updateObject(action);
         return InstanceManager.getDefault(DigitalBooleanActionManager.class).registerAction(action);
     }
     
     /** {@inheritDoc} */
     @Override
     public void updateObject(@Nonnull Base object) {
-        // Do nothing
+        if (! (object instanceof DigitalBooleanOnChange)) {
+            throw new IllegalArgumentException("object must be an DigitalBooleanOnChange but is a: "+object.getClass().getName());
+        }
+        DigitalBooleanOnChange action = (DigitalBooleanOnChange)object;
+        action.setTrigger(_triggerComboBox.getItemAt(_triggerComboBox.getSelectedIndex()));
     }
     
     /** {@inheritDoc} */


### PR DESCRIPTION
This PR fixes an important bug in the `On Change` action. The swing class for the `On Change` action didn't had a dropdown box to change the trigger of this action.

It's important to get this into 4.23.8.