### PR TITLE
Fix copy bug in LogixNG

### DIFF
--- a/java/src/jmri/jmrit/logixng/FemaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/FemaleSocket.java
@@ -61,7 +61,22 @@ public interface FemaleSocket extends Base {
      * @param name the name
      * @return true if the name is valid, false otherwise
      */
-    public boolean validateName(String name);
+    public default boolean validateName(String name) {
+        return validateName(name, false);
+    }
+    
+    /**
+     * Validates a name for a FemaleSocket.
+     * <P>
+     * The name must have at least one character and only alphanumeric
+     * characters. The first character must not be a digit.
+     * 
+     * @param name the name
+     * @param ignoreDuplicateErrors true if duplicate names should be ignored,
+     *                              false otherwise
+     * @return true if the name is valid, false otherwise
+     */
+    public boolean validateName(String name, boolean ignoreDuplicateErrors);
     
     /**
      * Set the name of this socket.
@@ -71,7 +86,21 @@ public interface FemaleSocket extends Base {
      * 
      * @param name the name
      */
-    public void setName(String name);
+    public default void setName(String name) {
+        setName(name, false);
+    }
+    
+    /**
+     * Set the name of this socket.
+     * <P>
+     * The name must have at least one character and only alphanumeric
+     * characters. The first character must not be a digit.
+     * 
+     * @param name the name
+     * @param ignoreDuplicateErrors true if duplicate names should be ignored,
+     *                              false otherwise
+     */
+    public void setName(String name, boolean ignoreDuplicateErrors);
     
     /**
      * Get the name of this socket.

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractBase.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractBase.java
@@ -38,8 +38,9 @@ public abstract class AbstractBase
     @Override
     public Base deepCopyChildren(Base original, Map<String, String> systemNames, Map<String, String> userNames) throws JmriException {
         for (int i=0; i < original.getChildCount(); i++) {
-            // Copy the name of the socket
-            getChild(i).setName(original.getChild(i).getName());
+            // Copy the name of the socket.
+            // Ignore duplicate errors since these errors might happen temporary in this loop.
+            getChild(i).setName(original.getChild(i).getName(), true);
 
             // Copy the child
             if (original.getChild(i).isConnected()) {

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractFemaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractFemaleSocket.java
@@ -132,7 +132,7 @@ public abstract class AbstractFemaleSocket implements FemaleSocket {
 
     /** {@inheritDoc} */
     @Override
-    public final boolean validateName(String name) {
+    public final boolean validateName(String name, boolean ignoreDuplicateErrors) {
         // Empty name is not allowed
         if (name.isEmpty()) return false;
         
@@ -146,7 +146,7 @@ public abstract class AbstractFemaleSocket implements FemaleSocket {
             }
         }
         
-        if (_parent != null) {
+        if (!ignoreDuplicateErrors && (_parent != null)) {
             // Check that no other female socket of the parent has the same name
             for (int i=0; i < _parent.getChildCount(); i++) {
                 FemaleSocket child = _parent.getChild(i);
@@ -160,8 +160,8 @@ public abstract class AbstractFemaleSocket implements FemaleSocket {
 
     /** {@inheritDoc} */
     @Override
-    public void setName(String name) {
-        if (!validateName(name)) {
+    public void setName(String name, boolean ignoreDuplicateErrors) {
+        if (!validateName(name, ignoreDuplicateErrors)) {
             throw new IllegalArgumentException("the name is not valid: " + name);
         }
         _name = name;


### PR DESCRIPTION
@dsand47 
I think that the bug in #10085 might happen when an item is copied there the socket names are not in sequence:
```
Many
    A3
    A2
    A5
    A1
```
During the copy process, there might be duplicate socket names temporary, but these duplicates will have gone away when the copy is completed. Therefore the duplicate socket name check isn't necessary during copy.

Can you check if this PR solves #10085 ? I was able to re-create some but not all the problems @JIM-MOOMAW had.