### PR TITLE
Block speed limit null pointer fix

### DIFF
--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -2700,7 +2700,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
 
         // If speed change is due to a signal, this signal should be the next signal ahead
         // However (see lines 2552-4) it is possible for it not to be the current _protectSignal.
-        if (!_waitForBlock && !_waitForWarrant) {   // must be a signal change
+        if (_protectSignal !=null && !_waitForBlock && !_waitForWarrant) {   // must be a signal change
             for (int idx = _idxCurrentOrder + 1; idx < _orders.size(); idx++) {
                 blkOrder = getBlockOrderAt(idx);
                 String sType = getPermissibleSpeedAt(blkOrder);


### PR DESCRIPTION
Fix null pointer when attempting to update the speed specified  by a signal when no signals are detected.