### PR TITLE
Ensure fields are initialized

### DIFF
--- a/java/src/jmri/jmrit/logixng/Module.java
+++ b/java/src/jmri/jmrit/logixng/Module.java
@@ -72,7 +72,7 @@ public interface Module extends Base, NamedBean {
      */
     public static class ParameterData extends VariableData {
         
-        public ReturnValueType _returnValueType;
+        public ReturnValueType _returnValueType = ReturnValueType.None;
         public String _returnValueData;
         
         public ParameterData(

--- a/java/src/jmri/jmrit/logixng/SymbolTable.java
+++ b/java/src/jmri/jmrit/logixng/SymbolTable.java
@@ -152,7 +152,7 @@ public interface SymbolTable {
     public static class VariableData {
         
         public String _name;
-        public InitialValueType _initalValueType;
+        public InitialValueType _initalValueType = InitialValueType.None;
         public String _initialValueData;
         
         public VariableData(


### PR DESCRIPTION
@dsand47 
When the user creates a new local variable but doesn't select the type of the variable, an exception occurs when the panel is stored. This PR ensures that local variables and parameters for modules are always initialized to a default value.