### PR TITLE
(Proposed draft) Update tech pages for Java 11

### DIFF
--- a/help/en/html/doc/Technical/JVMCapabilities.shtml
+++ b/help/en/html/doc/Technical/JVMCapabilities.shtml
@@ -21,22 +21,14 @@
       for future JMRI versions. (For pre-Java-1.8 content, see the <a href=
       "JVMCapabilitiesOlder.shtml">historical page</a>.)</p>
 
-      <p>Note: The Java community is moving from a "few big Java releases, years apart" development
+      <p>Note: The Java community has moved from a "few big Java releases, years apart" development
       cycle to a cycle with a new release every six months, and a long-term support (LTS) release
       every three years. (For background, see <a href=
       "https://mreinhold.org/blog/forward-faster#Proposal">here</a>, <a href=
       "http://openjdk.java.net/jeps/322?elq_mid=102312&amp;sh=251225172624122582213150247717&amp;cmid=WWMK170418P00047">
-      here</a>, <a href="http://www.oracle.com/technetwork/java/eol-135779.html">here</a>). It's
-      not yet clear what this will mean for JMRI's development and migration path. Much discussion
-      is necessary.</p>
-
-      <p>As of February 2018, Oracle has scheduled end-of-life for Java 8 in January 2019, and
-      intends to release the next Long Term Support version (notionally known as both Java 11 and
-      Java 18.9) in September of 2018. Given that some users will need to move forward for other
-      applications once Java 8 is End Of Life, at a minimum we'll have to have JMRI running under
-      both Java 8 and Java 11/18.9 by January 2019. For more information on this, see also this
-      <a href=
-      "http://www.javamagazine.mozaicreader.com/NovemberDecember2018/default/52/0/#&amp;pageSet=52&amp;page=0&amp;contentItem=0">
+      here</a>, <a href="http://www.oracle.com/technetwork/java/eol-135779.html">here</a>).
+      For more information on this, see also this
+      <a href="https://archive.org/details/JavaMagazine2018.1112/page/n52/mode/2up">
       Java Magazine article from November 2018</a> .</p>
 
       <h2>Capabilities</h2>

--- a/help/en/html/doc/Technical/JVMCapabilities.shtml
+++ b/help/en/html/doc/Technical/JVMCapabilities.shtml
@@ -333,7 +333,22 @@
         </tr>
 
         <tr>
-          <td>Win 11+ (64-bit)</td>
+          <td>Linux Fedora 33</td>
+          <td>11</td>
+        </tr>
+
+        <tr>
+          <td style="background-color: #FF8080">Linux Fedora 32</td>
+          <td>8</td>
+        </tr>
+
+        <tr>
+          <td>Linux Centos 7</td>
+          <td>11+</td>
+        </tr>
+
+        <tr>
+          <td>Win 11 (64-bit)</td>
           <td>11+</td>
         </tr>
 
@@ -509,7 +524,7 @@
               <a href="https://jmri.org/install/WindowsNew.shtml#sysreq">Windows</a>
             </th>
             <th>
-              <a href="https://jmri.org/install/Linux.shtml#sysreq">Linux</a>
+              <a href="https://jmri.org/install/Linux.shtml#sysreq">Oracle<br>Linux<br>(RHEL)</a>
             </th>
             <th>
               <a href="https://jmri.org/install/Ubuntu.shtml#sysreq">Ubuntu</a>
@@ -524,22 +539,22 @@
             <td>11</td>
             <td>10.10</td>
             <td>Windows Vista or later<br>64 bit only</td>
-            <td>5.5+</td>
+            <td>5.5</td>
             <!-- not sure what 5.5 means here, since JMRI 4.x works on CentOS 7, which has Linux kernel 3.10 -->
 
-            <td>12.04+</td>
+            <td>12.04</td>
             <td>14.04LTS</td>
           </tr>
 
           <tr>
             <td>4.*</td>
             <td>1.8</td>
-            <td>10.8.3+ Mountain Lion</td>
+            <td>10.8.3 Mountain Lion</td>
             <td>Win7 SP1/8/10, Vista SP2, (XP)</td>
-            <td>5.5+</td>
+            <td>5.5</td>
             <!-- not sure what 5.5 means here, since JMRI 4.x works on CentOS 7, which has Linux kernel 3.10 -->
 
-            <td>12.04+</td>
+            <td>12.04</td>
             <td>14.04LTS</td>
           </tr>
 
@@ -548,7 +563,7 @@
             <td>1.7</td>
             <td>10.7.3 Lion</td>
             <td>Win7 SP1/8/10, Vista SP2, (XP)</td>
-            <td>5.5+</td>
+            <td>5.5</td>
             <!-- not sure what 5.5 means here, since JMRI 3.x works on CentOS 6, which has Linux kernel 2.6.32 -->
 
             <td>12.04</td>

--- a/help/en/html/doc/Technical/JVMCapabilities.shtml
+++ b/help/en/html/doc/Technical/JVMCapabilities.shtml
@@ -38,7 +38,7 @@
       "JRE" column lists the first runtime environment that could run the feature, including the
       needed JVM and library support.</p>
 
-      <table style="width: 100%; padding: 10px 15px 10px 15px;">
+      <table style="width: 100%; padding: 10px 15px 10px 15px;" border="1">
         <tr>
           <th>Feature</th>
           <th>JDK</th>

--- a/help/en/html/doc/Technical/JVMCapabilities.shtml
+++ b/help/en/html/doc/Technical/JVMCapabilities.shtml
@@ -194,6 +194,20 @@
 
         <tr>
           <td>
+            A standard installation of
+            <a href="https://medium.com/graalvm/nashorn-removal-graalvm-to-the-rescue-d4da3605b6cb">GraalVM</a>
+            is available that can
+            <a href="https://www.graalvm.org/reference-manual/python/">run parts of Python 3.7</a>.
+            Although this is "far from complete", no other project appears to be emerging to
+            include Python 3 support in i.e. Jython. Having this available can let JMRI start a
+            gentler migration.
+          </td>
+          <td>11</td>
+          <td>11</td>
+        </tr>
+
+        <tr>
+          <td>
             The Nashorn interpreter will be removed in Java 15. Some adaptation will be needed to
             have a JavaScript interpreter, perhaps <a href=
             "https://medium.com/graalvm/nashorn-removal-graalvm-to-the-rescue-d4da3605b6cb">GraalVM</a>
@@ -203,17 +217,6 @@
           <td>15</td>
         </tr>
 
-        <tr>
-          <td>
-            A standard installation of GraalVM is available that can <a href=
-            "https://www.graalvm.org/reference-manual/python/">run parts of Python 3.7</a>.
-            Although this is "far from complete", no other project appears to be emerging to
-            include Python 3 support in i.e. Jython. Having this available can let JMRI start a
-            gentler migration.
-          </td>
-          <td>11</td>
-          <td>11</td>
-        </tr>
       </table>
       (* indicates that a compatibility library is used in the early version)
       <h2>JRE availability</h2>
@@ -222,8 +225,8 @@
       operating system versions. Please note that not all users of that operating system will have
       updated to this Java version; many will be using an older one.</p>
 
-      <p>JMRI development requires Java 8u101 or later. 8u101 contains a certificate change that's
-      needed to link to some remote Javadocs.</p>
+      <p>JMRI development requires Java 8u101 or later through January 2022. 8u101 contains a certificate change that's
+      needed to link to some remote Javadocs. After that, Java 11 will be required.</p>
 
       <p><a href="http://www.oracle.com/technetwork/java/javase/config-417990.html">Oracle's page
       on Java 1.7 requirements</a> says "Note: As of April 8, 2014 Microsoft stopped supporting
@@ -237,15 +240,33 @@
       "https://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase8-2177648.html">Java
       download archive page</a> for links to that.</p>
 
-      <p>As of April 18, 2018, the the <a href=
-      "https://java.com/en/download/release_notice.jsp">Oracle Java 8 page</a> was saying:</p>
+      <p>Java <a href="https://www.oracle.com/java/technologies/java-se-support-roadmap.html">plans
+      for end of life</a> of various versions:</p>
 
-      <blockquote cite="https://java.com/en/download/release_notice.jsp">
-        Public updates for Oracle Java SE 8 will remain available for individual, personal use
-        through at least the end of 2020.
-      </blockquote>
+      <ul>
+        <li>Java 8 will <a href=
+        "https://www.oracle.com/java/technologies/java-se-support-roadmap.html">keep receiving
+        free updates through March 2022</a> for personal use. Note that Oracle is <a href=
+        "https://blogs.oracle.com/java-platform-group/end-of-public-updates-is-a-process%2c-not-an-event">
+          no longer actively maintaining Java 8</a>.
+        </li>
 
-      <p>For more details, see the Java pages for:</p>
+        <li>
+          <a href="http://openjdk.java.net/projects/jdk/11/">Java 11</a>, made available in
+          September 2018, will be a "Long Term Support" (LTS) release. That means five years of
+          support,
+          <a href="https://www.oracle.com/java/technologies/java-se-support-roadmap.html">through September 2023</a>.
+        </li>
+
+        <li>Java 9, 10, and 12 through 16 will not be LTS releases, and support will end shortly
+        after the following release comes out.</li>
+
+        <li>Java 17 is the current LTS release, made available in September of 2021. It is also
+        expected to get five years of support,
+        <a href="https://www.oracle.com/java/technologies/java-se-support-roadmap.html">through September 2026</a>.</li>
+      </ul>
+
+      <p>For more information, see the Java pages for:</p>
 
       <ul>
         <li>
@@ -284,43 +305,28 @@
         <li>
           <a href="https://openjdk.java.net/projects/jdk/15/">Java 15 (Sept 2020)</a>
         </li>
-      </ul>
 
-      <p>Java <a href="https://www.oracle.com/java/technologies/java-se-support-roadmap.html">plans
-      for end of life</a> of various versions:</p>
-
-      <ul>
-        <li>Java 8 will <a href=
-        "https://www.oracle.com/java/technologies/java-se-support-roadmap.html">keep receiving
-        updates indefinitely</a> for personal use. which 18-month warning expected when
-        "indefinitely" ends. Note that Oracle is <a href=
-        "https://blogs.oracle.com/java-platform-group/end-of-public-updates-is-a-process%2c-not-an-event">
-          no longer actively maintaining Java 8</a>. Commercial support for security patches ends
-          in Spring 2020 for many organizations.
+        <li>
+          <a href="https://openjdk.java.net/projects/jdk/16/">Java 16 (March 2021)</a>
         </li>
 
         <li>
-          <a href="http://openjdk.java.net/projects/jdk/11/">Java 11</a>, made available in
-          September 2018, will be a "Long Term Support" (LTS) release. That means five years of
-          support, <a href=
-          "https://www.oracle.com/java/technologies/java-se-support-roadmap.html">through 2023</a>.
+          <a href="https://openjdk.java.net/projects/jdk/17/">Java 17 (Sept 2021)</a>
         </li>
 
-        <li>Java 9, 10, and 12 through 16 will not be LTS releases, and support will end shortly
-        after the following release comes out.</li>
-
-        <li>Java 17 is announced as the next LTS release, expected in September of 2021. It is also
-        expected to get five years of support.</li>
       </ul>
+
       Model railroaders may not care if they're using a Java version that's supported. Some of them
       don't connect their layout computers to the internet; some have single-purpose machines that,
       if messed up, they'll just reload. But other JMRI users have multi-purpose machines whose
       security matters; essentially all of the JMRI developers are in this situation. At least some
       of the developers use dual-purpose machines that are required to meet various security and
-      update standards. For those, Java 8 is going to increasing become a liability.
+      update standards. For those, Java 8 has increasing become a liability.
+
       <p>Java 11 JDK from Oracle only runs on 64-bit Windows versions (no 32-bit). <a href=
       "https://adoptopenjdk.net/">AdoptOpenJDK</a> continues to make 32 and 64-bit JREs and JDKs
-      available.</p>
+      available. Light red indicates unable to run Java 8 or later; darker red means able to
+      run Java 8, but not Java 11.</p>
 
       <table border="1">
         <tr>
@@ -335,22 +341,22 @@
         </tr>
 
         <tr>
-          <td>Win 1!+ (64-bit)</td>
+          <td>Win 11+ (64-bit)</td>
           <td>11+</td>
         </tr>
 
         <tr>
-          <td>Win 8 (32-bit)</td>
+          <td style="background-color: #FF8080">Win 8 (32-bit)</td>
           <td>8</td>
         </tr>
 
         <tr>
-          <td>Win 7 (32-bit)</td>
+          <td style="background-color: #FF8080">Win 7 (32-bit)</td>
           <td>8</td>
         </tr>
 
         <tr>
-          <td>Win Server 2008 (32-bit)</td>
+          <td style="background-color: #FF8080">Win Server 2008 (32-bit)</td>
           <td>8</td>
         </tr>
 
@@ -390,7 +396,7 @@
         </tr>
 
         <tr>
-          <td>Win Server 2008 R2 (64-bit)</td>
+          <td style="background-color: #FF8080">Win Server 2008 R2 (64-bit)</td>
           <td>10</td>
         </tr>
 
@@ -410,7 +416,7 @@
         </tr>
 
         <tr>
-          <td>Windows Vista (32-bit)</td>
+          <td style="background-color: #FF8080">Windows Vista (32-bit)</td>
           <td>
             8<br>
             <a href="https://www.java.com/en/download/faq/winxp.xml">Unofficial<br>
@@ -424,7 +430,7 @@
         </tr>
 
         <tr>
-          <td>Windows XP</td>
+          <td style="background-color: #FF8080">Windows XP</td>
           <td>
             8<br>
             <a href="https://www.java.com/en/download/faq/winxp.xml">Unofficial<br>
@@ -453,7 +459,7 @@
         </tr>
 
         <tr>
-          <td>Mac OS X 10.8.3 Mountain Lion</td>
+          <td style="background-color: #FF8080">Mac OS X 10.8.3 Mountain Lion</td>
           <td>8</td>
         </tr>
 
@@ -522,7 +528,19 @@
           </tr>
 
           <tr>
-            <td>4.2</td>
+            <td>5.*</td>
+            <td>11</td>
+            <td>10.10</td>
+            <td>Windows Vista or later<br>64 bit only</td>
+            <td>5.5+</td>
+            <!-- not sure what 5.5 means here, since JMRI 4.x works on CentOS 7, which has Linux kernel 3.10 -->
+
+            <td>12.04+</td>
+            <td>14.04LTS</td>
+          </tr>
+
+          <tr>
+            <td>4.*</td>
             <td>1.8</td>
             <td>10.8.3+ Mountain Lion</td>
             <td>Win7 SP1/8/10, Vista SP2, (XP)</td>

--- a/help/en/html/doc/Technical/TechRoadMap.shtml
+++ b/help/en/html/doc/Technical/TechRoadMap.shtml
@@ -141,9 +141,25 @@
         </tr>
 
         <tr>
-          <td>(Probably) 5.0</td>
+          <td>4.24</td>
           <td>Production version, culmination of Spring 2021 series</td>
-          <td>June 2021</td>
+          <td>July 2021</td>
+          <td>8</td>
+          <td>8</td>
+        </tr>
+
+        <tr>
+          <td>4.26</td>
+          <td>Production version, culmination of Fall 2021 series</td>
+          <td>January 2022</td>
+          <td>8</td>
+          <td>8</td>
+        </tr>
+
+        <tr>
+          <td>(Probably) 5.0</td>
+          <td>Production version, culmination of Spring 2022 series</td>
+          <td>June 2022</td>
           <td>11</td>
           <td>11</td>
         </tr>
@@ -152,44 +168,32 @@
       <h3>Java and JMRI in the Near Future</h3>
       The 4.1.* series of test releases in Fall 2015 started the requirement for Java 8. This has
       continued through the following release series. Java 8 will continue to be the requirement
-      through at least Fall of 2020. This involves doing development, test and production release
+      through the Fall of 2021. This involves doing development, test and production release
       builds using Java 1.8.0_181. (We also <a href=
       "https://builds.jmri.org/jenkins/job/Development/job/VersionChecks/job/JRE%208u151/">test on
       Jenkins with Java 1.8_0_151</a> to ensure Windows XP compatibility)
-      <p>The current long-term-support Java release is Java 11 from Fall of 2018. Oracle has
+      <p>The next long-term-support (LTS) Java release is Java 11 from Fall of 2018. Oracle has
       <a href=
       "https://blogs.oracle.com/java-platform-group/a-quick-summary-on-the-new-java-se-subscription">
       aligned their Java and the OpenJDK from that point</a>. Because some people will need to have
-      that on their computers for other purposes, we ensure JMRI can build and run on Oracle Java 8
+      that on their computers for other purposes, we have been building and running JMRI
+      for testing purposes on Oracle Java 8
       through 11 and OpenJDK version 11 by using <a href=
-      "https://builds.jmri.org/jenkins/job/Development/job/VersionChecks/">Jenkins</a> to</p>
-
-      <ul>
-        <li>Build and run AllTest on each of the JDKs for Java 9, 10, 11; and</li>
-
-        <li>Run allTest from each of those JDK 9, 10 and 11 builds on a Java 8u181 JRE; and</li>
-
-        <li>Run AllTest from our JDK 8 builds on each of the Java 9, 10 and 11 JREs.</li>
-      </ul>
+      "https://builds.jmri.org/jenkins/job/Development/job/VersionChecks/">Jenkins</a>.
       You can follow the current status of these on the <a href="CI-status.shtml">CI Status
       page</a>.
-      <p>At some point, the Java version required by JMRI has to move forward. For example, Oracle
-      <a href=
-      "http://www.oracle.com/technetwork/java/javase/javaclientroadmapupdate2018mar-4414431.pdf">has
-      announced</a> that they'll stop providing standalone JRE installers by the end of 2020, by
-      which time JMRI distributions will have to contain the Java runtime components or it won't be
-      possible to run JMRI on newly-bought PCs (<a href="http://adoptopenjdk.net">will continue to
-      provide independent JREs</a>). That in turn might require tools like jlink from Java 9 or
-      later.</p>
+      <p>Java 17 is the current LTS release.  JMRI is built and tests are run on it too,
+      but we don't recommend using it due to some remaining compatibility issues.
 
-      <p>While we don't know with certainty when JMRI development will move past Java 8, we expect
-      that it will be during the Spring 2021 development releases, leading to the June 2021
+      <p>In the near future, the Java version required by JMRI will move forward. We expect
+      that it will be during the Spring 2022 development releases, leading to the June 2022
       production releases requiring Java 11 and therefore being called JMRI 5.0. There might be one
       or two JMRI updates and minor releases early in Spring that would still work with Java 8.</p>
 
       <h4>Java Release and Operating System Support</h4>
       More information on Java releases and the operating systems that support them is on a
       <a href="JVMCapabilities.shtml">separate page</a>.
+
       <h2>Migration Notes</h2>
 
       <p>This is a section of notes for various code migrations that are in progress or
@@ -197,17 +201,6 @@
       but they may effect external users of the JMRI libraries.</p>
 
       <ul>
-        <li>At some point, we have to migrate away from <a href="Help.shtml">JavaHelp and
-        JHelpDev</a>. At a minimum, we'll need to <a href=
-        "http://weblogs.java.net/blog/brinkley/archive/2004/11/javahelp_v20_02.html">replace the
-        renderer</a>. There are <a href=
-        "http://stackoverflow.com/questions/9900110/javahelp-viewers-or-alternatives">several
-        alternative help systems</a> available. <a href=
-        "http://www.oracle.com/technetwork/topics/index-083946.html">Oracle Help</a> might be a
-        good choice. DocBook as a tool for generating multiple documentation forms is also being
-        considered.
-        </li>
-
         <li>USB access technology has advanced a lot since support for some basic libraries was
         added to JMRI. At some point, we should replace those early library versions, but it will
         break some user scripts.</li>

--- a/help/en/html/doc/Technical/TechRoadMap.shtml
+++ b/help/en/html/doc/Technical/TechRoadMap.shtml
@@ -24,144 +24,88 @@
 
       <h2>JMRI Releases</h2>
 
-      <p>This section describes the (notional) plans for JMRI releases in the future.</p>
+      <p>This section describes the history and (notional) plans for JMRI releases in the future.</p>
 
       <table border="1">
         <tr>
-          <th>Release</th>
-          <th>Description</th>
-          <th>Date</th>
-          <td>JRE</td>
-          <td>JDK</td>
+          <th style="text-align:center">Release</th>
+          <th style="text-align:left">Description</th>
+          <th style="text-align:center">Date</th>
+          <td style="text-align:center">JRE</td>
+          <td style="text-align:center">JDK</td>
         </tr>
 
         <tr>
-          <td>3.11.*</td>
+          <td style="text-align:center">3.11.*</td>
           <td>Development series</td>
           <td>
           </td>
-          <td>1.6</td>
-          <td>8</td>
+          <td style="text-align:center">1.6</td>
+          <td style="text-align:center">8</td>
         </tr>
 
         <tr>
-          <td>4.0</td>
+          <td style="text-align:center">4.0</td>
           <td>Production version, culmination of 3.11.* series</td>
-          <td>July 2015 <strong>(done)</strong></td>
-          <td>8</td>
-          <td>8</td>
+          <td style="text-align:center">July 2015</td>
+          <td style="text-align:center">8</td>
+          <td style="text-align:center">8</td>
         </tr>
 
         <tr>
-          <td>4.2</td>
+          <td style="text-align:center">4.2</td>
           <td>Production version, culmination of 4.1.* series</td>
-          <td>December 2015 <strong>(done)</strong></td>
-          <td>8</td>
-          <td>8</td>
+          <td style="text-align:center">December 2015</td>
+          <td style="text-align:center">8</td>
+          <td style="text-align:center">8</td>
         </tr>
 
         <tr>
-          <td>4.4</td>
-          <td>Production version, culmination of 4.3.* series</td>
-          <td>Early Summer 2016</td>
-          <td>8</td>
-          <td>8</td>
+          <td style="text-align:center">...</td>
+          <td>...</td>
+          <td style="text-align:center">...</td>
+          <td style="text-align:center">8</td>
+          <td style="text-align:center">8</td>
         </tr>
 
         <tr>
-          <td>4.6</td>
-          <td>Production version, culmination of 4.5.* series</td>
-          <td>Late Fall 2016</td>
-          <td>8</td>
-          <td>8</td>
-        </tr>
-
-        <tr>
-          <td>4.8</td>
-          <td>Production version, culmination of 4.7.* series</td>
-          <td>Early Summer 2017</td>
-          <td>8</td>
-          <td>8</td>
-        </tr>
-
-        <tr>
-          <td>4.10</td>
-          <td>Production version, culmination of 4.9.* series</td>
-          <td>December 2017</td>
-          <td>8</td>
-          <td>8</td>
-        </tr>
-
-        <tr>
-          <td>4.12</td>
-          <td>Production version, culmination of 4.11.* series</td>
-          <td>July 2018</td>
-          <td>8</td>
-          <td>8</td>
-        </tr>
-
-        <tr>
-          <td>4.14</td>
-          <td>Production version, culmination of 4.13.* series</td>
-          <td>December 2018</td>
-          <td>8</td>
-          <td>8</td>
-        </tr>
-
-        <tr>
-          <td>4.16</td>
-          <td>Production version, culmination of 4.15.* series</td>
-          <td>July 2019</td>
-          <td>8</td>
-          <td>8</td>
-        </tr>
-
-        <tr>
-          <td>4.18</td>
-          <td>Production version, culmination of Fall 2019 series</td>
-          <td>December 2019</td>
-          <td>8</td>
-          <td>8</td>
-        </tr>
-
-        <tr>
-          <td>4.20</td>
-          <td>Production version, culmination of Spring 2020 series</td>
-          <td>July 2020</td>
-          <td>8</td>
-          <td>8</td>
-        </tr>
-
-        <tr>
-          <td>4.22</td>
+          <td style="text-align:center">4.22</td>
           <td>Production version, culmination of Fall 2020 series</td>
-          <td>February 2021</td>
-          <td>8</td>
-          <td>8</td>
+          <td style="text-align:center">February 2021</td>
+          <td style="text-align:center">8</td>
+          <td style="text-align:center">8</td>
         </tr>
 
         <tr>
-          <td>4.24</td>
+          <td style="text-align:center">4.24</td>
           <td>Production version, culmination of Spring 2021 series</td>
-          <td>July 2021</td>
-          <td>8</td>
-          <td>8</td>
+          <td style="text-align:center">July 2021</td>
+          <td style="text-align:center">8</td>
+          <td style="text-align:center">8</td>
         </tr>
 
         <tr>
-          <td>4.26</td>
+          <td style="text-align:center">4.26</td>
           <td>Production version, culmination of Fall 2021 series</td>
-          <td>January 2022</td>
-          <td>8</td>
-          <td>8</td>
+          <td style="text-align:center">January 2022</td>
+          <td style="text-align:center">8</td>
+          <td style="text-align:center">8</td>
         </tr>
 
         <tr>
-          <td>(Probably) 5.0</td>
+          <td style="text-align:center">(Intended) 5.0</td>
           <td>Production version, culmination of Spring 2022 series</td>
-          <td>June 2022</td>
-          <td>11</td>
-          <td>11</td>
+          <td style="text-align:center">June 2022</td>
+          <td style="text-align:center"><b>11</b></td>
+          <td style="text-align:center"><b>11</b></td>
+        </tr>
+
+        <tr>
+          <td style="text-align:center">(Intended) 5.2</td>
+          <td>Production version, culmination of Fall 2022 series</td>
+          <td style="text-align:center">Jan 2023</td>
+          <td style="text-align:center"><b>11</b></td>
+          <td style="text-align:center"><b>11</b></td>
         </tr>
       </table>
 


### PR DESCRIPTION
Pending the decision to move JMRI forward to Java 11, this contains (draft) updates to the [Tech Road Map](https://htmlpreview.github.io/?https://github.com/bobjacobsen/JMRI/blob/j11-tech-pages/help/en/html/doc/Technical/TechRoadMap.shtml) and [JVM Capabilities](https://htmlpreview.github.io/?https://github.com/bobjacobsen/JMRI/blob/j11-tech-pages/help/en/html/doc/Technical/JVMCapabilities.shtml) pages.  Click on the links to see formatted versions of the new pages.
