### PR TITLE
Use a dynamic stub file instead of 1000s of static stub files.

### DIFF
--- a/help/en/html/doc/Technical/Help.shtml
+++ b/help/en/html/doc/Technical/Help.shtml
@@ -255,8 +255,6 @@
         "font-family: monospace;">addHelpMenu("package.jmri.jmrit.simpleclock.SimpleClockFrame", true);
         </pre>The help file is then located at
 <code>help/en/package/jmri/jmrit/simpleclock/SimpleClockFrame.shtml</code>.
-        <p>You should add the new page to the JmriHelp index to have JMRI accept it as a Help
-        target (see the next heading).</p>
 
         <p>A number of help files have been put in place without any contents; hopefully some users
         will edit them and contribute them back.</p>
@@ -270,7 +268,7 @@
 
       <div>
         <p><strong>HelpUtil</strong> is called when the <strong>Window Help</strong> or
-        <strong>General Help</strong> menu items are selected. The <strong>helpkey</strong>
+        <strong>General Help</strong> menu item is selected. The <strong>helpkey</strong>
         specified in the JMRI code is used to display the appropriate help page in the browser.</p>
 
         <p>Using <strong>Preferences ⇒ Help</strong>, the user can choose to have the local help
@@ -282,9 +280,11 @@
 
         <h3>Creating the JmriHelp files</h3>
 
-        <p>When a new <strong>helpkey</strong> has been defined in the JMRI code, it needs to be
-        added to the index and/or the table contents. These files are used to build the necessary
-        content to link the helpkey to the local help page.</p>
+        <p>When a new <strong>helpkey</strong> has been defined in the JMRI code, it can be
+        added to the index and/or the table contents.  This step is optional.  Displaying the help
+        page triggered by <strong>Window Help</strong> is independent of the table of contents and
+        index.  Since the default file based presentation does not display sidebars, it can be
+        helpful to include at least a basic entry in the TOC and/or Index to simplify navigation.</p>
 
         <h4>Update JmriHelp_**Index.xml and/or JmriHelp_**TOC.xml</h4>
 
@@ -294,6 +294,7 @@
         <p>These are xml files that can edited with any xml aware file editor. Each line in the
         file consists of a user friendly <strong>text</strong> name and the <strong>target</strong>
         helpkey.</p>
+
         <code>&lt;indexitem text="Setting The Internal Clock "
         target="package.jmri.jmrit.simpleclock.SimpleClockFrame"/&gt;<br>
         &lt;tocitem text="Setting the Internal Clock "
@@ -307,27 +308,26 @@
           <li><strong>index.html</strong> -- This is the web page loaded by the local browser when
           <strong>Help ⇒ Window Help</strong> or <strong>Help ⇒ General Help</strong> is invoked by
           JMRI. The page contains the table of contents in the left column and the selected help
-          page in an iframe on the right.</li>
+          page in an iframe on the right.  At the top are buttons for selecting the table of
+          contents or the index.</li>
 
           <li><strong>jmri_map.xml</strong> -- This file contains the helpkeys and the actual URL
-          for the help pag from the JmriHelp_**TOC.xml and JmriHelp_**Index.xml files along with
+          for the help page from the JmriHelp_**TOC.xml and JmriHelp_**Index.xml files along with
           other helpkeys that were not included in either the table of contents or index.</li>
 
           <li><strong>alternate_map.txt</strong> -- This contains a list of non-standard helpkeys
           and the target help page.</li>
 
-          <li><strong>stub_template.html</strong> -- This file is used to build the stub files in
-          the stub diretory.</li>
+          <li><strong>stub_template.html</strong> -- This file is used to build the stub file that
+          translates the helpkey into a file name to be loaded by the browser.</li>
 
-          <li><strong>stub</strong> -- This directory contains the stub files which are used to
-          link a JMRI helpkey to the index.html.</li>
         </ul>
 
         <p>The Java process to pass a file name to a browser does not support query (?) or id (#)
-        parameters. The build process creates a stub file for each entry in jmri_map.xml. The file
-        name is <strong>&lt;helpkey&gt;.html</strong>. The stub file does a re-direct to
-        <strong>local/index.html#helpkey</strong>. The javascript in index.html converts the
-        helpkey into the file name to be loaded into the iframe.</p>
+        parameters. HelpUtil builds a <strong>stub.html</strong> file in the <strong>
+        settings:jmrihelp</strong> location.  The stub file does a re-direct to <strong>
+        local/index.html#helpkey</strong>. Javascript in index.html converts the helpkey into the
+        file name to be loaded into the iframe.</p>
 
         <p>After JmriHelp_**TOC.xml and JmriHelp_**Index.xml have been updated, run the ant
         <strong>buildhelp</strong> target. This is run using the main JMRI ant build.xml file, not
@@ -496,17 +496,16 @@
         is nominally a test program, but it has a <code>public static main()</code> which makes it
         possible to be called from ant. It is excluded from <strong>alltest</strong> .</p>
 
-        <p>The program uses the <strong>JmriHelp_**</strong> files, the
-        <strong>alternate_map.txt</strong> file and scans of the help tree to create the
-        <strong>jmri_map.xml</strong> file and the stub files.</p>
+        <p>The program uses the <strong>JmriHelp_**</strong> files and the <strong>alternate_map.txt
+        </strong> file to create the <strong>jmri_map.xml</strong> file.</p>
 
-        <p>When the program is done, the <strong>buildhelp</strong> target calls
-        <strong>ant</strong> in each language location. The language specific ant process builds
-        the <strong>webtoc.shtml</strong> and <strong>webindex.shtml</strong> files from
-        JmriHelp_**TOC.xml, JmriHelp_**Index.xml and jmri_map.xml using <strong>format.xsl</strong>
-        . The third step builds the <strong>local/index.html</strong> file using the
-        <strong>JmriHelp_**TOC.xml</strong> and <strong>jmri_map.xml</strong> files using
-        <strong>formatLocalTOC.xsl</strong>.</p>
+        <p>When the program is done, the <strong>buildhelp</strong> target calls <strong>ant</strong>
+        in each language location. The language specific ant process builds the <strong>webtoc.shtml
+        </strong> and <strong>webindex.shtml</strong> files from JmriHelp_**TOC.xml,
+        JmriHelp_**Index.xml and jmri_map.xml using <strong>format.xsl</strong>. The third step
+        builds the <strong>local/index.html</strong> file using the <strong>JmriHelp_**TOC.xml
+        </strong>,  <strong>JmriHelp_**Index.xml</strong> and <strong>jmri_map.xml</strong> files
+        using <strong>formatLocalTOC.xsl</strong>.</p>
 
         <p><a href="#helpTop">[Go to top of page]</a>
         </p>

--- a/help/en/html/doc/Technical/Sidebar.shtml
+++ b/help/en/html/doc/Technical/Sidebar.shtml
@@ -76,10 +76,10 @@
         <dt class="dtheader">Help and Web Site</dt>
         <dd>
             <ul class="navigation">
-            <li><a href="Help.shtml">Providing Help using JavaHelp</a></li>
+            <li><a href="Help.shtml">Providing Help using JmriHelp</a></li>
             <li><a href="WebSite.shtml">The JMRI Web Site</a></li>
-                        <li><a href="UpdatingDocs.shtml">Updating JMRI Web and Help</a></li>
-                        <li><a href="Help.shtml#hwhelp">Creating Help for New Hardware</a></li>
+            <li><a href="UpdatingDocs.shtml">Updating JMRI Web and Help</a></li>
+            <li><a href="Help.shtml#hwhelp">Creating Help for New Hardware</a></li>
             <li><a href="Javadoc.shtml">Program Documentation Using Javadoc</a></li>
             </ul>
         </dd>

--- a/help/en/local/stub_template.html
+++ b/help/en/local/stub_template.html
@@ -4,13 +4,13 @@
 <title>JMRI: Redirected Page</title>
 <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
 <!-- This file is used as a template for the html files in the stub/ folder -->
-<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#<!--HELP_KEY-->">
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=<!--HELP_KEY-->">
 </head>
 <body>
 <p>JMRI Help</p>
 This page is a template. It's supposed to have displayed the help content you're looking for.  But something has gone wrong.
 <p></p>
-To see your help page, please click on <a href="../index.html#<!--HELP_KEY-->">this link</a>
+To see your help page, please click on <a href="<!--HELP_KEY-->">this link</a>
 <p></p>
 If you have Internet access, you can open the link on the JMRI web site. Click on <a href="https://jmri.org/help/en/<!--URL_HELP_KEY-->">https://jmri.org/help/en/<!--URL_HELP_KEY--></a>
 <p></p>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -564,6 +564,6 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>Simplify JmriHelp, eliminate static stub files.</li>
         </ul>
 

--- a/help/fr/local/stub_template.html
+++ b/help/fr/local/stub_template.html
@@ -4,18 +4,17 @@
 <title>JMRI: Redirected Page</title>
 <META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
 <!-- This file is used as a template for the html files in the stub/ folder -->
-<META HTTP-EQUIV="Refresh" CONTENT="0; URL=../index.html#<!--HELP_KEY-->">
+<META HTTP-EQUIV="Refresh" CONTENT="0; URL=<!--HELP_KEY-->">
 </head>
 <body>
 <p>JMRI Help</p>
 This page is a template. It's supposed to have displayed the help content you're looking for.  But something has gone wrong.
 <p></p>
-To see your help page, please click on <a href="../index.html#<!--HELP_KEY-->">this link</a>
+To see your help page, please click on <a href="<!--HELP_KEY-->">this link</a>
 <p></p>
-If you have Internet access, you can open the link on the JMRI web site. Click on <a href="https://jmri.org/help/en/<!--URL_HELP_KEY-->">https://jmri.org/help/en/<!--URL_HELP_KEY--></a>
+If you have Internet access, you can open the link on the JMRI web site. Click on <a href="https://jmri.org/help/fr/<!--URL_HELP_KEY-->">https://jmri.org/help/fr/<!--URL_HELP_KEY--></a>
 <p></p>
 <h2>Note for Safari browser users</h2>
 If you are using a Safari browser, you can fix this by going to Preferences -> Advanced and checking "Show Debug menu in menu bar". That should prevent this from happening again.
 </body>
 </html>
-  

--- a/java/src/jmri/util/UtilBundle.properties
+++ b/java/src/jmri/util/UtilBundle.properties
@@ -48,4 +48,6 @@ HelpError_Title                             = Help file not found
 HelpError_ReferenceNotFound                 = The help reference \"{0}\" is not found
 HelpWeb_Title                               = Web Help Error
 HelpWeb_ServerError                         = Unable to display the help page using a web server.\nDisplaying the local help page instead.
+HelpStub_Title                              = Help Stub File Error
+HelpError_StubFile                          = Unable to create the stub file for \"{0}\"
 

--- a/java/test/jmri/util/BuildHelpFilesTest.java
+++ b/java/test/jmri/util/BuildHelpFilesTest.java
@@ -1,21 +1,11 @@
 package jmri.util;
 
 import java.io.*;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
-import org.jsoup.*;
-import org.jsoup.nodes.*;
 import org.junit.Assume;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
@@ -29,11 +19,8 @@ import org.junit.jupiter.api.*;
 public class BuildHelpFilesTest {
 
     private String _lang;
-    private String _stubFolder;
-    private String _template;
     private PrintWriter _mapJhmWriter;
     private TreeSet<String> _helpKeys;
-    private TreeSet<String> _htmlPagesHelpKeys;
     private Properties _alternateMap;
 
 
@@ -52,81 +39,6 @@ public class BuildHelpFilesTest {
     private class XmlFile extends jmri.jmrit.XmlFile {
     }
 
-    private void generateStubFile(String helpKey) throws IOException {
-        Path path = Paths.get(_stubFolder + helpKey + ".html");
-        if (Files.exists(path)) {
-            return;
-        }
-
-        FileWriter fileWriter = new FileWriter(FileUtil.getProgramPath()
-                + "help/" + _lang + "/local/stub/"+helpKey+".html");
-
-        try (PrintWriter printWriter = new PrintWriter(fileWriter)) {
-
-            String expandedHelpKey = helpKey.replace(".", "/");
-            int pos = expandedHelpKey.indexOf('_');
-            if (pos == -1) {
-                expandedHelpKey = expandedHelpKey + ".shtml";
-            } else {
-                expandedHelpKey = expandedHelpKey.substring(0, pos) + ".shtml"
-                        + "#" + expandedHelpKey.substring(pos+1);
-            }
-
-            String contents = _template.replace("<!--HELP_KEY-->", helpKey);
-            contents = contents.replace("<!--URL_HELP_KEY-->", expandedHelpKey);
-            printWriter.print(contents);
-        }
-    }
-
-    private void parseNode(String helpKey, Node node, String pad) {
-        for (Node child : node.childNodes()) {
-//             System.out.format("%s%s, %s%n", pad, child.nodeName(), child.getClass().getName());
-            String name = child.attributes().get("id");
-            if (name == null || name.isEmpty()) {
-                name = child.attributes().get("name");      // The French help still uses the name attribute
-            }
-            if ((name != null) && !name.isEmpty()) {
-                if (!name.equals("mBody") && !name.equals("mainContent")) {     // Exclude standard id names
-                    String subHelpKey = helpKey+"_"+name;
-                    _htmlPagesHelpKeys.add(subHelpKey);
-//                     System.out.format("HelpKey: %s%n", subHelpKey);
-                }
-            }
-            parseNode(helpKey, child, pad+"    ");
-        }
-    }
-
-    private void searchHelpFolder(String rootFolder, String folder) throws IOException {
-        Path path = FileSystems.getDefault().getPath(folder);
-        Set<File> files = Stream.of(path.toFile().listFiles())
-                  .filter(file -> !file.isDirectory())
-                  .collect(Collectors.toSet());
-
-        for (File file : files) {
-            if (file.getName().endsWith(".shtml")) {
-                String fileName = file.getAbsolutePath().substring(rootFolder.length());
-                String helpKey = fileName.substring(0, fileName.indexOf(".shtml"))
-                            .replace('\\', '.').replace('/', '.');
-                _htmlPagesHelpKeys.add(helpKey);
-//                System.out.format("HelpKey: %s%n", helpKey);
-                Document doc = Jsoup.parse(file, "UTF-8");
-
-                org.jsoup.nodes.Element body = doc.body();
-                parseNode(helpKey, body, "");
-            }
-        }
-
-        Set<String> folders = Stream.of(path.toFile().listFiles())
-                  .filter(file -> file.isDirectory())
-                  .map(File::getName)
-                  .collect(Collectors.toSet());
-
-        for (String aFolder : folders) {
-            searchHelpFolder(rootFolder, folder + aFolder + "/");
-        }
-
-    }
-
     private void parseElement(Element e) throws IOException {
         String helpKey = e.getAttributeValue("target");
         if (helpKey != null) _helpKeys.add(helpKey);
@@ -140,11 +52,6 @@ public class BuildHelpFilesTest {
         boolean result = true;
 
         _lang = lang;
-        _stubFolder = FileUtil.getProgramPath() + "help/" + _lang + "/local/stub/";
-
-        Path path = Paths.get(FileUtil.getProgramPath() + "help/" + _lang + "/local/stub_template.html");
-        List<String> temp = Files.readAllLines(path);
-        _template = String.join("\n", temp) + "\n";
 
         _alternateMap = new Properties();
         try (InputStream input = new FileInputStream(FileUtil.getProgramPath() + "help/" + _lang + "/local/alternate_map.txt")) {
@@ -152,10 +59,6 @@ public class BuildHelpFilesTest {
         }
 
         _helpKeys = new TreeSet<>();
-        _htmlPagesHelpKeys = new TreeSet<>();
-
-        String folder = FileUtil.getProgramPath() + "help/" + _lang + "/";
-        searchHelpFolder(folder, folder);
 
         XmlFile xmlFile = new XmlFile();
         Assert.assertNotNull(xmlFile);
@@ -170,22 +73,6 @@ public class BuildHelpFilesTest {
                 + "help/" + _lang + "/JmriHelp_" + _lang + "Index.xml");
         Assert.assertNotNull(e);
         parseElement(e);
-
-        TreeSet<String> _stubHelpKeys = new TreeSet<>();
-        _stubHelpKeys.addAll(_helpKeys);
-        _stubHelpKeys.addAll(_htmlPagesHelpKeys);
-
-        // Generate the stub files
-        for (String helpKey : _stubHelpKeys) {
-            try {
-                if (!_alternateMap.containsKey(helpKey)) {
-                    generateStubFile(helpKey);
-                }
-            } catch (IOException ex) {
-                System.out.format("Failed to create stub file for key \"%s\"%n", helpKey);
-                result = false;
-            }
-        }
 
         // Generate jmri_map.xml
         FileWriter fileWriter = new FileWriter(FileUtil.getProgramPath() + "help/" + _lang + "/local/jmri_map.xml");


### PR DESCRIPTION
The new process creates a stub.html file in settings:jmrihelp.  Each selection of Window Help or General Help results in a modified stub.html.

The commit for removing the old stub files is deferred for code review.