### PR TITLE
LogixNG managers deleteBean() should delete children

### DIFF
--- a/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractLogixNGTableAction.java
@@ -1,13 +1,13 @@
 package jmri.jmrit.beantable;
 
-import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.Font;
+import java.awt.*;
 import java.awt.event.*;
+import java.beans.PropertyVetoException;
 import java.io.File;
 import java.io.IOException;
+import java.text.MessageFormat;
 import java.util.*;
+import java.util.List;
 
 import javax.annotation.Nonnull;
 import javax.swing.*;
@@ -89,6 +89,10 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
     protected abstract String getAddTitleKey();
 
     protected abstract String getCreateButtonHintKey();
+
+    protected abstract void getListenerRefsIncludingChildren(E t, List<String> list);
+
+    protected abstract boolean hasChildren(E t);
 
     // ------------ Methods for LogixNG Table Window ------------
 
@@ -819,30 +823,83 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
         final E x = getManager().getBySystemName(sName);
         final jmri.UserPreferencesManager p;
         p = jmri.InstanceManager.getNullableDefault(jmri.UserPreferencesManager.class);
-        if (p != null && p.getMultipleChoiceOption(getClassName(), "delete") == 0x02) {     // NOI18N
-            if (x != null) {
-                deleteBean(x);
+        
+        if (x == null) return;  // This should never happen
+
+        StringBuilder message = new StringBuilder();
+        try {
+            getManager().deleteBean(x, "CanDelete");  // NOI18N
+        } catch (PropertyVetoException e) {
+            if (e.getPropertyChangeEvent().getPropertyName().equals("DoNotDelete")) { // NOI18N
+                log.warn(e.getMessage());
+                message.append(Bundle.getMessage("VetoDeleteBean", x.getBeanType(), x.getDisplayName(NamedBean.DisplayOptions.USERNAME_SYSTEMNAME), e.getMessage()));
+                JOptionPane.showMessageDialog(null, message.toString(),
+                        Bundle.getMessage("QuestionTitle"),
+                        JOptionPane.ERROR_MESSAGE);
+                return;
             }
+            message.append(e.getMessage());
+        }
+        List<String> listenerRefs = new ArrayList<>();
+        getListenerRefsIncludingChildren(x, listenerRefs);
+        int listenerRefsCount = listenerRefs.size();
+        log.debug("Delete with {}", listenerRefsCount);
+        if (p != null && p.getMultipleChoiceOption(getClassName(), "delete") == 0x02 && message.toString().isEmpty()) {
+            deleteBean(x);
         } else {
             final JDialog dialog = new JDialog();
-            String msg;
-            dialog.setTitle(Bundle.getMessage("QuestionTitle"));     // NOI18N
-            dialog.setLocationRelativeTo(null);
-            dialog.setDefaultCloseOperation(javax.swing.JFrame.DISPOSE_ON_CLOSE);
+            dialog.setTitle(Bundle.getMessage("QuestionTitle"));
+            dialog.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
             JPanel container = new JPanel();
             container.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
             container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
-            msg = Bundle.getMessage("ConfirmLogixDelete", sName);    // NOI18N
-            JLabel question = new JLabel(msg);
-            question.setAlignmentX(Component.CENTER_ALIGNMENT);
-            container.add(question);
 
-            final JCheckBox remember = new JCheckBox(Bundle.getMessage("MessageRememberSetting"));  // NOI18N
+            if (listenerRefsCount > 0) { // warn of listeners attached before delete
+                String prompt = hasChildren(x)
+                        ? "DeleteWithChildrenPrompt" : "DeletePrompt";
+                JLabel question = new JLabel(Bundle.getMessage(prompt, x.getDisplayName(NamedBean.DisplayOptions.USERNAME_SYSTEMNAME)));
+                question.setAlignmentX(Component.CENTER_ALIGNMENT);
+                container.add(question);
+
+                ArrayList<String> listeners = new ArrayList<>();
+                for (String listenerRef : listenerRefs) {
+                    if (!listeners.contains(listenerRef)) {
+                        listeners.add(listenerRef);
+                    }
+                }
+
+                message.append("<br>");
+                message.append(Bundle.getMessage("ReminderInUse", listenerRefsCount));
+                message.append("<ul>");
+                for (String listener : listeners) {
+                    message.append("<li>");
+                    message.append(listener);
+                    message.append("</li>");
+                }
+                message.append("</ul>");
+
+                JEditorPane pane = new JEditorPane();
+                pane.setContentType("text/html");
+                pane.setText("<html>" + message.toString() + "</html>");
+                pane.setEditable(false);
+                JScrollPane jScrollPane = new JScrollPane(pane);
+                container.add(jScrollPane);
+            } else {
+                String prompt = hasChildren(x)
+                        ? "DeleteWithChildrenPrompt" : "DeletePrompt";
+                String msg = MessageFormat.format(
+                        Bundle.getMessage(prompt), x.getSystemName());
+                JLabel question = new JLabel(msg);
+                question.setAlignmentX(Component.CENTER_ALIGNMENT);
+                container.add(question);
+            }
+
+            final JCheckBox remember = new JCheckBox(Bundle.getMessage("MessageRememberSetting"));
             remember.setFont(remember.getFont().deriveFont(10f));
             remember.setAlignmentX(Component.CENTER_ALIGNMENT);
 
-            JButton yesButton = new JButton(Bundle.getMessage("ButtonYes"));    // NOI18N
-            JButton noButton = new JButton(Bundle.getMessage("ButtonNo"));      // NOI18N
+            JButton yesButton = new JButton(Bundle.getMessage("ButtonYes"));
+            JButton noButton = new JButton(Bundle.getMessage("ButtonNo"));
             JPanel button = new JPanel();
             button.setAlignmentX(Component.CENTER_ALIGNMENT);
             button.add(yesButton);
@@ -850,21 +907,16 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
             container.add(button);
 
             noButton.addActionListener((ActionEvent e) -> {
-                //there is no point in remebering this the user will never be
+                //there is no point in remembering this the user will never be
                 //able to delete a bean!
-                /*if(remember.isSelected()){
-                setDisplayDeleteMsg(0x01);
-                }*/
                 dialog.dispose();
             });
 
             yesButton.addActionListener((ActionEvent e) -> {
-                if (p != null && remember.isSelected()) {
+                if (remember.isSelected() && p != null) {
                     p.setMultipleChoiceOption(getClassName(), "delete", 0x02);  // NOI18N
                 }
-                if (x != null) {
-                    deleteBean(x);
-                }
+                deleteBean(x);
                 dialog.dispose();
             });
             container.add(remember);
@@ -872,13 +924,20 @@ public abstract class AbstractLogixNGTableAction<E extends NamedBean> extends Ab
             container.setAlignmentY(Component.CENTER_ALIGNMENT);
             dialog.getContentPane().add(container);
             dialog.pack();
+
+            dialog.getRootPane().setDefaultButton(noButton);
+            noButton.requestFocusInWindow(); // set default keyboard focus, after pack() before setVisible(true)
+            dialog.getRootPane().registerKeyboardAction(e -> { // escape to exit
+                    dialog.setVisible(false);
+                    dialog.dispose(); }, 
+                KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), JComponent.WHEN_IN_FOCUSED_WINDOW);
+
+            dialog.setLocation((Toolkit.getDefaultToolkit().getScreenSize().width) / 2 - dialog.getWidth() / 2, (Toolkit.getDefaultToolkit().getScreenSize().height) / 2 - dialog.getHeight() / 2);
             dialog.setModal(true);
             dialog.setVisible(true);
         }
-
-        f.setVisible(true);
     }
-
+    
     @Override
     public String getClassDescription() {
         return Bundle.getMessage("TitleLogixNGTable");        // NOI18N

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -237,6 +237,7 @@ LightWarn12                          = Error: ON and OFF times should be unique 
 
 ReminderInUse                        = It is in use by {0} other objects including.
 DeletePrompt                         = Are you sure you want to delete {0}?
+DeleteWithChildrenPrompt             = Are you sure you want to delete {0} and its children?
 #WarningUserName = User Name "{0}" has already been used. > moved to jmrit.Bundle
 WarningUserNameAsSystem              = User Name "{0}" has already been used as a System Name.
 WarningSystemNameAsUser              = System Name "{0}" has already been used as a User Name.

--- a/java/src/jmri/jmrit/beantable/LogixNGModuleTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGModuleTableAction.java
@@ -248,6 +248,16 @@ public class LogixNGModuleTableAction extends AbstractLogixNGTableAction<jmri.jm
         return panel5;
     }
 
+    @Override
+    protected void getListenerRefsIncludingChildren(Module module, java.util.List<String> list) {
+        module.getListenerRefsIncludingChildren(list);
+    }
+
+    @Override
+    protected boolean hasChildren(Module module) {
+        return module.getRootSocket().isConnected();
+    }
+
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNGModuleTableAction.class);
 
 }

--- a/java/src/jmri/jmrit/beantable/LogixNGModuleTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGModuleTableAction.java
@@ -1,29 +1,18 @@
 package jmri.jmrit.beantable;
 
-import java.awt.BorderLayout;
-import java.awt.Component;
 import java.awt.Container;
 import java.awt.FlowLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
-import java.awt.event.KeyEvent;
-import java.io.File;
-import java.io.IOException;
+import java.beans.PropertyVetoException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.*;
 
 import javax.swing.*;
-import javax.swing.table.TableColumn;
 
 import jmri.InstanceManager;
 import jmri.Manager;
-import jmri.UserPreferencesManager;
-import jmri.util.FileUtil;
 import jmri.util.JmriJFrame;
-
 
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.Module;
@@ -125,7 +114,12 @@ public class LogixNGModuleTableAction extends AbstractLogixNGTableAction<jmri.jm
 
     @Override
     protected void deleteBean(Module bean) {
-        InstanceManager.getDefault(ModuleManager.class).deleteModule(bean);
+        try {
+            InstanceManager.getDefault(ModuleManager.class).deleteBean(bean, "DoDelete");
+        } catch (PropertyVetoException e) {
+            //At this stage the DoDelete shouldn't fail, as we have already done a can delete, which would trigger a veto
+            log.error(e.getMessage());
+        }
     }
 
     @Override
@@ -253,5 +247,7 @@ public class LogixNGModuleTableAction extends AbstractLogixNGTableAction<jmri.jm
         });
         return panel5;
     }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNGModuleTableAction.class);
 
 }

--- a/java/src/jmri/jmrit/beantable/LogixNGTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableAction.java
@@ -217,6 +217,16 @@ public class LogixNGTableAction extends AbstractLogixNGTableAction<LogixNG> {
         return panel5;
     }
 
+    @Override
+    protected void getListenerRefsIncludingChildren(LogixNG logixNG, java.util.List<String> list) {
+        logixNG.getListenerRefsIncludingChildren(list);
+    }
+
+    @Override
+    protected boolean hasChildren(LogixNG logixNG) {
+        return logixNG.getNumConditionalNGs() > 0;
+    }
+
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNGTableAction.class);
 
 }

--- a/java/src/jmri/jmrit/beantable/LogixNGTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableAction.java
@@ -3,6 +3,7 @@ package jmri.jmrit.beantable;
 import java.awt.Container;
 import java.awt.FlowLayout;
 import java.awt.event.ItemEvent;
+import java.beans.PropertyVetoException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
@@ -13,7 +14,6 @@ import jmri.Manager;
 import jmri.util.JmriJFrame;
 
 
-import jmri.jmrit.logixng.Base;
 import jmri.jmrit.logixng.LogixNG;
 import jmri.jmrit.logixng.LogixNG_Manager;
 import jmri.jmrit.logixng.tools.swing.AbstractLogixNGEditor;
@@ -105,7 +105,12 @@ public class LogixNGTableAction extends AbstractLogixNGTableAction<LogixNG> {
     @Override
     public void deleteBean(LogixNG logixNG) {
         logixNG.setEnabled(false);
-        InstanceManager.getDefault(LogixNG_Manager.class).deleteLogixNG(logixNG);
+        try {
+            InstanceManager.getDefault(LogixNG_Manager.class).deleteBean(logixNG, "DoDelete");
+        } catch (PropertyVetoException e) {
+            //At this stage the DoDelete shouldn't fail, as we have already done a can delete, which would trigger a veto
+            log.error(e.getMessage());
+        }
     }
 
     @Override
@@ -211,5 +216,7 @@ public class LogixNGTableAction extends AbstractLogixNGTableAction<LogixNG> {
         });
         return panel5;
     }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNGTableAction.class);
 
 }

--- a/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
@@ -5,18 +5,16 @@ import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
+import java.beans.PropertyVetoException;
 
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
-import javax.swing.table.TableColumn;
 
 import jmri.InstanceManager;
 import jmri.Manager;
 import jmri.util.FileUtil;
 import jmri.util.JmriJFrame;
-
 
 import jmri.jmrit.logixng.NamedTable;
 import jmri.jmrit.logixng.NamedTableManager;
@@ -129,7 +127,12 @@ public class LogixNGTableTableAction extends AbstractLogixNGTableAction<NamedTab
 
     @Override
     protected void deleteBean(NamedTable bean) {
-        InstanceManager.getDefault(NamedTableManager.class).deleteNamedTable(bean);
+        try {
+            InstanceManager.getDefault(NamedTableManager.class).deleteBean(bean, "DoDelete");
+        } catch (PropertyVetoException e) {
+            //At this stage the DoDelete shouldn't fail, as we have already done a can delete, which would trigger a veto
+            log.error(e.getMessage());
+        }
     }
 
     @Override

--- a/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableTableAction.java
@@ -7,6 +7,7 @@ import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
 import java.beans.PropertyVetoException;
+import java.util.List;
 
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -339,6 +340,17 @@ public class LogixNGTableTableAction extends AbstractLogixNGTableAction<NamedTab
             autoSystemName();
         });
         return panel5;
+    }
+
+    @Override
+    protected void getListenerRefsIncludingChildren(NamedTable table, java.util.List<String> list) {
+        // Do nothing
+    }
+
+    @Override
+    protected boolean hasChildren(NamedTable table) {
+        // Tables doesn't have children
+        return false;
     }
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LogixNGTableTableAction.class);

--- a/java/src/jmri/jmrit/logixng/Base.java
+++ b/java/src/jmri/jmrit/logixng/Base.java
@@ -519,6 +519,15 @@ public interface Base extends PropertyChangeProvider {
     public ArrayList<String> getListenerRefs();
 
     /**
+     * Returns a list of all the listeners references for this object
+     * and all its children.
+     *
+     * @param list a list of textual references
+     */
+    @CheckReturnValue
+    public void getListenerRefsIncludingChildren(List<String> list);
+
+    /**
      * Number of current listeners. May return -1 if the information is not
      * available for some reason.
      *

--- a/java/src/jmri/jmrit/logixng/FemaleSocketManager.java
+++ b/java/src/jmri/jmrit/logixng/FemaleSocketManager.java
@@ -2,9 +2,6 @@ package jmri.jmrit.logixng;
 
 import java.util.Map;
 
-import jmri.Manager;
-import jmri.NamedBean;
-
 /**
  * Manager for FemaleSockets
  * 

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractBase.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractBase.java
@@ -1,9 +1,7 @@
 package jmri.jmrit.logixng.implementation;
 
 import java.io.PrintWriter;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -253,6 +251,15 @@ public abstract class AbstractBase
             RuntimeException e = new RuntimeException(method + " must not be called when listeners are registered");
             log.error(method + " must not be called when listeners are registered", e);
             throw e;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void getListenerRefsIncludingChildren(List<String> list) {
+        list.addAll(getListenerRefs());
+        for (int i=0; i < getChildCount(); i++) {
+            getChild(i).getListenerRefsIncludingChildren(list);
         }
     }
 

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractBaseManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractBaseManager.java
@@ -58,9 +58,24 @@ public abstract class AbstractBaseManager<E extends NamedBean> extends AbstractM
     
     /** {@inheritDoc} */
     @Override
+//    @OverridingMethodsMustInvokeSuper
+    public final void deleteBean(@Nonnull E n, @Nonnull String property) throws PropertyVetoException {
+        this.deleteBean((MaleSocket)n, property);
+    }
+    
+    /** {@inheritDoc} */
+    @Override
     @OverridingMethodsMustInvokeSuper
-    @SuppressWarnings("unchecked")  // cast in "deregister((E)socket)" is nessesary and cannot be avoided
+//    @SuppressWarnings("unchecked")  // cast in "deregister((E)socket)" is nessesary and cannot be avoided
     public void deleteBean(@Nonnull MaleSocket socket, @Nonnull String property) throws PropertyVetoException {
+        for (int i=0; i < socket.getChildCount(); i++) {
+            FemaleSocket child = socket.getChild(i);
+            if (child.isConnected()) {
+                MaleSocket maleSocket = child.getConnectedSocket();
+                maleSocket.getManager().deleteBean(maleSocket, property);
+            }
+        }
+        
         // throws PropertyVetoException if vetoed
         fireVetoableChange(property, socket);
         if (property.equals("DoDelete")) { // NOI18N

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractFemaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractFemaleSocket.java
@@ -488,9 +488,8 @@ public abstract class AbstractFemaleSocket implements FemaleSocket {
     /** {@inheritDoc} */
     @Override
     public void getListenerRefsIncludingChildren(List<String> list) {
-        list.addAll(getListenerRefs());
-        for (int i=0; i < getChildCount(); i++) {
-            getChild(i).getListenerRefsIncludingChildren(list);
+        if (isConnected()) {
+            getConnectedSocket().getListenerRefsIncludingChildren(list);
         }
     }
 

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractFemaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractFemaleSocket.java
@@ -485,6 +485,15 @@ public abstract class AbstractFemaleSocket implements FemaleSocket {
         throw new UnsupportedOperationException("Not supported");
     }
 
-   private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractFemaleSocket.class);
+    /** {@inheritDoc} */
+    @Override
+    public void getListenerRefsIncludingChildren(List<String> list) {
+        list.addAll(getListenerRefs());
+        for (int i=0; i < getChildCount(); i++) {
+            getChild(i).getListenerRefsIncludingChildren(list);
+        }
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractFemaleSocket.class);
 
 }

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
@@ -722,5 +722,11 @@ public abstract class AbstractMaleSocket implements MaleSocket {
         }
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return getObject().toString();
+    }
+
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractMaleSocket.class);
 }

--- a/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
+++ b/java/src/jmri/jmrit/logixng/implementation/AbstractMaleSocket.java
@@ -724,6 +724,15 @@ public abstract class AbstractMaleSocket implements MaleSocket {
 
     /** {@inheritDoc} */
     @Override
+    public void getListenerRefsIncludingChildren(List<String> list) {
+        list.addAll(getListenerRefs());
+        for (int i=0; i < getChildCount(); i++) {
+            getChild(i).getListenerRefsIncludingChildren(list);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public String toString() {
         return getObject().toString();
     }

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNG.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.logixng.implementation;
 
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 import static jmri.NamedBean.UNKNOWN;
 
@@ -11,6 +10,7 @@ import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.Manager;
 import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.Stack;
 import jmri.jmrit.logixng.util.LogixNG_Thread;
 import jmri.util.*;
 

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultConditionalNGManager.java
@@ -1,5 +1,10 @@
 package jmri.jmrit.logixng.implementation;
 
+import java.beans.*;
+
+import javax.annotation.Nonnull;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
+
 import jmri.InstanceManager;
 import jmri.InvokeOnGuiThread;
 import jmri.jmrit.logixng.*;
@@ -213,6 +218,52 @@ public class DefaultConditionalNGManager extends AbstractManager<ConditionalNG>
         return ConditionalNG.class;
     }
 
-
+    /**
+     * Inform all registered listeners of a vetoable change.If the propertyName
+     * is "CanDelete" ALL listeners with an interest in the bean will throw an
+     * exception, which is recorded returned back to the invoking method, so
+     * that it can be presented back to the user.However if a listener decides
+     * that the bean can not be deleted then it should throw an exception with
+     * a property name of "DoNotDelete", this is thrown back up to the user and
+     * the delete process should be aborted.
+     *
+     * @param p   The programmatic name of the property that is to be changed.
+     *            "CanDelete" will inquire with all listeners if the item can
+     *            be deleted. "DoDelete" tells the listener to delete the item.
+     * @param old The old value of the property.
+     * @throws java.beans.PropertyVetoException If the recipients wishes the
+     *                                          delete to be aborted (see above)
+     */
+    @OverridingMethodsMustInvokeSuper
+    public void fireVetoableChange(String p, Object old) throws PropertyVetoException {
+        PropertyChangeEvent evt = new PropertyChangeEvent(this, p, old, null);
+        for (VetoableChangeListener vc : vetoableChangeSupport.getVetoableChangeListeners()) {
+            vc.vetoableChange(evt);
+        }
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+//    @OverridingMethodsMustInvokeSuper
+    public final void deleteBean(@Nonnull ConditionalNG conditionalNG, @Nonnull String property) throws PropertyVetoException {
+        for (int i=0; i < conditionalNG.getChildCount(); i++) {
+            FemaleSocket child = conditionalNG.getChild(i);
+            if (child.isConnected()) {
+                MaleSocket maleSocket = child.getConnectedSocket();
+                maleSocket.getManager().deleteBean(maleSocket, property);
+            }
+        }
+        
+        // throws PropertyVetoException if vetoed
+        fireVetoableChange(property, conditionalNG);
+        if (property.equals("DoDelete")) { // NOI18N
+            if (conditionalNG.getLogixNG() != null) {
+                conditionalNG.getLogixNG().deleteConditionalNG(conditionalNG);
+            }
+            conditionalNG.dispose();
+        }
+    }
+    
+    
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultConditionalNGManager.class);
 }

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNG.java
@@ -253,7 +253,6 @@ public class DefaultLogixNG extends AbstractNamedBean
         }
         if (!found) {
             log.error("attempt to delete ConditionalNG not in LogixNG: {}", conditionalNG.getSystemName());  // NOI18N
-            return;
         }
     }
 
@@ -449,8 +448,8 @@ public class DefaultLogixNG extends AbstractNamedBean
     @Override
     public void getListenerRefsIncludingChildren(List<String> list) {
         list.addAll(getListenerRefs());
-        for (int i=0; i < getChildCount(); i++) {
-            getChild(i).getListenerRefsIncludingChildren(list);
+        for (int i=0; i < getNumConditionalNGs(); i++) {
+            getConditionalNG(i).getListenerRefsIncludingChildren(list);
         }
     }
 

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNG.java
@@ -445,5 +445,14 @@ public class DefaultLogixNG extends AbstractNamedBean
     public void getUsageDetail(int level, NamedBean bean, List<jmri.NamedBeanUsageReport> report, NamedBean cdl) {
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public void getListenerRefsIncludingChildren(List<String> list) {
+        list.addAll(getListenerRefs());
+        for (int i=0; i < getChildCount(); i++) {
+            getChild(i).getListenerRefsIncludingChildren(list);
+        }
+    }
+
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultLogixNG.class);
 }

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
@@ -1,15 +1,18 @@
 package jmri.jmrit.logixng.implementation;
 
 import java.awt.GraphicsEnvironment;
+import java.beans.*;
 import java.io.PrintWriter;
 import java.util.*;
+
+import javax.annotation.Nonnull;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 import javax.swing.JOptionPane;
 
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.Base.PrintTreeSettings;
 import jmri.jmrit.logixng.Module;
-import jmri.jmrit.logixng.util.LogixNG_Thread;
 import jmri.managers.AbstractManager;
 import jmri.util.LoggingUtil;
 import jmri.util.ThreadingUtil;
@@ -376,6 +379,48 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
         return _managers.get(className);
     }
 
+    /**
+     * Inform all registered listeners of a vetoable change.If the propertyName
+     * is "CanDelete" ALL listeners with an interest in the bean will throw an
+     * exception, which is recorded returned back to the invoking method, so
+     * that it can be presented back to the user.However if a listener decides
+     * that the bean can not be deleted then it should throw an exception with
+     * a property name of "DoNotDelete", this is thrown back up to the user and
+     * the delete process should be aborted.
+     *
+     * @param p   The programmatic name of the property that is to be changed.
+     *            "CanDelete" will inquire with all listeners if the item can
+     *            be deleted. "DoDelete" tells the listener to delete the item.
+     * @param old The old value of the property.
+     * @throws java.beans.PropertyVetoException If the recipients wishes the
+     *                                          delete to be aborted (see above)
+     */
+    @OverridingMethodsMustInvokeSuper
+    public void fireVetoableChange(String p, Object old) throws PropertyVetoException {
+        PropertyChangeEvent evt = new PropertyChangeEvent(this, p, old, null);
+        for (VetoableChangeListener vc : vetoableChangeSupport.getVetoableChangeListeners()) {
+            vc.vetoableChange(evt);
+        }
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+//    @OverridingMethodsMustInvokeSuper
+    public final void deleteBean(@Nonnull LogixNG logixNG, @Nonnull String property) throws PropertyVetoException {
+        for (int i=0; i < logixNG.getNumConditionalNGs(); i++) {
+            ConditionalNG child = logixNG.getConditionalNG(i);
+            InstanceManager.getDefault(ConditionalNG_Manager.class).deleteBean(child, property);
+        }
+        
+        // throws PropertyVetoException if vetoed
+        fireVetoableChange(property, logixNG);
+        if (property.equals("DoDelete")) { // NOI18N
+            deregister(logixNG);
+            logixNG.dispose();
+        }
+    }
+    
+    
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultLogixNGManager.class);
 
 }

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultNamedTableManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultNamedTableManager.java
@@ -1,13 +1,13 @@
 package jmri.jmrit.logixng.implementation;
 
+import java.beans.*;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.text.DecimalFormat;
 import java.util.Locale;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import javax.annotation.*;
 
 import jmri.*;
 import jmri.jmrit.logixng.*;
@@ -271,6 +271,43 @@ public class DefaultNamedTableManager extends AbstractManager<NamedTable>
         return NamedTable.class;
     }
 
+    /**
+     * Inform all registered listeners of a vetoable change.If the propertyName
+     * is "CanDelete" ALL listeners with an interest in the bean will throw an
+     * exception, which is recorded returned back to the invoking method, so
+     * that it can be presented back to the user.However if a listener decides
+     * that the bean can not be deleted then it should throw an exception with
+     * a property name of "DoNotDelete", this is thrown back up to the user and
+     * the delete process should be aborted.
+     *
+     * @param p   The programmatic name of the property that is to be changed.
+     *            "CanDelete" will inquire with all listeners if the item can
+     *            be deleted. "DoDelete" tells the listener to delete the item.
+     * @param old The old value of the property.
+     * @throws java.beans.PropertyVetoException If the recipients wishes the
+     *                                          delete to be aborted (see above)
+     */
+    @OverridingMethodsMustInvokeSuper
+    public void fireVetoableChange(String p, Object old) throws PropertyVetoException {
+        PropertyChangeEvent evt = new PropertyChangeEvent(this, p, old, null);
+        for (VetoableChangeListener vc : vetoableChangeSupport.getVetoableChangeListeners()) {
+            vc.vetoableChange(evt);
+        }
+    }
+    
+    /** {@inheritDoc} */
+    @Override
+//    @OverridingMethodsMustInvokeSuper
+    public final void deleteBean(@Nonnull NamedTable namedTable, @Nonnull String property) throws PropertyVetoException {
+        // throws PropertyVetoException if vetoed
+        fireVetoableChange(property, namedTable);
+        if (property.equals("DoDelete")) { // NOI18N
+            deregister(namedTable);
+            namedTable.dispose();
+        }
+    }
+    
+    
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultNamedTableManager.class);
 
 }

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGEditor.java
@@ -1209,7 +1209,6 @@ public final class LogixNGEditor implements AbstractLogixNGEditor<LogixNG> {
 
         public void doDelete() {
             try {
-                _curLogixNG.deleteConditionalNG(_curLogixNG.getConditionalNG(_row));
                 InstanceManager.getDefault(ConditionalNG_Manager.class).deleteBean(_conditionalNG, "DoDelete");  // NOI18N
                 _conditionalNGTableModel.fireTableRowsDeleted(_row, _row);
                 _numConditionalNGs--;

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGEditor.java
@@ -1255,39 +1255,37 @@ public final class LogixNGEditor implements AbstractLogixNGEditor<LogixNG> {
                 JPanel container = new JPanel();
                 container.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
                 container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
-                if (listenerRefsCount > 0) { // warn of listeners attached before delete
 
+                if (listenerRefsCount > 0) { // warn of listeners attached before delete
                     String prompt = _conditionalNG.getFemaleSocket().isConnected()
                             ? "DeleteWithChildrenPrompt" : "DeletePrompt";
                     JLabel question = new JLabel(Bundle.getMessage(prompt, _conditionalNG.getDisplayName(NamedBean.DisplayOptions.USERNAME_SYSTEMNAME)));
                     question.setAlignmentX(Component.CENTER_ALIGNMENT);
                     container.add(question);
 
-                    if (listenerRefsCount > 0) {
-                        ArrayList<String> listeners = new ArrayList<>();
-                        for (String listenerRef : listenerRefs) {
-                            if (!listeners.contains(listenerRef)) {
-                                listeners.add(listenerRef);
-                            }
+                    ArrayList<String> listeners = new ArrayList<>();
+                    for (String listenerRef : listenerRefs) {
+                        if (!listeners.contains(listenerRef)) {
+                            listeners.add(listenerRef);
                         }
-
-                        message.append("<br>");
-                        message.append(Bundle.getMessage("ReminderInUse", listenerRefsCount));
-                        message.append("<ul>");
-                        for (String listener : listeners) {
-                            message.append("<li>");
-                            message.append(listener);
-                            message.append("</li>");
-                        }
-                        message.append("</ul>");
-
-                        JEditorPane pane = new JEditorPane();
-                        pane.setContentType("text/html");
-                        pane.setText("<html>" + message.toString() + "</html>");
-                        pane.setEditable(false);
-                        JScrollPane jScrollPane = new JScrollPane(pane);
-                        container.add(jScrollPane);
                     }
+
+                    message.append("<br>");
+                    message.append(Bundle.getMessage("ReminderInUse", listenerRefsCount));
+                    message.append("<ul>");
+                    for (String listener : listeners) {
+                        message.append("<li>");
+                        message.append(listener);
+                        message.append("</li>");
+                    }
+                    message.append("</ul>");
+
+                    JEditorPane pane = new JEditorPane();
+                    pane.setContentType("text/html");
+                    pane.setText("<html>" + message.toString() + "</html>");
+                    pane.setEditable(false);
+                    JScrollPane jScrollPane = new JScrollPane(pane);
+                    container.add(jScrollPane);
                 } else {
                     String prompt = _conditionalNG.getFemaleSocket().isConnected()
                             ? "DeleteWithChildrenPrompt" : "DeletePrompt";

--- a/java/src/jmri/jmrit/logixng/tools/swing/LogixNGEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/LogixNGEditor.java
@@ -3,6 +3,7 @@ package jmri.jmrit.logixng.tools.swing;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
+import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.text.MessageFormat;
@@ -22,7 +23,6 @@ import jmri.jmrit.beantable.BeanTableDataModel;
 import jmri.jmrit.beantable.BeanTableFrame;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.util.LogixNG_Thread;
-import jmri.swing.NamedBeanComboBox;
 import jmri.util.JmriJFrame;
 import jmri.util.table.ButtonEditor;
 import jmri.util.table.ButtonRenderer;
@@ -1192,13 +1192,11 @@ public final class LogixNGEditor implements AbstractLogixNGEditor<LogixNG> {
 
         private final ConditionalNG _conditionalNG;
         private final int _row;
-        MaleSocket _maleSocket;
         boolean _hasDeleted = false;
 
         public DeleteBeanWorker(ConditionalNG conditionalNG, int row) {
             _conditionalNG = conditionalNG;
             _row = row;
-            _maleSocket = _conditionalNG.getFemaleSocket().getConnectedSocket();
         }
 
         public int getDisplayDeleteMsg() {
@@ -1209,24 +1207,8 @@ public final class LogixNGEditor implements AbstractLogixNGEditor<LogixNG> {
             InstanceManager.getDefault(UserPreferencesManager.class).setMultipleChoiceOption(TreeEditor.class.getName(), "deleteInUse", boo);
         }
 
-        private void findAllChilds(FemaleSocket femaleSocket, List<Map.Entry<FemaleSocket, MaleSocket>> sockets) {
-            if (!femaleSocket.isConnected()) return;
-            MaleSocket maleSocket = femaleSocket.getConnectedSocket();
-            sockets.add(new HashMap.SimpleEntry<>(femaleSocket, maleSocket));
-            for (int i=0; i < maleSocket.getChildCount(); i++) {
-                findAllChilds(maleSocket.getChild(i), sockets);
-            }
-        }
-
-        public void doDelete(List<Map.Entry<FemaleSocket, MaleSocket>> sockets) {
+        public void doDelete() {
             try {
-                for (Map.Entry<FemaleSocket, MaleSocket> entry : sockets) {
-                    FemaleSocket femaleSocket = entry.getKey();
-                    femaleSocket.disconnect();
-
-                    MaleSocket maleSocket = entry.getValue();
-                    maleSocket.getManager().deleteBean(maleSocket, "DoDelete");
-                }
                 _curLogixNG.deleteConditionalNG(_curLogixNG.getConditionalNG(_row));
                 InstanceManager.getDefault(ConditionalNG_Manager.class).deleteBean(_conditionalNG, "DoDelete");  // NOI18N
                 _conditionalNGTableModel.fireTableRowsDeleted(_row, _row);
@@ -1246,65 +1228,55 @@ public final class LogixNGEditor implements AbstractLogixNGEditor<LogixNG> {
         public Void doInBackground() {
             _conditionalNG.getFemaleSocket().unregisterListeners();
 
-            List<Map.Entry<FemaleSocket, MaleSocket>> sockets = new ArrayList<>();
-
-            findAllChilds(_conditionalNG.getFemaleSocket(), sockets);
-
             StringBuilder message = new StringBuilder();
             try {
                 InstanceManager.getDefault(ConditionalNG_Manager.class).deleteBean(_conditionalNG, "CanDelete");  // NOI18N
-                for (Map.Entry<FemaleSocket, MaleSocket> entry : sockets) {
-                    entry.getValue().getManager().deleteBean(_maleSocket, "CanDelete");  // NOI18N
-                }
             } catch (PropertyVetoException e) {
                 if (e.getPropertyChangeEvent().getPropertyName().equals("DoNotDelete")) { // NOI18N
                     log.warn(e.getMessage());
-                    message.append(jmri.jmrit.logixng.tools.swing.Bundle.getMessage("VetoDeleteBean", ((NamedBean)_maleSocket.getObject()).getBeanType(), ((NamedBean)_maleSocket.getObject()).getDisplayName(NamedBean.DisplayOptions.USERNAME_SYSTEMNAME), e.getMessage()));
+                    message.append(Bundle.getMessage("VetoDeleteBean", _conditionalNG.getBeanType(), _conditionalNG.getDisplayName(NamedBean.DisplayOptions.USERNAME_SYSTEMNAME), e.getMessage()));
                     JOptionPane.showMessageDialog(null, message.toString(),
-                            jmri.jmrit.logixng.tools.swing.Bundle.getMessage("WarningTitle"),
+                            Bundle.getMessage("WarningTitle"),
                             JOptionPane.ERROR_MESSAGE);
                     return null;
                 }
                 message.append(e.getMessage());
             }
-            int count = _maleSocket == null ? 0 : _maleSocket.getListenerRefs().size();
-            log.debug("Delete with {}", count);
+            List<String> listenerRefs = new ArrayList<>();
+            _conditionalNG.getListenerRefsIncludingChildren(listenerRefs);
+            int listenerRefsCount = listenerRefs.size();
+            log.debug("Delete with {}", listenerRefsCount);
             if (getDisplayDeleteMsg() == 0x02 && message.toString().isEmpty()) {
-                doDelete(sockets);
+                doDelete();
             } else {
                 final JDialog dialog = new JDialog();
-                dialog.setTitle(jmri.jmrit.logixng.tools.swing.Bundle.getMessage("WarningTitle"));
+                dialog.setTitle(Bundle.getMessage("WarningTitle"));
                 dialog.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
                 JPanel container = new JPanel();
                 container.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
                 container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
-                if (count > 0) { // warn of listeners attached before delete
+                if (listenerRefsCount > 0) { // warn of listeners attached before delete
 
-                    String prompt = _maleSocket.getChildCount() > 0 ? "DeleteWithChildrenPrompt" : "DeletePrompt";
-                    JLabel question = new JLabel(jmri.jmrit.logixng.tools.swing.Bundle.getMessage(prompt, ((NamedBean)_maleSocket.getObject()).getDisplayName(NamedBean.DisplayOptions.USERNAME_SYSTEMNAME)));
+                    String prompt = _conditionalNG.getFemaleSocket().isConnected()
+                            ? "DeleteWithChildrenPrompt" : "DeletePrompt";
+                    JLabel question = new JLabel(Bundle.getMessage(prompt, _conditionalNG.getDisplayName(NamedBean.DisplayOptions.USERNAME_SYSTEMNAME)));
                     question.setAlignmentX(Component.CENTER_ALIGNMENT);
                     container.add(question);
 
-                    ArrayList<String> listenerRefs = new ArrayList<>();
-
-                    for (Map.Entry<FemaleSocket, MaleSocket> entry : sockets) {
-                        listenerRefs.addAll(entry.getValue().getListenerRefs());
-                    }
-
-                    if (listenerRefs.size() > 0) {
+                    if (listenerRefsCount > 0) {
                         ArrayList<String> listeners = new ArrayList<>();
-                        for (int i = 0; i < listenerRefs.size(); i++) {
-                            if (!listeners.contains(listenerRefs.get(i))) {
-                                listeners.add(listenerRefs.get(i));
+                        for (String listenerRef : listenerRefs) {
+                            if (!listeners.contains(listenerRef)) {
+                                listeners.add(listenerRef);
                             }
                         }
 
                         message.append("<br>");
-                        message.append(jmri.jmrit.logixng.tools.swing.Bundle.getMessage("ReminderInUse", count));
+                        message.append(Bundle.getMessage("ReminderInUse", listenerRefsCount));
                         message.append("<ul>");
-                        for (int i = 0; i < listeners.size(); i++) {
+                        for (String listener : listeners) {
                             message.append("<li>");
-                            message.append(listeners.get(i));
+                            message.append(listener);
                             message.append("</li>");
                         }
                         message.append("</ul>");
@@ -1317,27 +1289,21 @@ public final class LogixNGEditor implements AbstractLogixNGEditor<LogixNG> {
                         container.add(jScrollPane);
                     }
                 } else {
-                    String prompt;
-                    String msg;
-                    if (_maleSocket == null) {
-                        prompt = "DeletePrompt";
-                        msg = jmri.jmrit.logixng.tools.swing.Bundle.getMessage(prompt, _conditionalNG.getDisplayName());
-                    } else {
-                        prompt = _maleSocket.getChildCount() > 0 ? "DeleteWithChildrenPrompt" : "DeletePrompt";
-                        msg = MessageFormat.format(jmri.jmrit.logixng.tools.swing.Bundle.getMessage(prompt),
-                                new Object[]{_maleSocket.getSystemName()});
-                    }
+                    String prompt = _conditionalNG.getFemaleSocket().isConnected()
+                            ? "DeleteWithChildrenPrompt" : "DeletePrompt";
+                    String msg = MessageFormat.format(
+                            Bundle.getMessage(prompt), _conditionalNG.getSystemName());
                     JLabel question = new JLabel(msg);
                     question.setAlignmentX(Component.CENTER_ALIGNMENT);
                     container.add(question);
                 }
 
-                final JCheckBox remember = new JCheckBox(jmri.jmrit.logixng.tools.swing.Bundle.getMessage("MessageRememberSetting"));
+                final JCheckBox remember = new JCheckBox(Bundle.getMessage("MessageRememberSetting"));
                 remember.setFont(remember.getFont().deriveFont(10f));
                 remember.setAlignmentX(Component.CENTER_ALIGNMENT);
 
-                JButton yesButton = new JButton(jmri.jmrit.logixng.tools.swing.Bundle.getMessage("ButtonYes"));
-                JButton noButton = new JButton(jmri.jmrit.logixng.tools.swing.Bundle.getMessage("ButtonNo"));
+                JButton yesButton = new JButton(Bundle.getMessage("ButtonYes"));
+                JButton noButton = new JButton(Bundle.getMessage("ButtonNo"));
                 JPanel button = new JPanel();
                 button.setAlignmentX(Component.CENTER_ALIGNMENT);
                 button.add(yesButton);
@@ -1354,7 +1320,7 @@ public final class LogixNGEditor implements AbstractLogixNGEditor<LogixNG> {
                     if (remember.isSelected()) {
                         setDisplayDeleteMsg(0x02);
                     }
-                    doDelete(sockets);
+                    doDelete();
                     dialog.dispose();
                 });
                 container.add(remember);
@@ -1362,6 +1328,14 @@ public final class LogixNGEditor implements AbstractLogixNGEditor<LogixNG> {
                 container.setAlignmentY(Component.CENTER_ALIGNMENT);
                 dialog.getContentPane().add(container);
                 dialog.pack();
+                
+                dialog.getRootPane().setDefaultButton(noButton);
+                noButton.requestFocusInWindow(); // set default keyboard focus, after pack() before setVisible(true)
+                dialog.getRootPane().registerKeyboardAction(e -> { // escape to exit
+                        dialog.setVisible(false);
+                        dialog.dispose(); }, 
+                    KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), JComponent.WHEN_IN_FOCUSED_WINDOW);
+
                 dialog.setLocation((Toolkit.getDefaultToolkit().getScreenSize().width) / 2 - dialog.getWidth() / 2, (Toolkit.getDefaultToolkit().getScreenSize().height) / 2 - dialog.getHeight() / 2);
                 dialog.setModal(true);
                 dialog.setVisible(true);

--- a/java/test/jmri/jmrit/beantable/LogixNGModuleTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixNGModuleTableActionTest.java
@@ -13,13 +13,10 @@ import javax.swing.tree.TreePath;
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.Module;
-import jmri.jmrit.logixng.actions.ActionTurnout;
-import jmri.jmrit.logixng.expressions.ExpressionSensor;
 import jmri.jmrit.logixng.tools.swing.ConditionalNGEditor;
 
 import jmri.util.*;
 import jmri.util.junit.rules.*;
-import jmri.util.swing.JemmyUtil;
 
 import org.junit.Assert;
 import org.junit.Assume;
@@ -28,7 +25,6 @@ import org.junit.jupiter.api.*;
 import org.junit.rules.Timeout;
 
 import org.netbeans.jemmy.operators.*;
-import org.netbeans.jemmy.util.NameComponentChooser;
 
 
 /*
@@ -709,7 +705,7 @@ public class LogixNGModuleTableActionTest extends AbstractTableActionBase<Module
     }
 
     @Test
-    public void testDeleteLogixNG() throws InterruptedException {
+    public void testDeleteModule() throws InterruptedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         AbstractLogixNGTableAction moduleTable = (AbstractLogixNGTableAction) a;
 
@@ -923,12 +919,7 @@ public class LogixNGModuleTableActionTest extends AbstractTableActionBase<Module
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(dialogTitle);
             JButtonOperator jbo = new JButtonOperator(jdo, buttonText);
-            try {
             new JLabelOperator(jdo, labelText);     // Throws exception if not found
-            } catch (Exception e2) {
-                e.printStackTrace();
-                throw e2;
-            }
             jbo.pushNoBlock();
         });
         t.setName(dialogTitle + " Close Dialog Thread");
@@ -938,7 +929,6 @@ public class LogixNGModuleTableActionTest extends AbstractTableActionBase<Module
 
     private JEditorPane findTextArea(Container container) {
         for (Component component : container.getComponents()) {
-//            System.out.format("Component: %s,%n", component.getClass().getName());
             if (component instanceof JEditorPane) {
                 return (JEditorPane) component;
             }
@@ -951,25 +941,13 @@ public class LogixNGModuleTableActionTest extends AbstractTableActionBase<Module
     }
 
     Thread createModalDialogOperatorThread_WithListenerRefs(String dialogTitle, String buttonText, String listenerRefs) {
-        RuntimeException e = new RuntimeException("Caller");
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(dialogTitle);
             JButtonOperator jbo = new JButtonOperator(jdo, buttonText);
-            try {
             JEditorPane textArea = findTextArea((Container) jdo.getComponent(0));
             Assert.assertNotNull(textArea);
             Assert.assertEquals(listenerRefs, textArea.getText());
-//            if (textArea != null) {
-//                System.out.format("TextArea found: '%s'%n", textArea.getText());
-//            } else {
-//                System.out.format("TextArea not found%n");
-//            }
-//            new JLabelOperator(jdo, labelText);     // Throws exception if not found
-            } catch (Exception e2) {
-                e.printStackTrace();
-                throw e2;
-            }
             jbo.pushNoBlock();
         });
         t.setName(dialogTitle + " Close Dialog Thread");

--- a/java/test/jmri/jmrit/beantable/LogixNGModuleTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixNGModuleTableActionTest.java
@@ -914,7 +914,6 @@ public class LogixNGModuleTableActionTest extends AbstractTableActionBase<Module
     }
 
     Thread createModalDialogOperatorThread(String dialogTitle, String buttonText, String labelText) {
-        RuntimeException e = new RuntimeException("Caller");
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(dialogTitle);

--- a/java/test/jmri/jmrit/beantable/LogixNGTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixNGTableActionTest.java
@@ -438,12 +438,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(dialogTitle);
             JButtonOperator jbo = new JButtonOperator(jdo, buttonText);
-            try {
             new JLabelOperator(jdo, labelText);     // Throws exception if not found
-            } catch (Exception e2) {
-                e.printStackTrace();
-                throw e2;
-            }
             jbo.pushNoBlock();
         });
         t.setName(dialogTitle + " Close Dialog Thread");
@@ -453,7 +448,6 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
 
     private JEditorPane findTextArea(Container container) {
         for (Component component : container.getComponents()) {
-//            System.out.format("Component: %s,%n", component.getClass().getName());
             if (component instanceof JEditorPane) {
                 return (JEditorPane) component;
             }
@@ -466,25 +460,13 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     }
 
     Thread createModalDialogOperatorThread_WithListenerRefs(String dialogTitle, String buttonText, String listenerRefs) {
-        RuntimeException e = new RuntimeException("Caller");
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(dialogTitle);
             JButtonOperator jbo = new JButtonOperator(jdo, buttonText);
-            try {
             JEditorPane textArea = findTextArea((Container) jdo.getComponent(0));
             Assert.assertNotNull(textArea);
             Assert.assertEquals(listenerRefs, textArea.getText());
-//            if (textArea != null) {
-//                System.out.format("TextArea found: '%s'%n", textArea.getText());
-//            } else {
-//                System.out.format("TextArea not found%n");
-//            }
-//            new JLabelOperator(jdo, labelText);     // Throws exception if not found
-            } catch (Exception e2) {
-                e.printStackTrace();
-                throw e2;
-            }
             jbo.pushNoBlock();
         });
         t.setName(dialogTitle + " Close Dialog Thread");

--- a/java/test/jmri/jmrit/beantable/LogixNGTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixNGTableActionTest.java
@@ -433,7 +433,6 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     }
 
     Thread createModalDialogOperatorThread(String dialogTitle, String buttonText, String labelText) {
-        RuntimeException e = new RuntimeException("Caller");
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(dialogTitle);

--- a/java/test/jmri/jmrit/beantable/LogixNGTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixNGTableActionTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.beantable;
 
+import java.awt.Component;
 import java.awt.Container;
 import java.awt.GraphicsEnvironment;
 import java.beans.PropertyChangeEvent;
@@ -25,8 +26,6 @@ import org.junit.jupiter.api.*;
 import org.junit.rules.Timeout;
 
 import org.netbeans.jemmy.operators.*;
-import org.openide.util.Exceptions;
-
 
 /*
 * Tests for the LogixNGTableAction Class
@@ -453,12 +452,12 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     }
 
     private JEditorPane findTextArea(Container container) {
-        for (java.awt.Component component : ((Container)container).getComponents()) {
+        for (Component component : container.getComponents()) {
 //            System.out.format("Component: %s,%n", component.getClass().getName());
             if (component instanceof JEditorPane) {
                 return (JEditorPane) component;
             }
-            if (container instanceof java.awt.Container) {
+            if (component instanceof Container) {
                 JEditorPane textArea = findTextArea((Container) component);
                 if (textArea != null) return textArea;
             }

--- a/java/test/jmri/jmrit/beantable/LogixNGTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixNGTableActionTest.java
@@ -1,6 +1,9 @@
 package jmri.jmrit.beantable;
 
+import java.awt.Container;
 import java.awt.GraphicsEnvironment;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.ResourceBundle;
 
 import javax.swing.*;
@@ -255,14 +258,14 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
         Assert.assertNotNull("Found LogixNG Frame", logixNGFrame);  // NOI18N
 
         // Delete IQ102, respond No
-        Thread t1 = createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonNo"));  // NOI18N
+        Thread t1 = createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonNo"), "Are you sure you want to delete IQ102?");  // NOI18N
         logixNGTable.deletePressed("IQ102");  // NOI18N
         t1.join();
         LogixNG chk102 = jmri.InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ102");  // NOI18N
         Assert.assertNotNull("Verify IQ102 Not Deleted", chk102);  // NOI18N
 
         // Delete IQ103, respond Yes
-        Thread t2 = createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonYes"));  // NOI18N
+        Thread t2 = createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonYes"), "Are you sure you want to delete IQ103?");  // NOI18N
         logixNGTable.deletePressed("IQ103");  // NOI18N
         t2.join();
         LogixNG chk103 = jmri.InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ103");  // NOI18N
@@ -271,11 +274,177 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
         JUnitUtil.dispose(logixNGFrame);
     }
 
-    Thread createModalDialogOperatorThread(String dialogTitle, String buttonText) {
+    @Test
+    public void testDeleteLogixNGWithConditionalNG() throws InterruptedException, SocketAlreadyConnectedException {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+
+        LogixNG logixNG_102 = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ102");   // NOI18N
+        InstanceManager.getDefault(ConditionalNG_Manager.class).createConditionalNG(logixNG_102, "IQC102", null);   // NOI18N
+
+        LogixNG logixNG_103 = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ103");   // NOI18N
+        InstanceManager.getDefault(ConditionalNG_Manager.class).createConditionalNG(logixNG_103, "IQC103", null);   // NOI18N
+
+        logixNGTable.actionPerformed(null); // show table
+        JFrame logixNGFrame = JFrameOperator.waitJFrame(Bundle.getMessage("TitleLogixNGTable"), true, true);  // NOI18N
+        Assert.assertNotNull("Found LogixNG Frame", logixNGFrame);  // NOI18N
+
+        // Delete IQ102, respond No
+        Thread t1 = createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonNo"), "Are you sure you want to delete IQ102 and its children?");  // NOI18N
+        logixNGTable.deletePressed("IQ102");  // NOI18N
+        t1.join();
+        LogixNG log102 = jmri.InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ102");  // NOI18N
+        Assert.assertNotNull("Verify IQ102 Not Deleted", log102);  // NOI18N
+        ConditionalNG cond102 = InstanceManager.getDefault(ConditionalNG_Manager.class).getBySystemName("IQC102");   // NOI18N
+        Assert.assertNotNull("Verify IQC102 Not Deleted", cond102);  // NOI18N
+
+        // Delete IQ103, respond Yes
+        Thread t2 = createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonYes"), "Are you sure you want to delete IQ103 and its children?");  // NOI18N
+        logixNGTable.deletePressed("IQ103");  // NOI18N
+        t2.join();
+        LogixNG chk103 = jmri.InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ103");  // NOI18N
+        Assert.assertNull("Verify IQ103 Is Deleted", chk103);  // NOI18N
+        ConditionalNG cond103 = InstanceManager.getDefault(ConditionalNG_Manager.class).getBySystemName("IQC103");   // NOI18N
+        Assert.assertNull("Verify IQC103 Is Deleted", cond103);  // NOI18N
+
+        JUnitUtil.dispose(logixNGFrame);
+    }
+
+    @Test
+    public void testDeleteLogixNGWithDigitalAction() throws InterruptedException, SocketAlreadyConnectedException {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+
+        LogixNG logixNG_102 = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ102");   // NOI18N
+        ConditionalNG conditionalNG_102 = InstanceManager.getDefault(ConditionalNG_Manager.class).createConditionalNG(logixNG_102, "IQC102", null);   // NOI18N
+        jmri.jmrit.logixng.actions.DigitalMany digitalMany_102 =
+                new jmri.jmrit.logixng.actions.DigitalMany("IQDA102", null);
+        conditionalNG_102.getFemaleSocket().connect(
+                InstanceManager.getDefault(DigitalActionManager.class)
+                .registerAction(digitalMany_102));
+
+        LogixNG logixNG_103 = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ103");   // NOI18N
+        ConditionalNG conditionalNG_103 = InstanceManager.getDefault(ConditionalNG_Manager.class).createConditionalNG(logixNG_103, "IQC103", null);   // NOI18N
+        jmri.jmrit.logixng.actions.DigitalMany digitalMany_103 =
+                new jmri.jmrit.logixng.actions.DigitalMany("IQDA103", null);
+        conditionalNG_103.getFemaleSocket().connect(
+                InstanceManager.getDefault(DigitalActionManager.class)
+                .registerAction(digitalMany_103));
+
+        logixNGTable.actionPerformed(null); // show table
+        JFrame logixNGFrame = JFrameOperator.waitJFrame(Bundle.getMessage("TitleLogixNGTable"), true, true);  // NOI18N
+        Assert.assertNotNull("Found LogixNG Frame", logixNGFrame);  // NOI18N
+
+        // Delete IQ102, respond No
+        Thread t1 = createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonNo"), "Are you sure you want to delete IQ102 and its children?");  // NOI18N
+        logixNGTable.deletePressed("IQ102");  // NOI18N
+        t1.join();
+        LogixNG log102 = jmri.InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ102");  // NOI18N
+        Assert.assertNotNull("Verify IQ102 Not Deleted", log102);  // NOI18N
+        ConditionalNG cond102 = InstanceManager.getDefault(ConditionalNG_Manager.class).getBySystemName("IQC102");   // NOI18N
+        Assert.assertNotNull("Verify IQC102 Not Deleted", cond102);  // NOI18N
+        MaleSocket digMany102 = InstanceManager.getDefault(DigitalActionManager.class).getBySystemName("IQDA102");   // NOI18N
+        Assert.assertNotNull("Verify IQDA102 Not Deleted", digMany102);  // NOI18N
+
+        // Delete IQ103, respond Yes
+        Thread t2 = createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonYes"), "Are you sure you want to delete IQ103 and its children?");  // NOI18N
+        logixNGTable.deletePressed("IQ103");  // NOI18N
+        t2.join();
+        LogixNG chk103 = jmri.InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ103");  // NOI18N
+        Assert.assertNull("Verify IQ103 Is Deleted", chk103);  // NOI18N
+        ConditionalNG cond103 = InstanceManager.getDefault(ConditionalNG_Manager.class).getBySystemName("IQC103");   // NOI18N
+        Assert.assertNull("Verify IQC103 Is Deleted", cond103);  // NOI18N
+        MaleSocket digMany103 = InstanceManager.getDefault(DigitalActionManager.class).getBySystemName("IQDA103");   // NOI18N
+        Assert.assertNull("Verify IQDA103 Is Deleted", digMany103);  // NOI18N
+
+        JUnitUtil.dispose(logixNGFrame);
+    }
+
+    @Test
+    public void testDeleteLogixNGWithDigitalActionWithListenerRef() throws InterruptedException, SocketAlreadyConnectedException {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+
+        PropertyChangeListener pcl = (PropertyChangeEvent evt) -> {
+            throw new UnsupportedOperationException("Not supported");
+        };
+        
+        final String listenerRefs =
+                "<html>\n" +
+                "  <head>\n" +
+                "    \n" +
+                "  </head>\n" +
+                "  <body>\n" +
+                "    <br>\n" +
+                "    It is in use by 1 other objects including.\n" +
+                "\n" +
+                "    <ul>\n" +
+                "      <li>\n" +
+                "        A listener ref\n" +
+                "      </li>\n" +
+                "    </ul>\n" +
+                "  </body>\n" +
+                "</html>\n";
+
+        LogixNG logixNG_102 = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ102");   // NOI18N
+        ConditionalNG conditionalNG_102 = InstanceManager.getDefault(ConditionalNG_Manager.class).createConditionalNG(logixNG_102, "IQC102", null);   // NOI18N
+        jmri.jmrit.logixng.actions.DigitalMany digitalMany_102 =
+                new jmri.jmrit.logixng.actions.DigitalMany("IQDA102", null);
+        conditionalNG_102.getFemaleSocket().connect(
+                InstanceManager.getDefault(DigitalActionManager.class)
+                .registerAction(digitalMany_102));
+        digitalMany_102.addPropertyChangeListener(pcl, null, "A listener ref");
+
+        LogixNG logixNG_103 = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ103");   // NOI18N
+        ConditionalNG conditionalNG_103 = InstanceManager.getDefault(ConditionalNG_Manager.class).createConditionalNG(logixNG_103, "IQC103", null);   // NOI18N
+        jmri.jmrit.logixng.actions.DigitalMany digitalMany_103 =
+                new jmri.jmrit.logixng.actions.DigitalMany("IQDA103", null);
+        conditionalNG_103.getFemaleSocket().connect(
+                InstanceManager.getDefault(DigitalActionManager.class)
+                .registerAction(digitalMany_103));
+        digitalMany_103.addPropertyChangeListener(pcl, null, "A listener ref");
+
+        logixNGTable.actionPerformed(null); // show table
+        JFrame logixNGFrame = JFrameOperator.waitJFrame(Bundle.getMessage("TitleLogixNGTable"), true, true);  // NOI18N
+        Assert.assertNotNull("Found LogixNG Frame", logixNGFrame);  // NOI18N
+
+        // Delete IQ102, respond No
+        Thread t1 = createModalDialogOperatorThread_WithListenerRefs(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonNo"), listenerRefs);  // NOI18N
+        logixNGTable.deletePressed("IQ102");  // NOI18N
+        t1.join();
+        LogixNG log102 = jmri.InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ102");  // NOI18N
+        Assert.assertNotNull("Verify IQ102 Not Deleted", log102);  // NOI18N
+        ConditionalNG cond102 = InstanceManager.getDefault(ConditionalNG_Manager.class).getBySystemName("IQC102");   // NOI18N
+        Assert.assertNotNull("Verify IQC102 Not Deleted", cond102);  // NOI18N
+        MaleSocket digMany102 = InstanceManager.getDefault(DigitalActionManager.class).getBySystemName("IQDA102");   // NOI18N
+        Assert.assertNotNull("Verify IQDA102 Not Deleted", digMany102);  // NOI18N
+
+        // Delete IQ103, respond Yes
+        Thread t2 = createModalDialogOperatorThread_WithListenerRefs(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonYes"), listenerRefs);  // NOI18N
+        logixNGTable.deletePressed("IQ103");  // NOI18N
+        t2.join();
+        LogixNG chk103 = jmri.InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ103");  // NOI18N
+        Assert.assertNull("Verify IQ103 Is Deleted", chk103);  // NOI18N
+        ConditionalNG cond103 = InstanceManager.getDefault(ConditionalNG_Manager.class).getBySystemName("IQC103");   // NOI18N
+        Assert.assertNull("Verify IQC103 Is Deleted", cond103);  // NOI18N
+        MaleSocket digMany103 = InstanceManager.getDefault(DigitalActionManager.class).getBySystemName("IQDA103");   // NOI18N
+        Assert.assertNull("Verify IQDA103 Is Deleted", digMany103);  // NOI18N
+
+        JUnitUtil.dispose(logixNGFrame);
+    }
+
+    Thread createModalDialogOperatorThread(String dialogTitle, String buttonText, String labelText) {
+        RuntimeException e = new RuntimeException("Caller");
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(dialogTitle);
             JButtonOperator jbo = new JButtonOperator(jdo, buttonText);
+            try {
+            new JLabelOperator(jdo, labelText);     // Throws exception if not found
+            } catch (Exception e2) {
+                e.printStackTrace();
+                throw e2;
+            }
             jbo.pushNoBlock();
         });
         t.setName(dialogTitle + " Close Dialog Thread");
@@ -283,6 +452,46 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
         return t;
     }
 
+    private JEditorPane findTextArea(Container container) {
+        for (java.awt.Component component : ((Container)container).getComponents()) {
+//            System.out.format("Component: %s,%n", component.getClass().getName());
+            if (component instanceof JEditorPane) {
+                return (JEditorPane) component;
+            }
+            if (container instanceof java.awt.Container) {
+                JEditorPane textArea = findTextArea((Container) component);
+                if (textArea != null) return textArea;
+            }
+        }
+        return null;
+    }
+
+    Thread createModalDialogOperatorThread_WithListenerRefs(String dialogTitle, String buttonText, String listenerRefs) {
+        RuntimeException e = new RuntimeException("Caller");
+        Thread t = new Thread(() -> {
+            // constructor for jdo will wait until the dialog is visible
+            JDialogOperator jdo = new JDialogOperator(dialogTitle);
+            JButtonOperator jbo = new JButtonOperator(jdo, buttonText);
+            try {
+            JEditorPane textArea = findTextArea((Container) jdo.getComponent(0));
+            Assert.assertNotNull(textArea);
+            Assert.assertEquals(listenerRefs, textArea.getText());
+//            if (textArea != null) {
+//                System.out.format("TextArea found: '%s'%n", textArea.getText());
+//            } else {
+//                System.out.format("TextArea not found%n");
+//            }
+//            new JLabelOperator(jdo, labelText);     // Throws exception if not found
+            } catch (Exception e2) {
+                e.printStackTrace();
+                throw e2;
+            }
+            jbo.pushNoBlock();
+        });
+        t.setName(dialogTitle + " Close Dialog Thread");
+        t.start();
+        return t;
+    }
 
     // Test that it's possible to
     // * Add a LogixNG

--- a/java/test/jmri/jmrit/logixng/FemaleSocketTestBase.java
+++ b/java/test/jmri/jmrit/logixng/FemaleSocketTestBase.java
@@ -670,6 +670,12 @@ public abstract class FemaleSocketTestBase {
             throw new UnsupportedOperationException("Not supported");
         }
 
+        /** {@inheritDoc} */
+        @Override
+        public void getListenerRefsIncludingChildren(List<String> list) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
         @Override
         public int getNumPropertyChangeListeners() {
             throw new UnsupportedOperationException("Not supported");

--- a/java/test/jmri/jmrit/logixng/implementation/AbstractFemaleSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/AbstractFemaleSocketTest.java
@@ -435,6 +435,12 @@ public class AbstractFemaleSocketTest {
             throw new UnsupportedOperationException("Not supported");
         }
 
+        /** {@inheritDoc} */
+        @Override
+        public void getListenerRefsIncludingChildren(List<String> list) {
+            throw new UnsupportedOperationException("Not supported");
+        }
+
         @Override
         public int getNumPropertyChangeListeners() {
             throw new UnsupportedOperationException("Not supported");

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
@@ -7,9 +7,10 @@ import jmri.jmrit.logixng.actions.*;
 import jmri.jmrit.logixng.expressions.*;
 import jmri.util.JUnitUtil;
 
-import org.junit.*;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test DefaultLogixNG
@@ -261,7 +262,6 @@ public class DefaultLogixNGManagerTest {
         System.out.format("%s%n", stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
         System.out.format("%s%n", digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
         
-        if (1==1) return;
         Assert.assertNull(logixNG_Manager.getBySystemName(logixNG.getSystemName()));
         Assert.assertNull(conditionalNG_Manager.getBySystemName(conditionalNG.getSystemName()));
         Assert.assertNull(analogActionManager.getBySystemName(actionAnalogManySocket.getSystemName()));
@@ -381,7 +381,6 @@ public class DefaultLogixNGManagerTest {
         System.out.format("%s%n", stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
         System.out.format("%s%n", digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
         
-        if (1==1) return;
         Assert.assertNotNull(logixNG_Manager.getBySystemName(logixNG.getSystemName()));
         Assert.assertNull(conditionalNG_Manager.getBySystemName(conditionalNG.getSystemName()));
         Assert.assertNull(analogActionManager.getBySystemName(actionAnalogManySocket.getSystemName()));
@@ -496,7 +495,6 @@ public class DefaultLogixNGManagerTest {
         System.out.format("%s%n", stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
         System.out.format("%s%n", digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
         
-        if (1==1) return;
         Assert.assertNull(moduleManager.getBySystemName(module.getSystemName()));
         Assert.assertNull(analogActionManager.getBySystemName(actionAnalogManySocket.getSystemName()));
         Assert.assertNull(analogExpressionManager.getBySystemName(expressionAnalogExpressionConstantSocket.getSystemName()));
@@ -514,7 +512,7 @@ public class DefaultLogixNGManagerTest {
     
 
     // The minimal setup for log4J
-    @Before
+    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
@@ -525,7 +523,7 @@ public class DefaultLogixNGManagerTest {
         JUnitUtil.initLogixNGManager();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.implementation;
 
+import java.beans.PropertyVetoException;
+
 import jmri.InstanceManager;
 import jmri.Manager;
 import jmri.jmrit.logixng.*;
@@ -155,7 +157,7 @@ public class DefaultLogixNGManagerTest {
     }
     
     @Test
-    public void testDeleteLogixNG() throws SocketAlreadyConnectedException {
+    public void testDeleteLogixNG() throws SocketAlreadyConnectedException, PropertyVetoException {
         LogixNG_Manager logixNG_Manager = InstanceManager.getDefault(LogixNG_Manager.class);
         ConditionalNG_Manager conditionalNG_Manager = InstanceManager.getDefault(ConditionalNG_Manager.class);
         AnalogActionManager analogActionManager = InstanceManager.getDefault(AnalogActionManager.class);
@@ -250,7 +252,8 @@ public class DefaultLogixNGManagerTest {
         Assert.assertNotNull(stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
         Assert.assertNotNull(digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
         
-        logixNG_Manager.deleteLogixNG(logixNG);
+        logixNG_Manager.deleteBean(logixNG, "CanDelete");
+        logixNG_Manager.deleteBean(logixNG, "DoDelete");
         
         System.out.format("%s%n", logixNG_Manager.getBySystemName(logixNG.getSystemName()));
         System.out.format("%s%n", conditionalNG_Manager.getBySystemName(conditionalNG.getSystemName()));

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
@@ -228,7 +228,7 @@ public class DefaultLogixNGManagerTest {
         femaleSocket = actionManySocket.getChild(3);
         MaleDigitalActionSocket logix = digitalActionManager
                         .registerAction(new Logix(digitalActionManager.getAutoSystemName(), null));
-        femaleSocket.connect(actionDoStringActionSocket);
+        femaleSocket.connect(logix);
 
         femaleSocket = logix.getChild(1);
         MaleDigitalBooleanActionSocket onChange = digitalBooleanActionManager
@@ -237,9 +237,12 @@ public class DefaultLogixNGManagerTest {
                                 null,
                                 DigitalBooleanOnChange.Trigger.CHANGE));
         femaleSocket.connect(onChange);
-
         
         
+        LastResultOfDigitalExpression lastResultOfDigitalExpression =
+                new LastResultOfDigitalExpression(
+                                digitalExpressionManager.getAutoSystemName(), null);
+        lastResultOfDigitalExpression.setDigitalExpression(expressionOrSocket);
         
         
         Assert.assertNotNull(logixNG_Manager.getBySystemName(logixNG.getSystemName()));
@@ -255,20 +258,18 @@ public class DefaultLogixNGManagerTest {
         try {
             logixNG_Manager.deleteBean(logixNG, "CanDelete");
         } catch (PropertyVetoException e) {
+            Assert.assertEquals("DoNotDelete", e.getPropertyChangeEvent().getPropertyName());
+            Assert.assertEquals("Expression is in use by \"IQDE:AUTO:0002\"", e.getMessage());
+        }
+        lastResultOfDigitalExpression.removeDigitalExpression();
+        
+        try {
+            logixNG_Manager.deleteBean(logixNG, "CanDelete");
+        } catch (PropertyVetoException e) {
             Assert.assertEquals("CanDelete", e.getPropertyChangeEvent().getPropertyName());
             Assert.assertEquals("", e.getMessage());
         }
         logixNG_Manager.deleteBean(logixNG, "DoDelete");
-        
-        System.out.format("%s%n", logixNG_Manager.getBySystemName(logixNG.getSystemName()));
-        System.out.format("%s%n", conditionalNG_Manager.getBySystemName(conditionalNG.getSystemName()));
-        System.out.format("%s%n", analogActionManager.getBySystemName(actionAnalogManySocket.getSystemName()));
-        System.out.format("%s%n", analogExpressionManager.getBySystemName(expressionAnalogExpressionConstantSocket.getSystemName()));
-        System.out.format("%s%n", digitalActionManager.getBySystemName(actionManySocket.getSystemName()));
-        System.out.format("%s%n", digitalExpressionManager.getBySystemName(expressionOrSocket.getSystemName()));
-        System.out.format("%s%n", stringActionManager.getBySystemName(actionStringManySocket.getSystemName()));
-        System.out.format("%s%n", stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
-        System.out.format("%s%n", digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
         
         Assert.assertNull(logixNG_Manager.getBySystemName(logixNG.getSystemName()));
         Assert.assertNull(conditionalNG_Manager.getBySystemName(conditionalNG.getSystemName()));
@@ -282,7 +283,7 @@ public class DefaultLogixNGManagerTest {
     }
     
     @Test
-    public void testDeleteConditionalNG() throws SocketAlreadyConnectedException {
+    public void testDeleteConditionalNG() throws SocketAlreadyConnectedException, PropertyVetoException {
         LogixNG_Manager logixNG_Manager = InstanceManager.getDefault(LogixNG_Manager.class);
         ConditionalNG_Manager conditionalNG_Manager = InstanceManager.getDefault(ConditionalNG_Manager.class);
         AnalogActionManager analogActionManager = InstanceManager.getDefault(AnalogActionManager.class);
@@ -353,7 +354,7 @@ public class DefaultLogixNGManagerTest {
         femaleSocket = actionManySocket.getChild(3);
         MaleDigitalActionSocket logix = digitalActionManager
                         .registerAction(new Logix(digitalActionManager.getAutoSystemName(), null));
-        femaleSocket.connect(actionDoStringActionSocket);
+        femaleSocket.connect(logix);
 
         femaleSocket = logix.getChild(1);
         MaleDigitalBooleanActionSocket onChange = digitalBooleanActionManager
@@ -362,9 +363,12 @@ public class DefaultLogixNGManagerTest {
                                 null,
                                 DigitalBooleanOnChange.Trigger.CHANGE));
         femaleSocket.connect(onChange);
-
         
         
+        LastResultOfDigitalExpression lastResultOfDigitalExpression =
+                new LastResultOfDigitalExpression(
+                                digitalExpressionManager.getAutoSystemName(), null);
+        lastResultOfDigitalExpression.setDigitalExpression(expressionOrSocket);
         
         
         Assert.assertNotNull(logixNG_Manager.getBySystemName(logixNG.getSystemName()));
@@ -377,17 +381,21 @@ public class DefaultLogixNGManagerTest {
         Assert.assertNotNull(stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
         Assert.assertNotNull(digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
         
-        conditionalNG_Manager.deleteConditionalNG(conditionalNG);
+        try {
+            conditionalNG_Manager.deleteBean(conditionalNG, "CanDelete");
+        } catch (PropertyVetoException e) {
+            Assert.assertEquals("DoNotDelete", e.getPropertyChangeEvent().getPropertyName());
+            Assert.assertEquals("Expression is in use by \"IQDE:AUTO:0002\"", e.getMessage());
+        }
+        lastResultOfDigitalExpression.removeDigitalExpression();
         
-        System.out.format("%s%n", logixNG_Manager.getBySystemName(logixNG.getSystemName()));
-        System.out.format("%s%n", conditionalNG_Manager.getBySystemName(conditionalNG.getSystemName()));
-        System.out.format("%s%n", analogActionManager.getBySystemName(actionAnalogManySocket.getSystemName()));
-        System.out.format("%s%n", analogExpressionManager.getBySystemName(expressionAnalogExpressionConstantSocket.getSystemName()));
-        System.out.format("%s%n", digitalActionManager.getBySystemName(actionManySocket.getSystemName()));
-        System.out.format("%s%n", digitalExpressionManager.getBySystemName(expressionOrSocket.getSystemName()));
-        System.out.format("%s%n", stringActionManager.getBySystemName(actionStringManySocket.getSystemName()));
-        System.out.format("%s%n", stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
-        System.out.format("%s%n", digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
+        try {
+            conditionalNG_Manager.deleteBean(conditionalNG, "CanDelete");
+        } catch (PropertyVetoException e) {
+            Assert.assertEquals("CanDelete", e.getPropertyChangeEvent().getPropertyName());
+            Assert.assertEquals("", e.getMessage());
+        }
+        conditionalNG_Manager.deleteBean(conditionalNG, "DoDelete");
         
         Assert.assertNotNull(logixNG_Manager.getBySystemName(logixNG.getSystemName()));
         Assert.assertNull(conditionalNG_Manager.getBySystemName(conditionalNG.getSystemName()));
@@ -401,7 +409,7 @@ public class DefaultLogixNGManagerTest {
     }
     
     @Test
-    public void testDeleteModule() throws SocketAlreadyConnectedException {
+    public void testDeleteModule() throws SocketAlreadyConnectedException, PropertyVetoException {
         FemaleSocketManager femaleSocketManager = InstanceManager.getDefault(FemaleSocketManager.class);
         ModuleManager moduleManager = InstanceManager.getDefault(ModuleManager.class);
         AnalogActionManager analogActionManager = InstanceManager.getDefault(AnalogActionManager.class);
@@ -469,7 +477,7 @@ public class DefaultLogixNGManagerTest {
         femaleSocket = actionManySocket.getChild(3);
         MaleDigitalActionSocket logix = digitalActionManager
                         .registerAction(new Logix(digitalActionManager.getAutoSystemName(), null));
-        femaleSocket.connect(actionDoStringActionSocket);
+        femaleSocket.connect(logix);
 
         femaleSocket = logix.getChild(1);
         MaleDigitalBooleanActionSocket onChange = digitalBooleanActionManager
@@ -478,9 +486,12 @@ public class DefaultLogixNGManagerTest {
                                 null,
                                 DigitalBooleanOnChange.Trigger.CHANGE));
         femaleSocket.connect(onChange);
-
         
         
+        LastResultOfDigitalExpression lastResultOfDigitalExpression =
+                new LastResultOfDigitalExpression(
+                                digitalExpressionManager.getAutoSystemName(), null);
+        lastResultOfDigitalExpression.setDigitalExpression(expressionOrSocket);
         
         
         Assert.assertNotNull(moduleManager.getBySystemName(module.getSystemName()));
@@ -492,18 +503,149 @@ public class DefaultLogixNGManagerTest {
         Assert.assertNotNull(stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
         Assert.assertNotNull(digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
         
-        moduleManager.deleteModule(module);
+        try {
+            moduleManager.deleteBean(module, "CanDelete");
+        } catch (PropertyVetoException e) {
+            Assert.assertEquals("DoNotDelete", e.getPropertyChangeEvent().getPropertyName());
+            Assert.assertEquals("Expression is in use by \"IQDE:AUTO:0002\"", e.getMessage());
+        }
+        lastResultOfDigitalExpression.removeDigitalExpression();
         
-        System.out.format("%s%n", moduleManager.getBySystemName(module.getSystemName()));
-        System.out.format("%s%n", analogActionManager.getBySystemName(actionAnalogManySocket.getSystemName()));
-        System.out.format("%s%n", analogExpressionManager.getBySystemName(expressionAnalogExpressionConstantSocket.getSystemName()));
-        System.out.format("%s%n", digitalActionManager.getBySystemName(actionManySocket.getSystemName()));
-        System.out.format("%s%n", digitalExpressionManager.getBySystemName(expressionOrSocket.getSystemName()));
-        System.out.format("%s%n", stringActionManager.getBySystemName(actionStringManySocket.getSystemName()));
-        System.out.format("%s%n", stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
-        System.out.format("%s%n", digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
+        try {
+            moduleManager.deleteBean(module, "CanDelete");
+        } catch (PropertyVetoException e) {
+            Assert.assertEquals("CanDelete", e.getPropertyChangeEvent().getPropertyName());
+            Assert.assertEquals("", e.getMessage());
+        }
+        moduleManager.deleteBean(module, "DoDelete");
         
         Assert.assertNull(moduleManager.getBySystemName(module.getSystemName()));
+        Assert.assertNull(analogActionManager.getBySystemName(actionAnalogManySocket.getSystemName()));
+        Assert.assertNull(analogExpressionManager.getBySystemName(expressionAnalogExpressionConstantSocket.getSystemName()));
+        Assert.assertNull(digitalActionManager.getBySystemName(actionManySocket.getSystemName()));
+        Assert.assertNull(digitalExpressionManager.getBySystemName(expressionOrSocket.getSystemName()));
+        Assert.assertNull(stringActionManager.getBySystemName(actionStringManySocket.getSystemName()));
+        Assert.assertNull(stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
+        Assert.assertNull(digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
+    }
+    
+    @Test
+    public void testDeleteAction() throws SocketAlreadyConnectedException, PropertyVetoException {
+//        LogixNG_Manager logixNG_Manager = InstanceManager.getDefault(LogixNG_Manager.class);
+//        ConditionalNG_Manager conditionalNG_Manager = InstanceManager.getDefault(ConditionalNG_Manager.class);
+        AnalogActionManager analogActionManager = InstanceManager.getDefault(AnalogActionManager.class);
+        AnalogExpressionManager analogExpressionManager = InstanceManager.getDefault(AnalogExpressionManager.class);
+        DigitalActionManager digitalActionManager = InstanceManager.getDefault(DigitalActionManager.class);
+        DigitalBooleanActionManager digitalBooleanActionManager = InstanceManager.getDefault(DigitalBooleanActionManager.class);
+        DigitalExpressionManager digitalExpressionManager = InstanceManager.getDefault(DigitalExpressionManager.class);
+        StringActionManager stringActionManager = InstanceManager.getDefault(StringActionManager.class);
+        StringExpressionManager stringExpressionManager = InstanceManager.getDefault(StringExpressionManager.class);
+        
+//        LogixNG logixNG = logixNG_Manager.createLogixNG("IQ1", "Some name");
+//        Assert.assertNotNull("exists", logixNG);
+        
+//        ConditionalNG conditionalNG = conditionalNG_Manager
+//                .createConditionalNG(logixNG, "A conditionalNG");  // NOI18N
+//        Assert.assertNotNull("exists", conditionalNG);
+        
+//        FemaleSocket femaleSocket = conditionalNG.getFemaleSocket();
+        MaleDigitalActionSocket actionManySocket = digitalActionManager
+                        .registerAction(new DigitalMany(digitalActionManager.getAutoSystemName(), null));
+//        femaleSocket.connect(actionManySocket);
+
+        FemaleSocket femaleSocket = actionManySocket.getChild(0);
+        MaleDigitalActionSocket actionIfThenSocket = digitalActionManager
+                        .registerAction(new IfThenElse(digitalActionManager.getAutoSystemName(), null));
+        femaleSocket.connect(actionIfThenSocket);
+
+        femaleSocket = actionIfThenSocket.getChild(0);
+        MaleDigitalExpressionSocket expressionOrSocket =
+                InstanceManager.getDefault(DigitalExpressionManager.class)
+                        .registerExpression(new Or(digitalExpressionManager.getAutoSystemName(), null));
+        femaleSocket.connect(expressionOrSocket);
+        
+        femaleSocket = actionManySocket.getChild(1);
+        MaleDigitalActionSocket actionDoAnalogActionSocket = digitalActionManager
+                        .registerAction(new DoAnalogAction(digitalActionManager.getAutoSystemName(), null));
+        femaleSocket.connect(actionDoAnalogActionSocket);
+
+        femaleSocket = actionDoAnalogActionSocket.getChild(0);
+        MaleAnalogExpressionSocket expressionAnalogExpressionConstantSocket =
+                analogExpressionManager
+                        .registerExpression(new AnalogExpressionConstant(analogExpressionManager.getAutoSystemName(), null));
+        femaleSocket.connect(expressionAnalogExpressionConstantSocket);
+        
+        femaleSocket = actionDoAnalogActionSocket.getChild(1);
+        MaleAnalogActionSocket actionAnalogManySocket =
+                InstanceManager.getDefault(AnalogActionManager.class)
+                        .registerAction(new AnalogMany(analogActionManager.getAutoSystemName(), null));
+        femaleSocket.connect(actionAnalogManySocket);
+
+        femaleSocket = actionManySocket.getChild(2);
+        MaleDigitalActionSocket actionDoStringActionSocket =
+                InstanceManager.getDefault(DigitalActionManager.class)
+                        .registerAction(new DoStringAction(digitalActionManager.getAutoSystemName(), null));
+        femaleSocket.connect(actionDoStringActionSocket);
+
+        femaleSocket = actionDoStringActionSocket.getChild(0);
+        MaleStringExpressionSocket expressionStringExpressionConstantSocket =
+                stringExpressionManager
+                        .registerExpression(new StringExpressionConstant(stringExpressionManager.getAutoSystemName(), null));
+        femaleSocket.connect(expressionStringExpressionConstantSocket);
+        
+        femaleSocket = actionDoStringActionSocket.getChild(1);
+        MaleStringActionSocket actionStringManySocket = stringActionManager
+                        .registerAction(new StringMany(stringActionManager.getAutoSystemName(), null));
+        femaleSocket.connect(actionStringManySocket);
+
+        femaleSocket = actionManySocket.getChild(3);
+        MaleDigitalActionSocket logix = digitalActionManager
+                        .registerAction(new Logix(digitalActionManager.getAutoSystemName(), null));
+        femaleSocket.connect(logix);
+
+        femaleSocket = logix.getChild(1);
+        MaleDigitalBooleanActionSocket onChange = digitalBooleanActionManager
+                        .registerAction(new DigitalBooleanOnChange(
+                                digitalBooleanActionManager.getAutoSystemName(),
+                                null,
+                                DigitalBooleanOnChange.Trigger.CHANGE));
+        femaleSocket.connect(onChange);
+        
+        
+        LastResultOfDigitalExpression lastResultOfDigitalExpression =
+                new LastResultOfDigitalExpression(
+                                digitalExpressionManager.getAutoSystemName(), null);
+        lastResultOfDigitalExpression.setDigitalExpression(expressionOrSocket);
+        
+        
+//        Assert.assertNotNull(logixNG_Manager.getBySystemName(logixNG.getSystemName()));
+//        Assert.assertNotNull(conditionalNG_Manager.getBySystemName(conditionalNG.getSystemName()));
+        Assert.assertNotNull(analogActionManager.getBySystemName(actionAnalogManySocket.getSystemName()));
+        Assert.assertNotNull(analogExpressionManager.getBySystemName(expressionAnalogExpressionConstantSocket.getSystemName()));
+        Assert.assertNotNull(digitalActionManager.getBySystemName(actionManySocket.getSystemName()));
+        Assert.assertNotNull(digitalExpressionManager.getBySystemName(expressionOrSocket.getSystemName()));
+        Assert.assertNotNull(stringActionManager.getBySystemName(actionStringManySocket.getSystemName()));
+        Assert.assertNotNull(stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
+        Assert.assertNotNull(digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
+        
+        try {
+            digitalActionManager.deleteBean(actionManySocket, "CanDelete");
+        } catch (PropertyVetoException e) {
+            Assert.assertEquals("DoNotDelete", e.getPropertyChangeEvent().getPropertyName());
+            Assert.assertEquals("Expression is in use by \"IQDE:AUTO:0002\"", e.getMessage());
+        }
+        lastResultOfDigitalExpression.removeDigitalExpression();
+        
+        try {
+            digitalActionManager.deleteBean(actionManySocket, "CanDelete");
+        } catch (PropertyVetoException e) {
+            Assert.assertEquals("CanDelete", e.getPropertyChangeEvent().getPropertyName());
+            Assert.assertEquals("", e.getMessage());
+        }
+        digitalActionManager.deleteBean(actionManySocket, "DoDelete");
+        
+//        Assert.assertNotNull(logixNG_Manager.getBySystemName(logixNG.getSystemName()));
+//        Assert.assertNull(conditionalNG_Manager.getBySystemName(conditionalNG.getSystemName()));
         Assert.assertNull(analogActionManager.getBySystemName(actionAnalogManySocket.getSystemName()));
         Assert.assertNull(analogExpressionManager.getBySystemName(expressionAnalogExpressionConstantSocket.getSystemName()));
         Assert.assertNull(digitalActionManager.getBySystemName(actionManySocket.getSystemName()));

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
@@ -252,7 +252,12 @@ public class DefaultLogixNGManagerTest {
         Assert.assertNotNull(stringExpressionManager.getBySystemName(expressionStringExpressionConstantSocket.getSystemName()));
         Assert.assertNotNull(digitalBooleanActionManager.getBySystemName(onChange.getSystemName()));
         
-        logixNG_Manager.deleteBean(logixNG, "CanDelete");
+        try {
+            logixNG_Manager.deleteBean(logixNG, "CanDelete");
+        } catch (PropertyVetoException e) {
+            Assert.assertEquals("CanDelete", e.getPropertyChangeEvent().getPropertyName());
+            Assert.assertEquals("", e.getMessage());
+        }
         logixNG_Manager.deleteBean(logixNG, "DoDelete");
         
         System.out.format("%s%n", logixNG_Manager.getBySystemName(logixNG.getSystemName()));

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultLogixNGManagerTest.java
@@ -10,7 +10,6 @@ import jmri.util.JUnitUtil;
 import org.junit.*;
 import org.junit.Assert;
 import org.junit.Test;
-//import org.junit.jupiter.api.*;
 
 /**
  * Test DefaultLogixNG
@@ -516,7 +515,6 @@ public class DefaultLogixNGManagerTest {
 
     // The minimal setup for log4J
     @Before
-//    @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
@@ -528,7 +526,6 @@ public class DefaultLogixNGManagerTest {
     }
 
     @After
-//    @AfterEach
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();


### PR DESCRIPTION
This PR changes all the LogixNG managers so that the method deleteBean() also traverses all the children.