### PR TITLE
Fix for two turnouts, one inverted, crashes jmri when switching #9832

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -5407,7 +5407,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             case LEVEL_XING_D: {
                 try {
                     fromObject.setConnection(fromPointType, toObject, toPointType);
-                } catch (jmri.JmriException e) {
+                } catch (JmriException e) {
                     // ignore (log.error in setConnection method)
                 }
                 break;
@@ -6267,7 +6267,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             case LEVEL_XING_D: {
                 try {
                     o.setConnection(type, null, HitPointType.NONE);
-                } catch (jmri.JmriException e) {
+                } catch (JmriException e) {
                     // ignore (log.error in setConnection method)
                 }
                 break;
@@ -7484,7 +7484,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent((prefsMgr) -> prefsMgr.setSimplePreferenceState(getWindowFrameRef() + ".highlightSelectedBlock", highlightSelectedBlockFlag));
 
             // thread this so it won't break the AppVeyor checks
-            jmri.util.ThreadingUtil.newThread(() -> {
+            ThreadingUtil.newThread(() -> {
                 if (highlightSelectedBlockFlag) {
                     // use the "Extra" color to highlight the selected block
                     if (!highlightBlockInComboBox(leToolBarPanel.blockIDComboBox)) {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurnoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurnoutEditor.java
@@ -425,9 +425,11 @@ public class LayoutTurnoutEditor extends LayoutTrackEditor {
                     if (layoutTurnout2 != null) {   // if 2nd LayoutTurnout is defined (to get here it should be)
                         // then flip its 2nd turnout's inverted condition
                         layoutTurnout2.setSecondTurnoutInverted(!layoutTurnout2.isSecondTurnoutInverted());
+                        log.warn("layoutTurnout2.setSecondTurnoutInverted() infinite loop prevented.");
                     } else {    // (but just in case)
                         // otherwise flip our 2nd turnout's inverted condition
                         layoutTurnout.setSecondTurnoutInverted(!layoutTurnout.isSecondTurnoutInverted());
+                        log.warn("layoutTurnout.setSecondTurnoutInverted() infinite loop prevented.");
                     }
                 }
             }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurnoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurnoutEditor.java
@@ -1,7 +1,7 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
 import java.awt.*;
-import java.awt.event.ActionEvent;
+import java.awt.event.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -202,9 +202,9 @@ public class LayoutTurnoutEditor extends LayoutTrackEditor {
 
         setUpContinuingSense();
         
-        editLayoutTurnoutFrame.addWindowListener(new java.awt.event.WindowAdapter() {
+        editLayoutTurnoutFrame.addWindowListener(new WindowAdapter() {
             @Override
-            public void windowClosing(java.awt.event.WindowEvent e) {
+            public void windowClosing(WindowEvent e) {
                 editLayoutTurnoutCancelPressed(null);
             }
         });
@@ -359,7 +359,7 @@ public class LayoutTurnoutEditor extends LayoutTrackEditor {
             newName = "";
         }
         if (!layoutTurnout.getTurnoutName().equals(newName)) {
-            // turnout has changed
+            // turnout has changed, is it valid?
             if (layoutEditor.validatePhysicalTurnout(
                     newName, editLayoutTurnoutFrame)) {
                 layoutTurnout.setTurnout(newName);
@@ -370,6 +370,7 @@ public class LayoutTurnoutEditor extends LayoutTrackEditor {
             editLayoutTurnoutNeedRedraw = true;
         }
 
+        // check if 2nd Turnout changed
         if (editLayoutTurnout2ndTurnoutCheckBox.isSelected()) {
             newName = editLayoutTurnout2ndTurnoutComboBox.getSelectedItemDisplayName();
             if (newName == null) {
@@ -380,6 +381,56 @@ public class LayoutTurnoutEditor extends LayoutTrackEditor {
             }
         } else {
             layoutTurnout.setSecondTurnout("");
+        }
+
+        // Do we have an infinite invert loop?
+        if (editLayoutTurnout2ndTurnoutCheckBox.isSelected()) {
+            Turnout turnout1 = layoutTurnout.getTurnout();
+            LayoutTurnout layoutTurnout2 = null;
+            int t1state = Turnout.CLOSED;
+            int t2state = t1state;  // start off the same
+            
+            // invert if 2nd is inverted
+            if (layoutTurnout.isSecondTurnoutInverted()) {
+                t2state = Turnout.invertTurnoutState(t2state);
+            }
+
+            LayoutEditorFindItems lf = layoutEditor.getFinder();
+            Turnout turnout2 = layoutTurnout.getSecondTurnout();
+            while ((turnout2 != null) && (turnout1 != turnout2)) {
+                // first try to find it using the system name
+                layoutTurnout2 = lf.findLayoutTurnoutByTurnoutName(turnout2.getSystemName());
+                if (layoutTurnout2 == null) {   // if we didn't find it
+                    //  then try to find it using the user name
+                    layoutTurnout2 = lf.findLayoutTurnoutByTurnoutName(turnout2.getUserName());
+                }
+                // if we found it
+                if (layoutTurnout2 != null) {
+                    // and its 2nd turnout is inverted
+                    if (layoutTurnout2.isSecondTurnoutInverted()) {
+                        //  then invert the expected state
+                        t2state = Turnout.invertTurnoutState(t2state);
+                    }
+                    // and get the next 2nd turnout
+                    turnout2 = layoutTurnout2.getSecondTurnout();
+                } else {
+                    break;  // we didn't find the next LayoutTurnout
+                }
+            }
+            // if we've come full circle
+            if (turnout1 == turnout2) {
+                // are the states different?
+                if (t1state != t2state) {
+                    // yes (infinite loop)
+                    if (layoutTurnout2 != null) {   // if 2nd LayoutTurnout is defined (to get here it should be)
+                        // then flip its 2nd turnout's inverted condition
+                        layoutTurnout2.setSecondTurnoutInverted(!layoutTurnout2.isSecondTurnoutInverted());
+                    } else {    // (but just in case)
+                        // otherwise flip our 2nd turnout's inverted condition
+                        layoutTurnout.setSecondTurnoutInverted(!layoutTurnout.isSecondTurnoutInverted());
+                    }
+                }
+            }
         }
 
         setContinuingRouteTurnoutState();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -1920,7 +1920,7 @@ abstract public class LayoutTurnout extends LayoutTrack {
         if (getSecondTurnout() != null) {
             int t2state = getSecondTurnout().getKnownState();
             if (secondTurnoutInverted) {
-                t2state = Turnout.invertTurnoutState(getSecondTurnout().getKnownState());
+                t2state = Turnout.invertTurnoutState(t2state);
             }
             if (result != t2state) {
                 return INCONSISTENT;
@@ -2658,7 +2658,7 @@ abstract public class LayoutTurnout extends LayoutTrack {
                     // the points on the TurnoutView itself. Change to
                     // direction from connections.
                     //lc.setDirection(Path.computeDirection(getCoordsA(), getCoordsB()));
-                    lc.setDirection( models.computeDirectionAB(this) );
+                    lc.setDirection(models.computeDirectionAB(this));
 
                     log.trace("getLayoutConnectivity lbA != lbB");
                     log.trace("   Block boundary  ('{}'<->'{}') found at {}", lbA, lbB, this);
@@ -2675,7 +2675,7 @@ abstract public class LayoutTurnout extends LayoutTrack {
                     // the points on the TurnoutView itself. Change to
                     // direction from connections.
                     //lc.setDirection(Path.computeDirection(getCoordsA(), getCoordsC()));
-                    lc.setDirection( models.computeDirectionAC(this) );
+                    lc.setDirection(models.computeDirectionAC(this));
 
                     log.trace("getLayoutConnectivity lbA != lbC");
                     log.trace("   Block boundary  ('{}'<->'{}') found at {}", lbA, lbC, this);
@@ -2692,7 +2692,7 @@ abstract public class LayoutTurnout extends LayoutTrack {
                     // the points on the TurnoutView itself. Change to
                     // direction from connections.
                     //lc.setDirection(Path.computeDirection(getCoordsC(), getCoordsD()));
-                    lc.setDirection( models.computeDirectionCD(this) );
+                    lc.setDirection(models.computeDirectionCD(this));
 
                     log.trace("getLayoutConnectivity lbC != lbD");
                     log.trace("   Block boundary  ('{}'<->'{}') found at {}", lbC, lbD, this);
@@ -2709,7 +2709,7 @@ abstract public class LayoutTurnout extends LayoutTrack {
                     // the points on the TurnoutView itself. Change to
                     // direction from connections.
                     //lc.setDirection(Path.computeDirection(getCoordsB(), getCoordsD()));
-                    lc.setDirection( models.computeDirectionBD(this) );
+                    lc.setDirection(models.computeDirectionBD(this));
 
                     log.trace("getLayoutConnectivity lbB != lbD");
                     log.trace("   Block boundary  ('{}'<->'{}') found at {}", lbB, lbD, this);


### PR DESCRIPTION
Add code in LayoutTurnoutEditor:editLayoutTurnoutDonePressed() to detect when an infinite loop condition exists and if detected fix it so it can't happen.