### PR TITLE
clear ShutDownManager to avoid test hanging on exit

### DIFF
--- a/java/test/jmri/jmrit/display/palette/IndicatorTOIconDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/IndicatorTOIconDialogTest.java
@@ -30,6 +30,7 @@ public class IndicatorTOIconDialogTest {
         JUnitUtil.dispose(t);
         JUnitUtil.dispose(df);
         JUnitUtil.dispose(editor);
+        JUnitUtil.clearShutDownManager();
     }
 
     @BeforeEach


### PR DESCRIPTION
jmri/jmrit/display/palette/IndicatorTOIconDialogTest was hanging due to an outstanding ShutDownItem that asked the user whether or not to store changes.  This clears that before ending the test.