### PR TITLE
WIP Comment  jmri.skipTestsRequiringSeparateRunning

### DIFF
--- a/java/test/jmri/SignalMastLogicTest.java
+++ b/java/test/jmri/SignalMastLogicTest.java
@@ -85,7 +85,7 @@ public class SignalMastLogicTest {
      */
     @Test
     public void testRename() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         // provide 2 virtual signal masts:
         SignalMast sm1 = new jmri.implementation.VirtualSignalMast("IF$vsm:AAR-1946:CPL($0001)");

--- a/java/test/jmri/implementation/LightControlTest.java
+++ b/java/test/jmri/implementation/LightControlTest.java
@@ -536,7 +536,7 @@ public class LightControlTest {
 
     @Test
     public void testTimedSensorFollowing() throws jmri.JmriException {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         Sensor s = InstanceManager.getDefault(jmri.SensorManager.class).provideSensor("S2");
 

--- a/java/test/jmri/jmrit/beantable/signalmast/AddSignalMastPanelTest.java
+++ b/java/test/jmri/jmrit/beantable/signalmast/AddSignalMastPanelTest.java
@@ -104,7 +104,7 @@ public class AddSignalMastPanelTest {
     @Test
     @Disabled("possible cause of 'No output has been received in the last 10m0s' failure")
     public void testCheckUserName() throws Exception {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         
         AddSignalMastPanel a = new AddSignalMastPanel();
         

--- a/java/test/jmri/jmrit/dispatcher/AutoActiveTrainsSMLStoppingTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AutoActiveTrainsSMLStoppingTest.java
@@ -58,7 +58,7 @@ public class AutoActiveTrainsSMLStoppingTest {
     @SuppressWarnings("null")  // spec says cannot happen, everything defined in test data.
     @Test
     public void testShowAndClose() throws Exception {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         jmri.configurexml.ConfigXmlManager cm = new jmri.configurexml.ConfigXmlManager() {
         };
         WarrantPreferences.getDefault().setShutdown(WarrantPreferences.Shutdown.NO_MERGE);

--- a/java/test/jmri/jmrit/dispatcher/AutoAllocateTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AutoAllocateTest.java
@@ -19,7 +19,7 @@ public class AutoAllocateTest {
 
     @Test
     public void testCTor() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         OptionsFile.setDefaultFileName("java/test/jmri/jmrit/dispatcher/dispatcheroptions.xml");  // exist?
 

--- a/java/test/jmri/jmrit/dispatcher/DispatcherFrameTest.java
+++ b/java/test/jmri/jmrit/dispatcher/DispatcherFrameTest.java
@@ -23,7 +23,7 @@ public class DispatcherFrameTest {
     @Test
     public void testShowAndClose() throws Exception {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         DispatcherFrame d = InstanceManager.getDefault(DispatcherFrame.class);
 
@@ -42,7 +42,7 @@ public class DispatcherFrameTest {
         // options file by creating a DispatcherFrame object.  A future
         // enhancement shold probably break this coupling.
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         DispatcherFrame d = InstanceManager.getDefault(DispatcherFrame.class);
 
@@ -90,7 +90,7 @@ public class DispatcherFrameTest {
     @Test
     public void testAddTrainButton() throws Exception {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         DispatcherFrame d = InstanceManager.getDefault(DispatcherFrame.class);
 
@@ -116,7 +116,7 @@ public class DispatcherFrameTest {
     @Test
     public void testAllocateExtraSectionButton() throws Exception {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         DispatcherFrame d = InstanceManager.getDefault(DispatcherFrame.class);
 
@@ -142,7 +142,7 @@ public class DispatcherFrameTest {
     @Test
     public void testCancelRestartButton() throws Exception {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         DispatcherFrame d = InstanceManager.getDefault(DispatcherFrame.class);
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitPathsTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitPathsTest.java
@@ -30,7 +30,7 @@ public class EditCircuitPathsTest {
     @Test
     public void testBasicOps() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         ControlPanelEditor frame = new ControlPanelEditor("EditCircuitPathsTest");
         frame.makeCircuitMenu(true);

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalDirectionTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalDirectionTest.java
@@ -25,7 +25,7 @@ public class EditPortalDirectionTest {
     @Test
     public void testSetup() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         ControlPanelEditor frame = new ControlPanelEditor("EditPortalDirectionTest");
         frame.makeCircuitMenu(true);

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalFrameTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalFrameTest.java
@@ -25,7 +25,7 @@ public class EditPortalFrameTest {
 
     @Test
     public void testCTor() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ControlPanelEditor frame = new ControlPanelEditor("EditPortalFrameTest");
         frame.makeCircuitMenu(true);

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditSignalFrameTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditSignalFrameTest.java
@@ -23,7 +23,7 @@ public class EditSignalFrameTest {
 
     @Test
     public void testCTor() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ControlPanelEditor frame = new ControlPanelEditor("EditSignalFrameTest");
         frame.makeCircuitMenu(true);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutDoubleSlipEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutDoubleSlipEditorTest.java
@@ -31,7 +31,7 @@ public class LayoutDoubleSlipEditorTest extends LayoutSlipEditorTest {
     @Test
     public void testEditDoubleSlipDone() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         createTurnouts();
         createBlocks();

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutLHTurnoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutLHTurnoutEditorTest.java
@@ -27,7 +27,7 @@ public class LayoutLHTurnoutEditorTest extends LayoutTurnoutEditorTest {
     @Test
     public void testEditLHTurnoutDone() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         LayoutTurnoutEditor editor = new LayoutLHTurnoutEditor(layoutEditor);
         turnoutTestSequence(editor, leftHandLayoutTurnoutView);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutRHTurnoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutRHTurnoutEditorTest.java
@@ -27,7 +27,7 @@ public class LayoutRHTurnoutEditorTest extends LayoutTurnoutEditorTest  {
     @Test
     public void testEditRHTurnoutDone() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         LayoutTurnoutEditor editor = new LayoutRHTurnoutEditor(layoutEditor);
         turnoutTestSequence(editor, rightHandLayoutTurnoutView);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutSingleSlipEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutSingleSlipEditorTest.java
@@ -33,7 +33,7 @@ public class LayoutSingleSlipEditorTest extends LayoutSlipEditorTest {
     @Test
     public void testEditSingleSlipDone() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         createTurnouts();
         createBlocks();

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurntableEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurntableEditorTest.java
@@ -32,7 +32,7 @@ public class LayoutTurntableEditorTest extends LayoutTrackEditorTest {
      @Test
     public void testEditTurntableDone() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         createTurnouts();
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutWyeEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutWyeEditorTest.java
@@ -27,7 +27,7 @@ public class LayoutWyeEditorTest extends LayoutTurnoutEditorTest {
     @Test
     public void testEditLHTurnoutDone() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         LayoutWyeEditor editor = new LayoutWyeEditor(layoutEditor);
         turnoutTestSequence(editor, layoutWyeView);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutXOverEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutXOverEditorTest.java
@@ -31,7 +31,7 @@ public class LayoutXOverEditorTest extends LayoutTrackEditorTest {
     @Test
     public void testEditXOverDone() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         createTurnouts();
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LevelXingEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LevelXingEditorTest.java
@@ -31,7 +31,7 @@ public class LevelXingEditorTest extends LayoutTrackEditorTest {
     @Test
     public void testEditXingDone() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         createBlocks();
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/TrackSegmentEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/TrackSegmentEditorTest.java
@@ -31,7 +31,7 @@ public class TrackSegmentEditorTest extends LayoutTrackEditorTest {
     @Test
     public void testEditTrackSegmentDone() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         trackSegmentView.setArc(true);
         trackSegmentView.setCircle(true);

--- a/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
+++ b/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
@@ -40,7 +40,7 @@ public class AddEntryExitPairPanelTest {
     public void testPanelActions() throws Exception {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         // Open the NX window
         AddEntryExitPairAction nxAction = new AddEntryExitPairAction("ENTRY EXIT", panels.get("Alpha"));  // NOI18N

--- a/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @Timeout(60)
 @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
-@DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
+//@DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
 public class LinkedWarrantTest {
 
     private OBlockManager _OBlockMgr;

--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -46,7 +46,7 @@ public class NXFrameTest {
 
     @Test
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
-    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
+//    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
     public void testRoutePanel() throws Exception {
         NXFrame nxFrame = new NXFrame();
         assertThat(nxFrame).withFailMessage("NXFrame").isNotNull();
@@ -71,7 +71,7 @@ public class NXFrameTest {
 
     @Test
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
-    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
+//    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
     public void testNXWarrantSetup() throws Exception {
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/NXWarrantTest.xml");
@@ -137,7 +137,7 @@ public class NXFrameTest {
     @Test
     @Timeout(60)
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
-    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
+//    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
     public void testNXWarrant() throws Exception {
         // The first part of this test duplicates testNXWarrantSetup().  It
         // then goes on to test a Warrant through the WarrantTableFrame.
@@ -259,7 +259,7 @@ public class NXFrameTest {
 
     @Test
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
-    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
+//    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
     public void testWarrantLoopRun() throws Exception {
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/NXWarrantTest.xml");
@@ -304,7 +304,7 @@ public class NXFrameTest {
 
     @Test
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
-    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
+//    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
     public void testWarrantRampHalt() throws Exception {
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/NXWarrantTest.xml");

--- a/java/test/jmri/jmrit/logix/PortalManagerTest.java
+++ b/java/test/jmri/jmrit/logix/PortalManagerTest.java
@@ -63,7 +63,7 @@ public class PortalManagerTest {
 
     @Test
     @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
-    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
+//    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
     public void testChangeNames() throws Exception {
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/ShortBlocksTest.xml");

--- a/java/test/jmri/jmrit/logix/TrackerTableActionTest.java
+++ b/java/test/jmri/jmrit/logix/TrackerTableActionTest.java
@@ -37,7 +37,7 @@ public class TrackerTableActionTest {
     @Test
     public void testTracking1() throws Exception {
         Assumptions.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assumptions.assumeFalse(Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
+//        Assumptions.assumeFalse(Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
         WarrantPreferences.getDefault().setShutdown(WarrantPreferences.Shutdown.NO_MERGE);
 
         // load and display
@@ -99,7 +99,7 @@ public class TrackerTableActionTest {
     @Test
     public void testTrackingDark() throws Exception {
         Assumptions.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assumptions.assumeFalse(Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
+//        Assumptions.assumeFalse(Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
         WarrantPreferences.getDefault().setShutdown(WarrantPreferences.Shutdown.NO_MERGE);
 
         // load and display
@@ -145,7 +145,7 @@ public class TrackerTableActionTest {
     @Test
     public void testMultipleTrackers() throws Exception {
         Assumptions.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assumptions.assumeFalse(Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
+//        Assumptions.assumeFalse(Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
         WarrantPreferences.getDefault().setShutdown(WarrantPreferences.Shutdown.NO_MERGE);
 
         // load and display

--- a/java/test/jmri/jmrit/logix/TrackerTest.java
+++ b/java/test/jmri/jmrit/logix/TrackerTest.java
@@ -51,7 +51,7 @@ public class TrackerTest {
     @Test
     public void testMultipleStartBlocks() throws Exception {
         Assumptions.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assumptions.assumeFalse(Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
+//        Assumptions.assumeFalse(Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"), "Ignoring intermittent test");
         WarrantPreferences.getDefault().setShutdown(WarrantPreferences.Shutdown.NO_MERGE);
 
         // load and display

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/CarSetFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/CarSetFrameTest.java
@@ -46,7 +46,7 @@ public class CarSetFrameTest extends OperationsTestCase {
 
     @Test
     public void testCarSetFrameSaveButton() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         JUnitOperationsUtil.initOperationsData();
 

--- a/java/test/jmri/jmrit/throttle/ThrottleFrameTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottleFrameTest.java
@@ -119,7 +119,7 @@ public class ThrottleFrameTest {
     @Test
     public void testStopButton() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         to.setAddressValue(new DccLocoAddress(42, false));
         to.setSpeedSlider(28);
@@ -135,7 +135,7 @@ public class ThrottleFrameTest {
     @Test
     public void testEStopButton() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         frame.setExtendedState(frame.getExtendedState() | java.awt.Frame.MAXIMIZED_BOTH);
         panel.toFront();

--- a/java/test/jmri/jmrix/AbstractMonPaneTestBase.java
+++ b/java/test/jmri/jmrix/AbstractMonPaneTestBase.java
@@ -99,7 +99,7 @@ public abstract class AbstractMonPaneTestBase extends jmri.util.swing.JmriPanelT
     @Test
     public void testFreezeButton() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         AbstractMonPaneScaffold s = new AbstractMonPaneScaffold(pane);
 
         // for Jemmy to work, we need the pane inside of a frame

--- a/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
@@ -35,7 +35,7 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
     
     @Test
     public void testIncomingFunctions() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
     
         // CbusThrottleManager cbtm = (CbusThrottleManager) tm;
         Assert.assertNotNull("exists",tm);
@@ -187,7 +187,7 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
     
     @Test
     public void testIncomingSpeedDirection() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         CbusThrottleManager cbtmb = (CbusThrottleManager) tm;
         Assert.assertNotNull("exists",cbtmb);
@@ -314,7 +314,7 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
 
     @Test
     public void testMessage() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         
         Assert.assertNotNull("exists",tm);
         DccLocoAddress addr = new DccLocoAddress(1234,true);

--- a/java/test/jmri/jmrix/loconet/LocoNetThrottledTransmitterTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetThrottledTransmitterTest.java
@@ -88,7 +88,7 @@ public class LocoNetThrottledTransmitterTest {
 
     @Test
     public void testSendOneNowOneLater() {
-        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+//        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         LocoNetInterfaceScaffold s = new LocoNetInterfaceScaffold(memo);
         LocoNetThrottledTransmitter q = new LocoNetThrottledTransmitter(s, false);
 

--- a/java/test/jmri/jmrix/roco/z21/simulator/Z21SimulatorAdapterTest.java
+++ b/java/test/jmri/jmrix/roco/z21/simulator/Z21SimulatorAdapterTest.java
@@ -35,7 +35,7 @@ public class Z21SimulatorAdapterTest {
      */
     @Test
     @Disabled("test is currently too unreliable in CI environments.  The class under test frequently fails to bind to the port")
-    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
+//    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
     public void testConnection() {
         // connect the port
         assertThatCode( () ->
@@ -98,7 +98,7 @@ public class Z21SimulatorAdapterTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
+//    @DisabledIfSystemProperty(named ="jmri.skipTestsRequiringSeparateRunning", matches ="true")
     public void Z21BroadCastFlagsReply() {
         cannedMessageCheck("getZ21BroadCastFlagsReply", "08 00 51 00 00 00 00 00");
     }


### PR DESCRIPTION
After we left Travis, no one of the tests marked with `jmri.skipTestsRequiringSeparateRunning` is executed. This PR reenables most of them.

There might be tests that we need to disable again, but it would be good if the majority of these tests could be executed.