### PR TITLE
Railcom lint / Railcom table

### DIFF
--- a/java/src/jmri/RailCom.java
+++ b/java/src/jmri/RailCom.java
@@ -67,45 +67,6 @@ public interface RailCom extends AddressedIdTag {
     public int getOrientation();
 
     /**
-     * Gets the address reported back as a {@link jmri.LocoAddress}.
-     *
-     * @return current DCC loco address
-     * @deprecated since 4.15.4  Use getLocoAddress() instead.
-     */
-    @Deprecated
-    default public DccLocoAddress getDccLocoAddress(){
-       return (DccLocoAddress) getLocoAddress();
-    }
-
-    /**
-     * Method for a RailCom Reader to set the Address type reported back from a
-     * device
-     *
-     * @param type set type of address
-     * @deprecated since 4.15.4  Use {@link jmri.LocoAddress.Protocol} instead.
-     */
-    @Deprecated
-    public void setAddressType(int type);
-
-    /**
-     * Gets the actual type of address reported back by the RailCom device
-     *
-     * @return -1 if not set.
-     * @deprecated since 4.15.4  Use {@link jmri.LocoAddress.Protocol} instead.
-     */
-    @Deprecated
-    public int getAddressType();
-
-    /**
-     * Gets the actual address type as a String.
-     *
-     * @return the address type
-     * @deprecated since 4.15.4  Use {@link jmri.LocoAddress.Protocol} instead.
-     */
-    @Deprecated
-    public String getAddressTypeAsString();
-
-    /**
      * Method for a RailCom Reader to set the Actual speed reported back from a
      * device
      *

--- a/java/src/jmri/implementation/DefaultRailCom.java
+++ b/java/src/jmri/implementation/DefaultRailCom.java
@@ -52,160 +52,90 @@ public class DefaultRailCom extends DefaultIdTag implements jmri.RailCom {
 
     @Override
     public void setOrientation(int type) {
-        setProperty("orientation",Integer.valueOf(type));
+        setProperty("orientation", type);
     }
 
     @Override
     public int getOrientation() {
         Integer t = (Integer)getProperty("orientation");
-        if(t != null ){
-           return t.intValue();
-        } else {
-          return Sensor.UNKNOWN;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Deprecated
-    @Override
-    public String getAddressTypeAsString() {
-        switch (addressTypeInt) {
-            case SHORT_ADDRESS:
-                return "Short";
-            case LONG_ADDRESS:
-                return "Long";
-            case CONSIST_ADDRESS:
-                return "Consist";
-            default:
-                return "No Address";
-        }
-    }
-
-    int addressTypeInt = 0;
-
-    /**
-     * {@inheritDoc}
-     */
-    @Deprecated
-    @Override
-    public void setAddressType(int type) {
-        addressTypeInt = type;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Deprecated
-    @Override
-    public int getAddressType() {
-        return addressTypeInt;
+        return ( t != null ? t : Sensor.UNKNOWN );
     }
 
     @Override
     public void setActualSpeed(int type) {
-        setProperty("actualspeed",Integer.valueOf(type));
+        setProperty("actualspeed", type);
     }
 
     @Override
     public int getActualSpeed() {
         Integer t = (Integer)getProperty("actualspeed");
-        if(t != null ){
-           return t.intValue();
-        } else {
-          return -1;
-        }
+        return ( t != null ? t : -1 );
     }
 
     @Override
     public void setActualLoad(int type) {
-        setProperty("actualload",Integer.valueOf(type));
+        setProperty("actualload", type);
     }
 
     @Override
     public int getActualLoad() {
         Integer t = (Integer)getProperty("actualload");
-        if(t != null ){
-           return t.intValue();
-        } else {
-          return -1;
-        }
+        return ( t != null ? t : -1 );
     }
 
     @Override
     public void setActualTemperature(int type) {
-        setProperty("actualtemperature",Integer.valueOf(type));
+        setProperty("actualtemperature", type);
     }
 
     @Override
     public int getActualTemperature() {
         Integer t = (Integer)getProperty("actualtemperature");
-        if(t != null ){
-           return t.intValue();
-        } else {
-          return -1;
-        }
+        return ( t != null ? t : -1 );
     }
 
     @Override
     public void setWaterLevel(int type) {
-        setProperty("waterlevel",Integer.valueOf(type));
+        setProperty("waterlevel", type);
     }
 
     @Override
     public int getWaterLevel() {
         Integer t = (Integer)getProperty("waterlevel");
-        if(t != null ){
-           return t.intValue();
-        } else {
-          return -1;
-        }
+        return ( t != null ? t : -1 );
     }
 
     @Override
     public void setFuelLevel(int type) {
-        setProperty("fuellevel",Integer.valueOf(type));
+        setProperty("fuellevel", type);
     }
 
     @Override
     public int getFuelLevel() {
         Integer t = (Integer)getProperty("fuellevel");
-        if(t != null ){
-           return t.intValue();
-        } else {
-          return -1;
-        }
+        return ( t != null ? t : -1 );
     }
 
     @Override
     public void setLocation(int type) {
-        setProperty("location",Integer.valueOf(type));
+        setProperty("location", type);
     }
 
     @Override
     public int getLocation() {
         Integer t = (Integer)getProperty("location");
-        if(t != null ){
-           return t.intValue();
-        } else {
-          return -1;
-        }
+        return ( t != null ? t : -1 );
     }
 
     @Override
     public void setRoutingNo(int type) {
-        setProperty("routing",Integer.valueOf(type));
+        setProperty("routing", type);
     }
 
     @Override
     public int getRoutingNo() {
         Integer t = (Integer)getProperty("routing");
-        if(t != null ){
-           return t.intValue();
-        } else {
-          return -1;
-        }
+        return ( t != null ? t : -1 );
     }
 
     private int expectedCV = -1;
@@ -272,45 +202,43 @@ public class DefaultRailCom extends DefaultIdTag implements jmri.RailCom {
 
     @Override
     public String toReportString() {
-        String comment;
+        StringBuilder sb = new StringBuilder(200);
         switch (getOrientation()) {
             case ORIENTA:
-                comment = "Orientation A ";
+                sb.append("Orientation A ");
                 break;
             case ORIENTB:
-                comment = "Orientation B ";
+                sb.append( "Orientation B ");
                 break;
             case UNKNOWN:
-                comment = "Unknown Orientation ";
-                break;
             default:
-                comment = "Unknown Orientation ";
+                sb.append( "Unknown Orientation ");
                 break;
         }
-        comment = comment + "Address " + getLocoAddress() + " ";
+        sb.append("Address ").append(getLocoAddress()).append(" ");
 
         if (getWaterLevel() != -1) {
-            comment = comment + "Water " + getWaterLevel() + " ";
+            sb.append("Water ").append(getWaterLevel()).append(" ");
         }
         if (getFuelLevel() != -1) {
-            comment = comment + "Fuel " + getFuelLevel() + " ";
+            sb.append("Fuel ").append(getFuelLevel()).append(" ");
         }
         if ((getLocation() != -1)) {
-            comment = comment + "Location : " + getLocation() + " ";
+            sb.append("Location : ").append(getLocation()).append(" ");
         }
         if ((getRoutingNo() != -1)) {
-            comment = comment + "Routing No : " + getRoutingNo() + " ";
+            sb.append("Routing No : ").append(getRoutingNo()).append(" ");
         }
         if ((getActualTemperature() != -1)) {
-            comment = comment + "Temperature : " + getActualTemperature() + " ";
+            sb.append("Temperature : ").append(getActualTemperature()).append(" ");
         }
         if ((getActualLoad() != -1)) {
-            comment = comment + "Load : " + getActualLoad() + " ";
+            sb.append("Load : ").append(getActualLoad()).append(" ");
         }
         if ((getActualSpeed() != -1)) {
-            comment = comment + "Speed : " + getActualSpeed();
+            sb.append("Speed : ").append(getActualSpeed()).append(" ");
         }
-        return comment;
+        return sb.toString();
     }
 
     private final static Logger log = LoggerFactory.getLogger(DefaultRailCom.class);

--- a/java/src/jmri/jmrit/beantable/RailComTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RailComTableAction.java
@@ -1,17 +1,13 @@
 package jmri.jmrit.beantable;
 
 import java.awt.event.ActionEvent;
-import java.text.DateFormat;
-import java.util.Date;
+
 import javax.annotation.Nonnull;
-import javax.swing.JButton;
-import javax.swing.JTable;
-import javax.swing.JTextField;
+
 import jmri.InstanceManager;
 import jmri.IdTag;
-import jmri.RailCom;
 import jmri.RailComManager;
-import jmri.Reporter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +28,6 @@ public class RailComTableAction extends AbstractTableAction<IdTag> {
      *
      * @param actionName title of the action
      */
-    @SuppressWarnings("OverridableMethodCallInConstructor")
     public RailComTableAction(String actionName) {
         super(actionName);
 
@@ -52,232 +47,7 @@ public class RailComTableAction extends AbstractTableAction<IdTag> {
      */
     @Override
     protected void createModel() {
-        m = new BeanTableDataModel<IdTag>() {
-
-            static public final int VALUECOL = 0;
-            public static final int WHERECOL = VALUECOL + 1;
-            public static final int WHENCOL = WHERECOL + 1;
-            public static final int CLEARCOL = WHENCOL + 1;
-            public static final int SPEEDCOL = CLEARCOL + 1;
-            public static final int LOADCOL = SPEEDCOL + 1;
-            public static final int TEMPCOL = LOADCOL + 1;
-            public static final int FUELCOL = TEMPCOL + 1;
-            public static final int WATERCOL = FUELCOL + 1;
-            public static final int LOCATIONCOL = WATERCOL + 1;
-            public static final int ROUTINGCOL = LOCATIONCOL + 1;
-            static public final int DELETECOL = ROUTINGCOL + 1;
-
-            static public final int NUMCOLUMN = DELETECOL + 1;
-
-            @Override
-            public String getValue(String name) {
-                RailCom tag = (RailCom) tagManager.getBySystemName(name);
-                if (tag == null) {
-                    return "?";
-                }
-                return tag.getTagID();
-            }
-
-            @Override
-            public RailComManager getManager() {
-                return tagManager;
-            }
-
-            @Override
-            public RailCom getBySystemName(@Nonnull String name) {
-                return (RailCom) tagManager.getBySystemName(name);
-            }
-
-            @Override
-            public RailCom getByUserName(@Nonnull String name) {
-                return (RailCom) tagManager.getByUserName(name);
-            }
-
-            @Override
-            public void clickOn(IdTag t) {
-                // don't do anything on click; not used in this class, because
-                // we override setValueAt
-            }
-
-            @Override
-            public void setValueAt(Object value, int row, int col) {
-                if (col == CLEARCOL) {
-                    RailCom t = getBySystemName(sysNameList.get(row));
-                    if (log.isDebugEnabled()) {
-                        log.debug("Clear where & when last seen for {}", t.getSystemName());
-                    }
-                    t.setWhereLastSeen(null);
-                    fireTableRowsUpdated(row, row);
-                } else if (col == DELETECOL) {
-                    // button fired, delete Bean
-                    deleteBean(row, col);
-                }
-            }
-
-            @Override
-            public int getColumnCount() {
-                return NUMCOLUMN;
-            }
-
-            @Override
-            public String getColumnName(int col) {
-                switch (col) {
-                    case VALUECOL:
-                        return Bundle.getMessage("ColumnAddress");
-                    case WHERECOL:
-                        return Bundle.getMessage("ColumnIdWhere");
-                    case WHENCOL:
-                        return Bundle.getMessage("ColumnIdWhen");
-                    case SPEEDCOL:
-                        return Bundle.getMessage("ColumnSpeed");
-                    case LOADCOL:
-                        return Bundle.getMessage("ColumnLoad");
-                    case TEMPCOL:
-                        return Bundle.getMessage("ColumnTemp");
-                    case FUELCOL:
-                        return Bundle.getMessage("ColumnFuelLevel");
-                    case WATERCOL:
-                        return Bundle.getMessage("ColumnWaterLevel");
-                    case LOCATIONCOL:
-                        return Bundle.getMessage("ColumnLocation");
-                    case ROUTINGCOL:
-                        return Bundle.getMessage("ColumnRouting");
-                    case DELETECOL:
-                        return "";
-                    case CLEARCOL:
-                        return "";
-                    default:
-                        return super.getColumnName(col);
-                }
-            }
-
-            @Override
-            public Class<?> getColumnClass(int col) {
-                switch (col) {
-                    case DELETECOL:
-                    case CLEARCOL:
-                        return JButton.class;
-                    default:
-                        return String.class;
-                }
-            }
-
-            @Override
-            public boolean isCellEditable(int row, int col) {
-                switch (col) {
-                    case DELETECOL:
-                    case CLEARCOL:
-                        return true;
-                    default:
-                        return false;
-                }
-            }
-
-            @Override
-            public Object getValueAt(int row, int col) {
-                RailCom t = getBySystemName(sysNameList.get(row));
-                if (t == null) {
-                    return null;
-                }
-                switch (col) {
-                    case VALUECOL:
-                        return t.getLocoAddress().toString();
-                    case WHERECOL:
-                        Reporter r;
-                        return (((r = t.getWhereLastSeen()) != null) ? r.getSystemName() : null);
-                    case WHENCOL:
-                        Date d;
-                        return (((d = t.getWhenLastSeen()) != null)
-                                ? DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM).format(d) : null);
-                    case CLEARCOL:
-                        return Bundle.getMessage("ButtonClear");
-                    case SPEEDCOL:
-                        if (t.getActualSpeed() == -1) {
-                            return null;
-                        }
-                        return t.getActualSpeed();
-                    case LOADCOL:
-                        if (t.getActualLoad() == -1) {
-                            return null;
-                        }
-                        return t.getActualLoad();
-                    case TEMPCOL:
-                        if (t.getActualTemperature() == -1) {
-                            return null;
-                        }
-                        return t.getActualTemperature();
-                    case FUELCOL:
-                        if (t.getFuelLevel() == -1) {
-                            return null;
-                        }
-                        return t.getFuelLevel();
-                    case WATERCOL:
-                        if (t.getWaterLevel() == -1) {
-                            return null;
-                        }
-                        return t.getWaterLevel();
-                    case LOCATIONCOL:
-                        if (t.getLocation() == -1) {
-                            return null;
-                        }
-                        return t.getLocation();
-                    case ROUTINGCOL:
-                        if (t.getRoutingNo() == -1) {
-                            return null;
-                        }
-                        return t.getRoutingNo();
-                    case DELETECOL:  //
-                        return Bundle.getMessage("ButtonDelete");
-                    default:
-                        // fall through
-                        break;
-                }
-                return null;
-            }
-
-            @Override
-            public int getPreferredWidth(int col) {
-                switch (col) {
-                    case WHERECOL:
-                    case WHENCOL:
-                        return new JTextField(12).getPreferredSize().width;
-                    case VALUECOL:
-                        return new JTextField(10).getPreferredSize().width;
-                    case CLEARCOL:
-                    case DELETECOL:
-                        return new JButton(Bundle.getMessage("ButtonClear")).getPreferredSize().width + 4;
-                    default:
-                        return new JTextField(5).getPreferredSize().width;
-                }
-            }
-
-            @Override
-            public void configValueColumn(JTable table) {
-                // value column isn't button, so config is null
-            }
-
-            @Override
-            protected boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
-                return true;
-                // return (e.getPropertyName().indexOf("alue")>=0);
-            }
-
-            @Override
-            public JButton configureButton() {
-                log.error("configureButton should not have been called");
-                return null;
-            }
-
-            @Override
-            protected String getMasterClassName() {
-                return getClassName();
-            }
-
-            @Override
-            protected String getBeanType() {
-                return "ID Tag";
-            }
-        };
+        m = new RailComTableDataModel(tagManager);
     }
 
     @Override

--- a/java/src/jmri/jmrit/beantable/RailComTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/RailComTableDataModel.java
@@ -1,0 +1,247 @@
+package jmri.jmrit.beantable;
+
+import java.text.DateFormat;
+import java.util.Date;
+
+import jmri.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+/**
+ * TableDataModel for the RailCom Table.
+ *
+ * Split from {@link RailComTableAction}
+ *
+ * @author  Bob Jacobsen Copyright (C) 2003
+ * @author  Matthew Harris Copyright (C) 2011
+ * @since 2.11.4
+ * @author Steve Young Copyright (C) 2021
+ */
+public class RailComTableDataModel extends BeanTableDataModel<IdTag> {
+
+    /**
+     * Create a new Memory Table Data Model.
+     * @param mgr Memory manager to use in the model, default MemoryManager always used.
+     */
+    public RailComTableDataModel(Manager<IdTag> mgr){
+        super();
+        setManager(mgr);
+    }
+    
+    static public final int VALUECOL = 0;
+    public static final int WHERECOL = VALUECOL + 1;
+    public static final int WHENCOL = WHERECOL + 1;
+    public static final int CLEARCOL = WHENCOL + 1;
+    public static final int SPEEDCOL = CLEARCOL + 1;
+    public static final int LOADCOL = SPEEDCOL + 1;
+    public static final int TEMPCOL = LOADCOL + 1;
+    public static final int FUELCOL = TEMPCOL + 1;
+    public static final int WATERCOL = FUELCOL + 1;
+    public static final int LOCATIONCOL = WATERCOL + 1;
+    public static final int ROUTINGCOL = LOCATIONCOL + 1;
+    static public final int DELETECOL = ROUTINGCOL + 1;
+
+    static public final int NUMCOLUMN = DELETECOL + 1;
+
+    @Override
+    public String getValue(String name) {
+        RailCom tag = (RailCom) getManager().getBySystemName(name);
+        if (tag == null) {
+            return "?";
+        }
+        return tag.getTagID();
+    }
+    
+    private RailComManager manager;
+    
+    @Override
+    public final void setManager(Manager<IdTag> mgr){
+        if (mgr instanceof RailComManager){
+            manager = (RailComManager)mgr;
+        }
+    }
+
+    @Override
+    public RailComManager getManager() {
+        return ( manager!=null ? manager : InstanceManager.getDefault(RailComManager.class));
+    }
+
+    @Override
+    public RailCom getBySystemName(@Nonnull String name) {
+        return (RailCom) getManager().getBySystemName(name);
+    }
+
+    @Override
+    public RailCom getByUserName(@Nonnull String name) {
+        return (RailCom) getManager().getByUserName(name);
+    }
+
+    @Override
+    public void clickOn(IdTag t) {
+        // don't do anything on click; not used in this class, because
+        // we override setValueAt
+    }
+
+    @Override
+    public void setValueAt(Object value, int row, int col) {
+        if (col == CLEARCOL) {
+            RailCom t = getBySystemName(sysNameList.get(row));
+            if (log.isDebugEnabled()) {
+                log.debug("Clear where & when last seen for {}", t.getSystemName());
+            }
+            t.setWhereLastSeen(null);
+            fireTableRowsUpdated(row, row);
+        } else if (col == DELETECOL) {
+            // button fired, delete Bean
+            deleteBean(row, col);
+        }
+    }
+
+    @Override
+    public int getColumnCount() {
+        return NUMCOLUMN;
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        switch (col) {
+            case VALUECOL:
+                return Bundle.getMessage("ColumnAddress");
+            case WHERECOL:
+                return Bundle.getMessage("ColumnIdWhere");
+            case WHENCOL:
+                return Bundle.getMessage("ColumnIdWhen");
+            case SPEEDCOL:
+                return Bundle.getMessage("ColumnSpeed");
+            case LOADCOL:
+                return Bundle.getMessage("ColumnLoad");
+            case TEMPCOL:
+                return Bundle.getMessage("ColumnTemp");
+            case FUELCOL:
+                return Bundle.getMessage("ColumnFuelLevel");
+            case WATERCOL:
+                return Bundle.getMessage("ColumnWaterLevel");
+            case LOCATIONCOL:
+                return Bundle.getMessage("ColumnLocation");
+            case ROUTINGCOL:
+                return Bundle.getMessage("ColumnRouting");
+            case DELETECOL:
+                return "";
+            case CLEARCOL:
+                return "";
+            default:
+                return super.getColumnName(col);
+        }
+    }
+
+    @Override
+    public Class<?> getColumnClass(int col) {
+        switch (col) {
+            case DELETECOL:
+            case CLEARCOL:
+                return JButton.class;
+            default:
+                return String.class;
+        }
+    }
+
+    @Override
+    public boolean isCellEditable(int row, int col) {
+        switch (col) {
+            case DELETECOL:
+            case CLEARCOL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        RailCom t = getBySystemName(sysNameList.get(row));
+        if (t == null) {
+            return null;
+        }
+        switch (col) {
+            case VALUECOL:
+                return t.getLocoAddress().toString();
+            case WHERECOL:
+                Reporter r = t.getWhereLastSeen();
+                return (r != null ? r.getSystemName() : null);
+            case WHENCOL:
+                Date d;
+                return (((d = t.getWhenLastSeen()) != null)
+                        ? DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM).format(d) : null);
+            case CLEARCOL:
+                return Bundle.getMessage("ButtonClear");
+            case SPEEDCOL:
+                return (t.getActualSpeed()!=-1 ? t.getActualSpeed() : null);
+            case LOADCOL:
+                return (t.getActualLoad()!=-1 ? t.getActualLoad() : null);
+            case TEMPCOL:
+                return (t.getActualTemperature()!=-1 ? t.getActualTemperature() : null);
+            case FUELCOL:
+                return (t.getFuelLevel()!=-1 ? t.getFuelLevel() : null);
+            case WATERCOL:
+                return (t.getWaterLevel()!=-1 ? t.getWaterLevel() : null);
+            case LOCATIONCOL:
+                return (t.getLocation()!=-1 ? t.getLocation() : null);
+            case ROUTINGCOL:
+                return (t.getRoutingNo()!=-1 ? t.getRoutingNo() : null);
+            case DELETECOL:  //
+                return Bundle.getMessage("ButtonDelete");
+            default:
+                return super.getValueAt(row, col);
+        }
+    }
+
+    @Override
+    public int getPreferredWidth(int col) {
+        switch (col) {
+            case WHERECOL:
+            case WHENCOL:
+                return new JTextField(12).getPreferredSize().width;
+            case VALUECOL:
+                return new JTextField(10).getPreferredSize().width;
+            case CLEARCOL:
+            case DELETECOL:
+                return new JButton(Bundle.getMessage("ButtonClear")).getPreferredSize().width + 4;
+            default:
+                return new JTextField(5).getPreferredSize().width;
+        }
+    }
+
+    @Override
+    public void configValueColumn(JTable table) {
+        // value column isn't button, so config is null
+    }
+
+    @Override
+    protected boolean matchPropertyName(java.beans.PropertyChangeEvent e) {
+        return true;
+        // return (e.getPropertyName().indexOf("alue")>=0);
+    }
+
+    @Override
+    public JButton configureButton() {
+        log.error("configureButton should not have been called");
+        return null;
+    }
+
+    @Override
+    protected String getMasterClassName() {
+        return RailComTableAction.class.getName();
+    }
+
+    @Override
+    protected String getBeanType() {
+        return "ID Tag";
+    }
+    
+    private static final Logger log = LoggerFactory.getLogger(RailComTableDataModel.class);
+
+}

--- a/java/src/jmri/managers/DefaultRailComManager.java
+++ b/java/src/jmri/managers/DefaultRailComManager.java
@@ -25,12 +25,16 @@ public class DefaultRailComManager extends DefaultIdTagManager
     @SuppressWarnings("deprecation")
     public DefaultRailComManager() {
         super(new jmri.jmrix.ConflictingSystemConnectionMemo("R", "RailCom")); // NOI18N
+        setInstances();
+    }
+    
+    final void setInstances() {
         InstanceManager.store(this, RailComManager.class);
         InstanceManager.setIdTagManager(this);
     }
 
     @Override
-    protected RailCom createNewIdTag(String systemName, String userName) {
+    protected RailCom createNewIdTag(@Nonnull String systemName, String userName) {
         // we've decided to enforce that IdTag system
         // names start with RD by prepending if not present
         if (!systemName.startsWith(getSystemPrefix() + "D")) {
@@ -49,9 +53,13 @@ public class DefaultRailComManager extends DefaultIdTagManager
         }
     }
 
+    /**
+     * Provide by userName, then SystemName, else create new.
+     * {@inheritDoc}
+     */
     @Override
     @Nonnull
-    public IdTag newIdTag(@Nonnull String systemName, @CheckForNull String userName) {
+    public IdTag newIdTag(@Nonnull String systemName, @CheckForNull String userName) throws IllegalArgumentException {
         log.debug("new IdTag: {};{}", systemName, (userName == null ? "null" : userName));
         checkSystemName(systemName, userName);
 

--- a/java/test/jmri/implementation/DefaultRailComTest.java
+++ b/java/test/jmri/implementation/DefaultRailComTest.java
@@ -3,8 +3,7 @@ package jmri.implementation;
 import java.util.Calendar;
 import java.util.Date;
 
-import jmri.RailCom;
-import jmri.Reporter;
+import jmri.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -39,15 +38,6 @@ public class DefaultRailComTest {
     public void testRailComGetLocoAddress() {
         RailCom r = new DefaultRailCom("ID1234");
         Assert.assertEquals("Loco Address ", new jmri.DccLocoAddress(1234,true), r.getLocoAddress());
-    }
-
-    @Test
-    public void testRailComGetDccLocoAddress() {
-        // this is testing a now deprecated default method in
-        // the RailCom interface.  For code coverage, we need to
-        // leave this until the deprecated method can be removed.
-        RailCom r = new DefaultRailCom("ID1234");
-        Assert.assertEquals("Dcc Loco Address ", new jmri.DccLocoAddress(1234,true), r.getDccLocoAddress());
     }
 
     @Test
@@ -88,7 +78,7 @@ public class DefaultRailComTest {
             public void setState(int s) {
                 state = s;
             }
-            int state = 0;
+            private int state = 0;
         };
 
         Date timeBefore = Calendar.getInstance().getTime();
@@ -98,15 +88,113 @@ public class DefaultRailComTest {
         Date timeAfter = Calendar.getInstance().getTime();
 
         Assert.assertEquals("Where last seen is 'IR1'", rep, r.getWhereLastSeen());
-        Assert.assertNotNull("When last seen is not null", r.getWhenLastSeen());
+        
+        Date date = r.getWhenLastSeen();
+        Assert.assertNotNull("When last seen is not null", date);
         Assert.assertEquals("Status is SEEN", RailCom.SEEN, r.getState());
         Assert.assertTrue("Time when last seen is later than 'timeBefore'", r.getWhenLastSeen().after(timeBefore));
         Assert.assertTrue("Time when last seen is earlier than 'timeAfter'", r.getWhenLastSeen().before(timeAfter));
 
         r.setWhereLastSeen(null);
-        Assert.assertNull("After setWhereLastSeen(null), Reporter where seen is null", r.getWhereLastSeen());
-        Assert.assertNull("After setWhereLastSeen(null), Date when seen is null", r.getWhenLastSeen());
+        Assert.assertTrue("Time when last seen is later than 'timeBefore'", date.after(timeBefore));
+        Assert.assertTrue("Time when last seen is earlier than 'timeAfter'", date.before(timeAfter));
         Assert.assertEquals("After setWhereLastSeen(null), RailCom status is UNSEEN", RailCom.UNSEEN, r.getState());
+
+    }
+    
+    @Test
+    public void testGetSetOrientation(){
+        RailCom r = new DefaultRailCom("ID0415556BC1");
+        Assert.assertEquals("getorientation is UNKNOWN at start", Sensor.UNKNOWN , r.getOrientation());
+        r.setOrientation(RailCom.ORIENTA);
+        Assert.assertEquals("getorientation is RailCom.ORIENTA", RailCom.ORIENTA , r.getOrientation());
+    }
+
+    @Test
+    public void testGetSetActualSpeed(){
+        RailCom r = new DefaultRailCom("ID0415556BC2");
+        Assert.assertEquals("ActualSpeed is UNKNOWN at start", -1 , r.getActualSpeed());
+        r.setActualSpeed(44);
+        Assert.assertEquals("ActualSpeed is 44", 44 , r.getActualSpeed());
+    }
+
+    @Test
+    public void testGetSetActualLoad(){
+        RailCom r = new DefaultRailCom("ID0415556BC3");
+        Assert.assertEquals("ActualLoad is UNKNOWN at start", -1 , r.getActualLoad());
+        r.setActualLoad(3);
+        Assert.assertEquals("ActualLoad is 3", 3 , r.getActualLoad());
+    }
+
+    @Test
+    public void testGetSetActualTemperature(){
+        RailCom r = new DefaultRailCom("ID0415556BC4");
+        Assert.assertEquals("ActualTemperature is UNKNOWN at start", -1 , r.getActualTemperature());
+        r.setActualTemperature(4);
+        Assert.assertEquals("ActualTemperature is 4", 4 , r.getActualTemperature());
+    }
+
+    @Test
+    public void testGetSetWaterLevel(){
+        RailCom r = new DefaultRailCom("ID0415556BC5");
+        Assert.assertEquals("WaterLevel is UNKNOWN at start", -1 , r.getWaterLevel());
+        r.setWaterLevel(5);
+        Assert.assertEquals("WaterLevel is 5", 5 , r.getWaterLevel());
+    }
+
+    @Test
+    public void testGetSetFuelLevel(){
+        RailCom r = new DefaultRailCom("ID0415556BC6");
+        Assert.assertEquals("FuelLevel is UNKNOWN at start", -1 , r.getFuelLevel());
+        r.setFuelLevel(6);
+        Assert.assertEquals("FuelLevel is 6", 6 , r.getFuelLevel());
+    }
+
+    @Test
+    public void testGetSetLocation(){
+        RailCom r = new DefaultRailCom("ID0415556BC7");
+        Assert.assertEquals("Location is UNKNOWN at start", -1 , r.getLocation());
+        r.setLocation(7);
+        Assert.assertEquals("Location is 7", 7 , r.getLocation());
+    }
+
+    @Test
+    public void testGetSetRoutingNo(){
+        RailCom r = new DefaultRailCom("ID0415556BD1");
+        Assert.assertEquals("RoutingNo is UNKNOWN at start", -1 , r.getRoutingNo());
+        r.setRoutingNo(8);
+        Assert.assertEquals("RoutingNo is 8", 8 , r.getRoutingNo());
+    }
+
+    @Test
+    public void testGetSetExpectedCv(){
+        RailCom r = new DefaultRailCom("ID0415556BD2");
+        Assert.assertEquals("ExpectedCv is UNKNOWN at start", -1 , r.getExpectedCv());
+        r.setExpectedCv(9);
+        Assert.assertEquals("ExpectedCv is 9", 9 , r.getExpectedCv());
+    }
+
+    @Test
+    public void TestToReportString(){
+        DefaultRailCom r = new DefaultRailCom("ID1234");
+        Assert.assertEquals("Basic Report String", "Unknown Orientation Address 1234(L) " , r.toReportString());
+
+        r.setOrientation(RailCom.ORIENTA);
+        Assert.assertEquals("Report String ORIENTA", "Orientation A Address 1234(L) " , r.toReportString());
+
+        r.setOrientation(RailCom.ORIENTB);
+        Assert.assertEquals("Report String ORIENTB", "Orientation B Address 1234(L) " , r.toReportString());
+
+        r.setWaterLevel(2);
+        r.setFuelLevel(3);
+        r.setLocation(4);
+        r.setRoutingNo(5);
+        r.setActualTemperature(6);
+        r.setActualLoad(7);
+        r.setActualSpeed(8);
+        Assert.assertEquals("Report String ORIENTB", 
+            "Orientation B Address 1234(L) Water 2 Fuel 3 Location : 4 Routing No : 5 Temperature : 6 Load : 7 Speed : 8 "
+            , r.toReportString());
 
     }
 

--- a/java/test/jmri/jmrit/beantable/RailComTableDataModelTest.java
+++ b/java/test/jmri/jmrit/beantable/RailComTableDataModelTest.java
@@ -1,0 +1,78 @@
+package jmri.jmrit.beantable;
+
+import jmri.IdTag;
+import jmri.IdTagManager;
+import jmri.RailComManager;
+
+import jmri.InstanceManager;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author Steve Young (C) 2021
+ */
+public class RailComTableDataModelTest extends AbstractBeanTableDataModelBase<IdTag>{
+    
+    @Test
+    public void testCTor() {
+        Assert.assertNotNull("exists",t);
+    }
+    
+    @Override
+    public int getModelColumnCount(){
+        return 12;
+    }
+    
+    @Test
+    @Override
+    public void testGetWidthNoColumn() {
+        Assert.assertTrue("Default column 5",t.getPreferredWidth(t.getColumnCount())>0);
+    }
+    
+    @Test
+    @Override
+    public void testSetValueAtNoColumn() {
+        createBean(); // ensure there is a row 0
+        t.setValueAt(null,0,t.getColumnCount());
+    }
+    
+    @Test
+    @Override
+    public void testGetBaseColumnClasses() {
+    }
+    
+    @Test
+    @Override
+    public void testGetBaseColumnNames() {
+    }
+    
+    @Test
+    @Override
+    public void testGetColumnClassNone() {
+        assertEquals("Default column class String",String.class,t.getColumnClass(t.getColumnCount()) );
+    }
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        t = new RailComTableDataModel(InstanceManager.getDefault(RailComManager.class));
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        if (t!=null){
+            t.dispose();
+        }
+        t = null;
+        InstanceManager.getDefault(IdTagManager.class).dispose(); // kills shutdown task
+        JUnitUtil.tearDown();
+    }
+    
+}


### PR DESCRIPTION
Remove deprecated since 4.15.4
Moves RailCom Table Data Model to own class.