### PR TITLE
Fix MERG CBUS Console Response Event Reporting

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -86,7 +86,7 @@
 
         <h4>MERG</h4>
             <ul>
-                <li></li>
+                <li>Fixed - Response Events are sometimes shown as normal Events in MERG CBUS Console ( from 4.13.4 ).</li>
             </ul>
 
         <h4>MQTT</h4>

--- a/java/src/jmri/jmrix/can/cbus/CbusLight.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLight.java
@@ -112,12 +112,12 @@ public class CbusLight extends AbstractLight implements CanListener, CbusEventIn
 
     /** {@inheritDoc} */
     @Override
-    public void reply(CanReply f) {
-        if ( f.extendedOrRtr() ) {
+    public void reply(CanReply origf) {
+        if ( origf.extendedOrRtr() ) {
             return;
         }
         // convert response events to normal
-        f = CbusMessage.opcRangeToStl(f);
+        CanReply f = CbusMessage.opcRangeToStl(origf);
         if (addrOn.match(f)) {
             notifyStateChange(getState(), ON);
         } else if (addrOff.match(f)) {

--- a/java/src/jmri/jmrix/can/cbus/CbusMessage.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusMessage.java
@@ -30,10 +30,11 @@ public class CbusMessage {
      * If a response event, set to normal event
      * In future, this may also translate extended messages down to normal messages.
      *
-     * @param msg CanReply to be coverted to normal opc
-     * @return CanReply perhaps converted from response OPC to normal OPC.
+     * @param original CanReply to be coverted to normal opc
+     * @return new CanReply perhaps converted from response OPC to normal OPC.
      */
-    public static CanReply opcRangeToStl(CanReply msg){
+    public static CanReply opcRangeToStl(CanReply original){
+        CanReply msg = new CanReply(original);
         int opc = getOpcode(msg);
         // log.debug(" about to check opc {} ",opc);
         switch (opc) {

--- a/java/src/jmri/jmrix/can/cbus/CbusSensor.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensor.java
@@ -68,8 +68,7 @@ public class CbusSensor extends AbstractSensor implements CanListener, CbusEvent
      */
     @Override
     public void requestUpdateFromLayout() {
-        CanMessage m;
-        m = addrActive.makeMessage(tc.getCanid());
+        CanMessage m = addrActive.makeMessage(tc.getCanid());
         int opc = CbusMessage.getOpcode(m);
         if (CbusOpCodes.isShortEvent(opc)) {
             m.setOpCode(CbusConstants.CBUS_ASRQ);
@@ -189,10 +188,10 @@ public class CbusSensor extends AbstractSensor implements CanListener, CbusEvent
             return;
         }
         // convert response events to normal
-        f = CbusMessage.opcRangeToStl(f);
-        if (addrActive.match(f)) {
+        CanReply opcf = CbusMessage.opcRangeToStl(f);
+        if (addrActive.match(opcf)) {
             setOwnState(!getInverted() ? Sensor.ACTIVE : Sensor.INACTIVE);
-        } else if (addrInactive.match(f)) {
+        } else if (addrInactive.match(opcf)) {
             setOwnState(!getInverted() ? Sensor.INACTIVE : Sensor.ACTIVE);
         }
     }

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
@@ -219,12 +219,12 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
      * @see jmri.jmrix.can.CanListener#reply(jmri.jmrix.can.CanReply)
      */
     @Override
-    public void reply(CanReply f) {
-        if ( f.isExtended() || f.isRtr() ) {
+    public void reply(CanReply origf) {
+        if ( origf.extendedOrRtr()) {
             return;
         }
         // convert response events to normal
-        f = CbusMessage.opcRangeToStl(f);
+        CanReply f = CbusMessage.opcRangeToStl(origf);
         if (addrThrown.match(f)) {
             int state = (!getInverted() ? THROWN : CLOSED);
             newCommandedState(state);


### PR DESCRIPTION
Fixes minor bug introduced in #5798

CbusLight, CbusSensor and CbusTurnout were modifying the actual CAN Frames ( in CanReply form ) received by the Traffic Controller, causing the modified Frame to be sent to further listeners by the Traffic Controller, not the original Frame.

This may result in the incorrect CAN Frame being displaed in the MERG CBUS Console.