### PR TITLE
WIP - SPI for LnMenu item extension

### DIFF
--- a/java/src/jmri/jmrix/loconet/swing/LnMenuItem.java
+++ b/java/src/jmri/jmrix/loconet/swing/LnMenuItem.java
@@ -1,0 +1,56 @@
+package jmri.jmrix.loconet.swing;
+
+/**
+ * A class to handle Menu Items for LocoNet-based connections.
+ * <p>
+ * This class was separated out from jmri.jmrix.loconet.swing.LocoNetMenu.java.
+ * <hr>
+ * This file is part of JMRI.
+ * <p>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * <p>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * <p>
+ * @author B. Milhaupt Copyright (C) 2021
+ * @author Bob Jacobsen Copyright 2003, 2010
+ */
+public class LnMenuItem {
+
+    private final String menuItemName;
+    private final String classNameOfItem;
+    private final boolean requiresLocoNetAccess;
+
+    /**
+     * Describes a Menu Item for inclusion in a LocoNet-based connection's
+     * connection-specific menu.
+     *
+     * @param menuItemName - user name to be displayed in the Menu item
+     * @param classToLoad - fully-qualified path to the LnPanel
+     * @param requiresAccessToLocoNet - true if the menu item is only to be displayed
+     *      for connections which provide access to a physical LocoNet; false
+     *      to indicate that the menu item should be shown regardless of
+     *      the connection's ability to communicate with physical LocoNet devices.
+     *      Note that standalone programmer connections do not provide such
+     *      functionality.
+     */
+    public LnMenuItem(String menuItemName, String classToLoad, boolean requiresAccessToLocoNet) {
+        this.menuItemName = menuItemName;
+        this.classNameOfItem = classToLoad;
+        this.requiresLocoNetAccess = requiresAccessToLocoNet;
+    }
+    public final String getMenuItemName() {
+        return menuItemName;
+    }
+
+    public final String getClassToLoad() {
+        return classNameOfItem;
+    }
+
+    public final boolean getRequiresAccessToLocoNet() {
+        return requiresLocoNetAccess;
+    }
+}

--- a/java/src/jmri/jmrix/loconet/swing/LnMenuItemExtensionService.java
+++ b/java/src/jmri/jmrix/loconet/swing/LnMenuItemExtensionService.java
@@ -1,0 +1,98 @@
+package jmri.jmrix.loconet.swing;
+
+import java.util.List;
+import java.util.ArrayList;
+import jmri.jmrix.loconet.swing.spi.LnMenuItemExtension;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+import javax.annotation.Nonnull;
+
+
+/**
+ * Service which supports Service Providers for LocoNet Menu Items.
+ * <p>
+ * jmri.jmrix.loconet.swing.LocoNetMenu uses this SPI service to collect any
+ * LocoNet menu items from LnMenuItemExtension "Service providers".  Any such menu
+ * items are added to the bottom of any LocoNet-based system connection's menu.
+ * <p>
+ * The service class is based on the the principles described in the JAVA SPI
+ * methodology, as described in the "Creating Extensible Applications" section
+ * of the Oracle Java 8 Tutorial.
+ * <hr>
+ * This file is part of JMRI.
+ * <p>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * <p>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * <p>
+ * @author B. Milhaupt  Copyright 2021
+ */
+
+public class LnMenuItemExtensionService {
+
+    private static LnMenuItemExtensionService service;
+    private final ServiceLoader<LnMenuItemExtension> loader;
+
+    private LnMenuItemExtensionService() {
+        loader = ServiceLoader.load(LnMenuItemExtension.class);
+    }
+
+    /**
+     * Provide access to the "Singleton" instance.
+     * <p>
+     * @return the singleton instance
+     */
+    public static synchronized LnMenuItemExtensionService getInstance() {
+        if (service == null) {
+            service = new LnMenuItemExtensionService();
+        }
+        return service;
+    }
+
+    /**
+     * Return a List of all SPI-based LnMenuItemExtension implementations.
+     * Find an interpretation (if available) via any available interpretation
+     * "Service Provider".
+     * <p>
+     * @param locale as used by JMRI
+     * @return a list of all SPI-based LnMenuItem extensionIterator.  May return
+     *      an empty list.
+     */
+    public List<LnMenuItem> getExtensionLnMenuItems(@Nonnull java.util.Locale locale) {
+        List<LnMenuItem> extensionMenuItems = new ArrayList<>();
+
+        try {
+            Iterator<LnMenuItemExtension> extensionIterator = loader.iterator();
+
+            while (extensionIterator.hasNext()) {
+                LnMenuItemExtension xtn = extensionIterator.next();
+
+                List<LnMenuItem> menuItems = xtn.getLocoNetMenuInfo(locale);
+                Iterator<LnMenuItem> itemIterator = menuItems.iterator();
+
+                while (itemIterator.hasNext()) {
+                    LnMenuItem lmi = itemIterator.next();
+                    extensionMenuItems.add(lmi);
+                    log.debug("Adding menu item {}", lmi.getClassToLoad());
+                }
+            }
+        } catch (ServiceConfigurationError serviceError) {
+            // Suppress the exception; where no service providers have been found,
+            // this will result in returning an empty List.
+        }
+
+        return extensionMenuItems;
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(LnMenuItemExtensionService.class);
+}

--- a/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
+++ b/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
@@ -1,15 +1,24 @@
 package jmri.jmrix.loconet.swing;
 
+import java.util.Iterator;
+
 import javax.swing.JMenu;
+
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import jmri.jmrix.loconet.LnCommandStationType;
+import jmri.jmrix.loconet.swing.spi.LnMenuItemExtension;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Create a "Systems" menu containing the Jmri LocoNet-specific tools.
  *
  * @author Bob Jacobsen Copyright 2003, 2010
+ * @author B. Milhaupt Copyright 2021
  */
 public class LocoNetMenu extends JMenu {
+    java.util.ArrayList<LnMenuItem> panelItems = new java.util.ArrayList<>();
 
     /**
      * Create a LocoNet menu. Preloads the TrafficController to certain actions.
@@ -20,6 +29,29 @@ public class LocoNetMenu extends JMenu {
      */
     public LocoNetMenu(LocoNetSystemConnectionMemo memo) {
         super();
+
+        panelItems.add(new LnMenuItem("MenuItemLocoNetMonitor",
+                "jmri.jmrix.loconet.locomon.LocoMonPane", false)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemSlotMonitor", "jmri.jmrix.loconet.slotmon.SlotMonPane", false)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemClockMon", "jmri.jmrix.loconet.clockmon.ClockMonPane", true)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemLocoStats", "jmri.jmrix.loconet.locostats.swing.LocoStatsPanel", false)); // NOI18N
+        panelItems.add(null);
+        panelItems.add(new LnMenuItem("MenuItemBDL16Programmer", "jmri.jmrix.loconet.bdl16.BDL16Panel", true)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemPM4Programmer", "jmri.jmrix.loconet.pm4.PM4Panel", true)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemSE8cProgrammer", "jmri.jmrix.loconet.se8.SE8Panel", true)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemDS64Programmer", "jmri.jmrix.loconet.ds64.Ds64TabbedPanel", true)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemCmdStnConfig", "jmri.jmrix.loconet.cmdstnconfig.CmdStnConfigPane",true)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemSetID", "jmri.jmrix.loconet.locoid.LocoIdPanel", true)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemDuplex", "jmri.jmrix.loconet.duplexgroup.swing.DuplexGroupTabbedPanel", true)); // NOI18N
+        panelItems.add(null);
+        panelItems.add(new LnMenuItem("MenuItemThrottleMessages", "jmri.jmrix.loconet.swing.throttlemsg.MessagePanel", true)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemSendPacket", "jmri.jmrix.loconet.locogen.LocoGenPanel", false)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemLncvProg", "jmri.jmrix.loconet.swing.lncvprog.LncvProgPane", true)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemPr3ModeSelect", "jmri.jmrix.loconet.pr3.swing.Pr3SelectPane", false)); // NOI18N
+        panelItems.add(null);
+        panelItems.add(new LnMenuItem("MenuItemDownload", "jmri.jmrix.loconet.downloader.LoaderPane", false)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemSoundload", "jmri.jmrix.loconet.soundloader.LoaderPane", false)); // NOI18N
+        panelItems.add(new LnMenuItem("MenuItemSoundEditor", "jmri.jmrix.loconet.soundloader.EditorPane", false)); // NOI18N
 
         LnCommandStationType cmdStation = null;
         if (memo != null) {
@@ -50,62 +82,66 @@ public class LocoNetMenu extends JMenu {
          */
         boolean lastWasSeparator = true;
 
-        for (Item item : panelItems) {
+        for (LnMenuItem item : panelItems) {
             if (item == null) {
                 if (!lastWasSeparator) {
                     add(new javax.swing.JSeparator());
                     lastWasSeparator = true;
                 }
             } else {
-                if ((!item.interfaceOnly) ||
+                if ((!item.getRequiresAccessToLocoNet()) ||
                         isLocoNetInterface) {
-                    add(new LnNamedPaneAction(Bundle.getMessage(item.name), wi, item.load, memo));
+                    try {
+                        add(new LnNamedPaneAction(Bundle.getMessage(item.getMenuItemName()), wi, item.getClassToLoad(), memo));
+                    } catch (java.util.MissingResourceException e) {
+                        add(new LnNamedPaneAction(item.getMenuItemName(), wi, item.getClassToLoad(), memo));
+
+                    }
                     lastWasSeparator = false;
                 }
             }
         }
-
+        
+        // Special-case for those menu item actions which do not include GUI functionality
         if (isLocoNetInterface) {
             add(new javax.swing.JSeparator());
             add(new jmri.jmrix.loconet.locormi.LnMessageServerAction(Bundle.getMessage("MenuItemStartLocoNetServer")));
             add(new jmri.jmrix.loconet.loconetovertcp.LnTcpServerAction(Bundle.getMessage("MenuItemLocoNetOverTCPServer")));
         }
-    }
 
-    Item[] panelItems = new Item[]{
-        new Item("MenuItemLocoNetMonitor", "jmri.jmrix.loconet.locomon.LocoMonPane", false), // NOI18N
-        new Item("MenuItemSlotMonitor", "jmri.jmrix.loconet.slotmon.SlotMonPane", false), // NOI18N
-        new Item("MenuItemClockMon", "jmri.jmrix.loconet.clockmon.ClockMonPane", true), // NOI18N
-        new Item("MenuItemLocoStats", "jmri.jmrix.loconet.locostats.swing.LocoStatsPanel", false), // NOI18N
-        null,
-        new Item("MenuItemBDL16Programmer", "jmri.jmrix.loconet.bdl16.BDL16Panel", true), // NOI18N
-        new Item("MenuItemPM4Programmer", "jmri.jmrix.loconet.pm4.PM4Panel", true), // NOI18N
-        new Item("MenuItemSE8cProgrammer", "jmri.jmrix.loconet.se8.SE8Panel", true), // NOI18N
-        new Item("MenuItemDS64Programmer", "jmri.jmrix.loconet.ds64.Ds64TabbedPanel", true), // NOI18N
-        new Item("MenuItemCmdStnConfig", "jmri.jmrix.loconet.cmdstnconfig.CmdStnConfigPane",true), // NOI18N
-        new Item("MenuItemSetID", "jmri.jmrix.loconet.locoid.LocoIdPanel", true), // NOI18N
-        new Item("MenuItemDuplex", "jmri.jmrix.loconet.duplexgroup.swing.DuplexGroupTabbedPanel", true), // NOI18N
-        null,
-        new Item("MenuItemThrottleMessages", "jmri.jmrix.loconet.swing.throttlemsg.MessagePanel", true), // NOI18N
-        new Item("MenuItemSendPacket", "jmri.jmrix.loconet.locogen.LocoGenPanel", false), // NOI18N
-        new Item("MenuItemLncvProg", "jmri.jmrix.loconet.swing.lncvprog.LncvProgPane", true), // NOI18N
-        new Item("MenuItemPr3ModeSelect", "jmri.jmrix.loconet.pr3.swing.Pr3SelectPane", false), // NOI18N
-        null,
-        new Item("MenuItemDownload", "jmri.jmrix.loconet.downloader.LoaderPane", false), // NOI18N
-        new Item("MenuItemSoundload", "jmri.jmrix.loconet.soundloader.LoaderPane", false), // NOI18N
-        new Item("MenuItemSoundEditor", "jmri.jmrix.loconet.soundloader.EditorPane", false) // NOI18N
-    };
+        // Handle menu items from SPI "service providers"
+        panelItems.clear();
+        // add anything from SPI extensions, as appropriate
+        Iterator<LnMenuItem> itemsIterator = LnMenuItemExtensionService.getInstance()
+                .getExtensionLnMenuItems(java.util.Locale.getDefault()).iterator();
 
-    static class Item {
-
-        Item(String name, String load, boolean interfaceOnly) {
-            this.name = name;
-            this.load = load;
-            this.interfaceOnly = interfaceOnly;
+        boolean moreToAdd = false;
+        while (itemsIterator != null && itemsIterator.hasNext()) {
+            panelItems.add(itemsIterator.next());
+            moreToAdd = true;
         }
-        String name;
-        String load;
-        boolean interfaceOnly;
+
+        if (moreToAdd) {
+            add(new javax.swing.JSeparator());
+            lastWasSeparator = true;
+        }
+
+        for (LnMenuItem item : panelItems) {
+            if (item == null) {
+                if (!lastWasSeparator) {
+                    add(new javax.swing.JSeparator());
+                    lastWasSeparator = true;
+                }
+            } else {
+                if ((!item.getRequiresAccessToLocoNet()) ||
+                        isLocoNetInterface) {
+                    add(new LnNamedPaneAction(item.getMenuItemName(), wi, item.getClassToLoad(), memo));
+                    lastWasSeparator = false;
+                }
+            }
+        }
+
     }
+    private static final Logger log = LoggerFactory.getLogger(LocoNetMenu.class);
 
 }

--- a/java/src/jmri/jmrix/loconet/swing/spi/LnMenuItemExtension.java
+++ b/java/src/jmri/jmrix/loconet/swing/spi/LnMenuItemExtension.java
@@ -1,0 +1,55 @@
+package jmri.jmrix.loconet.swing.spi;
+
+import java.util.List;
+import java.util.Locale;
+import jmri.spi.JmriServiceProviderInterface;
+
+/**
+ * Provide for including menu items from "extensions" which implement LnPanel
+ * objects and which require inclusion on the LocoNet connection's menu.
+ * <p>
+ * This interface provides a JAVA SPI-based mechanism to allow an extension to
+ * add items to the LocoNet connection's menu.
+ * <p>
+ * When the jmri.jrmix.loconet.swing.LocoNetMenu object prepares its menu, it
+ * adds all of the JMRI-native menu items, then invokes
+ * jmri.jmrix.loconet.swing.LnMenuItemExtensionSerivce.getExtensionLnMenuItems
+ * to retrieve any menu items from "extensions".  If any are found, those menu
+ * items are added to the bottom of the menu.
+ * <p>
+ * Note that any extension's .jar file _must_ be included in the JAVA "classpath"
+ * in order to be seen by the SPI's loader.
+ * <hr>
+ * This file is part of JMRI.
+ * <p>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * <p>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * <p>
+ * @author B. Milhaupt  Copyright 2021
+ */
+import jmri.jmrix.loconet.swing.LnMenuItem;
+
+public interface LnMenuItemExtension extends JmriServiceProviderInterface {
+    /**
+     * Provide the LocoNet menu item information for the extension.
+     * <p>
+     * Provides the information needed by jmri.jmrix.loconet.swing.LocoNetMenu
+     * to include an extension's menu items on JMRI LocoNet connection's menu.
+     * <p>
+     * Developers are encouraged to support internationalization of their menuItem's
+     * name (and other GUI functionality).  For convenience, JMRI's active Locale
+     * is provided as a parameter.
+     * <p>
+     * @param locale to be used, where supported, to internationalize the menu
+     *          item text
+     * @return the list of LnMenuItems to be added to the JMRI LocoNet
+     *          connection's menu.
+     */
+
+    public List<LnMenuItem> getLocoNetMenuInfo(Locale locale);
+}


### PR DESCRIPTION
This P/R provides an mechanism to allow "extension" code in a separate JAR file to integrate its own `...loconet.swing.LnPanel`-based functionality into the JMRI LocoNet connection's menu.

This mechanism uses JAVA SPI methodologies, both in JMRI and in the 3rd-party "extension", to provide the link between JMRI and the extension.

The key modifications to `...loconet.swing.LocoNetMenu.java` are found in lines 112 to 141.  The SPI "interface" is defined in `...loconet.swing.spi.LnMenuItemExtension.java`.  The SPI "service" is implemented in `...loconet.swing.LnMenuItemExtensionService.java`.  

`...loconet.swing.LnMenuItem.java` provides the data structure which conveys the menu item text and the class which the menu item will invoke.  It also includes a LocoNet-specific boolean that is used to determine whether the menu item applies for the connection type.  A connection which only allows decoder programming on the service track does not need a tool to configure a LocoNet-connected device; this boolean value allows selective filtering of menu items based on need to access to a physical LocoNet's devices.

See [https://github.com/devel-bobm/sampleLnMenuExtension](url) for example code which implements a simple extension (i.e. a SPI "service provider) which provides a LnPanel containing a pushbutton which sends LocoNet "power on" and "power off" messages, and which shows the most-recently-received LocoNet message, in hexadecimal digit pairs.  This gives a simple example of how such a 3rd-party extension may make use of existing JMRI code features to interact with the LocoNet connection, without including 3rd-party code within the JMRI code-base.

How to make use of this P/R and the sample extension

1) Apply the P/R code to JMRI.  Create a `jmri.jar` file containing those changes.  If desired, create a new "installer" and install the modified JMRI version.
2) Create the `sampleLnMenuItemExtension.jar` file using whatever mechanisms you prefer.  Note that it is necessary to _compile_ the java source using the libraries listed below.  I simply configure the project to reference the `jmri.jar` file in the `dist` directory of my local JMRI repository library, and to reference the library files from the local JMRI repository `lib` directory.
- `jmri.jar`
- `org-openide-util-lookup-RELEASE113.jar`
- `jsr305.jar`

3) Modify your environment to include "sampleLnMenuExtension.jar" in JMRI's `CLASSPATH`.  I generally work in an IDE via ant, so I copy the .jar to JMRI's `lib` directory, and modify build.xml to include the .jar file in the `runtime.class.path` .
4) Run JMRI, configure a LocoNet connection (if not already available), and select the LocoNet connection's menu.  The last element in the menu should be "Extension Menu Item".

I leave it up to the individual developer to figure out how to configure the developement environment to compile using this set of libraries, and to figure out how to include the extension's jar file in the `CLASSPATH` in the run-time environment.
