### PR TITLE
Update panel files to not trigger execution of a script

### DIFF
--- a/java/test/jmri/jmrit/display/layoutEditor/load/PU-MonP-Signal-Panel-4-19-6.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/load/PU-MonP-Signal-Panel-4-19-6.xml
@@ -11053,16 +11053,16 @@
       <conditionalStateVariable operator="1" negated="no" type="4" systemName="LU-MX" dataString="" num1="0" num2="0" triggersCalc="yes" />
       <conditionalAction option="1" type="3" systemName="LUX6" data="16" delay="0" string="" />
     </conditional>
-    <conditional systemName="IX-OPSC1" userName="OPS 00:00" antecedent="R1" logicType="1" triggerOnChange="yes">
+    <conditional systemName="IX-OPSC1" userName="OPS 01:00" antecedent="R1" logicType="1" triggerOnChange="yes">
       <systemName>IX-OPSC1</systemName>
-      <userName>OPS 00:00</userName>
-      <conditionalStateVariable operator="4" negated="no" type="10" systemName="Clock" dataString="" num1="0" num2="1" triggersCalc="yes" />
+      <userName>OPS 01:00</userName>
+      <conditionalStateVariable operator="4" negated="no" type="10" systemName="Clock" dataString="" num1="60" num2="61" triggersCalc="yes" />
       <conditionalAction option="1" type="16" systemName=" " data="-1" delay="0" string="preference:Scripts/EMRA OPs Power Cycle.py" />
     </conditional>
-    <conditional systemName="IX-OPSC2" userName="OPS 12:00" antecedent="R1" logicType="1" triggerOnChange="yes">
+    <conditional systemName="IX-OPSC2" userName="OPS 11:00" antecedent="R1" logicType="1" triggerOnChange="yes">
       <systemName>IX-OPSC2</systemName>
-      <userName>OPS 12:00</userName>
-      <conditionalStateVariable operator="4" negated="no" type="10" systemName="Clock" dataString="" num1="720" num2="721" triggersCalc="yes" />
+      <userName>OPS 11:00</userName>
+      <conditionalStateVariable operator="4" negated="no" type="10" systemName="Clock" dataString="" num1="660" num2="661" triggersCalc="yes" />
       <conditionalAction option="1" type="16" systemName=" " data="-1" delay="0" string="preference:Scripts/EMRA OPs Power Cycle.py" />
     </conditional>
     <conditional systemName="IX-VEC1" userName="VEM-turnouts active" antecedent="R1 and R2 and R3 and R4 and R5 and R6" logicType="2" triggerOnChange="yes">

--- a/java/test/jmri/jmrit/display/layoutEditor/loadref/PU-MonP-Signal-Panel-4-19-6.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/loadref/PU-MonP-Signal-Panel-4-19-6.xml
@@ -11053,16 +11053,16 @@
       <conditionalStateVariable operator="1" negated="no" type="4" systemName="LU-MX" dataString="" num1="0" num2="0" triggersCalc="yes" />
       <conditionalAction option="1" type="3" systemName="LUX6" data="16" delay="0" string="" />
     </conditional>
-    <conditional systemName="IX-OPSC1" userName="OPS 00:00" antecedent="R1" logicType="1" triggerOnChange="yes">
+    <conditional systemName="IX-OPSC1" userName="OPS 01:00" antecedent="R1" logicType="1" triggerOnChange="yes">
       <systemName>IX-OPSC1</systemName>
-      <userName>OPS 00:00</userName>
-      <conditionalStateVariable operator="4" negated="no" type="10" systemName="Clock" dataString="" num1="0" num2="1" triggersCalc="yes" />
+      <userName>OPS 01:00</userName>
+      <conditionalStateVariable operator="4" negated="no" type="10" systemName="Clock" dataString="" num1="60" num2="61" triggersCalc="yes" />
       <conditionalAction option="1" type="16" systemName=" " data="-1" delay="0" string="preference:Scripts/EMRA OPs Power Cycle.py" />
     </conditional>
-    <conditional systemName="IX-OPSC2" userName="OPS 12:00" antecedent="R1" logicType="1" triggerOnChange="yes">
+    <conditional systemName="IX-OPSC2" userName="OPS 11:00" antecedent="R1" logicType="1" triggerOnChange="yes">
       <systemName>IX-OPSC2</systemName>
-      <userName>OPS 12:00</userName>
-      <conditionalStateVariable operator="4" negated="no" type="10" systemName="Clock" dataString="" num1="720" num2="721" triggersCalc="yes" />
+      <userName>OPS 11:00</userName>
+      <conditionalStateVariable operator="4" negated="no" type="10" systemName="Clock" dataString="" num1="660" num2="661" triggersCalc="yes" />
       <conditionalAction option="1" type="16" systemName=" " data="-1" delay="0" string="preference:Scripts/EMRA OPs Power Cycle.py" />
     </conditional>
     <conditional systemName="IX-VEC1" userName="VEM-turnouts active" antecedent="R1 and R2 and R3 and R4 and R5 and R6" logicType="2" triggerOnChange="yes">


### PR DESCRIPTION
@bobjacobsen @dsand47 
This PR tries to solve issue #10168:
> LoadAndStoreTest>LoadAndStoreTestBase.tearDown:390 Unexpected ERROR or higher messages emitted: File D:\a\JMRI\JMRI\temp\Scripts\EMRA OPs Power Cycle.py not found.

> If the JMRI fast clock time is between 00:00 and 00:01 or 12:00 and 12:01, the IX-OPS Logix will attempt to load the script.

I tried to solve this by changing the fast clock from 0:00-0:01 and 12:00-12:01 to 1:00-1:01 and 11:00-11:01.

This commit changes the panel file in the hope that the script will not be executed. But I'm not sure this is the way the problem should be solved.

Closing #10168