### PR TITLE
TCS V5 4-Byte productID decoder identification support

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -352,7 +352,10 @@
     <h3>DecoderPro</h3>
         <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
-            <li></li>
+            <li>Updated TCS Decoder identification processes to allow for 4-byte decoder
+            with ids stored in CV's 253, 254, 255, and 256. Process only effects TCS decoders
+            CV249 > 175. 
+            </li>
         </ul>
 
     <h3>CTC Tool</h3>

--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -290,7 +290,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             return true;
         } else if (mfgID == 153) {  // TCS
             productIDhigh = value;
-            statusUpdate("Read decoder product hash #2 CV 256");
+            statusUpdate("Read decoder product hash #4 CV 256");
             readCV("256");
             return false;
         }

--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -152,8 +152,15 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             writeCV("50", 4);
             return false;
         } else if (mfgID == 153) {  // TCS
-            productID = value;
-            return true;
+            if(value < 175){ //check for pre-version 5 sound decoders
+                productID = value;
+                return true;
+            }
+            else{
+                statusUpdate("Read decoder product hash #1 CV 253");
+                readCV("253");
+                return false;
+            }
         } else if (mfgID == 48) {  // Hornby
             if (isOptionalCv()) {
                 return true;
@@ -227,6 +234,11 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             statusUpdate("Read decoder product ID #3 CV 49");
             readCV("49");
             return false;
+        } else if (mfgID == 153) {  // DIY
+            productIDhighest = value;
+            statusUpdate("Read decoder product hash #2 CV 254");
+            readCV("254");
+            return false;
         }
         log.error("unexpected step 5 reached with value: {}", value);
         return true;
@@ -249,6 +261,11 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             statusUpdate("Read decoder product ID #4 CV 50");
             readCV("50");
             return false;
+        } else if (mfgID == 153) {  // DIY
+            productIDhigh = value;
+            statusUpdate("Read decoder product hash #3 CV 255");
+            readCV("255");
+            return false;
         }
         log.error("unexpected step 6 reached with value: {}", value);
         return true;
@@ -269,6 +286,11 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             productIDlowest = value;
             productID = (((((productIDhighest << 8) | productIDhigh) << 8) | productIDlow) << 8) | productIDlowest;
             return true;
+        } else if (mfgID == 153) {  // DIY
+            productIDlow = value;
+            statusUpdate("Read decoder product hash #2 CV 256");
+            readCV("256");
+            return false;
         }
         log.error("unexpected step 7 reached with value: {}", value);
         return true;
@@ -285,6 +307,10 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             statusUpdate("Read productID Byte 4");
             readCV("264");
             return false;
+        } else if (mfgID == 153) {  // DIY
+            productIDlowest = value;
+            productID = 
+            return true;
         }
         log.error("unexpected step 8 reached with value: {}", value);
         return true;

--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -235,7 +235,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             readCV("49");
             return false;
         } else if (mfgID == 153) {  // DIY
-            productIDhighest = value;
+            productIDlowest = value;
             statusUpdate("Read decoder product hash #2 CV 254");
             readCV("254");
             return false;
@@ -262,7 +262,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             readCV("50");
             return false;
         } else if (mfgID == 153) {  // DIY
-            productIDhigh = value;
+            productIDlow = value;
             statusUpdate("Read decoder product hash #3 CV 255");
             readCV("255");
             return false;
@@ -287,7 +287,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             productID = (((((productIDhighest << 8) | productIDhigh) << 8) | productIDlow) << 8) | productIDlowest;
             return true;
         } else if (mfgID == 153) {  // DIY
-            productIDlow = value;
+            productIDhigh = value;
             statusUpdate("Read decoder product hash #2 CV 256");
             readCV("256");
             return false;
@@ -308,8 +308,8 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             readCV("264");
             return false;
         } else if (mfgID == 153) {  // DIY
-            productIDlowest = value;
-            productID = (productIDhighest*256*256*256) + (productIDhigh*256*256) + (productIDlow*256) + productIDlowest
+            productIDhighest = value;
+            productID = (productIDhighest*256*256*256) + (productIDhigh*256*256) + (productIDlow*256) + productIDlowest;
             return true;
         }
         log.error("unexpected step 8 reached with value: {}", value);

--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -23,7 +23,9 @@ import org.slf4j.LoggerFactory;
  * models, in which case no "productID" can be determined. (This code uses
  * {@link #setOptionalCv(boolean flag) setOptionalCv()} and
  * {@link #isOptionalCv() isOptionalCv()} as documented below.)</li>
- * <li>TCS: (mfgID == 153) CV249 is ID</li>
+ * <li>TCS: (mfgID == 153) CV249 is physical hardware id, V5 and above use
+ * CV253, CV254, CV255, and CV256 to identify specific sound sets and 
+ * features. New productID process triggers if (CV249 > 175).</li>
  * <li>Zimo: (mfgID == 145) CV250 is ID</li>
  * <li>SoundTraxx: (mfgID == 141, modelID == 70 or 71) CV253 is high byte, CV256
  * is low byte of ID</li>
@@ -234,7 +236,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             statusUpdate("Read decoder product ID #3 CV 49");
             readCV("49");
             return false;
-        } else if (mfgID == 153) {  // DIY
+        } else if (mfgID == 153) {  // TCS
             productIDlowest = value;
             statusUpdate("Read decoder product hash #2 CV 254");
             readCV("254");
@@ -261,7 +263,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             statusUpdate("Read decoder product ID #4 CV 50");
             readCV("50");
             return false;
-        } else if (mfgID == 153) {  // DIY
+        } else if (mfgID == 153) {  // TCS
             productIDlow = value;
             statusUpdate("Read decoder product hash #3 CV 255");
             readCV("255");
@@ -286,7 +288,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             productIDlowest = value;
             productID = (((((productIDhighest << 8) | productIDhigh) << 8) | productIDlow) << 8) | productIDlowest;
             return true;
-        } else if (mfgID == 153) {  // DIY
+        } else if (mfgID == 153) {  // TCS
             productIDhigh = value;
             statusUpdate("Read decoder product hash #2 CV 256");
             readCV("256");
@@ -307,7 +309,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             statusUpdate("Read productID Byte 4");
             readCV("264");
             return false;
-        } else if (mfgID == 153) {  // DIY
+        } else if (mfgID == 153) {  // TCS
             productIDhighest = value;
             productID = (productIDhighest*256*256*256) + (productIDhigh*256*256) + (productIDlow*256) + productIDlowest;
             return true;

--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -309,7 +309,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             return false;
         } else if (mfgID == 153) {  // DIY
             productIDlowest = value;
-            productID = 
+            productID = (productIDhighest*256*256*256) + (productIDhigh*256*256) + (productIDlow*256) + productIDlowest
             return true;
         }
         log.error("unexpected step 8 reached with value: {}", value);

--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * {@link #isOptionalCv() isOptionalCv()} as documented below.)</li>
  * <li>TCS: (mfgID == 153) CV249 is physical hardware id, V5 and above use
  * CV253, CV254, CV255, and CV256 to identify specific sound sets and 
- * features. New productID process triggers if (CV249 > 175).</li>
+ * features. New productID process triggers if (CV249 &gt; 175).</li>
  * <li>Zimo: (mfgID == 145) CV250 is ID</li>
  * <li>SoundTraxx: (mfgID == 141, modelID == 70 or 71) CV253 is high byte, CV256
  * is low byte of ID</li>

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -435,7 +435,7 @@ public class IdentifyDecoderTest {
      * Should pass
      */
     @Test
-    public void testIdentifyTCS() {
+    public void testIdentifyTCSV5() {
         // create our test object
         IdentifyDecoder i = new IdentifyDecoder(p) {
             @Override
@@ -491,6 +491,49 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("found mfg ID ", 153, i.mfgID);
         Assert.assertEquals("found model ID ", 5, i.modelID);
         Assert.assertEquals("found product ID ", 67305985, i.productID);
+    }
+    
+        /**
+     * Test TCS decoder with single byte, CV249 productID.
+     * Should pass
+     */
+    @Test
+    public void testIdentifyTCSV4() {
+        // create our test object
+        IdentifyDecoder i = new IdentifyDecoder(p) {
+            @Override
+            public void done(int mfgID, int modelID, int productID) {
+            }
+
+            @Override
+            public void message(String m) {
+            }
+
+            @Override
+            public void error() {
+            }
+        };
+
+        i.start();
+        Assert.assertEquals("step 1 reads CV ", 8, cvRead);
+        Assert.assertEquals("running after 1 ", true, i.isRunning());
+
+        // simulate CV read complete on CV8, start 7
+        i.programmingOpReply(153, 0);
+        Assert.assertEquals("step 2 reads CV ", 7, cvRead);
+        Assert.assertEquals("running after 2 ", true, i.isRunning());
+
+        // simulate CV read complete on CV7, start 249
+        i.programmingOpReply(4, 0);
+        Assert.assertEquals("step 3 reads CV ", 249, cvRead);
+        Assert.assertEquals("running after 3 ", true, i.isRunning());
+
+        // simulate CV read complete on CV249, end
+        i.programmingOpReply(80, 0);
+
+        Assert.assertEquals("found mfg ID ", 153, i.mfgID);
+        Assert.assertEquals("found model ID ", 4, i.modelID);
+        Assert.assertEquals("found product ID ", 80, i.productID);
     }
 
     /**

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -476,21 +476,21 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("running after 6 ", true, i.isRunning());
         
         // simulate CV read complete on CV254, start 255
-        i.programmingOpReply(1, 0);
+        i.programmingOpReply(2, 0);
         Assert.assertEquals("step 7 reads CV ", 255, cvRead);
         Assert.assertEquals("running after 7 ", true, i.isRunning());
         
         // simulate CV read complete on CV255, start 256
-        i.programmingOpReply(1, 0);
+        i.programmingOpReply(3, 0);
         Assert.assertEquals("step 8 reads CV ", 256, cvRead);
         Assert.assertEquals("running after 8 ", true, i.isRunning());
         
         // simulate CV read complete on CV256, end
-        i.programmingOpReply(1, 0);
+        i.programmingOpReply(4, 0);
 
         Assert.assertEquals("found mfg ID ", 153, i.mfgID);
         Assert.assertEquals("found model ID ", 5, i.modelID);
-        Assert.assertEquals("found product ID ", 16843009, i.productID);
+        Assert.assertEquals("found product ID ", 67305985, i.productID);
     }
 
     /**

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -429,6 +429,69 @@ public class IdentifyDecoderTest {
         jmri.util.JUnitAppender.assertWarnMessage("Stopping due to error: "
                             + p.decodeErrorCode(2));
     }
+    
+    /**
+     * Test TCS decoder with 4-digit productID.
+     * Should pass
+     */
+    @Test
+    public void testIdentifyTCS() {
+        // create our test object
+        IdentifyDecoder i = new IdentifyDecoder(p) {
+            @Override
+            public void done(int mfgID, int modelID, int productID) {
+            }
+
+            @Override
+            public void message(String m) {
+            }
+
+            @Override
+            public void error() {
+            }
+        };
+
+        i.start();
+        Assert.assertEquals("step 1 reads CV ", 8, cvRead);
+        Assert.assertEquals("running after 1 ", true, i.isRunning());
+
+        // simulate CV read complete on CV8, start 7
+        i.programmingOpReply(153, 0);
+        Assert.assertEquals("step 2 reads CV ", 7, cvRead);
+        Assert.assertEquals("running after 2 ", true, i.isRunning());
+
+        // simulate CV read complete on CV7, start 249
+        i.programmingOpReply(5, 0);
+        Assert.assertEquals("step 3 reads CV ", 249, cvRead);
+        Assert.assertEquals("running after 3 ", true, i.isRunning());
+
+        // simulate CV read complete on CV249, start 253
+        i.programmingOpReply(176, 0);
+        Assert.assertEquals("step 5 reads CV ", 253, cvRead);
+        Assert.assertEquals("running after 5 ", true, i.isRunning());
+        
+        // simulate CV read complete on CV253, start 254
+        i.programmingOpReply(1, 0);
+        Assert.assertEquals("step 6 reads CV ", 254, cvRead);
+        Assert.assertEquals("running after 6 ", true, i.isRunning());
+        
+        // simulate CV read complete on CV254, start 255
+        i.programmingOpReply(1, 0);
+        Assert.assertEquals("step 7 reads CV ", 255, cvRead);
+        Assert.assertEquals("running after 7 ", true, i.isRunning());
+        
+        // simulate CV read complete on CV255, start 256
+        i.programmingOpReply(1, 0);
+        Assert.assertEquals("step 8 reads CV ", 256, cvRead);
+        Assert.assertEquals("running after 8 ", true, i.isRunning());
+        
+        // simulate CV read complete on CV256, end
+        i.programmingOpReply(1, 0);
+
+        Assert.assertEquals("found mfg ID ", 153, i.mfgID);
+        Assert.assertEquals("found model ID ", 5, i.modelID);
+        Assert.assertEquals("found product ID ", 16843009, i.productID);
+    }
 
     /**
      * Initialize the system.


### PR DESCRIPTION
TCS' new V5 platform of sound decoders uses a 4-byte sound set and feature identifier stored over CVs 253, 254, 255, and 256. This change allows V4 sound and non-sound decoders to still be identified in the the same three reads (CV8, CV7, and CV249), but in instances where CV249 > 175 IdentifyDecoder.java will proceed to read in the 253-256 CV range, convert to a single int, and store result as productID.

Unit tests were included for both older decoder identification and new decoder identification. All new unit tests pass.

current-draft-notes.shtml has been updated to note the change.

 