### PR TITLE
Fix duplicate Operations Bundle keys

### DIFF
--- a/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_en_GB.properties
@@ -111,13 +111,9 @@ HoldCarsWithCustomLoadsTip = Wagons with custom loads will wait for the siding t
 
 # track analysis
 
-SpurTrackThatAccept = Sidings that accept wagon type {0}:
 YardTrackThatAccept = Yard tracks that accept wagon type {0}:
 InterchangesThatAccept = Classification/Interchange tracks that accept wagon type {0}:
 StageTrackThatAccept = Fiddle yards that accept wagon type {0}:
-
-TotalLengthSpur     = Sidings that accept type {0} {1} {2} percentage used {3}%
-TotalLengthStage    = Fiddle yards that accept type {0} {1} {2} percentage used {3}%
 
 # track error analysis
 
@@ -184,10 +180,7 @@ sequentialMessage   = ({0}) in {1} mode, car ({2}) type({3}) schedule({4}) railw
 # Physical Location Tools Dialog
 
 # schedules by load
-trackSchedule       = Siding (schedule)
 receiveTypeLoad     = Receive (type, delivery, railway, load)
-
-spurNotTypeLoad     = Siding ({0}) doesn''t service type ({1}) load ({2})
 
 # TrackEditCommentsFrame.java
 

--- a/java/src/jmri/jmrit/operations/trains/JmritOperationsTrainsBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/operations/trains/JmritOperationsTrainsBundle_en_GB.properties
@@ -326,8 +326,6 @@ buildNoDestSpace            = Wagon ({0}) would overload {1} ({2}, {3}), current
 buildSearchForSpur          = Find siding for wagon ({0}) type ({1}) custom {2} ({3}) at ({4}, {5})
 buildCouldNotFindTrack       = Could not find a reachable {0} for wagon ({1}) load ({2})
 
-buildReturnCarToStaging     = Returning wagon ({0}) to fiddle yard ({1}), no other tracks available
-
 buildSortCarsByLastDate		= Sort wagons on FIFO and LIFO tracks:
 buildTrackModePriority   	= Wagon ({0}) on {1} track ({2}) has service order {3} last moved {4}
 buildTrackModeCarPriority   = {0} track ({1}) in mode {2}, wagon ({3}) last moved {4} has priority over wagon ({5}) last moved {6}
@@ -394,7 +392,6 @@ blockNotAbleFinalDest       = Not able to block wagon ({0}), it has final destin
 blockNotAbleCustomLoad      = Not able to block wagon ({0}), it has custom load ({1})
 blockNotAbleCarType         = Not able to block wagon ({0}) destination ({1}) doesn''t accept type ({2})
 blockingCar                 = Blocking wagon ({0}) originally from ({1}) to destination ({2})
-buildStagingCanAcceptLoad   = Fiddle yard ({0}, {1}) can accept wagon''s load ({2})
 
 NoCarPickUps                = No wagon pick ups for this train at this location
 NoCarDrops                  = No wagon set outs for this train at this location


### PR DESCRIPTION
Fixes duplicate Bundle keys as per https://builds.jmri.org/jenkins/job/development/job/builds/798/console
See #10005

```
[resourceCheck] Enabled checks: [duplicate key check, empty key check, messageformat check, unicode check, invalid char check]
[resourceCheck] duplicate key check: key SpurTrackThatAccept defined more than once (114:Sidings that accept wagon type {0}:) (/var/lib/jenkins/workspace/development/builds/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_en_GB.properties:104:Siding tracks that accept wagon type {0}: + 114:Sidings that accept wagon type {0}:)
[resourceCheck] duplicate key check: key TotalLengthSpur defined more than once (119:Sidings that accept type {0} {1} {2} percentage used {3}%) (/var/lib/jenkins/workspace/development/builds/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_en_GB.properties:105:Sidings that accept type {0} {1} {2} percentage used {3}% + 119:Sidings that accept type {0} {1} {2} percentage used {3}%)
[resourceCheck] duplicate key check: key TotalLengthStage defined more than once (120:Fiddle yards that accept type {0} {1} {2} percentage used {3}%) (/var/lib/jenkins/workspace/development/builds/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_en_GB.properties:106:Fiddle yards that accept type {0} {1} {2} percentage used {3}% + 120:Fiddle yards that accept type {0} {1} {2} percentage used {3}%)
[resourceCheck] duplicate key check: key trackSchedule defined more than once (187:Siding (schedule)) (/var/lib/jenkins/workspace/development/builds/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_en_GB.properties:170:Siding (schedule) + 187:Siding (schedule))
[resourceCheck] duplicate key check: key spurNotTypeLoad defined more than once (190:Siding ({0}) doesn''t service type ({1}) load ({2})) (/var/lib/jenkins/workspace/development/builds/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_en_GB.properties:171:Siding ({0}) doesn''t service type ({1}) load ({2}) + 190:Siding ({0}) doesn''t service type ({1}) load ({2}))
[resourceCheck] duplicate key check: key buildReturnCarToStaging defined more than once (329:Returning wagon ({0}) to fiddle yard ({1}), no other tracks available) (/var/lib/jenkins/workspace/development/builds/java/src/jmri/jmrit/operations/trains/JmritOperationsTrainsBundle_en_GB.properties:310:Returning wagon ({0}) to fiddle yard ({1}), no other tracks available + 329:Returning wagon ({0}) to fiddle yard ({1}), no other tracks available)
[resourceCheck] duplicate key check: key buildStagingCanAcceptLoad defined more than once (397:Fiddle yard ({0}, {1}) can accept wagon''s load ({2})) (/var/lib/jenkins/workspace/development/builds/java/src/jmri/jmrit/operations/trains/JmritOperationsTrainsBundle_en_GB.properties:357:Fiddle yard ({0}, {1}) can accept wagon''s load ({2}) + 397:Fiddle yard ({0}, {1}) can accept wagon''s load ({2}))
```