### PR TITLE
Fix duplicate key in operations/trains/JmritOperationsTrainsBundle_en_GB

### DIFF
--- a/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_en_GB.properties
@@ -23,7 +23,6 @@ engineCanNotHp      = Can not save engine horsepower!
 WeightFormatTon        = Engine weight must be in the format of xx tons
 WeightTonError  = Can not save engine weight!
 findEngine           = Find Engine by railway number
-engineWithRoadNumNotFound = Engine with road number "{0}" not found
 engineCouldNotFind  = Could not find engine!
 engineSureDelete    = Are you sure you want to delete all the engines in your roster?
 engineDeleteAll     = Delete all Engines?

--- a/java/src/jmri/jmrit/operations/trains/JmritOperationsTrainsBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/operations/trains/JmritOperationsTrainsBundle_en_GB.properties
@@ -47,7 +47,6 @@ TipFRED             = Last wagon on the train must have a Flashing Rear End Devi
 TipCaboose          = Last wagon on the train must be a break van
 
 ModelEngineTip      = Optionally select engine model
-RoadEngineTip       = Optionally select engine road name
 TipNumberOfLocos    = Select the number of engines for this train
 
 # manifest messages


### PR DESCRIPTION
Introduced in #9962 Causing builds to fail, 
https://builds.jmri.org/jenkins/job/development/job/builds/779/console

```
[resourceCheck] Enabled checks: [duplicate key check, empty key check, messageformat check, unicode check, invalid char check]
[resourceCheck] duplicate key check: key engineWithRoadNumNotFound defined more than once (26:Engine with road number "{0}" not found) (/var/lib/jenkins/workspace/development/builds/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_en_GB.properties:19:Engine with railway number "{0}" not found + 26:Engine with road number "{0}" not found)
[resourceCheck] duplicate key check: key RoadEngineTip defined more than once (50:Optionally select engine road name) (/var/lib/jenkins/workspace/development/builds/java/src/jmri/jmrit/operations/trains/JmritOperationsTrainsBundle_en_GB.properties:41:Optionally select engine railway name + 50:Optionally select engine road name)
```