### PR TITLE
Update current-draft-note.shtml

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -460,7 +460,7 @@
         <ul>
             <li>For some hardware types, sensors.requestAll() can request a status update for any Sensors known to JMRI.
             <br>This is not possible for many hardware types, eg. Internal Connections.
-            <br>For multiple hardware connections, this will query all connections.</li>
+            <br>For multiple hardware connections, sensors.updateAll() will query all connections.</li>
         </ul>
 
     <h3>Signals</h3>


### PR DESCRIPTION
This PR updates the draft note related to #9928. PR #9928 updated the draft note, but didn't tell the user which function call to use instead of `sensors.requestAll()`.

I rarely write scripts so I hope I have got the change right.