### PR TITLE
Improve CTC sample script

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -499,7 +499,7 @@
 	    <h4>USS CTC Logic</h4>
             <ul>
                 <li>Improve the
-                <a href="http://jmri.org/jython/ctc/TwoColumnMachine.py ">jython/ctc/TwoColumnMachine.py </a>
+                <a href="http://jmri.org/jython/ctc/TwoColumnMachine.py">jython/ctc/TwoColumnMachine.py </a>
                 sample script</li>
             </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -498,7 +498,9 @@
 
 	    <h4>USS CTC Logic</h4>
             <ul>
-                <li></li>
+                <li>Improve the
+                <a href="http://jmri.org/jython/ctc/TwoColumnMachine.py ">jython/ctc/TwoColumnMachine.py </a>
+                sample script</li>
             </ul>
 
    <h3>Switchboard Editor</h3>

--- a/java/src/jmri/jmrit/ussctc/RouteLock.java
+++ b/java/src/jmri/jmrit/ussctc/RouteLock.java
@@ -21,7 +21,7 @@ public class RouteLock implements Lock {
         this.list = list;
         this.beans = null;
     }
-    
+
     /**
      * @param list SignalHeads that cover this route
      * @param beans Defines the specific route
@@ -30,7 +30,7 @@ public class RouteLock implements Lock {
         this.list = list;
         this.beans = beans;
     }
-    
+
     /**
      * @param array User or system names of SignalHeads that cover this route
      */
@@ -65,13 +65,13 @@ public class RouteLock implements Lock {
             }
         }
         this.list = q1;
-        
+
         ArrayDeque<BeanSetting> q2 = new ArrayDeque<>();
         for (BeanSetting bean : beans) {
             q2.add(bean);
         }
         this.beans = q2;
-        
+
     }
 
     /**
@@ -81,9 +81,9 @@ public class RouteLock implements Lock {
         this(new String[]{head});
     }
 
-    Iterable<NamedBeanHandle<SignalHead>> list; 
+    Iterable<NamedBeanHandle<SignalHead>> list;
     Iterable<BeanSetting> beans;
-    
+
     /**
      * Test the lock conditions
      * @return True if lock is clear and operation permitted
@@ -95,22 +95,26 @@ public class RouteLock implements Lock {
             for (BeanSetting bean : beans) {
                 if ( ! bean.check()) {
                     lockLogger.setStatus(this, "");
+                    log.debug("RouteLock OK because {} doesn't match, route not engaged", bean.getBeanName());
                     return true;
                 }
             }
         }
-        
+
         for (NamedBeanHandle<SignalHead> handle : list) {
             if ( isSignalClear(handle) ) {
                 lockLogger.setStatus(this, "Locked due to route including signal "+handle.getBean().getDisplayName());
+                log.debug("RouteLock locked due to route including signal {} set clear", handle.getBean().getDisplayName());
                 return false;
             }
         }
         lockLogger.setStatus(this, "");
+        log.debug("RouteLock OK, no signals set clear");
         return true;
     }
-    
+
     boolean isSignalClear(@Nonnull NamedBeanHandle<SignalHead> handle) {
         return handle.getBean().getState() != SignalHead.RED;
     }
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(RouteLock.class);
 }

--- a/jython/ctc/README.md
+++ b/jython/ctc/README.md
@@ -1,4 +1,4 @@
 The jython/ctc directory contains example and utility scripts for the [JMRI USS CTC](http://jmri.org/JavaDoc/doc/jmri/jmrit/ussctc/package-summary.html) package of tools.
 
-The [jython/ctc/TwoColumnMachine.py](http://jmri.org/jython/ctc/TwoColumnMachine.py) animates a sample two-column CTC machine. To use it, load the [jython/ctc//TwoColumnMachine.xml](http://jmri.org/jython/ctc//TwoColumnMachine.xml) panel file first, then run the sample script.
+The [jython/ctc/TwoColumnMachine.py](http://jmri.org/jython/ctc/TwoColumnMachine.py) animates a sample two-column CTC machine. To use it, load the [jython/ctc/TwoColumnMachine.xml](http://jmri.org/jython/ctc/TwoColumnMachine.xml) panel file first, then run the sample script.
 

--- a/jython/ctc/README.md
+++ b/jython/ctc/README.md
@@ -1,4 +1,4 @@
 The jython/ctc directory contains example and utility scripts for the [JMRI USS CTC](http://jmri.org/JavaDoc/doc/jmri/jmrit/ussctc/package-summary.html) package of tools.
 
-The [jython/ctc/TwoColumnMachine.py](http://jmri.org/jython/ctc/TwoColumnMachine.py) animates a sample two-column CTC machine. To use it, load the [xml/samples/TwoColumnMachine.xml](http://jmri.org/xml/samples/TwoColumnMachine.xml) panel file first, then run the sample script.
+The [jython/ctc/TwoColumnMachine.py](http://jmri.org/jython/ctc/TwoColumnMachine.py) animates a sample two-column CTC machine. To use it, load the [jython/ctc//TwoColumnMachine.xml](http://jmri.org/jython/ctc//TwoColumnMachine.xml) panel file first, then run the sample script.
 

--- a/jython/ctc/TwoColumnMachine.py
+++ b/jython/ctc/TwoColumnMachine.py
@@ -32,6 +32,7 @@ turnouts.provideTurnout("IT12").setUserName("Sta 1 Code")
 sensors.provideSensor  ("IS12").setUserName("Sta 1 Code")
 turnouts.provideTurnout("IT13").setUserName("Sta 1 TO 1 N")
 sensors.provideSensor  ("IS13").setUserName("Sta 1 TO 1 N")
+sensors.provideSensor  ("IS13").state = ACTIVE
 turnouts.provideTurnout("IT14").setUserName("Sta 1 TO 1 R")
 sensors.provideSensor  ("IS14").setUserName("Sta 1 TO 1 R")
 turnouts.provideTurnout("IT15").setUserName("Sta 1 Left Approach TC")
@@ -41,6 +42,7 @@ turnouts.provideTurnout("IT22").setUserName("Sta 2 Code")
 sensors.provideSensor  ("IS22").setUserName("Sta 2 Code")
 turnouts.provideTurnout("IT23").setUserName("Sta 2 TO 3 N")
 sensors.provideSensor  ("IS23").setUserName("Sta 2 TO 3 N")
+sensors.provideSensor  ("IS23").state = ACTIVE
 turnouts.provideTurnout("IT24").setUserName("Sta 2 TO 3 R")
 sensors.provideSensor  ("IS24").setUserName("Sta 2 TO 3 R")
 turnouts.provideTurnout("IT25").setUserName("Sta 2 Main TC")
@@ -76,4 +78,24 @@ station.add(TrackCircuitSection("TC Main", "Sta 2 Main TC", station))
 station.add(TrackCircuitSection("TC Siding", "Sta 2 Siding TC", station))
 station.add(TrackCircuitSection("TC Sta 2 OS", "Sta 2 OS TC", station))
 station.add(TrackCircuitSection("TC Right Approach", "Sta 2 Right Approach TC", station, bell))
+
+# Optionally, set timings
+print "Setting timings"
+
+jmri.implementation.AbstractTurnout.DELAYED_FEEDBACK_INTERVAL = 5000  # turnout throw time
+print "Turnout throw delay: ", jmri.implementation.AbstractTurnout.DELAYED_FEEDBACK_INTERVAL/1000., "seconds"
+
+jmri.jmrit.ussctc.CodeLine.CODE_SEND_DELAY = 3000
+print "Code send delay: ", jmri.jmrit.ussctc.CodeLine.CODE_SEND_DELAY/1000., "seconds"
+
+# Start pulses for code and indication set to 1 second
+jmri.jmrit.ussctc.CodeLine.START_PULSE_LENGTH = 1000
+jmri.jmrit.ussctc.CodeLine.INTER_INDICATION_DELAY = 1000
+
+jmri.jmrit.ussctc.SignalHeadSection.MOVEMENT_DELAY = 5000
+print"Signal movement delay: ", jmri.jmrit.ussctc.SignalHeadSection.MOVEMENT_DELAY/1000., "seconds"
+
+jmri.jmrit.ussctc.SignalHeadSection.DEFAULT_RUN_TIME_LENGTH = 5000
+memories.providetMemory("IMUSS CTC:SIGNALHEADSECTION:1:TIME").setValue(jmri.jmrit.ussctc.SignalHeadSection.DEFAULT_RUN_TIME_LENGTH)
+print "Running time for", jmri.jmrit.ussctc.SignalHeadSection.DEFAULT_RUN_TIME_LENGTH/1000., "seconds"
 

--- a/jython/ctc/TwoColumnMachine.py
+++ b/jython/ctc/TwoColumnMachine.py
@@ -12,8 +12,9 @@ from jmri.jmrit.ussctc import *
 # to the layout
 
 # Define objects on layout
-turnouts.provideTurnout("IT1").setUserName("Code Sequencer Start")
-turnouts.provideTurnout("IT2").setUserName("Bell")
+turnouts.provideTurnout("IT1").setUserName("Code Indication Start")
+turnouts.provideTurnout("IT2").setUserName("Code Send Start")
+turnouts.provideTurnout("IT3").setUserName("Bell")
 
 sensors.provideSensor("IS101").setUserName("TC Left Approach")
 sensors.provideSensor("IS102").setUserName("TC Sta 1 OS")
@@ -31,21 +32,21 @@ turnouts.provideTurnout("IT12").setUserName("Sta 1 Code")
 sensors.provideSensor  ("IS12").setUserName("Sta 1 Code")
 turnouts.provideTurnout("IT13").setUserName("Sta 1 TO 1 N")
 sensors.provideSensor  ("IS13").setUserName("Sta 1 TO 1 N")
-turnouts.provideTurnout("IT13").setUserName("Sta 1 TO 1 R")
-sensors.provideSensor  ("IS13").setUserName("Sta 1 TO 1 R")
-turnouts.provideTurnout("IT14").setUserName("Sta 1 Left Approach TC")
-turnouts.provideTurnout("IT15").setUserName("Sta 1 OS TC")
+turnouts.provideTurnout("IT14").setUserName("Sta 1 TO 1 R")
+sensors.provideSensor  ("IS14").setUserName("Sta 1 TO 1 R")
+turnouts.provideTurnout("IT15").setUserName("Sta 1 Left Approach TC")
+turnouts.provideTurnout("IT16").setUserName("Sta 1 OS TC")
 
 turnouts.provideTurnout("IT22").setUserName("Sta 2 Code")
 sensors.provideSensor  ("IS22").setUserName("Sta 2 Code")
 turnouts.provideTurnout("IT23").setUserName("Sta 2 TO 3 N")
 sensors.provideSensor  ("IS23").setUserName("Sta 2 TO 3 N")
-turnouts.provideTurnout("IT23").setUserName("Sta 2 TO 3 R")
-sensors.provideSensor  ("IS23").setUserName("Sta 2 TO 3 R")
-turnouts.provideTurnout("IT14").setUserName("Sta 2 Main TC")
-turnouts.provideTurnout("IT15").setUserName("Sta 2 Siding TC")
-turnouts.provideTurnout("IT16").setUserName("Sta 2 OS TC")
-turnouts.provideTurnout("IT17").setUserName("Sta 2 Right Approach TC")
+turnouts.provideTurnout("IT24").setUserName("Sta 2 TO 3 R")
+sensors.provideSensor  ("IS24").setUserName("Sta 2 TO 3 R")
+turnouts.provideTurnout("IT25").setUserName("Sta 2 Main TC")
+turnouts.provideTurnout("IT26").setUserName("Sta 2 Siding TC")
+turnouts.provideTurnout("IT27").setUserName("Sta 2 OS TC")
+turnouts.provideTurnout("IT28").setUserName("Sta 2 Right Approach TC")
 
 # The core of the sample script starts here, defining & connecting
 # the USS CTC objects to run the panel
@@ -55,7 +56,7 @@ turnouts.provideTurnout("IT17").setUserName("Sta 2 Right Approach TC")
 bell = PhysicalBell("Bell")
 codeline = CodeLine("Code Indication Start", "Code Send Start", "IT101", "IT102", "IT103", "IT104")
 
-# Set up Station 1 - stations are numbered 1, 2, 3 etc. 
+# Set up Station 1 - stations are numbered 1, 2, 3 etc.
 # Station 1 is levers 1 and 2
 
 station = Station("1", codeline, CodeButton("Sta 1 Code", "Sta 1 Code"))
@@ -70,7 +71,7 @@ station.add(TrackCircuitSection("TC Sta 1 OS", "Sta 1 OS TC", station))
 
 station = Station("2", codeline, CodeButton("Sta 2 Code", "Sta 2 Code"))
 
-station.add(TurnoutSection("Sta 2 Layout TO", "Sta 2 TO 3 N", "Sta 2 TO 3 R", "Sta 2 TO 3 N", "Sta 2 TO 3 R", station))   
+station.add(TurnoutSection("Sta 2 Layout TO", "Sta 2 TO 3 N", "Sta 2 TO 3 R", "Sta 2 TO 3 N", "Sta 2 TO 3 R", station))
 station.add(TrackCircuitSection("TC Main", "Sta 2 Main TC", station))
 station.add(TrackCircuitSection("TC Siding", "Sta 2 Siding TC", station))
 station.add(TrackCircuitSection("TC Sta 2 OS", "Sta 2 OS TC", station))

--- a/jython/ctc/TwoColumnMachine.py
+++ b/jython/ctc/TwoColumnMachine.py
@@ -30,25 +30,46 @@ turnouts.provideTurnout("IT21").setUserName("Sta 2 Layout TO")
 # Define objects on panel
 turnouts.provideTurnout("IT12").setUserName("Sta 1 Code")
 sensors.provideSensor  ("IS12").setUserName("Sta 1 Code")
+
 turnouts.provideTurnout("IT13").setUserName("Sta 1 TO 1 N")
 sensors.provideSensor  ("IS13").setUserName("Sta 1 TO 1 N")
 sensors.provideSensor  ("IS13").state = ACTIVE
 turnouts.provideTurnout("IT14").setUserName("Sta 1 TO 1 R")
 sensors.provideSensor  ("IS14").setUserName("Sta 1 TO 1 R")
-turnouts.provideTurnout("IT15").setUserName("Sta 1 Left Approach TC")
-turnouts.provideTurnout("IT16").setUserName("Sta 1 OS TC")
+
+turnouts.provideTurnout("IT15").setUserName("Sta 1 SI 2 L")
+sensors.provideSensor  ("IS15").setUserName("Sta 1 SI 2 L")
+turnouts.provideTurnout("IT16").setUserName("Sta 1 SI 2 C")
+sensors.provideSensor  ("IS16").setUserName("Sta 1 SI 2 C")
+sensors.provideSensor  ("IS16").state = ACTIVE
+turnouts.provideTurnout("IT17").setUserName("Sta 1 SI 1 R")
+sensors.provideSensor  ("IS17").setUserName("Sta 1 SI 1 R")
+
+turnouts.provideTurnout("IT18").setUserName("Sta 1 Left Approach TC")
+turnouts.provideTurnout("IT19").setUserName("Sta 1 OS TC")
+
 
 turnouts.provideTurnout("IT22").setUserName("Sta 2 Code")
 sensors.provideSensor  ("IS22").setUserName("Sta 2 Code")
+
 turnouts.provideTurnout("IT23").setUserName("Sta 2 TO 3 N")
 sensors.provideSensor  ("IS23").setUserName("Sta 2 TO 3 N")
 sensors.provideSensor  ("IS23").state = ACTIVE
 turnouts.provideTurnout("IT24").setUserName("Sta 2 TO 3 R")
 sensors.provideSensor  ("IS24").setUserName("Sta 2 TO 3 R")
-turnouts.provideTurnout("IT25").setUserName("Sta 2 Main TC")
-turnouts.provideTurnout("IT26").setUserName("Sta 2 Siding TC")
-turnouts.provideTurnout("IT27").setUserName("Sta 2 OS TC")
-turnouts.provideTurnout("IT28").setUserName("Sta 2 Right Approach TC")
+
+turnouts.provideTurnout("IT25").setUserName("Sta 2 SI 4 L")
+sensors.provideSensor  ("IS25").setUserName("Sta 2 SI 4 L")
+turnouts.provideTurnout("IT26").setUserName("Sta 2 SI 4 C")
+sensors.provideSensor  ("IS26").setUserName("Sta 2 SI 4 C")
+sensors.provideSensor  ("IS26").state = ACTIVE
+turnouts.provideTurnout("IT27").setUserName("Sta 2 SI 4 R")
+sensors.provideSensor  ("IS27").setUserName("Sta 2 SI 4 R")
+
+turnouts.provideTurnout("IT28").setUserName("Sta 2 Main TC")
+turnouts.provideTurnout("IT29").setUserName("Sta 2 Siding TC")
+turnouts.provideTurnout("IT30").setUserName("Sta 2 OS TC")
+turnouts.provideTurnout("IT31").setUserName("Sta 2 Right Approach TC")
 
 # The core of the sample script starts here, defining & connecting
 # the USS CTC objects to run the panel

--- a/jython/ctc/TwoColumnMachine.py
+++ b/jython/ctc/TwoColumnMachine.py
@@ -119,7 +119,9 @@ turnout.addLocks([occupancyLock, routeLock, TimeLock(signal2)]);
 
 station = Station("2", codeline, CodeButton("Sta 2 Code", "Sta 2 Code"))
 
-station.add(TurnoutSection("Sta 2 Layout TO", "Sta 2 TO 3 N", "Sta 2 TO 3 R", "Sta 2 TO 3 N", "Sta 2 TO 3 R", station))
+turnout = TurnoutSection("Sta 2 Layout TO", "Sta 2 TO 3 N", "Sta 2 TO 3 R", "Sta 2 TO 3 N", "Sta 2 TO 3 R", station)
+station.add(turnout)
+
 station.add(TrackCircuitSection("TC Main", "Sta 2 Main TC", station))
 station.add(TrackCircuitSection("TC Siding", "Sta 2 Siding TC", station))
 station.add(TrackCircuitSection("TC Sta 2 OS", "Sta 2 OS TC", station))
@@ -129,6 +131,10 @@ rightward = arrayList(["4 Main", "4 Siding"])
 leftward  = arrayList(["4 Upper", "4 Lower"])
 signal4 = SignalHeadSection(rightward, leftward, "Sta 2 SI 4 L", "Sta 2 SI 4 C", "Sta 2 SI 4 R", "Sta 2 SI 4 L", "Sta 2 SI 4 R", station);
 station.add(signal4)
+
+occupancyLock = OccupancyLock("TC Sta 2 OS")
+routeLock = RouteLock(["4 Upper", "4 Lower", "4 Main", "4 Siding"]);
+turnout.addLocks([occupancyLock, routeLock, TimeLock(signal4)]);
 
 # Optionally, set timings
 print "Setting timings"

--- a/jython/ctc/TwoColumnMachine.py
+++ b/jython/ctc/TwoColumnMachine.py
@@ -2,8 +2,9 @@
 #
 # Uses only internal Sensors and Turnouts so it can be run as a sample.
 #
-# Author: Bob Jacobsen, copyright 2017
+# Author: Bob Jacobsen, copyright 2017, 2021
 # Part of the JMRI distribution
+import java
 import jmri
 from jmri.jmrit.ussctc import *
 
@@ -11,65 +12,80 @@ from jmri.jmrit.ussctc import *
 # These are normally defined in a panel file with names specific
 # to the layout
 
-# Define objects on layout
-turnouts.provideTurnout("IT1").setUserName("Code Indication Start")
-turnouts.provideTurnout("IT2").setUserName("Code Send Start")
-turnouts.provideTurnout("IT3").setUserName("Bell")
+# initialize objects on layout
+turnouts.getTurnout("Code Indication Start")    .state = CLOSED
+turnouts.getTurnout("Code Send Start")          .state = CLOSED
+turnouts.getTurnout("Bell")                     .state = CLOSED
 
-sensors.provideSensor("IS101").setUserName("TC Left Approach")
-sensors.provideSensor("IS102").setUserName("TC Sta 1 OS")
-sensors.provideSensor("IS103").setUserName("TC Main")
-sensors.provideSensor("IS104").setUserName("TC Siding")
-sensors.provideSensor("IS105").setUserName("TC Sta 2 OS")
-sensors.provideSensor("IS106").setUserName("TC Right Approach")
+sensors. getSensor( "TC Left Approach")         .state = INACTIVE
+sensors. getSensor( "TC Sta 1 OS")              .state = INACTIVE
+sensors. getSensor( "TC Main")                  .state = INACTIVE
+sensors. getSensor( "TC Siding")                .state = INACTIVE
+sensors. getSensor( "TC Sta 2 OS")              .state = INACTIVE
+sensors. getSensor( "TC Right Approach")        .state = INACTIVE
 
-turnouts.provideTurnout("IT11").setUserName("Sta 1 Layout TO")
+turnouts.getTurnout("Sta 1 Layout TO")          .state = CLOSED
 
-turnouts.provideTurnout("IT21").setUserName("Sta 2 Layout TO")
+turnouts.getTurnout("Sta 2 Layout TO")          .state = CLOSED
 
-# Define objects on panel
-turnouts.provideTurnout("IT12").setUserName("Sta 1 Code")
-sensors.provideSensor  ("IS12").setUserName("Sta 1 Code")
+# initialize_options objects on panel
+turnouts.getTurnout("Sta 1 Code")               .state = CLOSED
+sensors. getSensor( "Sta 1 Code")               .state = INACTIVE
 
-turnouts.provideTurnout("IT13").setUserName("Sta 1 TO 1 N")
-sensors.provideSensor  ("IS13").setUserName("Sta 1 TO 1 N")
-sensors.provideSensor  ("IS13").state = ACTIVE
-turnouts.provideTurnout("IT14").setUserName("Sta 1 TO 1 R")
-sensors.provideSensor  ("IS14").setUserName("Sta 1 TO 1 R")
+turnouts.getTurnout("Sta 1 TO 1 N")             .state = CLOSED
+sensors. getSensor( "Sta 1 TO 1 N")             .state = ACTIVE
+turnouts.getTurnout("Sta 1 TO 1 R")             .state = CLOSED
+sensors. getSensor( "Sta 1 TO 1 R")             .state = INACTIVE
 
-turnouts.provideTurnout("IT15").setUserName("Sta 1 SI 2 L")
-sensors.provideSensor  ("IS15").setUserName("Sta 1 SI 2 L")
-turnouts.provideTurnout("IT16").setUserName("Sta 1 SI 2 C")
-sensors.provideSensor  ("IS16").setUserName("Sta 1 SI 2 C")
-sensors.provideSensor  ("IS16").state = ACTIVE
-turnouts.provideTurnout("IT17").setUserName("Sta 1 SI 1 R")
-sensors.provideSensor  ("IS17").setUserName("Sta 1 SI 1 R")
+turnouts.getTurnout("Sta 1 SI 2 L")             .state = CLOSED
+sensors. getSensor( "Sta 1 SI 2 L")             .state = INACTIVE
+turnouts.getTurnout("Sta 1 SI 2 C")             .state = CLOSED
+sensors. getSensor( "Sta 1 SI 2 C")             .state = ACTIVE
+turnouts.getTurnout("Sta 1 SI 2 R")             .state = CLOSED
+sensors. getSensor( "Sta 1 SI 2 R")             .state = INACTIVE
 
-turnouts.provideTurnout("IT18").setUserName("Sta 1 Left Approach TC")
-turnouts.provideTurnout("IT19").setUserName("Sta 1 OS TC")
+turnouts.getTurnout("Sta 1 Left Approach TC")   .state = CLOSED
+turnouts.getTurnout("Sta 1 OS TC")              .state = CLOSED
 
 
-turnouts.provideTurnout("IT22").setUserName("Sta 2 Code")
-sensors.provideSensor  ("IS22").setUserName("Sta 2 Code")
+turnouts.getTurnout("Sta 2 Code")               .state = CLOSED
+sensors. getSensor( "Sta 2 Code")               .state = INACTIVE
 
-turnouts.provideTurnout("IT23").setUserName("Sta 2 TO 3 N")
-sensors.provideSensor  ("IS23").setUserName("Sta 2 TO 3 N")
-sensors.provideSensor  ("IS23").state = ACTIVE
-turnouts.provideTurnout("IT24").setUserName("Sta 2 TO 3 R")
-sensors.provideSensor  ("IS24").setUserName("Sta 2 TO 3 R")
+turnouts.getTurnout("Sta 2 TO 3 N")             .state = CLOSED
+sensors. getSensor( "Sta 2 TO 3 N")             .state = ACTIVE
+turnouts.getTurnout("Sta 2 TO 3 R")             .state = CLOSED
+sensors. getSensor( "Sta 2 TO 3 R")             .state = INACTIVE
 
-turnouts.provideTurnout("IT25").setUserName("Sta 2 SI 4 L")
-sensors.provideSensor  ("IS25").setUserName("Sta 2 SI 4 L")
-turnouts.provideTurnout("IT26").setUserName("Sta 2 SI 4 C")
-sensors.provideSensor  ("IS26").setUserName("Sta 2 SI 4 C")
-sensors.provideSensor  ("IS26").state = ACTIVE
-turnouts.provideTurnout("IT27").setUserName("Sta 2 SI 4 R")
-sensors.provideSensor  ("IS27").setUserName("Sta 2 SI 4 R")
+turnouts.getTurnout("Sta 2 SI 4 L")             .state = CLOSED
+sensors. getSensor( "Sta 2 SI 4 L")             .state = INACTIVE
+turnouts.getTurnout("Sta 2 SI 4 C")             .state = CLOSED
+sensors. getSensor( "Sta 2 SI 4 C")             .state = ACTIVE
+turnouts.getTurnout("Sta 2 SI 4 R")             .state = CLOSED
+sensors. getSensor( "Sta 2 SI 4 R")             .state = INACTIVE
 
-turnouts.provideTurnout("IT28").setUserName("Sta 2 Main TC")
-turnouts.provideTurnout("IT29").setUserName("Sta 2 Siding TC")
-turnouts.provideTurnout("IT30").setUserName("Sta 2 OS TC")
-turnouts.provideTurnout("IT31").setUserName("Sta 2 Right Approach TC")
+turnouts.getTurnout("Sta 2 Main TC")            .state = CLOSED
+turnouts.getTurnout("Sta 2 Siding TC")          .state = CLOSED
+turnouts.getTurnout("Sta 2 OS TC")              .state = CLOSED
+turnouts.getTurnout("Sta 2 Right Approach TC")  .state = CLOSED
+
+# needed until signal logic in place
+signals.getSignalHead("2 Upper").state = GREEN
+signals.getSignalHead("2 Lower").state = GREEN
+signals.getSignalHead("2 Main").state = GREEN
+signals.getSignalHead("2 Siding").state = GREEN
+
+signals.getSignalHead("4 Upper").state = GREEN
+signals.getSignalHead("4 Lower").state = GREEN
+signals.getSignalHead("4 Main").state = GREEN
+signals.getSignalHead("4 Siding").state = GREEN
+
+
+# service routine to make entries clearer
+def arrayList(contents) :
+    retval = java.util.ArrayList()
+    for item in contents :
+        retval.add(item)
+    return retval
 
 # The core of the sample script starts here, defining & connecting
 # the USS CTC objects to run the panel
@@ -90,6 +106,11 @@ station.add(turnout)
 station.add(TrackCircuitSection("TC Left Approach", "Sta 1 Left Approach TC", station, bell))
 station.add(TrackCircuitSection("TC Sta 1 OS", "Sta 1 OS TC", station))
 
+rightward = arrayList(["2 Upper", "2 Lower"])
+leftward  = arrayList(["2 Main", "2 Siding"])
+signal2 = SignalHeadSection(rightward, leftward, "Sta 1 SI 2 L", "Sta 1 SI 2 C", "Sta 1 SI 2 R", "Sta 1 SI 2 L", "Sta 1 SI 2 R", station);
+station.add(signal2)
+
 # Set up Station 2 - levers 3 and 4
 
 station = Station("2", codeline, CodeButton("Sta 2 Code", "Sta 2 Code"))
@@ -99,6 +120,11 @@ station.add(TrackCircuitSection("TC Main", "Sta 2 Main TC", station))
 station.add(TrackCircuitSection("TC Siding", "Sta 2 Siding TC", station))
 station.add(TrackCircuitSection("TC Sta 2 OS", "Sta 2 OS TC", station))
 station.add(TrackCircuitSection("TC Right Approach", "Sta 2 Right Approach TC", station, bell))
+
+rightward = arrayList(["4 Main", "4 Siding"])
+leftward  = arrayList(["4 Upper", "4 Lower"])
+signal4 = SignalHeadSection(rightward, leftward, "Sta 2 SI 4 L", "Sta 2 SI 4 C", "Sta 2 SI 4 R", "Sta 2 SI 4 L", "Sta 2 SI 4 R", station);
+station.add(signal4)
 
 # Optionally, set timings
 print "Setting timings"
@@ -119,4 +145,3 @@ print"Signal movement delay: ", jmri.jmrit.ussctc.SignalHeadSection.MOVEMENT_DEL
 jmri.jmrit.ussctc.SignalHeadSection.DEFAULT_RUN_TIME_LENGTH = 5000
 memories.provideMemory("IMUSS CTC:SIGNALHEADSECTION:1:TIME").setValue(jmri.jmrit.ussctc.SignalHeadSection.DEFAULT_RUN_TIME_LENGTH)
 print "Running time for", jmri.jmrit.ussctc.SignalHeadSection.DEFAULT_RUN_TIME_LENGTH/1000., "seconds"
-

--- a/jython/ctc/TwoColumnMachine.py
+++ b/jython/ctc/TwoColumnMachine.py
@@ -96,6 +96,6 @@ jmri.jmrit.ussctc.SignalHeadSection.MOVEMENT_DELAY = 5000
 print"Signal movement delay: ", jmri.jmrit.ussctc.SignalHeadSection.MOVEMENT_DELAY/1000., "seconds"
 
 jmri.jmrit.ussctc.SignalHeadSection.DEFAULT_RUN_TIME_LENGTH = 5000
-memories.providetMemory("IMUSS CTC:SIGNALHEADSECTION:1:TIME").setValue(jmri.jmrit.ussctc.SignalHeadSection.DEFAULT_RUN_TIME_LENGTH)
+memories.provideMemory("IMUSS CTC:SIGNALHEADSECTION:1:TIME").setValue(jmri.jmrit.ussctc.SignalHeadSection.DEFAULT_RUN_TIME_LENGTH)
 print "Running time for", jmri.jmrit.ussctc.SignalHeadSection.DEFAULT_RUN_TIME_LENGTH/1000., "seconds"
 

--- a/jython/ctc/TwoColumnMachine.py
+++ b/jython/ctc/TwoColumnMachine.py
@@ -111,6 +111,10 @@ leftward  = arrayList(["2 Main", "2 Siding"])
 signal2 = SignalHeadSection(rightward, leftward, "Sta 1 SI 2 L", "Sta 1 SI 2 C", "Sta 1 SI 2 R", "Sta 1 SI 2 L", "Sta 1 SI 2 R", station);
 station.add(signal2)
 
+occupancyLock = OccupancyLock("TC Sta 1 OS")
+routeLock = RouteLock(["2 Upper", "2 Lower", "2 Main", "2 Siding"]);
+turnout.addLocks([occupancyLock, routeLock, TimeLock(signal2)]);
+
 # Set up Station 2 - levers 3 and 4
 
 station = Station("2", codeline, CodeButton("Sta 2 Code", "Sta 2 Code"))

--- a/jython/ctc/TwoColumnMachine.xml
+++ b/jython/ctc/TwoColumnMachine.xml
@@ -736,7 +736,8 @@
       </inconsistent>
       <iconmaps />
     </sensoricon>
-    <memoryInputIcon colWidth="30" memory="IMUSS CTC:CODELINE:1:LOG" x="502" y="736" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.MemoryInputIconXml" />
+    <memoryInputIcon colWidth="30" memory="IMUSS CTC:CODELINE:1:LOG" x="502" y="714" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.MemoryInputIconXml" />
+    <memoryInputIcon colWidth="30" memory="IMUSS CTC:LOCK:1:LOG" x="502" y="736" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.MemoryInputIconXml" />
     <multisensoricon x="104" y="505" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" updown="false" class="jmri.jmrit.display.configurexml.MultiSensorIconXml">
       <active url="program:resources/icons/USS/plate/levers/l-left.gif" degrees="0" scale="1.0" sensor="Sta 1 SI 2 L">
         <rotation>0</rotation>

--- a/jython/ctc/TwoColumnMachine.xml
+++ b/jython/ctc/TwoColumnMachine.xml
@@ -22,6 +22,18 @@
       <userName>Sta 1 TO 1 R</userName>
     </sensor>
     <sensor inverted="false">
+      <systemName>IS15</systemName>
+      <userName>Sta 1 SI 2 L</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS16</systemName>
+      <userName>Sta 1 SI 2 C</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS17</systemName>
+      <userName>Sta 1 SI 1 R</userName>
+    </sensor>
+    <sensor inverted="false">
       <systemName>IS22</systemName>
       <userName>Sta 2 Code</userName>
     </sensor>
@@ -32,6 +44,18 @@
     <sensor inverted="false">
       <systemName>IS24</systemName>
       <userName>Sta 2 TO 3 R</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS25</systemName>
+      <userName>Sta 2 SI 4 L</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS26</systemName>
+      <userName>Sta 2 SI 4 C</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS27</systemName>
+      <userName>Sta 2 SI 4 R</userName>
     </sensor>
     <sensor inverted="false">
       <systemName>IS101</systemName>
@@ -56,6 +80,9 @@
     <sensor inverted="false">
       <systemName>IS106</systemName>
       <userName>TC Right Approach</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>ISSta 1 SI 2 R</systemName>
     </sensor>
   </sensors>
   <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
@@ -94,10 +121,22 @@
     </turnout>
     <turnout feedback="DIRECT" inverted="false" automate="Off">
       <systemName>IT15</systemName>
-      <userName>Sta 1 Left Approach TC</userName>
+      <userName>Sta 1 SI 2 L</userName>
     </turnout>
     <turnout feedback="DIRECT" inverted="false" automate="Off">
       <systemName>IT16</systemName>
+      <userName>Sta 1 SI 2 C</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT17</systemName>
+      <userName>Sta 1 SI 1 R</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT18</systemName>
+      <userName>Sta 1 Left Approach TC</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT19</systemName>
       <userName>Sta 1 OS TC</userName>
     </turnout>
     <turnout feedback="DIRECT" inverted="false" automate="Off">
@@ -118,18 +157,30 @@
     </turnout>
     <turnout feedback="DIRECT" inverted="false" automate="Off">
       <systemName>IT25</systemName>
-      <userName>Sta 2 Main TC</userName>
+      <userName>Sta 2 SI 4 L</userName>
     </turnout>
     <turnout feedback="DIRECT" inverted="false" automate="Off">
       <systemName>IT26</systemName>
-      <userName>Sta 2 Siding TC</userName>
+      <userName>Sta 2 SI 4 C</userName>
     </turnout>
     <turnout feedback="DIRECT" inverted="false" automate="Off">
       <systemName>IT27</systemName>
-      <userName>Sta 2 OS TC</userName>
+      <userName>Sta 2 SI 4 R</userName>
     </turnout>
     <turnout feedback="DIRECT" inverted="false" automate="Off">
       <systemName>IT28</systemName>
+      <userName>Sta 2 Main TC</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT29</systemName>
+      <userName>Sta 2 Siding TC</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT30</systemName>
+      <userName>Sta 2 OS TC</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT31</systemName>
       <userName>Sta 2 Right Approach TC</userName>
     </turnout>
     <turnout feedback="DIRECT" inverted="false" automate="Off">
@@ -156,10 +207,44 @@
       <systemName>IMUSS CTC:SIGNALHEADSECTION:1:TIME</systemName>
     </memory>
   </memories>
+  <signalheads class="jmri.managers.configurexml.AbstractSignalHeadManagerXml">
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH2Lmain</systemName>
+      <userName>1 SI 2 Main</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH2Lsiding</systemName>
+      <userName>1 SI 2 Siding</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH2Rlower</systemName>
+      <userName>1 SI 2 Lower</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH2Rupper</systemName>
+      <userName>1 SI 2 Upper</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH4Lmain</systemName>
+      <userName>2 SI 4 Main</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH4Lsiding</systemName>
+      <userName>2 SI 4 Siding</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH4Rlower</systemName>
+      <userName>2 SI 4 Lower</userName>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
+      <systemName>IH4Rupper</systemName>
+      <userName>2 SI 4 Upper</userName>
+    </signalhead>
+  </signalheads>
   <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
     <logicDelay>500</logicDelay>
   </signalmastlogics>
-  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="Panel" x="1232" y="195" height="817" width="1048" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="no" panelmenu="yes" scrollable="both" redBackground="255" greenBackground="255" blueBackground="255">
+  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="Panel" x="55" y="57" height="817" width="1048" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="no" panelmenu="yes" scrollable="both" redBackground="255" greenBackground="255" blueBackground="255">
     <positionablelabel x="0" y="0" level="1" forcecontroloff="false" hidden="no" positionable="true" showtooltip="false" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
       <icon url="program:resources/icons/USSpanels/Panels/USS-15.gif" degrees="0" scale="1.0">
         <rotation>0</rotation>
@@ -652,69 +737,414 @@
       <iconmaps />
     </sensoricon>
     <memoryInputIcon colWidth="30" memory="IMUSS CTC:CODELINE:1:LOG" x="502" y="736" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.MemoryInputIconXml" />
+    <multisensoricon x="104" y="505" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" updown="false" class="jmri.jmrit.display.configurexml.MultiSensorIconXml">
+      <active url="program:resources/icons/USS/plate/levers/l-left.gif" degrees="0" scale="1.0" sensor="Sta 1 SI 2 L">
+        <rotation>0</rotation>
+      </active>
+      <active url="program:resources/icons/USS/plate/levers/l-vertical.gif" degrees="0" scale="1.0" sensor="Sta 1 SI 2 C">
+        <rotation>0</rotation>
+      </active>
+      <active url="program:resources/icons/USS/plate/levers/l-right.gif" degrees="0" scale="1.0" sensor="Sta 1 SI 2 R">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/USS/plate/levers/l-inactive.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/USS/plate/levers/l-unknown.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/USS/plate/levers/l-inconsistent.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+    </multisensoricon>
+    <multisensoricon x="233" y="504" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" updown="false" class="jmri.jmrit.display.configurexml.MultiSensorIconXml">
+      <active url="program:resources/icons/USS/plate/levers/l-left.gif" degrees="0" scale="1.0" sensor="Sta 2 SI 4 L">
+        <rotation>0</rotation>
+      </active>
+      <active url="program:resources/icons/USS/plate/levers/l-vertical.gif" degrees="0" scale="1.0" sensor="Sta 2 SI 4 C">
+        <rotation>0</rotation>
+      </active>
+      <active url="program:resources/icons/USS/plate/levers/l-right.gif" degrees="0" scale="1.0" sensor="Sta 2 SI 4 R">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/USS/plate/levers/l-inactive.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/USS/plate/levers/l-unknown.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/USS/plate/levers/l-inconsistent.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+    </multisensoricon>
+    <turnouticon turnout="Sta 1 SI 2 C" x="107" y="451" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-g.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 2 SI 4 C" x="235" y="451" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-g.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 1 SI 2 L" x="93" y="467" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-y.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 2 SI 4 L" x="221" y="465" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-y.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 2 SI 4 R" x="252" y="465" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-r.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 1 SI 1 R" x="123" y="468" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-r.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <signalheadicon signalhead="2 SI 4 Upper" x="270" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="2 SI 4 Lower" x="281" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="2 SI 4 Siding" x="203" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="2 SI 4 Main" x="202" y="134" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="1 SI 2 Upper" x="84" y="136" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="1 SI 2 Lower" x="71" y="136" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-marker.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="1 SI 2 Siding" x="131" y="83" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
+    <signalheadicon signalhead="1 SI 2 Main" x="130" y="105" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+      <icons>
+        <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </held>
+        <dark url="program:resources/icons/smallschematics/searchlights/left-dark-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </dark>
+        <red url="program:resources/icons/smallschematics/searchlights/left-red-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </red>
+        <yellow url="program:resources/icons/smallschematics/searchlights/left-yellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </yellow>
+        <green url="program:resources/icons/smallschematics/searchlights/left-green-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </green>
+        <flashred url="program:resources/icons/smallschematics/searchlights/left-flashred-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashred>
+        <flashyellow url="program:resources/icons/smallschematics/searchlights/left-flashyellow-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashyellow>
+        <flashgreen url="program:resources/icons/smallschematics/searchlights/left-flashgreen-marker.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </flashgreen>
+      </icons>
+      <iconmaps />
+    </signalheadicon>
   </paneleditor>
   <filehistory>
     <operation>
       <type>app</type>
-      <date>Thu Sep 09 22:08:38 EDT 2021</date>
+      <date>Fri Sep 10 06:38:40 EDT 2021</date>
       <filename>JMRI program</filename>
     </operation>
     <operation>
       <type>Load OK</type>
-      <date>Thu Sep 09 22:09:17 EDT 2021</date>
-      <filename>/Users/jake/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
+      <date>Fri Sep 10 06:38:50 EDT 2021</date>
+      <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
       <filehistory>
         <operation>
           <type>app</type>
-          <date>Thu Sep 09 21:44:12 EDT 2021</date>
+          <date>Fri Sep 10 06:23:54 EDT 2021</date>
           <filename>JMRI program</filename>
         </operation>
         <operation>
           <type>Load OK</type>
-          <date>Thu Sep 09 21:44:46 EDT 2021</date>
-          <filename>/Users/jake/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
-          <filehistory>
-            <operation>
-              <type>app</type>
-              <date>Thu Sep 09 21:25:35 EDT 2021</date>
-              <filename>JMRI program</filename>
-            </operation>
-            <operation>
-              <type>Load OK</type>
-              <date>Thu Sep 09 21:26:27 EDT 2021</date>
-              <filename>/Users/jake/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
-              <filehistory>
-                <operation>
-                  <type>app</type>
-                  <date>Thu Sep 09 21:06:22 EDT 2021</date>
-                  <filename>JMRI program</filename>
-                </operation>
-                <operation>
-                  <type>Store</type>
-                  <date>Thu Sep 09 21:22:05 EDT 2021</date>
-                  <filename />
-                </operation>
-              </filehistory>
-            </operation>
-            <operation>
-              <type>Store</type>
-              <date>Thu Sep 09 21:42:10 EDT 2021</date>
-              <filename />
-            </operation>
-          </filehistory>
+          <date>Fri Sep 10 06:24:18 EDT 2021</date>
+          <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
         </operation>
         <operation>
           <type>Store</type>
-          <date>Thu Sep 09 22:01:37 EDT 2021</date>
+          <date>Fri Sep 10 06:33:33 EDT 2021</date>
           <filename />
         </operation>
       </filehistory>
     </operation>
     <operation>
       <type>Store</type>
-      <date>Thu Sep 09 22:12:58 EDT 2021</date>
+      <date>Fri Sep 10 06:41:44 EDT 2021</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.25.3ish+jake+20210910T0208Z+Rb7bbcd85d5 on Thu Sep 09 22:12:58 EDT 2021-->
+  <!--Written by JMRI version 4.25.3ish+jake+20210910T1038Z+R9109c295e7 on Fri Sep 10 06:41:44 EDT 2021-->
 </layout-config>

--- a/jython/ctc/TwoColumnMachine.xml
+++ b/jython/ctc/TwoColumnMachine.xml
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-4-19-2.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-4-19-2.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>25</minor>
+    <test>3</test>
+    <modifier>ish</modifier>
+  </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor inverted="false">
+      <systemName>IS12</systemName>
+      <userName>Sta 1 Code</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS13</systemName>
+      <userName>Sta 1 TO 1 N</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS14</systemName>
+      <userName>Sta 1 TO 1 R</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS22</systemName>
+      <userName>Sta 2 Code</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS23</systemName>
+      <userName>Sta 2 TO 3 N</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS24</systemName>
+      <userName>Sta 2 TO 3 R</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS101</systemName>
+      <userName>TC Left Approach</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS102</systemName>
+      <userName>TC Sta 1 OS</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS103</systemName>
+      <userName>TC Main</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS104</systemName>
+      <userName>TC Siding</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS105</systemName>
+      <userName>TC Sta 2 OS</userName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>IS106</systemName>
+      <userName>TC Right Approach</userName>
+    </sensor>
+  </sensors>
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
+    <operations automate="false">
+      <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
+    </operations>
+    <defaultclosedspeed>Normal</defaultclosedspeed>
+    <defaultthrownspeed>Restricted</defaultthrownspeed>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT1</systemName>
+      <userName>Code Indication Start</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT2</systemName>
+      <userName>Code Send Start</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT3</systemName>
+      <userName>Bell</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT11</systemName>
+      <userName>Sta 1 Layout TO</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT12</systemName>
+      <userName>Sta 1 Code</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT13</systemName>
+      <userName>Sta 1 TO 1 N</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT14</systemName>
+      <userName>Sta 1 TO 1 R</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT15</systemName>
+      <userName>Sta 1 Left Approach TC</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT16</systemName>
+      <userName>Sta 1 OS TC</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT21</systemName>
+      <userName>Sta 2 Layout TO</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT22</systemName>
+      <userName>Sta 2 Code</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT23</systemName>
+      <userName>Sta 2 TO 3 N</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT24</systemName>
+      <userName>Sta 2 TO 3 R</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT25</systemName>
+      <userName>Sta 2 Main TC</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT26</systemName>
+      <userName>Sta 2 Siding TC</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT27</systemName>
+      <userName>Sta 2 OS TC</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT28</systemName>
+      <userName>Sta 2 Right Approach TC</userName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT101</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT102</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT103</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT104</systemName>
+    </turnout>
+  </turnouts>
+  <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
+    <memory>
+      <systemName>IMUSS CTC:CODELINE:1:LOG</systemName>
+    </memory>
+  </memories>
+  <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
+    <logicDelay>500</logicDelay>
+  </signalmastlogics>
+  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="Panel" x="1232" y="195" height="817" width="1048" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="no" panelmenu="yes" scrollable="both" redBackground="255" greenBackground="255" blueBackground="255">
+    <positionablelabel x="0" y="0" level="1" forcecontroloff="false" hidden="no" positionable="true" showtooltip="false" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/Panels/USS-15.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <turnouticon turnout="Sta 1 TO 1 N" x="25" y="353" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-dg.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-g.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 2 TO 3 N" x="89" y="355" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-dg.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-g.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 2 TO 3 R" x="119" y="355" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-dg.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-y.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 1 TO 1 R" x="56" y="354" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-dg.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-y.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 1 Code" x="39" y="594" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-w.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 2 Code" x="100" y="596" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
+          <rotation>1</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-w.gif" degrees="0" scale="1.0">
+          <rotation>1</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>1</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>1</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <positionablelabel x="20" y="349" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/Plates/sw-1.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="84" y="352" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/Plates/sw-3.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="23" y="448" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/Plates/si-2.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="85" y="446" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/Plates/si-4.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <multisensoricon x="39" y="393" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" updown="false" class="jmri.jmrit.display.configurexml.MultiSensorIconXml">
+      <active url="program:resources/icons/USS/plate/levers/l-left.gif" degrees="0" scale="1.0" sensor="Sta 1 TO 1 N">
+        <rotation>0</rotation>
+      </active>
+      <active url="program:resources/icons/USS/plate/levers/l-right.gif" degrees="0" scale="1.0" sensor="Sta 1 TO 1 R">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/USS/plate/levers/l-inactive.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/USS/plate/levers/l-unknown.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/USS/plate/levers/l-inconsistent.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+    </multisensoricon>
+    <multisensoricon x="103" y="394" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" updown="false" class="jmri.jmrit.display.configurexml.MultiSensorIconXml">
+      <active url="program:resources/icons/USS/plate/levers/l-left.gif" degrees="0" scale="1.0" sensor="Sta 2 TO 3 N">
+        <rotation>0</rotation>
+      </active>
+      <active url="program:resources/icons/USS/plate/levers/l-right.gif" degrees="0" scale="1.0" sensor="Sta 2 TO 3 R">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/USS/plate/levers/l-inactive.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/USS/plate/levers/l-unknown.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/USS/plate/levers/l-inconsistent.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+    </multisensoricon>
+    <turnouticon turnout="Sta 2 Code" x="104" y="559" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-w.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 1 Code" x="40" y="560" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-w.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+  </paneleditor>
+  <filehistory>
+    <operation>
+      <type>app</type>
+      <date>Thu Sep 09 21:06:22 EDT 2021</date>
+      <filename>JMRI program</filename>
+    </operation>
+    <operation>
+      <type>Store</type>
+      <date>Thu Sep 09 21:22:05 EDT 2021</date>
+      <filename />
+    </operation>
+  </filehistory>
+  <!--Written by JMRI version 4.25.3ish+jake+20210910T0106Z+R1b9b0d7c42 on Thu Sep 09 21:22:05 EDT 2021-->
+</layout-config>

--- a/jython/ctc/TwoColumnMachine.xml
+++ b/jython/ctc/TwoColumnMachine.xml
@@ -146,8 +146,11 @@
     </turnout>
   </turnouts>
   <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
-    <memory>
+    <memory value="">
       <systemName>IMUSS CTC:CODELINE:1:LOG</systemName>
+    </memory>
+    <memory value="">
+      <systemName>IMUSS CTC:LOCK:1:LOG</systemName>
     </memory>
   </memories>
   <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
@@ -223,40 +226,6 @@
         </unknown>
         <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
-        </inconsistent>
-      </icons>
-      <iconmaps />
-    </turnouticon>
-    <turnouticon turnout="Sta 1 Code" x="103" y="591" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="true" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
-      <icons>
-        <closed url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
-          <rotation>0</rotation>
-        </closed>
-        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-w.gif" degrees="0" scale="1.0">
-          <rotation>0</rotation>
-        </thrown>
-        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
-          <rotation>0</rotation>
-        </unknown>
-        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
-          <rotation>0</rotation>
-        </inconsistent>
-      </icons>
-      <iconmaps />
-    </turnouticon>
-    <turnouticon turnout="Sta 2 Code" x="235" y="599" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="true" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
-      <icons>
-        <closed url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
-          <rotation>1</rotation>
-        </closed>
-        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-w.gif" degrees="0" scale="1.0">
-          <rotation>1</rotation>
-        </thrown>
-        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
-          <rotation>1</rotation>
-        </unknown>
-        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
-          <rotation>1</rotation>
         </inconsistent>
       </icons>
       <iconmaps />
@@ -515,7 +484,7 @@
       </inconsistent>
       <iconmaps />
     </sensoricon>
-    <sensoricon sensor="TC Main" x="170" y="178" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="false" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
+    <sensoricon sensor="TC Main" x="171" y="206" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="false" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
       <active url="program:resources/icons/smallschematics/tracksegments/circuit-occupied.gif" degrees="0" scale="1.0">
         <rotation>0</rotation>
       </active>
@@ -545,7 +514,7 @@
       </inconsistent>
       <iconmaps />
     </sensoricon>
-    <sensoricon sensor="TC Siding" x="169" y="204" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="false" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
+    <sensoricon sensor="TC Siding" x="172" y="179" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="false" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
       <active url="program:resources/icons/smallschematics/tracksegments/circuit-occupied.gif" degrees="0" scale="1.0">
         <rotation>0</rotation>
       </active>
@@ -610,35 +579,121 @@
         <rotation>0</rotation>
       </icon>
     </positionablelabel>
+    <positionablelabel x="873" y="678" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USS/plate/base-plates/misc/code.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <turnouticon turnout="Code Indication Start" x="971" y="724" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-w.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Code Send Start" x="906" y="724" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-w.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <sensoricon sensor="Sta 1 Code" x="104" y="594" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="true" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
+      <active url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+      <iconmaps />
+    </sensoricon>
+    <sensoricon sensor="Sta 2 Code" x="236" y="593" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="true" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
+      <active url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+      <iconmaps />
+    </sensoricon>
   </paneleditor>
   <filehistory>
     <operation>
       <type>app</type>
-      <date>Thu Sep 09 21:25:35 EDT 2021</date>
+      <date>Thu Sep 09 21:44:12 EDT 2021</date>
       <filename>JMRI program</filename>
     </operation>
     <operation>
       <type>Load OK</type>
-      <date>Thu Sep 09 21:26:27 EDT 2021</date>
+      <date>Thu Sep 09 21:44:46 EDT 2021</date>
       <filename>/Users/jake/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
       <filehistory>
         <operation>
           <type>app</type>
-          <date>Thu Sep 09 21:06:22 EDT 2021</date>
+          <date>Thu Sep 09 21:25:35 EDT 2021</date>
           <filename>JMRI program</filename>
         </operation>
         <operation>
+          <type>Load OK</type>
+          <date>Thu Sep 09 21:26:27 EDT 2021</date>
+          <filename>/Users/jake/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
+          <filehistory>
+            <operation>
+              <type>app</type>
+              <date>Thu Sep 09 21:06:22 EDT 2021</date>
+              <filename>JMRI program</filename>
+            </operation>
+            <operation>
+              <type>Store</type>
+              <date>Thu Sep 09 21:22:05 EDT 2021</date>
+              <filename />
+            </operation>
+          </filehistory>
+        </operation>
+        <operation>
           <type>Store</type>
-          <date>Thu Sep 09 21:22:05 EDT 2021</date>
+          <date>Thu Sep 09 21:42:10 EDT 2021</date>
           <filename />
         </operation>
       </filehistory>
     </operation>
     <operation>
       <type>Store</type>
-      <date>Thu Sep 09 21:42:10 EDT 2021</date>
+      <date>Thu Sep 09 22:01:37 EDT 2021</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.25.3ish+jake+20210910T0125Z+R8d3ff7a023 on Thu Sep 09 21:42:10 EDT 2021-->
+  <!--Written by JMRI version 4.25.3ish+jake+20210910T0144Z+R20a202f6b0 on Thu Sep 09 22:01:37 EDT 2021-->
 </layout-config>

--- a/jython/ctc/TwoColumnMachine.xml
+++ b/jython/ctc/TwoColumnMachine.xml
@@ -159,7 +159,7 @@
         <rotation>0</rotation>
       </icon>
     </positionablelabel>
-    <turnouticon turnout="Sta 1 TO 1 N" x="25" y="353" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+    <turnouticon turnout="Sta 1 TO 1 N" x="88" y="353" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
       <icons>
         <closed url="program:resources/icons/USSpanels/Lamps/lamp-dg.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -176,7 +176,7 @@
       </icons>
       <iconmaps />
     </turnouticon>
-    <turnouticon turnout="Sta 2 TO 3 N" x="89" y="355" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+    <turnouticon turnout="Sta 2 TO 3 N" x="219" y="353" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
       <icons>
         <closed url="program:resources/icons/USSpanels/Lamps/lamp-dg.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -193,7 +193,7 @@
       </icons>
       <iconmaps />
     </turnouticon>
-    <turnouticon turnout="Sta 2 TO 3 R" x="119" y="355" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+    <turnouticon turnout="Sta 2 TO 3 R" x="252" y="352" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
       <icons>
         <closed url="program:resources/icons/USSpanels/Lamps/lamp-dg.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -210,7 +210,7 @@
       </icons>
       <iconmaps />
     </turnouticon>
-    <turnouticon turnout="Sta 1 TO 1 R" x="56" y="354" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+    <turnouticon turnout="Sta 1 TO 1 R" x="120" y="351" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
       <icons>
         <closed url="program:resources/icons/USSpanels/Lamps/lamp-dg.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -227,7 +227,7 @@
       </icons>
       <iconmaps />
     </turnouticon>
-    <turnouticon turnout="Sta 1 Code" x="39" y="594" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+    <turnouticon turnout="Sta 1 Code" x="103" y="591" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="true" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
       <icons>
         <closed url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -244,7 +244,7 @@
       </icons>
       <iconmaps />
     </turnouticon>
-    <turnouticon turnout="Sta 2 Code" x="100" y="596" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+    <turnouticon turnout="Sta 2 Code" x="235" y="599" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="true" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
       <icons>
         <closed url="program:resources/icons/USSpanels/Plates/code-button.gif" degrees="0" scale="1.0">
           <rotation>1</rotation>
@@ -261,27 +261,27 @@
       </icons>
       <iconmaps />
     </turnouticon>
-    <positionablelabel x="20" y="349" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+    <positionablelabel x="85" y="349" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
       <icon url="program:resources/icons/USSpanels/Plates/sw-1.gif" degrees="0" scale="1.0">
         <rotation>0</rotation>
       </icon>
     </positionablelabel>
-    <positionablelabel x="84" y="352" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+    <positionablelabel x="218" y="349" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
       <icon url="program:resources/icons/USSpanels/Plates/sw-3.gif" degrees="0" scale="1.0">
         <rotation>0</rotation>
       </icon>
     </positionablelabel>
-    <positionablelabel x="23" y="448" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+    <positionablelabel x="88" y="450" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
       <icon url="program:resources/icons/USSpanels/Plates/si-2.gif" degrees="0" scale="1.0">
         <rotation>0</rotation>
       </icon>
     </positionablelabel>
-    <positionablelabel x="85" y="446" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+    <positionablelabel x="216" y="448" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
       <icon url="program:resources/icons/USSpanels/Plates/si-4.gif" degrees="0" scale="1.0">
         <rotation>0</rotation>
       </icon>
     </positionablelabel>
-    <multisensoricon x="39" y="393" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" updown="false" class="jmri.jmrit.display.configurexml.MultiSensorIconXml">
+    <multisensoricon x="103" y="393" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" updown="false" class="jmri.jmrit.display.configurexml.MultiSensorIconXml">
       <active url="program:resources/icons/USS/plate/levers/l-left.gif" degrees="0" scale="1.0" sensor="Sta 1 TO 1 N">
         <rotation>0</rotation>
       </active>
@@ -298,7 +298,7 @@
         <rotation>0</rotation>
       </inconsistent>
     </multisensoricon>
-    <multisensoricon x="103" y="394" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" updown="false" class="jmri.jmrit.display.configurexml.MultiSensorIconXml">
+    <multisensoricon x="235" y="392" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" updown="false" class="jmri.jmrit.display.configurexml.MultiSensorIconXml">
       <active url="program:resources/icons/USS/plate/levers/l-left.gif" degrees="0" scale="1.0" sensor="Sta 2 TO 3 N">
         <rotation>0</rotation>
       </active>
@@ -315,7 +315,7 @@
         <rotation>0</rotation>
       </inconsistent>
     </multisensoricon>
-    <turnouticon turnout="Sta 2 Code" x="104" y="559" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+    <turnouticon turnout="Sta 2 Code" x="238" y="560" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
       <icons>
         <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -332,7 +332,7 @@
       </icons>
       <iconmaps />
     </turnouticon>
-    <turnouticon turnout="Sta 1 Code" x="40" y="560" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+    <turnouticon turnout="Sta 1 Code" x="106" y="558" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
       <icons>
         <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -349,18 +349,296 @@
       </icons>
       <iconmaps />
     </turnouticon>
+    <turnouticon turnout="Sta 1 Layout TO" x="93" y="93" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/TrackSegments/os-lefthand-west-closed.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/TrackSegments/os-lefthand-west-thrown.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/TrackSegments/os-lefthand-west-unknown.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/TrackSegments/os-lefthand-west-error.gif" degrees="0" scale="1.0">
+          <rotation>2</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 1 Left Approach TC" x="45" y="114" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-occ.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 1 OS TC" x="117" y="115" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-occ.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 2 Main TC" x="164" y="115" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-occ.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 2 Siding TC" x="164" y="93" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-occ.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 2 Right Approach TC" x="282" y="116" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-occ.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 2 Layout TO" x="223" y="94" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/TrackSegments/os-righthand-west-closed.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/TrackSegments/os-righthand-west-thrown.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/TrackSegments/os-righthand-west-unknown.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/TrackSegments/os-lefthand-45-SE-thrown.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <turnouticon turnout="Sta 2 OS TC" x="221" y="116" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+      <icons>
+        <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </closed>
+        <thrown url="program:resources/icons/USSpanels/Lamps/lamp-occ.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </thrown>
+        <unknown url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </unknown>
+        <inconsistent url="program:resources/icons/USSpanels/Lamps/lamp-b.gif" degrees="0" scale="1.0">
+          <rotation>0</rotation>
+        </inconsistent>
+      </icons>
+      <iconmaps />
+    </turnouticon>
+    <sensoricon sensor="TC Left Approach" x="52" y="205" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="false" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
+      <active url="program:resources/icons/smallschematics/tracksegments/circuit-occupied.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/smallschematics/tracksegments/circuit-empty.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+      <iconmaps />
+    </sensoricon>
+    <sensoricon sensor="TC Sta 1 OS" x="123" y="206" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="false" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
+      <active url="program:resources/icons/smallschematics/tracksegments/circuit-occupied.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/smallschematics/tracksegments/circuit-empty.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+      <iconmaps />
+    </sensoricon>
+    <sensoricon sensor="TC Main" x="170" y="178" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="false" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
+      <active url="program:resources/icons/smallschematics/tracksegments/circuit-occupied.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/smallschematics/tracksegments/circuit-empty.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+      <iconmaps />
+    </sensoricon>
+    <sensoricon sensor="TC Right Approach" x="289" y="205" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="false" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
+      <active url="program:resources/icons/smallschematics/tracksegments/circuit-occupied.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/smallschematics/tracksegments/circuit-empty.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+      <iconmaps />
+    </sensoricon>
+    <sensoricon sensor="TC Siding" x="169" y="204" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="false" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
+      <active url="program:resources/icons/smallschematics/tracksegments/circuit-occupied.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/smallschematics/tracksegments/circuit-empty.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+      <iconmaps />
+    </sensoricon>
+    <sensoricon sensor="TC Sta 2 OS" x="229" y="204" level="10" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" momentary="false" icon="yes" class="jmri.jmrit.display.configurexml.SensorIconXml">
+      <active url="program:resources/icons/smallschematics/tracksegments/circuit-occupied.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </active>
+      <inactive url="program:resources/icons/smallschematics/tracksegments/circuit-empty.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inactive>
+      <unknown url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </unknown>
+      <inconsistent url="program:resources/icons/smallschematics/tracksegments/circuit-error.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </inconsistent>
+      <iconmaps />
+    </sensoricon>
+    <positionablelabel x="55" y="116" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/TrackSegments/block.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="32" y="116" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/TrackSegments/block.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="185" y="117" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/TrackSegments/block.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="132" y="117" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/TrackSegments/block.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="269" y="117" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/TrackSegments/block.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="186" y="94" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/TrackSegments/block.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
+    <positionablelabel x="134" y="93" level="3" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
+      <icon url="program:resources/icons/USSpanels/TrackSegments/block.gif" degrees="0" scale="1.0">
+        <rotation>0</rotation>
+      </icon>
+    </positionablelabel>
   </paneleditor>
   <filehistory>
     <operation>
       <type>app</type>
-      <date>Thu Sep 09 21:06:22 EDT 2021</date>
+      <date>Thu Sep 09 21:25:35 EDT 2021</date>
       <filename>JMRI program</filename>
     </operation>
     <operation>
+      <type>Load OK</type>
+      <date>Thu Sep 09 21:26:27 EDT 2021</date>
+      <filename>/Users/jake/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
+      <filehistory>
+        <operation>
+          <type>app</type>
+          <date>Thu Sep 09 21:06:22 EDT 2021</date>
+          <filename>JMRI program</filename>
+        </operation>
+        <operation>
+          <type>Store</type>
+          <date>Thu Sep 09 21:22:05 EDT 2021</date>
+          <filename />
+        </operation>
+      </filehistory>
+    </operation>
+    <operation>
       <type>Store</type>
-      <date>Thu Sep 09 21:22:05 EDT 2021</date>
+      <date>Thu Sep 09 21:42:10 EDT 2021</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.25.3ish+jake+20210910T0106Z+R1b9b0d7c42 on Thu Sep 09 21:22:05 EDT 2021-->
+  <!--Written by JMRI version 4.25.3ish+jake+20210910T0125Z+R8d3ff7a023 on Thu Sep 09 21:42:10 EDT 2021-->
 </layout-config>

--- a/jython/ctc/TwoColumnMachine.xml
+++ b/jython/ctc/TwoColumnMachine.xml
@@ -31,7 +31,7 @@
     </sensor>
     <sensor inverted="false">
       <systemName>IS17</systemName>
-      <userName>Sta 1 SI 1 R</userName>
+      <userName>Sta 1 SI 2 R</userName>
     </sensor>
     <sensor inverted="false">
       <systemName>IS22</systemName>
@@ -81,9 +81,6 @@
       <systemName>IS106</systemName>
       <userName>TC Right Approach</userName>
     </sensor>
-    <sensor inverted="false">
-      <systemName>ISSta 1 SI 2 R</systemName>
-    </sensor>
   </sensors>
   <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
@@ -129,7 +126,7 @@
     </turnout>
     <turnout feedback="DIRECT" inverted="false" automate="Off">
       <systemName>IT17</systemName>
-      <userName>Sta 1 SI 1 R</userName>
+      <userName>Sta 1 SI 2 R</userName>
     </turnout>
     <turnout feedback="DIRECT" inverted="false" automate="Off">
       <systemName>IT18</systemName>
@@ -203,6 +200,9 @@
     <memory value="">
       <systemName>IMUSS CTC:LOCK:1:LOG</systemName>
     </memory>
+    <memory>
+      <systemName>IMUSS CTC:SIGNALHEADSECTION:1:LOG</systemName>
+    </memory>
     <memory value="5000">
       <systemName>IMUSS CTC:SIGNALHEADSECTION:1:TIME</systemName>
     </memory>
@@ -210,41 +210,41 @@
   <signalheads class="jmri.managers.configurexml.AbstractSignalHeadManagerXml">
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
       <systemName>IH2Lmain</systemName>
-      <userName>1 SI 2 Main</userName>
+      <userName>2 Main</userName>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
       <systemName>IH2Lsiding</systemName>
-      <userName>1 SI 2 Siding</userName>
+      <userName>2 Siding</userName>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
       <systemName>IH2Rlower</systemName>
-      <userName>1 SI 2 Lower</userName>
+      <userName>2 Lower</userName>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
       <systemName>IH2Rupper</systemName>
-      <userName>1 SI 2 Upper</userName>
+      <userName>2 Upper</userName>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
       <systemName>IH4Lmain</systemName>
-      <userName>2 SI 4 Main</userName>
+      <userName>4 Main</userName>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
       <systemName>IH4Lsiding</systemName>
-      <userName>2 SI 4 Siding</userName>
+      <userName>4 Siding</userName>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
       <systemName>IH4Rlower</systemName>
-      <userName>2 SI 4 Lower</userName>
+      <userName>4 Lower</userName>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml">
       <systemName>IH4Rupper</systemName>
-      <userName>2 SI 4 Upper</userName>
+      <userName>4 Upper</userName>
     </signalhead>
   </signalheads>
   <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
     <logicDelay>500</logicDelay>
   </signalmastlogics>
-  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="Panel" x="55" y="57" height="817" width="1048" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="no" panelmenu="yes" scrollable="both" redBackground="255" greenBackground="255" blueBackground="255">
+  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="Panel" x="32" y="25" height="817" width="1048" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="yes" panelmenu="yes" scrollable="both" redBackground="255" greenBackground="255" blueBackground="255">
     <positionablelabel x="0" y="0" level="1" forcecontroloff="false" hidden="no" positionable="true" showtooltip="false" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
       <icon url="program:resources/icons/USSpanels/Panels/USS-15.gif" degrees="0" scale="1.0">
         <rotation>0</rotation>
@@ -862,7 +862,7 @@
       </icons>
       <iconmaps />
     </turnouticon>
-    <turnouticon turnout="Sta 1 SI 1 R" x="123" y="468" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
+    <turnouticon turnout="Sta 1 SI 2 R" x="123" y="468" level="7" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" tristate="false" momentary="false" directControl="false" class="jmri.jmrit.display.configurexml.TurnoutIconXml">
       <icons>
         <closed url="program:resources/icons/USSpanels/Lamps/lamp-d.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -879,7 +879,7 @@
       </icons>
       <iconmaps />
     </turnouticon>
-    <signalheadicon signalhead="2 SI 4 Upper" x="270" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+    <signalheadicon signalhead="4 Upper" x="270" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
       <icons>
         <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -908,7 +908,7 @@
       </icons>
       <iconmaps />
     </signalheadicon>
-    <signalheadicon signalhead="2 SI 4 Lower" x="281" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+    <signalheadicon signalhead="4 Lower" x="281" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
       <icons>
         <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -937,7 +937,7 @@
       </icons>
       <iconmaps />
     </signalheadicon>
-    <signalheadicon signalhead="2 SI 4 Siding" x="203" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+    <signalheadicon signalhead="4 Siding" x="203" y="104" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
       <icons>
         <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
           <rotation>2</rotation>
@@ -966,7 +966,7 @@
       </icons>
       <iconmaps />
     </signalheadicon>
-    <signalheadicon signalhead="2 SI 4 Main" x="202" y="134" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+    <signalheadicon signalhead="4 Main" x="202" y="134" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
       <icons>
         <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
           <rotation>2</rotation>
@@ -995,7 +995,7 @@
       </icons>
       <iconmaps />
     </signalheadicon>
-    <signalheadicon signalhead="1 SI 2 Upper" x="84" y="136" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+    <signalheadicon signalhead="2 Upper" x="84" y="136" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
       <icons>
         <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
           <rotation>2</rotation>
@@ -1024,7 +1024,7 @@
       </icons>
       <iconmaps />
     </signalheadicon>
-    <signalheadicon signalhead="1 SI 2 Lower" x="71" y="136" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+    <signalheadicon signalhead="2 Lower" x="71" y="136" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
       <icons>
         <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
           <rotation>2</rotation>
@@ -1053,7 +1053,7 @@
       </icons>
       <iconmaps />
     </signalheadicon>
-    <signalheadicon signalhead="1 SI 2 Siding" x="131" y="83" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+    <signalheadicon signalhead="2 Siding" x="131" y="83" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
       <icons>
         <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -1082,7 +1082,7 @@
       </icons>
       <iconmaps />
     </signalheadicon>
-    <signalheadicon signalhead="1 SI 2 Main" x="130" y="105" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
+    <signalheadicon signalhead="2 Main" x="130" y="105" level="9" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" clickmode="3" litmode="false" class="jmri.jmrit.display.configurexml.SignalHeadIconXml">
       <icons>
         <held url="program:resources/icons/smallschematics/searchlights/left-held-marker.gif" degrees="0" scale="1.0">
           <rotation>0</rotation>
@@ -1115,36 +1115,53 @@
   <filehistory>
     <operation>
       <type>app</type>
-      <date>Fri Sep 10 06:38:40 EDT 2021</date>
+      <date>Fri Sep 10 07:12:50 EDT 2021</date>
       <filename>JMRI program</filename>
     </operation>
     <operation>
       <type>Load OK</type>
-      <date>Fri Sep 10 06:38:50 EDT 2021</date>
+      <date>Fri Sep 10 07:13:01 EDT 2021</date>
       <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
       <filehistory>
         <operation>
           <type>app</type>
-          <date>Fri Sep 10 06:23:54 EDT 2021</date>
+          <date>Fri Sep 10 06:38:40 EDT 2021</date>
           <filename>JMRI program</filename>
         </operation>
         <operation>
           <type>Load OK</type>
-          <date>Fri Sep 10 06:24:18 EDT 2021</date>
+          <date>Fri Sep 10 06:38:50 EDT 2021</date>
           <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
+          <filehistory>
+            <operation>
+              <type>app</type>
+              <date>Fri Sep 10 06:23:54 EDT 2021</date>
+              <filename>JMRI program</filename>
+            </operation>
+            <operation>
+              <type>Load OK</type>
+              <date>Fri Sep 10 06:24:18 EDT 2021</date>
+              <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
+            </operation>
+            <operation>
+              <type>Store</type>
+              <date>Fri Sep 10 06:33:33 EDT 2021</date>
+              <filename />
+            </operation>
+          </filehistory>
         </operation>
         <operation>
           <type>Store</type>
-          <date>Fri Sep 10 06:33:33 EDT 2021</date>
+          <date>Fri Sep 10 06:41:44 EDT 2021</date>
           <filename />
         </operation>
       </filehistory>
     </operation>
     <operation>
       <type>Store</type>
-      <date>Fri Sep 10 06:41:44 EDT 2021</date>
+      <date>Fri Sep 10 07:27:41 EDT 2021</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.25.3ish+jake+20210910T1038Z+R9109c295e7 on Fri Sep 10 06:41:44 EDT 2021-->
+  <!--Written by JMRI version 4.25.3ish+jake+20210910T1112Z+R391f0db392 on Fri Sep 10 07:27:41 EDT 2021-->
 </layout-config>

--- a/jython/ctc/TwoColumnMachine.xml
+++ b/jython/ctc/TwoColumnMachine.xml
@@ -200,7 +200,7 @@
     <memory value="">
       <systemName>IMUSS CTC:LOCK:1:LOG</systemName>
     </memory>
-    <memory>
+    <memory value="">
       <systemName>IMUSS CTC:SIGNALHEADSECTION:1:LOG</systemName>
     </memory>
     <memory value="5000">
@@ -241,10 +241,52 @@
       <userName>4 Upper</userName>
     </signalhead>
   </signalheads>
+  <signalelements class="jmri.jmrit.blockboss.configurexml.BlockBossLogicProviderXml">
+    <signalelement signal="4 Siding" mode="3" watchedturnout="Sta 2 Layout TO" limitspeed1="false" limitspeed2="false" useflashyellow="false" distantsignal="false">
+      <sensorname>TC Sta 2 OS</sensorname>
+      <sensorname>TC Right Approach</sensorname>
+      <comment />
+    </signalelement>
+    <signalelement signal="2 Lower" mode="3" watchedturnout="Sta 1 Layout TO" watchedsignal1="4 Siding" limitspeed1="false" limitspeed2="false" useflashyellow="false" distantsignal="false">
+      <sensorname>TC Sta 1 OS</sensorname>
+      <sensorname>TC Siding</sensorname>
+      <comment />
+    </signalelement>
+    <signalelement signal="2 Upper" mode="2" watchedturnout="Sta 1 Layout TO" watchedsignal1="4 Main" limitspeed1="false" limitspeed2="false" useflashyellow="false" distantsignal="false">
+      <sensorname>TC Sta 1 OS</sensorname>
+      <sensorname>TC Main</sensorname>
+      <comment />
+    </signalelement>
+    <signalelement signal="4 Main" mode="2" watchedturnout="Sta 2 Layout TO" limitspeed1="false" limitspeed2="false" useflashyellow="false" distantsignal="false">
+      <sensorname>TC Sta 2 OS</sensorname>
+      <sensorname>TC Right Approach</sensorname>
+      <comment />
+    </signalelement>
+    <signalelement signal="2 Siding" mode="3" watchedturnout="Sta 1 Layout TO" limitspeed1="false" limitspeed2="false" useflashyellow="false" distantsignal="false">
+      <sensorname>TC Sta 1 OS</sensorname>
+      <sensorname>TC Left Approach</sensorname>
+      <comment />
+    </signalelement>
+    <signalelement signal="2 Main" mode="2" watchedturnout="Sta 1 Layout TO" limitspeed1="false" limitspeed2="false" useflashyellow="false" distantsignal="false">
+      <sensorname>TC Sta 1 OS</sensorname>
+      <sensorname>TC Left Approach</sensorname>
+      <comment />
+    </signalelement>
+    <signalelement signal="4 Upper" mode="2" watchedturnout="Sta 2 Layout TO" watchedsignal1="2 Main" limitspeed1="false" limitspeed2="false" useflashyellow="false" distantsignal="false">
+      <sensorname>TC Sta 2 OS</sensorname>
+      <sensorname>TC Main</sensorname>
+      <comment />
+    </signalelement>
+    <signalelement signal="4 Lower" mode="3" watchedturnout="Sta 2 Layout TO" watchedsignal1="2 Siding" limitspeed1="false" limitspeed2="false" useflashyellow="false" distantsignal="false">
+      <sensorname>TC Sta 2 OS</sensorname>
+      <sensorname>TC Siding</sensorname>
+      <comment />
+    </signalelement>
+  </signalelements>
   <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
     <logicDelay>500</logicDelay>
   </signalmastlogics>
-  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="Panel" x="32" y="25" height="817" width="1048" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="yes" panelmenu="yes" scrollable="both" redBackground="255" greenBackground="255" blueBackground="255">
+  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="Panel" x="32" y="25" height="817" width="1048" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="no" panelmenu="yes" scrollable="both" redBackground="255" greenBackground="255" blueBackground="255">
     <positionablelabel x="0" y="0" level="1" forcecontroloff="false" hidden="no" positionable="true" showtooltip="false" editable="true" icon="yes" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
       <icon url="program:resources/icons/USSpanels/Panels/USS-15.gif" degrees="0" scale="1.0">
         <rotation>0</rotation>
@@ -1116,53 +1158,70 @@
   <filehistory>
     <operation>
       <type>app</type>
-      <date>Fri Sep 10 07:12:50 EDT 2021</date>
+      <date>Fri Sep 10 08:11:05 EDT 2021</date>
       <filename>JMRI program</filename>
     </operation>
     <operation>
       <type>Load OK</type>
-      <date>Fri Sep 10 07:13:01 EDT 2021</date>
+      <date>Fri Sep 10 08:11:30 EDT 2021</date>
       <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
       <filehistory>
         <operation>
           <type>app</type>
-          <date>Fri Sep 10 06:38:40 EDT 2021</date>
+          <date>Fri Sep 10 07:12:50 EDT 2021</date>
           <filename>JMRI program</filename>
         </operation>
         <operation>
           <type>Load OK</type>
-          <date>Fri Sep 10 06:38:50 EDT 2021</date>
+          <date>Fri Sep 10 07:13:01 EDT 2021</date>
           <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
           <filehistory>
             <operation>
               <type>app</type>
-              <date>Fri Sep 10 06:23:54 EDT 2021</date>
+              <date>Fri Sep 10 06:38:40 EDT 2021</date>
               <filename>JMRI program</filename>
             </operation>
             <operation>
               <type>Load OK</type>
-              <date>Fri Sep 10 06:24:18 EDT 2021</date>
+              <date>Fri Sep 10 06:38:50 EDT 2021</date>
               <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
+              <filehistory>
+                <operation>
+                  <type>app</type>
+                  <date>Fri Sep 10 06:23:54 EDT 2021</date>
+                  <filename>JMRI program</filename>
+                </operation>
+                <operation>
+                  <type>Load OK</type>
+                  <date>Fri Sep 10 06:24:18 EDT 2021</date>
+                  <filename>/Users/jake/Documents/Trains/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
+                </operation>
+                <operation>
+                  <type>Store</type>
+                  <date>Fri Sep 10 06:33:33 EDT 2021</date>
+                  <filename />
+                </operation>
+              </filehistory>
             </operation>
             <operation>
               <type>Store</type>
-              <date>Fri Sep 10 06:33:33 EDT 2021</date>
+              <date>Fri Sep 10 06:41:44 EDT 2021</date>
               <filename />
             </operation>
           </filehistory>
         </operation>
         <operation>
           <type>Store</type>
-          <date>Fri Sep 10 06:41:44 EDT 2021</date>
+          <date>Fri Sep 10 07:27:41 EDT 2021</date>
           <filename />
         </operation>
       </filehistory>
     </operation>
     <operation>
       <type>Store</type>
-      <date>Fri Sep 10 07:27:41 EDT 2021</date>
+      <date>Fri Sep 10 08:25:01 EDT 2021</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.25.3ish+jake+20210910T1112Z+R391f0db392 on Fri Sep 10 07:27:41 EDT 2021-->
+  <!--Written by JMRI version 4.25.3ish+jake+20210910T1211Z+Rf2b568e7ca on Fri Sep 10 08:25:01 EDT 2021-->
 </layout-config>

--- a/jython/ctc/TwoColumnMachine.xml
+++ b/jython/ctc/TwoColumnMachine.xml
@@ -152,6 +152,9 @@
     <memory value="">
       <systemName>IMUSS CTC:LOCK:1:LOG</systemName>
     </memory>
+    <memory value="5000">
+      <systemName>IMUSS CTC:SIGNALHEADSECTION:1:TIME</systemName>
+    </memory>
   </memories>
   <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
     <logicDelay>500</logicDelay>
@@ -648,52 +651,70 @@
       </inconsistent>
       <iconmaps />
     </sensoricon>
+    <memoryInputIcon colWidth="30" memory="IMUSS CTC:CODELINE:1:LOG" x="502" y="736" level="5" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" size="13" style="0" red="0" green="0" blue="0" hasBackground="no" justification="centre" class="jmri.jmrit.display.configurexml.MemoryInputIconXml" />
   </paneleditor>
   <filehistory>
     <operation>
       <type>app</type>
-      <date>Thu Sep 09 21:44:12 EDT 2021</date>
+      <date>Thu Sep 09 22:08:38 EDT 2021</date>
       <filename>JMRI program</filename>
     </operation>
     <operation>
       <type>Load OK</type>
-      <date>Thu Sep 09 21:44:46 EDT 2021</date>
+      <date>Thu Sep 09 22:09:17 EDT 2021</date>
       <filename>/Users/jake/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
       <filehistory>
         <operation>
           <type>app</type>
-          <date>Thu Sep 09 21:25:35 EDT 2021</date>
+          <date>Thu Sep 09 21:44:12 EDT 2021</date>
           <filename>JMRI program</filename>
         </operation>
         <operation>
           <type>Load OK</type>
-          <date>Thu Sep 09 21:26:27 EDT 2021</date>
+          <date>Thu Sep 09 21:44:46 EDT 2021</date>
           <filename>/Users/jake/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
           <filehistory>
             <operation>
               <type>app</type>
-              <date>Thu Sep 09 21:06:22 EDT 2021</date>
+              <date>Thu Sep 09 21:25:35 EDT 2021</date>
               <filename>JMRI program</filename>
             </operation>
             <operation>
+              <type>Load OK</type>
+              <date>Thu Sep 09 21:26:27 EDT 2021</date>
+              <filename>/Users/jake/JMRI/projects/JMRI/jython/ctc/TwoColumnMachine.xml</filename>
+              <filehistory>
+                <operation>
+                  <type>app</type>
+                  <date>Thu Sep 09 21:06:22 EDT 2021</date>
+                  <filename>JMRI program</filename>
+                </operation>
+                <operation>
+                  <type>Store</type>
+                  <date>Thu Sep 09 21:22:05 EDT 2021</date>
+                  <filename />
+                </operation>
+              </filehistory>
+            </operation>
+            <operation>
               <type>Store</type>
-              <date>Thu Sep 09 21:22:05 EDT 2021</date>
+              <date>Thu Sep 09 21:42:10 EDT 2021</date>
               <filename />
             </operation>
           </filehistory>
         </operation>
         <operation>
           <type>Store</type>
-          <date>Thu Sep 09 21:42:10 EDT 2021</date>
+          <date>Thu Sep 09 22:01:37 EDT 2021</date>
           <filename />
         </operation>
       </filehistory>
     </operation>
     <operation>
       <type>Store</type>
-      <date>Thu Sep 09 22:01:37 EDT 2021</date>
+      <date>Thu Sep 09 22:12:58 EDT 2021</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.25.3ish+jake+20210910T0144Z+R20a202f6b0 on Thu Sep 09 22:01:37 EDT 2021-->
+  <!--Written by JMRI version 4.25.3ish+jake+20210910T0208Z+Rb7bbcd85d5 on Thu Sep 09 22:12:58 EDT 2021-->
 </layout-config>

--- a/jython/test/TwoColumnMachineTest.py
+++ b/jython/test/TwoColumnMachineTest.py
@@ -1,11 +1,15 @@
 # Test the ctc/TwoColumnMachine.py script
+import java
 import jmri
+
+cm = jmri.InstanceManager.getDefault(jmri.ConfigureManager)
+cm.load(java.io.File(jmri.util.FileUtil.getExternalFilename("program:jython/ctc/TwoColumnMachine.xml")))
 
 execfile("jython/ctc/TwoColumnMachine.py")
 
 # press Code 1
 sensors.getSensor("Sta 1 Code").setState(ACTIVE)
 
-# check results
+# check results (has to run immediately)
 if (turnouts.getTurnout("Sta 1 Code").state != THROWN) : raise AssertionError('Code 1 not set')
-if (turnouts.getTurnout("Sta 2 Code").state == CLOSED) : raise AssertionError('Code 2 should not be set')
+if (turnouts.getTurnout("Sta 2 Code").state == THROWN) : raise AssertionError('Code 2 should not be set')


### PR DESCRIPTION
Fixes system names of sample turnouts and sensors to make it easier to transfer to real hardware names.

No code changes except to this example.