### PR TITLE
Throttle can be null when bulk loading multiple trains during startup.

### DIFF
--- a/java/src/jmri/jmrit/dispatcher/AutoTrainsFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoTrainsFrame.java
@@ -495,7 +495,11 @@ public class AutoTrainsFrame extends jmri.util.JmriJFrame {
                 panel.setVisible(true);
                 ActiveTrain at = aat.getActiveTrain();
                 JLabel tName = _trainLabels.get(i);
-                updateStatusLabel(_throttleStatus.get(i),_throttles.get(i).getSpeedSetting(),_throttles.get(i).getIsForward());
+                if (_throttles.get(i) != null) {
+                    updateStatusLabel(_throttleStatus.get(i),_throttles.get(i).getSpeedSetting(),_throttles.get(i).getIsForward());
+                } else {
+                    updateStatusLabel(_throttleStatus.get(i), 0.0f, true);
+                }
                 tName.setText(at.getTrainName());
                 JButton stopButton = _stopButtons.get(i);
                 if (at.getStatus() == ActiveTrain.STOPPED) {


### PR DESCRIPTION
When bulk loading auto trains the throttles arrive slower than the load, so the throttle can be null.