### PR TITLE
The nullness annotation @Nonnull is not applicable for the primitive …

### DIFF
--- a/java/src/jmri/jmrit/logixng/actions/ActionLight.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionLight.java
@@ -270,7 +270,7 @@ public class ActionLight extends AbstractDigitalAction implements VetoableChange
     }
 
 
-    public void setLightValue(@Nonnull int value) {
+    public void setLightValue(int value) {
         _lightValue = value;
     }
 


### PR DESCRIPTION
The nullness annotation @Nonnull is not applicable for the primitive type int