### PR TITLE
Update RaspberryPi TurnoutManager Test

### DIFF
--- a/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
@@ -82,8 +82,6 @@ public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnout
         // GpioFactory.setDefaultProvider(null);
         l.dispose();
 
-        JUnitUtil.clearShutDownManager();
-        JUnitUtil.resetInstanceManager();
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
Remove call to resetInstanceManager from tearDown

May have caused build 784 to fail, see
https://builds.jmri.org/jenkins/job/development/job/builds/784/testReport/

No clearShutDownManager errors noted by removing deprecated call.

```
java.util.ServiceConfigurationError: jmri.InstanceInitializer: Error reading configuration file
	at java.util.ServiceLoader.fail(ServiceLoader.java:232)
	at java.util.ServiceLoader.parse(ServiceLoader.java:309)
	at java.util.ServiceLoader.access$200(ServiceLoader.java:185)
	at java.util.ServiceLoader$LazyIterator.hasNextService(ServiceLoader.java:357)
	at java.util.ServiceLoader$LazyIterator.hasNext(ServiceLoader.java:393)
	at java.util.ServiceLoader$1.hasNext(ServiceLoader.java:474)
	at java.lang.Iterable.forEach(Iterable.java:74)
	at jmri.InstanceManager.<init>(InstanceManager.java:718)
	at jmri.InstanceManager$LazyInstanceManager.resetInstanceManager(InstanceManager.java:834)
	at jmri.InstanceManager.clearAll(InstanceManager.java:778)
	at jmri.util.JUnitUtil.resetInstanceManager(JUnitUtil.java:679)
	at jmri.jmrix.pi.RaspberryPiTurnoutManagerTest.tearDown(RaspberryPiTurnoutManagerTest.java:86)
```