### PR TITLE
Remove use of deprecated SecurityManager

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -570,5 +570,7 @@
                 by no longer including the date.  The time is still included.
                 If you have a copy of the 'default.lcf' file in your local JMRI
                 setting directory, you won't see this change until you update it.</li>
+            <li>Access to the deprecated SecurityManager class has been removed;
+                Java access security is now enforced by default.</li>
         </ul>
 

--- a/java/src/jmri/jmrix/loconet/locormi/LnMessageClient.java
+++ b/java/src/jmri/jmrix/loconet/locormi/LnMessageClient.java
@@ -76,10 +76,7 @@ public class LnMessageClient extends LnTrafficRouter {
         log.debug("configureRemoteConnection: {} {}", remoteHostName, timeoutSec);
 
         try {
-            if (System.getSecurityManager() == null) {
-                System.setSecurityManager(new SecurityManager());
-            }
-            log.debug("security manager set, set interface to //{}//{}", // NOI18N
+            log.debug("set interface to //{}//{}", // NOI18N
                     remoteHostName, LnMessageServer.serviceName);
             LnMessageServerInterface lnServer = (LnMessageServerInterface) java.rmi.Naming.lookup(
                     "//" + serverName + "/" + LnMessageServer.serviceName); // NOI18N

--- a/java/src/jmri/jmrix/loconet/locormi/LnMessageServer.java
+++ b/java/src/jmri/jmrix/loconet/locormi/LnMessageServer.java
@@ -32,9 +32,6 @@ public class LnMessageServer extends UnicastRemoteObject implements LnMessageSer
 
     public static synchronized LnMessageServer getInstance() throws RemoteException {
         if (self == null) {
-            if (System.getSecurityManager() == null) {
-                System.setSecurityManager(new SecurityManager());
-            }
             self = new LnMessageServer();
         }
         return self;

--- a/java/test/jmri/jmrix/loconet/locormi/LnMessageClientTest.java
+++ b/java/test/jmri/jmrix/loconet/locormi/LnMessageClientTest.java
@@ -12,17 +12,10 @@ import org.junit.jupiter.api.*;
  */
 public class LnMessageClientTest {
 
-    private static final SecurityManager SM = System.getSecurityManager();
-
     @Test
     public void testCTor() {
         LnMessageClient t = new LnMessageClient();
         Assert.assertNotNull("exists", t);
-    }
-
-    @AfterAll
-    public static void tearDownClass() throws Exception {
-        System.setSecurityManager(SM);
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/loconet/locormi/LnMessageServerTest.java
+++ b/java/test/jmri/jmrix/loconet/locormi/LnMessageServerTest.java
@@ -15,38 +15,10 @@ import org.junit.jupiter.api.BeforeAll;
  */
 public class LnMessageServerTest {
 
-    private static final SecurityManager SM = System.getSecurityManager();
-
     @Test
     public void testGetInstance() throws java.rmi.RemoteException {
         LnMessageServer t = LnMessageServer.getInstance();
         Assert.assertNotNull("exists", t);
-    }
-
-    @BeforeAll
-    public static void setUpClass() {
-        if (SM == null) {
-            System.setSecurityManager(new SecurityManager() {
-                @Override
-                public void checkPermission(Permission perm) {
-                }
-
-                @Override
-                public void checkPermission(Permission perm, Object context) {
-                }
-
-                @Override
-                public void checkExit(int status) {
-                    String message = "System exit requested with error " + status;
-                    throw new SecurityException(message);
-                }
-            });
-        }
-    }
-
-    @AfterAll
-    public static void tearDownClass() throws Exception {
-        System.setSecurityManager(SM);
     }
 
     @BeforeEach


### PR DESCRIPTION
SecurityManager is no longer used in Java 8 and deprecated for removal in later versions.  This PR removes the references to it, which should have no run-time effect.

Note that removal of the runtime setting of `security.policy` is left for another day.

For background, see [JEP 411](https://openjdk.java.net/jeps/411).