### PR TITLE
Fix bug when deleting a bean in LogixNG

### DIFF
--- a/java/src/jmri/jmrit/logixng/implementation/AbstractBaseManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractBaseManager.java
@@ -77,7 +77,7 @@ public abstract class AbstractBaseManager<E extends NamedBean> extends AbstractM
         // sockets. A male socket might be contained in another male socket.
         // In some cases, it seems that the male socket used in this call is
         // not the male socket that's registered in the manager. To resolve
-        // this, we search for the registered bean with the system namem and
+        // this, we search for the registered bean with the system name and
         // then deregister the bean we have found.
         E bean = getBySystemName(s.getSystemName());
         if (bean == null) {

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractBaseManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractBaseManager.java
@@ -69,6 +69,24 @@ public abstract class AbstractBaseManager<E extends NamedBean> extends AbstractM
         }
     }
     
+    /** {@inheritDoc} */
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void deregister(@Nonnull E s) {
+        // A LogixNG action or expression is contained in one or more male
+        // sockets. A male socket might be contained in another male socket.
+        // In some cases, it seems that the male socket used in this call is
+        // not the male socket that's registered in the manager. To resolve
+        // this, we search for the registered bean with the system namem and
+        // then deregister the bean we have found.
+        E bean = getBySystemName(s.getSystemName());
+        if (bean == null) {
+            // This should never happen.
+            throw new IllegalArgumentException(s.getSystemName() + " is not registered in manager");
+        }
+        super.deregister(bean);
+    }
+    
     /**
      * Test if parameter is a properly formatted system name.
      *


### PR DESCRIPTION
A LogixNG action or expression is contained in one or more male sockets. A male socket might be contained in another male socket. In some cases, it seems that the male socket used in the call to `deregister()` is not the male socket that's registered in the manager. To resolve this, we search for the registered bean with the system name and then deregister the bean we have found.