### PR TITLE
ReporterManager NonNull IllegalArgumentException Annotation

### DIFF
--- a/java/src/jmri/ReporterManager.java
+++ b/java/src/jmri/ReporterManager.java
@@ -54,7 +54,7 @@ public interface ReporterManager extends ProvidingManager<Reporter> {
      *                                  can't be parsed.
      */
     @Nonnull
-    public Reporter provideReporter(@Nonnull String name);
+    public Reporter provideReporter(@Nonnull String name) throws IllegalArgumentException;
 
     /** {@inheritDoc} */
     @Override
@@ -104,7 +104,9 @@ public interface ReporterManager extends ProvidingManager<Reporter> {
     public Reporter getByDisplayName(@Nonnull String userName);
 
     /**
-     * Return an instance with the specified system and user names. Note that
+     * Return an instance with the specified system and user names.
+     * <p>
+     * Note that
      * two calls with the same arguments will get the same instance; there is
      * only one Reporter object representing a given physical Reporter and
      * therefore only one with a specific system or user name.
@@ -133,7 +135,7 @@ public interface ReporterManager extends ProvidingManager<Reporter> {
      *                                  be parsed.
      */
     @Nonnull
-    public Reporter newReporter(@Nonnull String systemName, String userName);
+    public Reporter newReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException;
 
     /**
      * Determine if it is possible to add a range of reporters in numerical

--- a/java/src/jmri/jmrix/can/cbus/CbusReporterManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusReporterManager.java
@@ -42,7 +42,8 @@ public class CbusReporterManager extends AbstractReporterManager {
      * {@inheritDoc}
      */
     @Override
-    protected Reporter createNewReporter(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         log.debug("ReporterManager create new CbusReporter: {}", systemName);
         String addr = systemName.substring(getSystemNamePrefix().length());
         Reporter t = new CbusReporter(addr, getMemo());

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcReporterManager.java
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcReporterManager.java
@@ -24,13 +24,9 @@ public class Dcc4PcReporterManager extends jmri.managers.AbstractReporterManager
         return (Dcc4PcSystemConnectionMemo) memo;
     }
 
+    @Nonnull
     @Override
-    public void dispose() {
-        super.dispose();
-    }
-
-    @Override
-    public Reporter createNewReporter(@Nonnull String systemName, String userName) {
+    protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Reporter r = new Dcc4PcReporter(systemName, userName);
         register(r);
         return r;

--- a/java/src/jmri/jmrix/ecos/EcosReporterManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosReporterManager.java
@@ -24,13 +24,9 @@ public class EcosReporterManager extends jmri.managers.AbstractReporterManager {
         return (EcosSystemConnectionMemo) memo;
     }
 
+    @Nonnull
     @Override
-    public void dispose() {
-        super.dispose();
-    }
-
-    @Override
-    public Reporter createNewReporter(@Nonnull String systemName, String userName) {
+    protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Reporter r = new EcosReporter(systemName, userName);
         register(r);
         return r;

--- a/java/src/jmri/jmrix/internal/InternalReporterManager.java
+++ b/java/src/jmri/jmrix/internal/InternalReporterManager.java
@@ -20,8 +20,9 @@ public class InternalReporterManager extends jmri.managers.AbstractReporterManag
      *
      * @return an internal Reporter of class TrackReporter object with the given name
      */
+    @Nonnull
     @Override
-    protected Reporter createNewReporter(@Nonnull String systemName, String userName) {
+    protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         return new TrackReporter(systemName, userName);
     }
 

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientReporterManager.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientReporterManager.java
@@ -27,10 +27,10 @@ public class JMRIClientReporterManager extends jmri.managers.AbstractReporterMan
     }
 
     @Override
-    public Reporter createNewReporter(@Nonnull String systemName, String userName) {
-        Reporter r;
+    @Nonnull
+    protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         int addr = Integer.parseInt(systemName.substring(getSystemPrefix().length() + 1));
-        r = new JMRIClientReporter(addr, getMemo());
+        Reporter r = new JMRIClientReporter(addr, getMemo());
         r.setUserName(userName);
         return r;
     }

--- a/java/src/jmri/jmrix/loconet/LnReporterManager.java
+++ b/java/src/jmri/jmrix/loconet/LnReporterManager.java
@@ -53,7 +53,8 @@ public class LnReporterManager extends jmri.managers.AbstractReporterManager imp
     }
 
     @Override
-    public Reporter createNewReporter(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         Reporter t;
         int addr = Integer.parseInt(systemName.substring(getSystemNamePrefix().length()));
         t = new LnReporter(addr, tc, getSystemPrefix());

--- a/java/src/jmri/jmrix/rfid/generic/standalone/StandaloneReporterManager.java
+++ b/java/src/jmri/jmrix/rfid/generic/standalone/StandaloneReporterManager.java
@@ -34,7 +34,8 @@ public class StandaloneReporterManager extends RfidReporterManager {
     }
 
     @Override
-    protected Reporter createNewReporter(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         log.debug("Create new Reporter: {}", systemName);
         if (!systemName.matches(getSystemNamePrefix() + "[" + tc.getRange() + "]")) {
             log.warn("Invalid Reporter name: {} - out of supported range {}", systemName, tc.getRange());

--- a/java/src/jmri/jmrix/rfid/merg/concentrator/ConcentratorReporterManager.java
+++ b/java/src/jmri/jmrix/rfid/merg/concentrator/ConcentratorReporterManager.java
@@ -34,14 +34,14 @@ public class ConcentratorReporterManager extends RfidReporterManager {
     }
 
     @Override
-    protected Reporter createNewReporter(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         log.debug("Create new Reporter: {}", systemName);
         if (!systemName.matches(getSystemNamePrefix() + "[" + tc.getRange() + "]")) {
             log.warn("Invalid Reporter name: {}} - out of supported range {}", systemName, tc.getRange());
             throw new IllegalArgumentException("Invalid Reporter name: " + systemName + " - out of supported range " + tc.getRange());
         }
-        Reporter r;
-        r = new TimeoutReporter( new RfidReporter(systemName, userName));
+        Reporter r = new TimeoutReporter( new RfidReporter(systemName, userName));
         r.addPropertyChangeListener(this);
         return r;
     }

--- a/java/src/jmri/jmrix/roco/z21/Z21ReporterManager.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21ReporterManager.java
@@ -62,7 +62,8 @@ public class Z21ReporterManager extends jmri.managers.AbstractReporterManager im
     }
 
     @Override
-    public Reporter createNewReporter(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         if (!systemName.matches(getSystemPrefix() + typeLetter() + "[" + 1 + "]")) {
             int bitNum = Z21CanBusAddress.getBitFromSystemName(systemName, getSystemPrefix());
             if (bitNum != -1) {

--- a/java/src/jmri/jmrix/rps/RpsReporterManager.java
+++ b/java/src/jmri/jmrix/rps/RpsReporterManager.java
@@ -33,7 +33,8 @@ public class RpsReporterManager extends jmri.managers.AbstractReporterManager {
      * System name is normalized to ensure uniqueness.
      */
     @Override
-    protected Reporter createNewReporter(@Nonnull String systemName, String userName) {
+    @Nonnull
+    protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         log.debug("creating {}", userName);
         RpsReporter r = new RpsReporter(systemName, userName, getSystemPrefix());
         Distributor.instance().addMeasurementListener(r);

--- a/java/src/jmri/managers/AbstractReporterManager.java
+++ b/java/src/jmri/managers/AbstractReporterManager.java
@@ -42,13 +42,14 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
     /** {@inheritDoc} */
     @Override
     @Nonnull
-    public Reporter provideReporter(@Nonnull String sName) {
+    public Reporter provideReporter(@Nonnull String sName) throws IllegalArgumentException {
         Reporter r = getReporter(sName);
         return r == null ? newReporter(makeSystemName(sName, true), null) : r;
     }
 
     /** {@inheritDoc} */
     @Override
+    @CheckForNull
     public Reporter getReporter(@Nonnull String name) {
         Reporter r = getByUserName(name);
         return r == null ? getBySystemName(name) : r;
@@ -71,6 +72,7 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
 
     /** {@inheritDoc} */
     @Override
+    @CheckForNull
     public Reporter getByDisplayName(@Nonnull String key) {
         return getReporter(key);        
     }
@@ -94,14 +96,18 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
 
         // return existing if there is one
         Reporter r;
-        if ((userName != null) && ((r = getByUserName(userName)) != null)) {
-            if (getBySystemName(systemName) != r) {
-                log.error("inconsistent user ({}) and system name ({}) results; userName related to ({})",
-                        userName, systemName, r.getSystemName());
+        if (userName != null) {
+            r = getByUserName(userName);
+            if (r!=null) {
+                if (getBySystemName(systemName) != r) {
+                    log.error("inconsistent user ({}) and system name ({}) results; userName related to ({})",
+                            userName, systemName, r.getSystemName());
+                }
+                return r;
             }
-            return r;
         }
-        if ((r = getBySystemName(systemName)) != null) {
+        r = getBySystemName(systemName);
+        if (r != null) {
             if ((r.getUserName() == null) && (userName != null)) {
                 r.setUserName(userName);
             } else if (userName != null) {
@@ -131,7 +137,8 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
      * @param userName username.
      * @return never null
      */
-    abstract protected Reporter createNewReporter(@Nonnull String systemName, String userName);
+    @Nonnull
+    abstract protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException;
 
     /** {@inheritDoc} */
     @Override

--- a/java/src/jmri/managers/ProxyReporterManager.java
+++ b/java/src/jmri/managers/ProxyReporterManager.java
@@ -1,6 +1,8 @@
 package jmri.managers;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+
 import jmri.Manager;
 import jmri.Reporter;
 import jmri.ReporterManager;
@@ -33,12 +35,14 @@ public class ProxyReporterManager extends AbstractProvidingProxyManager<Reporter
      * @return Null if nothing by that name exists
      */
     @Override
+    @CheckForNull
     public Reporter getReporter(@Nonnull String name) {
         return super.getNamedBean(name);
     }
 
     @Override
-    protected Reporter makeBean(Manager<Reporter> manager, String systemName, String userName) {
+    @Nonnull
+    protected Reporter makeBean(Manager<Reporter> manager, String systemName, String userName) throws IllegalArgumentException {
         return ((ReporterManager) manager).newReporter(systemName, userName);
     }
 
@@ -54,6 +58,7 @@ public class ProxyReporterManager extends AbstractProvidingProxyManager<Reporter
     public Reporter provide(@Nonnull String name) throws IllegalArgumentException { return provideReporter(name); }
 
     @Override
+    @CheckForNull
     public Reporter getByDisplayName(@Nonnull String key) {
         // First try to find it in the user list.
         // If that fails, look it up in the system list
@@ -79,8 +84,7 @@ public class ProxyReporterManager extends AbstractProvidingProxyManager<Reporter
      * provided
      * <li>If a null reference is given for the system name, a system name will
      * _somehow_ be inferred from the user name. How this is done is system
-     * specific. Note: a future extension of this interface will add an
-     * exception to signal that this was not possible.
+     * specific.
      * <li>If both names are provided, the system name defines the hardware
      * access of the desired Reporter, and the user address is associated with
      * it.
@@ -95,7 +99,7 @@ public class ProxyReporterManager extends AbstractProvidingProxyManager<Reporter
      */
     @Override
     @Nonnull
-    public Reporter newReporter(@Nonnull String systemName, String userName) {
+    public Reporter newReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
         return newNamedBean(systemName, userName);
     }
 
@@ -110,15 +114,21 @@ public class ProxyReporterManager extends AbstractProvidingProxyManager<Reporter
         return getNextValidAddress(curAddress, prefix, typeLetter());
     }
     
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting) throws jmri.JmriException {
         return getNextValidAddress(curAddress, prefix, ignoreInitialExisting, typeLetter());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     @Nonnull
     public String getBeanTypeHandled(boolean plural) {
-        return Bundle.getMessage(plural ? "BeanNameReporters" : "BeanNameReporter");
+        return Bundle.getMessage(plural ? "BeanNameReporters" : "BeanNameReporter"); // NOI18N
     }
 
     /**

--- a/java/test/jmri/jmrix/rfid/RfidReporterManagerTest.java
+++ b/java/test/jmri/jmrix/rfid/RfidReporterManagerTest.java
@@ -100,8 +100,9 @@ public class RfidReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
         memo = new RfidSystemConnectionMemo();
         l = new RfidReporterManager(memo){
             @Override
-            protected Reporter createNewReporter(@Nonnull String systemName, String userName){
-               return null;
+            @Nonnull
+            protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+               return new RfidReporter(systemName, userName);
             }
             @Override
             public void message(RfidMessage m){}

--- a/java/test/jmri/jmrix/rfid/RfidSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/rfid/RfidSystemConnectionMemoTest.java
@@ -44,8 +44,9 @@ public class RfidSystemConnectionMemoTest extends SystemConnectionMemoTestBase<R
         scm.setRfidTrafficController(tc);
         RfidSensorManager s = new RfidSensorManager(scm) {
             @Override
-            protected Sensor createNewSensor(@Nonnull String systemName, String userName) {
-                return null;
+            @Nonnull
+            protected Sensor createNewSensor(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+                return new RfidSensor(systemName, userName);
             }
 
             @Override
@@ -59,8 +60,9 @@ public class RfidSystemConnectionMemoTest extends SystemConnectionMemoTestBase<R
         };
         RfidReporterManager r = new RfidReporterManager(scm) {
             @Override
-            protected Reporter createNewReporter(@Nonnull String systemName, String userName) {
-                return null;
+            @Nonnull
+            protected Reporter createNewReporter(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+                return new RfidReporter(systemName, userName);
             }
 
             @Override


### PR DESCRIPTION
Continued development of #7661 

Corrects annotation in ReporterManagers.