### PR TITLE
Remove the unused method Base.isExternal()

### DIFF
--- a/java/src/jmri/jmrit/display/logixng/ActionPositionable.java
+++ b/java/src/jmri/jmrit/display/logixng/ActionPositionable.java
@@ -231,12 +231,6 @@ public class ActionPositionable extends AbstractDigitalAction implements Vetoabl
         return CategoryDisplay.DISPLAY;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
     private String getNewState() throws JmriException {
         
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/Base.java
+++ b/java/src/jmri/jmrit/logixng/Base.java
@@ -290,15 +290,6 @@ public interface Base extends PropertyChangeProvider {
     public Category getCategory();
 
     /**
-     * Is this external?
-     * Does it affects or is dependent on external things, like
-     * turnouts and sensors? Timers are considered as internal since they
-     * behavies the same on every computer on every layout.
-     * @return true if this is external
-     */
-    public boolean isExternal();
-
-    /**
      * Is this item active? If this item is enabled and all the parents are
      * enabled, this item is active.
      * @return true if active, false otherwise.

--- a/java/src/jmri/jmrit/logixng/actions/ActionAtomicBoolean.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionAtomicBoolean.java
@@ -73,12 +73,6 @@ public class ActionAtomicBoolean extends AbstractDigitalAction {
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() {
         _atomicBoolean.set(_newValue);
     }

--- a/java/src/jmri/jmrit/logixng/actions/ActionAudio.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionAudio.java
@@ -227,12 +227,6 @@ public class ActionAudio extends AbstractDigitalAction implements VetoableChange
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_operationAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionBlock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionBlock.java
@@ -301,12 +301,6 @@ public class ActionBlock extends AbstractDigitalAction implements VetoableChange
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewOperation() throws JmriException {
 
         switch (_operationAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionClock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionClock.java
@@ -75,12 +75,6 @@ public class ActionClock extends AbstractDigitalAction {
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         ClockState theState = _clockState;
         ThreadingUtil.runOnLayoutWithJmriException(() -> {

--- a/java/src/jmri/jmrit/logixng/actions/ActionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionEntryExit.java
@@ -231,12 +231,6 @@ public class ActionEntryExit extends AbstractDigitalAction implements VetoableCh
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewLock() throws JmriException {
 
         switch (_operationAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionLight.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionLight.java
@@ -307,12 +307,6 @@ public class ActionLight extends AbstractDigitalAction implements VetoableChange
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionLightIntensity.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionLightIntensity.java
@@ -146,12 +146,6 @@ public class ActionLightIntensity extends AbstractDigitalAction
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
     @Override
     public void vetoableChange(java.beans.PropertyChangeEvent evt) throws java.beans.PropertyVetoException {
         if ("CanDelete".equals(evt.getPropertyName())) { // No I18N

--- a/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeans.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeans.java
@@ -112,12 +112,6 @@ public class ActionListenOnBeans extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void execute() {
         // Do nothing.
         // The purpose of this action is only to listen on property changes

--- a/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeansTable.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionListenOnBeansTable.java
@@ -174,12 +174,6 @@ public class ActionListenOnBeansTable extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void execute() {
         // Do nothing.
         // The purpose of this action is only to listen on property changes

--- a/java/src/jmri/jmrit/logixng/actions/ActionLocalVariable.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionLocalVariable.java
@@ -187,12 +187,6 @@ public class ActionLocalVariable extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         if (_localVariable == null) return;
 

--- a/java/src/jmri/jmrit/logixng/actions/ActionMemory.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionMemory.java
@@ -293,12 +293,6 @@ public class ActionMemory extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
 
         Memory memory;

--- a/java/src/jmri/jmrit/logixng/actions/ActionOBlock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionOBlock.java
@@ -298,12 +298,6 @@ public class ActionOBlock extends AbstractDigitalAction implements VetoableChang
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewOperation() throws JmriException {
 
         switch (_operationAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionPower.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionPower.java
@@ -49,12 +49,6 @@ public class ActionPower extends AbstractDigitalAction {
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         AtomicReference<JmriException> exception = new AtomicReference<>();
         ThreadingUtil.runOnLayoutWithJmriException(() -> {

--- a/java/src/jmri/jmrit/logixng/actions/ActionReporter.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionReporter.java
@@ -274,12 +274,6 @@ public class ActionReporter extends AbstractDigitalAction implements VetoableCha
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
 
     Reporter getSourceReporter() throws JmriException {
         Reporter reporter = null;

--- a/java/src/jmri/jmrit/logixng/actions/ActionScript.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionScript.java
@@ -184,12 +184,6 @@ public class ActionScript extends AbstractDigitalAction {
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getTheScript() throws JmriException {
         
         switch (_scriptAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionSensor.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSensor.java
@@ -225,12 +225,6 @@ public class ActionSensor extends AbstractDigitalAction implements VetoableChang
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionSignalHead.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSignalHead.java
@@ -345,12 +345,6 @@ public class ActionSignalHead extends AbstractDigitalAction
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private int getAppearanceFromName(String name) {
         if (_signalHeadHandle == null) throw new UnsupportedOperationException("_signalHeadHandle is null");
 

--- a/java/src/jmri/jmrit/logixng/actions/ActionSignalMast.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSignalMast.java
@@ -344,12 +344,6 @@ public class ActionSignalMast extends AbstractDigitalAction
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewAspect() throws JmriException {
 
         switch (_aspectAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionSound.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionSound.java
@@ -181,12 +181,6 @@ public class ActionSound extends AbstractDigitalAction {
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getTheSound() throws JmriException {
         
         switch (_soundAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionThrottle.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionThrottle.java
@@ -81,12 +81,6 @@ public class ActionThrottle extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         
         int currentLocoAddress = -1;

--- a/java/src/jmri/jmrit/logixng/actions/ActionTimer.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionTimer.java
@@ -99,12 +99,6 @@ public class ActionTimer extends AbstractDigitalAction
         return Category.COMMON;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
     /**
      * Get a new timer task.
      */

--- a/java/src/jmri/jmrit/logixng/actions/ActionTurnout.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionTurnout.java
@@ -225,12 +225,6 @@ public class ActionTurnout extends AbstractDigitalAction implements VetoableChan
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionTurnoutLock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionTurnoutLock.java
@@ -225,12 +225,6 @@ public class ActionTurnoutLock extends AbstractDigitalAction implements Vetoable
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewLock() throws JmriException {
 
         switch (_lockAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ActionWarrant.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionWarrant.java
@@ -310,12 +310,6 @@ public class ActionWarrant extends AbstractDigitalAction implements VetoableChan
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
 
     private String getNewOper() throws JmriException {
 

--- a/java/src/jmri/jmrit/logixng/actions/AnalogActionLightIntensity.java
+++ b/java/src/jmri/jmrit/logixng/actions/AnalogActionLightIntensity.java
@@ -138,12 +138,6 @@ public class AnalogActionLightIntensity extends AbstractAnalogAction
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
     @Override
     public void vetoableChange(java.beans.PropertyChangeEvent evt) throws java.beans.PropertyVetoException {
         if ("CanDelete".equals(evt.getPropertyName())) { // No I18N

--- a/java/src/jmri/jmrit/logixng/actions/AnalogActionMemory.java
+++ b/java/src/jmri/jmrit/logixng/actions/AnalogActionMemory.java
@@ -121,12 +121,6 @@ public class AnalogActionMemory extends AbstractAnalogAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public String getShortDescription(Locale locale) {
         return Bundle.getMessage(locale, "AnalogActionMemory_Short");
     }

--- a/java/src/jmri/jmrit/logixng/actions/AnalogMany.java
+++ b/java/src/jmri/jmrit/logixng/actions/AnalogMany.java
@@ -118,12 +118,6 @@ public class AnalogMany extends AbstractAnalogAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void setValue(double value) throws JmriException {
         for (ActionEntry actionEntry : _actionEntries) {
             actionEntry._socket.setValue(value);

--- a/java/src/jmri/jmrit/logixng/actions/DigitalBooleanMany.java
+++ b/java/src/jmri/jmrit/logixng/actions/DigitalBooleanMany.java
@@ -111,12 +111,6 @@ public class DigitalBooleanMany extends AbstractDigitalBooleanAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void execute(boolean hasChangedToTrue, boolean hasChangedToFalse) throws JmriException {
         for (ActionEntry actionEntry : _actionEntries) {
             actionEntry._socket.execute(hasChangedToTrue, hasChangedToFalse);

--- a/java/src/jmri/jmrit/logixng/actions/DigitalBooleanOnChange.java
+++ b/java/src/jmri/jmrit/logixng/actions/DigitalBooleanOnChange.java
@@ -65,12 +65,6 @@ public class DigitalBooleanOnChange extends AbstractDigitalBooleanAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute(boolean hasChangedToTrue, boolean hasChangedToFalse) throws JmriException {
         if (_socket.isConnected()) {
             switch (_trigger) {

--- a/java/src/jmri/jmrit/logixng/actions/DigitalCallModule.java
+++ b/java/src/jmri/jmrit/logixng/actions/DigitalCallModule.java
@@ -108,12 +108,6 @@ public class DigitalCallModule extends AbstractDigitalAction implements Vetoable
         return Category.OTHER;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
     /**
      * Return the symbols
      * @param symbolTable the symbol table

--- a/java/src/jmri/jmrit/logixng/actions/DigitalMany.java
+++ b/java/src/jmri/jmrit/logixng/actions/DigitalMany.java
@@ -111,12 +111,6 @@ public class DigitalMany extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         for (ActionEntry actionEntry : _actionEntries) {
             actionEntry._socket.execute();

--- a/java/src/jmri/jmrit/logixng/actions/DoAnalogAction.java
+++ b/java/src/jmri/jmrit/logixng/actions/DoAnalogAction.java
@@ -58,12 +58,6 @@ public class DoAnalogAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         double result = _analogExpressionSocket.evaluate();
         

--- a/java/src/jmri/jmrit/logixng/actions/DoStringAction.java
+++ b/java/src/jmri/jmrit/logixng/actions/DoStringAction.java
@@ -48,12 +48,6 @@ public class DoStringAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         String result = _stringExpressionSocket.evaluate();
         

--- a/java/src/jmri/jmrit/logixng/actions/EnableLogix.java
+++ b/java/src/jmri/jmrit/logixng/actions/EnableLogix.java
@@ -226,12 +226,6 @@ public class EnableLogix extends AbstractDigitalAction implements VetoableChange
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
     private String getNewLock() throws JmriException {
         
         switch (_operationAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/ExecuteDelayed.java
+++ b/java/src/jmri/jmrit/logixng/actions/ExecuteDelayed.java
@@ -69,12 +69,6 @@ public class ExecuteDelayed
         return Category.COMMON;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
     /**
      * Get a new timer task.
      */

--- a/java/src/jmri/jmrit/logixng/actions/For.java
+++ b/java/src/jmri/jmrit/logixng/actions/For.java
@@ -64,12 +64,6 @@ public class For extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         _initActionSocket.execute();
         while (_whileExpressionSocket.evaluate()) {

--- a/java/src/jmri/jmrit/logixng/actions/IfThenElse.java
+++ b/java/src/jmri/jmrit/logixng/actions/IfThenElse.java
@@ -63,12 +63,6 @@ public class IfThenElse extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         boolean result = _ifExpressionSocket.evaluate();
         TriState _expressionResult = TriState.getValue(result);

--- a/java/src/jmri/jmrit/logixng/actions/LogData.java
+++ b/java/src/jmri/jmrit/logixng/actions/LogData.java
@@ -109,12 +109,6 @@ public class LogData extends AbstractDigitalAction
         return Category.OTHER;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private List<Object> getDataValues() throws JmriException {
         List<Object> values = new ArrayList<>();
         for (Data _data : _dataList) {

--- a/java/src/jmri/jmrit/logixng/actions/LogLocalVariables.java
+++ b/java/src/jmri/jmrit/logixng/actions/LogLocalVariables.java
@@ -38,12 +38,6 @@ public class LogLocalVariables extends AbstractDigitalAction {
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() {
         ConditionalNG c = getConditionalNG();
         log.warn(Bundle.getMessage("LogLocalVariables_Start"));

--- a/java/src/jmri/jmrit/logixng/actions/Logix.java
+++ b/java/src/jmri/jmrit/logixng/actions/Logix.java
@@ -49,12 +49,6 @@ public class Logix extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         boolean result = _expressionSocket.evaluate();
         boolean hasChangedToTrue = result && !_lastExpressionResult;

--- a/java/src/jmri/jmrit/logixng/actions/Sequence.java
+++ b/java/src/jmri/jmrit/logixng/actions/Sequence.java
@@ -131,12 +131,6 @@ public class Sequence extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         if (_stopExpressionSocket.isConnected()
                 && _stopExpressionSocket.evaluate()) {

--- a/java/src/jmri/jmrit/logixng/actions/ShutdownComputer.java
+++ b/java/src/jmri/jmrit/logixng/actions/ShutdownComputer.java
@@ -50,12 +50,6 @@ public class ShutdownComputer extends AbstractDigitalAction {
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() {
         jmri.util.ThreadingUtil.runOnGUI(() -> {
             switch (_operation) {

--- a/java/src/jmri/jmrit/logixng/actions/StringActionMemory.java
+++ b/java/src/jmri/jmrit/logixng/actions/StringActionMemory.java
@@ -118,12 +118,6 @@ public class StringActionMemory extends AbstractStringAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public String getShortDescription(Locale locale) {
         return Bundle.getMessage(locale, "StringActionMemory_Short");
     }

--- a/java/src/jmri/jmrit/logixng/actions/StringActionStringIO.java
+++ b/java/src/jmri/jmrit/logixng/actions/StringActionStringIO.java
@@ -118,12 +118,6 @@ public class StringActionStringIO extends AbstractStringAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public String getShortDescription(Locale locale) {
         return Bundle.getMessage(locale, "StringActionStringIO_Short");
     }

--- a/java/src/jmri/jmrit/logixng/actions/StringMany.java
+++ b/java/src/jmri/jmrit/logixng/actions/StringMany.java
@@ -118,12 +118,6 @@ public class StringMany extends AbstractStringAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void setValue(String value) throws JmriException {
         for (ActionEntry actionEntry : _actionEntries) {
             actionEntry._socket.setValue(value);

--- a/java/src/jmri/jmrit/logixng/actions/TableForEach.java
+++ b/java/src/jmri/jmrit/logixng/actions/TableForEach.java
@@ -57,12 +57,6 @@ public class TableForEach extends AbstractDigitalAction
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         
 //        System.out.format("TableForEach.execute: %s%n", getLongDescription());

--- a/java/src/jmri/jmrit/logixng/actions/TriggerRoute.java
+++ b/java/src/jmri/jmrit/logixng/actions/TriggerRoute.java
@@ -230,12 +230,6 @@ public class TriggerRoute extends AbstractDigitalAction implements VetoableChang
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewLock() throws JmriException {
 
         switch (_operationAddressing) {

--- a/java/src/jmri/jmrit/logixng/actions/WebBrowser.java
+++ b/java/src/jmri/jmrit/logixng/actions/WebBrowser.java
@@ -47,12 +47,6 @@ public class WebBrowser
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public void execute() throws JmriException {
         String url = _urlExpressionSocket.evaluate();
         

--- a/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionAnalogIO.java
+++ b/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionAnalogIO.java
@@ -64,12 +64,6 @@ public class AnalogExpressionAnalogIO extends AbstractAnalogExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     public void setAnalogIO(@Nonnull String analogIOName) {
         assertListenersAreNotRegistered(log, "setAnalogIO");
         AnalogIO analogIO = InstanceManager.getDefault(AnalogIOManager.class).getNamedBean(analogIOName);

--- a/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionConstant.java
+++ b/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionConstant.java
@@ -42,12 +42,6 @@ public class AnalogExpressionConstant extends AbstractAnalogExpression {
         return Category.ITEM;
     }
     
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
     public void setValue(double value) {
         assertListenersAreNotRegistered(log, "setValue");
         _value = value;

--- a/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionMemory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/AnalogExpressionMemory.java
@@ -64,12 +64,6 @@ public class AnalogExpressionMemory extends AbstractAnalogExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     public void setMemory(@Nonnull String memoryName) {
         assertListenersAreNotRegistered(log, "setMemory");
         Memory memory = InstanceManager.getDefault(MemoryManager.class).getMemory(memoryName);

--- a/java/src/jmri/jmrit/logixng/expressions/AnalogFormula.java
+++ b/java/src/jmri/jmrit/logixng/expressions/AnalogFormula.java
@@ -134,12 +134,6 @@ public class AnalogFormula extends AbstractAnalogExpression implements FemaleSoc
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public double evaluate() throws JmriException {
         
         if (_formula.isEmpty()) {

--- a/java/src/jmri/jmrit/logixng/expressions/And.java
+++ b/java/src/jmri/jmrit/logixng/expressions/And.java
@@ -71,12 +71,6 @@ public class And extends AbstractDigitalExpression implements FemaleSocketListen
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() throws JmriException {
         boolean result = true;
         for (ExpressionEntry e : _expressionEntries) {

--- a/java/src/jmri/jmrit/logixng/expressions/Antecedent.java
+++ b/java/src/jmri/jmrit/logixng/expressions/Antecedent.java
@@ -93,12 +93,6 @@ public class Antecedent extends AbstractDigitalExpression implements FemaleSocke
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() throws JmriException {
         
         if (_antecedent.isEmpty()) {

--- a/java/src/jmri/jmrit/logixng/expressions/DigitalCallModule.java
+++ b/java/src/jmri/jmrit/logixng/expressions/DigitalCallModule.java
@@ -108,12 +108,6 @@ public class DigitalCallModule extends AbstractDigitalExpression implements Veto
         return Category.OTHER;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
     /**
      * Return the symbols
      * @param symbolTable the symbol table

--- a/java/src/jmri/jmrit/logixng/expressions/DigitalFormula.java
+++ b/java/src/jmri/jmrit/logixng/expressions/DigitalFormula.java
@@ -134,12 +134,6 @@ public class DigitalFormula extends AbstractDigitalExpression implements FemaleS
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() throws JmriException {
         
         if (_formula.isEmpty()) {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionBlock.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionBlock.java
@@ -319,12 +319,6 @@ public class ExpressionBlock extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionClock.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionClock.java
@@ -51,12 +51,6 @@ public class ExpressionClock extends AbstractDigitalExpression implements Proper
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return false;
-    }
-
     public void set_Is_IsNot(Is_IsNot_Enum is_IsNot) {
         _is_IsNot = is_IsNot;
     }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionConditional.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionConditional.java
@@ -229,12 +229,6 @@ public class ExpressionConditional extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionEntryExit.java
@@ -236,12 +236,6 @@ public class ExpressionEntryExit extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionLight.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionLight.java
@@ -233,12 +233,6 @@ public class ExpressionLight extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionLocalVariable.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionLocalVariable.java
@@ -195,12 +195,6 @@ public class ExpressionLocalVariable extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getString(Object o) {
         if (o != null) {
             return o.toString();

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionMemory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionMemory.java
@@ -224,12 +224,6 @@ public class ExpressionMemory extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getString(Object o) {
         if (o != null) {
             return o.toString();

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionOBlock.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionOBlock.java
@@ -235,12 +235,6 @@ public class ExpressionOBlock extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionPower.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionPower.java
@@ -60,12 +60,6 @@ public class ExpressionPower extends AbstractDigitalExpression
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() throws JmriException {
         
         PowerState checkPowerState = _powerState;

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionReference.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionReference.java
@@ -91,12 +91,6 @@ public class ExpressionReference extends AbstractDigitalExpression
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() {
         if (_reference == null) return false;
         

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionReporter.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionReporter.java
@@ -234,12 +234,6 @@ public class ExpressionReporter extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getString(Object o) {
         if (o != null) {
             return o.toString();

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionScript.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionScript.java
@@ -215,12 +215,6 @@ public class ExpressionScript extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getTheScript() throws JmriException {
         
         switch (_scriptAddressing) {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSensor.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSensor.java
@@ -233,12 +233,6 @@ public class ExpressionSensor extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalHead.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalHead.java
@@ -345,12 +345,6 @@ public class ExpressionSignalHead extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private int getAppearanceFromName(String name) {
         if (_signalHeadHandle == null) throw new UnsupportedOperationException("_signalHeadHandle is null");
 

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalMast.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionSignalMast.java
@@ -346,12 +346,6 @@ public class ExpressionSignalMast extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewAspect() throws JmriException {
 
         switch (_aspectAddressing) {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionTurnout.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionTurnout.java
@@ -233,12 +233,6 @@ public class ExpressionTurnout extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionWarrant.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionWarrant.java
@@ -235,12 +235,6 @@ public class ExpressionWarrant extends AbstractDigitalExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private String getNewState() throws JmriException {
 
         switch (_stateAddressing) {

--- a/java/src/jmri/jmrit/logixng/expressions/False.java
+++ b/java/src/jmri/jmrit/logixng/expressions/False.java
@@ -37,12 +37,6 @@ public class False extends AbstractDigitalExpression {
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() {
         return false;
     }

--- a/java/src/jmri/jmrit/logixng/expressions/Hold.java
+++ b/java/src/jmri/jmrit/logixng/expressions/Hold.java
@@ -62,12 +62,6 @@ public class Hold extends AbstractDigitalExpression implements FemaleSocketListe
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() throws JmriException {
         if (_isActive) {
             _isActive = _holdExpressionSocket.evaluate()

--- a/java/src/jmri/jmrit/logixng/expressions/LastResultOfDigitalExpression.java
+++ b/java/src/jmri/jmrit/logixng/expressions/LastResultOfDigitalExpression.java
@@ -102,12 +102,6 @@ public class LastResultOfDigitalExpression extends AbstractDigitalExpression
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() {
         if (_digitalExpressionHandle != null) {
             MaleSocket m = (MaleSocket) _digitalExpressionHandle.getBean();

--- a/java/src/jmri/jmrit/logixng/expressions/LogData.java
+++ b/java/src/jmri/jmrit/logixng/expressions/LogData.java
@@ -118,12 +118,6 @@ public class LogData extends AbstractDigitalExpression
         return Category.OTHER;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     private List<Object> getDataValues() throws JmriException {
         List<Object> values = new ArrayList<>();
         for (Data _data : _dataList) {

--- a/java/src/jmri/jmrit/logixng/expressions/Not.java
+++ b/java/src/jmri/jmrit/logixng/expressions/Not.java
@@ -55,12 +55,6 @@ public class Not extends AbstractDigitalExpression implements FemaleSocketListen
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() throws JmriException {
         return !_socket.evaluate();
     }

--- a/java/src/jmri/jmrit/logixng/expressions/Or.java
+++ b/java/src/jmri/jmrit/logixng/expressions/Or.java
@@ -70,12 +70,6 @@ public class Or extends AbstractDigitalExpression implements FemaleSocketListene
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() throws JmriException {
         boolean result = false;
         for (ExpressionEntry e : _expressionEntries) {

--- a/java/src/jmri/jmrit/logixng/expressions/StringExpressionConstant.java
+++ b/java/src/jmri/jmrit/logixng/expressions/StringExpressionConstant.java
@@ -41,12 +41,6 @@ public class StringExpressionConstant extends AbstractStringExpression {
         return Category.ITEM;
     }
     
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
     public void setValue(String value) {
         assertListenersAreNotRegistered(log, "setValue");
         _value = value;

--- a/java/src/jmri/jmrit/logixng/expressions/StringExpressionMemory.java
+++ b/java/src/jmri/jmrit/logixng/expressions/StringExpressionMemory.java
@@ -64,12 +64,6 @@ public class StringExpressionMemory extends AbstractStringExpression
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-
     public void setMemory(@Nonnull String memoryName) {
         assertListenersAreNotRegistered(log, "setMemory");
         Memory memory = InstanceManager.getDefault(MemoryManager.class).getMemory(memoryName);

--- a/java/src/jmri/jmrit/logixng/expressions/StringFormula.java
+++ b/java/src/jmri/jmrit/logixng/expressions/StringFormula.java
@@ -134,12 +134,6 @@ public class StringFormula extends AbstractStringExpression implements FemaleSoc
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public String evaluate() throws JmriException {
         
         if (_formula.isEmpty()) {

--- a/java/src/jmri/jmrit/logixng/expressions/TimeSinceMidnight.java
+++ b/java/src/jmri/jmrit/logixng/expressions/TimeSinceMidnight.java
@@ -46,12 +46,6 @@ public class TimeSinceMidnight extends AbstractAnalogExpression implements Prope
         return Category.ITEM;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return false;
-    }
-
     public void setType(Type type) {
         assertListenersAreNotRegistered(log, "setType");
         _type = type;

--- a/java/src/jmri/jmrit/logixng/expressions/TriggerOnce.java
+++ b/java/src/jmri/jmrit/logixng/expressions/TriggerOnce.java
@@ -58,12 +58,6 @@ public class TriggerOnce extends AbstractDigitalExpression implements FemaleSock
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() throws JmriException {
         if (_childExpression.evaluate() && !_childLastState) {
             _childLastState = true;

--- a/java/src/jmri/jmrit/logixng/expressions/True.java
+++ b/java/src/jmri/jmrit/logixng/expressions/True.java
@@ -37,12 +37,6 @@ public class True extends AbstractDigitalExpression {
     
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
-    /** {@inheritDoc} */
-    @Override
     public boolean evaluate() {
         return true;
     }

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractFemaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractFemaleSocket.java
@@ -253,12 +253,6 @@ public abstract class AbstractFemaleSocket implements FemaleSocket {
 
     /** {@inheritDoc} */
     @Override
-    public boolean isExternal() {
-        throw new UnsupportedOperationException("Not supported.");
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public FemaleSocket getChild(int index) {
         throw new UnsupportedOperationException("Not supported.");
     }

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
@@ -95,12 +95,6 @@ public abstract class AbstractMaleSocket implements MaleSocket {
         return _object.getCategory();
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public final boolean isExternal() {
-        return _object.isExternal();
-    }
-
     @Override
     public final FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
         return _object.getChild(index);

--- a/java/src/jmri/jmrit/logixng/implementation/ClipboardMany.java
+++ b/java/src/jmri/jmrit/logixng/implementation/ClipboardMany.java
@@ -97,12 +97,6 @@ public class ClipboardMany extends AbstractBase
         return Category.COMMON;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return false;
-    }
-    
     @Override
     public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
         return _itemEntries.get(index)._socket;

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultClipboard.java
@@ -193,11 +193,6 @@ public class DefaultClipboard extends AbstractBase implements Clipboard {
         throw new UnsupportedOperationException("Not supported");
     }
 
-    @Override
-    public boolean isExternal() {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
     
     private class MaleRootSocket extends AbstractMaleSocket {
 

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
@@ -261,11 +261,6 @@ public class DefaultConditionalNG extends AbstractBase
         throw new UnsupportedOperationException("Not supported.");
     }
 
-    @Override
-    public boolean isExternal() {
-        throw new UnsupportedOperationException("Not supported.");
-    }
-
     public void setSocketSystemName(String systemName) {
         if ((systemName == null) || (!systemName.equals(_socketSystemName))) {
             _femaleSocket.disconnect();

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNG.java
@@ -99,11 +99,6 @@ public class DefaultLogixNG extends AbstractNamedBean
         throw new UnsupportedOperationException("Not supported.");
     }
 
-    @Override
-    public boolean isExternal() {
-        throw new UnsupportedOperationException("Not supported.");
-    }
-
     /** {@inheritDoc} */
     @Override
     final public void setup() {

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultModule.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultModule.java
@@ -169,11 +169,6 @@ public class DefaultModule extends AbstractBase
     public Category getCategory() {
         return Category.OTHER;
     }
-
-    @Override
-    public boolean isExternal() {
-        return false;
-    }
 /*
     protected void printTreeRow(Locale locale, PrintWriter writer, String currentIndent) {
         writer.append(currentIndent);

--- a/java/src/jmri/jmrix/loconet/logixng/ActionClearSlots.java
+++ b/java/src/jmri/jmrix/loconet/logixng/ActionClearSlots.java
@@ -42,12 +42,6 @@ public class ActionClearSlots extends AbstractDigitalAction {
         return CategoryLocoNet.LOCONET;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
     public void setMemo(LocoNetSystemConnectionMemo memo) {
         assertListenersAreNotRegistered(log, "setMemo");
         _memo = memo;

--- a/java/src/jmri/jmrix/loconet/logixng/ActionUpdateSlots.java
+++ b/java/src/jmri/jmrix/loconet/logixng/ActionUpdateSlots.java
@@ -40,12 +40,6 @@ public class ActionUpdateSlots extends AbstractDigitalAction {
         return CategoryLocoNet.LOCONET;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
     public void setMemo(LocoNetSystemConnectionMemo memo) {
         assertListenersAreNotRegistered(log, "setMemo");
         _memo = memo;

--- a/java/src/jmri/jmrix/loconet/logixng/ExpressionSlotUsage.java
+++ b/java/src/jmri/jmrix/loconet/logixng/ExpressionSlotUsage.java
@@ -59,12 +59,6 @@ public class ExpressionSlotUsage extends AbstractDigitalExpression
         return CategoryLocoNet.LOCONET;
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean isExternal() {
-        return true;
-    }
-    
     public void setMemo(LocoNetSystemConnectionMemo memo) {
         assertListenersAreNotRegistered(log, "setMemo");
         _memo = memo;

--- a/java/test/jmri/jmrit/display/logixng/ActionPositionableTest.java
+++ b/java/test/jmri/jmrit/display/logixng/ActionPositionableTest.java
@@ -477,11 +477,6 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Icon/Label on panel", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/AbstractBaseTestBase.java
+++ b/java/test/jmri/jmrit/logixng/AbstractBaseTestBase.java
@@ -1048,11 +1048,6 @@ public abstract class AbstractBaseTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported.");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/java/test/jmri/jmrit/logixng/ConditionalNGTest.java
+++ b/java/test/jmri/jmrit/logixng/ConditionalNGTest.java
@@ -185,20 +185,6 @@ public class ConditionalNGTest {
         }
         Assert.assertTrue("exception thrown", hasThrown);
     }
-
-    @Test
-    public void testIsExternal() {
-        LogixNG logixNG = InstanceManager.getDefault(LogixNG_Manager.class)
-                .createLogixNG("A new logix for test");  // NOI18N
-        ConditionalNG conditionalNG = InstanceManager.getDefault(ConditionalNG_Manager.class).createConditionalNG(logixNG, "A new conditionalng for test");  // NOI18N
-        boolean hasThrown = false;
-        try {
-            conditionalNG.isExternal();
-        } catch (UnsupportedOperationException e) {
-            hasThrown = true;
-        }
-        Assert.assertTrue("exception thrown", hasThrown);
-    }
 /*
     @Test
     public void testSetLock() {

--- a/java/test/jmri/jmrit/logixng/FemaleSocketTestBase.java
+++ b/java/test/jmri/jmrit/logixng/FemaleSocketTestBase.java
@@ -377,14 +377,6 @@ public abstract class FemaleSocketTestBase {
 
         errorFlag.set(false);
         try {
-            _femaleSocket.isExternal();
-        } catch (UnsupportedOperationException ex) {
-            errorFlag.set(true);
-        }
-        Assert.assertTrue("method not supported", errorFlag.get());
-
-        errorFlag.set(false);
-        try {
             _femaleSocket.getChild(0);
         } catch (UnsupportedOperationException ex) {
             errorFlag.set(true);
@@ -570,11 +562,6 @@ public abstract class FemaleSocketTestBase {
 
         @Override
         public Category getCategory() {
-            throw new UnsupportedOperationException("Not supported.");
-        }
-
-        @Override
-        public boolean isExternal() {
             throw new UnsupportedOperationException("Not supported.");
         }
 

--- a/java/test/jmri/jmrit/logixng/LogixNGTest.java
+++ b/java/test/jmri/jmrit/logixng/LogixNGTest.java
@@ -112,18 +112,6 @@ public class LogixNGTest {
     }
 
     @Test
-    public void testIsExternal() {
-        LogixNG logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
-        boolean hasThrown = false;
-        try {
-            logixNG.isExternal();
-        } catch (UnsupportedOperationException e) {
-            hasThrown = true;
-        }
-        Assert.assertTrue("exception thrown", hasThrown);
-    }
-
-    @Test
     public void testSwapConditionalNG() {
         LogixNG logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         ConditionalNG conditionalNG_1 = InstanceManager.getDefault(ConditionalNG_Manager.class).createConditionalNG(logixNG, "A conditionalNG");  // NOI18N

--- a/java/test/jmri/jmrit/logixng/MaleSocketTestBase.java
+++ b/java/test/jmri/jmrit/logixng/MaleSocketTestBase.java
@@ -50,16 +50,6 @@ public abstract class MaleSocketTestBase {
     }
     
     @Test
-    public void testIsExternal() throws JmriException {
-        Assert.assertEquals("isExternal() is correct",
-                maleSocketA.getObject().isExternal(), maleSocketA.isExternal());
-        Assert.assertEquals("isExternal() is correct",
-                maleSocketB.getObject().isExternal(), maleSocketB.isExternal());
-//        Assert.assertNotEquals("isExternal() are different",
-//                maleSocketA.isExternal(), maleSocketB.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() throws JmriException {
         Assert.assertEquals("getShortDescription() is correct",
                 maleSocketA.getObject().getShortDescription(), maleSocketA.getShortDescription());

--- a/java/test/jmri/jmrit/logixng/actions/AbstractDigitalActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AbstractDigitalActionTest.java
@@ -126,11 +126,6 @@ public class AbstractDigitalActionTest {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported.");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/java/test/jmri/jmrit/logixng/actions/AbstractDigitalBooleanActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AbstractDigitalBooleanActionTest.java
@@ -132,11 +132,6 @@ public class AbstractDigitalBooleanActionTest {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported.");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/java/test/jmri/jmrit/logixng/actions/ActionAtomicBooleanTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionAtomicBooleanTest.java
@@ -165,11 +165,6 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Atomic boolean", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
@@ -487,11 +487,6 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Light", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
@@ -89,11 +89,6 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Listen on beans", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
@@ -264,11 +264,6 @@ public class ActionMemoryTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Memory", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
@@ -486,11 +486,6 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Sensor", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/actions/ActionThrottleTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionThrottleTest.java
@@ -380,11 +380,6 @@ public class ActionThrottleTest extends AbstractDigitalActionTestBase {
     }
 
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Throttle", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/actions/ActionTimerTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTimerTest.java
@@ -211,11 +211,6 @@ public class ActionTimerTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         ActionTimer a1 = new ActionTimer("IQDA321", null);
         Assert.assertEquals("strings are equal", "Timer", a1.getShortDescription());

--- a/java/test/jmri/jmrit/logixng/actions/ActionTurnoutLockTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTurnoutLockTest.java
@@ -474,11 +474,6 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Turnout, lock", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/actions/ActionTurnoutTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTurnoutTest.java
@@ -486,11 +486,6 @@ public class ActionTurnoutTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Turnout", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/actions/AnalogActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AnalogActionMemoryTest.java
@@ -208,11 +208,6 @@ public class AnalogActionMemoryTest extends AbstractAnalogActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Memory", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/actions/AnalogManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AnalogManyTest.java
@@ -270,11 +270,6 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // Test the methods connected(FemaleSocket) and getActionSystemName(int)
     @Test
     public void testConnected_getActionSystemName() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/actions/DigitalBooleanOnChangeTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DigitalBooleanOnChangeTest.java
@@ -207,11 +207,6 @@ public class DigitalBooleanOnChangeTest extends AbstractDigitalBooleanActionTest
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testGetShortDescription() {
         DigitalBooleanActionBean a1 = new DigitalBooleanOnChange("IQDB321", null, DigitalBooleanOnChange.Trigger.CHANGE_TO_TRUE);
         Assert.assertEquals("strings are equal", "On change", a1.getShortDescription());

--- a/java/test/jmri/jmrit/logixng/actions/DigitalManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DigitalManyTest.java
@@ -263,11 +263,6 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // Test the methods connected(FemaleSocket) and getActionSystemName(int)
     @Test
     public void testConnected_getActionSystemName() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/actions/DoAnalogActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DoAnalogActionTest.java
@@ -266,11 +266,6 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals("Category matches", Category.COMMON, _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/actions/DoStringActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DoStringActionTest.java
@@ -266,11 +266,6 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals("Category matches", Category.COMMON, _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
@@ -98,11 +98,6 @@ public class ExecuteDelayedTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         ExecuteDelayed a1 = new ExecuteDelayed("IQDA321", null);
         Assert.assertEquals("strings are equal", "Execute delayed", a1.getShortDescription());

--- a/java/test/jmri/jmrit/logixng/actions/ForTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ForTest.java
@@ -227,11 +227,6 @@ public class ForTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         TableForEach a1 = new TableForEach("IQDA321", null);
         Assert.assertEquals("strings are equal", "Table: For each", a1.getShortDescription());

--- a/java/test/jmri/jmrit/logixng/actions/IfThenElseTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/IfThenElseTest.java
@@ -346,11 +346,6 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/actions/LogixTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/LogixTest.java
@@ -281,11 +281,6 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         Assert.assertTrue("Category matches", Category.OTHER == _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/actions/ShutdownComputerTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ShutdownComputerTest.java
@@ -91,11 +91,6 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     @Override
     public void testMaleSocketIsActive() {
         super.testMaleSocketIsActive();

--- a/java/test/jmri/jmrit/logixng/actions/StringActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/StringActionMemoryTest.java
@@ -213,11 +213,6 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Memory", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/actions/StringManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/StringManyTest.java
@@ -267,11 +267,6 @@ public class StringManyTest extends AbstractStringActionTestBase {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // Test the methods connected(FemaleSocket) and getActionSystemName(int)
     @Test
     public void testConnected_getActionSystemName() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
@@ -210,11 +210,6 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         TableForEach a1 = new TableForEach("IQDA321", null);
         Assert.assertEquals("strings are equal", "Table: For each", a1.getShortDescription());
@@ -365,11 +360,6 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
 
         @Override
         public Category getCategory() {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
-        public boolean isExternal() {
             throw new UnsupportedOperationException("Not supported");
         }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AbstractDigitalExpressionTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AbstractDigitalExpressionTest.java
@@ -125,11 +125,6 @@ public class AbstractDigitalExpressionTest {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported.");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionConstantTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionConstantTest.java
@@ -183,11 +183,6 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Analog constant", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionMemoryTest.java
@@ -312,11 +312,6 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Memory as analog value", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogFormulaTest.java
@@ -384,11 +384,6 @@ public class AnalogFormulaTest extends AbstractAnalogExpressionTestBase {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // Test the methods connected(FemaleSocket) and getExpressionSystemName(int)
     @Test
     public void testConnected_getExpressionSystemName() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/expressions/AndTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AndTest.java
@@ -306,11 +306,6 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // Test the methods connected(FemaleSocket) and getExpressionSystemName(int)
     @Test
     public void testConnected_getExpressionSystemName() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/expressions/AntecedentTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AntecedentTest.java
@@ -370,11 +370,6 @@ public class AntecedentTest extends AbstractDigitalExpressionTestBase implements
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // Test the methods connected(FemaleSocket) and getExpressionSystemName(int)
     @Test
     public void testConnected_getExpressionSystemName() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/expressions/DigitalFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/DigitalFormulaTest.java
@@ -386,11 +386,6 @@ public class DigitalFormulaTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // Test the methods connected(FemaleSocket) and getExpressionSystemName(int)
     @Test
     public void testConnected_getExpressionSystemName() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionLightTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionLightTest.java
@@ -180,11 +180,6 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionLocalVariableTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionLocalVariableTest.java
@@ -174,11 +174,6 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
@@ -186,11 +186,6 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionReferenceTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionReferenceTest.java
@@ -142,11 +142,6 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         Assert.assertEquals("Reference", expressionReference.getShortDescription());
         Assert.assertEquals("Reference '' is Nothing", expressionReference.getLongDescription());

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionSensorTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionSensorTest.java
@@ -180,11 +180,6 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionTurnoutTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionTurnoutTest.java
@@ -180,11 +180,6 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);

--- a/java/test/jmri/jmrit/logixng/expressions/FalseTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/FalseTest.java
@@ -138,11 +138,6 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         False e1 = new False("IQDE321", null);
         Assert.assertTrue("Always false".equals(e1.getShortDescription()));

--- a/java/test/jmri/jmrit/logixng/expressions/HoldTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/HoldTest.java
@@ -311,11 +311,6 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         Hold e1 = new Hold("IQDE321", null);
         Assert.assertTrue("Hold".equals(e1.getShortDescription()));

--- a/java/test/jmri/jmrit/logixng/expressions/NotTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/NotTest.java
@@ -246,11 +246,6 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         Not e1 = new Not("IQDE321", null);
         Assert.assertTrue("Not".equals(e1.getShortDescription()));

--- a/java/test/jmri/jmrit/logixng/expressions/OrTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/OrTest.java
@@ -302,11 +302,6 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // Test the methods connected(FemaleSocket) and getExpressionSystemName(int)
     @Test
     public void testConnected_getExpressionSystemName() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/expressions/StringExpressionConstantTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringExpressionConstantTest.java
@@ -198,11 +198,6 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "String constant", _base.getShortDescription(Locale.ENGLISH));
     }

--- a/java/test/jmri/jmrit/logixng/expressions/StringExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringExpressionMemoryTest.java
@@ -315,11 +315,6 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertTrue("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testShortDescription() {
         Assert.assertEquals("Memory as string value", _base.getShortDescription());
     }

--- a/java/test/jmri/jmrit/logixng/expressions/StringFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringFormulaTest.java
@@ -389,11 +389,6 @@ public class StringFormulaTest extends AbstractStringExpressionTestBase {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
     
-    @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
     // Test the methods connected(FemaleSocket) and getExpressionSystemName(int)
     @Test
     public void testConnected_getExpressionSystemName() throws SocketAlreadyConnectedException {

--- a/java/test/jmri/jmrit/logixng/expressions/TriggerOnceTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/TriggerOnceTest.java
@@ -252,11 +252,6 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription()
             throws NamedBean.BadUserNameException,
                     NamedBean.BadSystemNameException,

--- a/java/test/jmri/jmrit/logixng/expressions/TrueTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/TrueTest.java
@@ -138,11 +138,6 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
     }
     
     @Test
-    public void testIsExternal() {
-        Assert.assertFalse("is external", _base.isExternal());
-    }
-    
-    @Test
     public void testDescription() {
         DigitalExpressionBean e1 = new True("IQDE321", null);
         Assert.assertTrue("Always true".equals(e1.getShortDescription()));

--- a/java/test/jmri/jmrit/logixng/implementation/AbstractFemaleSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/AbstractFemaleSocketTest.java
@@ -351,11 +351,6 @@ public class AbstractFemaleSocketTest {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/AnalogActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/AnalogActionManagerTest.java
@@ -162,11 +162,6 @@ public class AnalogActionManagerTest extends AbstractManagerTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/AnalogExpressionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/AnalogExpressionManagerTest.java
@@ -172,11 +172,6 @@ public class AnalogExpressionManagerTest extends AbstractManagerTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultConditionalNGTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultConditionalNGTest.java
@@ -148,11 +148,6 @@ public class DefaultConditionalNGTest {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported8");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported9");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocketTest.java
@@ -276,11 +276,6 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            return false;
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleAnalogExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleAnalogExpressionSocketTest.java
@@ -283,11 +283,6 @@ public class DefaultMaleAnalogExpressionSocketTest extends MaleSocketTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            return false;
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalActionSocketTest.java
@@ -239,11 +239,6 @@ public class DefaultMaleDigitalActionSocketTest extends MaleSocketTestBase{
         }
 
         @Override
-        public boolean isExternal() {
-            return false;
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalBooleanActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalBooleanActionSocketTest.java
@@ -260,11 +260,6 @@ public class DefaultMaleDigitalBooleanActionSocketTest extends MaleSocketTestBas
         }
 
         @Override
-        public boolean isExternal() {
-            return false;
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleDigitalExpressionSocketTest.java
@@ -238,11 +238,6 @@ public class DefaultMaleDigitalExpressionSocketTest extends MaleSocketTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            return false;
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleStringActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleStringActionSocketTest.java
@@ -242,11 +242,6 @@ public class DefaultMaleStringActionSocketTest extends MaleSocketTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            return false;
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleStringExpressionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleStringExpressionSocketTest.java
@@ -240,11 +240,6 @@ public class DefaultMaleStringExpressionSocketTest extends MaleSocketTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            return false;
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported.");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/DigitalActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DigitalActionManagerTest.java
@@ -162,11 +162,6 @@ public class DigitalActionManagerTest extends AbstractManagerTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/DigitalBooleanActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DigitalBooleanActionManagerTest.java
@@ -162,11 +162,6 @@ public class DigitalBooleanActionManagerTest extends AbstractManagerTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/DigitalExpressionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DigitalExpressionManagerTest.java
@@ -178,11 +178,6 @@ public class DigitalExpressionManagerTest extends AbstractManagerTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/StringActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/StringActionManagerTest.java
@@ -162,11 +162,6 @@ public class StringActionManagerTest extends AbstractManagerTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported");
         }

--- a/java/test/jmri/jmrit/logixng/implementation/StringExpressionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/StringExpressionManagerTest.java
@@ -172,11 +172,6 @@ public class StringExpressionManagerTest extends AbstractManagerTestBase {
         }
 
         @Override
-        public boolean isExternal() {
-            throw new UnsupportedOperationException("Not supported");
-        }
-
-        @Override
         public void setup() {
             throw new UnsupportedOperationException("Not supported");
         }


### PR DESCRIPTION
@dsand47 
I had an idea that was never implemented when I added the method `isExternal()`. So this method is never used, except in tests, and it will never be used. So I remove it to clean up the code.

We can merge your new PR with the Dispatcher action/expression before this PR is merged since this PR will break your PR if this is merged first.