### PR TITLE
Provide a re-direct to jmri.org for pages in the help/**/manual/ directory

### DIFF
--- a/help/en/formatLocalTOC.xsl
+++ b/help/en/formatLocalTOC.xsl
@@ -42,7 +42,24 @@
     <xsl:comment>=====================================================================</xsl:comment>
 
     <script>
+
+        var use_internet = false;
+
         function openLink(link) {
+
+            if (link.includes("/manual/")) {
+                if (!use_internet) {
+                    if (window.confirm("Manual help pages are not installed.\nIf internet is available, use jmri.org?")) {
+                        use_internet = true;
+                    }
+                }
+                if (use_internet) {
+                    link = "https://jmri.org/help/en/manual/" + link;
+                } else {
+                    return;
+                }
+            }
+
             document.getElementById("page").src = link;
         }
 

--- a/help/en/local/index.html
+++ b/help/en/local/index.html
@@ -10,7 +10,24 @@
 <!--Do not edit it directly-->
 <!--=====================================================================-->
 <script>
+
+        var use_internet = false;
+
         function openLink(link) {
+
+            if (link.includes("/manual/")) {
+                if (!use_internet) {
+                    if (window.confirm("Manual help pages are not installed.\nIf internet is available, use jmri.org?")) {
+                        use_internet = true;
+                    }
+                }
+                if (use_internet) {
+                    link = "https://jmri.org/help/en/manual/" + link;
+                } else {
+                    return;
+                }
+            }
+
             document.getElementById("page").src = link;
         }
 

--- a/help/en/local/stub/html.scripthelp.LnBushbyForwarder.LnBushbyForwarder.html
+++ b/help/en/local/stub/html.scripthelp.LnBushbyForwarder.LnBushbyForwarder.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#html.scripthelp.LnBushbyForwarder.LnBushbyForwarder">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/package.jmri.jmrit.operations.Operations_ModifyingBuiltTrain.html
+++ b/help/en/local/stub/package.jmri.jmrit.operations.Operations_ModifyingBuiltTrain.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#package.jmri.jmrit.operations.Operations_ModifyingBuiltTrain">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/package.jmri.jmrit.operations.Operations_Yardmaster.html
+++ b/help/en/local/stub/package.jmri.jmrit.operations.Operations_Yardmaster.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#package.jmri.jmrit.operations.Operations_Yardmaster">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.current-draft-note_LnBushbyForwarder.html
+++ b/help/en/local/stub/releasenotes.current-draft-note_LnBushbyForwarder.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.current-draft-note_LnBushbyForwarder">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_CPE-CB.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_CPE-CB.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_CPE-CB">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_CPE-P.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_CPE-P.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_CPE-P">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_CPE.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_CPE.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_CPE">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_DecoderPro.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_DecoderPro.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_DecoderPro">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Dispatcher.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Dispatcher.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Dispatcher">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Dispatcher_System.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Dispatcher_System.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Dispatcher_System">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_I18N.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_I18N.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_I18N">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_LE.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_LE.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_LE">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Logix.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Logix.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Logix">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Meters.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Meters.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Meters">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Misc.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Misc.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Misc">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Operations.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Operations.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Operations">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_PE-CTC.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_PE-CTC.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_PE-CTC">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_PE.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_PE.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_PE">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Preferences.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Preferences.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Preferences">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Resources.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Resources.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Resources">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Roster.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Roster.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Roster">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Routes.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Routes.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Routes">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_SW.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_SW.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_SW">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Scripting.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Scripting.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Scripting">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Signals.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Signals.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Signals">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_TLae.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_TLae.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_TLae">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Timetable.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Timetable.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Timetable">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Tr.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Tr.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Tr">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_VSD.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_VSD.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_VSD">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_WA.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_WA.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_WA">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_WS.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_WS.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_WS">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_WhereUsed.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_WhereUsed.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_WhereUsed">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_Wt.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_Wt.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_Wt">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_server.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_server.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_server">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/en/local/stub/releasenotes.jmri4.25-master_throttle.html
+++ b/help/en/local/stub/releasenotes.jmri4.25-master_throttle.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>JMRI: Redirected Page</title>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<!-- This file is used as a template for the html files in the stub/ folder -->
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#releasenotes.jmri4.25-master_throttle">
+</head>
+<body>
+<p>Template</p>
+</body>
+</html>

--- a/help/fr/formatLocalTOC.xsl
+++ b/help/fr/formatLocalTOC.xsl
@@ -42,7 +42,24 @@
     <xsl:comment>=====================================================================</xsl:comment>
 
     <script>
+
+        var use_internet = false;
+
         function openLink(link) {
+
+            if (link.includes("/manual/")) {
+                if (!use_internet) {
+                    if (window.confirm("Manual help pages are not installed.\nIf internet is available, use jmri.org?")) {
+                        use_internet = true;
+                    }
+                }
+                if (use_internet) {
+                    link = "https://jmri.org/help/en/manual/" + link;
+                } else {
+                    return;
+                }
+            }
+
             document.getElementById("page").src = link;
         }
 

--- a/help/fr/local/index.html
+++ b/help/fr/local/index.html
@@ -10,7 +10,24 @@
 <!--Do not edit it directly-->
 <!--=====================================================================-->
 <script>
+
+        var use_internet = false;
+
         function openLink(link) {
+
+            if (link.includes("/manual/")) {
+                if (!use_internet) {
+                    if (window.confirm("Manual help pages are not installed.\nIf internet is available, use jmri.org?")) {
+                        use_internet = true;
+                    }
+                }
+                if (use_internet) {
+                    link = "https://jmri.org/help/en/manual/" + link;
+                } else {
+                    return;
+                }
+            }
+
             document.getElementById("page").src = link;
         }
 


### PR DESCRIPTION
The contents of help/en/manual are about 30MB.  Including this content increases the JMRI distribution size by about 15%.

When a reference is made to a manual page, a prompt will be displayed to provide an option to fetch the page from jmri.org.

