### PR TITLE
Fix bug in AnalogIO manager

### DIFF
--- a/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
@@ -133,17 +133,6 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.DefaultSystemConnec
         return meterManager;
     }
 
-    public InternalAnalogIOManager getAnalogIOManager() {
-        InternalAnalogIOManager analogIOManager = (InternalAnalogIOManager) classObjectMap.get(AnalogIOManager.class);
-        if (analogIOManager == null) {
-            log.debug("Create InternalAnalogIOManager by request", getSystemPrefix());
-            analogIOManager = new InternalAnalogIOManager(this);
-            // special due to ProxyManager support
-            InstanceManager.setAnalogIOManager(analogIOManager);
-        }
-        return analogIOManager;
-    }
-
     public InternalStringIOManager getStringIOManager() {
         InternalStringIOManager stringIOManager = (InternalStringIOManager) classObjectMap.get(StringIOManager.class);
         if (stringIOManager == null) {

--- a/java/src/jmri/jmrix/internal/configurexml/InternalAnalogIOManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalAnalogIOManagerXml.java
@@ -1,0 +1,30 @@
+package jmri.jmrix.internal.configurexml;
+
+import org.jdom2.Element;
+
+/**
+ * Provides load and store functionality for configuring
+ * InternalAnalogIOManager.
+ *
+ * @author Bob Jacobsen      Copyright: Copyright (c) 2006
+ * @author Daniel Bergqvist  Copyright: Copyright (c) 2021
+ */
+public class InternalAnalogIOManagerXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+
+    public InternalAnalogIOManagerXml() {
+        super();
+    }
+
+    @Override
+    public Element store(Object o) {
+        return null;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) {
+        return true;
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(InternalAnalogIOManagerXml.class);
+
+}


### PR DESCRIPTION
The AnalogIO manager works fine if the manager is initialized before any bean is registered that supports the AnalogIO interface. But if beans are registered first and the AnalogIO manager is initialized later, the manager didn't read the beans that was already registered.

This PR ensures that the AnalogIO manager collects the beans that are already registered.