### PR TITLE
Fix to 28 and 14 Speed Step mode for Intellibox-1

### DIFF
--- a/java/src/jmri/jmrit/operations/trains/TrainsTableModel.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainsTableModel.java
@@ -35,7 +35,7 @@ import jmri.util.table.ButtonRenderer;
 public class TrainsTableModel extends javax.swing.table.AbstractTableModel implements PropertyChangeListener {
 
     TrainManager trainManager = InstanceManager.getDefault(TrainManager.class); // There is only one manager
-    List<Train> sysList = trainManager.getTrainsByTimeList();
+    volatile List<Train> sysList = trainManager.getTrainsByTimeList();
     JTable _table = null;
     TrainsTableFrame _frame = null;
     


### PR DESCRIPTION
The Intellibox-1 handles 28 speed step mode and 14SS mode differently than a Digitrax command station.  Loconet speeds from 2-126 are mapped relatively uniformly to the DCC speed steps/codes by the IB1, unlike Digitrax command stations.  This manifests itself by not allowing the engine to reach its lowest speed when using a JMRI/EngineDriver/WiThrottle throttle with the IB1.

The methods floatSpeed and intSpeed need to be overridden in Ib1Throttle.java to account for this difference. The changes proposed fix the low speed issue.