### PR TITLE
Remove explicit boxing

### DIFF
--- a/java/src/jmri/util/swing/ResizableImagePanel.java
+++ b/java/src/jmri/util/swing/ResizableImagePanel.java
@@ -147,7 +147,7 @@ public class ResizableImagePanel extends JPanel implements ComponentListener {
 
     /**
      * Read pixel image and handle exif information if it exists in the file.
-     * 
+     *
      * @param file the image file
      * @return the image
      * @throws IOException in case of an I/O error
@@ -156,24 +156,24 @@ public class ResizableImagePanel extends JPanel implements ComponentListener {
         ThumbnailParameterBuilder builder = new ThumbnailParameterBuilder();
         builder.scale(1.0);
         ThumbnailParameter param = builder.build();
-        
+
         FileImageSource fileImageSource = new FileImageSource(file);
         fileImageSource.setThumbnailParameter(param);
 
         BufferedImage img = fileImageSource.read();
-        
+
         // Perform the image filters
         for (ImageFilter filter : param.getImageFilters()) {
             img = filter.apply(img);
         }
-        
+
         return img;
     }
 
   /**
    * Read vector image
    * Use the SAXSVGDocumentFactory to parse the given URI into a DOM.
-   * 
+   *
    * @param uri The path to the SVG file to read.
    * @return A Document instance that represents the SVG file.
    * @throws IOException The file could not be read.
@@ -202,7 +202,7 @@ public class ResizableImagePanel extends JPanel implements ComponentListener {
         }
         log.debug("Image path is now : {}", _imagePath);
         if (_imagePath != null) {
-            try {                
+            try {
                 File imf = new File(_imagePath);
                 if ( _imagePath.toUpperCase().endsWith(".SVG") ) {
                     svgImage = createSVGDocument(imf.toURI().toString());
@@ -351,8 +351,8 @@ public class ResizableImagePanel extends JPanel implements ComponentListener {
         } else if (svgImage != null) {
             MyTranscoder transcoder = new MyTranscoder();
             TranscodingHints hints = new TranscodingHints();
-            hints.put(ImageTranscoder.KEY_WIDTH, new Float(getSize().getWidth()) );
-            hints.put(ImageTranscoder.KEY_HEIGHT, new Float(getSize().getHeight()) );
+            hints.put(ImageTranscoder.KEY_WIDTH, getSize().getWidth() );
+            hints.put(ImageTranscoder.KEY_HEIGHT, getSize().getHeight() );
             transcoder.setTranscodingHints(hints);
             try {
                 transcoder.transcode(new TranscoderInput(svgImage), null);
@@ -362,7 +362,7 @@ public class ResizableImagePanel extends JPanel implements ComponentListener {
             scaledImage = transcoder.getImage();
         }
     }
-    
+
     private static class MyTranscoder extends ImageTranscoder {
         private BufferedImage image = null;
         @Override

--- a/java/test/jmri/jmrit/vsdecoder/FloatTriggerTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/FloatTriggerTest.java
@@ -93,32 +93,32 @@ public class FloatTriggerTest {
             }
         });
         PropertyChangeEvent e = new PropertyChangeEvent(this, "test event",
-                new Float(1.0f),
-                new Float(2.0f));
+                1.0f,
+                2.0f);
         uut.propertyChange(e);
 
         uut.setCompareType(Trigger.CompareType.LT);
         e = new PropertyChangeEvent(this, "test event",
-                new Float(2.0f),
-                new Float(1.0f));
+                2.0f,
+                1.0f);
         uut.propertyChange(e);
 
         uut.setCompareType(Trigger.CompareType.GTE);
         e = new PropertyChangeEvent(this, "test event",
-                new Float(2.0f),
-                new Float(0.5f));
+                2.0f,
+                0.5f);
         uut.propertyChange(e);
 
         uut.setCompareType(Trigger.CompareType.LTE);
         e = new PropertyChangeEvent(this, "test event",
-                new Float(2.0f),
-                new Float(0.5f));
+                2.0f,
+                0.5f);
         uut.propertyChange(e);
 
         uut.setCompareType(Trigger.CompareType.EQ);
         e = new PropertyChangeEvent(this, "test event",
-                new Float(2.0f),
-                new Float(0.5f));
+                2.0f,
+                0.5f);
         uut.propertyChange(e);
     }
 

--- a/java/test/jmri/util/MathUtilTest.java
+++ b/java/test/jmri/util/MathUtilTest.java
@@ -209,8 +209,8 @@ public class MathUtilTest {
     public void testDoubleLerp() {
         boolean passed = true;    // assume success (optimist!)
         double minV = -666.66, maxV = +999.99;
-        Double minD = new Double(minV);
-        Double maxD = new Double(maxV);
+        Double minD = minV;
+        Double maxD = maxV;
         for (double theV = 0.0; theV < 2.f; theV += 0.15) {
             double c = MathUtil.lerp(minV, maxV, theV);
             double t = (c - minV) / (maxV - minV);
@@ -220,7 +220,7 @@ public class MathUtilTest {
                 break;
             }
 
-            Double theD = new Double(theV);
+            Double theD = theV;
             Double cD = MathUtil.lerp(minD, maxD, theD);
             Double tD = (cD - minD) / (maxD - minD);
             Assert.assertEquals("MathUtil.lerp(minD, maxD, vD)", tD, theD, tolerance);

--- a/java/test/jmri/util/ThreadingUtilTest.java
+++ b/java/test/jmri/util/ThreadingUtilTest.java
@@ -11,15 +11,15 @@ import org.junit.jupiter.api.*;
 public class ThreadingUtilTest {
 
     boolean done;
-    
+
     @Test
     public void testToLayout() {
         done = false;
-        
-        ThreadingUtil.runOnLayout( ()-> { 
-            done = true; 
+
+        ThreadingUtil.runOnLayout( ()-> {
+            done = true;
         } );
-        
+
         Assert.assertTrue(done);
     }
 
@@ -30,7 +30,7 @@ public class ThreadingUtilTest {
         Assert.assertEquals(tg.getName(), "JMRI");
         Assert.assertEquals(tg, ThreadingUtil.getJmriThreadGroup());
     }
-    
+
     @Test
     public void testThreadStartEnd() throws InterruptedException {
         ThreadingUtil.getJmriThreadGroup();  // just used to create the group
@@ -47,10 +47,10 @@ public class ThreadingUtilTest {
         // if (!java.lang.management.ManagementFactory
         //                                        .getThreadMXBean().isSynchronizerUsageSupported())
         //        log.info("This JVM doesn't support synchronized lock tracking");
-                                                
+
         final Object lockedThing = new Object();
         done = false;
-        
+
         synchronized (lockedThing) {
             // first, run something that also wants the lock
             new Thread(() -> {
@@ -58,12 +58,12 @@ public class ThreadingUtilTest {
                     testRef = lockedThing;
                 }
             }).start();
-            
-            ThreadingUtil.runOnGUI( ()-> { 
-                done = true; 
+
+            ThreadingUtil.runOnGUI( ()-> {
+                done = true;
                 Assert.assertNull(testRef); // due to lock
             } );
- 
+
             JUnitUtil.waitFor( ()->{ return done; }, "GUI thread complete");
             Assert.assertNull(testRef); // due to lock
         }
@@ -73,18 +73,18 @@ public class ThreadingUtilTest {
     @Test
     public void testThreadingNesting() {
         done = false;
-        
+
         Thread t = new Thread(
             new Runnable() {
                 @Override
                 public void run() {
                     // now on another thread
                     // switch back to Layout thread
-                    ThreadingUtil.runOnLayout( ()-> { 
+                    ThreadingUtil.runOnLayout( ()-> {
                         // on layout thread, confirm
                         Assert.assertTrue("on Layout thread", ThreadingUtil.isLayoutThread());
                         // mark done so we know
-                        done = true; 
+                        done = true;
                     } );
                 }
             }
@@ -99,18 +99,18 @@ public class ThreadingUtilTest {
     @Test
     public void testThreadingNestingToSwing() {
         done = false;
-        
+
         javax.swing.SwingUtilities.invokeLater(
             new Runnable() {
                 @Override
                 public void run() {
                     // now on Swing thread
                     // switch back to Layout thread
-                    ThreadingUtil.runOnLayout( ()-> { 
+                    ThreadingUtil.runOnLayout( ()-> {
                         // on layout thread, confirm
                         Assert.assertTrue("on Layout thread", ThreadingUtil.isLayoutThread());
                         // mark done so we known
-                        done = true; 
+                        done = true;
                     } );
                 }
             }
@@ -123,14 +123,14 @@ public class ThreadingUtilTest {
     @Test
     public void testThreadingDelayGUI() {
         done = false;
-        
-        ThreadingUtil.runOnGUIDelayed( ()-> { 
-            done = true; 
+
+        ThreadingUtil.runOnGUIDelayed( ()-> {
+            done = true;
         }, 200 );
 
         // ensure not done now
         Assert.assertTrue(!done);
-        
+
         // wait for separate thread to do it's work before confirming test
         JUnitUtil.waitFor( ()->{ return done; }, "Delayed operation complete");
     }
@@ -138,37 +138,37 @@ public class ThreadingUtilTest {
     @Test
     public void testThreadingRunOnGUIwithReturn() {
         done = false;
-        
-        Integer value = ThreadingUtil.runOnGUIwithReturn( ()-> { 
-            done = true; 
-            return new Integer(21);
+
+        Integer value = ThreadingUtil.runOnGUIwithReturn( ()-> {
+            done = true;
+            return 21;
         });
 
         Assert.assertTrue(done);
-        Assert.assertEquals(new Integer(21), value);
+        Assert.assertEquals(Integer.valueOf(21), value);
     }
 
     @Test
     public void testThreadingDelayLayout() {
         done = false;
-        
-        ThreadingUtil.runOnLayoutDelayed( ()-> { 
-            done = true; 
+
+        ThreadingUtil.runOnLayoutDelayed( ()-> {
+            done = true;
         }, 200 );
 
         // ensure not done now
         Assert.assertTrue(!done);
-        
+
         // wait for separate thread to do it's work before confirming test
         JUnitUtil.waitFor( ()->{ return done; }, "Delayed oepration complete");
     }
 
     @Test
     public void testThreadingTests() {
-        ThreadingUtil.runOnLayout( ()-> { 
+        ThreadingUtil.runOnLayout( ()-> {
             ThreadingUtil.requireLayoutThread(log);
         } );
-        ThreadingUtil.runOnGUI( ()-> { 
+        ThreadingUtil.runOnGUI( ()-> {
             ThreadingUtil.requireGuiThread(log);
         } );
         Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
@@ -182,15 +182,15 @@ public class ThreadingUtilTest {
         ThreadingUtil.requireGuiThread(log);
         ThreadingUtil.requireLayoutThread(log);
         Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
-        
+
    }
-    
+
     /**
      * Show how to query state of _current_ thread
      */
     @Test
     public void testSelfState() {
-    
+
         // To run the tests, this thread has to be running, not waiting
         Assert.assertTrue(ThreadingUtil.canThreadRun(Thread.currentThread()));
         Assert.assertFalse(ThreadingUtil.isThreadWaiting(Thread.currentThread()));


### PR DESCRIPTION
Removes some boxing calls (i.e. `new Float(3.0)` and similar) that are no longer needed and cause deprecation warnings. No functional changes.