### PR TITLE
Don't throw exception if message is empty

### DIFF
--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -452,7 +452,8 @@ public abstract class AbstractManager<E extends NamedBean> extends VetoableChang
                     message.append(e.getMessage()).append("<hr>"); // NOI18N
                 }
             }
-            throw new PropertyVetoException(message.toString(), evt);
+            String msg = message.toString();
+            if (!msg.isEmpty()) throw new PropertyVetoException(msg, evt);
         } else {
             try {
                 vetoableChangeSupport.fireVetoableChange(evt);


### PR DESCRIPTION
While working on a test for LogixNG, I discovered that these two lines throws a PropertyVetoException despite no one is using this LogixNG. It turns out that `AbstractManager.fireVetoableChange()` always throws a PropertyVetoException even if there are no listeners registered.

```
LogixNG logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("IQ1", "Some name");
logixNG_Manager.deleteBean(logixNG, "CanDelete");
```
