### PR TITLE
SwingPropertyChangeListener was deferring work if not on GUI thread, …

### DIFF
--- a/java/src/jmri/beans/SwingPropertyChangeListener.java
+++ b/java/src/jmri/beans/SwingPropertyChangeListener.java
@@ -59,5 +59,5 @@ public class SwingPropertyChangeListener implements PropertyChangeListener {
         return notifyOnEDT;
     }
 
-    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SwingPropertyChangeListener.class);
+    // private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SwingPropertyChangeListener.class);
 }

--- a/java/src/jmri/beans/SwingPropertyChangeListener.java
+++ b/java/src/jmri/beans/SwingPropertyChangeListener.java
@@ -42,20 +42,22 @@ public class SwingPropertyChangeListener implements PropertyChangeListener {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * This implementation calls the listener's implementation on the EDT if
      * {@link #isNotifyOnEDT()} is true.
      */
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
-        if (!notifyOnEDT || SwingUtilities.isEventDispatchThread()) {
+        if (!notifyOnEDT || jmri.util.ThreadingUtil.isGUIThread()) {
             listener.propertyChange(evt);
         } else {
-            SwingUtilities.invokeLater(() -> listener.propertyChange(evt));
+            jmri.util.ThreadingUtil.runOnGUI(() -> listener.propertyChange(evt));
         }
     }
 
     public boolean isNotifyOnEDT() {
         return notifyOnEDT;
     }
+
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SwingPropertyChangeListener.class);
 }


### PR DESCRIPTION
…but using classes assumed that the work was done immediately

This is an attempt to correct concurrent mod exceptions in LayoutEditorToolsTest