### PR TITLE
jmri.util.swing.ToggleOrPressButtonModel inherits from new class for 8v311 compatibility

### DIFF
--- a/java/src/jmri/jmrit/throttle/FunctionButton.java
+++ b/java/src/jmri/jmrit/throttle/FunctionButton.java
@@ -14,7 +14,7 @@ import javax.swing.*;
 import jmri.Throttle;
 import jmri.util.FileUtil;
 import jmri.util.swing.ResizableImagePanel;
-import jmri.util.swing.ToggleOrPressButtonModel;
+import jmri.util.com.sun.ToggleOrPressButtonModel;
 
 import org.jdom2.Element;
 import org.slf4j.Logger;
@@ -48,15 +48,15 @@ public class FunctionButton extends JToggleButton {
     private FunctionButtonPropertyEditor editor ;
     private String iconPath;
     private String selectedIconPath;
-    private String dropFolder;    
+    private String dropFolder;
     private ToggleOrPressButtonModel _model;
     private Throttle _throttle;
     private int img_size = DEFAULT_IMG_SIZE;
 
-    private final static int BUT_HGHT = 24;    
+    private final static int BUT_HGHT = 24;
     private final static int BUT_MAX_WDTH = 256;
     private final static int BUT_MIN_WDTH = 100;
-    
+
     public final static int DEFAULT_FONT_SIZE = 12;
     public final static int DEFAULT_IMG_SIZE = 48;
 
@@ -75,7 +75,7 @@ public class FunctionButton extends JToggleButton {
     public static int getButtonWidth() {
         return BUT_MIN_WDTH;
     }
-    
+
     /**
      * Get the Image Button Width.
      * @return width.
@@ -91,7 +91,7 @@ public class FunctionButton extends JToggleButton {
     public void setButtonImageSize(int is) {
         img_size = is;
     }
-    
+
     /**
      * Construct the FunctionButton.
      */
@@ -100,10 +100,10 @@ public class FunctionButton extends JToggleButton {
         listeners = new ArrayList<>();
         initGUI();
     }
-    
-    private void initGUI(){      
+
+    private void initGUI(){
         _model = new ToggleOrPressButtonModel(this, true);
-        setModel(_model);       
+        setModel(_model);
         //Add listener to components that can bring up popupMenu menus.
         addMouseListener(new PopupListener());
         setFont(new Font("Monospaced", Font.PLAIN, DEFAULT_FONT_SIZE));
@@ -135,7 +135,7 @@ public class FunctionButton extends JToggleButton {
      * Does not send update to layout, just updates button status.
      * <p>
      * To update AND send to layout use setSelected(boolean).
-     * 
+     *
      * @param isOn True if the function should be active.
      */
     public void setState(boolean isOn) {
@@ -155,7 +155,7 @@ public class FunctionButton extends JToggleButton {
     /**
      * Set the locking state of the button.
      * <p>
-     * Changes in this parameter are only be sent to the 
+     * Changes in this parameter are only be sent to the
      * listeners if the dirty bit is set.
      *
      * @param isLockable True if the a clicking and releasing the button changes
@@ -234,7 +234,7 @@ public class FunctionButton extends JToggleButton {
     public void setButtonLabel(String label) {
         buttonLabel = label;
     }
-    
+
     /**
      * Set Button Text.
      * {@inheritDoc}
@@ -280,27 +280,27 @@ public class FunctionButton extends JToggleButton {
             if (getButtonLabel() != null) {
                 int butWidth = getFontMetrics(getFont()).stringWidth(getButtonLabel()) + 64; // pad out the width a bit
                 butWidth = Math.min(butWidth, FunctionButton.BUT_MAX_WDTH );
-                butWidth = Math.max(butWidth, FunctionButton.BUT_MIN_WDTH );                
+                butWidth = Math.max(butWidth, FunctionButton.BUT_MIN_WDTH );
                 setPreferredSize(new Dimension( butWidth, FunctionButton.BUT_HGHT));
             } else {
                 setPreferredSize(new Dimension(BUT_MIN_WDTH, BUT_HGHT));
             }
         }
-    }    
+    }
 
     /**
      * Change the state of the function.
      * Sets internal state, setSelected, and sends to listeners.
      *
      * @param newState The new state. True = Is on, False = Is off.
-     * @deprecated since 4.19.6; use 
+     * @deprecated since 4.19.6; use
      * {@link jmri.jmrit.throttle.FunctionButton#setSelected(boolean) } instead
      */
     @Deprecated
     public void changeState(boolean newState) {
         setSelected(newState);
     }
-    
+
     /**
      * Change the state of the function.
      * Sets internal state, setSelected, and sends to listeners.
@@ -323,7 +323,7 @@ public class FunctionButton extends JToggleButton {
      *
      * @param l The FunctionListener that wants notifications via the
      *          FunctionListener.notifyFunctionStateChanged.
-     * @deprecated since 4.19.6; use 
+     * @deprecated since 4.19.6; use
      * {@link jmri.jmrit.throttle.FunctionButton#addFunctionListener(jmri.jmrit.throttle.FunctionListener) } instead
      */
     @Deprecated
@@ -351,14 +351,14 @@ public class FunctionButton extends JToggleButton {
     public void removeFunctionListener(FunctionListener l) {
         listeners.remove(l);
     }
-    
+
     /**
      * Set the folder where droped images in function button property panel will be stored
-     * 
+     *
      * @param df the folder path
      */
     void setDropFolder(String df) {
-        dropFolder = df;        
+        dropFolder = df;
     }
 
     /**
@@ -375,7 +375,7 @@ public class FunctionButton extends JToggleButton {
         public void mouseClicked(MouseEvent e) {
             checkTrigger(e);
         }
-        
+
         /**
          * If the event is the popupMenu trigger, which is dependent on the platform, present the popupMenu menu.
          * @param e The MouseEvent causing the action.
@@ -393,7 +393,7 @@ public class FunctionButton extends JToggleButton {
         public void mouseReleased(MouseEvent e) {
             checkTrigger( e);
         }
-        
+
         private void checkTrigger( MouseEvent e) {
             if (e.isPopupTrigger() && e.getComponent().isEnabled() ) {
                 initPopupMenu();
@@ -401,24 +401,24 @@ public class FunctionButton extends JToggleButton {
             }
         }
     }
-        
+
     private void initPopupMenu() {
         if (popupMenu == null) {
             JMenuItem propertiesItem = new JMenuItem(Bundle.getMessage("MenuItemProperties"));
             propertiesItem.addActionListener((ActionEvent e) -> {
                 if (editor == null) {
-                    editor = new FunctionButtonPropertyEditor(this);            
+                    editor = new FunctionButtonPropertyEditor(this);
                 }
                 editor.resetProperties();
                 editor.setLocation(MouseInfo.getPointerInfo().getLocation());
                 editor.setVisible(true);
-                editor.setDropFolder(dropFolder);                
+                editor.setDropFolder(dropFolder);
             });
             popupMenu = new JPopupMenu();
             popupMenu.add(propertiesItem);
         }
     }
-    
+
     /**
      * Collect the prefs of this object into XML Element.
      * <ul>
@@ -584,15 +584,15 @@ public class FunctionButton extends JToggleButton {
     public boolean isSelectedImageOK() {
         return isSelectedImageOK;
     }
-    
-    /** 
+
+    /**
      * Set Throttle.
      * @param throttle the throttle that this button is associated with.
      */
     protected void setThrottle( Throttle throttle) {
         _throttle = throttle;
     }
-    
+
     /**
      * Get Throttle for this button.
      * @return throttle associated with this button.  May be null if no throttle currently associated.

--- a/java/src/jmri/util/com/sun/README
+++ b/java/src/jmri/util/com/sun/README
@@ -1,4 +1,0 @@
-This directory contains sample and tutorial code from Sun.
-
-See the comments at the top of each file for source and Sun's 
-licensing terms

--- a/java/src/jmri/util/com/sun/ToggleOrPressButtonModel.java
+++ b/java/src/jmri/util/com/sun/ToggleOrPressButtonModel.java
@@ -1,4 +1,4 @@
-package jmri.util.swing;
+package jmri.util.com.sun;
 
 import java.awt.event.ActionEvent;
 import javax.swing.DefaultButtonModel;

--- a/java/src/jmri/util/com/sun/package-info.java
+++ b/java/src/jmri/util/com/sun/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * This directory contains sample and tutorial code from Sun.
+ * <p>
+ * See the comments at the top of each file for source and Sun's
+ * licensing terms.
+ * <p>
+ * We separately package this code
+ * <ol>
+ * <li>to make clear where the code comes from, and
+ * <li>to highlight that because this has been copied from Java code, it might be
+ *     quite brittle against changes from one Java version to another.
+ * </ol>
+ */
+// include empty DefaultAnnotation to avoid excessive recompilation
+@edu.umd.cs.findbugs.annotations.DefaultAnnotation(value={})
+package jmri.util.com.sun;

--- a/java/test/jmri/util/com/sun/ToggleOrPressButtonModelTest.java
+++ b/java/test/jmri/util/com/sun/ToggleOrPressButtonModelTest.java
@@ -1,4 +1,4 @@
-package jmri.util.swing;
+package jmri.util.com.sun;
 
 import jmri.util.JUnitUtil;
 
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.*;
  * @author Steve Young Copyright (C) 2020
  */
 public class ToggleOrPressButtonModelTest {
-    
+
     @Test
     public void testCTor() {
         ToggleOrPressButtonModel t = new ToggleOrPressButtonModel(null,true);


### PR DESCRIPTION
This (small) change prevents the exception that's appeared in Throttle function-button operations with Java 8 311.

`jmri.util.swing.ToggleOrPressButtonModel` was previously copied and modified from the source of `javax.swing.JToggleButton`.  It's not clear to me what the changes are, so it's not clear to me that the rest of the class is correct with more recent Java's (the copy-and-modify is a couple years old) Java versions.  

Also includes:
 - move `jmri.util.swing.ToggleOrPressButtonModel` to `jmri.util.com.sun.ToggleOrPressButtonModel` so that it's clear this is copied code
 -  replaced `README` with `package-info` in `jmri.util.com.sun`

I can only test this with simulator now.  Would appreciate people testing it with live hardware under both Java 8v311 and earlier Java versions.