### PR TITLE
Update LogixNG Many actions

### DIFF
--- a/java/src/jmri/jmrit/logixng/actions/AnalogMany.java
+++ b/java/src/jmri/jmrit/logixng/actions/AnalogMany.java
@@ -7,14 +7,7 @@ import java.util.Map;
 
 import jmri.InstanceManager;
 import jmri.JmriException;
-import jmri.jmrit.logixng.AnalogActionManager;
-import jmri.jmrit.logixng.Base;
-import jmri.jmrit.logixng.Category;
-import jmri.jmrit.logixng.FemaleAnalogActionSocket;
-import jmri.jmrit.logixng.FemaleSocket;
-import jmri.jmrit.logixng.FemaleSocketListener;
-import jmri.jmrit.logixng.MaleSocket;
-import jmri.jmrit.logixng.SocketAlreadyConnectedException;
+import jmri.jmrit.logixng.*;
 
 /**
  * Execute many Actions in a specific order.
@@ -124,11 +117,13 @@ public class AnalogMany extends AbstractAnalogAction
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
         return _actionEntries.get(index)._socket;
     }
 
+    /** {@inheritDoc} */
     @Override
     public int getChildCount() {
         return _actionEntries.size();
@@ -167,6 +162,82 @@ public class AnalogMany extends AbstractAnalogAction
         }
     }
     
+    /** {@inheritDoc} */
+    @Override
+    public boolean isSocketOperationAllowed(int index, FemaleSocketOperation oper) {
+        switch (oper) {
+            case Remove:    // Possible if socket is not connected and there are at least two sockets
+                if (_actionEntries.size() == 1) return false;
+                return ! getChild(index).isConnected();
+            case InsertBefore:
+                return true;    // Always possible
+            case InsertAfter:
+                return true;    // Always possible
+            case MoveUp:
+                return index > 0;   // Possible if not first socket
+            case MoveDown:
+                return index+1 < getChildCount();   // Possible if not last socket
+            default:
+                throw new UnsupportedOperationException("Oper is unknown" + oper.name());
+        }
+    }
+    
+    private void insertNewSocket(int index) {
+        FemaleAnalogActionSocket socket =
+                InstanceManager.getDefault(AnalogActionManager.class)
+                        .createFemaleSocket(this, this, getNewSocketName());
+        _actionEntries.add(index, new ActionEntry(socket));
+        
+        List<FemaleSocket> addList = new ArrayList<>();
+        addList.add(socket);
+        firePropertyChange(Base.PROPERTY_CHILD_COUNT, null, addList);
+    }
+    
+    private void removeSocket(int index) {
+        List<FemaleSocket> removeList = new ArrayList<>();
+        removeList.add(_actionEntries.remove(index)._socket);
+        firePropertyChange(Base.PROPERTY_CHILD_COUNT, removeList, null);
+    }
+    
+    private void moveSocketDown(int index) {
+        ActionEntry temp = _actionEntries.get(index);
+        _actionEntries.set(index, _actionEntries.get(index+1));
+        _actionEntries.set(index+1, temp);
+        
+        List<FemaleSocket> list = new ArrayList<>();
+        list.add(_actionEntries.get(index)._socket);
+        list.add(_actionEntries.get(index+1)._socket);
+        firePropertyChange(Base.PROPERTY_CHILD_REORDER, null, list);
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public void doSocketOperation(int index, FemaleSocketOperation oper) {
+        switch (oper) {
+            case Remove:
+                if (getChild(index).isConnected()) throw new UnsupportedOperationException("Socket is connected");
+                removeSocket(index);
+                break;
+            case InsertBefore:
+                insertNewSocket(index);
+                break;
+            case InsertAfter:
+                insertNewSocket(index+1);
+                break;
+            case MoveUp:
+                if (index == 0) throw new UnsupportedOperationException("cannot move up first child");
+                moveSocketDown(index-1);
+                break;
+            case MoveDown:
+                if (index+1 == getChildCount()) throw new UnsupportedOperationException("cannot move down last child");
+                moveSocketDown(index);
+                break;
+            default:
+                throw new UnsupportedOperationException("Oper is unknown" + oper.name());
+        }
+    }
+    
+    /** {@inheritDoc} */
     @Override
     public void connected(FemaleSocket socket) {
         if (disableCheckForUnconnectedSocket) return;
@@ -181,6 +252,7 @@ public class AnalogMany extends AbstractAnalogAction
         checkFreeSocket();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void disconnected(FemaleSocket socket) {
         for (ActionEntry entry : _actionEntries) {
@@ -191,14 +263,33 @@ public class AnalogMany extends AbstractAnalogAction
         }
     }
     
+    /** {@inheritDoc} */
     @Override
     public String getShortDescription(Locale locale) {
         return Bundle.getMessage(locale, "Many_Short");
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getLongDescription(Locale locale) {
         return Bundle.getMessage(locale, "Many_Long");
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+        // Do nothing
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
     }
     
     
@@ -217,23 +308,6 @@ public class AnalogMany extends AbstractAnalogAction
         
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public void registerListenersForThisClass() {
-        // Do nothing
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void unregisterListenersForThisClass() {
-        // Do nothing
-    }
-    
-    /** {@inheritDoc} */
-    @Override
-    public void disposeMe() {
-    }
-    
     
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AnalogMany.class);
 

--- a/java/src/jmri/jmrit/logixng/actions/DigitalMany.java
+++ b/java/src/jmri/jmrit/logixng/actions/DigitalMany.java
@@ -117,11 +117,13 @@ public class DigitalMany extends AbstractDigitalAction
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
         return _actionEntries.get(index)._socket;
     }
 
+    /** {@inheritDoc} */
     @Override
     public int getChildCount() {
         return _actionEntries.size();
@@ -235,6 +237,7 @@ public class DigitalMany extends AbstractDigitalAction
         }
     }
     
+    /** {@inheritDoc} */
     @Override
     public void connected(FemaleSocket socket) {
         if (disableCheckForUnconnectedSocket) return;
@@ -249,6 +252,7 @@ public class DigitalMany extends AbstractDigitalAction
         checkFreeSocket();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void disconnected(FemaleSocket socket) {
         for (ActionEntry entry : _actionEntries) {
@@ -259,11 +263,13 @@ public class DigitalMany extends AbstractDigitalAction
         }
     }
     
+    /** {@inheritDoc} */
     @Override
     public String getShortDescription(Locale locale) {
         return Bundle.getMessage(locale, "Many_Short");
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getLongDescription(Locale locale) {
         return Bundle.getMessage(locale, "Many_Long");

--- a/java/src/jmri/jmrit/logixng/actions/DigitalMany.java
+++ b/java/src/jmri/jmrit/logixng/actions/DigitalMany.java
@@ -164,7 +164,8 @@ public class DigitalMany extends AbstractDigitalAction
     @Override
     public boolean isSocketOperationAllowed(int index, FemaleSocketOperation oper) {
         switch (oper) {
-            case Remove:        // Possible if socket is not connected
+            case Remove:    // Possible if socket is not connected and there is at least two sockets
+                if (_actionEntries.size() == 1) return false;
                 return ! getChild(index).isConnected();
             case InsertBefore:
                 return true;    // Always possible

--- a/java/src/jmri/jmrit/logixng/actions/DigitalMany.java
+++ b/java/src/jmri/jmrit/logixng/actions/DigitalMany.java
@@ -164,7 +164,7 @@ public class DigitalMany extends AbstractDigitalAction
     @Override
     public boolean isSocketOperationAllowed(int index, FemaleSocketOperation oper) {
         switch (oper) {
-            case Remove:    // Possible if socket is not connected and there is at least two sockets
+            case Remove:    // Possible if socket is not connected and there are at least two sockets
                 if (_actionEntries.size() == 1) return false;
                 return ! getChild(index).isConnected();
             case InsertBefore:

--- a/java/src/jmri/jmrit/logixng/actions/StringMany.java
+++ b/java/src/jmri/jmrit/logixng/actions/StringMany.java
@@ -7,14 +7,7 @@ import java.util.Map;
 
 import jmri.InstanceManager;
 import jmri.JmriException;
-import jmri.jmrit.logixng.Base;
-import jmri.jmrit.logixng.Category;
-import jmri.jmrit.logixng.FemaleSocket;
-import jmri.jmrit.logixng.FemaleSocketListener;
-import jmri.jmrit.logixng.FemaleStringActionSocket;
-import jmri.jmrit.logixng.MaleSocket;
-import jmri.jmrit.logixng.SocketAlreadyConnectedException;
-import jmri.jmrit.logixng.StringActionManager;
+import jmri.jmrit.logixng.*;
 
 /**
  * Execute many Actions in a specific order.
@@ -171,6 +164,81 @@ public class StringMany extends AbstractStringAction
     
     /** {@inheritDoc} */
     @Override
+    public boolean isSocketOperationAllowed(int index, FemaleSocketOperation oper) {
+        switch (oper) {
+            case Remove:    // Possible if socket is not connected and there are at least two sockets
+                if (_actionEntries.size() == 1) return false;
+                return ! getChild(index).isConnected();
+            case InsertBefore:
+                return true;    // Always possible
+            case InsertAfter:
+                return true;    // Always possible
+            case MoveUp:
+                return index > 0;   // Possible if not first socket
+            case MoveDown:
+                return index+1 < getChildCount();   // Possible if not last socket
+            default:
+                throw new UnsupportedOperationException("Oper is unknown" + oper.name());
+        }
+    }
+    
+    private void insertNewSocket(int index) {
+        FemaleStringActionSocket socket =
+                InstanceManager.getDefault(StringActionManager.class)
+                        .createFemaleSocket(this, this, getNewSocketName());
+        _actionEntries.add(index, new ActionEntry(socket));
+        
+        List<FemaleSocket> addList = new ArrayList<>();
+        addList.add(socket);
+        firePropertyChange(Base.PROPERTY_CHILD_COUNT, null, addList);
+    }
+    
+    private void removeSocket(int index) {
+        List<FemaleSocket> removeList = new ArrayList<>();
+        removeList.add(_actionEntries.remove(index)._socket);
+        firePropertyChange(Base.PROPERTY_CHILD_COUNT, removeList, null);
+    }
+    
+    private void moveSocketDown(int index) {
+        ActionEntry temp = _actionEntries.get(index);
+        _actionEntries.set(index, _actionEntries.get(index+1));
+        _actionEntries.set(index+1, temp);
+        
+        List<FemaleSocket> list = new ArrayList<>();
+        list.add(_actionEntries.get(index)._socket);
+        list.add(_actionEntries.get(index+1)._socket);
+        firePropertyChange(Base.PROPERTY_CHILD_REORDER, null, list);
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+    public void doSocketOperation(int index, FemaleSocketOperation oper) {
+        switch (oper) {
+            case Remove:
+                if (getChild(index).isConnected()) throw new UnsupportedOperationException("Socket is connected");
+                removeSocket(index);
+                break;
+            case InsertBefore:
+                insertNewSocket(index);
+                break;
+            case InsertAfter:
+                insertNewSocket(index+1);
+                break;
+            case MoveUp:
+                if (index == 0) throw new UnsupportedOperationException("cannot move up first child");
+                moveSocketDown(index-1);
+                break;
+            case MoveDown:
+                if (index+1 == getChildCount()) throw new UnsupportedOperationException("cannot move down last child");
+                moveSocketDown(index);
+                break;
+            default:
+                throw new UnsupportedOperationException("Oper is unknown" + oper.name());
+        }
+    }
+    
+    /** {@inheritDoc} */
+    @Override
     public void connected(FemaleSocket socket) {
         if (disableCheckForUnconnectedSocket) return;
         
@@ -207,22 +275,6 @@ public class StringMany extends AbstractStringAction
         return Bundle.getMessage(locale, "Many_Long");
     }
     
-    
-    private static class ActionEntry {
-        private String _socketSystemName;
-        private final FemaleStringActionSocket _socket;
-        
-        private ActionEntry(FemaleStringActionSocket socket, String socketSystemName) {
-            _socketSystemName = socketSystemName;
-            _socket = socket;
-        }
-        
-        private ActionEntry(FemaleStringActionSocket socket) {
-            this._socket = socket;
-        }
-        
-    }
-
     /** {@inheritDoc} */
     @Override
     public void registerListenersForThisClass() {
@@ -240,6 +292,22 @@ public class StringMany extends AbstractStringAction
     public void disposeMe() {
     }
     
+    
+    private static class ActionEntry {
+        private String _socketSystemName;
+        private final FemaleStringActionSocket _socket;
+        
+        private ActionEntry(FemaleStringActionSocket socket, String socketSystemName) {
+            _socketSystemName = socketSystemName;
+            _socket = socket;
+        }
+        
+        private ActionEntry(FemaleStringActionSocket socket) {
+            this._socket = socket;
+        }
+        
+    }
+
     
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(StringMany.class);
 


### PR DESCRIPTION
The digital action Many had a bug which made it possible to remove all its children. This shouldn't be possible, since it needs to have at least on child.

While fixing this, I discovered that the Analog Many and String Many actions didn't supported female socket operations so I have added that as well. Female socket operations allow the user to remove an empty socket, move a socket up and down and insert a socket before or after another socket.