### PR TITLE
Fix web pages that have no sidebar

### DIFF
--- a/help/en/html/scripthelp/DispatcherSystem/DispatcherSystem.shtml
+++ b/help/en/html/scripthelp/DispatcherSystem/DispatcherSystem.shtml
@@ -2,18 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-  <!-- Copyright ($Author$) 2016 -->
-
   <title>JMRI: Dispatcher System</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Dispatcher System</h1>
 
@@ -53,35 +49,35 @@
       designated by yourself.</p>
 
       <p>Provided you have set up a system as described in System Requirements, by pressing
-      a few buttons on theSystem Generation Panel, a complete system will be set 
-      up for you complete with Transits, Train Info files, and buttons for you to press 
+      a few buttons on theSystem Generation Panel, a complete system will be set
+      up for you complete with Transits, Train Info files, and buttons for you to press
       which will route trains across your layout.</p>
 
-      <p>A network will be set up behind the scenes which will find the best 
+      <p>A network will be set up behind the scenes which will find the best
           route from
-      the train's location to the required location, and set  in place a set of 
+      the train's location to the required location, and set  in place a set of
       transits
       which will guide the train to the required location.</p>
 
-      <p>The train will either stop at all stations on the route, or travel 
+      <p>The train will either stop at all stations on the route, or travel
           without
-      stopping at intermediate stops, depending on whether express or stopping 
+      stopping at intermediate stops, depending on whether express or stopping
       mode is
       selected</p>
 
-      <p>Provision is made for multiple train operation, the trains stopping 
+      <p>Provision is made for multiple train operation, the trains stopping
           for each other.
-      This is a feature of Dispatcher, but the system allows easy selecting of 
+      This is a feature of Dispatcher, but the system allows easy selecting of
       each train
       to control each one.</p>
 
       <a  name="steps" id="steps"></a>
       <h3>Steps in setting up the system</h3>
 
-      <p>There are several stages to set up the system for automatic train 
+      <p>There are several stages to set up the system for automatic train
           running:</p>
 
-      <p>Fulfil the prerequisites, which include having speed profiled your 
+      <p>Fulfil the prerequisites, which include having speed profiled your
           locos that you wish to run with the system</p>
 
       <ul>
@@ -96,7 +92,7 @@
           </ul>
         </li>
         <li>Bring up the Dispatcher System Panel</li>
-        <li>Run Stage1 to generate an intermediate panel with icons to move 
+        <li>Run Stage1 to generate an intermediate panel with icons to move
             trains</li>
         <li>Restart</li>
         <li>Run Stage2 to generate a run system panel</li>
@@ -119,11 +115,11 @@
             <li>set up with a speed profile</li>
           </ul>
         </li>
-        <li>the required stopping places (blocks) should be indicated by 
+        <li>the required stopping places (blocks) should be indicated by
             entering stop in the comments field for the appropriate block</li>
-        <li>Provision is made for a station announcement to be made when a train 
+        <li>Provision is made for a station announcement to be made when a train
             departs from a station.</li>
-        <li>If the block name is unpronounceable, a good stop name can be 
+        <li>If the block name is unpronounceable, a good stop name can be
             entered in the comments field for the departure announcements</li>
         <li>Typical blocks comments would be</li>
         <li><img src="images/NewItem31.png" alt="" /></li>
@@ -132,10 +128,10 @@
       <a name="stage1" id="stage1"></a>
       <h2>Running Stage1 &mdash; Editing the panel</h2>
 
-      <p>Run DispatcherSystem.py in the main jython directory. You will get 
+      <p>Run DispatcherSystem.py in the main jython directory. You will get
           something like this:</p>
       <p><img alt="" style="padding : 1px;" src="images/NewItem3.png"></p>
-      <p>You are prompted to run Stage1 which adds all the icons required to run 
+      <p>You are prompted to run Stage1 which adds all the icons required to run
           the system on a new panel.</p>
       <p>if the old panel name was WR.xml, the new panel will be WR_icons.xml</p>
       <p>Some checks are done first</p>
@@ -147,21 +143,21 @@
         <li>stops are set up</li>
         <li>all blocks have lengths</li>
       </ul>
-      <p>If no trains are present in the roster with speed profiles, this will 
+      <p>If no trains are present in the roster with speed profiles, this will
           be picked up, and can be corrected at run time.</p>
-      <p>When the icons file is produced, a message similar to the following 
+      <p>When the icons file is produced, a message similar to the following
           will be produced:</p>
       <p><img alt="" style="padding : 1px;" src="images/NewItem34.png"></p>
-      <p>A new panel has been created. You should close down and load the new 
+      <p>A new panel has been created. You should close down and load the new
           panel, instead of the original.</p>
       <p>Note:</p>
       <p>The panel will have been created by loading the original xml file (in
-          this case WR.ml), editing the details and saving to a new file 
+          this case WR.ml), editing the details and saving to a new file
           (WR_icons.xml). </p>
-      <p>If there were any unsaved edits in the original file these will not be 
-          present in the new file, but you will not lose them provided you save 
-          them either to the original file or another file once Stage1 has 
-          completed. We advise saving all edits before running Stage1, so they 
+      <p>If there were any unsaved edits in the original file these will not be
+          present in the new file, but you will not lose them provided you save
+          them either to the original file or another file once Stage1 has
+          completed. We advise saving all edits before running Stage1, so they
           are picked up.</p>
 
 
@@ -185,93 +181,93 @@
       so there can be quite a number produced.</p>
       <p>Once the transits and train-info files are produced we get a message:</p>
       <p><img alt="" style="padding : 1px;" src="images/NewItem35.png"></p>
-      <p>You should then restart JMRI and load the run panel instead of the 
+      <p>You should then restart JMRI and load the run panel instead of the
           icons panel, in this example WR_run.xml</p>
 
       <a name="stage3" id="stage3"></a>
       <h2>Running Stage3 Final Checks</h2>
 
       <p></p>
-      <p>Restart JMRI and load the newly produced run panel, in our example 
+      <p>Restart JMRI and load the newly produced run panel, in our example
           WR_run.xml</p>
       <p">Run dispatcher System again to get</p>
       <p><img alt="" style="padding : 1px;" src="images/NewItem11.png"></p>
-      <p>Click Stage3 and one gets two screens opening,the Dispatcher options 
+      <p>Click Stage3 and one gets two screens opening,the Dispatcher options
           screen and another
       saying the options that need to be set for the Dispatcher system to work</p>
       <p><img alt="" style="padding : 1px;" src="images/NewItem12.png"></p>
       <p><img alt="" style="padding : 1px;" src="images/NewItem13.png"></p>
-      <p>Set the required option and we get a message reminding you to save the 
+      <p>Set the required option and we get a message reminding you to save the
           changed options</p>
       <p><img alt="" style="padding : 1px;" src="images/NewItem14.png"></p>
-      <p>Select the dispatcher window that has opened automatically and click 
+      <p>Select the dispatcher window that has opened automatically and click
           =&gt; Save Options</p>
       <p><img alt="" style="padding : 1px;" src="images/NewItem32.png"></p>
-      
-      
+
+
       <a name="runningprogram" id="runningprogram"></a>
       <h2>Running the Program</h2>
-      
-      
-      <p>To run the system it is advised to have the thread monitor running 
+
+
+      <p>To run the system it is advised to have the thread monitor running
           (Panels =&gt; Thread Monitor)</p>
       <p>You will notice several buttons in the top RH corner.</p>
       <p><img src="images/NewItem38.png" alt="NewItem38" /></p>
-      <p>The first two start and end the threads required for the program to 
-          run. The threads need to be in operation for the other buttons to 
-          work. The threads can be viewed by clicking Panels | Thread Monitor on 
+      <p>The first two start and end the threads required for the program to
+          run. The threads need to be in operation for the other buttons to
+          work. The threads can be viewed by clicking Panels | Thread Monitor on
           the PanelPro Window.</p>
       <p><img src="images/NewItem40.png" alt="NewItem40" /></p>
       <p>To run the system the following needs to be set up</p>
       <ol>
-      <li>Place a train on the layout. If you wish to simulate the train to get 
-          an idea of how the system will operate click the bottom left button of 
+      <li>Place a train on the layout. If you wish to simulate the train to get
+          an idea of how the system will operate click the bottom left button of
           a station which will make the station occupied.</li>
-      <li>Register the train with the dispatcher system telling the system what 
-          way it s facing so the system knows what trainsit to use to move the 
-          train (forwards or backwards). Press the 'Setup Train in Section' 
+      <li>Register the train with the dispatcher system telling the system what
+          way it s facing so the system knows what trainsit to use to move the
+          train (forwards or backwards). Press the 'Setup Train in Section'
           button to do this.</li>
       <li>&nbsp;Set up a dispatch. This can be done in several ways.</li>
       <ol>
-      <li>Click the Run Dispatch Button and click a station button and specify 
+      <li>Click the Run Dispatch Button and click a station button and specify
           which registered train will move towards that station</li>
-      <li>Setup a Route and run the route. A Route consists of a path joining 
-          several stations. The stations joined can be anywhere on the layout 
-          no matter how far apart they are, and the system will find valid paths 
-          between the stations.The station buttons can be used to either setup a 
-          dispatch or setup a route depending upon whether "Setup Route or "Run 
-          Dispatch" is selected. The route is run by pressing the "Run Route" 
+      <li>Setup a Route and run the route. A Route consists of a path joining
+          several stations. The stations joined can be anywhere on the layout
+          no matter how far apart they are, and the system will find valid paths
+          between the stations.The station buttons can be used to either setup a
+          dispatch or setup a route depending upon whether "Setup Route or "Run
+          Dispatch" is selected. The route is run by pressing the "Run Route"
           button.</li>
       <li>Setup routes, Setup Scheduled Trains and then start the scheduler.</li>
       </ol>
-      <li>If a physical train is on the layout at the start of the dispatch the 
-          train should move. If you have just made the block occupied with no 
-          physical train you can press the 'Simulate the Dispatched Train' 
-          button to get an idea of how the train will run. The train will 
-          simulate much quicker than a real train and takes no account of the 
+      <li>If a physical train is on the layout at the start of the dispatch the
+          train should move. If you have just made the block occupied with no
+          physical train you can press the 'Simulate the Dispatched Train'
+          button to get an idea of how the train will run. The train will
+          simulate much quicker than a real train and takes no account of the
           train length.</li>
-      <li>Announcements can be activated by pressing the 'Enable Announcements' 
+      <li>Announcements can be activated by pressing the 'Enable Announcements'
           button. This is off by default as they can get a but irritating.</li>
       </ol>
-      <p>Press the run button. The Express Train and the Run Dispatch options 
-          will be highlighted and the run Dispatch option will cause the 
+      <p>Press the run button. The Express Train and the Run Dispatch options
+          will be highlighted and the run Dispatch option will cause the
           following prompt to be displayed:</p>
       <p><img src="images/NewItem39.png" alt="NewItem39" /></p>
-      
+
       <a name="RegisteraTrain" id="RegisteraTrain"></a>
       <h2>Register a Train</h2>
-      
-      
-      <p>The first step is to register a train in a siding or at a stop. If you 
-          are simulating the system to see whether it will work before running 
-          trains you may press the bottom left hand small button which will make 
-          the section occupied. Drive a train to the required stop, and press 
+
+
+      <p>The first step is to register a train in a siding or at a stop. If you
+          are simulating the system to see whether it will work before running
+          trains you may press the bottom left hand small button which will make
+          the section occupied. Drive a train to the required stop, and press
           Setup Train in Siding.</p>
       <p>We need to tell the system which way the train is pointing.</p>
       <ul>
-      <li>At a siding it's easy there is one direction the train can go, and we 
+      <li>At a siding it's easy there is one direction the train can go, and we
           say which way it is facing out of the siding</li>
-      <li>At another stop we have to indicate which way we are talking about and 
+      <li>At another stop we have to indicate which way we are talking about and
           we highlight one direction</li>
       </ul>
       <p>suppose we have the following layout</p>
@@ -280,7 +276,7 @@
       <p>We click SetupTrain in siding</p>
       <p>If the train is siding 1b as indicated one gets the following message</p>
       <p><img src="images/NewItem17.png" alt="NewItem17" /></p>
-      <p>Where if we click the dropdown we get all the trains in the system with 
+      <p>Where if we click the dropdown we get all the trains in the system with
           a speed profile. We choose the required train and click OK</p>
       <p>Register the Direction the train is facing</p>
       <p>The following message then pops up</p>
@@ -288,42 +284,42 @@
       <p>Select the correct direction and click OK.</p>
       <p>The train will appear in the memory location for the block</p>
       <p><img src="images/NewItem20.png" alt="NewItem20" width="629" height="140" /></p>
-      
+
       <a name="Setupadispatch" id="Setupadispatch"></a>
       <h2>Set up a dispatch</h2>
-      
-      
-      <p>To set up a dispatch a train (or several trains bust be registered with 
+
+
+      <p>To set up a dispatch a train (or several trains bust be registered with
           the system, and located in a stop).</p>
       <p>Clicking a red button will allow a dispatch to be set up to that location.</p>
-      <p>Suppose one has the following layout with a train in siding1. Click the 
+      <p>Suppose one has the following layout with a train in siding1. Click the
           Passing Loop button as indicated to set up a dispatch to Passing Loop.</p>
       <p><img src="images/NewItem24.png" alt="NewItem24" width="681" height="304" /></p>
-      <p>There is an express icon. If set the train type will default to express 
-          (moves without stopping at intermediate stations), If unset, will 
+      <p>There is an express icon. If set the train type will default to express
+          (moves without stopping at intermediate stations), If unset, will
           default to stopping as shown.</p>
       <p><img src="images/NewItem26.png" alt="NewItem26" /></p>
       <p><img src="images/NewItem25.png" alt="NewItem25" /></p>
-      <p>Select the required train from the drop down, and a dispatch will be 
+      <p>Select the required train from the drop down, and a dispatch will be
           set up to the next stop (Siding1A).</p>
       <p><img src="images/NewItem27.png" alt="NewItem27" width="692" height="157" /></p>
-      <p>The train will start moving, and the speed indicated in the Auto trains 
+      <p>The train will start moving, and the speed indicated in the Auto trains
           window.</p>
       <p><img src="images/NewItem28.png" alt="NewItem28" /></p>
-      <p>The train will move to Siding1B, stop and the dispatch will terminate, 
-          another dispatch will start up to the next stop which will be to 
+      <p>The train will move to Siding1B, stop and the dispatch will terminate,
+          another dispatch will start up to the next stop which will be to
           passing loop.</p>
-      
+
       <a name="SetupaRoute" id="SetupaRoute"></a>
       <h2>Setup a Route</h2>
-      
-      
+
+
       <p>Click 'Setup Route'. The following message will be displayed:</p>
       <p><img src="images/NewItem41.png" alt="NewItem41" /></p>
-      <p>You now press the red section (station) buttons to set the route. The 
+      <p>You now press the red section (station) buttons to set the route. The
           first button will be the start of the route.</p>
       <p><img src="images/NewItem46.png" alt="NewItem46" /></p>
-      <p>The subsequent buttons will be the intermediate stations. At each 
+      <p>The subsequent buttons will be the intermediate stations. At each
           station you will be asjked:</p>
       <p><img src="images/NewItem44.png" alt="NewItem44" /></p>
       <p>You will be told what station you have selected and be asked whether to:</p>
@@ -332,108 +328,108 @@
       <li>select no more stations and complete the route</li>
       <li>cancel</li>
       </ul>
-      <p>If you press complete route, a route will be automatically set up with 
-          the name being the amalgam of the start station and the end section. 
-          If a route already exists with that name, an index will be appended. 
-          The name of the route can be changed bu clicking the 'View / Edit Route' 
+      <p>If you press complete route, a route will be automatically set up with
+          the name being the amalgam of the start station and the end section.
+          If a route already exists with that name, an index will be appended.
+          The name of the route can be changed bu clicking the 'View / Edit Route'
           button or the View Route button on the pop-up.</p>
       <p><img src="images/NewItem45.png" alt="NewItem45" /></p>
-      
+
       <a name="RunRoute" id="RunRoute"></a>
       <h2>Run Route</h2>
-      
-      
+
+
       <p>To run a route a route must already have been set up. Click Run Route</p>
       <p><img src="images/NewItem47.png" alt="NewItem47" /></p>
       <p>You will be prompted with all the routes you have set up</p>
       <p><img src="images/NewItem48.png" alt="NewItem48" /></p>
       <p>Choose the required route and click OK.</p>
-      <p>If you have no train in a station registered with the system, or 
-          all trains registered are being dispatched you will get the 
+      <p>If you have no train in a station registered with the system, or
+          all trains registered are being dispatched you will get the
           following message:</p>
       <p><img src="images/NewItem49.png" alt="NewItem49" /></p>
-      <p>Put a train in a station, register it and try again. In the below 
+      <p>Put a train in a station, register it and try again. In the below
           example we have one train available 'Class 20'</p>
       <p><img src="images/NewItem50.png" alt="NewItem50" /></p>
       <p>You will then get the following message:</p>
       <p><img src="images/NewItem51.png" alt="NewItem51" /></p>
       <ol>
-      <li>Stop at End of Route: The train will travel from its current 
+      <li>Stop at End of Route: The train will travel from its current
           position to the start of the route, travel along the route, then stop</li>
-      <li>return to start position: The train will travel from its current 
-          position to the start of the route, travel along the route, then 
+      <li>return to start position: The train will travel from its current
+          position to the start of the route, travel along the route, then
           return to the start position</li>
       <li>return to start position and repeat: As (2) but repeat forever</li>
       </ol>
-      
+
       <a name="ScheduleRoute" id="ScheduleRoute"></a>
       <h2>Schedule Route</h2>
-      
-      
-      <p>To store the routes we have used the mechanism provided by Operations 
-          which normally provides instructions to move trains manually. To 
+
+
+      <p>To store the routes we have used the mechanism provided by Operations
+          which normally provides instructions to move trains manually. To
           schedule the trains we use the scheduling mechanism of Operations.</p>
       <p>To check that we have some routes setup we press 'View/Edit Routes'.</p>
-      <p>To schedule these routes we press 'View/Edit Scheduled Trains'. 
+      <p>To schedule these routes we press 'View/Edit Scheduled Trains'.
           Here we have set up 3 trains to be scheduled.</p>
       <p><img src="images/NewItem42.png" alt="NewItem42" width="770" height="181" /></p>
-      <p>To setup a new train press 'Add...'. To see the route press Edit for the 
+      <p>To setup a new train press 'Add...'. To see the route press Edit for the
           particular train. For instructions on how to set up the trains you can l
           ook at the help for Operations which can be seen by pressing Help | Window Help.</p>
-      <p>The mechanism is quite straightforward and you probably can setup the 
+      <p>The mechanism is quite straightforward and you probably can setup the
           train without any further help.</p>
       <p>On Add train you will get the following pop-up</p>
       <p><img src="images/NewItem43.png" alt="NewItem43" /></p>
       <p>Note that you have to fill in</p>
       <ol>
-      <li>Train Name (this is arbitrary. The actual train that will run is the 
+      <li>Train Name (this is arbitrary. The actual train that will run is the
           train sitting in the start position of the route</li>
-      <li>Description (this can be left blank, but if the following key words are 
+      <li>Description (this can be left blank, but if the following key words are
           entered (any order) they will have the following effect</li>
       <ol>
       <li>skip : the train will be ignored when scheduling takes place</li>
       <li>repeat : the train will go along the route, then repeat forever</li>
-      <li>stopping : the train will normally go direct from station to station on 
-          the route. Stopping will cause the train to stop at any station it 
+      <li>stopping : the train will normally go direct from station to station on
+          the route. Stopping will cause the train to stop at any station it
           passes on the route</li>
       </ol>
 
       </ol>
       <p>All other entries can be ignored as the Dispatcher System does not use them.</p>
-      
+
       <a name="running" id="running"></a>
       <h2>Run scheduled trains</h2>
-      
-      
-      <p>If the trains have been scheduled in the Operations scheduler as described 
-          above pressing the 'Start Scheduler' button will start the scheduler at a 
+
+
+      <p>If the trains have been scheduled in the Operations scheduler as described
+          above pressing the 'Start Scheduler' button will start the scheduler at a
           midnight on a fast clock 1 times the normal speed.</p>
       <p><img src="images/NewItem53.png" alt="NewItem53" /></p>
-      <p>If you wish to change the start time (trains may start later) or wish to 
+      <p>If you wish to change the start time (trains may start later) or wish to
           change other parameters press Set scheduler start time.</p>
       <p><img src="images/NewItem54.png" alt="NewItem54" /></p>
-      <p>I recommend changing the fast clock to 10 times normal speed, and the fast 
-          clock time to whatever you require, but at least a few minutes before the 
+      <p>I recommend changing the fast clock to 10 times normal speed, and the fast
+          clock time to whatever you require, but at least a few minutes before the
           first train to be scheduled.</p>
-      <p>You may wish to view the fast clock. I like the analog clock so there is a 
-          button 'Show Analog Clock', but if you wish to see another clock change 
+      <p>You may wish to view the fast clock. I like the analog clock so there is a
+          button 'Show Analog Clock', but if you wish to see another clock change
           the code or use the menu on PanelPro | Tools | Clocks.</p>
-      <p>To start the scheduler press 'Start Scheduler' and the clock will start 
-          and the trains set up to be dispatched will start when the fast clock 
+      <p>To start the scheduler press 'Start Scheduler' and the clock will start
+          and the trains set up to be dispatched will start when the fast clock
           gets to the correct time.</p>
-      
+
       <a name="FeaturesSystem" id="FeaturesSystem"></a>
       <h2>Features of the Dispatcher System</h2>
-      
-      
+
+
       <ol>
-      <li>The Dispatcher system is designed to run trains from station to station. 
-          The system has been set up with a network graph which allows the system 
-          to get the shortest path between two stations, and this is used to get 
-          the route between the two stations. At present if a train is in a station 
-          en route, the system will not re-route to avoid the train, and the train 
+      <li>The Dispatcher system is designed to run trains from station to station.
+          The system has been set up with a network graph which allows the system
+          to get the shortest path between two stations, and this is used to get
+          the route between the two stations. At present if a train is in a station
+          en route, the system will not re-route to avoid the train, and the train
           may get stuck. Care must be taken when running trains.</li>
-      
+
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/html/scripthelp/yaat/YAAT.shtml
+++ b/help/en/html/scripthelp/yaat/YAAT.shtml
@@ -3,9 +3,6 @@
 <html lang="en">
 <head>
   <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-  <!-- Copyright ($Author$) 2016 -->
-
   <title>YAAT</title>
   <!--#include virtual="/Style.shtml" -->
   <style type="text/css">
@@ -15,8 +12,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>YetAnotherAutoTrain.py -- Data driven automatic trains</h1>
 

--- a/help/en/html/tools/signaling/ldt/output.shtml
+++ b/help/en/html/tools/signaling/ldt/output.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: Examples of LDT Signaling</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
       <!-- Page Body -->
 
       <h1>JMRI: Examples of LDT Signaling</h1>

--- a/help/en/html/tools/signaling/ldt/output1.shtml
+++ b/help/en/html/tools/signaling/ldt/output1.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: LDT Signaling for SBB (Swiss Federal Railways) type
@@ -13,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
       <!-- Page Body -->
 
       <h2>JMRI: LDT Signaling for SBB (Swiss Federal Railways) type

--- a/help/en/html/tools/signaling/ldt/output2.shtml
+++ b/help/en/html/tools/signaling/ldt/output2.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: LDT Signaling for DB (German Federal Railways) Signals</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
       <!-- Page Body -->
 
       <h2>JMRI: LDT Signaling for DB (German Federal Railways )

--- a/help/en/html/tools/signaling/ldt/output3.shtml
+++ b/help/en/html/tools/signaling/ldt/output3.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: LDT Signaling for DR (German National Railways)
@@ -13,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
       <!-- Page Body -->
 
       <h2>JMRI: LDT Signaling for DR (German National Railways)

--- a/help/en/html/tools/signaling/ldt/output4.shtml
+++ b/help/en/html/tools/signaling/ldt/output4.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: Examples of LDT Signaling for NS - Nederlandse
@@ -13,15 +11,15 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
       <!-- Page Body -->
 
       <h2>JMRI: Examples of LDT Signaling for NS - Nederlandse
       Spoorwegen (Dutch National Railways) Signals</h2>
 
       <h2><b>Three-aspects signal with/without illuminated speed sign</b>
-      <b><img src="output4_html_3840eb.png" align="middle" width="9" height="31" border="0"> 
+      <b><img src="output4_html_3840eb.png" align="middle" width="9" height="31" border="0">
       <img src="output4_html_71c5a86b.png" align="middle" width="9" height="20" border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-NS</p>

--- a/help/en/html/tools/signaling/ldt/output5.shtml
+++ b/help/en/html/tools/signaling/ldt/output5.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: LDT Signaling for OEBB (Austrian Federal Railways)
@@ -13,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
       <!-- Page Body -->
 
       <h2>JMRI: LDT Signaling for OEBB (Austrian Federal Railways)

--- a/help/en/html/tools/signaling/ldt/output6.shtml
+++ b/help/en/html/tools/signaling/ldt/output6.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: LDT Signaling for CSD/CD/ZSR Signals</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
       <!-- Page Body -->
 
       <h2>JMRI: LDT Signaling for CSD/CD/ZSR Signals</h2>

--- a/help/en/package/apps/AppConfigPanel.shtml
+++ b/help/en/package/apps/AppConfigPanel.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Older Preferences Pane</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help preferences">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent class="no-sidebar">
 
       <h1>JMRI: Older Preferences Pane</h1>
 

--- a/help/en/package/apps/AppConfigPanelErrorPage.shtml
+++ b/help/en/package/apps/AppConfigPanelErrorPage.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Setting Preferences</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help preferences">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: Setting The JMRI Preferences</h1>This Help screen
       opens automatically when the JMRI Preferences have not been

--- a/help/en/package/apps/InstallTest/InstallTest.shtml
+++ b/help/en/package/apps/InstallTest/InstallTest.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: InstallTest Main Window</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help preferences">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: InstallTest Main Window</h1>The InstallTest main
       window is intended to show if you have Java and JMRI

--- a/help/en/package/apps/util/issuereporter/swing/IssueReporter.shtml
+++ b/help/en/package/apps/util/issuereporter/swing/IssueReporter.shtml
@@ -10,25 +10,25 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: Issue Reporter</h1>
       <p>The JMRI Issue Reporter allows you
-        to create an entry in JMRI's 
+        to create an entry in JMRI's
         <a href="https://github.com/JMRI/JMRI/issues">Issue tracking system</a>
         for either a Bug report or a Feature request.</p>
-        
+
     <p>In order to create an entry, you need a (free)
         GitHub account. If you don't have one yet, follow
         <a href="https://github.com/join?ref_cta=Sign+up">this link</a>
         and sign up for one first.</p>
-        
+
     <a href="Report_Issue__Window.png"><img src="Report_Issue__Window.png" alt="The Report Issue window"
        align="right" width="264" height="256" ></a>
-    <p>In your default web browser, sign on to the 
+    <p>In your default web browser, sign on to the
         <a href="https://github.com/login">GitHub web site</a>.</p>
-    
+
     <p>From the JMRI Help menu, select "Report Issue...".
         A window like the one on the right will open (click the image to enlarge).
         <ul>
@@ -36,18 +36,18 @@
             <li>Leave "JMRI" selected as the report destination
             <li>Add a useful title.  That really helps getting attention to your item.
             <li>Add a detailed description.  (You can add screen shots to it later on)
-            <li>Click the check boxes for the information you want to send 
+            <li>Click the check boxes for the information you want to send
                 along with the report. We recommend you check all three. Be aware they
                 may contain information about you computer, such as your user name.
             <li>Finally click the "Submit to GitHub" button.
         </ul>
-        
+
     <p>A GitHub window should open in your browser.
-    <p>If JMRI can't open your browser, it'll pop a window 
+    <p>If JMRI can't open your browser, it'll pop a window
         asking for permission to copy a URL to your clipboard (essentially, internally
         doing a copy operation on the URL). Click "Copy" to do that, then
         paste the URL you got into a new window of your browser and fetch the indicated page.
-    
+
     <p>If you checked any of the attachment boxes,
         a new Explorer/Finder window will open, showing some files on your computer.
         These are the files that contain the contents you selected. Drag
@@ -56,12 +56,12 @@
     <a href="Issue_after_drag.png"><img src="Issue_after_drag.png" alt="GitHub Edit Issue
     screen" align="right" width="465" height="326" ></a>
     <p>You can also drag in screen shots or other files that you think will help.
-        
+
     <p>Finally, pn GitHub click the "Submit new issue" button.
-    
+
     <p>Thank you!  Your issue has been entered.  If somebody has additional
         questions or a solution, they'll contact you through your GitHub account.
-        
+
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/configurexml/ErrorHandler.shtml
+++ b/help/en/package/jmri/configurexml/ErrorHandler.shtml
@@ -19,8 +19,8 @@
 
     <body>
         <!--#include virtual="/Header.shtml" -->
-        <div class="nomenu" id="mBody">
-            <div id="mainContent">
+        <div id="mBody">
+            <div id="mainContent" class="no-sidebar">
 
                 <h1>XML Error Handling</h1>
                 <p>JMRI will sometimes encounter errors loading XML files including layout

--- a/help/en/package/jmri/jmrit/automat/monitor/AutomatTableFrame.shtml
+++ b/help/en/package/jmri/jmrit/automat/monitor/AutomatTableFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Automat Table Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Automat Thread Table">
@@ -13,20 +10,20 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The Automat (Thread) Table</h1>
-      
+
       The Thread Table lets you see the threads used by
       scripts that are implementing the "AbstractAutomat" class.
       <p>
       Each time the class execute's it's "handle" routine,
       the count will be incremented.  You can stop the thread
       with the button.
-      
+
       <p>
-      Note that the name column won't be particularly 
+      Note that the name column won't be particularly
       useful unless your script sets a distinct name:
 <pre><code>
 # create one of these
@@ -36,12 +33,12 @@ a = AutomatExample()
 a.setName("Automat example script")
 </code></pre>
       <p>
-      See the 
+      See the
       <a href="../../../../../html/tools/automation/viaJava.shtml">scripting pages</a>
       for more information on writing scripts.
-      
+
       <p>This is the
-      help/jmri/jmrit/automat/monitor/AutomatTable help page 
+      help/jmri/jmrit/automat/monitor/AutomatTable help page
       <!--#include virtual="/Footer.shtml" -->
     </div>
   </div><!-- close #mBody -->

--- a/help/en/package/jmri/jmrit/beantable/UserMessagePreferences.shtml
+++ b/help/en/package/jmri/jmrit/beantable/UserMessagePreferences.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: User Message Preferences</title>
   <meta name="author" content="Kevin Dickerson">
   <meta name="keywords" content="User Message Preferences">
@@ -13,13 +10,13 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>User Message Preferences</h1>This allows you to change
       the way that information and warning messages are displayed
       in JMRI. It will also allow you to configure a default
-      responses and the question being displayed. 
+      responses and the question being displayed.
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrit/beantable/ViewSpecialActions.shtml
+++ b/help/en/package/jmri/jmrit/beantable/ViewSpecialActions.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Transit - Actions</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Transit Actions</h1>
 

--- a/help/en/package/jmri/jmrit/catalog/ImageIndex.shtml
+++ b/help/en/package/jmri/jmrit/catalog/ImageIndex.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Panel Editor Help</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI help Index Editor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The Image Index Editor</h1>This window is used to create
       an Image Index. The index may be organized according to any

--- a/help/en/package/jmri/jmrit/conditional/ConditionalCopy.shtml
+++ b/help/en/package/jmri/jmrit/conditional/ConditionalCopy.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Conditional State Variables and Actions List</title>
   <meta name="author" content="Pete cressman">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Conditional Copy List</h1>
 
@@ -23,12 +20,12 @@
         <dd>
           <h2><a name="logix" id="logix">Logix Copy</a></h2>
 
-          <p>The conditionals of one logix can be copied into another 
+          <p>The conditionals of one logix can be copied into another
           logix by selecting the "Copy" item from the <strong>Select</strong>
           menu. The <Strong>Copy Logix</strong> window will be displayed.
           This window is similar to the <Strong>Add Logix</strong> window and
           the same rules must be be followed when creating a new logix.
-          Additionally, you may enter the name of an existing logix and copy 
+          Additionally, you may enter the name of an existing logix and copy
           conditionals into it. You may even copy logix conditionals back into the same
           logix.  Of course the same restrictions about duplicate system and
           user names of conditionals must be followed. For detailed information
@@ -38,26 +35,26 @@
 
           <h2><a name="CopyList" id="CopyList">The Copy List</a></h2>
 
-          <p>After choosing a target logix and pressing the copy button, the 
+          <p>After choosing a target logix and pressing the copy button, the
           <strong>Copy List</strong> window is displays the list of conditionals
           of the source logix.  Select a conditional from the list to copy.
           There are two ways to add the conditional to the target logix.
           Either is done by the radio buttons under the conditional list.</p>
            <p></P>
-           
+
           <h3>The Change Items Only Button</h3>
 
           <p>This choice (the default) displays a copy of the selected conditional
           for quick copying where you only want to change the items tested or
           items to react. The tests and actions of the item are shown but cannot
           be changed. The logical expression cannot be changed either.</p>
-          
+
           <p>The items under the <strong>Name</strong> columns of the Variables and
-          Actions tables are combo boxes (see "Logix Option Choices" below). 
+          Actions tables are combo boxes (see "Logix Option Choices" below).
           These drop down to select the change of item for
           the variable or action. Actions may be deleted, but not variables.</p>
-          
-          <p>This choice is intended to for simply changing item names. Provide 
+
+          <p>This choice is intended to for simply changing item names. Provide
           a name for the new conditional and press the
           <strong>Save</strong> button.  The conditional is saved to the target
           logix and you are returned to the Copy List window.</p>
@@ -68,7 +65,7 @@
           <p>This choice displays a copy of the selected conditional with
           full conditional editing capabilities. There are no restrictions
           on how the copy is changed.</p>
-          
+
           <p>Provide a name for the new conditional and press the
           <strong>Save</strong> button.  The conditional is saved to the target
           logix and you are returned to the Copy List window.</p>
@@ -76,11 +73,11 @@
 
           <h2>Logix Option Choices</h2>
 
-          <p>The choices made under the Logix <strong>Options</strong> menu are 
+          <p>The choices made under the Logix <strong>Options</strong> menu are
           followed by edit conditional window displayed by the
           <strong>Edit all Data</strong> button.</p>
 
-          <p>The quick edit window displayed by the <strong>Change Items Only</strong> 
+          <p>The quick edit window displayed by the <strong>Change Items Only</strong>
           button uses drop drop down combo boxes for the "Traditional Pick List"
           option. If you prefer using a picklist other than combo boxes, use
           the "Single Pick List" option. To enter an indirect reference to a

--- a/help/en/package/jmri/jmrit/conditional/ConditionalListEditor.shtml
+++ b/help/en/package/jmri/jmrit/conditional/ConditionalListEditor.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Conditional List Editor</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Conditional List Editor</h1>
 
@@ -45,7 +42,7 @@
       names may be any useful text, provided the new user name is
       not used by another Conditional belonging to this Logix. It
       may be the same as the user name of another Logix's
-      Conditional. <em>When editing the user name (or any item in    
+      Conditional. <em>When editing the user name (or any item in
       any JMRI table) please remember to move to another cell in
       the table so that the program is notified that you have
       finished your entry, otherwise the entry may not take
@@ -114,7 +111,7 @@
 
       <div style="margin-left: 2em;"><p><code>if (logical expression) then
       (action)</code></p></div>
-      
+
       <p>A Conditional has two distinct parts: its "logical
       expression" and its "action". The window has separate
       sections for the set up of each.</p>
@@ -170,7 +167,7 @@
       <p>The <strong>Reorder</strong> button is used to changed the order of the
       conditional variables.  This button is disabled if the Logic Operator is set
       to <strong>Mixed</strong>.<span class="since">since 4.9.2</span></p>
-      
+
       <p>The default <strong>Logic Operator</strong> is "AND". In this case
       the Conditional will test if all variable tests are true,
       after taking the "NOT" negations into account. Using the
@@ -184,7 +181,7 @@
       R2, R3 for the 1st three variables, you can use the operators
       "and", "or" and "not" in addition to parentheses. Some
       examples:</p>
-      
+
       <div style="margin-left: 2em;"><p><code>
       R1 and R2<br>
       R1 or (R2 and R3)<br>
@@ -285,15 +282,15 @@
 
       <p class="important">Note:
          <br>As an advanced feature, the name of an entity can be entered as
-         an "indirect reference" to a memory location.  By that we mean, 
-         rather than naming the action directly, the value of a memory  
-         location is used for the name of the action. To do this you enter  
+         an "indirect reference" to a memory location.  By that we mean,
+         rather than naming the action directly, the value of a memory
+         location is used for the name of the action. To do this you enter
            the name of the memory entity preceded with the "@" symbol.
         <br>
          For example, suppose an Input Memory icon or a ComboBox Memory
-         icon sets the value of memory <em>MyMemory10</em> to a turnout name. 
-         Also let an action entity of type turnout be named <em>@MyMemory10</em>. 
-         Also let its action type be "Set Turnout Position Thrown" when 
+         icon sets the value of memory <em>MyMemory10</em> to a turnout name.
+         Also let an action entity of type turnout be named <em>@MyMemory10</em>.
+         Also let its action type be "Set Turnout Position Thrown" when
          the change option is "On Change to True".
          When the logical expression changes to true, the turnout named
           in the current value of memory MyMemory10 will be thrown.
@@ -354,7 +351,7 @@
 
       <p>For more information, consult the <a href="../../../../html/tools/Logix.shtml">
       main Logix documentation</a>.</p>
-      
+
       <h2>Logix Documentation Pages Logically Listed</h2>
 
       <!--#include virtual="LogixDocList.shtml" -->

--- a/help/en/package/jmri/jmrit/conditional/ConditionalTreeEditor.shtml
+++ b/help/en/package/jmri/jmrit/conditional/ConditionalTreeEditor.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Conditional Tree Editor</title>
   <meta name="author" content="Dave Sand">
   <meta name="keywords" content=
@@ -18,8 +15,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Conditional Tree Editor</h1>
 
@@ -156,7 +153,7 @@
       this expression, each variable is referred to by number, e.g. R1, R2, R3
       for the first three variables, you can use the operators "and", "or" and
       "not" in addition to parentheses. Some examples:</p>
-      
+
       <div style="margin-left: 2em;"><p><code>
       R1 and R2<br>
       R1 or (R2 and R3)<br>
@@ -177,7 +174,7 @@
       on the conditional name selection method setting. See
       <a href="../beantable/LogixTable.shtml#logixOptions">
       Conditional Name Selection Method</a>.</p>
-      
+
       <p>For Conditional Variables, the text input field is replaced by two
       drop down combo boxes.  The first box is used to select the Logix, the
       second box is used to select a Conditional that belongs to the selected
@@ -232,7 +229,7 @@
       will depend on the conditional name selection method setting.
       See <a href="../beantable/LogixTable.shtml#logixOptions">
       Conditional Name Selection Method</a>.</p>
-      
+
       <p>The data items needed to completely specify the
       action will appear in the detail pane. If you don't
       know what needs to be entered in a data field, hover your

--- a/help/en/package/jmri/jmrit/conditional/StateVariableActionList.shtml
+++ b/help/en/package/jmri/jmrit/conditional/StateVariableActionList.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Conditional State Variables and Actions List</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Conditional State Variables and Actions List</h1>
 
@@ -156,7 +153,7 @@
             </ul></li>
 
             <li>Occupancy Block<ul>
-              <li><strong>Occupied</strong>: Evaluates to true when the 
+              <li><strong>Occupied</strong>: Evaluates to true when the
               block is occupied.</li>
               <li><strong>Power Error</strong>: Evaluates to true when a
               power error has occurred.</li>
@@ -166,7 +163,7 @@
               to dark.</li>
               <li><strong>Path Occupied</strong>: Evaluates to true when a
               path is occupied</li>
-              <li><strong>Unoccupied</strong>: Evaluates to true when a 
+              <li><strong>Unoccupied</strong>: Evaluates to true when a
               path is not occupied.</li>
               <li><strong>Allocated</strong>: Evaluates to true when the
               block is allocated.</li>
@@ -453,7 +450,7 @@
               block. Specify the OBlock by entering its System Name or
               User Name.</li>
 
-              <li><strong>Set Block Value</strong>: Set a value for the 
+              <li><strong>Set Block Value</strong>: Set a value for the
               selected block.</li>
 
               <li><strong>Set Block Error</strong>: Set the selected
@@ -492,7 +489,7 @@
               dialog to copy it (including its path) to the
               field.</li>
 
-              <li><strong>Script: Execute Jython Command</strong>: Enter the 
+              <li><strong>Script: Execute Jython Command</strong>: Enter the
               command in the Script Command field.</li>
             </ul></li>
 
@@ -503,13 +500,13 @@
           </ul>
         </dd>
       </dl>
-      
+
             <h2>Logix Documentation Pages Logically Listed</h2>
 
       <!--#include virtual="LogixDocList.shtml" -->
 
 
-      
+
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrit/consisttool/ConsistToolFrame.shtml
+++ b/help/en/package/jmri/jmrit/consisttool/ConsistToolFrame.shtml
@@ -13,8 +13,8 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
     <h1>Consist Tool</h1>
 

--- a/help/en/package/jmri/jmrit/display/CircuitBuilder.shtml
+++ b/help/en/package/jmri/jmrit/display/CircuitBuilder.shtml
@@ -11,8 +11,8 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
     <h1>Circuit Builder</h1>
 
@@ -20,7 +20,7 @@
     The <b>Circuit Builder</b> is a view of a
     <b><a href="ControlPanelEditor.shtml">Control Panel Editor</a></b> panel
     (CPE in short). CB is an alternative to using the
-    <a href="../logix/OBlockTable.shtml">Occupancy Block Tables</a> to create 
+    <a href="../logix/OBlockTable.shtml">Occupancy Block Tables</a> to create
     <b>OBlocks, Portals and OPaths</b>.
     Circuit Builder is a graphical tool to create and configure these objects
     by "point and click" mouse operations on your CPE panel. Here "track circuit"
@@ -34,7 +34,7 @@
     signaling system providing a way to manage safe usage of its trackage.  So
     to model a prototype block, several track circuits may be needed.
     The term <b>track circuit</b> here in JMRI is just an attempt to get a little closer to
-    prototype usage, but it is just another name for <b>OBlock</b> and the stuff 
+    prototype usage, but it is just another name for <b>OBlock</b> and the stuff
     (<b>Portals</b> and <b>OPaths</b>) that gets it to act a little more like a
     prototype "Block".  Creating track circuits, that is, making and configuring
     OBlocks, Portals and OPaths enables the creation and running of
@@ -46,7 +46,7 @@
     indicate track conditions on your layout. These signals then can modify Warrants
     during their runtime to respond to track conditions. More on this below.
     </p>
-    
+
     <h3>Getting Started</h3>
 
     The Circuit Builder tool can be opened from either the <b>Circuit Builder</b>
@@ -80,16 +80,16 @@
       submenu for errors and omissions.
       </li>
     </ul>
-	    
+
     <h2>Basic Operational Model of Circuit Builder</h2>
 
-    Circuit Builder works by using icons on a block by block basis. 
+    Circuit Builder works by using icons on a block by block basis.
     OBlocks, Portals and OPaths are created and linked by "point and click" on the
     icons of your layout diagram.  The element types (OBlock, Portal,
     OPath, Signal) are created and edited using various editing modes of the tool.
     In short, it works as follows:
     <p>
-    First create an OBlock by selecting track icons. Then create Portals by dragging 
+    First create an OBlock by selecting track icons. Then create Portals by dragging
     an icon that overlaps two OBlocks. Then create OPaths by selecting the portal icons
     and track icons that indicate the path. Finally perhaps add a signal to protect an
     OBlock by selecting the portal of the approach. The result
@@ -104,8 +104,8 @@
     Indicator Track icons.  See the <a href="ItemPalette.shtml">Item Palette help</a>
     for more information about Indicator track icons.
     </p><p>
-    CircuitBuilder is aware of all the objects defined in the Occupancy Block tables. 
-    When your layout track diagram is split up among several panels, each panel has a 
+    CircuitBuilder is aware of all the objects defined in the Occupancy Block tables.
+    When your layout track diagram is split up among several panels, each panel has a
     its own CircuitBuilder to edit its icons. It may post messages about missing icons but if the objects
     are not meant to be represented on that panel, ignore them. This "discrepancy" is due
     to the fact that OBlocks, Portals and Paths are global for all panels of your JMRI
@@ -126,11 +126,11 @@
 
     <h3>Portal Icons</h3>
     When not in one of the CircuitBuilder editing modes, portal icons are usually invisible. The only
-    situation in normal panel operation where they may be visible is when a warrant is allocated. 
+    situation in normal panel operation where they may be visible is when a warrant is allocated.
     In this case direction arrows can be shown
     indicating the direction of travel of the warranted train.  Portal icons are necessary
     for CircuitBuilder to be able to define Portals and OPaths. In such editing modes the icon is
-    usually a red circle that may be dragged or selected. <b>Note:</b> <i>It is important 
+    usually a red circle that may be dragged or selected. <b>Note:</b> <i>It is important
     for defining paths that every track circuit depicted on the panel have <b>each</b> of its
     portals represented by a portal icon.</i>
 
@@ -142,9 +142,9 @@
     src="images/CircuitBuilderSelectOBlockPane.png"
     alt="After choosing a menu item, select an OBlock in this pane to work on">
     <ul>
-     <li><b>Add New Detector Circuit</b> - Create an OBlock track circuit and assign the icons 
+     <li><b>Add New Detector Circuit</b> - Create an OBlock track circuit and assign the icons
             that display it, then continue with the editing of the Circuit OBlock data.</li>
-     <li><b>Edit Circuit OBlock</b> - Edit an existing track circuit.  In this window you select or 
+     <li><b>Edit Circuit OBlock</b> - Edit an existing track circuit.  In this window you select or
      	    deselect the track icons that represent the OBlock graphically. Names of the sensors
      	    that detect occupancy or errors should be entered as well as a length for the block.
      	    (Warrants need a length for the paths to calculate speed changes.)  </li>
@@ -152,7 +152,7 @@
      		choosing an OBlock, you will be in <b>portal editing</b> mode. In this window you define
      		Portals by positioning them over track icons to connect OBlocks.</li>
      <li><b>Add/Edit Circuit Paths</b> - Create or edit the paths (OPath) through a track circuit. After
-     		choosing an OBlock you will be in <b>path editing</b> mode. In this window you define 
+     		choosing an OBlock you will be in <b>path editing</b> mode. In this window you define
      		OPaths by selecting track and portal icons.</li>
      <li><b><a href="#DirectionArrows">Edit Portal Direction Icons</a></b> - <span class="since">(since
         3.8)</span>
@@ -164,15 +164,15 @@
        protected by the the signal.
        After choosing an OBlock you will be in <b>signal icon editing</b> mode.</li>
 	   <li><a name="Errors" id="Errors"></a>
-     		<b>Error Checks</b> - Provides information about objects that may require editing. These 
+     		<b>Error Checks</b> - Provides information about objects that may require editing. These
      		menu sub-items either highlight the icons representing the object or display a list of track
         circuits or Portals that may require editing.  Selecting an item from such a list will open a
         window for the appropriate editing mode.
     	  <ul>
-        <li><b>Circuits without icons in this panel</b> - Has a submenu for each track circuit 
-        	OBlock that does not have an icon. A track circuit needs at least one Indicator 
+        <li><b>Circuits without icons in this panel</b> - Has a submenu for each track circuit
+        	OBlock that does not have an icon. A track circuit needs at least one Indicator
         	Track icon to display its state.</li>
-        <li><b>Circuits whose icons need conversion</b> - Has a submenu for each track circuit OBlock 
+        <li><b>Circuits whose icons need conversion</b> - Has a submenu for each track circuit OBlock
         	whose track icons are not Indicator Track icons.<br>
         	<b>Note:</b> <i>Only Indicator Track icons can display circuit state information.</i></li>
         <li><b>Highlight track icons needing conversion</b> - Highlights all track icons that are not
@@ -181,16 +181,16 @@
         <li><b>Highlight Indicator Track icons without circuits</b> - Highlights all track icons that are not
         	associated with a track circuit.  If every track icon is associated with a circuit
         	this menu item is labeled <b>All track icons belong to Circuits</b> </li>
-        <li><b>Circuits without a Portal or Path</b> - <span class="since">(since 4.17.3)</span> Has 
-        	a submenu for each track circuit OBlock that does not have a Portal or Path.  
+        <li><b>Circuits without a Portal or Path</b> - <span class="since">(since 4.17.3)</span> Has
+        	a submenu for each track circuit OBlock that does not have a Portal or Path.
         	Select an item to add the required portal or Path.</li>
-        <li><b>Circuits with misplaced Portal Icons</b> - <span class="since">(since 4.16)</span> Has a 
-        	submenu for each track circuit OBlock that has a Portal icon positioned incorrectly. 
+        <li><b>Circuits with misplaced Portal Icons</b> - <span class="since">(since 4.16)</span> Has a
+        	submenu for each track circuit OBlock that has a Portal icon positioned incorrectly.
         <li><b>Highlight misplaced Portal Icons</b> - Highlights all portal icons that are not
         	positioned correctly.
         	If every portal icon is positioned correctly
         	this menu item is labeled <b>All Portal icons positioned OK</b> </li>
-       	<li><b>Portals without icons in this panel</b> - <span class="since">(since 4.16)</span> Has a 
+       	<li><b>Portals without icons in this panel</b> - <span class="since">(since 4.16)</span> Has a
        		submenu for each Portal lacking an icon. Selecting an item opens a Portal Editing
        		window and an icon can be dragged onto the panel.</li>
         <li><b>Highlight Signals not configured to protect an OBlock</b> - <span class="since">(since 4.17.3)</span>
@@ -213,7 +213,7 @@
 	a picklist is opened for you to select a circuit OBlock to edit. Selecting a row and pressing
     the <b>Show OBlock</b> button then opens the window for the desired editing of that block.
     <p>
-    Rather than having to do that for each editing operation, for convenience, 
+    Rather than having to do that for each editing operation, for convenience,
 	the <b>Warrants</b> menu item <b>Open CircuitBuilder</b> keeps a widow open with the block
 	pick table and the various editing modes available from radio buttons.
 	</p>
@@ -227,9 +227,9 @@
     <h3>Creating OBlocks</h3>
 
      <p>From the <b>Circuit Builder</b> menu select the <b>Add New Detector Circuit</b> menu item.
-     This opens a dialog for you to create a circuit OBlock by supplying its system and user name. 
+     This opens a dialog for you to create a circuit OBlock by supplying its system and user name.
      The window has fields to enter the system and user names for a new OBlock.  After pressing the
-     <b>Create OBlock</b> button, the System Name field will disappear and the button will be 
+     <b>Create OBlock</b> button, the System Name field will disappear and the button will be
      replaced with buttons that will allow you to change the user name or delete the block.
        The window is now appears as <b>Edit Circuit OBlock</b> menu item.</p>
 
@@ -245,11 +245,11 @@
     <ul>
         <li>At the top of the window is a non-editable field to show the current state of the circuit.
         </li>
-        <li>The window has a text field showing the OBlock User Name. The field can be edited 
+        <li>The window has a text field showing the OBlock User Name. The field can be edited
         to change the user name of the OBlock circuit. Below it is a
         <b>Change Name</b> button to accomplish the name change.
         </li>
-        <li> Alongside is a <b>Delete Circuit</b> button to delete all components of the track circuit. 
+        <li> Alongside is a <b>Delete Circuit</b> button to delete all components of the track circuit.
          <b>Note</b> this means, <i>the OBlock, <b>all</b> the
          OPaths in it and <b>all</b> portals into and out of the block.</i>
         </li>
@@ -262,7 +262,7 @@
         and dropped onto the sensor name text fields.  If no occupancy detection sensor is named, the circuit will
         be a <b>Dark Block</b>.  Warrants are able to start, end or pass through dark blocks.
         </li>
-        <li>The window has a text field to enter the length of the OBlock and button for either 
+        <li>The window has a text field to enter the length of the OBlock and button for either
         inches or centimeter units.<br><b>Note:</b> <i>In order to create and run NXWarrants
         over a block, the block must have a length.  Running recorded warrants also needs
         block lengths to compute ramp parameters when responding to signals and other track
@@ -276,7 +276,7 @@
     </ul>
 
      <p>When exiting the Edit Circuit window the OBlock is checked for any possible deficiencies. If
-     any are detected you will be prompted and given the option to return to the window or 
+     any are detected you will be prompted and given the option to return to the window or
      continue to close it.
      <b>Note:</b> <i>Each OBlock must have at least one Indicator Track icon to represent it.
      Otherwise CircuitBuilder cannot define Portals and Paths</i>.</p>
@@ -287,21 +287,21 @@
     The track circuit icons are highlighted in blue. if any Portals have been defined, they
      will be shown as a red circle and also highlighted in blue.
     The blocks a portal connects are determined by positioning the icon so it spans the two
-    blocks it connects.  That is, the icon should overlap a track icon representing each of 
+    blocks it connects.  That is, the icon should overlap a track icon representing each of
     the two blocks. In this mode, only portal icons can be repositioned.
     No other panel items can be moved or selected.
     <p>
     To create a new portal type in a name for it in the <b>Portal Name</b> text field. Then
-    drag the red circle portal icon to the panel. Place it so that it intersects with 
-    a track icon representing the OBlock you selected to open the window. The OBlock circuit 
-    you selected is the "home" block. Position the portal icon so it also intersects with a 
+    drag the red circle portal icon to the panel. Place it so that it intersects with
+    a track icon representing the OBlock you selected to open the window. The OBlock circuit
+    you selected is the "home" block. Position the portal icon so it also intersects with a
     track icon representing an adjacent block. Overlapping both blocks defines the portal.
     </p><p>
     To create an icon for a portal previously defined, perhaps from the Occupancy Block tables,
     select the portal from the "Portals into and out of circuit ..." list. Then, as above
     drag and position the red circle icon.
     </p><p>
-    Notice that when you select a portal from the portal list, its icon highlight 
+    Notice that when you select a portal from the portal list, its icon highlight
     changes from blue to pink. Conversely, selecting an portal icon
     on the panel with a mouse click will select the portal it represents
     in the portal list.  When repositioning a portal icon it may be necessary to "unlock"
@@ -309,13 +309,13 @@
     </p><p>
      There may be diagrams where a portal icon cannot span icons from each block
      that the portal connects. An example of this might be when the panel diagram depicts a loop
-     as a line of blocks across the panel from left to right. Here a leftmost block icon 
+     as a line of blocks across the panel from left to right. Here a leftmost block icon
      cannot be spanned by one from the rightmost block. This can be handled in one of two ways.
 	 A non-contiguous track icon could be placed from one edge onto the opposite edge of the diagram
 	 and a have the portal icon overlap both blocks there.<br>
 	 <span class="since">(since 4.17.3)</span>
 	 Or <b>two</b> portal icons can be used for the same portal.
-	 Each icon placed on the respective blocks at the opposite sides of the diagram. 
+	 Each icon placed on the respective blocks at the opposite sides of the diagram.
     <ul>
         <li>The Edit Portal window has a list of the portals already defined for the
         track circuit (OBlock) and a text field to name new portals to be created. The window
@@ -328,7 +328,7 @@
         <li>Portals that were created in the <b>Occupancy Tables</b> do not have red circle icons.
         For any portal in the Portal List that does not have an icon, select it from the list and
         drag a red circle icon to its position between the blocks it connects.
-        Portal icons are needed to create and display paths.<br><b>Note</b> <i>Please be 
+        Portal icons are needed to create and display paths.<br><b>Note</b> <i>Please be
         sure <b>all</b> of the OBlock's portals are represented by icons before making paths.</i></li>
         <li>To change the name of a portal, first select it from the list, then change the name in the
         <b>Portal Name</b> text field and lastly, press the <b>Change Name</b> button.</li>
@@ -337,7 +337,7 @@
     </ul>
 
     <p>When exiting the Add/Edit Portal window the Portal is checked for any possible deficiencies. If
-    any are detected you will be prompted and given the option to return to the window or 
+    any are detected you will be prompted and given the option to return to the window or
     continue to close it.</p>
 
 	<a name="OPaths" id="OPaths"></a>
@@ -349,14 +349,14 @@
     <p>
     To create a new OPath, first press the <b>Clear Selection</b> button. Then type a name for the
     path into the <b>Path Name</b> text field. Now select all
-    the track icons that mark the route. Selected route icons change their color to green. 
+    the track icons that mark the route. Selected route icons change their color to green.
     When selecting a turnout track icon, the position of
     the points may not be correct. <b><i>To change the position of the points</i></b>, hold the <b>Shift</b>
     key down while clicking on the turnout icon. At least one portal must be selected
-    to complete the definition of an OPath.  A selected a portal icon changes from a red 
+    to complete the definition of an OPath.  A selected a portal icon changes from a red
     circle to a green square.
     </p><p>
-    Be sure you select all the turnout icons for turnouts that need to be set to define the path.  
+    Be sure you select all the turnout icons for turnouts that need to be set to define the path.
     Also, if the path traverses the block,
     be sure that portal icons are selected for both entrance and exit. A path must have at
     least one portal and at most two.
@@ -382,56 +382,56 @@
         	exit from the block) if it is a through path.</li>
         <li>To change the name of a path, first select it from the list, then change the name in the
         	<b>Path Name</b> text field and lastly, press the <b>Change Name</b> button.</li>
-        <li>The window has a text field to enter the length of the OPath and button for either 
+        <li>The window has a text field to enter the length of the OPath and button for either
         	inches or centimeter units.</li>
         <li>To delete a path, select it from the list and press the <b>Delete Path</b> button.</li>
     </ul>
 
     <p>When exiting the Add/Edit Path window the Path is checked for any possible deficiencies. If
-    any are detected you will be prompted and given the option to return to the window or 
+    any are detected you will be prompted and given the option to return to the window or
     continue to close it.</p>
-    
+
 	<a name="DirectionArrows" id="DirectionArrows"></a>
     <h3>Portals - Edit Portal Direction Icons</h3>
      <span class="since">Since 3.8</span><br>
     Use this window to modify the portal icon to show the direction
-    of travel for a warrant. Portal icons must exist in order to have direction arrows when a 
+    of travel for a warrant. Portal icons must exist in order to have direction arrows when a
     warrant is allocated.
      The track circuit icons are highlighted in blue and the portal icons are
      shown with a red circle highlighted in blue.
     <p>
-    To set the direction, either select a portal icon or select a portal from the 
+    To set the direction, either select a portal icon or select a portal from the
     "Portals into and out of circuit ..." list. A green arrow will replace the red circle on
      the highlighted portal icon. To have the arrow display the correct direction the arrow
 	must point <b>into</b> the OBlock circuit. If it does not, select one or the other of the
 	green arrows on the <b>Entry Icon</b> box. The arrows can be moved and rotated to display a
 	more desirable direction. <i>If an icon is moved, be sure it retains its position
-	overlapping the blocks it joins.</i> 
+	overlapping the blocks it joins.</i>
 	</p><p>
 	If you do not want an arrow to display at the portal when
 	a warrant is allocated, select the "No Icon" icon.
 	</p><p>
-	After all the portal icon arrows are pointing into the block, verify that each adjacent OBock 
-	also has its portal direction arrow set <b>into</b> that block.</p> 
+	After all the portal icon arrows are pointing into the block, verify that each adjacent OBock
+	also has its portal direction arrow set <b>into</b> that block.</p>
 
 	<a name="Signals" id="Signals"></a>
     <h3>Signals - Edit Signal Masts</h3>
      <span class="since">Since 4.17.3</span><br>
      <img src="images/CircuitBuilderSignalEditPane.png" alt="Edit Signal (on Portal) panel" align="right">
-     Use this window to configure a Signal Head or Signal Mast to protect the OBlock. 
+     Use this window to configure a Signal Head or Signal Mast to protect the OBlock.
      The track circuit icons are highlighted in blue and the portal icons are
      shown with a red circle highlighted in blue.
     <p>
     To set a signal to protect the OBlock, choose the portal where the signal will guard
     entrance into the block. The opposing block of the portal will be the
     approach OBlock. Choosing the portal can be done by
-    either selecting a highlighted portal icon or selecting a portal from the 
+    either selecting a highlighted portal icon or selecting a portal from the
     "Portals into and out of circuit ..." list.
     </p><p>
     Enter the name of the signal into the <b>Signal Name</b> text field. Alternatively
     there are <b>Open Picklist</b> buttons to display signal names. Drag a name into
     the Signal Name text field. Pressing the <b>Configure Signal</b> button will attach the signal
-    at the portal. 
+    at the portal.
     </p><p>
     <b>Important Note:</b><br>
     It is recommended to use Signal Masts rather than Signal Heads.  If you do use a Signal Head
@@ -441,7 +441,7 @@
 	</p><p>
       The signal add/edit window has the following items.</p>
     <ul>
-    	<li>A list of the portals into the OBlock. Select a portal to add or remove the 
+    	<li>A list of the portals into the OBlock. Select a portal to add or remove the
     		block protection by a signal. If a signal already protects at the selected
     		portal, its name is displayed in the Signal Name text field.</li>
     	<li>A Signal Name text field for the name of a protecting signal.</li>
@@ -456,7 +456,7 @@
     </ul>
 	<p>Selecting a signal icon will select the portal if it protects the block there.
 	Otherwise a dialog windows opens to configure or replace protection.</p>
-    
+
     <h2>Further Reference</h2>
     <ul>
         <li>For a step-by-step instruction on Warrants and Circuit Builder, check out the

--- a/help/en/package/jmri/jmrit/display/ControlPanelEditor.shtml
+++ b/help/en/package/jmri/jmrit/display/ControlPanelEditor.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Control Panel Editor Help</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI help Panel Editor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The Control Panel Editor</h1>
 

--- a/help/en/package/jmri/jmrit/display/CoordinateEdit.shtml
+++ b/help/en/package/jmri/jmrit/display/CoordinateEdit.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Coordinate Edit Help</title>
   <meta name="author" content="Dan Boudreau">
   <meta name="keywords" content="JMRI Coordinate Edit Help">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The Label and Icon Property Editor</h1>
 

--- a/help/en/package/jmri/jmrit/display/EditLayoutBlock.shtml
+++ b/help/en/package/jmri/jmrit/display/EditLayoutBlock.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Edit Block Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Layout Editor Block">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Create/Edit Block</h1>Blocks are sections of track whose
       occupancy may be individually monitored. Dividing track into

--- a/help/en/package/jmri/jmrit/display/EditLayoutSlip.shtml
+++ b/help/en/package/jmri/jmrit/display/EditLayoutSlip.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Edit Level Crossing Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Edit Layout Slip</h1>A Slip is a special piece of track
       that represents two tracks crossing at grade, with the

--- a/help/en/package/jmri/jmrit/display/EditLayoutTurnout.shtml
+++ b/help/en/package/jmri/jmrit/display/EditLayoutTurnout.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Edit Turnout Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Layout Editor Turnout">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Edit Turnout</h1>
 

--- a/help/en/package/jmri/jmrit/display/EditLevelXing.shtml
+++ b/help/en/package/jmri/jmrit/display/EditLevelXing.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Edit Level Crossing Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Edit Level Crossing</h1>A level crossing is a special
       piece of track that represents two tracks crossing at grade.

--- a/help/en/package/jmri/jmrit/display/EditTrackSegment.shtml
+++ b/help/en/package/jmri/jmrit/display/EditTrackSegment.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Edit Track Segment Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Edit Track Segment</h1>
 
@@ -77,7 +74,7 @@
       Edit Track Segment dialog also allows an Edit Block dialog to
       be requested, so information for the track segment's block
       may be entered or changed. Blocks are discussed more fully in
-      the help page of the Create/Edit Block dialog. 
+      the help page of the Create/Edit Block dialog.
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrit/display/EditTurntable.shtml
+++ b/help/en/package/jmri/jmrit/display/EditTurntable.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Edit Turntable Help</title>
   <meta name="author" content="Dave Duchamp">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Edit Turntable</h1>A Layout Editor turntable is a
       schematic representation of a turntable on the layout. A

--- a/help/en/package/jmri/jmrit/display/EnterTrackWidth.shtml
+++ b/help/en/package/jmri/jmrit/display/EnterTrackWidth.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Set Track Width Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Layout Editor Track">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Set Track Width</h1>The Set Track Width dialog allows
       changing widths of both types of track used in Layout Editor

--- a/help/en/package/jmri/jmrit/display/IconAdder.shtml
+++ b/help/en/package/jmri/jmrit/display/IconAdder.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>jmri: Icon Editor Help</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI help Panel Editor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The Icon Editors</h1>
 

--- a/help/en/package/jmri/jmrit/display/ItemPalette.shtml
+++ b/help/en/package/jmri/jmrit/display/ItemPalette.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Item Palette Help</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI help Item Palette">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The Item Palette</h1>
       <b>The Item Palette</b> is used to
@@ -22,7 +19,7 @@
       The palette is a tabbed window with tabs for each item type.
       The common method all items use to add an item to a panel is
       "Drag and Drop". Each tab has a bordered <b>Preview</b> panel
-      containing a labeled <b>Drag to Panel</b> panel. Drag the 
+      containing a labeled <b>Drag to Panel</b> panel. Drag the
       item inside this border over
       to your Panel. In the cases where the icon represents a layout
       device (e.g. a turnout, a sensor, etc.), tab may also contain
@@ -30,19 +27,19 @@
       row from a table to associate that particular device with the
       icon - and then drag the icon to the Panel.
       <p>
-      The window shown when the <b>Edit XYZ</b> menu item of a panel 
+      The window shown when the <b>Edit XYZ</b> menu item of a panel
       item is invoked shows the corresponding Item Palette tab pane
       without the labeled <b>Drag to Panel</b> panel.</p>
 
       <h2>Iconic Items</h2>
       Some device types need a set of icons to depict each of their
       states The Item Palette provides multiple sets of icons to
-      choose from to associate with a device. There is a radio button 
+      choose from to associate with a device. There is a radio button
       for each icon set defined for the tab item. For
       example, under the sensor tab you may have sets of large
       jewels, small jewels, each size with several sets with
       different colors for active and inactive - e.g. red-green,
-      yellow-dark, etc. 
+      yellow-dark, etc.
       <p>
       The individual icons are displayed in the preview on the
       background of the last editor to open the Item Palette.
@@ -54,7 +51,7 @@
       <h3>Editing and Creating New Icon Sets</h3>
 	  <ul>
 	  		<li>The <b>Show Icons</b> button displays all the icons in the
-      		selected set. 
+      		selected set.
       		</li><li>
             The <b>Edit Icons</b> button opens a dialog where the icons
              may be changed by dragging new icons from the Icon Catalog.
@@ -153,8 +150,8 @@
 
         <li><b>Icon</b> The bordered icons displayed (labeled with
         their names) can be dragged directly to a panel. Icons can
-        also be dragged directly from the Icon Catalog. to add icons 
-        to this tab, just drop them into the preview panel from 
+        also be dragged directly from the Icon Catalog. to add icons
+        to this tab, just drop them into the preview panel from
         the Icon Catalog.</li>
 
         <li><b>Background</b> Background icons are placed in a
@@ -269,7 +266,7 @@
       </p><p>
       When an <b>Edit Icons</b> window is displayed all icons are shown,
       Icons from the Icon Catalog may be dragged and dropped to any
-      icon shown. 
+      icon shown.
       </p>
 
       <!--#include virtual="/Footer.shtml" -->

--- a/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
+++ b/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Layout Editor Help</title>
   <meta name="author" content="Dave Duchamp">
   <meta name="keywords" content="JMRI help Layout Editor panel">
@@ -25,8 +22,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The Layout Editor</h1><a name="contents" id=
       "contents"></a>
@@ -783,9 +780,9 @@
 
             <li><strong>Hide Track Construction Lines</strong> - Some track
             objects create construction lines.  This mainly applies to curved
-            track.  If this option is enabled, then those lines are not displayed. Note: 
+            track.  If this option is enabled, then those lines are not displayed. Note:
             This state remains in effect ONLY during the current PanelPro session and WILL NOT
-            be stored to the PanelPro file if the panel file is stored.  To store the state of the 
+            be stored to the PanelPro file if the panel file is stored.  To store the state of the
             given track segment in the PanelPro file, right click on the given track segment, select
             hide construction lines from the resulting pop up menu, and store the panel.</li>
 

--- a/help/en/package/jmri/jmrit/display/MultiSensorIconAdder.shtml
+++ b/help/en/package/jmri/jmrit/display/MultiSensorIconAdder.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: MultiSensor Icon Editor Help</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI help Panel Editor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The MultiSensor Icon Editor</h1>
 

--- a/help/en/package/jmri/jmrit/display/MultiSensorIconDefaultsFrame.shtml
+++ b/help/en/package/jmri/jmrit/display/MultiSensorIconDefaultsFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: MultiSensorIcon Defaults Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help MultiSensorIcon">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The MultiSensorIcon Defaults Frame</h1>This is the
       help/jmri/jmrit/display/MultiSensorIconDefaultsFrame help

--- a/help/en/package/jmri/jmrit/display/MultiSensorIconFrame.shtml
+++ b/help/en/package/jmri/jmrit/display/MultiSensorIconFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: MultiSensorIcon Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help MultiSensorIcon">
@@ -13,11 +10,11 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The MultiSensorIcon</h1>This is the
-      help/jmri/jmrit/display/MultiSensorIconFrame help page 
+      help/jmri/jmrit/display/MultiSensorIconFrame help page
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrit/display/PanelEditor.shtml
+++ b/help/en/package/jmri/jmrit/display/PanelEditor.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Panel Editor Help</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI help Panel Editor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The Panel Editor</h1>
 

--- a/help/en/package/jmri/jmrit/display/PanelMenuHelp.shtml
+++ b/help/en/package/jmri/jmrit/display/PanelMenuHelp.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Panels Menu</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: Panels Menu</h1>
         <div class="noted">

--- a/help/en/package/jmri/jmrit/display/PanelTarget.shtml
+++ b/help/en/package/jmri/jmrit/display/PanelTarget.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Panel Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Panel">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The Panel</h1>
 

--- a/help/en/package/jmri/jmrit/display/RpsIcon.shtml
+++ b/help/en/package/jmri/jmrit/display/RpsIcon.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: RPS Icon</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: RPS Icon</h1>RPS is a system for measuring the
       positions of rolling stock on your layout. More information
@@ -234,12 +232,12 @@
         probably be all on one line):
           <pre style="font-family: monospace;">
 
-    &lt;sensoricon x="95" y="150" level="10" 
-            active="resources/icons/smallschematics/tracksegments/circuit-occupied.gif" 
-            error="resources/icons/smallschematics/tracksegments/circuit-error.gif" 
-            rotate="0" forcecontroloff="false" momentary="false" 
-            sxscale="11.849106591612951" syscale="-11.889381744148094" 
-            sxorigin="41" syorigin="768" 
+    &lt;sensoricon x="95" y="150" level="10"
+            active="resources/icons/smallschematics/tracksegments/circuit-occupied.gif"
+            error="resources/icons/smallschematics/tracksegments/circuit-error.gif"
+            rotate="0" forcecontroloff="false" momentary="false"
+            sxscale="11.849106591612951" syscale="-11.889381744148094"
+            sxorigin="41" syorigin="768"
             class="jmri.jmrit.display.configurexml.RpsPositionIconXml" /&gt;
 </pre>
         </li>
@@ -249,12 +247,12 @@
         to have it track transmitter 5510, change the line to:
           <pre style="font-family: monospace;">
 
-    &lt;sensoricon filter="5510" x="95" y="150" level="10" 
-            active="resources/icons/smallschematics/tracksegments/circuit-occupied.gif" 
-            error="resources/icons/smallschematics/tracksegments/circuit-error.gif" 
+    &lt;sensoricon filter="5510" x="95" y="150" level="10"
+            active="resources/icons/smallschematics/tracksegments/circuit-occupied.gif"
+            error="resources/icons/smallschematics/tracksegments/circuit-error.gif"
             rotate="0" forcecontroloff="false" momentary="false" s
-            xscale="11.849106591612951" syscale="-11.889381744148094" 
-            sxorigin="41" syorigin="768" 
+            xscale="11.849106591612951" syscale="-11.889381744148094"
+            sxorigin="41" syorigin="768"
             class="jmri.jmrit.display.configurexml.RpsPositionIconXml" /&gt;
 </pre>
         </li>

--- a/help/en/package/jmri/jmrit/display/ScaleTrackDiagram.shtml
+++ b/help/en/package/jmri/jmrit/display/ScaleTrackDiagram.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Scale/Translate Track Diagram Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Layout Editor Track">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Scale/Translate Track Diagram</h1>
 

--- a/help/en/package/jmri/jmrit/display/SetSignalsAt3WayTurnout.shtml
+++ b/help/en/package/jmri/jmrit/display/SetSignalsAt3WayTurnout.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Set Signals at 3-Way Turnout Help</title>
   <meta name="author" content="Dave Duchamp">
   <meta name="keywords" content="JMRI help Layout Editor panel">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Set Signals at 3-Way Turnout</h1>
 

--- a/help/en/package/jmri/jmrit/display/SetSignalsAtBoundary.shtml
+++ b/help/en/package/jmri/jmrit/display/SetSignalsAtBoundary.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Set Signals at Block Boundary Help</title>
   <meta name="author" content="Dave Duchamp">
   <meta name="keywords" content="JMRI help Layout Editor Tool">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Set Signals at Block Boundary</h1>
 

--- a/help/en/package/jmri/jmrit/display/SetSignalsAtLevelXing.shtml
+++ b/help/en/package/jmri/jmrit/display/SetSignalsAtLevelXing.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Set Signals at Level Crossing Help</title>
   <meta name="author" content="Dave Duchamp">
   <meta name="keywords" content="JMRI help Layout Editor panel">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Set Signals at Level Crossing</h1>
 

--- a/help/en/package/jmri/jmrit/display/SetSignalsAtSlip.shtml
+++ b/help/en/package/jmri/jmrit/display/SetSignalsAtSlip.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Set Signals at Throat-to-Throat Turnouts
   Help</title>
   <meta name="author" content="Kevin Dickerson">
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Set Signals at A Single/Double Slip</h1>
 

--- a/help/en/package/jmri/jmrit/display/SetSignalsAtTToTTurnout.shtml
+++ b/help/en/package/jmri/jmrit/display/SetSignalsAtTToTTurnout.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Set Signals at Throat-to-Throat Turnouts
   Help</title>
   <meta name="author" content="Dave Duchamp">
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Set Signals at Throat-to-Throat Turnouts</h1>
 

--- a/help/en/package/jmri/jmrit/display/SetSignalsAtTurnout.shtml
+++ b/help/en/package/jmri/jmrit/display/SetSignalsAtTurnout.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Set Signals at Turnout Help</title>
   <meta name="author" content="Dave Duchamp">
   <meta name="keywords" content="JMRI help Layout Editor Tool">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Set Signals at Turnout</h1>
 

--- a/help/en/package/jmri/jmrit/display/SetSignalsAtXoverTurnout.shtml
+++ b/help/en/package/jmri/jmrit/display/SetSignalsAtXoverTurnout.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Set Signals at Crossover Help</title>
   <meta name="author" content="Dave Duchamp">
   <meta name="keywords" content="JMRI help Layout Editor panel">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Set Signals at Crossover</h1>
 

--- a/help/en/package/jmri/jmrit/display/SlipTurnoutIcon.shtml
+++ b/help/en/package/jmri/jmrit/display/SlipTurnoutIcon.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: SlipTurnout Icon Editor Help</title>
   <meta name="author" content="Kevin Dickerson">
   <meta name="keywords" content="JMRI help Panel Editor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent class="no-sidebar"">
 
       <h1>The Slip Turnout Editor</h1>
 

--- a/help/en/package/jmri/jmrit/display/SwitchboardEditor.shtml
+++ b/help/en/package/jmri/jmrit/display/SwitchboardEditor.shtml
@@ -10,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>The Switchboard Editor</h1>
 

--- a/help/en/package/jmri/jmrit/display/TranslateSelection.shtml
+++ b/help/en/package/jmri/jmrit/display/TranslateSelection.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Translate Selection Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Translate Selection</h1>
 

--- a/help/en/package/jmri/jmrit/entryexit/EntryExitFrame.shtml
+++ b/help/en/package/jmri/jmrit/entryexit/EntryExitFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Entry/Exit Tools</title>
   <meta name="author" content="Kevin Dickerson, Egbert Broerse">
   <!--#include virtual="/Style.shtml" -->
@@ -12,9 +9,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
     <h1>JMRI: Entry/Exit (NX) Tool</h1>
 
     For a full description of Entry/Exit (NX), see

--- a/help/en/package/jmri/jmrit/inControl/inControl.shtml
+++ b/help/en/package/jmri/jmrit/inControl/inControl.shtml
@@ -13,8 +13,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: inControl - Web Throttles and Frames
       (inControl.html application)</h1>

--- a/help/en/package/jmri/jmrit/logix/CreateEditWarrant.shtml
+++ b/help/en/package/jmri/jmrit/logix/CreateEditWarrant.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Create/Edit Warrant Help</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI help Create/Edit Warrant">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Creating and Editing Warrants</h1>
 
@@ -23,7 +20,7 @@
       address of the locomotive or consist, the turnout settings
       of the paths through the blocks of the route and the
       throttle commands to use at various points along the route.
-      Among these are speed changes, when to show lights, 
+      Among these are speed changes, when to show lights,
       sound horns, bells or other
       sound effects. For an overview discussion of Warrants, see
       <a href="Warrant.shtml">Warrants</a>.
@@ -40,9 +37,9 @@
             <li>Record the throttle commands.</li>
         </ol>
       <p>When a <b>Create Warrant</b> menu is selected, a window to
-      define the warrant is displayed. At the top, you may enter 
+      define the warrant is displayed. At the top, you may enter
       a System Name and a User Name. After the warrant is saved by
-      pressing the <b>Save</b> button at the bottom of the window, 
+      pressing the <b>Save</b> button at the bottom of the window,
       the System name cannot be changed.  The User Name may be changed
       anytime the warrant is edited.</p>
 
@@ -82,7 +79,7 @@
         User Name of a Block can be dragged and dropped into the
         Location Block fields on the left hand side of the pane.
         Alternatively, you can mouse click on an Indicator Track
-        icon of the block in the layout diagram and it will be 
+        icon of the block in the layout diagram and it will be
         selected for the location.
       </div>
 
@@ -250,7 +247,7 @@
           <p>The bottom half displays six
           outlined areas; <b>Choose Engine Consist</b>,
           <b>Select Type</b>, <b>Settings</b>,
-          <b>Learn mode</b>, <b>Run Parameters,</b> and  
+          <b>Learn mode</b>, <b>Run Parameters,</b> and
           <b>Test Run Train</b>. More about the use of these areas
           will be discussed below.<br>
           The first thing to do
@@ -266,13 +263,13 @@
           fill in the <b>Address</b> text field
           and assigns the engine to power the warrant.
 
-          <p>Alternatively a DCC address can be typed into the 
+          <p>Alternatively a DCC address can be typed into the
           <b>Address</b> text field and it
           will be used whether or not it is found in the JMRI
           Engine Roster. Chose or enter the
           address of the train positioned on the "Origin"
           block of the route.</p>
-          
+
           <h2>Learn Mode</h2>Throttle commands are created by
           recording the commands you send to a train while
           operating it manually from a throttle in <b>Learn
@@ -293,59 +290,59 @@
             commands. Whatever throttle is used, start and stop the
             recording with the buttons in the <b>Learn Mode</b>
             box.
-            
+
             <p>Be sure that the train is located on the path
             of the Origin block of the route and note the direction
             of you intend the train to take. If needed, the first
             command you make on the learn throttle should be the
-            engine direction toward the exit portal of the Origin block. 
+            engine direction toward the exit portal of the Origin block.
 
           </p><p>The learn script should be done with a completely
           clear route - All turnouts should be set for the
           route, all blocks unoccupied (except the origin), all signals
           should be set for clear running and no changes made during
-          the recording period. The recorded 
+          the recording period. The recorded
           speeds and elapsed times should be for unrestricted
           "Normal" speeds.
-          
+
           Once the <b>Start</b> button is pressed and
-          recording has begun, the Route Pane is replaced by 
-          the Throttle Commands Pane.<br>        
+          recording has begun, the Route Pane is replaced by
+          the Throttle Commands Pane.<br>
           <a href="images/WarrantCreate3.png"><img
           src="images/WarrantCreate3.png" width="897"
           height="433" alt="the Throttle Commands Pane"></a>
-          
-          	<p>In normal operation, when the script is played back, 
+
+          	<p>In normal operation, when the script is played back,
           	the train will follow the commands as recorded.
-			However if a track condition ahead of it is detected that 
+			However if a track condition ahead of it is detected that
 			requires a speed change, the warrant will modify the recorded
 			speed accordingly.
 			When the warrant makes such a speed change it "ramps" the change
 			in small steps to give a more prototypical smooth look to
 			the change.  When decreasing speed it calculates and issues
-			these step-wise speed changes so that the required speed is 
+			these step-wise speed changes so that the required speed is
 			achieved just at the point where the speed limit must be enforced.
 			When increasing speed it begins a similar "ramp up" when entering
 			the block permitting the speed increase.
            <a href="SpeedChanges.shtml">Warrant Speed Changes</a> has details
            about how warrants modify recorded speeds.</p>
-           
+
           <p>
             <b>Note:</b> The train should <b><i>not</i></b> be moving
             when the recording is stopped. <i>When play back of the
             warrant ends, the train might continue to run without a
-            warrant to control it!</i> After recording a script, check 
+            warrant to control it!</i> After recording a script, check
             the ending throttle commands to see that the speed is set
-            to 0.0           
+            to 0.0
           </p>
-          
+
           <p>When the route has been traversed and all throttle commands
-          are done, recording is  completed by pressing 
+          are done, recording is  completed by pressing
           the <b>Stop</b> button. After this, the throttle
           commands can be edited and additional run parameters set.</p>
- 
+
           <h3>What the Warrant Does on Playback.</h3>
-          The script records the elapsed times traversing each 
+          The script records the elapsed times traversing each
           occupancy block and knows when to expect the train to
           enter each block.
 
@@ -364,11 +361,11 @@
           milliseconds between them. In spite of an exact repeat of
           the recorded throttle settings, the track speed and
           position of the train may not be at the same place as
-          they were when it was recorded. 
+          they were when it was recorded.
           Changing the consist of the train or
           even a temperature change between recording and
           playback, may result in the train not performing a
-          throttle command at exactly the same place on the on the 
+          throttle command at exactly the same place on the on the
           route where it was recorded.</p>
 
           <p>If a more precise way is needed to have a script event
@@ -381,7 +378,7 @@
 
           <h3>Test Running</h3>
           <p>After a script is recorded, reset the train to the Origin
-          block and press the <b>AutoRun</b> button in the 
+          block and press the <b>AutoRun</b> button in the
           <b>Test Run Train</b> box. This sends
           the throttle commands to the train specified in the
             warrant.</p>
@@ -394,11 +391,11 @@
 			<li><b>Resume</b> Ramp the speed up to its previous speed.</li>
 			<li><b>Emergency Stop</b> Issue an Emergency Stop to the train.</li>
 			<li><b>Abort</b> Stop the train and null the warrant.</li>
-			</ul>         
+			</ul>
 		  <p>Name and save the warrant when you are satisfied by its
           performance by pressing the <b>Save</b>
           button. This adds the warrant to the <a href=
-          "WarrantTable.shtml">Warrant Table</a> and closes the 
+          "WarrantTable.shtml">Warrant Table</a> and closes the
           Create/Edit Warrant window.</p>
 
 			<h3>Run Parameters</h3>
@@ -421,8 +418,8 @@
                 <li><b>Use Elapsed Time Only</b> - Do not use
                 block detection. <i>Using this option allows Warrants to
                 be run on layouts without block detection.</i></li>
-			</ul> 
-			Using the "Don't Ramp" or "Elapsed Time" options are the 
+			</ul>
+			Using the "Don't Ramp" or "Elapsed Time" options are the
 			only cases where block path lengths and engine speed factors
             are <i>not</i> necessary.
 
@@ -430,7 +427,7 @@
 		  The warrant can be edited to use a different engine. A different
 		  engine may have different speed characteristics. If the engine
 		  has a Speed Profile, it can be viewed.
-		  
+
           <p>The <b>View Speed Profile</b> button displays a table
           of the track speeds corresponding to the throttle settings
           for the addressed locomotive or consist. The speed
@@ -457,11 +454,11 @@
             <li><b>Value</b>: - The value of the command. Chose a
             value from the drop down combo box. the choices are
             dependent on the command being edited.</li>
-            
+
             <li><b>Block or Sensor Name</b>: - The block the train occupied when
-            the throttle command was recorded. If the command being edited 
+            the throttle command was recorded. If the command being edited
             is <b>Set Sensor</b> or <b>Wait Sensor</b> then the name
-            of the sensor should be entered. If the command 
+            of the sensor should be entered. If the command
             is <b>Run Warrant</b> then the name
             of the warrant should be entered</li>
 
@@ -470,7 +467,7 @@
             and the Speed Profile of engine consist.</li>
           </ul>
           The recorded throttle commands execute according to
-          the elapsed time between commands. The entry into each 
+          the elapsed time between commands. The entry into each
           block is recorded with a "NoOp"
           marker. These markers are used to synchronize the elapsed
           time of the automatic running of the train when it enters
@@ -510,12 +507,12 @@
           For this to be done, a speed profile is needed for the
           locomotive/consist running the warrant.  The feature helps
           compensate for changes in the size of the train or
-          different address of the power, by attempting to produce 
+          different address of the power, by attempting to produce
           the same track speed. Lacking a speed profile, the recorded
-          throttle setting is used.  In <i>Release 4.9.4</i> the 
+          throttle setting is used.  In <i>Release 4.9.4</i> the
           scripted throttle setting is not modified by the track speed.
           (i.e. the above is a 4.9.2 feature only)
-          
+
           <p>On the right of the Throttle Command table is a button
           labeled <b>Track Speed</b> or <b>Scale speed</b>. Pressing
           the button will display the last column of the Throttle
@@ -523,30 +520,30 @@
           in terms of one of four kinds of
           units - millimeters per second, inches per second track
           speed or miles per hour, kilometers per Hour scale speed.</p>
-          
-          <p>The DCC address used in the recording is the "standard 
+
+          <p>The DCC address used in the recording is the "standard
           power" of the warrant. To base the track speeds on a different
-          address or roster entry, select that entry and press the 
+          address or roster entry, select that entry and press the
           <b>track/scale speed</b> button.  Warrants recorded before Release
           4.9.2 can be upgraded this way.</p>
           <div style="margin-left: 2em">
-            <b>NOTE:</b>Recording track speeds in warrants makes 
+            <b>NOTE:</b>Recording track speeds in warrants makes
             panels saved with Release 4.9.2 fail to load with earlier
             versions of JMRI. However, Recorded track speeds can be
             set to "0.000" by selecting no address or roster entry
             then pressing <b>Add Speeds</b>.  Saving the panel now
             will allow it to be loaded by earlier versions.
           </div>
-           
+
           <h2>Triggering External Events From Scripts</h2>External
           animation or other events may be triggered by the
           "<b>Set Sensor</b>" command. To do this insert a row,
           then select <b>Set Sensor</b> from the list of items
           under the
           <b><i>Command</i></b> column. Next select the action
-           (<b>active</b> or <b>inactive</b>) you 
+           (<b>active</b> or <b>inactive</b>) you
           want from the <b>Value</b> column. Lastly, enter a sensor name in
-          the <b>Block or Sensor</b> column. 
+          the <b>Block or Sensor</b> column.
           Also enter or adjust the elapsed time when to
           trigger the setting of the sensor. On playback when this
           command is executed the state of the sensor will be set.
@@ -563,20 +560,20 @@
           movement of the train is sustained until the sensor
           changes to the specified state. When that happens the
           script continues to execute according to the recorded
-          times. 
-          
+          times.
+
           <p>For example the "Wait Sensor" might be an optical
           sensor named "sStopTrain" positioned to detect specific point.
           The "Wait Sensor" command is bracketed
           with speed commands, the one before
           with a very slow speed and the one after with speed 0.
           Sensor "sStopTrain" is set inactive and then the script
-          is set to wait until it goes active. 
+          is set to wait until it goes active.
           The script will then have the train creep at the current
           slow speed of 11.4 mm/sec until the sensor detects the
           trains desired position. Then the
           script continues to set speed to 0, which stops the train.
-          Following that, the scrip must wait for 
+          Following that, the scrip must wait for
           another sensor named "sStartTrain" to go active before it
           can continue.<br>
 
@@ -636,7 +633,7 @@
 
           <h2>Save etc.</h2>
           At the bottom of the Create Warrant pane the <b>Status</b>
-          field displays messages when doing test runs from the 
+          field displays messages when doing test runs from the
           <b>AutoRun</b> button. Below that are three
           buttons that let you:
 

--- a/help/en/package/jmri/jmrit/logix/NXWarrant.shtml
+++ b/help/en/package/jmri/jmrit/logix/NXWarrant.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: NX Warrant Help</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI NX Warrant Help">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Warrants: NX Warrants</h1>
       <p>An NX Warrant is a computer generated Warrant. Rather
@@ -30,7 +27,7 @@
       A speed profile for the selected engine/consist
       to provide track speeds is desirable.  Lacking a speed profile,
       the <i>Throttle Factor</i> and <i>Layout Scale</i> are used
-      for a rough estimate of track speed. If block lengths are not  
+      for a rough estimate of track speed. If block lengths are not
       specified, you will be prompted to provide a length.
       <a href="SpeedChanges.shtml">When Warrant Speeds Are Modified</a>
       profides more details about how Warrants modify recorded speeds.</p>
@@ -65,7 +62,7 @@
       </ul>
 
       <p>Blocks are chosen either by typing in the block name or
-      dragging it from a displayed OBlock table 
+      dragging it from a displayed OBlock table
       (use the <b>OBlock Pick List</b> button). The origin and
       destination blocks can also be chosen by clicking on track
       icons that represent these OBlocks. To use this feature your
@@ -83,7 +80,7 @@
       have this feature. <a href="CreateEditWarrant.shtml">Creating
       and Editing Warrants</a> also discusses choosing routes.</p>
 
-      <p>The <b>Max Number of Blocks in Route</b> field puts an 
+      <p>The <b>Max Number of Blocks in Route</b> field puts an
       upper limit on the length of the route the algorithm computes.
       If your layout contains loops, then an infinite number of
       routes can theoretically be counted.
@@ -91,18 +88,18 @@
       is much larger than the number of blocks in the longest
       route. <i>However, using too small a number can terminate the
       search prematurely before the route is found.</i></p>
-      
-      <p>Pressing the <b>Calculate</b> button runs a computer 
+
+      <p>Pressing the <b>Calculate</b> button runs a computer
       algorithm to determine all the intermediate
       blocks and paths to make the route. If more than one route
       meets the criterion, you are presented with a list to review
       and select the route you want. Note, the Via and Avoid
       location fields may be used to restrict the list. Possibly
-      you will be presented with a dialog stating that no route 
+      you will be presented with a dialog stating that no route
       could be found. You can view a tree of all the possible
       searches the algorithm used to find the route. Typical
       errors are the Portals of the selected paths are mismatched
-      for exit and entry. Also check that the paths have the 
+      for exit and entry. Also check that the paths have the
       needed portals for exit and entry.</p>
 
       <p>Once the route has been chosen, the window changes to
@@ -128,7 +125,7 @@
         train id will be displayed.</li>
 
         <li><b>Address</b> - The decoder address of the locomotive
-        of the train. This is a required field, but it will be 
+        of the train. This is a required field, but it will be
         displayed automatically if a train is selected from the roster.
         You may enter the DCC address of a non-Roster locomotive.</li>
       </ul>
@@ -141,7 +138,7 @@
       </div>
 
       <p>The <b>View Speed Profile</b> button displays a table of the
-      track speeds that will be used in the calculations for the 
+      track speeds that will be used in the calculations for the
       Warrant.  The table is comprised of the Roster Speed Profile
       merged with any speed measurements that have been made during
       the current session.  If the table is empty, the values for
@@ -160,24 +157,24 @@
         The "<i><b>units"</b></i> button cycles through the choices:
         Miles per hour, Kilometers per hour, millimeters per
         second, inches per second.
-        If a speed profile exists. it is used to make the 
+        If a speed profile exists. it is used to make the
         conversion to throttle setting percent. Otherwise the
         throttle factor settings of Warrant Preferences are
         used.</li>
-        
+
         <li><b>Start Distance</b> is the position of the train in
         the Origin block. Set the distance of the train's position
-        to the exit portal of the origin block. You may choose 
+        to the exit portal of the origin block. You may choose
         either inches or centimeters for units.</li>
-        
+
         <li><b>End Distance</b> is the position where the train
-        should stop in the Destination block. Set the distance 
+        should stop in the Destination block. Set the distance
         from the entry portal of the destination block to the
-        desired stop point. You may choose either inches or 
+        desired stop point. You may choose either inches or
         centimeters for units.</li>
       </ul>
 
-      <p>NXWarrants ramp up and ramp down the train speed in increments 
+      <p>NXWarrants ramp up and ramp down the train speed in increments
       to provide a prototypical appearance when leaving the Origin
       block and ending in the Destination block. The parameters for
       the increments to use are set by the <b>Ramp Step Time</b>
@@ -192,14 +189,14 @@
         direction of the locomotive.</li>
       </ul>
 
-      <p>On the right is a list of some options to consider for 
+      <p>On the right is a list of some options to consider for
       running the warrant.</p>
       <ul>
         <li>The checkbox <b>Don't Ramp Speed changes</b> Sets an
         option on how to change the speed when a signal or rogue
-        occupation is detected ahead. The default is to incrementally 
-        slow the train before reaching the end of the approach block. 
-        Selecting the option will make an immediate speed change upon 
+        occupation is detected ahead. The default is to incrementally
+        slow the train before reaching the end of the approach block.
+        Selecting the option will make an immediate speed change upon
         entering the approach block.</li>
 
         <li>The checkbox <b>Skip Sound Commands</b> Sounding the
@@ -210,11 +207,11 @@
         train make an emergency stop upon entering the last block.
         <i>Rarely Needed.</i></li>
 
-        <li>The checkbox <b>Halt Start at Origin Block</b> will 
+        <li>The checkbox <b>Halt Start at Origin Block</b> will
         allocate and set the Warrant, but won't start the train
         until you issue a <b>Resume</b> command to the Warrant from the
         Warrant List Table or via a Logix Warrant Control action.</li>
-        
+
         <li>The checkbox <b>Clearance to Share Route</b> will allow
         another Warrant to acquire clearance to run ahead of
         the Warrant.  The additional Warrant will cause this Warrant
@@ -231,9 +228,9 @@
       operator must acquire the throttle and drive the train.</p>
 
       <ul>
-        <li>Radio button <b>Run Auto</b> launches the Automated 
+        <li>Radio button <b>Run Auto</b> launches the Automated
         Warrant</li>
-        <li> <b>Run Manual</b> allocates and sets the route for 
+        <li> <b>Run Manual</b> allocates and sets the route for
         a manual operator. This is similar to setting a Tracker
         where the route is prescribed and highlighted on the
         layout.</li>
@@ -251,8 +248,8 @@
       The NX Warrant script sets the direction, turns the light on,
       blows two horn/whistle blasts and starts to ramp up speed.
       There should be a
-      reasonable estimate for block length know for each OBlock. 
-      If the length of the route is not known, you will be prompted 
+      reasonable estimate for block length know for each OBlock.
+      If the length of the route is not known, you will be prompted
       to enter a length for the path through the block.
       The algorithm will ramp up to the maximum speed and
       ramp down to a stop in the last block.
@@ -262,37 +259,37 @@
       <p>For a series of short blocks the length needed to
       ramp up or ramp down is distributed over as many blocks as
       are needed. For short routes, the algorithm may decide the
-      maximum speed cannot be achieved without over-running the 
+      maximum speed cannot be achieved without over-running the
       last block. In this case, the max throttle setting is
       modified so ramp up and ramp down can finish without
       over-running the last block.</p>
 
       <p>The elapsed times to traverse each block is computed
       from what is known about the engine's speed profile and
-      the length of the path in each block. 
+      the length of the path in each block.
       <b>Note!</b> if the route includes a
-      <i>Dark</i> block, i.e. no occupancy detection, it is 
+      <i>Dark</i> block, i.e. no occupancy detection, it is
       important it's block length is known since in this case,
       synchronization cannot be done.</p>
 
       <h3>Saving NX Warrants to make them Permanent</h3>
       When the <b>Run NX Warrant</b> button is pressed and the
-      NXWarrant starts its run, the warrant is listed in the 
-      Warrant List table with the name 
-      <b>NX(</b><i>address</i><b>)</b>. If the table is 
+      NXWarrant starts its run, the warrant is listed in the
+      Warrant List table with the name
+      <b>NX(</b><i>address</i><b>)</b>. If the table is
       not visible, it will be displayed.
-      Notice that the <b>Edit</b> button label for the 
+      Notice that the <b>Edit</b> button label for the
       warrant is <b>Save</b>.
       <p>If you press this button before the warrant completes,
       a Create/Edit Warrant Window for the NX Warrant will open.
-      This window has a copy of the NXWarrant. After providing 
+      This window has a copy of the NXWarrant. After providing
       a name and any other information you want changed,
       press the <b>Save</b> button to make a permanent warrant.
 
       <h3>Some Tips for Smooth Start Up and Slow Down</h3>
       <p>It is
-      necessary to have a length specified for each path in a 
-      block. A rough estimate within 5% of the actual length 
+      necessary to have a length specified for each path in a
+      block. A rough estimate within 5% of the actual length
       is adequate. Each path inherits the length specified
       for the block, so it is only important to input a separate
       length for a path when its length is significantly less
@@ -301,9 +298,9 @@
       Edit Path menu or in the OBlock tables.</p>
 
       <p>The algorithm calculates the speed changes using the
-      the step intervals for time and throttle setting 
+      the step intervals for time and throttle setting
       specified in Warrant Preferences. These are the values
-      that give a prototypical look when changing speeds for 
+      that give a prototypical look when changing speeds for
       signal aspects and starting and stopping. The Warrants pane
       at <i>Edit-&gt;Preferences-&gt;Warrants</i> is where this and
       other Warrant parameters can be set.</p>

--- a/help/en/package/jmri/jmrit/logix/OBlockEdit.shtml
+++ b/help/en/package/jmri/jmrit/logix/OBlockEdit.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: OBlock Add/Edit Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help OBlock Table">
@@ -20,8 +17,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Warrants: Creating and Editing OBlocks, Portals and OPaths</h1>
 

--- a/help/en/package/jmri/jmrit/logix/OBlockTable.shtml
+++ b/help/en/package/jmri/jmrit/logix/OBlockTable.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Occupancy Block Table Help</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Occupancy OBlock Table">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Warrants: The Occupancy Block Tables</h1>
 

--- a/help/en/package/jmri/jmrit/logix/SCWarrant.shtml
+++ b/help/en/package/jmri/jmrit/logix/SCWarrant.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-          "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Warrants Help</title>
   <meta name="author" content="Karl Johan Lisby">
   <meta name="keywords" content="JMRI Fast Reacting Warrant Help">
@@ -13,8 +10,8 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Fast Reacting Warrants</h1>
       <p>This type of Warrant does not follow

--- a/help/en/package/jmri/jmrit/logix/SpeedChanges.shtml
+++ b/help/en/package/jmri/jmrit/logix/SpeedChanges.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Warrant Speeds Help</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI help Modifying Warrant Speeds">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Warrants: When Warrant Speeds Are Modified</h1>
 
@@ -39,36 +36,36 @@
       need for a speed change and schedule the right time to do it
       - all the while making the change smoothly and completing it
       in prototypical fashion.</p>
-      
+
       <h3>Configuring Speed Restrictions</h3>
       <p>For a warrant to detect a <b>signaled speed change</b> the signal
-      must be configured in the Occupancy Block Tables. 
+      must be configured in the Occupancy Block Tables.
       The Signal Table there configures the entrance Portal to the
-      OBlock that the signal protects.  The warrant then uses the 
+      OBlock that the signal protects.  The warrant then uses the
       signal system configured for the signal to define the aspect
       speed.<br>
       Likewise, <b>Block Speeds</b> are configured in the Occupancy
       Block Tables.  A column in the OBlock Table allows you to
       choose an aspect speed that the Warrant will enforce
       before entering the block.</p>
-      
+
       <p>When an <b>occupancy</b> sensor is activated ahead of the train
       on its route, the warrant will take note of it and
       bring the train to a stop before entering the block.</p>
- 
+
       <p>Finally, you can manually instruct the Warrant to ramp
       down to a stop using the <b>Halt</b> control command.
       - or issue an emergency stop with the <b>E-Stop</b> command,
-      Also, you can ramp up from a stop and resume the train's 
+      Also, you can ramp up from a stop and resume the train's
       former speed with a <b>Resume</b> command. With the exception
       of E-Stop, all these unscripted speed changes are made smoothly.</p>
-      
+
 	  <p>When a warrant ramps down a speed change due to a signal, block
       or rouge occupancy condition, That speed change remains in
       effect until the condition is removed. At that time the
       speed is ramped up to the previous "normal" speed.  The
       precedence order is: rouge occupancy, signal aspect, block speed.</p>
-            
+
       <h2>How Signal Aspects and Block Speeds Modify a Train's
       Speed</h2>
       When a speed restriction is required before entering a block,
@@ -78,13 +75,13 @@
       block, it looks ahead to see if any speed changes are coming
       up. The look ahead distance must be adequate for the train to
       be able to stop should that be needed. The warrant calculates
-      the look ahead distance to be what is needed to stop from its 
-      present speed. This distance may include several blocks. 
+      the look ahead distance to be what is needed to stop from its
+      present speed. This distance may include several blocks.
       If a signal or block is
       encountered within this look ahead distance, and the aspect
       protecting the block indicates the speed must be restricted,
       then the warrant performs a "ramp down".</p>
-      
+
       <p>When a speed restriction is lifted, the problem is much
       simpler.  The warrant can immediately begin a "ramp up" upon
       entering the block.
@@ -94,24 +91,24 @@
        order for it to done smoothly in prototypical fashion, it
        depends on the following parameters:
       <ul>
-        <li><b>Ramp Step Time</b> The number of milliseconds 
+        <li><b>Ramp Step Time</b> The number of milliseconds
         between making throttle setting changes.</li>
         <li><b>Ramp Step Throttle Increment</b> The initial
         throttle increment when increasing speed, or last
-        increment when decreasing speed.</li> 
+        increment when decreasing speed.</li>
       </ul>
       These are configured in Warrant Preferences. See <a href=
       "../../../apps/TabbedPreferences.shtml#Warrants">Warrant
       Preferences</a> for information about configuration of
       Warrant parameters.
-      
+
        <h3>Parameters Needed for Look Ahead</h3>
        <p>Both the
        look ahead distance and the time when to begin the speed
        change require knowing the track speed. Thus to get the
        train to begin and end its speed changes at the proper points,
        and relating the throttle settings to the actual track
-       speed, some crucial information is needed. Without such 
+       speed, some crucial information is needed. Without such
        information a fast running
        engine may overrun the point where a speed change expects to
        be completed, or a slow running train may stop too far short
@@ -123,49 +120,49 @@
           <b>Block Lengths</b> are needed for distances.  There
           is a length column in the OBlock Table. (Use menu
           <b>Add Items -&gt; Occupancy Blocks</b>).  Also  the
-          <b>Paths</b> column in the table opens its path tables. 
-          Each Path Table has a length column as well.  
-          <p>Likewise the menus 
-          <b>Circuit Builder -&gt; Add/Edit Circuit OBlock</b> 
+          <b>Paths</b> column in the table opens its path tables.
+          Each Path Table has a length column as well.
+          <p>Likewise the menus
+          <b>Circuit Builder -&gt; Add/Edit Circuit OBlock</b>
           and <b>Circuit Builder -&gt; Add/Edit Circuit OPaths</b>
-          in Circuit Builder have text fields to enter 
-          lengths.</p> 
+          in Circuit Builder have text fields to enter
+          lengths.</p>
           <p>Inches or centimeters may be used for all of these fields.
           <p>When no block length is specified error messages
-          are written to the console and you may have trains 
-          over-running their stopping points.  It is 
+          are written to the console and you may have trains
+          over-running their stopping points.  It is
           <b><i>highly recommended</i></b>
-          that path lengths be specified.  If the 
+          that path lengths be specified.  If the
           paths within a block vary widely, path lengths
           should be set. Otherwise, path
           lengths are inherited from the block length.</p>
         </li>
         <li><b>Layout Scale</b> is needed for distances when speed is
         expressed as Mph or Kmph.  This is set from a drop down box at
-        the <b>Edit-&gt;Preferences-&gt;Warrants</b> menu of the main 
+        the <b>Edit-&gt;Preferences-&gt;Warrants</b> menu of the main
         PanelPro window</li>
-        <li><b>Track Speed</b> of the train.  A correlation of 
+        <li><b>Track Speed</b> of the train.  A correlation of
           the throttle settings to the actual speed
-          of the train on the layout must be known. For this 
+          of the train on the layout must be known. For this
           two methods are used.
           <ul>
             <li>
             A first approximation is the <b>"Throttle Setting/Speed Factor"</b>
             value at Edit-&gt;Preferences-&gt;Warrants.
             When used, this factor is a linear multiplier to relate throttle
-            setting to track speed.  <b>Note</b> this is a global value for 
+            setting to track speed.  <b>Note</b> this is a global value for
             all of the locomotives in your fleet and over the entire speed
             range of each.  Obviously this may not function optimally.
             However, it could be satisfactory for your tastes.</li>
-            <li> 
+            <li>
             For more precision a <b>Speed Profile</b> can be used for each
-            locomotive. These provide track speed values that give more  
-            accurate calculations for time and distances.  
+            locomotive. These provide track speed values that give more
+            accurate calculations for time and distances.
             The Speed Profiler
             is found at <b>Roster-&gt;Speed Profiling</b> is used to
-            create a speed profilr for each locomotive or consist.</li>  
+            create a speed profilr for each locomotive or consist.</li>
           </ul>
-        </li> 
+        </li>
       </ul>
 
       <h3>Getting Speed Profiles for your Trains</h3>
@@ -185,7 +182,7 @@
       is used for running a Warrant. A data point is recorded whenever
       a path with known length is traversed with a known throttle
       setting. The data is kept for the layout
-      session and when the session ends this Session Speed Profile 
+      session and when the session ends this Session Speed Profile
       can be merged into the Roster Speed Profile.  Warrant Preferences
       provides choices for how you may want to manage the merging of
       Roster Speed Profiles. See <a href=
@@ -193,18 +190,18 @@
       Preferences</a> for how you want to manage the end of session
       behavior.  The default is you are prompted for how you want
       to treat each Session Speed Profile.</p>
-      
+
       <h3>Track Speeds for Throttle Settings</h3>
       <p>If you used the Roster Speed Profiling tool most likely you ran
-      an engine running light over a straight level track. With 
+      an engine running light over a straight level track. With
       Warrant dynamic speed profiling, measurements are made over
       straight level track, but also upgrade, down grade, curved
-      gently or severely, running light or pulling 30+ cars. 
+      gently or severely, running light or pulling 30+ cars.
       <i>The track speeds are not going to be all the same for a
-      given throttle setting.</i>  When merging, new values are 
+      given throttle setting.</i>  When merging, new values are
       averaged with the old, with the intention of a composite
       speed profile that reflects average use.</p>
-       
+
       <p>At some point, merging this data
       may make a speed profile that is not monotonic increasing.
       (Certainly increasing throttle setting increases speed). When
@@ -216,7 +213,7 @@
       do the editing after letting more values accumulate.
       Of course, a value resulting when the train was shorted
       or was dragging a derailed car should be deleted.</p>
-      
+
       <h4>Editing a Speed Profile</h4>
       <p>When given the opportunity to edit, either the value of
       a single cell can be changed or an entire row deleted.
@@ -252,7 +249,7 @@
         <li>
           <b>Percent of Full Throttle</b> - The value is an
           absolute throttle setting expressed as a percentage of
-          full throttle. <i>All speed names must be a number 
+          full throttle. <i>All speed names must be a number
           between 0 and 100.</i> The warrant sets the modified speed
           to be the value as a percentage of the full throttle
           setting.
@@ -267,8 +264,8 @@
         </li>
         <li>
           <b>Kilometers per Hour</b> - The value is the scale
-          speed expressed as Kilometers per hour. <i>All speed 
-          names must be expressed as kilometers per hour.</i> 
+          speed expressed as Kilometers per hour. <i>All speed
+          names must be expressed as kilometers per hour.</i>
           The warrant, using layout scale,
           converts the value to track speed and finds the
           corresponding throttle setting for the

--- a/help/en/package/jmri/jmrit/logix/Tracker.shtml
+++ b/help/en/package/jmri/jmrit/logix/Tracker.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Using Trackers</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI help Using Tracker">
@@ -13,30 +10,30 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Train Trackers</h1>
-     	A <b>Tracker</b> is a means to to see the movement of trains on your layout panel. 
-    	A Tracker has a marker identifying a train 
+     	A <b>Tracker</b> is a means to to see the movement of trains on your layout panel.
+    	A Tracker has a marker identifying a train
     	moving on your panel layout diagram following wherever an operator
-    	drives his train on your layout.  The position of each tracked train and the time is spends 
+    	drives his train on your layout.  The position of each tracked train and the time is spends
     	occupying a block is displayed in a window. A status log
     	is kept of the progress of the trackers.
 
       <h2>What's Needed to Have a Tracker</h2>
       	Trackers function on the same foundation as Warrants. That is, track occupation
       	detection is by <b>OBlocks</b> and the directions trains move by
-      	<b>Portals</b> and <b>Paths</b>. For detailed information about what 
+      	<b>Portals</b> and <b>Paths</b>. For detailed information about what
       	these objects are and how to make
       	them see <a href="../display/CircuitBuilder.shtml">Circuit Builder</a>
-      	or <a href="../OBlockTable.shtml">Occupancy Block Tables</a>. 
+      	or <a href="../OBlockTable.shtml">Occupancy Block Tables</a>.
       	<p>
       	Next, your panel
       	layout diagram must done with Indicator Track icons. These icons display the status
-      	of the block they represent with colors and can show names.  If your diagram has already 
+      	of the block they represent with colors and can show names.  If your diagram has already
       	been created using regular track icons, they can easily be converted to Indicator
-      	Track icons with <b><a href="../display/CircuitBuilder.shtml">Circuit Builder</a></b>. 
+      	Track icons with <b><a href="../display/CircuitBuilder.shtml">Circuit Builder</a></b>.
       	The <a href="../display/ItemPalette.shtml">Item Palette help</a> provides more information
       	about Indicator Track icons.
       	</p><p>
@@ -44,24 +41,24 @@
       	with OBlocks, even the sections with no sensors. Although Tracker cannot detect
       	when such a "dark block" is entered, it is smart enough to know when a train has
       	passed through one. So it is beneficial to configure them when there is a path
-      	through them connecting one occupancy block with another. 
+      	through them connecting one occupancy block with another.
       	</p><p>
       	The last requirement is each block should have
       	at least one Indicator Track icon configured to display names. The popup
       	window displayed when the <i>Edit Icon</i> menu item is selected
       	has a checkbox labeled "<i>Display Train Name when occupied</i>".
-      	(You must edit with 
+      	(You must edit with
       	<a href="../display/ControlPanelEditor.shtml">Control Panel Editor</a>
-      	to get this window.) 
+      	to get this window.)
       	Check this box to show the current location of a tracked train.
       	</p>
 
       <h2>How to Make a Tracker</h2>
-      	The <b>Warrants</b> menu has a <i>Train Trackers</i> item that opens the 
+      	The <b>Warrants</b> menu has a <i>Train Trackers</i> item that opens the
       	<b>Tracker Table</b> window. The table has a <b>New Tracker...</b> button that
-      	displays a Create Tracker dialog. Enter the name of the train and the block 
+      	displays a Create Tracker dialog. Enter the name of the train and the block
       	that it occupies to make a tracker for the train. The name will appear on
-      	the track icon selected for display in every block the train occupies. As 
+      	the track icon selected for display in every block the train occupies. As
       	train moves track icons change colors and show the name of the tracker
 
 		<h3>An Easier Way to Make a Tracker</h3>
@@ -109,11 +106,11 @@
       	Any block adjacent to the head or tail of its train becoming occupied
       	is assumed to be the move of the train.  However, when two or
       	more trackers have adjacent blocks in common and a common block becomes
-      	occupied, which tracker has actually made the move is indeterminate. 
-      	When this happens a dialog is displayed for the 
+      	occupied, which tracker has actually made the move is indeterminate.
+      	When this happens a dialog is displayed for the
       	panel user to determine which tracked train occupies contested the block.
 
-		<h3>Filtering Multiple Trackers</h3>      	
+		<h3>Filtering Multiple Trackers</h3>
       	When multiple trackers "compete" for occupation of a block there is no way to
       	guarantee the selection of the train actually entering the block.  However,
       	the Tracker Table can make an educated guess. The <b>Multiple Trackers Ranking</b>
@@ -123,7 +120,7 @@
       	based on the following logic:
       	<p>
       	A tracker that has both a path set to exit its current block and a path set to enter
-      	the newly occupied block is chosen over a tracker having only one path exiting 
+      	the newly occupied block is chosen over a tracker having only one path exiting
       	or entering the block. The latter such tracker has precedence over a tracker with
       	neither an exit nor an entrance path set.
       	</p><p>

--- a/help/en/package/jmri/jmrit/logix/Warrant.shtml
+++ b/help/en/package/jmri/jmrit/logix/Warrant.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Warrants Help</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI Warrant Help">
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: Warrants</h1>
       <p>A Warrant in JMRI is a collection of information
@@ -100,7 +97,7 @@
       "../display/CircuitBuilder.shtml">Circuit Builder</a> Help.</p>
 
       <h3>Compatibility with Layout Editor</h3>
-      <p>Layout Editor panel Blocks are created and stored independently from OBlocks, although they can 
+      <p>Layout Editor panel Blocks are created and stored independently from OBlocks, although they can
       share use of the same Sensors for determining block occupancy.  OBlocks, Portals and OPaths can be created manually
       (without using Circuit Builder in a CPE panel) and imported from Layout Editor Blocks (see the command under
       <strong>Options</strong> in the <a href="OBlockTable.shtml">Occupancy Block Table.</a>
@@ -138,7 +135,7 @@
 
         <li><b>Train Trackers</b> - Opens the Tracker Table window.
         The <a href="Tracker.shtml">Train Trackers</a> help page
-        discusses how the movements of a train can be displayed 
+        discusses how the movements of a train can be displayed
         as they move from one occupancy block to another.</li>
 
         <li><b>Create NX Warrant</b> - Opens a window to create a
@@ -150,9 +147,9 @@
         the Warrant and train tracking status messages.</li>
 
         <li><b>Open Circuit builder</b> - Opens a window for
-        the circuit Builder to present its options for 
-        interactively editing and creating OBlocks, Portals, 
-        Paths. Also configures Signals and Indicator Track 
+        the circuit Builder to present its options for
+        interactively editing and creating OBlocks, Portals,
+        Paths. Also configures Signals and Indicator Track
         icons. <a href="../display/CircuitBuilder.shtml">
         Circuit Builder</a> has details.</li>
       </ul>
@@ -179,7 +176,7 @@
       set and verify that the route is properly set on the layout itself.
       Again, the train will proceed according to the <i>elapsed times</i>
       and <i>throttle settings</i> that were recorded.</p>
-	    
+
       <h3>The Importance of Block Path Lengths</h3>
       <p>A Warrant detects a position of its train when it enters
       a block having occupancy detection.  All other positional
@@ -195,11 +192,11 @@
       See <a href="SpeedChanges.shtml">When Warrant Speeds Are Modified</a>
       for what track conditions require speed changes, they are detected
       and how Warrants make gradual changes of speed.
-	    
+
       <h3>Warrant Types</h3>
       <p>There are three types of Warrants available:</p>
       <ul>
-        <li>A <b>Recorded Script Warrant</b>, where throttle commands 
+        <li>A <b>Recorded Script Warrant</b>, where throttle commands
         are recorded from a throttle you use to drive a train over
         preselected route. The Warrant then replicates all the
         commands when played back. To create a Recorded Script
@@ -210,7 +207,7 @@
         <li>An <b>NX Warrant</b> (eNtry/eXit), where throttle commands
         are generated automatically to move a train between Blocks
         chosen by you "on the fly". A dialog allows you to choose
-        start and destination distances and to set the maximum 
+        start and destination distances and to set the maximum
         Throttle settings. To create an NX Warrant,
         select the <b>Warrants &rArr; Tables &rArr; Create NX Warrant</b>
         menu item. More on <a href="NXWarrant.shtml">NX Warrants</a></li>
@@ -298,7 +295,7 @@
       rogue train or even intervention by you to halt the train.<br>
       Warrants are able to deal with these
       restrictions and will modify their <i>"Normal"</i> speeds as needed
-      to comply with the restrictions. 
+      to comply with the restrictions.
       <a href="SpeedChanges.shtml">When Warrant Speeds Are Modified</a>
       explains this relationship.</p>
 
@@ -308,12 +305,12 @@
       commands you make when driving the train over the route. The
       script can then be replayed to drive the train automatically.
       All possible throttle functions can be recorded and played
-      back. <a href="CreateEditWarrant.shtml">Creating and 
+      back. <a href="CreateEditWarrant.shtml">Creating and
       Editing Warrants</a> details how to do this.</p>
 
       <p>With LocoNet you may steal the address and manual
       LocoNet throttle. For other command systems, a WiFi
-      throttle may take the same address as the screen throttle 
+      throttle may take the same address as the screen throttle
       and be used to record a walk around script.</p>
 
       <h4>Generated Scripts</h4>
@@ -326,7 +323,7 @@
 
       <h4>"Normal" Track Speeds</h4>
       When recording a Warrant throttle command script, the train
-      should be run with all track conditions set to "Clear". 
+      should be run with all track conditions set to "Clear".
       NX Warrant script are generated using "Clear" track conditions also.
       This is reported in status messages as the "<b>Normal</b>"
       speed.  However, when running the Warrant, the train may

--- a/help/en/package/jmri/jmrit/logix/WarrantTable.shtml
+++ b/help/en/package/jmri/jmrit/logix/WarrantTable.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Warrant Table Help</title>
   <meta name="author" content="Pete Cressman">
   <meta name="keywords" content="JMRI help Warrant Table">
@@ -13,15 +10,15 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Warrants: The Warrant List</h1>
 
       <p>The Warrant List is a table of all Recorded Warrants.
       It also temporarily lists NX Warrants during the time they
       are in effect. The Warrant List window is a dispatchers sheet
-      to run and control warranted trains. 
+      to run and control warranted trains.
       </p>
       <p>You access the Warrant Table by selecting
       <b>Warrant List</b> from the Warrants menu of your
@@ -153,7 +150,7 @@
 
         <li><b>Train Trackers</b> - Opens the Tracker Table window.
         The <a href="Tracker.shtml">Train Trackers</a> help page
-        discusses how the movements of a train can be displayed 
+        discusses how the movements of a train can be displayed
         as they move from one occupancy block to another.</li>
 
         <li><b>Create NX Warrant</b> - Opens a window to create an
@@ -184,25 +181,25 @@
       to run the train, but additional control of the train can be
       done through the choices provided by the <b>Control/Status</b>
       down down combobox. Note there are two ways to stop the
-      train: <b>Emergency Stop</b> an immediate stop or <b>Halt</b> 
+      train: <b>Emergency Stop</b> an immediate stop or <b>Halt</b>
       that slows the train to a stop smoothly. Once stopped, the
       <b>Resume</b>command will restart it, keeping the Warrant in effect.
        <b>Move into Next Block</b> is "repair" command
       should the train overrun a block and become "Lost". This
       command aligns the Warrant to the next block and restarts the
-      train. The <b>Abort</b> command does an emergency stop and 
+      train. The <b>Abort</b> command does an emergency stop and
       annuls the Warrant.
 
       <p>There are separate operations in the Warrant List
-      table to reserve a Warrant route; the safer <b>Allocate</b> 
+      table to reserve a Warrant route; the safer <b>Allocate</b>
       will not throw turnouts in blocks possibly occupied by
       trains or the
-      <b>Set</b> (allocate and set turnouts). These operations 
+      <b>Set</b> (allocate and set turnouts). These operations
       do not have to be done before running an automated train. They are
       used to preview the route. An <b>AutoRun</b> operation
       can begin without them. The train will seek allocation and
       set turnouts as it proceeds on the route.</p>
-      
+
       <h3>Automatic control of trains</h3>
       Whenever a warranted train has
       permission to enter the next Block, the turnouts are reset
@@ -211,7 +208,7 @@
       have permission the enter a block, no turnouts for the
       route are thrown in the block or in the blocks beyond it.
 
-      <p>"Stop" aspects of Signals, detection of occupancy or 
+      <p>"Stop" aspects of Signals, detection of occupancy or
       allocation to another warrant will deny permission for
       a warranted train to enter a block. Also, signals may
       prescribe speed restrictions. Whenever the train
@@ -221,7 +218,7 @@
       throttle commands and issue throttle commands it calculates
       to ramp the train's speed smoothly to meet the required
 	  speed or stop just before entering the block.</p>
-      
+
       <p>When permission to enter a block is denied, a warranted
       train will not move. Clearing these conditions causing
       the a denial is cleared, the
@@ -235,7 +232,7 @@
       with Signal Heads or Signal Masts protecting the blocks they
       join, the train will modify the speed according to the
       appearance or aspect of the signal. <a href="SpeedChanges.shtml">
-      When Warrant Speeds Are Modified</a> has details about 
+      When Warrant Speeds Are Modified</a> has details about
       how Warrants modifyrecorded speeds.</p>
 
       <h3>When the Starting block is Unoccupied</h3>

--- a/help/en/package/jmri/jmrit/mailreport/Report.shtml
+++ b/help/en/package/jmri/jmrit/mailreport/Report.shtml
@@ -2,22 +2,19 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Send Problem Report</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: Upload Debugging Information</h1>
-      
-      <b>Note:  This tool is now obsolete.  Please 
-      see the new 
+
+      <b>Note:  This tool is now obsolete.  Please
+      see the new
       <a href="../../../apps/util/issuereporter/swing/IssueReporter.shtml">"Report Issue ..." menu item</a>
       instead.</b>
       <a href="SampleReportForm.png"><img src="SampleReportForm.png" height="25%" width="25%" align="right"></a>

--- a/help/en/package/jmri/jmrit/messager/MessageFrame.shtml
+++ b/help/en/package/jmri/jmrit/messager/MessageFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: Send Throttle Message</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: Send Throttle Message</h1>JMRI has a limited
       ability to send messages to a hand-held throttle.

--- a/help/en/package/jmri/jmrit/roster/swing/RosterGroupTable.shtml
+++ b/help/en/package/jmri/jmrit/roster/swing/RosterGroupTable.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>Roster Grouping</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Roster Grouping">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Roster Grouping</h1>
 

--- a/help/en/package/jmri/jmrit/roster/swing/speedprofile/SpeedProfileFrame.shtml
+++ b/help/en/package/jmri/jmrit/roster/swing/speedprofile/SpeedProfileFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Speed Profiling</title>
   <meta name="author" content="Kevin Dickerson">
   <meta name="keywords" content="JMRI help Roster Speed Profiling">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Roster Speed Profiling</h1>
 

--- a/help/en/package/jmri/jmrit/signalling/AddEditSignalingLogic.shtml
+++ b/help/en/package/jmri/jmrit/signalling/AddEditSignalingLogic.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Adding/Editing Signal Mast Logic</title>
   <!-- copy from jmrit/beantable/ to  jmrit/signalling/ to keep identical-->
   <meta name="author" content="Kevin Dickerson, Egbert Broerse">
@@ -15,8 +12,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <a name="Adding_Editing_Routes"
       id="Adding_Editing_Routes"></a>

--- a/help/en/package/jmri/jmrit/signalling/SignallingSourceFrame.shtml
+++ b/help/en/package/jmri/jmrit/signalling/SignallingSourceFrame.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Signal Group Table</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-  <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: Signal Logic Source Frame</h1>
       <p>From this window you

--- a/help/en/package/jmri/jmrit/simpleclock/SimpleClockFrame.shtml
+++ b/help/en/package/jmri/jmrit/simpleclock/SimpleClockFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Setup Fast Clock</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Setup Fast Clock">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
     <h1>Fast Clock Setup </h1>
 

--- a/help/en/package/jmri/jmrit/speedometer/SpeedometerFrame.shtml
+++ b/help/en/package/jmri/jmrit/speedometer/SpeedometerFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Speedometer</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Route Add Edit">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Speedometer</h1>
 

--- a/help/en/package/jmri/jmrit/symbolicprog/tabbedframe/PaneOpsProgFrame.shtml
+++ b/help/en/package/jmri/jmrit/symbolicprog/tabbedframe/PaneOpsProgFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2009 -->
   <!-- Copyright Walt Thompson 2010 -->
 
@@ -13,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: DecoderPro Operations Mode Programmer</h1><a name=
       "contents" id="contents"></a>

--- a/help/en/package/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.shtml
+++ b/help/en/package/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2009 -->
   <!-- Copyright Walt Thompson 2010 -->
 
@@ -13,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: DecoderPro Service Mode Programmer</h1><a name=
       "contents" id="contents"></a>
@@ -46,10 +44,10 @@
       <ul>
       <li>
       The top field is labelled "ID".
-      Each roster entry has an identifier (also called Roster ID) by 
+      Each roster entry has an identifier (also called Roster ID) by
       which it's known. This is your name for it.
       When the program wants you to select a Roster
-      entry, it will ask you to pick from a selection box or menu containing 
+      entry, it will ask you to pick from a selection box or menu containing
       Roster IDs. You can use anything you want for this:
       Road number, type, even "That crummy old model I need to
       repaint" or "My beautiful Shay".
@@ -62,27 +60,27 @@
       You can change this at any time later,
       just remember to save the entry to make the new ID permanent.</p>
 
-      <li>Road Name, Road Number, Manufacturer, Owner, Model, 
+      <li>Road Name, Road Number, Manufacturer, Owner, Model,
       Comment and Decoder Comment are for you to use as you see fit.
       Some people put information in all of these, some in none of them.
-      See the 
+      See the
       <a href="../../../../apps/gui3/dp3/DecoderPro3.shtml">help on the main DecoderPro window</a>
       for what appears there when you fill them out.
-      
+
       <li>The Throttle Speed Limit sets the Maximum throttle
       percentage allowed when using various JMRI throttle tools.
-      
+
       <li>The DCC Address field is the active DCC address for this
       loco. It comes from the locomotive settings, and you can't change it
       here. See the <a href="#Basic">Basic Pane</a>.
 
       <li>The Decoder Family and Decoder Model values were defined
       when you created this entry earlier.  They can't be changed.
-      The Date Modified value is updated automatically when you 
-      save the entry to the roster.  After the first time you 
+      The Date Modified value is updated automatically when you
+      save the entry to the roster.  After the first time you
       do that, the filename entry will appear.
       </ul>
-        
+
       <p>The Save button stores the current decoder information to
       your Roster folder. The default storage is in the same
       directory the Preferences are stored in.</p>

--- a/help/en/package/jmri/jmrit/throttle/ThrottleFrame.shtml
+++ b/help/en/package/jmri/jmrit/throttle/ThrottleFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Throttle</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Setup Fast Clock">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI Throttle</h1>This is the quick reference page for
       the JMRI Throttle tool.<br>

--- a/help/en/package/jmri/jmrit/webThrottle/webThrottle.shtml
+++ b/help/en/package/jmri/jmrit/webThrottle/webThrottle.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: webThrottle - Web control for locos, panels,
   turnouts and routes</title>
   <!--#include virtual="/Style.shtml" -->
@@ -12,8 +9,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: webThrottle - Web control for locos, panels,
       turnouts and routes</h1>

--- a/help/en/package/jmri/jmrix/AbstractMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/AbstractMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Communications Monitor Window</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help monitor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Communications Monitor Window</h1>JMRI provides a
       communications monitor window so you can see what's happening

--- a/help/en/package/jmri/jmrix/acela/acelamon/AcelaMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/acela/acelamon/AcelaMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Monitor CTI Acela Traffic</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Monitor CTI Acela Traffic</h1>
       This is the

--- a/help/en/package/jmri/jmrix/acela/nodeconfig/NodeConfigFrame.shtml
+++ b/help/en/package/jmri/jmrix/acela/nodeconfig/NodeConfigFrame.shtml
@@ -12,8 +12,8 @@
 
 <body>
 <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
 <h1>Acela Node Configuration Tool</h1>
 
@@ -46,7 +46,7 @@ So, if you make a change and SAVE your configuration file (by pressing the SAVE 
 <p>
 This is all fine and dandy until you realize that you were not connected to your layout and just lost your CTI Acela custom configuration (see below).
 <p>
-So, again, make backup copies of your configuration files (i.e. DecoderProConfig2.xml, PanelProConfig2.xml) often and store them in a safe place. 
+So, again, make backup copies of your configuration files (i.e. DecoderProConfig2.xml, PanelProConfig2.xml) often and store them in a safe place.
 
 <h2>Connecting to Your CTI Acela System
 </h2>
@@ -94,7 +94,7 @@ It will look something like (note the second "connection port" line):
 <p>
 &lt;/layout-config&gt;
 
-<h3>Let JMRI discover your CTI Acela network configuration  
+<h3>Let JMRI discover your CTI Acela network configuration
 </h3>
 Restart JMRI (DecoderPro or PanelPro).  If you specified the correct serial port in the previous step then the JMRI software should automatically connect to the CTI Acela network, reset the Acela node and then poll the CTI Acela network and discover which modules (JMRI calls a module a node) you have and in what order.
 <p>
@@ -371,14 +371,14 @@ Remember to save your new configuration by using the Save button in the Preferen
 		<ul>
 		<li>If no control power is applied to the relay then the circuit between the common terminal and the normally closed terminal will be closed, that is, it will behave as if a switch is turned on.
 		<li>When wired in this manner the output circuit will operate opposite of normal -- that is, Off will mean on and On will mean off.
-		<li>This is useful if you want the circuit to behave as if the relay were not there when the module has no power or has not been initialized. 
+		<li>This is useful if you want the circuit to behave as if the relay were not there when the module has no power or has not been initialized.
 		<li>This could switch track power off if wanted, but would default to on if no control power was applied to the CTI module (i.e. the CTI units are not powered up or not initialized).
 		</ul>
 		<li>As a router
 			<ul>
 			<li>When wired in this manner the signal is connected to the common terminal and then one possible route is connected to the NO terminal and the second possible route is connected to the NC terminal.
-			<li>This is useful if you want the relay to route say DCC current to the rail (say, via the NC terminal) or route say Programming Mode current to the rail (say, via the NO terminal). 
-			<li>Another use for this would be to control a Tortoise Switch Machine by routing either +voltage or -voltage to the stall motor. 
+			<li>This is useful if you want the relay to route say DCC current to the rail (say, via the NC terminal) or route say Programming Mode current to the rail (say, via the NO terminal).
+			<li>Another use for this would be to control a Tortoise Switch Machine by routing either +voltage or -voltage to the stall motor.
 			<li>When used in this mode, set the default to Normally Open or Normally Closed depending upon how you want the circuit to operate if no control power was applied to the CTI module (i.e. the CTI units are not powered up or not initialized).
 			</ul>
 		</ul>

--- a/help/en/package/jmri/jmrix/acela/packetgen/AcelaPacketGenFrame.shtml
+++ b/help/en/package/jmri/jmrix/acela/packetgen/AcelaPacketGenFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Send CTI Acela Message</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Send CTI Acela Message</h1>This is the
       help/jmri/jmrix/acela/packetgen/SerialPacketGenFrame help

--- a/help/en/package/jmri/jmrix/bachrus/SpeedoConsoleFrame.shtml
+++ b/help/en/package/jmri/jmrix/bachrus/SpeedoConsoleFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: SpeedoConsole</title>
   <meta name="author" content="Andrew Crosland">
   <meta name="author" content="Dennis Miller">
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Bachrus Speedometer</h1>
       - awaiting image -<br>

--- a/help/en/package/jmri/jmrix/can/cbus/swing/bootloader/CbusBootloaderPane.shtml
+++ b/help/en/package/jmri/jmrix/can/cbus/swing/bootloader/CbusBootloaderPane.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: CBUS&reg; Bootloader Tool</title>
   <meta name="author" content="Andrew Crosland">
   <meta name="keywords" content="JMRI CBUS Bootloader">
@@ -13,45 +10,45 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
     <h1>JMRI : CBUS&reg; Bootloader Tool</h1>
 
-    <p>The bootloader tool allows you to update the firmware in a connected CBUS 
+    <p>The bootloader tool allows you to update the firmware in a connected CBUS
         node</p>
-    <p>To update the firmware you will need a firmware programming file (.hex 
+    <p>To update the firmware you will need a firmware programming file (.hex
         file) saved on your computer</p>
     <p>Start the firmware update tool from the SPROG generation 5 menu.<br><br></p>
     <img src="images/FirmwareMenu.png" alt="CBUS menu entry for bootloader client">
     <p></p>
-    
-    <p>Enter the Node Number (the default is 65534) and click Read Node 
+
+    <p>Enter the Node Number (the default is 65534) and click Read Node
         Parameters.<br><br></p>
     <img src="images/UpdateNN.png" alt="Select Node Number to be updated">
     <p></p>
-    
+
     <p>Browse to wherever you saved the .hex file and click Open.<br><br></p>
     <img src="images/BrowseToHexFile.png" alt="Browse to the new firmware hex file">
     <p></p>
-    
+
     <p>Select EEPROM Memory Option to preserve EEPROM contents (Node Variables).<br><br></p>
     <img src="images/SelectEEPROM.png" alt="Select preserve EEPROM">
     <p></p>
-    
+
     <p>Click the Start Programming button.<br><br></p>
     <img src="images/StartProgramming.png" alt="Start programming">
     <p></p>
-    
-    <p>The new firmware will be written to the node. Wait fro the programming to 
-        complete, which may take a little while, indicated by the "Bootloading 
+
+    <p>The new firmware will be written to the node. Wait fro the programming to
+        complete, which may take a little while, indicated by the "Bootloading
         complete..." message in the console.<br><br></p>
     <img src="images/Wait.png" alt="Wait for programming to complete">
     <p></p>
-    
+
     <h2></h2>
     <p>CBUS is a registered trade mark of Dr Michael Bolton</p>
-      
+
     <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorPane.shtml
+++ b/help/en/package/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorPane.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: CBUS&reg; Console Tool</title>
   <meta name="author" content="Steve Young">
   <meta name="keywords" content="JMRI CBUS Command station throttle session monitor cancmd">
@@ -13,27 +10,27 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
      <h1>JMRI : CBUS Command Station Monitor</h1>
         <p>Main Table - Monitoring train sessions.</p>
 
-    <h3>Top Menu Items</h3>    
-        <p>Stop All Button - This is different to the JMRI throttle stop all in that this sends 
+    <h3>Top Menu Items</h3>
+        <p>Stop All Button - This is different to the JMRI throttle stop all in that this sends
         a system-wide stop, not just to JMRI throttles.</p>
         <p>Track Power Button - On / Off / Unknown</p>
         <p>Signal data Button - On / Off - Experimental</p>
         <p>Session Columns Dropdown - Choose which columns to display in table</p>
-        
+
     <h2>Main Table - Train List</h2>
-        <p> Every train heard on the network will be added to the table, 
+        <p> Every train heard on the network will be added to the table,
         there is one row per loco.</p>
-        <p>Train speed and direction, function status etc. are updated in real time 
-        according to the latest instruction by 
-        a JMRI throttle, MERG CANCAB throttle controller, 
+        <p>Train speed and direction, function status etc. are updated in real time
+        according to the latest instruction by
+        a JMRI throttle, MERG CANCAB throttle controller,
         or CBUS connected Command Station.</p>
-        
+
         <h3>Train Session columns : </h3>
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/command-station/cs-session-626x179.png"
         width="626" height="179" alt="CBUS Command Station Monitor Session Columns">
@@ -48,13 +45,13 @@
         <li>Speed Steps ( System defaults to 128 )</li>
         <li>Consist ID</li>
         <li>Flags</li>
-        
+
         </ul>
-        
+
     <h3><a name="opc" id="opc">Supported Operation Codes</a></h3>
 
     <p>Sent by the Command Station Monitor</p>
-    
+
         <ul>
         <li>QLOC </li>
         <li>RSTAT </li>
@@ -65,7 +62,7 @@
 
 
       <p>Listeners for message sent, either by JMRI itself or external to JMRI</p>
-    
+
         <ul>
         <li>PLOC </li>
         <li>RLOC </li>
@@ -90,21 +87,21 @@
         </ul>
 
     <h3>JMRI Help</h3>
-        
+
         <p>The Cab Signalling tool <a name="cabdata" id="cabdata"></a>previously within this monitor
         has been relocated to the dedicated
         JMRI Cab Signal.</p>
-        
-        <p>You can view this help page within JMRI by selecting Help > Window Help in the top bar of the 
+
+        <p>You can view this help page within JMRI by selecting Help > Window Help in the top bar of the
         CBUS Command Station Monitor.</p>
-      
+
         <p><a href="../../../../../../../html/hardware/can/cbus/index.shtml">Main JMRI CBUS Help page</a>.</p>
-        
-        <p>View debug information for the Command station Monitor by adding 
-        log4j.category.jmri.jmrix.can.cbus.swing.cbusslotmonitor=DEBUG 
+
+        <p>View debug information for the Command station Monitor by adding
+        log4j.category.jmri.jmrix.can.cbus.swing.cbusslotmonitor=DEBUG
         to your default.lcf file.</p>
-        
-        
+
+
         <h2></h2>
         <p>CBUS&reg; is a registered trade mark of Dr Michael Bolton</p>
         <p></p>

--- a/help/en/package/jmri/jmrix/can/cbus/swing/configtool/ConfigToolFrame.shtml
+++ b/help/en/package/jmri/jmrix/can/cbus/swing/configtool/ConfigToolFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <meta name="keywords" content="JMRI help CBUS event capture">
   <title>JMRI: CBUS&reg; Event Capture Tool</title>
   <!--#include virtual="/Style.shtml" -->
@@ -11,18 +9,18 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
      <h1>JMRI: CBUS Event Capture Tool</h1>
-      
+
       <ul class="nav">
       <li><a href="#examinemultipleevents">Examine Multiple Events</a></li>
       <li><a href="#eventid">Manual entry of the Event ID</a></li>
       <li><a href="#capturenextevent">Capture the Next event</a></li>
-      <li><a href="#filterhighlight">Filter and Highlight Events</a></li>      
+      <li><a href="#filterhighlight">Filter and Highlight Events</a></li>
       </ul>
-      
+
       <img src="../../../../../../../html/hardware/can/cbus/images/swing/event-capture/event-capture-413x677.png"
        alt="Event Capture Tool screenshot" width="413" height="677" align="right">
 
@@ -35,11 +33,11 @@
       "../../../../../../../html/hardware/can/cbus/index.shtml">configure
       JMRI Sensors, Turnouts and Lights</a>, you need to identify the
       associated CBUS events. There are several ways to do this.</p>
-      
-      <p>This page uses the capture tool to configure a Sensor as an example, 
+
+      <p>This page uses the capture tool to configure a Sensor as an example,
       similar methods work for Turnouts and Lights.</p>
 
-     <h3><a name="examinemultipleevents" id="examinemultipleevents" 
+     <h3><a name="examinemultipleevents" id="examinemultipleevents"
      >Examine Multiple Events</a></h3>
       <p>The upper part of the screen
       can capture multiple CBUS Events, which you can then use to
@@ -55,8 +53,8 @@
       paste it into the boxes in the lower part of the window. If
       your computer allows it, you can also just drag and drop the
       value into the lower field.</p>
-      
-      
+
+
      <h3><a name="eventid" id="eventid">Manually enter the Event ID</a></h3>
       <p>You can just type an <a href=
       "../../../../../../../html/hardware/can/cbus/index.shtml">Event
@@ -88,29 +86,29 @@
 
      <h3><a name="filterhighlight" id="filterhighlight"
      >Filtering and Highlighting</a></h3>
-      <p>You can open up a new 
-      <a href="../console/CbusConsoleFrame.shtml#filter">filter</a> or 
+      <p>You can open up a new
+      <a href="../console/CbusConsoleFrame.shtml#filter">filter</a> or
       <a href="../console/CbusConsoleFrame.shtml#highlighter">event highlighter</a>
       window by clicking on the buttons at top of the screen.
         </p>
 
-      <p>You can also open the Capture Tool via the 
+      <p>You can also open the Capture Tool via the
       <a href="../console/CbusConsoleFrame.shtml">Console Log</a>.
-      <br>In this case, the filter and event highlighter used by 
+      <br>In this case, the filter and event highlighter used by
       the console log will be shared with the capture tool.
       </p>
-      
-      
-      
-      
+
+
+
+
     <img src="../../../../../../../html/hardware/can/cbus/images/swing/event-capture/merg-cbus-event-capture-title-525x88.png"
        alt="Event Capture Tool Title" height="88" width="525">
-      
-    <p>Any windows opened this way can be identified by the title.</p>  
-      
+
+    <p>Any windows opened this way can be identified by the title.</p>
+
 
     <h3>JMRI Help</h3>
-    
+
       <p>Once you've created a CBUS Sensor or
       Turnout, you can use the <a href=
       "../../../../../jmrit/beantable/SensorTable.shtml">Sensor
@@ -123,16 +121,16 @@
       <p>The <a href="../console/CbusConsoleFrame.shtml">CBUS
       Console</a> can help you figure out what events are happening
       on your layout.</p>
-      
+
       <p>You can view this help page within JMRI by selecting Help > Window Help in the top bar of the CBUS Event Capture window.</p>
-      
+
       <p><a href="../../../../../../../html/hardware/can/cbus/index.shtml">Main JMRI CBUS Support page</a>.</p>
 
         <h2></h2>
         <p>CBUS&reg; is a registered trade mark of Dr Michael Bolton</p>
         <p></p>
 
-      
+
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrix/can/cbus/swing/console/CbusConsoleFrame.shtml
+++ b/help/en/package/jmri/jmrix/can/cbus/swing/console/CbusConsoleFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: CBUS&reg; Console Tool</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI CBUS help monitor console log logging event long short">
@@ -13,11 +10,11 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
      <h1>JMRI : CBUS Console Tool</h1>
-     
+
      <ul class="snav">
       <li><a href="#logtofile">Logging</a></li>
       <li><a href="#stats">Statistics</a></li>
@@ -27,36 +24,36 @@
       <li><a href="#highlighter">Highlighter</a></li>
       <li><a href="#eventcapture">Event Capture Tool</a></li>
      </ul>
-     
+
       <img src="../../../../../../../html/hardware/can/cbus/images/swing/console/merg-cbus-console-min-631x357.png"
       width="400" height="226" alt="Initial Merg Cbus Console Tool Screen" align="right">
-      
+
         <p>JMRI provides a communications monitor window so you can
         see what's happening on the layout network.</p>
-    
+
         <p>Once you open a Console window, it will automatically
         display all traffic.<br>
         The left part contains the raw CAN frames. The right part
         interprets their CBUS meaning.</p>
-        
-        <p>If the CBUS event table is running, the event table will be queried for 
+
+        <p>If the CBUS event table is running, the event table will be queried for
         event and node names.</p>
-        
-        <p>You can open multiple console windows, whereby an 
+
+        <p>You can open multiple console windows, whereby an
         instance number is added to the title bar.
-        <br> This number is also added to any Filter, Highlight or 
+        <br> This number is also added to any Filter, Highlight or
         event Capture windows which are opened via the console.</p>
-        
-        
+
+
         <p>You can drag the window boundaries between these to suit your display.</p>
         <p>The vertical scrollbar synchronises both windows.</p>
-        
+
         <p>Short CBUS events appear in the Console with a node number of 00.</p>
-        
+
     <h3>Buttons</h3>
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/console/merg-cbus-console-max-400x396.png"
         width="400" height="396" alt="Merg Cbus Console Tool Screen Expanded" align="right">
-      
+
        <dl>
         <dt>Clear Screen</dt>
         <dd>Erases the log area at the top of the screen.</dd>
@@ -66,7 +63,7 @@
         information stops scrolling up.</dd>
 
        </dl>
-        
+
     <h3>Checkboxes</h3>
         <dl>
         <dt>Timestamps</dt>
@@ -79,68 +76,68 @@
         <dd>If you'd like each message to be preceded by the CBUS
         priorities used in sending the message, check this
         box.</dd>
-        
+
         <dt>Direction</dt>
         <dd>Displays a visual clue to network flow.</dd>
-        
+
         <dt>CanID</dt>
         <dd>Displays the Can ID of the message sender.</dd>
-        
+
         <dt>RTR</dt>
         <dd>Displays the RTR status of the CAN message.</dd>
 
         <dt>OPC</dt>
         <dd>Displays the OPC of the message.</dd>
-        
+
         <dt>OPC Extra</dt>
         <dd>Displays extra information on the OPC.</dd>
 
         <dt>Address</dt>
         <dd>Displays the CBUS short an ID of the message.
-        <br>You can use this to enter as a CBUS hardware 
+        <br>You can use this to enter as a CBUS hardware
         address for sensor inputs or turnout and light outputs.</dd>
 
         <dt>CAN</dt>
         <dd>Displays the CAN message as appears in left side of main console.
         <br>Enables Including the CAN message in your log files.</dd>
-        
+
         </dl>
-        
-        
+
+
      <h2><a name="logtofile" id="logtofile">Logging To A File</a></h2>
         <div>
-        
+
         <p>Sometimes, it's helpful to capture
         what's happening. For example, you might encounter a bug
         (!!), and want to send a copy of what's happening to the
         people who are trying to fix it.</p>
-    
+
         <p>Small amounts of data can be copied from the log window
         with your computers "copy" command (e.g. ctrl-C or cmd-C),
         and then pasted into an email.</p>
-    
+
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/console/merg-cbus-console-logging-771x49.png"
         width="771" height="49" alt="CBUS Console Logging to File">
-    
+
         <p>If you want to capture more, you can have the window write
         a log file on your computer's disk. To do this:</p>
-    
+
         <ol>
             <li>Click "Choose log file". A file-chooser window will
             open. Navigate to where you want to store the file, enter a
-            name for the new log file, and click "Save". 
+            name for the new log file, and click "Save".
             <br><b>Note that if
             you pick a file that already exists, it will be
             overwritten.</b> </li>
-    
+
             <li>When you're ready to capture the data you want, click
             "Start logging" on the monitor window.</li>
-    
+
             <li>When you're done, click "Stop logging" to store the
             data and close the file.</li>
         </ol>
-        
-        <p>You can view contents of the log file by clicking on the 
+
+        <p>You can view contents of the log file by clicking on the
         Open Log File Button. </p>
 
         <p>If you'd like to annotate the message log with your own
@@ -152,8 +149,8 @@
         <div>
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/console/merg-cbus-console-statistics-608x73.png"
         width="608" height="73" alt="CBUS Console Statistics">
-    
-    
+
+
         <p>This part of the window shows the
         number of packets received and transmitted.</p>
 
@@ -163,7 +160,7 @@
         <div>
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/console/merg-cbus-console-packets-810x131.png"
         width="810" height="131" alt="CBUS Console Packets">
-    
+
         <p>This displays the most
         recent packet received from the layout, along with a send packet tool.
         <br>The individual
@@ -190,7 +187,7 @@
         <div>
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/console/merg-cbus-console-send-event-494x59.png"
         width="494" height="59" alt="CBUS Console Send Event">
-    
+
         <p>At the bottom part of the Console, you can construct an Event
         packet to be sent to the layout. For normal operation, do not
         edit the preloaded values in the dynamic and normal priority
@@ -218,7 +215,7 @@
         <dt>Clear</dt>
         <dd>Clears the data entry fields and preloads the priority
         values.</dd>
-        
+
         <dt>Decimal Data Entry/Display</dt>
         <dd>When the decimal data entry/display checkbox
         is not selected (hexadecimal mode), any value with three or
@@ -228,41 +225,41 @@
         </dd>
       </dl>
         </div>
-        
+
     <h2><a name="filter" id="filter">Filter</a></h2>
         <div>
-        
-        <p>The filter logic works from top-to-bottom, 
+
+        <p>The filter logic works from top-to-bottom,
         following the order of the list for any applicable categories.</p>
 
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/filter/filter-426x254.png"
-        width="426" height="254" alt="CBUS Filter">        
-        
+        width="426" height="254" alt="CBUS Filter">
+
         <p>The filter listens for new nodes heard on the network,
         when a new node is heard it is listed under Nodes and is filterable.</p>
-        
-        <p>The minimum and max event ( device ) number filter 
+
+        <p>The minimum and max event ( device ) number filter
         also applies to data device numbers.</p>
-        
-        <p>The node filter works for all OPCs with a 2 byte node value, 
+
+        <p>The node filter works for all OPCs with a 2 byte node value,
         including node programming.</p>
 
         <p>To see which OPC's are included mouse-over the sub-category. <br>
         ( You can set the time the tooltip is displayed for in Main Prefernces > Display ).</p>
 
         <p>OPC's are not modified to a short event if no node number is detected.<br>
-        ( You could identify these by filtering short events, passing long events, 
+        ( You could identify these by filtering short events, passing long events,
         and then filter by node number less than 1 ).</p>
 
         <p>
         When a filter is changed between pass and filter, this is displayed in the console log.</p>
 
         <p>Changing the settings takes effect instantly.</p>
-        
+
         <h3>Filter Categories</h3>
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/filter/events-426x413.png"
         width="426" height="413" align="right" alt="CBUS Event Filter">
-        
+
         <ul>
         <li>Incoming</li>
         <li>Outgoing</li>
@@ -332,59 +329,59 @@
         </li>
         </ul>
         </div>
-        
-    <h2><a name="highlighter" id="highlighter">Event Highlighter</a></h2>        
+
+    <h2><a name="highlighter" id="highlighter">Event Highlighter</a></h2>
         <div>
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/highlighter/merg-cbus-highlighter-460x337.png"
-        width="460" height="337" alt="CBUS Event Highlighter">  
-        
+        width="460" height="337" alt="CBUS Event Highlighter">
+
         <p>This window can be accessed from the Display options at top of the main console.</p>
-        
+
         <p>It can highlight a specific node or event CBUS message, both on and off options.</p>
-        
+
         <p>You will need at least 1 type ( or / off ) and 1 direction ( in / out ) to activate the highlight.</p>
-        
+
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/highlighter/merg-cbus-console-highlighter-output-616x146.png"
-        width="616" height="146" alt="CBUS Event Highlighter Output"> 
+        width="616" height="146" alt="CBUS Event Highlighter Output">
         </div>
 
     <h2><a name="eventcapture" id="eventcapture">Event Capture</a></h2>
         <div>
         <p>You can open a new Event Capture window from within the Console tool.
         The capture tool will share an event highlighter or filter with the console it was opened with.</p>
-        
+
             <img src="../../../../../../../html/hardware/can/cbus/images/swing/event-capture/merg-cbus-event-capture-title-525x88.png"
        alt="Event Capture Tool Title" height="88" width="525">
-        
-        
-        <p>For more information, see the 
+
+
+        <p>For more information, see the
         <a href="../configtool/ConfigToolFrame.shtml"
         >Event Capture Tool</a>.</p>
-        
+
         <p>This window will close when the main console window is closed.</p>
-        
+
         </div>
 
-        
+
     <h3><a name="opc" id="opc">Supported Operation Codes</a></h3>
-      
+
         <p>All OPCs supported, additional OPC information available.</p>
         <p>Received OPCS can be from either other JMRI components,
         or from an external CBUS connection.</p>
         <p>Very minor changes to OPC description text for increased screen readability.</p>
 
     <h3>JMRI Help</h3>
-      
+
       <p>You can view this help page within JMRI by selecting Help > Window Help in the top bar of the CBUS Console window.</p>
-      
+
       <p><a href="../../../../../../../html/hardware/can/cbus/index.shtml">Main JMRI CBUS Help page</a>.</p>
-        
-        
+
+
         <h2></h2>
         <p>CBUS&reg; is a registered trade mark of Dr Michael Bolton</p>
         <p></p>
 
-        
+
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestTablePane.shtml
+++ b/help/en/package/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestTablePane.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <meta name="keywords" content="JMRI CBUS help support event request feedback monitor monitoring tool">
   <title>JMRI: CBUS&reg; Event Request Table</title>
   <!--#include virtual="/Style.shtml" -->
@@ -11,80 +9,80 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: CBUS Event Request Monitor Table</h1>
-      
+
         <ul class="snav">
         <li><a href="#stats">Columns</a></li>
         <li><a href="#status">Requesting Event Status</a></li>
         <li><a href="#opc">OPCs</a></li>
         </ul>
-      
+
       <img src="../../../../../../../html/hardware/can/cbus/images/swing/event-table/ev-table-630x210.png"
       width="630" height="210" alt="CBUS Event Request Table" align="right">
 
       <p>The CBUS Event Table displays event information on your <a href=
       "../../../../../../../html/hardware/can/cbus/index.shtml">CBUS</a>
       connection.</p>
-      
+
       <p>Both incoming to JMRI and outgoing messages are logged to the table.</p>
 
-      <p>While the window is open, it will maintain a list of short on / off events, 
+      <p>While the window is open, it will maintain a list of short on / off events,
       long on / off events, extended OPC on / off events, on / off accessory response events.</p>
 
-      
+
       <p>Each event and node combination is unique, the maximum event number is 65,535.</p>
       <p>The maximum node number is also 65,535.</p>
-      
+
       <p>The table will always start with no entries, data is not maintained between sessions.</p>
-      
+
       <p>You can open the table automatically by adding it to your JMRI startup action list.
       <br>PanelPro > Edit Preferences > Start Up > Add > Perform Action > Open CBUS Event Table.
       </p>
 
       <p>Short event codes will be stripped of any node number contained within the event CAN message.</p>
       <p>All numeric values decimal.</p>
-      
+
 
     <h2><a name="stats" id="stats">Columns</a></h2>
 
       <p>Columns can be selected for display via the top menu bar,
       these are split into 2 categories.</p>
-      
+
         <ul>
         <li>Event Columns</li>
         <li>Feedback Columns</li>
         </ul>
-      
+
         <p>The column order can be rearranged by dragging the column header. </p>
         <p>Change the column sort order by left clicking on the column header.</p>
-      
+
     <h3>Event Columns</h3>
-    
+
         <ul>
         <li>Event : Event ( or device ) number reported within an event CAN message.</li>
         <li>Node : Node number reported by an event CAN message.</li>
-        <li>Event Name .</li>  
+        <li>Event Name .</li>
         <li>Send Request : Sends a request event. If the the event has a node number, this will be a long event otherwise short.</li>
         <li>Delete : ( The request event will be re-added to the table if re-heard on the network. )</li>
         </ul>
-        
-    
-    <h3>Feedback Columns</h3>  
-    
+
+
+    <h3>Feedback Columns</h3>
+
     <ul>
       <li>FB Status - Status of the very last feedback request.  OK, Waiting or NO Feedback.</li>
-      
+
       <li>FB reqiured - Number of response events required to prove.</li>
 
-      <li>FB Outstanding - Number of feedback events are currently outstanding.</li> 
-      
+      <li>FB Outstanding - Number of feedback events are currently outstanding.</li>
+
       <li>FB Timeout - ms before alerts set in.</li>
-      
+
       <li>FB Event - If another event is feedback for this event, add the other event number.</li>
-      
+
       <li>FB Node - If another event is feedback for this event, add the other event node number.</li>
      </ul>
 
@@ -92,29 +90,29 @@
       <p>When an event is sent by JMRI which has a number in the feedback response column,
       the event request table will listen for its response and warn if this is not received.
       </p>
-      
-      <p>The system will listen for a feedback event in the 
+
+      <p>The system will listen for a feedback event in the
       form of a response event, or a normal on off event.
-      The response events do not have to status ( on or off ) match, 
+      The response events do not have to status ( on or off ) match,
       and can be any of the data lengths.</p>
-   
+
       <img src="../../../../../../../html/hardware/can/cbus/images/swing/event-table/merg-cbus-ev-table-feedback-792x221.png"
-      width="792" height="221" alt="CBUS Event Table Feedback" >      
-      
+      width="792" height="221" alt="CBUS Event Table Feedback" >
+
     <h3><a name="status" id="status">Requesting Event Status</a></h3>
         <div>
-      <p>On clicking Status, JMRI sends an event accessory status request message 
+      <p>On clicking Status, JMRI sends an event accessory status request message
       to the network, long if the event has a node, short if without.</p>
-      <p>This triggers a JMRI event listener which awaits a response 
-      from the event, either a request response or a normal event 
+      <p>This triggers a JMRI event listener which awaits a response
+      from the event, either a request response or a normal event
       is accepted as a response.</p>
-      <p>If nothing is set in event feedback, the default timeout is 
+      <p>If nothing is set in event feedback, the default timeout is
       4 seconds from the same event and node combination.</p>
-      <p>Some users may want to create a new JMRI turnout, sensor or light 
+      <p>Some users may want to create a new JMRI turnout, sensor or light
       to represent the get status button and send the event request status message.
-      
+
       <br>The hardware addresses for these request events would look something like:</p>
-      
+
         <table border="1">
         <tbody>
         <tr>
@@ -130,40 +128,40 @@
         <td>Accessory Request Short</td>
         <td>0</td>
         <td>123</td>
-        </tr>      
+        </tr>
         <tr>
         <td>X92007B01C8</td>
         <td>92</td>
         <td>Accessory Request Long</td>
         <td>123</td>
         <td>456</td>
-        </tr>  
+        </tr>
         </tbody>
         </table>
-      
-      <p>There are a few methods within JMRI of sending this event to ping every few seconds, 
-      one being to create a jython script to ping 1 sensor every few seconds, 
+
+      <p>There are a few methods within JMRI of sending this event to ping every few seconds,
+      one being to create a jython script to ping 1 sensor every few seconds,
       and use logix on this 1 sensor to create other ping event status requests outputs.</p>
 
-      <p>When an event response request message is heard on the network, 
+      <p>When an event response request message is heard on the network,
       the event table will listen for event feedback.</p>
       </div>
-        
-      
-      
+
+
+
     <h3><a name="opc" id="opc">Supported Operation Codes</a></h3>
-      
+
         <ul>
-        <li>ASRQ - Sent when user clicks status button, node number 0</li>      
+        <li>ASRQ - Sent when user clicks status button, node number 0</li>
         <li>AREQ - Sent when user clicks status button, node number > 0</li>
         </ul>
-      
+
         <p>Received OPC's can be from other JMRI components,
         or from an external CBUS connection.</p>
-        
-        <p>All opscodes defined as an accessory event ( with the exception of Fast Clock ) 
+
+        <p>All opscodes defined as an accessory event ( with the exception of Fast Clock )
         are constant listeners, ie </p>
-        
+
         <ul>
         <li>ASRQ / AREQ - Autostarts feedback timer for the associated event.</li>
         <li>ACON / ACOF</li>
@@ -187,25 +185,25 @@
         <li>DDRS</li>
         <li>ARSON3 / ARSOF3</li>
         </ul>
-      
+
 
       <h4>Variance to CBUS Developers Guide 6b</h4>
-        <p>In this data model, it is assumed that event and node combinations are the unique factor.</p>      
-        <p>Any event OPCs sent with extra data bytes will be logged according to its core event and node combination, 
+        <p>In this data model, it is assumed that event and node combinations are the unique factor.</p>
+        <p>Any event OPCs sent with extra data bytes will be logged according to its core event and node combination,
         irrelevant of extra data bytes.</p>
-       
-      
+
+
     <h3>JMRI Help</h3>
-      
+
         <p>You can view this help page within JMRI by selecting Help > Window Help in the top bar of the MERG Event Table window.</p>
-        
+
         <p>The <a href="../console/CbusConsoleFrame.shtml">CBUS
         Console</a> can help you figure out what events are happening
         on your layout.</p>
-      
-      
+
+
       <p><a href="../../../../../../../html/hardware/can/cbus/index.shtml">Main JMRI CBUS Help page</a>.</p>
-        
+
         <h2></h2>
         <p>CBUS&reg; is a registered trade mark of Dr Michael Bolton</p>
         <p></p>

--- a/help/en/package/jmri/jmrix/can/cbus/swing/eventtable/EventTablePane.shtml
+++ b/help/en/package/jmri/jmrix/can/cbus/swing/eventtable/EventTablePane.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <meta name="keywords" content="JMRI CBUS help support event table tool">
   <title>JMRI: CBUS&reg; Event Table</title>
   <!--#include virtual="/Style.shtml" -->
@@ -11,35 +9,35 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: CBUS Event Table</h1>
-      
+
         <ul class="snav">
         <li><a href="#stats">Columns</a></li>
         <li><a href="#importexport">Table Import and Export</a></li>
         <li><a href="#opc">OPCs</a></li>
         </ul>
-      
+
       <img src="../../../../../../../html/hardware/can/cbus/images/swing/event-table/ev-table-630x210.png"
       width="630" height="210" alt="CBUS Event Table Screen" align="right">
 
       <p>The CBUS Event Table displays event information on your <a href=
       "../../../../../../../html/hardware/can/cbus/index.shtml">CBUS</a>
       connection.</p>
-      
+
       <p>Both incoming to JMRI and outgoing messages are logged to the table.</p>
 
-      <p>While the window is open, it will maintain a list of short on / off events, 
+      <p>While the window is open, it will maintain a list of short on / off events,
       long on / off events, extended OPC on / off events, on / off accessory response events.</p>
 
-      
+
       <p>Each event and node combination is unique, the maximum event number is 65,535.</p>
       <p>The maximum node number is also 65,535.</p>
-      
+
       <p>The table will always start with no entries, data is not maintained between sessions.</p>
-      
+
       <p>You can open the table automatically by adding it to your JMRI startup action list.
       <br>PanelPro > Edit Preferences > Start Up > Add > Perform Action > Open CBUS Event Table.
       </p>
@@ -47,14 +45,14 @@
       <p>Short event codes will be stripped of any node number contained within the event CAN message.</p>
       <p>All numeric values decimal.</p>
 
-      
+
       <p>The filter will highlight any text entered, you can use and spaces in the search field.
       <br>The table will then only show events which contain the search phrase.
       <br>Text in the information panel at the bottom of the event table will also be highlighted.</p>
-      
-      <p>New events added to the table created manually with the create event window at 
+
+      <p>New events added to the table created manually with the create event window at
       the right of the filter window default to an unknown status, and do not send an event message on creation.</p>
-      
+
             <img src="../../../../../../../html/hardware/can/cbus/images/swing/event-table/merg-cbus-ev-table-filter-611x271.png"
       width="611" height="271" alt="CBUS Event Table Filter" align="right">
 
@@ -62,25 +60,25 @@
 
       <p>Columns can be selected for display via the top menu bar,
       these are split into 4 categories.</p>
-      
+
         <ul>
         <li>Event Columns</li>
         <li>Statistic Columns</li>
         <li>Feedback Columns</li>
         <li>JMRI Columns</li>
         </ul>
-      
+
         <p>The column order can be rearranged by dragging the column header. </p>
         <p>Change the column sort order by left clicking on the column header.</p>
-      
+
     <h3>Event Columns</h3>
-    
+
         <ul>
         <li>Event : Event ( or device ) number reported within an event CAN message.</li>
         <li>Node : Node number reported by an event CAN message.</li>
-        <li>Event Name : Editable Event name ( Provided by FCU File Import ).</li>  
+        <li>Event Name : Editable Event name ( Provided by FCU File Import ).</li>
         <li>Node Name : Editable Node name ( Provided by FCU File Import ).</li>
-        <li>Event Comment : Editable</li> 
+        <li>Event Comment : Editable</li>
         <li>On or Off : Current state of event, blank for unknown.</li>
         <li>Toggle : If event last reported state is currently on, sends an off event and vice versa.</li>
         <li>Send On : Sends an On event, If the the event has a node number, this will be a long event otherwise short.</li>
@@ -88,81 +86,81 @@
         <li>CAN ID : The last CAN ID heard by the event.</li>
         <li>Delete : ( The event will be re-added to the table if re-heard on the network. )</li>
         </ul>
-        
-    <h3>Statistic Columns</h3>  
+
+    <h3>Statistic Columns</h3>
 
       <img src="../../../../../../../html/hardware/can/cbus/images/swing/event-table/merg-cbus-ev-table-stats-804x244.png"
       width="802" height="244" alt="CBUS Event Table Statistics" >
-      
+
         <ul>
         <li>Last Heard : Time + datestamp of the last time the event was heard.</li>
         <li>Total Session : Running total</li>
         <li>On Session : Running total on events.</li>
         <li>Off Session : Running total off events.</li>
         <li>In Session : Running total events received in by JMRI.</li>
-        <li>Out Session : Running total events sent out by JMRI.</li>    
+        <li>Out Session : Running total events sent out by JMRI.</li>
         </ul>
-    
+
     <h3>JMRI Link Columns</h3>
-      
+
       <ul>
       <li>On Event JMRI Links</li>
       <li>Off Event JMRI Links</li>
       </ul>
-      
-        <p>The event table can loop through the sensor, turnout and light table 
+
+        <p>The event table can loop through the sensor, turnout and light table
         for any CBUS hardware addresses ( not internal items ).
         <br>Any new events found not already on the table will be added.</p>
-      
-        <p>Clicking on JMRI columns, then Refresh Columns to populate the JMRI Event On and JMRI Event Off 
+
+        <p>Clicking on JMRI columns, then Refresh Columns to populate the JMRI Event On and JMRI Event Off
         columns.</p>
-      
+
         <p>The address username is displayed, if not present then the hardware address will be displayed.</p>
-    
-        <p>There could well be multiple items linked to an on or off event, 
+
+        <p>There could well be multiple items linked to an on or off event,
         these are all displayed though you may need to widen the column.
         <br>( This will not work with addresses setup to listen to a range of events though these don't seem to common ).</p>
-      
+
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/event-table/event-table-jmri-links-1096x279.png"
         width="1096" height="279" alt="CBUS Event Table JMRI Links" >
-      
-    
 
-      
+
+
+
     <h3><a name="importexport" id="importexport">Printing and Export / Import from MERG FCU</a></h3>
-    
+
         <p>From the File menu, choose Export to open file save dialog and save
         the contents of the table in a CSV (comma separated values) text file.</p>
-        
+
         <p>Choose the Print (Preview) menu to create a
         hard copy of the Event Table.</p>
 
         <p>The events are not currently maintained between sessions.</p>
-      
+
         <p>It is not currently possible to load previous session data into the table from file.</p>
 
         <p>You can import event names and node names from a MERG FCU config file.
         This is accessed from the <a href="../nodeconfig/NodeConfigToolPane.shtml#fcuimport">JMRI CBUS Node Manager</a>,
         where the FCU file can be previewed before import.</p>
-      
-      
+
+
     <h3><a name="opc" id="opc">Supported Operation Codes</a></h3>
-      
+
         <ul>
         <li>ASON - Sent when user clicks send on / toggle button, node number 0 </li>
         <li>ASOF - Sent when user clicks send off / toggle button, node number 0</li>
         <li>ACON - Sent when user clicks send on / toggle button, node number > 0</li>
         <li>ACOF - Sent when user clicks send off / toggle button, node number > 0</li>
-        <li>ASRQ - Sent when user clicks status button, node number 0</li>      
+        <li>ASRQ - Sent when user clicks status button, node number 0</li>
         <li>AREQ - Sent when user clicks status button, node number > 0</li>
         </ul>
-      
+
         <p>Received OPC's can be from other JMRI components,
         or from an external CBUS connection.</p>
-        
-        <p>All opscodes defined as an accessory event ( with the exception of Fast Clock ) 
+
+        <p>All opscodes defined as an accessory event ( with the exception of Fast Clock )
         are constant listeners, ie </p>
-        
+
         <ul>
         <li>ASRQ / AREQ - Autostarts feedback timer for the associated event.</li>
         <li>ACON / ACOF</li>
@@ -182,27 +180,27 @@
         <li>ASON3 / ASOF3</li>
         <li>ARSON3 / ARSOF3</li>
         </ul>
-      
+
 
       <h4>Variance to CBUS Developers Guide 6b</h4>
-        <p>In this data model, it is assumed that event and node combinations are the unique factor.</p>      
-        <p>Any event OPCs sent with extra data bytes will be logged according to its core event and node combination, 
+        <p>In this data model, it is assumed that event and node combinations are the unique factor.</p>
+        <p>Any event OPCs sent with extra data bytes will be logged according to its core event and node combination,
         irrelevant of extra data bytes.</p>
-        <p>The extra data is not currently displayed in the table, 
+        <p>The extra data is not currently displayed in the table,
         although likely to be added as a column at some point.</p>
-       
-      
+
+
     <h3>JMRI Help</h3>
-      
+
         <p>You can view this help page within JMRI by selecting Help > Window Help in the top bar of the MERG Event Table window.</p>
-        
+
         <p>The <a href="../console/CbusConsoleFrame.shtml">CBUS
         Console</a> can help you figure out what events are happening
         on your layout.</p>
-      
-      
+
+
       <p><a href="../../../../../../../html/hardware/can/cbus/index.shtml">Main JMRI CBUS Help page</a>.</p>
-        
+
         <h2></h2>
         <p>CBUS&reg; is a registered trade mark of Dr Michael Bolton</p>
         <p></p>

--- a/help/en/package/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusSimpleModeSwitcherFrame.shtml
+++ b/help/en/package/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusSimpleModeSwitcherFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: SPROG CBUS&reg; Simple Mode Switcher Tool</title>
   <meta name="author" content="Andrew Crosland">
   <meta name="keywords" content="JMRI SPROG CBUS Simple Mode Switcher Tool">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
     <h1>JMRI : CBUS Simple Mode Switcher Tool</h1>
 
@@ -25,29 +22,29 @@
     <p>Open the Mode Switcher (if available) from the SPROG Generation 5 menu.<br><br></p>
 
     <img src="images/ModeSwitcherMenu.png" alt="Mode switcher menu entry">
-    
+
     <p></p>
 
-    <p>Select programmer mode for service mode programming on a programming 
+    <p>Select programmer mode for service mode programming on a programming
         track</p>
 
     <p>Select command station mode for running trains and using ops mode (on the
        main) programming.<br><br></p>
-    
+
     <img src="images/SimpleModeSwitcher.png" alt="SPROG simple mode switcher">
-    
+
     <p></p>
 
-    <p>The Decoder Pro main window status bar shows the currently available 
+    <p>The Decoder Pro main window status bar shows the currently available
         programmers.<br><br></p>
 
     <img src="images/StatusBar.png" alt="DP3 status bar">
-    
+
     <p></p>
 
     <h2></h2>
     <p>CBUS&reg; is a registered trade mark of Dr Michael Bolton</p>
-      
+
     <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusSprog3PlusModeSwitcherFrame.shtml
+++ b/help/en/package/jmri/jmrix/can/cbus/swing/modeswitcher/SprogCbusSprog3PlusModeSwitcherFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: SPROG CBUS&reg; SPROG 3 plus Mode Switcher Tool</title>
   <meta name="author" content="Andrew Crosland">
   <meta name="keywords" content="JMRI SPROG CBUS Simple Mode Switcher Tool">
@@ -13,11 +10,11 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI : CBUS SPROG 3 Plus Mode Switcher Tool</h1>
-    
+
       <p>The mode switcher controls the programming modes that are available for
         the connected command station. Not all CBUS command stations support
         the mode switcher.</p>
@@ -25,25 +22,25 @@
       <p>Open the Mode Switcher (if available) from the SPROG Generation 5 menu.<br><br></p>
 
       <img src="images/ModeSwitcherMenu.png" alt="Mode switcher menu entry">
-    
+
       <p></p>
 
       <p>Select the desired mode by clicking one of the radio buttons.<br><br></p>
 
       <img src="images/Sprog3PlusModeSwitcher.png" alt="SPROG 3 Plus mode switcher">
-    
+
       <p></p>
 
-      <p>The Decoder Pro main window status bar shows the currently available 
+      <p>The Decoder Pro main window status bar shows the currently available
         programmers.<br><br></p>
 
       <img src="images/StatusBar.png" alt="DP3 status bar">
-    
+
       <p></p>
 
       <h2></h2>
       <p>CBUS&reg; is a registered trade mark of Dr Michael Bolton</p>
-      
+
     <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolPane.shtml
+++ b/help/en/package/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolPane.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <meta name="keywords" content="JMRI help CBUS NODE Manager CONFIG TOOL configuration variable">
   <title>JMRI: CBUS&reg; Node Manager</title>
   <!--#include virtual="/Style.shtml" -->
@@ -11,11 +9,11 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
      <h1>JMRI: CBUS Node Manager</h1>
-     
+
       <ul class="snav">
       <li><a href="#table">Node Table</a></li>
       <li><a href="#nodeinfo">Node Info</a></li>
@@ -25,42 +23,42 @@
       <li><a href="#nodenumber">Node Numbers</a></li>
       <li><a href="#fcuimport">Restore from FCU</a></li>
       </ul>
-     
-     
-     
+
+
+
       <img src="../../../../../../../html/hardware/can/cbus/images/swing/node-config/cbus-node-manager-752x541.png"
       width="676" height="487" alt="CBUS Node Manager screenshot"
       align="right">
-      
+
       <p>The node manager comprises a Node Table, along with node configuration abilities.</p>
 
-      <p>Apart from being a setup tool, this table is used by JMRI to locate DC / DCC Command stations, 
+      <p>Apart from being a setup tool, this table is used by JMRI to locate DC / DCC Command stations,
       enabling features for the command stations which support them.</p>
 
         <p>You can open multiple manager windows, these will all use the same node database.</p>
-      
-      
-      
+
+
+
     <h2><a name="table" id="table">Node Table</a></h2>
     <div>
-    
+
         <p>The top half of the screen displays a Node table, while the bottom half
         displays details about the selected node.</p>
-        
+
         <p>Nodes will be added to the table when a node admin operation OPC
         is heard for the node number.</p>
-        
+
         <p>Nodes ( and command stations ) will also be added following a node
         or command station search.</p>
-        
+
         <p>There is one row in the table for each node number.</p>
-        
+
         <p>The manager will query any node added to the table for its properties.</p>
-        
+
         <p>If enabled, this will trigger the background fetch of the full node configuration.</p>
-        
+
         <p>When a node is selected in the table, any background fetching will be prioritised to that node.</p>
-        
+
         <p>Columns : </p>
         <ul>
         <li>Node Number</li>
@@ -73,42 +71,42 @@
         <li>Total Bytes - Total node data bytes</li>
         <li>Learn Mode - Checked if the node is currently in learn mode</li>
         </ul>
-        
+
         <p>Pre-fetching enables quick node editing, and may be the basis for any future node backup integration.</p>
-        
+
         <p>Node data bytes are calculated as the sum of :</p>
-        
+
         <ul>
         <li>Number of Node Parameters</li>
         <li>Number of Node Variables ( NVs )</li>
         <li>Number of events x 5 ( initial event index fetch )</li>
         <li>Number of events x Number of event variables per event</li>
         </ul>
-        
+
         <p>You can click into the Node Name cell to edit the node name.</p>
-        
+
         <p>You can remove a node from the table via the Node Setup tab.</p>
-        
-        
-        
+
+
+
         <h4>File Menu</h4>
         <p>Import Node Names from FCU File ( node names not currently maintained between sessions )</p>
         <p>Restore Node From FCU File - see <a href="#fcuimport">Restore from FCU</a></p>
-        
+
         <h4>Options Menu</h4>
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/node-config/cbus-node-manager-options-372x216.png"
       width="372" height="216" alt="CBUS Node Manager options"
       align="right">
-        
-        
+
+
         <ul>
         <li>Search for Nodes and Command Stations
             <p>You can select Options > Search for Nodes and Command Stations
-            whereby the manager will request each node 
+            whereby the manager will request each node
             on the CBUS network to report back.
-            <br>Each node which reports itself is sent a message to take it out of 
+            <br>Each node which reports itself is sent a message to take it out of
             any existing learn event mode.
-            <br>A message identifying nodes in setup mode, ie requesting a node number 
+            <br>A message identifying nodes in setup mode, ie requesting a node number
             will also be sent to the network.</p>
         </li>
         <li>Send System Reset OPC</li>
@@ -126,17 +124,17 @@
         <li>Search for Command Stations on JMRI startup</li>
         <li>Search for nodes on JMRI startup</li>
         </ul>
-        
+
         <p>Options are saved between sessions on a per-profile basis.</p>
-        
-        
+
+
     </div>
 
     <h3><a name="nodeinfo" id="nodeinfo">Node Info</a></h3>
     <div>
-    
+
         <p>Additional node information including, if available</p>
-    
+
         <ul>
         <li>Manufacturer</li>
         <li>Node type text</li>
@@ -148,203 +146,203 @@
         <li>Bus type</li>
         <li>Node Support Link</li>
         </ul>
-    
+
     </div>
 
     <h3><a name="variables" id="variables">Node Variables</a></h3>
     <div>
-    
+
     <p>This is a generic tool for Node Variable and Node Event editing.</p>
-        
+
         <p><strong>Other tools may be more appropriate for full node configuration.</strong></p>
-        
-        
+
+
         <p>JMRI does not save node configuration changes, this is all saved on the node.</p>
-        
-        <p>It is sensible to make regular backups of your node configurations using 
+
+        <p>It is sensible to make regular backups of your node configurations using
         appropriate software.</p>
-        
-        
-        <p>Do not blindly change NVs to <i>see what happens!</i> Use in conjunction with 
+
+
+        <p>Do not blindly change NVs to <i>see what happens!</i> Use in conjunction with
         the individual module documentation.</p>
-        
-    
-    
+
+
+
         <p>These are displayed in a table form.</p>
-     
+
         <p>Table columns include the NV number, along with the NV value in decimal, hex and binary forms.</p>
-        
+
         <p>Click edit to edit the NVs, the edit screen will open in a new window.</p>
-        
+
         <h4>Editing Node Variables</h4>
-        
+
         <p>Columns on the left are the current values, columns on the right show proposed.</p>
-        
+
         <p>If the values have been changed, the row is highlighted yellow.</p>
 
         <p>To write the new NV's, the save button is enabled when a variable has been changed.</p>
-        
+
         <p>Click on this button for a confirmation before writing, after which the window will close.</p>
-        
+
     </div>
-    
+
     <h3><a name="events" id="events">Node Events</a></h3>
     <div>
     <img src="../../../../../../../html/hardware/can/cbus/images/swing/node-config/cbus-generic-edit-ev-488x525.png"
       width="488" height="525" alt="CBUS Node Event Generic Config" align="right">
-      
+
       <p>You can create new node events by dragging an event from the CBUS event table to the Node Manager window.</p>
-      
+
       <p>If the event is new to the node it will open in a new event window.</p>
-      
+
       <p>If the event is already on the node, it will open in an edit event window.</p>
-      
-      
-      <p>Click on the Edit button in the event list, or the new event button 
+
+
+      <p>Click on the Edit button in the event list, or the new event button
       to bring up the edit event window.</p>
       <p>The event and node combination are set at the top of the list</p>
-      
+
       <p>The node and event names are looked up from the CBUS Event Table when the spinners are changed.</p>
       <p>The action buttons will be enabled or disabled depending on how the event number has changed.</p>
-      
-      <p>Do not blindly change Event Variables to <i>see what happens!</i> Use in conjunction with 
+
+      <p>Do not blindly change Event Variables to <i>see what happens!</i> Use in conjunction with
         the individual node documentation.</p>
-      
+
       <p>Any existing values are shown on the left of the table, proposed values on the right.</p>
 
       <p>Zero values are not displayed for binary columns to help identify populated values.</p>
 
 
       <p>Use the spinners or enter a value in the cell to edit the value.</p>
-      
+
       <p>Any changed variables will have their rows highlighted yellow.</p>
 
-      <p>The number of variables per event will depend on the node specific 
+      <p>The number of variables per event will depend on the node specific
       event settings and firmware.</p>
-      
+
       <p>Click on edit or new event to save this to the node.</p>
-      
+
       <p>When teaching, </p>
-      
+
       <p>Copying an event will also copy the event variables into a new event ready for editing.</p>
-      
+
       <p>If deleting an event from the node you will be asked to confirm this.</p>
-      
+
       <p>The edit event window will remain open after teach or edit event operations.</p>
-      
+
       <p>At present, only the generic tab is available.  Templates may be available in due course.</p>
-      
+
     </div>
-    
+
     <h3><a name="setup" id="setup">Node Setup</a></h3>
     <div>
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/node-config/cbus-node-setup-752x541.png"
       width="676" height="487" alt="CBUS Node Setup" align="right">
-      
+
       <p>The node setup tab contains some lesser used node setup functionality.</p>
-      
+
       <p>The node JMRI user name is used to refer to the node in the CBUS Console and other CBUS applications.</p>
-      
-      
+
+
         <p>CAN Self-enumeration sends an enumeration request to the node,
         which should then sort itself out with a good CAN ID.</p>
-      
+
       <p>The CAN can also be set manually by clicking on the force set button.
       <br>A popup dialogue will ask for the new CAN ID, min 1, max 99.</p>
-      
+
       <p>Clear All Events from Node button</p>
-      
+
       <p>Remove from table button</p>
-      
-    </div>    
-    
-    
+
+    </div>
+
+
     <h3><a name="nodenumber" id="nodenumber">Node Numbers</a></h3>
         <div>
-        
+
         <p>Node Number : Each individual module in FLIM operation has a node number.</p>
-        
+
         <p>A node number is requested by the holding down the FLiM button on a node.</p>
-        
+
         <p>JMRI can listen for modules requesting a node number.</p>
-        
+
         <p>This is enabled by default, though can be disabled in the Node Manager options menu.</p>
-        
+
         <p>On hearing a node number request, an allocation popup window will be displayed.</p>
-        
+
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/node-config/cbus-node-config-qnn_278x151.png"
         width="278" height="151" alt="Merg CBUS Node Configuration Request Node Number">
 
         <p>Using the number spinner or keyboard, enter the numerical Node number
-        you would like for the node.</p>   
-        
+        you would like for the node.</p>
+
         <p>It is suggested that you allocate node numbers above 256, the maximum non-reserved number is 65,533</p>
-        
-        <p>If a reserved OpCode is used, the background will turn yellow with explanation.</p>      
+
+        <p>If a reserved OpCode is used, the background will turn yellow with explanation.</p>
         <p>If an existing node number being used is selected, the background will turn red.</p>
-      
+
       </div>
-      
+
     <h3><a name="fcuimport" id="fcuimport">MERG FCU xml file - Restore Node / Import CBUS Event and Node Names</a></h3>
     <div>
         <img src="../../../../../../../html/hardware/can/cbus/images/swing/node-config/cbus_node_restore_from_fcu_661x619.png"
       width="661" height="619" alt="CBUS Node Setup" align="right">
-      
+
       <ul>
       <li>Restore Node NV's and Events</li>
       <li>Import Node Names to the main Node Manager</li>
       <li>Import Event Names to the <a href="../eventtable/EventTablePane.shtml">JMRI CBUS Event Table</a></li>
       </ul>
-      
+
         <p>Open the restore window via the Node Manager File Menu > Restore Node from FCU xml</p>
-      
+
         <p>Select an FCU xml file from the button at top of the screen.</p>
-      
+
         <p>Nodes within the file will appear in the top table.</p>
-        <p>There are tabs for viewing the information on the selected node, 
+        <p>There are tabs for viewing the information on the selected node,
             node variables and node events in the centre of the window.</p>
 
 
         <p>If the JMRI CBUS Event Table is running, the button to import event names will be enabled.
         <br>An event name will be added to an existing event table entry if it has no event name.</p>
-      
+
         <p>Node names are imported to the main node table, updating the node name if unset.
-        <br>If a node number is not present in the table, 
-        a new row will be created enabling the node name 
+        <br>If a node number is not present in the table,
+        a new row will be created enabling the node name
         to be used within other JMRI CBUS applications.</p>
-        
+
         <p>Restore options are towards the bottom of the screen.</p>
-      
+
         <p>Nodes from the main Node Table are listed toward the bottom left of the restore screen.</p>
-      
+
         <p>Both NV and event transfer can be independently selected.</p>
-      
+
         <p>There is also an option to clear any existing events on the node.</p>
-        
-        <p>When a matching FCU node and a node table node have both been selected, 
+
+        <p>When a matching FCU node and a node table node have both been selected,
         the Update Node button will become active.  </p>
-      
+
         <p>The donor node and the target node require the same amount of NVs or Event Variables.</p>
-      
+
         <p>Once clicked, there's a confirmation popup
         confirming the options which are set.</p>
-        
+
       <img src="../../../../../../../html/hardware/can/cbus/images/swing/node-config/cbus-teach-from-fcu-file-confirm-278x215.png"
       width="278" height="215" alt="CBUS Confirm write restore" >
-      
+
         <p>Click OK, the busy icon will appear and the write process will commence.</p>
         <p>Any unchanged values will NOT be written to the node.</p>
         <p>As with other operations, the node being taught will update in real time via the main node table.</p>
-        
-        <p>On teach completion, the busy icon will dissapear and a teach failure popup 
+
+        <p>On teach completion, the busy icon will dissapear and a teach failure popup
         will display should any issues be detected.</p>
 
-      
-      
-    </div>   
-      
-      
-      
+
+
+    </div>
+
+
+
     <h3><a name="opc" id="opc">Sent Operation Codes</a></h3>
     <div>
       <ul>
@@ -363,15 +361,15 @@
       <li>RQNPN - Sent when node selected to receive node parameter total, also sent to get each node parameter.</li>
       <li>SNN - Sent to allocate a node number following user choosing number.</li>
       </ul>
-      
+
       <h4>Received Operation Codes</h4>
-      
+
       <ul>
       <li>CANID - Listener to set node to a specific CAN ID.</li>
       <li>CMDERR - Constant listener with extra functionality
                 <ul>
                 <li>When waiting for unlearn event response </li>
-                <li>When waiting for a response to setting event </li> 
+                <li>When waiting for a response to setting event </li>
                 <li>When waiting for a response to setting NV </li>
                 </ul>
                 </li>
@@ -390,13 +388,13 @@
       <li>NVANS - Listener when waiting for node NV's.</li>
       <li>NVSET - Listener for node set single NV.</li>
       <li>NUMEV - Listener when waiting for number of node events.</li>
-      <li>PARAMS - Listener for setup mode on node list refresh, 
+      <li>PARAMS - Listener for setup mode on node list refresh,
                 listener when an RQNP has been sent.</li>
       <li>PARAN - Listener when waiting for node ( which is not in setup ) parameters.</li>
       <li>PNN - Update from Node - Can create a new Node Manager table row.</li>
       <li>RQNN - Constant listener for node number requests.</li>
       <li>STAT - Update from Command Station - Can create a new Node Manager table row.</li>
-      <li>WRACK - 
+      <li>WRACK -
                 <ul>
                 <li>Listener when waiting for unlearn event response</li>
                 <li>Listener when waiting for a response to setting event</li>
@@ -404,29 +402,29 @@
                 </ul>
                 </li>
       </ul>
-      
+
       <p>All nodes are referred to by both Manufacturer and Node Type.</p>
-    
+
     </div>
-    
+
     <h4>Variance to CBUS Developers Guide 6b</h4>
-    
+
     <div>
-      
-      <p>It cannot be guaranteed that another program within the JMRI suite 
+
+      <p>It cannot be guaranteed that another program within the JMRI suite
       will not send any normal operational OPC to a module which is in learn mode.</p>
     </div>
-      
+
     <h3>JMRI Help</h3>
-      
-      <p>You can view this help page within JMRI by selecting Help > Window Help 
+
+      <p>You can view this help page within JMRI by selecting Help > Window Help
       in the top bar of the CBUS Node Manager window.</p>
-      
+
       <p>The methods to teach nodes are accessible via Jython script, and include single commands
       which take care of all of the loops.</p>
-      
+
       <p><a href="../../../../../../../html/hardware/can/cbus/index.shtml">Main JMRI CBUS Support page</a>.</p>
-      
+
         <h2></h2>
         <p>CBUS&reg; is a registered trade mark of Dr Michael Bolton</p>
         <p></p>

--- a/help/en/package/jmri/jmrix/can/cbus/swing/simulator/SimulatorPane.shtml
+++ b/help/en/package/jmri/jmrix/can/cbus/swing/simulator/SimulatorPane.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <meta name="keywords" content="JMRI help CBUS Simulator simulate offline command station emulate emulator">
   <title>JMRI: CBUS&reg; Simulator</title>
   <!--#include virtual="/Style.shtml" -->
@@ -11,11 +9,11 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
      <h1>JMRI: CBUS Network Simulation Tool</h1>
-      
+
       <ul class="snav">
       <li><a href="#direction">Direction</a></li>
       <li><a href="#cs">Command stations</a></li>
@@ -23,19 +21,19 @@
       <li><a href="#nodes">Nodes</a></li>
       <li><a href="#opc">OPCs</a></li>
       </ul>
-      
+
       <img src="../../../../../../../html/hardware/can/cbus/images/swing/simulator/cbus-network-simulation-pane-315x322.png"
        alt="CBUS Network Simulator screenshot" width="315" height="322" align="right">
-       
+
       <p>The tool will start in the background of a CAN Simulation MERG Hardware Connection.</p>
-      
+
       <p>You can also start the simulator manually for all connections by opening via the main MERG menu.</p>
-      
+
       <p>Default options are shown on the right.</p>
-      
+
       <p>You can add extra command stations, nodes or event responders by selecting Add in the top menu.</p>
 
-      
+
      <h2><a name="direction" id="direction">Direction and Delay</a></h2>
      <p>Direction and delay are unique to each simulated object.</p>
       <ul>
@@ -49,11 +47,11 @@
 
      <h2><a name="cs" id="cs">Command Stations</a></h2>
       <p>You can select between a standard command station, along with disabling the command station.</p>
-      
+
       <p>disabling the command station will cancel any current sessions.</p>
-      
+
       <p>The number to the right of the dropdown indicates the current number of sessions it is handling.</p>
-      
+
       <p>The reset button is equivalent to switching the command station off and on ( hard reset ).</p>
 
 
@@ -61,9 +59,9 @@
      <h2><a name="ev" id="ev" >Response Events</a></h2>
       <p>The tool can issue on or off response events to any requests that it hears on the network.
         </p>
-        
+
         <p>Event Response: </p>
-        
+
         <ul>
         <li>Disabled</li>
         <li>Random on / off</li>
@@ -71,9 +69,9 @@
         <li>On</li>
         <li>Off</li>
         </ul>
-        
+
         <p>The requests can also be filtered by node.</p>
-        
+
         <ul>
         <li> -1 : No filter</li>
         <li> 0 : Just short events</li>
@@ -83,13 +81,13 @@
 
      <h2><a name="nodes" id="nodes" >Nodes</a></h2>
         <p>No nodes are simulated by default.</p>
-        <p>When selecting a node, in enters in SLiM mode, you'll need to 
+        <p>When selecting a node, in enters in SLiM mode, you'll need to
         press the FLiM button to introduce it to the network.</p>
         <p>When selecting a new node ( or disabling by selecting SLiM ),
         any existing events or node variables will be reset.</p>
         <p>Simulated nodes currently provide node admin operations,
         however do not support actual incoming or outgoing events.</p>
-        
+
         <p>Current simulated nodes include : </p>
         <ul>
         <li>SLiM ( simulation disabled )</li>
@@ -113,16 +111,16 @@
         <li>DKEEP</li>
         <li>KLOC</li>
         </ul>
-        
+
         <p>Event Status Requests</p>
-        
+
         <ul>
-        <li>ASRQ - Sent when user clicks status button, node number 0</li>      
+        <li>ASRQ - Sent when user clicks status button, node number 0</li>
         <li>AREQ - Sent when user clicks status button, node number > 0</li>
         </ul>
-        
+
         <p>Node Simulation</p>
-        
+
         <ul>
         <li>RQMN - Setup Mode only</li>
         <li>RQNP - Setup Mode only</li>
@@ -174,13 +172,13 @@
         <li>NEVAL</li>
         <li>ENRSP</li>
         <li>NUMEV</li>
-        
+
         </ul>
 
     <h3>JMRI Help</h3>
-      
+
       <p>You can view this help page within JMRI by selecting Help > Window Help in the top bar of the CBUS Event Capture window.</p>
-      
+
       <p><a href="../../../../../../../html/hardware/can/cbus/index.shtml">Main JMRI CBUS Support page</a>.</p>
 
         <h2></h2>

--- a/help/en/package/jmri/jmrix/can/swing/send/CanSendFrame.shtml
+++ b/help/en/package/jmri/jmrix/can/swing/send/CanSendFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Send CAN Frame</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help send CBUS packets long short can events frames event hex">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
      <h1>Send CAN Frame</h1>
       <img src="../../../../../../html/hardware/can/images/can-send-can-frame-349x392.png"
@@ -26,72 +23,72 @@
 
       <p>The top section of the window lets you send a single
       frame, the bottom section acts as a frame sequencer. </p>
-      
+
       <p>You can enter packets in <a href=
       "../../../../../../html/hardware/can/cbus/Names.shtml">CBUS&reg;
-      address format</a>, e.g. "+1", "-2" or "+n4e1" ( decimal, without the quotation marks ). 
+      address format</a>, e.g. "+1", "-2" or "+n4e1" ( decimal, without the quotation marks ).
       <br>
-      Once you've entered the packet, just click "send" or press Enter.</p>      
-      
+      Once you've entered the packet, just click "send" or press Enter.</p>
+
       <p>You can enter the packet's data contents as hexadecimal
       numbers, for example "83 7C".</p>
-      
+
       <p>Any spaces in the packets will be removed before sending.</p>
-      
+
       <p>If you want to specify header
       contents, precede the packet data with the header in "( )"
       characters or "[ ]" characters for a standard or extended
       header, respectively.</p>
 
-      
+
       <p>This tool works well in combination with the <a href=
       "../../cbus/swing/console/CbusConsoleFrame.shtml">CBUS
       Console</a>, where the actual frames generated and received can be viewed.</p>
-      
+
       <p>If a message is unable to be created, a popup dialogue box will notify you.</p>
-      
+
       <p>Remember, if sending out messages to a live CBUS network, these will be received and acted upon accordingly!</p>
-      
+
       <h2><a name="sequencer" id="sequencer">Sequencer</a></h2>
       <img src="../../../../../../html/hardware/can/images/can-send-can-frame-sequence-352x393.gif"
       width="352" height="393" alt="JMRI CBUS Send Frame Tool Sequencer" align="right">
-      
-      
-      
+
+
+
       <p>The bottom section lets you enter from one to four frames
       that will be repeatedly sent in sequence, with user-defined
       delays in between.</p>
-      
+
       <p>Press the "Go" button to start the
       transmission sequence, and press it again to stop the
       sequence.</p>
-      
-      <p>You can alter the messages while it is running, those changes take effect 
+
+      <p>You can alter the messages while it is running, those changes take effect
       the next time the frame is called in the sequence.</p>
-      
-      <p>The last frame to have been sent in the sequence is highlighted by 
+
+      <p>The last frame to have been sent in the sequence is highlighted by
       a different background colour.</p>
-      
+
       <p>You will be notified if the sequencer is unable to send a can frame.</p>
-      
-      
+
+
       <h2>Options</h2>
       <p>CBUS priority - Adds a priority to the message header.</p>
-      <p>Send as outgoing CanMessage - Sends as if message originating from JMRI 
+      <p>Send as outgoing CanMessage - Sends as if message originating from JMRI
       ( selected by default ).</p>
       <p>Send as outgoing CanMessage - Sends as if message originating from outside of JMRI </p>
-      
+
      <h3>JMRI Help</h3>
-      
+
       <p>You can view this help page within JMRI by selecting Help > Window Help in the top bar of the MERG Send CAN Frame window.</p>
       <p><a href="../../../../../../html/hardware/can/cbus/index.shtml">Main JMRI CBUS Support page</a>.</p>
 
-      
+
         <h2></h2>
         <p>CBUS&reg; is a registered trade mark of Dr Michael Bolton</p>
         <p></p>
 
-      
+
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrix/cmri/serial/assignment/ListFrame.shtml
+++ b/help/en/package/jmri/jmrix/cmri/serial/assignment/ListFrame.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Connector Pin Assignments</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: Connector Pin Assignments</h2>
       <p>This tool lets you check the pin assignments for your C/MRI nodes.</p>

--- a/help/en/package/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetManagerFrame.shtml
+++ b/help/en/package/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetManagerFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: C/MRInet Manager</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: C/MRInet Manager</h2>
 

--- a/help/en/package/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetMetricsFrame.shtml
+++ b/help/en/package/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetMetricsFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: C/MRInet Metrics</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: C/MRInet Metrics</h2>
 

--- a/help/en/package/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.shtml
+++ b/help/en/package/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: C/MRI Diagnostics</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: C/MRI Diagnostics</h2>
       <p>When it asks for output card

--- a/help/en/package/jmri/jmrix/cmri/serial/nodeconfig/NodeConfigFrame.shtml
+++ b/help/en/package/jmri/jmrix/cmri/serial/nodeconfig/NodeConfigFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: C/MRI Node Configuration</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: C/MRI Node Configuration</h2>This is the
       cmri/serial/nodeconfig/NodeConfigFrame.shtml page

--- a/help/en/package/jmri/jmrix/cmri/serial/nodeconfigmanager/NodeConfigManagerFrame.shtml
+++ b/help/en/package/jmri/jmrix/cmri/serial/nodeconfigmanager/NodeConfigManagerFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: C/MRI Node Configuration Manager</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: C/MRI Node Configuration Manager</h2>
       This is the cmri/serial/nodeconfigmanager/NodeConfigManagerFrame.shtml page.

--- a/help/en/package/jmri/jmrix/cmri/serial/serialmon/SerialFilterFrame.shtml
+++ b/help/en/package/jmri/jmrix/cmri/serial/serialmon/SerialFilterFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Filter C/MRI Traffic</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Filter C/MRI Device Traffic</h1>
       This is the help/jmri/jmrix/cmri/serial/serialmon/SerialFilterFrame help

--- a/help/en/package/jmri/jmrix/cmri/serial/serialmon/SerialMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/cmri/serial/serialmon/SerialMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Monitor C/MRI Traffic</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Monitor C/MRI Device Traffic</h1>This is the
       help/jmri/jmrix/cmri/serial/serialmon/SerialMonFrame help

--- a/help/en/package/jmri/jmrix/dcc4pc/swing/packetgen/PacketGenFrame.shtml
+++ b/help/en/package/jmri/jmrix/dcc4pc/swing/packetgen/PacketGenFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Send DCC4PC Message</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Send DCC4PC Message</h1>
       This is the help/jmri/jmrix/dcc4pc/swing/packetgen/PacketGenFrame help

--- a/help/en/package/jmri/jmrix/ecos/swing/locodatabase/EcosLocoTable.shtml
+++ b/help/en/package/jmri/jmrix/ecos/swing/locodatabase/EcosLocoTable.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Ecos Loco Database</title>
   <meta name="author" content="Dan Boudreau">
   <meta name="keywords" content="JMRI Help ECoS Loco Database Table">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>ECoS Loco Database</h1>
 

--- a/help/en/package/jmri/jmrix/ecos/swing/packetgen/PacketGenFrame.shtml
+++ b/help/en/package/jmri/jmrix/ecos/swing/packetgen/PacketGenFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Ecos Command Generator</title>
   <meta name="author" content="Dan Boudreau">
   <meta name="keywords" content="JMRI Help ECoS Command Generator">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>ECoS Command Generator</h1>
 

--- a/help/en/package/jmri/jmrix/ecos/swing/preferencesframe/PreferencesFrame.shtml
+++ b/help/en/package/jmri/jmrix/ecos/swing/preferencesframe/PreferencesFrame.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: ECoS Preferences</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: ECoS Preferences</h1>
       The ECoS User Preferences allows you to control the way

--- a/help/en/package/jmri/jmrix/ecos/swing/statusframe/StatusFrame.shtml
+++ b/help/en/package/jmri/jmrix/ecos/swing/statusframe/StatusFrame.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: ECoS Info Tool</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: ECoS Info Tool</h1>
 

--- a/help/en/package/jmri/jmrix/grapevine/nodeconfig/NodeConfigFrame.shtml
+++ b/help/en/package/jmri/jmrix/grapevine/nodeconfig/NodeConfigFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Configure Grapevine Nodes</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Configure Grapevine Nodes</h1>
 

--- a/help/en/package/jmri/jmrix/grapevine/nodetable/NodeTableFrame.shtml
+++ b/help/en/package/jmri/jmrix/grapevine/nodetable/NodeTableFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Grapevine Node Table</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Grapevine Node Table</h1>
 

--- a/help/en/package/jmri/jmrix/grapevine/nodetable/RenumberFrame.shtml
+++ b/help/en/package/jmri/jmrix/grapevine/nodetable/RenumberFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Renumber Grapevine Node</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Change Grapevine Board Address</h1>
       <p>This tool lets you change the address of a Grapevine board.</p>

--- a/help/en/package/jmri/jmrix/grapevine/packetgen/SerialPacketGenFrame.shtml
+++ b/help/en/package/jmri/jmrix/grapevine/packetgen/SerialPacketGenFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Send Grapevine message</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Send grapevine message packet">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Send Grapevine Message</h1>This is the
       help/jmri/jmrix/grapevine/packetgen/SerialPacketGenFrame help

--- a/help/en/package/jmri/jmrix/grapevine/serialmon/SerialMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/grapevine/serialmon/SerialMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Monitor Grapevine Traffic</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Monitor Grapevine Traffic</h1>
       <p>For more information on the various controls and options,

--- a/help/en/package/jmri/jmrix/ieee802154/swing/nodeconfig/AddNodeFrame.shtml
+++ b/help/en/package/jmri/jmrix/ieee802154/swing/nodeconfig/AddNodeFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <meta name="keywords" content="JMRI help IEEE802154 NODE Manager CONFIG TOOL configuration variable">
   <title>JMRI: IEEE802154 Add Node Frame</title>
   <!--#include virtual="/Style.shtml" -->
@@ -11,11 +9,11 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
      <h1>JMRI: IEEE802154 - Add Node Frame</h1>
-     
+
         Help is on the way.
 
       <!--#include virtual="/Footer.shtml" -->

--- a/help/en/package/jmri/jmrix/ieee802154/swing/nodeconfig/EditNodeFrame.shtml
+++ b/help/en/package/jmri/jmrix/ieee802154/swing/nodeconfig/EditNodeFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <meta name="keywords" content="JMRI help IEEE802154 NODE Manager CONFIG TOOL configuration variable">
   <title>JMRI: IEEE802154 Edit Node Frame</title>
   <!--#include virtual="/Style.shtml" -->
@@ -11,11 +9,11 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
      <h1>JMRI: IEEE802154 - Edit Node Frame</h1>
-     
+
         Help is on the way.
 
       <!--#include virtual="/Footer.shtml" -->

--- a/help/en/package/jmri/jmrix/ieee802154/swing/nodeconfig/NodeConfigFrame.shtml
+++ b/help/en/package/jmri/jmrix/ieee802154/swing/nodeconfig/NodeConfigFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <meta name="keywords" content="JMRI help IEEE802154 NODE Manager CONFIG TOOL configuration variable">
   <title>JMRI: IEEE802154 Node Configuration</title>
   <!--#include virtual="/Style.shtml" -->
@@ -11,11 +9,11 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
      <h1>JMRI: IEEE802154 - Node Configuration</h1>
-     
+
         Help is on the way.
 
       <!--#include virtual="/Footer.shtml" -->

--- a/help/en/package/jmri/jmrix/jinput/treemodel/TreeFrame.shtml
+++ b/help/en/package/jmri/jmrix/jinput/treemodel/TreeFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: USB Input Control</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: USB Input Control</h2><a href=
       "TreeFrame.jpg"><img src="TreeFrame.jpg" align="right"

--- a/help/en/package/jmri/jmrix/lenz/stackmon/StackMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/lenz/stackmon/StackMonFrame.shtml
@@ -2,20 +2,17 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Stack Monitor Tool</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: Stack Monitor Tool</h2>This is the
-      jmri.jmrix.lenz.stackmon.StackMonFrame help page. 
+      jmri.jmrix.lenz.stackmon.StackMonFrame help page.
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrix/lenz/systeminfo/SystemInfoFrame.shtml
+++ b/help/en/package/jmri/jmrix/lenz/systeminfo/SystemInfoFrame.shtml
@@ -2,20 +2,17 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: System Info Tool</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: System Info Tool</h2>This is the
-      jmri.jmrix.lenxz.systeminfo.SystemInfoFrame help page. 
+      jmri.jmrix.lenxz.systeminfo.SystemInfoFrame help page.
       <!--#include virtual="/Footer.shtml" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/package/jmri/jmrix/loconet/bdl16/BDL16Frame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/bdl16/BDL16Frame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Configure Digitrax BDL168</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="author" content="B. Milhaupt">
@@ -14,57 +11,57 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
     <a href="BDL16xConfigTool.png"><img src="BDL16xConfigTool.png"
-    alt="BDL16x Configuration Tool Screen" width="386" height="423" 
+    alt="BDL16x Configuration Tool Screen" width="386" height="423"
     style="float:right; margin: 5px;"></a>
 
-    <div id="mainContent">
 
       <h1>Configure Digitrax BDL16x</h1>
       <p>The JMRI BDL16x programming tool lets you configure the
       internal options of a BDL16, BDL162, or BDL168 directly from
-      your computer, when the board is connected to a JMRI LocoNet 
+      your computer, when the board is connected to a JMRI LocoNet
       connection.</p>
 
       <p>To open this tool select "Configure BDL16/BDL162/BDL168" from the LocoNet
       menu.</p>
-      
+
       <h2>Selecting the BDL16x board</h2>
-      
+
       <p>Each BDL16x device present on the LocoNet connection is identified by its "Board ID".
-      This tool may access a particular BDL16x device by entering the "Board ID" number in 
+      This tool may access a particular BDL16x device by entering the "Board ID" number in
       the selection box at the upper left of the tool window.</p>
-      
-      <p>Upon start-up, this tool queries the LocoNet connection to create a list 
+
+      <p>Upon start-up, this tool queries the LocoNet connection to create a list
       of BDL16x devices.  Each BDL16x Board ID is added to the list in the pull-down
-      selector, accessed by selecting the downward-pointing triangle which is just 
+      selector, accessed by selecting the downward-pointing triangle which is just
       to the right of the Board ID text entry space.</p>
-      
+
       <p>Any time that a Board ID number is typed into the Board ID text entry space,
       the number will be added to the list if it is not already present in the list.</p>
-      
+
       <p>While it is possible to change the Board ID number using JMRI, it cannot
-          be done using this tool due to limitations of the BDL16x design.  Instead, 
+          be done using this tool due to limitations of the BDL16x design.  Instead,
           follow the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
-          here</a>.  Those instructions are for programming a BDL168 board, but 
+          here</a>.  Those instructions are for programming a BDL168 board, but
           they are believed to apply also to BDL16 and BDL162 boards.</p>
-      
+
       <h2>Reading and writing the OpSw settings</h2>
-       
-      <p>This tool only accesses the board's OpSw values when the "Read Full Sheet" 
+
+      <p>This tool only accesses the board's OpSw values when the "Read Full Sheet"
           or "Write Full Sheet" button is pressed.</p>
-      
-      <p>The "Read Full Sheet" button may be used to read the OpSw settings from 
+
+      <p>The "Read Full Sheet" button may be used to read the OpSw settings from
       the BDL16x.  Performing the "Read Full Sheet" operation reads all OpSw values from the
-      board selected by the "Board ID" field and updates each of the tool's 
+      board selected by the "Board ID" field and updates each of the tool's
       selections.</p>
-      
-      <p>The "Write Full Sheet" button may be used to write the OpSw settings 
+
+      <p>The "Write Full Sheet" button may be used to write the OpSw settings
           currently shown in the tool to the BDL16x device specified by the "Board ID"
-          number shown at the top of the window.  Performing the "Write Full Sheet" 
+          number shown at the top of the window.  Performing the "Write Full Sheet"
           operation writes all OpSw values to the board.</p>
-      
+
       <h2>The configurable options</h2>
 
       <p>The basic operating settings are shown grouped into three sections:
@@ -74,16 +71,16 @@
         and BDL168.</li>
         <li>Below this are the basic operating settings which apply only to the BDL168.</li>
       </ul>
-      
+
       <p>Each setting may be changed by selecting one of the options from the pull-down
       list of values.</p>
 
-      <p>When performing a "Write Full Sheet" operation to a BDL16 or BDL162 device, 
+      <p>When performing a "Write Full Sheet" operation to a BDL16 or BDL162 device,
           this tool will write all of the OpSw values, not just the OpSw values which
           are defined for the BDL16 or BDL162 device.  This is thought to be safe, as
           it is thought that these OpSw values will be ignored by the hardware.  If
-          you are concerned that this may not be acceptable, then select the "default" 
-          value for the OpSw values which do not apply to the board type which you 
+          you are concerned that this may not be acceptable, then select the "default"
+          value for the OpSw values which do not apply to the board type which you
           are configuring. </p>
 
       <h2>Limitations</h2>
@@ -91,7 +88,7 @@
       <ul>
         <li>This tool is not able to detect the difference between
         a BDL16, a BDL162, and a BDL168. As such, it always shows
-        all OpSw values and descriptions for the BDL168, and the "Write 
+        all OpSw values and descriptions for the BDL168, and the "Write
         Full Sheet" operation will write all OpSw values.</li>
 
         <li>This tool is able to access BDL16x boards with
@@ -104,9 +101,9 @@
         <li>Because of the way the BDL16x board works, this tool
         can't change the basic address of the unit. The BDL16x
         documentation describes how to change the board
-        address.  It is possible to change the Board ID number using JMRI by 
+        address.  It is possible to change the Board ID number using JMRI by
         following the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
-        here</a>. Those instructions are for programming a BDL168 board, but 
+        here</a>. Those instructions are for programming a BDL168 board, but
         they are believed to apply also to BDL16 and BDL162 boards.</li>
       </ul>
 

--- a/help/en/package/jmri/jmrix/loconet/clockmon/ClockMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/clockmon/ClockMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: LocoNet Fast Clock Control</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>LocoNet Fast Clock Control</h1>
 

--- a/help/en/package/jmri/jmrix/loconet/cmdstnconfig/CmdStnConfigFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/cmdstnconfig/CmdStnConfigFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Configure Digitrax Command Station</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,13 +11,13 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Configure a Digitrax Command Station</h1>
-      
+
       <p>Recent JMRI versions support configuration of the Command Station
-          "Operation Switches" (OpSws) via a "roster" entry.  See the JMRI 
+          "Operation Switches" (OpSws) via a "roster" entry.  See the JMRI
           <a href="../../../../../html/hardware/loconet/CommandStationConfig.shtml">
           Digitrax Command Station Configuration</a> page for details.  The
           new "roster" entry-based method is preferred over the tool described

--- a/help/en/package/jmri/jmrix/loconet/downloader/LoaderFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/downloader/LoaderFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Digitrax Downloader</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="author" content="B. Milhaupt">
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>LocoNet&reg; "Download Firmware" Tool</h1>
 

--- a/help/en/package/jmri/jmrix/loconet/ds64/DS64TabbedPanel.shtml
+++ b/help/en/package/jmri/jmrix/loconet/ds64/DS64TabbedPanel.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Configure Digitrax DS64</title>
   <meta name="author" content="B. Milhaupt">
   <meta name="keywords" content="JMRI help configure loconet DS64">
@@ -13,12 +10,12 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
     <a href="../../../../../html/hardware/loconet/images/DS64TabbedPanel.png">
     <img src="../../../../../html/hardware/loconet/images/DS64TabbedPanel.png"
-         style="float:right; margin: 5px;" height="408" width="438" 
+         style="float:right; margin: 5px;" height="408" width="438"
          alt="Configure DS64 panel image"></a>
-    <div id="mainContent">
 
       <h1>Configure Digitrax DS64</h1>
 
@@ -28,88 +25,88 @@
 
       <p>To open this tool select "Configure DS64" from the LocoNet
       menu for the connection this DS64 is attached to.</p>
-      
+
       <h2>Selecting the DS64 board</h2>
       <p>Each DS64 present on LocoNet is identified uniquely by its <a href=
           "http://www.digitrax.com/tsd/KB805/ds64-setting-board-id-for-additional-ds64s/">
           "Board ID"</a>.  This tool may access a particular DS64 by entering the
           Board ID number in the selection box at the top of the window.</p>
-      <p>Upon start-up, this tool queries LocoNet to create a list of DS64s.  Each 
+      <p>Upon start-up, this tool queries LocoNet to create a list of DS64s.  Each
           DS64 Board Id is listed in the pull-down selector.  New Board Id numbers
           may be typed into the box and will be added to the list.</p>
       <p>While it is possible to change the Board ID number using JMRI, it cannot
-          be done using this tool due to limitations of the DS64 design.  Instead, 
+          be done using this tool due to limitations of the DS64 design.  Instead,
           follow the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
           here</a>, but you must consult the DS64 manual and modify the JMRI-based process
           to suit the DS64's buttons, button press time, and lamp flashes.</p>
 
       <h2>Configuring the basic operating modes</h2>
-      <p>The basic operations are configured on the "Basic Settings" tab.  This tab 
-          gives human-readable descriptions of the various options.  Changes made 
-          here are immediately reflected on the "OpSw Values" tab, but are not 
-          written to the addressed DS64 until the "Write full sheet" button is 
+      <p>The basic operations are configured on the "Basic Settings" tab.  This tab
+          gives human-readable descriptions of the various options.  Changes made
+          here are immediately reflected on the "OpSw Values" tab, but are not
+          written to the addressed DS64 until the "Write full sheet" button is
           pressed.</p>
       <p>The "Read full Sheet" button may be used to read the OpSw settings from the DS64.</p>
-          
+
       <h2>Configuring the OpSws</h2>
       <p>The "OpSw Values" tab displays the individual "OpSw" settings which correspond to
           the settings found on the "Basic Settings" tab.  Changes made on this tab will
           immediately reflected on the "Basic Settings" tab.</p>
-      <p>The "Read full Sheet" pushbutton may be used to read the OpSws from the 
-          addressed DS64.  The "Write Full Sheet" pushbutton may be used to write 
+      <p>The "Read full Sheet" pushbutton may be used to read the OpSws from the
+          addressed DS64.  The "Write Full Sheet" pushbutton may be used to write
           the OpSw values to the addressed DS64.</p>
 
       <h2>Configuring the Output Addresses</h2>
-      <p>The "Output Addresses" tab allows reading and writing the DS64 output 
-          addresses.  The addresses need not be sequential.  
-      <p>The "Read full Sheet" pushbutton may be used to read the Output addresses from the 
-          addressed DS64.  The "Write Full Sheet" pushbutton may be used to write 
+      <p>The "Output Addresses" tab allows reading and writing the DS64 output
+          addresses.  The addresses need not be sequential.
+      <p>The "Read full Sheet" pushbutton may be used to read the Output addresses from the
+          addressed DS64.  The "Write Full Sheet" pushbutton may be used to write
           the Output addresses to the addressed DS64.</p>
 
       <h2>Configuring Routes</h2>
       <p>Each DS64 may be programmed to hold up to 8 "Routes".  Each route consists
           of a "Top" (or "trigger") switch command, plus up to seven additional switch commands.
-          When the "Top" ("trigger") switch command is seen by the DS64 on LocoNet, the 
+          When the "Top" ("trigger") switch command is seen by the DS64 on LocoNet, the
           DS64 will send the other switch commands to LocoNet.</p>
       <p>When the proper OpSw settings are made, the DS64 A* and S* input signals may
           each be used to trigger one of the programmed routes.</p>
       <p>This tool allows configuring each of the 8 "Routes" via the "Routes" tab.
-          Once the "Routes" tab is selected, an individual "Route" is selected on 
+          Once the "Routes" tab is selected, an individual "Route" is selected on
           the left side by selecting one of the tabs.</p>
-      <p>Within each individual Route, the "Top" turnout command is the command 
+      <p>Within each individual Route, the "Top" turnout command is the command
           which begins the sequence.  The received LocoNet command must match the "Top" turnout
-          command exactly - both in address and direction, in order to trigger the 
-          route via a LocoNet command.  Once triggered, the DS64 will transmit the 
-          subsequent turnout messages to LocoNet, until it finds an entry marked as 
+          command exactly - both in address and direction, in order to trigger the
+          route via a LocoNet command.  Once triggered, the DS64 will transmit the
+          subsequent turnout messages to LocoNet, until it finds an entry marked as
           "unused", or until it has sent the 8th entry, which ever comes first.</p>
-      <p>When a DS64 input is used to trigger the route, and the route has a "Top" entry 
+      <p>When a DS64 input is used to trigger the route, and the route has a "Top" entry
           which is something other than "Unused", the DS64 will transmit (on LocoNet) the
-          "Top" switch command, as well as any subsequent commands, until the 8th entry 
-          of the route has been sent or until it reaches an entry marked as "Unused", 
+          "Top" switch command, as well as any subsequent commands, until the 8th entry
+          of the route has been sent or until it reaches an entry marked as "Unused",
           whichever happens first.
-      <p>If the topmost entry of a route is marked as "unused", the whole route is 
+      <p>If the topmost entry of a route is marked as "unused", the whole route is
           considered invalid.</p>
-      <p>Note that it is not necessary to enter a duplicate turnout command to terminate 
-          the route before the end of the list.  Simply configure a turnout as "Unused" 
+      <p>Note that it is not necessary to enter a duplicate turnout command to terminate
+          the route before the end of the list.  Simply configure a turnout as "Unused"
           to terminate the route.  For example, if there are five turnouts in the route,
           including the top-most turnout, then set the sixth turnout entry as "Unused".
           The DS64 will then ignore the sixth, seventh and eighth entries for the route.</p>
       <h3>Clearing a Route</h3>
-      <p>When the "Routes" tab has been selected, the tool provides an additional 
-          button for "clearing" the route.  This button is found at the top of the 
-          window.  When this button is pressed, the tool will ask for confirmation 
+      <p>When the "Routes" tab has been selected, the tool provides an additional
+          button for "clearing" the route.  This button is found at the top of the
+          window.  When this button is pressed, the tool will ask for confirmation
           before making any changes to the DS64.  Upon user confirmation, the tool
           updates the DS64 to clear the route which is selected.</p>
-      <p>Only the selected route will be cleared; other routes remain unmodified.</p>   
+      <p>Only the selected route will be cleared; other routes remain unmodified.</p>
 
       <h2>Limitations</h2>
       <ul>
-          <li>Because of the way the DS64 board works, this tool can't change the 
-              basic address (the "Board ID") of the unit.  It is possible to change 
-              the Board ID number using JMRI by following the instructions found 
+          <li>Because of the way the DS64 board works, this tool can't change the
+              basic address (the "Board ID") of the unit.  It is possible to change
+              the Board ID number using JMRI by following the instructions found
               <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
-              here</a>. Note that it is necessary to consult the DS64 manual and 
-              modify the JMRI-based process shown at the link above to suit the 
+              here</a>. Note that it is necessary to consult the DS64 manual and
+              modify the JMRI-based process shown at the link above to suit the
               DS64's buttons, button press time, and lamp flashes.</li>
           <li>This tool does not have the capability to save the DS64 configuration.</li>
           <li>The "Output Addresses" tab shows the state of the output <i>at the time
@@ -117,8 +114,8 @@
               to track any ongoing turnout control messages, so it cannot provide real-time
               updates of the DS64 output state.</li>
           <li>When a route is "cleared", the tool will simply update the DS64 with
-              the information that the top-most entry is "Unused", and then clear 
-              the route display.  The remaining information from the route remains 
+              the information that the top-most entry is "Unused", and then clear
+              the route display.  The remaining information from the route remains
               un-modified in the DS64.  It cannot be executed as a route.
               A "Read full sheet" operation, for the route, will display the remaining
               "orphaned" route information.

--- a/help/en/package/jmri/jmrix/loconet/duplexgroup/DuplexGroupTabbedPanel.shtml
+++ b/help/en/package/jmri/jmrix/loconet/duplexgroup/DuplexGroupTabbedPanel.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Duplex Network Configuration Tool</title>
   <meta name="author" content="B. Milhaupt">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Digitrax Duplex Network Configuration Tool</h1>
 
@@ -125,7 +122,7 @@
       properly with future Digitrax Duplex-related hardware.</p>
 
       <p>Note that this tool can have some effect on the configuration
-          of the Digitrax LNWI device.  This is a "feature" of the 
+          of the Digitrax LNWI device.  This is a "feature" of the
           Digitrax design.  The Digitrax software package "DigiGroupSetup"
           has the same sorts of effects.  See <a href="#LNWISideEffects">Effect on LNWI device configuration</a>.</p>
 
@@ -661,43 +658,43 @@
       <h3><a name="LNWISideEffects" id="LNWISideEffects">Effect on LNWI device configuration</a></h3>
       <p>Like the Digitra DigiGroupSetup program, this tool can have an effect on the
           LNWI device.</p>
-      <p>If a LNWI device is connected to LocoNet and has certaion OpSw settings, 
+      <p>If a LNWI device is connected to LocoNet and has certaion OpSw settings,
           when this tool is used to configure the Duplex Group identity information,
           the LNWI device can also be re-configured.  The UR92 and LNWI are configured by
-          default to use the same "name" and "net number".  They also, under the 
+          default to use the same "name" and "net number".  They also, under the
           default configuration, configure their "channel" number to be related but not
           identical values.  This is summarized below:</p>
       <ul>
-          <li>When the Duplex Group "name" is changed, the LNWI will inherit the 
+          <li>When the Duplex Group "name" is changed, the LNWI will inherit the
               same name if the LNWI OpSw 11 is set to "t"hrown.  If the LNWI OpSw 11
-          is set to "c"losed, then the LNWI will ignore changes to the Duplex 
+          is set to "c"losed, then the LNWI will ignore changes to the Duplex
           Group "name".</li>
-          <li>When the Duplex Group "channel" is changed, the LNWI will inherit 
-          a WIFI channel number which is 10 less than the duplex group channel 
+          <li>When the Duplex Group "channel" is changed, the LNWI will inherit
+          a WIFI channel number which is 10 less than the duplex group channel
           number if the LNWI OpSw 12 is set to "t"hrown.  If the LNWI OpSw 12
-          is set to "c"losed, then the LNWI will ignore changes to the Duplex 
-          Group "channel" number.  If the Duplex Group "channel" number is greater 
+          is set to "c"losed, then the LNWI will ignore changes to the Duplex
+          Group "channel" number.  If the Duplex Group "channel" number is greater
           than 21, then the LNWI seems to default to WIFI channel 1.</li>
           <li>When the Duplex Group "net" number is changed, the LNWI will inherit
-          the same "net" number if the LNWI OpSw13 is set to "t"hrown.  If the 
-          LNWI OpSw13 is set to "c"losed, then the LNWI will ignore changes to 
-          the Duplex Group "net" number.  Note that the Duplex system seems to 
-          ignore the "net" number, but the LNWI does pay attention to the "net" 
-          number.  Note that it may be desirable to set LNWI OpSw 13 to "c" to avoid 
-          sharing the same frequency spectrum between LNWI WiFi and Duplex 
-          operations - see <a href="#DuplexLnWiChannels">a note on Duplex and WiFi 
+          the same "net" number if the LNWI OpSw13 is set to "t"hrown.  If the
+          LNWI OpSw13 is set to "c"losed, then the LNWI will ignore changes to
+          the Duplex Group "net" number.  Note that the Duplex system seems to
+          ignore the "net" number, but the LNWI does pay attention to the "net"
+          number.  Note that it may be desirable to set LNWI OpSw 13 to "c" to avoid
+          sharing the same frequency spectrum between LNWI WiFi and Duplex
+          operations - see <a href="#DuplexLnWiChannels">a note on Duplex and WiFi
           frequency sharing</a>, below.</li>
-          <li>When the Duplex Group "passcode" is set, the LNWI accepts the passcode 
-          if LNWI OpSw 17 is "c"losed and OpSw18 is "t"hrown, and uses this as 
-          a WiFi "WPA2" passcode.  If LNWI OpSw 17 is 
-          "t"hrown or LNWI Opsw 18 is "c"losed, then the Duplex Group "passcode" 
+          <li>When the Duplex Group "passcode" is set, the LNWI accepts the passcode
+          if LNWI OpSw 17 is "c"losed and OpSw18 is "t"hrown, and uses this as
+          a WiFi "WPA2" passcode.  If LNWI OpSw 17 is
+          "t"hrown or LNWI Opsw 18 is "c"losed, then the Duplex Group "passcode"
           is ignored.</li>
       </ul>
-      <p>Note that any time that the LNWI "name", "channel" number, "net" number, 
-      or "passcode" is chaged, all LNWI WiFi connections are "dropped" it will 
-      need to be re-established using the new WiFi SSID "connection name" and/or 
+      <p>Note that any time that the LNWI "name", "channel" number, "net" number,
+      or "passcode" is chaged, all LNWI WiFi connections are "dropped" it will
+      need to be re-established using the new WiFi SSID "connection name" and/or
       new security passcode.</p>
-          
+
 
       <h2><a name="Interfere" id="Interfere">Some possible
       interference sources</a></h2>
@@ -717,12 +714,12 @@
 
         <li>2.4 GHz wireless video cameras</li>
       </ul>
-      
-      <p><a name="DuplexLnWiChannels" id="DuplexLnWiChannels">Note</a> that, by 
-          default, the LNWI "WiFi" device "channel" shares some frequency spectrum 
-          with the Duplex "channel".  This can cause "contention" between the 
+
+      <p><a name="DuplexLnWiChannels" id="DuplexLnWiChannels">Note</a> that, by
+          default, the LNWI "WiFi" device "channel" shares some frequency spectrum
+          with the Duplex "channel".  This can cause "contention" between the
           LNWI radio signal and the Duplex radio signal.  Ideally, each radio system
-          would operate within non-overlapping frequency spectra.  The table below 
+          would operate within non-overlapping frequency spectra.  The table below
           summarizes the "overlap" between WiFi channels and Duplex channels:</p>
       <table border="2">
           <tr><th align="center">WiFi Channel</th><th align="center">Overlapping Duplex Channels</th></tr>
@@ -746,11 +743,11 @@
           steps listed below:</p>
       <ul>
           <li>Set the LNWI to accept Duplex "channel" number writes (LNWI OpSw 12 = "t")</li>
-          <li>Use this tool to configure set the Duplex channel to give the desired 
+          <li>Use this tool to configure set the Duplex channel to give the desired
               LNWI channel, which is 10 less than the Duplex "channel" number</li>
-          <li>Set the LNWI to ignore Duplex "channel" writes by setting LNWI 
+          <li>Set the LNWI to ignore Duplex "channel" writes by setting LNWI
               OpSw 12 to "c"</li>
-          <li>)Use this tool to configure the desired "channel" number for use 
+          <li>)Use this tool to configure the desired "channel" number for use
               by the Duplex radio system.</li>
       </ul>
 

--- a/help/en/package/jmri/jmrix/loconet/lnsvf2/Sv2DiscoverPane.shtml
+++ b/help/en/package/jmri/jmrix/loconet/lnsvf2/Sv2DiscoverPane.shtml
@@ -11,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Discover LocoNet SV2 Devices</h1>
       <p>The "Send Discover SV2 Devices" tool lets you list all connected

--- a/help/en/package/jmri/jmrix/loconet/locogen/LocoGenFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/locogen/LocoGenFrame.shtml
@@ -3,9 +3,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Send LocoNet Packet</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help send loconet packets">
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Send LocoNet Packet</h1><a href=
       "../../../../../html/hardware/loconet/images/Send_LocoNet_Packet_Plain.png"><img src="../../../../../html/hardware/loconet/images/Send_LocoNet_Packet_Plain.png"

--- a/help/en/package/jmri/jmrix/loconet/locoid/LocoIdFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/locoid/LocoIdFrame.shtml
@@ -3,9 +3,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Configure LocoNet ID</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help configure loconet ID">
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Configure LocoNet ID Tool</h1>
 

--- a/help/en/package/jmri/jmrix/loconet/locoio/LocoIOFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/locoio/LocoIOFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Configure LocoIO (deprecated)</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Configure LocoIO (deprecated)</h1>
 

--- a/help/en/package/jmri/jmrix/loconet/locomon/LocoMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/locomon/LocoMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Monitor LocoNet Traffic</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="author" content="B.Milhaupt">
@@ -15,8 +12,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Monitor LocoNet Traffic</h1><a href=
       "../../../../../html/hardware/loconet/images/LocoMonFrame.png"><img src="../../../../../html/hardware/loconet/images/LocoMonFrame.png"

--- a/help/en/package/jmri/jmrix/loconet/locostats/LocoStatsFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/locostats/LocoStatsFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: LocoNet Statistics</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help digitrax downloader">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>LocoNet Statistics</h1>
       <p>Advanced LocoNet interfaces like

--- a/help/en/package/jmri/jmrix/loconet/pm4/PM4Frame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/pm4/PM4Frame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Configure Digitrax PM4</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help configure loconet PM4">
@@ -13,12 +10,13 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
+
     <a href="PM4xConfigTool.png">
-    <img src="PM4xConfigTool.png" style="float:right; margin: 5px;" 
+    <img src="PM4xConfigTool.png" style="float:right; margin: 5px;"
          alt="PM4x Configuration Tool Screen Capture"></a>
-      
-    <div id="mainContent">
+
 
       <h1>Configure Digitrax PM4x</h1>
 
@@ -36,14 +34,14 @@
 
       <p>You can then, if you wish, change the checkboxes and click
       "Write to PM4x" to make your changes permanent.</p>
-      
+
       <p>The tool relies upon each PM4x board to have a unique "Board ID" (Board
-      Address) in order to configure each device individually.  While it is 
-      possible to change the Board ID number using JMRI, it cannot be done using 
-      this tool due to limitations of the PM4x design.  Instead, 
+      Address) in order to configure each device individually.  While it is
+      possible to change the Board ID number using JMRI, it cannot be done using
+      this tool due to limitations of the PM4x design.  Instead,
       follow the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
-      here</a>, but you must consult the appropriate PM4x manual and modify the 
-      JMRI-based process to suit the PM4x device's buttons, button press time, 
+      here</a>, but you must consult the appropriate PM4x manual and modify the
+      JMRI-based process to suit the PM4x device's buttons, button press time,
       and lamp flashes.</p>
 
       <h2>Limitations</h2>
@@ -59,10 +57,10 @@
         <li>Because of the way the PM4x board works, this tool
         can't change the basic address of the unit. The PM4x
         documentation describes how to change the board
-        address.  It is possible to change the Board ID number using JMRI by 
+        address.  It is possible to change the Board ID number using JMRI by
         following the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
-        here</a>. Note that it is necessary to consult the appropriate PM4x 
-        manual and modify the JMRI-based process shown at the link above to suit 
+        here</a>. Note that it is necessary to consult the appropriate PM4x
+        manual and modify the JMRI-based process shown at the link above to suit
         the PM4x's buttons, button press time, and lamp flashes.</li>
       </ul>
 

--- a/help/en/package/jmri/jmrix/loconet/pr3/swing/Pr3Select.shtml
+++ b/help/en/package/jmri/jmrix/loconet/pr3/swing/Pr3Select.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: Select PR3 Mode</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: Select PR3 Mode</h2>A <a href=
       "../../../../../../html/hardware/loconet/PR3.shtml">Digitrax

--- a/help/en/package/jmri/jmrix/loconet/pr4/swing/Pr4Select.shtml
+++ b/help/en/package/jmri/jmrix/loconet/pr4/swing/Pr4Select.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: Select PR3 Mode</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: Select PR3 Mode</h2>A <a href=
       "../../../../../../html/hardware/loconet/PR3.shtml">Digitrax

--- a/help/en/package/jmri/jmrix/loconet/sdfeditor/EditorFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/sdfeditor/EditorFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: SDF Sound File Editor</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>SDF Sound File Editor</h1>
       <p>Digitrax sound decoders are

--- a/help/en/package/jmri/jmrix/loconet/sdfeditor/TriggerConditions.shtml
+++ b/help/en/package/jmri/jmrix/loconet/sdfeditor/TriggerConditions.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: SDF Trigger Conditions</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>SDF Trigger Conditions</h1>This page documents the
       meaning of the trigger conditions that can defined in a

--- a/help/en/package/jmri/jmrix/loconet/se8/SE8Frame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/se8/SE8Frame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Configure Digitrax SE8c</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help configure loconet SE8C">
@@ -13,12 +10,13 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
+
     <a href="SE8cConfigTool.png"><img src="SE8cConfigTool.png"
-      alt="SE8c Configuration Tool Screen Capture" 
+      alt="SE8c Configuration Tool Screen Capture"
       style="float:right; margin: 5px;"></a>
-      
-    <div id="mainContent">
+
 
       <h1>Configure Digitrax SE8c</h1>
 
@@ -38,23 +36,23 @@
       "Write to SE8c" to make your changes permanent.</p>
 
       <p>The tool relies upon each SE8C board to have a unique "Board ID" (Board
-      Address) in order to configure each device individually.  While it is 
-      possible to change the Board ID number using JMRI, it cannot be done using 
-      this tool due to limitations of the SE8C design.  Instead, 
+      Address) in order to configure each device individually.  While it is
+      possible to change the Board ID number using JMRI, it cannot be done using
+      this tool due to limitations of the SE8C design.  Instead,
       follow the instructions found <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
-      here</a>, but you must consult the SE8C manual and modify the 
-      JMRI-based process to suit the SE8C device's buttons, button press time, 
+      here</a>, but you must consult the SE8C manual and modify the
+      JMRI-based process to suit the SE8C device's buttons, button press time,
       and lamp flashes.</p>
 
       <h2>Limitations</h2>
 
       <ul>
         <li>Because of the way the SE8c board works, this tool
-        can't change the basic address of the unit.  It is possible to change 
-              the Board ID number using JMRI by following the instructions found 
+        can't change the basic address of the unit.  It is possible to change
+              the Board ID number using JMRI by following the instructions found
               <a href="../../../../../html/hardware/loconet/Digitrax.shtml#deviceBoardId">
-              here</a>. Note that it is necessary to consult the SE8C manual and 
-              modify the JMRI-based process shown at the link above to suit the 
+              here</a>. Note that it is necessary to consult the SE8C manual and
+              modify the JMRI-based process shown at the link above to suit the
               SE8C's buttons, button press time, and lamp flashes.</li>
 
         <li>The SE8c can be configured to send Sensor status on the

--- a/help/en/package/jmri/jmrix/loconet/slotmon/SlotMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/slotmon/SlotMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: LocoNet Slot Monitor</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help loconet slot monitor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>LocoNet Slot Monitor</h1>
       <a href=

--- a/help/en/package/jmri/jmrix/loconet/soundloader/EditorFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/soundloader/EditorFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Sound Editor</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help sound editor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>SPJ Sound File Editor</h1>
       <p>Digitrax sound decoders are

--- a/help/en/package/jmri/jmrix/loconet/soundloader/LoaderFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/soundloader/LoaderFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Sound Loader</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help loconet sound loader">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Sound Loader</h1>Digitrax sound decoders are loaded with
       "sound projects", stored in "Sound Project" (.spj) files.

--- a/help/en/package/jmri/jmrix/loconet/swing/lncvprog/LncvProgPane.shtml
+++ b/help/en/package/jmri/jmrix/loconet/swing/lncvprog/LncvProgPane.shtml
@@ -10,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>LocoNet LNCV Programming Pane</h1>
 

--- a/help/en/package/jmri/jmrix/loconet/swing/throttlemsg/MessageFrame.shtml
+++ b/help/en/package/jmri/jmrix/loconet/swing/throttlemsg/MessageFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: Send Throttle Message</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: Send Throttle Message</h1>
       <p>JMRI has a limited

--- a/help/en/package/jmri/jmrix/loconet/usb_dcs240/swing/Dcs240UsbModeSelect.shtml
+++ b/help/en/package/jmri/jmrix/loconet/usb_dcs240/swing/Dcs240UsbModeSelect.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: Select DCS240 USB Mode</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: Select DCS240 USB Mode</h2>A <a href=
       "../../../../../../html/hardware/loconet/DCS240.shtml">Digitrax

--- a/help/en/package/jmri/jmrix/loconet/usb_dcs52/swing/Dcs52UsbModeSelect.shtml
+++ b/help/en/package/jmri/jmrix/loconet/usb_dcs52/swing/Dcs52UsbModeSelect.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: Select DCS52 USB Mode</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: Select DCS52 USB Mode</h2>A <a href=
       "../../../../../../html/hardware/loconet/DCS52.shtml">Digitrax

--- a/help/en/package/jmri/jmrix/maple/assignment/ListFrame.shtml
+++ b/help/en/package/jmri/jmrix/maple/assignment/ListFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: Maple Input and Output Assignments</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: Maple Input and Output Assignments</h2>
 

--- a/help/en/package/jmri/jmrix/maple/nodeconfig/NodeConfigFrame.shtml
+++ b/help/en/package/jmri/jmrix/maple/nodeconfig/NodeConfigFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: Maple Node Configuration</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>JMRI: Maple Node Configuration</h2>
 

--- a/help/en/package/jmri/jmrix/maple/serialmon/SerialMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/maple/serialmon/SerialMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Monitor Maple Traffic</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h2>Monitor Maple Traffic</h2>
 

--- a/help/en/package/jmri/jmrix/marklin/swing/packetgen/PacketGenFrame.shtml
+++ b/help/en/package/jmri/jmrix/marklin/swing/packetgen/PacketGenFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Send M&auml;rklin Message</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Send M&auml;rklin&trade; Message</h1>
       This is the help/jmri/jmrix/marklin/swing/packetgen/PacketGenFrame help

--- a/help/en/package/jmri/jmrix/mrc/swing/monitor/MrcMonPanel.shtml
+++ b/help/en/package/jmri/jmrix/mrc/swing/monitor/MrcMonPanel.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: MRC Command Monitor</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: MRC Command Monitor</h1>This is the
       package/jmri/jmrix/mrc/swing/monitor/MrcMonPanel.shtml

--- a/help/en/package/jmri/jmrix/mrc/swing/packetgen/MrcPacketGenPanel.shtml
+++ b/help/en/package/jmri/jmrix/mrc/swing/packetgen/MrcPacketGenPanel.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: MRC Command Generator</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: MRC Command Generator</h1>
 

--- a/help/en/package/jmri/jmrix/nce/analyzer/NcePacketMonitorFrame.shtml
+++ b/help/en/package/jmri/jmrix/nce/analyzer/NcePacketMonitorFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: NCE DCC Packet Analyzer</title>
   <meta name="author" content="Dan Boudreau">
   <meta name="keywords" content="JMRI Help DCC Analyzer">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>NCE DCC Packet Analyzer</h1>
 
@@ -167,7 +164,7 @@
       Same as H6 mode except spaces will delimit each pair of hex
       characters<br>
       Example: P 03 68 6B<br>
-      Three byte packet following with bytes of 0x03, 0x68, 0x6B 
+      Three byte packet following with bytes of 0x03, 0x68, 0x6B
       </p>
 
       <h2>Verbose mode displays:</h2>Verbose mode displays are

--- a/help/en/package/jmri/jmrix/nce/boosterprog/BoosterProgPanel.shtml
+++ b/help/en/package/jmri/jmrix/nce/boosterprog/BoosterProgPanel.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: NCE Booster</title>
   <meta name="author" content="Dan Boudreau">
   <meta name="keywords" content="JMRI NCE Booster">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>NCE Booster</h1>
 

--- a/help/en/package/jmri/jmrix/nce/cab/NceShowCabFrame.shtml
+++ b/help/en/package/jmri/jmrix/nce/cab/NceShowCabFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: NCE Cab Monitor</title>
   <meta name="author" content="Ken Cameron">
   <meta name="keywords" content="JMRI Help NCE Cab Monitor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>NCE Cab Monitor</h1>
 

--- a/help/en/package/jmri/jmrix/nce/clockmon/ClockMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/nce/clockmon/ClockMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: NCE Clock Monitor</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Route Add Edit">
@@ -13,11 +10,11 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>NCE Fast Clock</h1>
-      
+
         <p>The NCE fast clock can be
           either a source of fast time or can be commanded to
           follow the internal clock. The best synchronization is

--- a/help/en/package/jmri/jmrix/nce/consist/NceConsistEditFrame.shtml
+++ b/help/en/package/jmri/jmrix/nce/consist/NceConsistEditFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Edit NCE Consist</title>
   <meta name="author" content="Dan Boudreau">
   <meta name="keywords" content="JMRI Help NCE Edit Consist">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Edit NCE Consist</h1>This tool allows you to review,
       edit, and save NCE style consists. It also allows you to

--- a/help/en/package/jmri/jmrix/nce/macro/NceMacroEditFrame.shtml
+++ b/help/en/package/jmri/jmrix/nce/macro/NceMacroEditFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Edit NCE Macro</title>
   <meta name="author" content="Dan Boudreau">
   <meta name="keywords" content="JMRI Help NCE Edit Macro">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Edit NCE Macro</h1>This tool allows you to review, edit,
       and save NCE style macros. It also allows you to backup and

--- a/help/en/package/jmri/jmrix/nce/packetgen/NcePacketGenFrame.shtml
+++ b/help/en/package/jmri/jmrix/nce/packetgen/NcePacketGenFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator"
-    content="HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Command Generator</title>
   <meta name="author" content="Dan Boudreau">
   <meta name="keywords" content="JMRI Help NCE Command Generator">
@@ -13,8 +10,8 @@
 
 <body>
  <!--#include virtual="/Header.shtml" -->
- <div class="nomenu" id="mBody">
-  <div id="mainContent">
+ <div id="mBody">
+  <div id="mainContent" class="no-sidebar">
 
    <h1>NCE Command Generator</h1>
    NCE binary commands are designed to work in a computer friendly mode.<br> Command format is:

--- a/help/en/package/jmri/jmrix/nce/usbinterface/UsbInterfacePanel.shtml
+++ b/help/en/package/jmri/jmrix/nce/usbinterface/UsbInterfacePanel.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: NCE USB Interface Tool</title>
   <meta name="author" content="Ken Cameron">
   <meta name="keywords" content="JMRI Help NCE Cab Monitor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>NCE USB Interface Tool</h1>
 

--- a/help/en/package/jmri/jmrix/oaktree/nodeconfig/NodeConfigFrame.shtml
+++ b/help/en/package/jmri/jmrix/oaktree/nodeconfig/NodeConfigFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <meta name="keywords" content="JMRI help CBUS NODE Manager CONFIG TOOL configuration variable">
   <title>JMRI: Oaktree Node Configuration</title>
   <!--#include virtual="/Style.shtml" -->
@@ -11,11 +9,11 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
      <h1>JMRI: Oaktree - Node Configuration</h1>
-     
+
         Help is on the way.
 
       <!--#include virtual="/Footer.shtml" -->

--- a/help/en/package/jmri/jmrix/openlcb/swing/downloader/LoaderFrame.shtml
+++ b/help/en/package/jmri/jmrix/openlcb/swing/downloader/LoaderFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: OpenLCB Firmware Downloader</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="author" content="B. Milhaupt">
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>OpenLCB "Download Firmware" Tool</h1>
 

--- a/help/en/package/jmri/jmrix/openlcb/swing/downloader/OpenLCBlibrary.html
+++ b/help/en/package/jmri/jmrix/openlcb/swing/downloader/OpenLCBlibrary.html
@@ -2,9 +2,6 @@
 
 <html>
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>Freeze/Unfreeze in the OpenLCB protocols</title>
 </head>
 

--- a/help/en/package/jmri/jmrix/openlcb/swing/hub/HubPane.shtml
+++ b/help/en/package/jmri/jmrix/openlcb/swing/hub/HubPane.shtml
@@ -11,17 +11,17 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>OpenLCB Hub Control</h1><a href="OpenLCB_Hub_Control.png"><img src=
       "OpenLCB_Hub_Control.png" width="394" height="124" alt=
       "OpenLCB Hub Control" align="right"></a><br>
-      
+
       <p>The "OpenLCB Hub Control" tool enables a physical OpenLCB connection to be shared on a Network Connection.</p>
-      
+
       <p>The window displays the IP address and port of the Hub.</p>
-      
+
       <p>The OpenLCB Hub can be opened by adding as a system startup action.</p>
 
       <!--#include virtual="/Footer.shtml" -->

--- a/help/en/package/jmri/jmrix/openlcb/swing/networktree/NetworkTreePane.shtml
+++ b/help/en/package/jmri/jmrix/openlcb/swing/networktree/NetworkTreePane.shtml
@@ -3,9 +3,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI OpenLCB: Browse Configuration</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI OpenLCB">
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>OpenLCB: Browse Configuration</h1>The "Configure Nodes"
       OpenLCB tool lets you directly see the nodes on your OpenLCB

--- a/help/en/package/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendFrame.shtml
+++ b/help/en/package/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendFrame.shtml
@@ -3,9 +3,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Send CAN Frame</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help send loconet packets">
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Send OpenLCB Frame</h1><a href="SendFrame.jpg"><img src=
       "SendFrame.jpg" width="221" height="176" alt=

--- a/help/en/package/jmri/jmrix/openlcb/swing/tie/TieToolFrame.shtml
+++ b/help/en/package/jmri/jmrix/openlcb/swing/tie/TieToolFrame.shtml
@@ -3,9 +3,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Tie Config Frame</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help OpenLCB Tie">
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>OpenLCB Tie Configuration Tool</h1>
       <a href="FrameExample.gif"><img src=

--- a/help/en/package/jmri/jmrix/powerline/nodeconfig/NodeConfigFrame.shtml
+++ b/help/en/package/jmri/jmrix/powerline/nodeconfig/NodeConfigFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Configure Powerline Device Nodes</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Configure Powerline Devices</h1>This is the
       help/jmri/jmrix/powerline/nodeconfig/NodeConfigFrame help

--- a/help/en/package/jmri/jmrix/powerline/packetgen/PowerlinePacketGenPane.shtml
+++ b/help/en/package/jmri/jmrix/powerline/packetgen/PowerlinePacketGenPane.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Send Powerline Device message</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Send Powerline message packet">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Send Powerline Device Message</h1>
 

--- a/help/en/package/jmri/jmrix/powerline/serialmon/SerialMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/powerline/serialmon/SerialMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Monitor Powerline Device Traffic</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Monitor Powerline Device Traffic</h1>This is the
       help/jmri/jmrix/powerline/serialmon/SerialMonFrame help page

--- a/help/en/package/jmri/jmrix/roco/z21/swing/configtool/ConfigToolFrame.shtml
+++ b/help/en/package/jmri/jmrix/roco/z21/swing/configtool/ConfigToolFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <meta name="keywords" content="JMRI help CBUS NODE Manager CONFIG TOOL configuration variable">
   <title>JMRI: Lenz Z21 Configuration Tool</title>
   <!--#include virtual="/Style.shtml" -->
@@ -11,11 +9,11 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
      <h1>JMRI: Lenz Z21 Configuration Tool</h1>
-     
+
         Help is on the way.
 
       <!--#include virtual="/Footer.shtml" -->

--- a/help/en/package/jmri/jmrix/rps/aligntable/AlignTableFrame.shtml
+++ b/help/en/package/jmri/jmrix/rps/aligntable/AlignTableFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: RPS Receiver Control</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: RPS Receiver Control</h1><a href=
       "../../../../../html/hardware/rps/images/ReceiverControl.gif"><img src="../../../../../html/hardware/rps/images/ReceiverControl.gif"

--- a/help/en/package/jmri/jmrix/rps/reversealign/AlignmentPanel.shtml
+++ b/help/en/package/jmri/jmrix/rps/reversealign/AlignmentPanel.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: RPS Alignment Tools</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: RPS Alignment Tool</h1>
       <p>This is the

--- a/help/en/package/jmri/jmrix/rps/swing/debugger/DebuggerFrame.shtml
+++ b/help/en/package/jmri/jmrix/rps/swing/debugger/DebuggerFrame.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: RPS Debugger</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: RPS Debugger</h1><a href=
       "../../../../../../html/hardware/rps/images/Debugger.jpg"><img src="../../../../../../html/hardware/rps/images/Debugger.jpg"

--- a/help/en/package/jmri/jmrix/rps/swing/polling/PollTableFrame.shtml
+++ b/help/en/package/jmri/jmrix/rps/swing/polling/PollTableFrame.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: RPS Polling Control</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: RPS Polling Control</h1><a href=
       "../../../../../../html/hardware/rps/images/PollControl.gif"><img src="../../../../../../html/hardware/rps/images/PollControl.gif"

--- a/help/en/package/jmri/jmrix/rps/swing/soundset/SoundSetFrame.shtml
+++ b/help/en/package/jmri/jmrix/rps/swing/soundset/SoundSetFrame.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: RPS Sound Speed Control</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: RPS Sound Speed Control</h1><a href=
       "../../../../../../html/hardware/rps/images/SoundControl.gif"><img src="../../../../../../html/hardware/rps/images/SoundControl.gif"

--- a/help/en/package/jmri/jmrix/rps/trackingpanel/RpsTrackingFrame.shtml
+++ b/help/en/package/jmri/jmrix/rps/trackingpanel/RpsTrackingFrame.shtml
@@ -2,8 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
   <!-- Copyright Bob Jacobsen 2008 -->
 
   <title>JMRI: RPS Tracking Frame</title>
@@ -12,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: RPS Tracking Frame</h1><a href=
       "../../../../../html/hardware/rps/images/RpsTracker.jpg"><img src="../../../../../html/hardware/rps/images/RpsTracker.jpg"

--- a/help/en/package/jmri/jmrix/secsi/nodeconfig/NodeConfigFrame.shtml
+++ b/help/en/package/jmri/jmrix/secsi/nodeconfig/NodeConfigFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Configure SECSI Nodes</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Configure SECSI Nodes</h1>
 

--- a/help/en/package/jmri/jmrix/secsi/packetgen/SerialPacketGenFrame.shtml
+++ b/help/en/package/jmri/jmrix/secsi/packetgen/SerialPacketGenFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Send SECSI Message</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Send SECSI Message</h1>This is the
       help/jmri/jmrix/secsi/packetgen/SerialPacketGenFrame help

--- a/help/en/package/jmri/jmrix/secsi/serialmon/SerialMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/secsi/serialmon/SerialMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Monitor SECSI Traffic</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Monitor SECSI Traffic</h1>
 

--- a/help/en/package/jmri/jmrix/sprog/console/SprogConsoleFrame.shtml
+++ b/help/en/package/jmri/jmrix/sprog/console/SprogConsoleFrame.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: SPROG Console</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: SPROG Console</h1>
       <p>The SPROG Console window provides

--- a/help/en/package/jmri/jmrix/sprog/packetgen/SprogPacketGenFrame.shtml
+++ b/help/en/package/jmri/jmrix/sprog/packetgen/SprogPacketGenFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Send SPROG Command</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Send SPROG command packet">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Send SPROG Command</h1>
 

--- a/help/en/package/jmri/jmrix/sprog/sprogmon/SprogMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/sprog/sprogmon/SprogMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: SPROG Monitor</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help Send SPROG message monitor">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: SPROG Command Monitor</h1>
       <p>The SPROG Command Monitor window provides

--- a/help/en/package/jmri/jmrix/sprog/sprogslotmon/SprogSlotMonFrame.shtml
+++ b/help/en/package/jmri/jmrix/sprog/sprogslotmon/SprogSlotMonFrame.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Monitor SPROG Slots</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content="JMRI help monitor sprog slots">
@@ -13,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Monitor SPROG Slots</h1>
 

--- a/help/en/package/jmri/jmrix/sprog/update/SprogIIUpdateFrame.shtml
+++ b/help/en/package/jmri/jmrix/sprog/update/SprogIIUpdateFrame.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: SPROG II Update Tool</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: SPROG II Update Tool</h1>
       <p>The SPROG II Update Tool lets you load new firmware

--- a/help/en/package/jmri/jmrix/sprog/update/SprogVersionFrame.shtml
+++ b/help/en/package/jmri/jmrix/sprog/update/SprogVersionFrame.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: SPROG Version Tool</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: SPROG Version Tool</h1>
       <p>The SPROG Version Tool displays the version reply from the SPROG.<br>

--- a/help/en/package/jmri/jmrix/sprog/update/Sprogv4UpdateFrame.shtml
+++ b/help/en/package/jmri/jmrix/sprog/update/Sprogv4UpdateFrame.shtml
@@ -2,17 +2,14 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: SPROG V4 Update Tool</title>
   <!--#include virtual="/Style.shtml" -->
 </head>
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>JMRI: SPROG V4 Update Tool</h1>
       <p>The SPROG V4 Update Tool

--- a/help/en/package/jmri/jmrix/tams/swing/locodatabase/LocoDataFrame.shtml
+++ b/help/en/package/jmri/jmrix/tams/swing/locodatabase/LocoDataFrame.shtml
@@ -10,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Tams LocoData Frame</h1>
       The Tams LocoData tool lets you read and write Locomotive Data

--- a/help/en/package/jmri/jmrix/tams/swing/packetgen/PacketGenFrame.shtml
+++ b/help/en/package/jmri/jmrix/tams/swing/packetgen/PacketGenFrame.shtml
@@ -10,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>TAMs Command Generator</h1>The TAMs command generator
       tool lets you type a message for the TAMs command station

--- a/help/en/package/jmri/jmrix/tams/swing/statusframe/StatusPanel.shtml
+++ b/help/en/package/jmri/jmrix/tams/swing/statusframe/StatusPanel.shtml
@@ -10,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>TAMs Status Panel</h1>
       <p>Displays Application Version and serial number.</p>

--- a/help/en/package/jmri/jmrix/zimo/swing/monitor/Mx1MonPanel.shtml
+++ b/help/en/package/jmri/jmrix/zimo/swing/monitor/Mx1MonPanel.shtml
@@ -2,9 +2,6 @@
 
 <html lang="en">
 <head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-
   <title>JMRI: Monitor Zimo Device Traffic</title>
   <meta name="author" content="Bob Jacobsen">
   <meta name="keywords" content=
@@ -14,8 +11,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Monitor Zimo Device Traffic</h1>This is the
       help/jmri/jmrix/zimo/swing/monitor/Mx1MonPanel help page

--- a/help/en/package/jmri/jmrix/zimo/swing/packetgen/Mx1PacketGenPanel.shtml
+++ b/help/en/package/jmri/jmrix/zimo/swing/packetgen/Mx1PacketGenPanel.shtml
@@ -10,8 +10,8 @@
 
 <body>
   <!--#include virtual="/Header.shtml" -->
-  <div class="nomenu" id="mBody">
-    <div id="mainContent">
+  <div id="mBody">
+    <div id="mainContent" class="no-sidebar">
 
       <h1>Zimo Command Generator</h1>The Zimo command generator
       tool lets you type a message for the Zimo command station


### PR DESCRIPTION
This PR should cover the remaining web pages in the `help/en` tree that have a blank sidebar.  

- Remove the **nomenu** class from the the **mBody** div.
- Add the **no-sidebar** class to the the **mainContent** div.

