### PR TITLE
Fix for simple server turnout to return status when thrown/closed not…

### DIFF
--- a/java/src/jmri/jmris/simpleserver/SimpleTurnoutServer.java
+++ b/java/src/jmri/jmris/simpleserver/SimpleTurnoutServer.java
@@ -54,15 +54,9 @@ public class SimpleTurnoutServer extends AbstractTurnoutServer {
     }
 
     @Override
-    public void parseStatus(String statusString) throws jmri.JmriException, java.io.IOException {
-        int index;
-        index = statusString.indexOf(' ') + 1;
-        int endIndex = statusString.indexOf(' ', index + 1);
-        if(endIndex == -1)
-        {
-            endIndex = statusString.length() - 1;
-        }
-        String turnoutName = statusString.substring(index, endIndex);
+    public void parseStatus(String statusString) throws jmri.JmriException, java.io.IOException {        
+        
+        String turnoutName = statusString.split(" ")[1];
         log.debug(statusString);
         if (statusString.contains("THROWN")) {
             if (log.isDebugEnabled()) {
@@ -81,10 +75,10 @@ public class SimpleTurnoutServer extends AbstractTurnoutServer {
         } else {
             // default case, return status for this turnout
             try {
-                sendStatus(statusString.substring(index),
-                    InstanceManager.turnoutManagerInstance().provideTurnout(statusString.substring(index)).getKnownState());
+                sendStatus(turnoutName,
+                    InstanceManager.turnoutManagerInstance().provideTurnout(turnoutName).getKnownState());
             } catch (IllegalArgumentException ex) {
-                log.warn("Failed to provide Turnout \"{}\" in parseStatus", statusString.substring(index));
+                log.warn("Failed to provide Turnout \"{}\" in parseStatus", turnoutName);
             }
         }
     }

--- a/java/src/jmri/jmris/simpleserver/SimpleTurnoutServer.java
+++ b/java/src/jmri/jmris/simpleserver/SimpleTurnoutServer.java
@@ -57,7 +57,12 @@ public class SimpleTurnoutServer extends AbstractTurnoutServer {
     public void parseStatus(String statusString) throws jmri.JmriException, java.io.IOException {
         int index;
         index = statusString.indexOf(' ') + 1;
-        String turnoutName = statusString.substring(index, statusString.indexOf(' ', index + 1));
+        int endIndex = statusString.indexOf(' ', index + 1);
+        if(endIndex == -1)
+        {
+            endIndex = statusString.length() - 1;
+        }
+        String turnoutName = statusString.substring(index, endIndex);
         log.debug(statusString);
         if (statusString.contains("THROWN")) {
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
… specified.

Hi.  I have been setting up raspberry pi's for remote access to turnouts and sensors.  While setting things up I noticed that an exception was occurring when trying to retrieve status of the turnout.  The proposed change below seems to fix the issue.  I am not a java expert so if there is a different approach to fix this issue please let me know.  The issue is that when the client asks for status there is not another space in the statusString and the index of returns a -1...