### PR TITLE
Update warning re Java 8/311

### DIFF
--- a/help/en/html/setup/index.shtml
+++ b/help/en/html/setup/index.shtml
@@ -73,8 +73,9 @@
         
       </ul>
 
-      <p class="noted"><span class="since"><strong>Since JMRI 4.24</strong></span><strong>NOTE RE Java 8 Version 311:  DO NOT INSTALL THIS VERSION.</strong>  
-      Errors have been reported which can be fixed by reverting to version 301 or upgrading to Java 11. [As of 20 October 2021]</p>
+      <p class="noted"><span class="since"><strong>ALL JMRI VERSIONS</strong></span><strong>NOTE re Java 8 Version 311:  DO NOT INSTALL THIS VERSION.</strong>  
+      Errors have been reported which can be fixed by reverting to <a href="https://www.oracle.com/java/technologies/javase/javase8u211-later-archive-downloads.html"
+	    target="_blank">version 301 </a> or upgrading to Java 11. [As of 20 October 2021]</p>
       
       <p>As of JMRI 4.20, JMRI is only fully supported when running on the most current update
       possible to the two most recent Java Long Term Support (LTS) releases (8 or 11 as of July


### PR DESCRIPTION
For all versions of JMRI.
Add link to Java 8/301.