### PR TITLE
Clean up test threads left running

### DIFF
--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -201,6 +201,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
                 }
             };
             thr = new Thread(r);
+            thr.setName("Turnout "+getDisplayName()+" setCommandedStateAtInterval");
             thr.start();
         } else {
             log.debug("nextWait has passed");
@@ -390,7 +391,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         throw new IllegalArgumentException("Unexpected mode: " + mode);
     }
 
-    /** 
+    /**
      * On change, fires Property Change "feedbackchange".
      * {@inheritDoc}
      */
@@ -444,7 +445,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
     }
 
-    /** 
+    /**
      * On change, fires Property Change "inverted".
      * {@inheritDoc}
      */
@@ -492,9 +493,9 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
     /**
      * Turnouts that are locked should only respond to JMRI commands to change
      * state.
-     * We simulate a locked turnout by monitoring the known state (turnout 
+     * We simulate a locked turnout by monitoring the known state (turnout
      * feedback is required) and if we detect that the known state has
-     * changed, 
+     * changed,
      * negate it by forcing the turnout to return to the commanded
      * state.
      * Turnouts that have local buttons can also be locked if their
@@ -582,7 +583,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         return false;
     }
 
-    /** {@inheritDoc} 
+    /** {@inheritDoc}
      * Not implemented in AbstractTurnout.
      */
     @Override
@@ -644,8 +645,8 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         return _decoderName;
     }
 
-    /** 
-     * {@inheritDoc} 
+    /**
+     * {@inheritDoc}
      * On change, fires Property Change "decoderNameChange".
      */
     @Override
@@ -682,8 +683,8 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         return myTurnoutOperation;
     }
 
-    /** 
-     * {@inheritDoc} 
+    /**
+     * {@inheritDoc}
      * Fires Property Change "TurnoutOperationState".
      */
     @Override
@@ -779,7 +780,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
     }
 
-    /** 
+    /**
      * On change, fires Property Change "TurnoutFeedbackFirstSensorChange".
      * @param s the Handle for First Feedback Sensor
      */
@@ -833,7 +834,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         }
     }
 
-    /** 
+    /**
      * On change, fires Property Change "TurnoutFeedbackSecondSensorChange".
      * @param s the Handle for Second Feedback Sensor
      */
@@ -1076,8 +1077,8 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         return _divergeSpeed;
     }
 
-    /** 
-     * {@inheritDoc} 
+    /**
+     * {@inheritDoc}
      * On change, fires Property Change "TurnoutDivergingSpeedChange".
      */
     @Override

--- a/java/src/jmri/implementation/DefaultRoute.java
+++ b/java/src/jmri/implementation/DefaultRoute.java
@@ -773,6 +773,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
                 log.debug("Setting route {}", this.getSystemName());
                 setRouteBusy(true);
                 SetRouteThread thread = new SetRouteThread(this);
+                thread.setName("Route "+getDisplayName()+" setRoute");
                 thread.start();
             } else {
                 log.debug("Not setting route {} because busy", this.getSystemName());

--- a/java/src/jmri/implementation/MatrixSignalMast.java
+++ b/java/src/jmri/implementation/MatrixSignalMast.java
@@ -73,7 +73,7 @@ public class MatrixSignalMast extends AbstractSignalMast {
 
         mast = mast.substring(0, mast.indexOf("("));
         setMastType(mast);
-        
+
         String tmp = parts[2].substring(parts[2].indexOf("($") + 2, parts[2].indexOf(")")); // retrieve ordinal from name
         try {
             int autoNumber = Integer.parseInt(tmp);
@@ -323,7 +323,7 @@ public class MatrixSignalMast extends AbstractSignalMast {
         // to do: use for loop
         ArrayList<String> outputlist = new ArrayList<>();
         //list = outputsToBeans.keySet();
-        
+
         int index = 1;
         while (outputsToBeans.containsKey("output" + index)) {
             outputlist.add(outputsToBeans.get("output" + index).getName());
@@ -394,7 +394,9 @@ public class MatrixSignalMast extends AbstractSignalMast {
                     try {
                         Thread.sleep(mDelay); // only the Mast specific user defined delay is applied here
                     } catch (InterruptedException e) {
+                        log.debug("interrupted in updateOutputs");
                         Thread.currentThread().interrupt(); // retain if needed later
+                        return;
                     }
                 }
             }

--- a/java/src/jmri/jmrit/logix/Engineer.java
+++ b/java/src/jmri/jmrit/logix/Engineer.java
@@ -74,7 +74,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
     @Override
     @SuppressFBWarnings(value="UW_UNCOND_WAIT", justification="waits may be indefinite until satisfied or thread aborted")
     public void run() {
-        if (log.isDebugEnabled()) 
+        if (log.isDebugEnabled())
             log.debug("Engineer started warrant {} _throttle= {}", _warrant.getDisplayName(), _throttle.getClass().getName());
 
         int cmdBlockIdx = 0;
@@ -97,7 +97,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                     cmdBlockIdx = idx;
                 }
             }
-            if (cmdBlockIdx < _warrant.getCurrentOrderIndex() || 
+            if (cmdBlockIdx < _warrant.getCurrentOrderIndex() ||
                     (command.equals(Command.NOOP) && (cmdBlockIdx <= _warrant.getCurrentOrderIndex()))) {
                 // Train advancing too fast, need to process commands more quickly,
                 // allow some time for whistle toots etc.
@@ -111,15 +111,15 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
             }
 
             long cmdStart = System.currentTimeMillis();
-            if (log.isDebugEnabled()) 
+            if (log.isDebugEnabled())
                 log.debug("Start Cmd #{} for block \"{}\" currently in \"{}\". wait {}ms to do cmd {}. Warrant {}",
-                    _idxCurrentCommand+1, _currentCommand.getBeanDisplayName(), _warrant.getCurrentBlockName(), 
+                    _idxCurrentCommand+1, _currentCommand.getBeanDisplayName(), _warrant.getCurrentBlockName(),
                     cmdWaitTime, command.toString(), _warrant.getDisplayName());
                     // Note: command indexes biased from 0 to 1 to match Warrant display of commands.
             synchronized (this) {
                 if (!Warrant.Normal.equals(_speedType)) {
                     cmdWaitTime = (long)(cmdWaitTime*_timeRatio); // extend et when speed has been modified from scripted speed
-                }                
+                }
                 try {
                     if (cmdWaitTime > 0) {
                         wait(cmdWaitTime);
@@ -128,9 +128,10 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                         break;
                     }
                 } catch (InterruptedException ie) {
-                    log.error("At time wait {}", ie);
+                    log.debug("InterruptedException during time wait {}", ie);
                     _warrant.debugInfo();
                     Thread.currentThread().interrupt();
+                    return;
                 } catch (java.lang.IllegalArgumentException iae) {
                     log.error("At time wait {}", iae);
                 }
@@ -147,15 +148,16 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                 synchronized (this) {
                     try {
                         _waitForSync = true;
-                        if (log.isDebugEnabled()) 
+                        if (log.isDebugEnabled())
                             log.debug("Wait for train to enter \"{}\". Warrant {}",
                                 _warrant.getBlockAt(_syncIdx).getDisplayName(), _warrant.getDisplayName());
                         _warrant.fireRunStatus("WaitForSync", _idxCurrentCommand - 1, _idxCurrentCommand);
                         wait();
                     } catch (InterruptedException ie) {
-                        log.error("At _waitForSync {}", ie);
+                        log.debug("InterruptedException during _waitForSync {}", ie);
                         _warrant.debugInfo();
                         Thread.currentThread().interrupt();
+                        return;
                     }
                     finally {
                         _waitForSync = false;
@@ -172,14 +174,15 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                 if (_waitForClear) {
                     try {
                         _atClear = true;
-                        if (log.isDebugEnabled()) 
+                        if (log.isDebugEnabled())
                             log.debug("Waiting for clearance. _waitForClear= {} _halt= {} \"{}\".  Warrant {}",
                                 _waitForClear, _halt, _warrant.getBlockAt(cmdBlockIdx).getDisplayName(), _warrant.getDisplayName());
                         wait();
                     } catch (InterruptedException ie) {
-                        log.error("At _atClear {}", ie);
+                        log.debug("InterruptedException during _atClear {}", ie);
                         _warrant.debugInfo();
                         Thread.currentThread().interrupt();
+                        return;
                     }
                     finally {
                         _waitForClear = false;
@@ -196,14 +199,15 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                 if (_halt) {
                     try {
                         _atHalt = true;
-                        if (log.isDebugEnabled()) 
+                        if (log.isDebugEnabled())
                             log.debug("Waiting to Resume. _halt= {}, _waitForClear= {}, Block \"{}\".  Warrant {}",
                                 _halt, _waitForClear, _warrant.getBlockAt(cmdBlockIdx).getDisplayName(), _warrant.getDisplayName());
                         wait();
                     } catch (InterruptedException ie) {
-                        log.error("At _atHalt {}", ie);
+                        log.debug("InterruptedException during _atHalt {}", ie);
                         _warrant.debugInfo();
                         Thread.currentThread().interrupt();
+                        return;
                     }
                     finally {
                         _halt = false;
@@ -220,13 +224,14 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                 if (_ramp != null && !_ramp.ready) {
                     int idx = _idxCurrentCommand;
                     try {
-                        if (log.isDebugEnabled()) 
-                            log.debug("Waiting for ramp to finish at Cmd #{}.  Warrant {}", 
+                        if (log.isDebugEnabled())
+                            log.debug("Waiting for ramp to finish at Cmd #{}.  Warrant {}",
                                     _idxCurrentCommand+1, _warrant.getDisplayName());
                         wait();
                     } catch (InterruptedException ie) {
                         _warrant.debugInfo();
                         Thread.currentThread().interrupt();
+                        return;
                     }
                     // ramp will decide whether to skip or execute _currentCommand
                     et = System.currentTimeMillis() - cmdStart;
@@ -247,7 +252,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
 
         }
         // shut down
-        setSpeed(0.0f); // for safety to be sure train stops                               
+        setSpeed(0.0f); // for safety to be sure train stops
         _warrant.stopWarrant(_abort, true);
     }
 
@@ -264,7 +269,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                 } else {
                     _timeRatio = 1.0f;
                 }
-                setSpeed(speedMod);                                
+                setSpeed(speedMod);
                 break;
             case NOOP:
                 break;
@@ -305,7 +310,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
      */
     private void advanceToCommandIndex(int idx) {
         _idxSkipToSpeedCommand = idx;
-//        if (log.isTraceEnabled()) 
+//        if (log.isTraceEnabled())
             log.debug("advanceToCommandIndex to {} - {}", _idxSkipToSpeedCommand+1, _commands.get(idx));
             // Note: command indexes biased from 0 to 1 to match Warrant display of commands, which are 1-based.
     }
@@ -338,7 +343,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
      */
     protected synchronized void clearWaitForSync() {
         if (_waitForSync) {
-            if (log.isDebugEnabled()) 
+            if (log.isDebugEnabled())
                 log.debug("_waitForSync={} clearWaitForSync() calls notify()", _waitForSync);
             notifyAll();   // if wait is cleared, this sets _waitForSync= false
         } else {
@@ -346,7 +351,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
             OBlock block = _warrant.getCurrentBlockOrder().getBlock();
             // block went active. if waiting on cmdWaitTime, clear it
             if (ts.getCommand().equals(Command.NOOP) && ts.getBeanDisplayName().equals(block.getDisplayName())) {
-                if (log.isDebugEnabled()) 
+                if (log.isDebugEnabled())
                     log.debug("_waitForSync={} clearWaitForSync() calls notify()", _waitForSync);
                 notifyAll();
             }
@@ -360,7 +365,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
      *
      * @param endSpeedType signal aspect speed name
      * @param endBlockIdx BlockOrder index of where ramp is to end.
-     * @param useIndex false if endBlockIdx should not be considered 
+     * @param useIndex false if endBlockIdx should not be considered
      */
     protected void rampSpeedTo(String endSpeedType, int endBlockIdx, boolean useIndex) {
         if (!setSpeedRatio(endSpeedType)) {
@@ -370,10 +375,10 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
             return;
         }
         synchronized (this) {
-            if (log.isDebugEnabled()) 
+            if (log.isDebugEnabled())
                 log.debug("rampSpeedTo type= {}, throttle from {} to {}. warrant {}",
-                    endSpeedType, getSpeedSetting(), 
-                    _speedUtil.modifySpeed(_normalSpeed, endSpeedType), 
+                    endSpeedType, getSpeedSetting(),
+                    _speedUtil.modifySpeed(_normalSpeed, endSpeedType),
                     _warrant.getDisplayName());
 
             if (_ramp == null) {
@@ -395,6 +400,9 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                     time += 20;
                 }
                 catch (InterruptedException ie) { // ignore
+                    log.debug("InterruptedException during rampSpeedTo {}", ie);
+                    Thread.currentThread().interrupt();
+                    return;
                 }
             }
             if (_ramp.ready) {
@@ -434,7 +442,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
         _throttle.setSpeedSetting(speed);       // CAN MISS SETTING SPEED! (as done when runOnLayoutEventually used) ??
         // Late update to GUI is OK, this is just an informational status display
         _warrant.fireRunStatus("SpeedChange", null, _speedType);
-        if (log.isDebugEnabled()) 
+        if (log.isDebugEnabled())
             log.debug("_throttle.setSpeedSetting({}) called, ({}).  warrant {}",
                     speed, _speedType, _warrant.getDisplayName());
     }
@@ -496,7 +504,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                 setSpeed(_speedUtil.modifySpeed(_normalSpeed, speedType));
             }
         }
-        if (log.isDebugEnabled()) 
+        if (log.isDebugEnabled())
             log.debug("setSpeedToType({}) scriptSpeed= {}", speedType, _normalSpeed);
     }
 
@@ -507,13 +515,13 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
      * @param halt true if train should halt
      */
     public synchronized void setHalt(boolean halt) {
-        if (log.isDebugEnabled()) 
+        if (log.isDebugEnabled())
             log.debug("setHalt({}): _atHalt= {}, _waitForClear= {}, _waitForSync= {}, warrant {}",
                 halt, _atHalt, _waitForClear, _waitForSync, _warrant.getDisplayName());
         if (!halt) {    // resume normal running
             _halt = false;
             if (_atHalt) {
-                if (log.isDebugEnabled()) 
+                if (log.isDebugEnabled())
                     log.debug("setHalt calls notify()");
                 notifyAll();   // free wait at _atHalt
             }
@@ -530,13 +538,13 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
      * @param stop true if train should stop
      */
     protected synchronized void setWaitforClear(boolean stop) {
-        if (log.isDebugEnabled()) 
+        if (log.isDebugEnabled())
             log.debug("setWaitforClear({}): _atClear= {}, throttle speed= {}, _halt= {}, _waitForSync= {}, warrant {}",
                 stop, _atClear,  _throttle.getSpeedSetting(), _halt, _waitForSync, _warrant.getDisplayName());
         if (!stop) {    // resume normal running
             _waitForClear = false;
             if (_atClear) {
-                if (log.isDebugEnabled()) 
+                if (log.isDebugEnabled())
                     log.debug("setWaitforClear calls notify");
                 notifyAll();   // free wait at _atClear
             }
@@ -587,7 +595,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
             }
             return Warrant.STOP_PENDING;
         } else if (_resumePending) {
-            return Warrant.RAMPING_UP;            
+            return Warrant.RAMPING_UP;
         } else if (_waitForClear) {
             return Warrant.WAIT_FOR_CLEAR;
         } else if (_waitForSensor) {
@@ -608,7 +616,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
 
     public void stopRun(boolean abort, boolean turnOffFunctions) {
         if (abort) {
-            _abort =true;            
+            _abort =true;
         }
         if (_waitSensor != null) {
             _waitSensor.removePropertyChangeListener(this);
@@ -641,7 +649,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
     }
 
     private void setFunction(int cmdNum, ValueType type) {
-        if ( cmdNum < 0 || cmdNum > 28 ) {       
+        if ( cmdNum < 0 || cmdNum > 28 ) {
             throw new java.lang.IllegalArgumentException("setFunction " + cmdNum + " out of range");
         }
         if (type == ValueType.VAL_ON) {
@@ -654,7 +662,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
     }
 
     private void setFunctionMomentary(int cmdNum, ValueType type) {
-        if ( cmdNum < 0 || cmdNum > 28 ) {       
+        if ( cmdNum < 0 || cmdNum > 28 ) {
             log.error("Function value {} out of range",cmdNum);
             throw new java.lang.IllegalArgumentException("setFunctionMomentary " + cmdNum + " out of range");
         }
@@ -719,7 +727,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
             return;
         }
         _waitSensor.addPropertyChangeListener(this);
-        if (log.isDebugEnabled()) 
+        if (log.isDebugEnabled())
             log.debug("Listen for propertyChange of {}, wait for State= {}", _waitSensor.getDisplayName(), _sensorWaitState);
         // suspend commands until sensor changes state
         synchronized (this) {   // DO NOT USE _waitForSensor for synch
@@ -728,7 +736,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                 try {
                     _warrant.fireRunStatus("SensorWaitCommand", type.toString(), _waitSensor.getDisplayName());
                     wait();
-                    String name =  _waitSensor.getDisplayName();    // save name, _waitSensor will be null 'eventually' 
+                    String name =  _waitSensor.getDisplayName();    // save name, _waitSensor will be null 'eventually'
                     _warrant.fireRunStatus("SensorWaitCommand", null, name);
                 } catch (InterruptedException ie) {
                     log.error("Engineer interrupted at _waitForSensor ",ie);
@@ -757,7 +765,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
     @Override
     @SuppressFBWarnings(value = "NN_NAKED_NOTIFY", justification="Sensor change on another thread is expected even when Engineer (this) has not done any modifing")
     public void propertyChange(java.beans.PropertyChangeEvent evt) {
-        if (log.isDebugEnabled()) 
+        if (log.isDebugEnabled())
             log.debug("propertyChange {} new value= {}", evt.getPropertyName(), evt.getNewValue());
         if ((evt.getPropertyName().equals("KnownState")
                 && ((Number) evt.getNewValue()).intValue() == _sensorWaitState)) {
@@ -775,7 +783,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
             return;
         }
         Warrant warrant =  (Warrant)bean;
-        
+
         int num = Math.round(cmdVal.getFloat());
         if (num <= 0) {
             return;
@@ -931,15 +939,15 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
             _endSpeedType = endSpeedType;
             _endBlockIdx = endBlockIdx;
             _useIndex = useIndex;
-            _stopPending = endSpeedType.equals(Warrant.Stop);                    
+            _stopPending = endSpeedType.equals(Warrant.Stop);
         }
 
         boolean duplicate(String endSpeedType, int endBlockIdx, boolean useIndex) {
-            if (endBlockIdx != _endBlockIdx || 
+            if (endBlockIdx != _endBlockIdx ||
                     !endSpeedType.equals(_endSpeedType) || useIndex != _useIndex) {
                 return false;
             }
-            return true;                    
+            return true;
         }
 
         RampData getRampData () {
@@ -947,10 +955,10 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
         }
 
         /**
-         * 
+         *
          * @param blockIdx  index of block order where ramp finishes
          * @param cmdIdx   current command index
-         * @return command index of block where commands should not be executed 
+         * @return command index of block where commands should not be executed
          */
         int getCommandIndexLimit(int blockIdx, int cmdIdx) {
             // get next block
@@ -970,7 +978,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                 endBlkName = _warrant.getBlockAt(blockIdx+1).getDisplayName();
                 for (int cmd = cmdIdx; cmd < _commands.size(); cmd++) {
                     ThrottleSetting ts = _commands.get(cmd);
-                    if (ts.getBeanDisplayName().equals(endBlkName) && 
+                    if (ts.getBeanDisplayName().equals(endBlkName) &&
                             ts.getValue().getType().equals(ValueType.VAL_NOOP)) {
                         limit = cmd;
                         break;
@@ -1001,7 +1009,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
             // the time 'right now' is at having done _idxCurrentCommand-1 and is waiting
             // to do the _idxCurrentCommand.  A non-scripted speed change is to begin now.
             // current speed at _idxCurrentCommand is (should be) _normalSpeed modified by _speedType
-            // Note on ramp down the _normalSpeed value may be modified. 
+            // Note on ramp down the _normalSpeed value may be modified.
             // "idxSkipToSpeedCommand" may be used rather than "_idxCurrentCommand".
             // Note on ramp up endSpeed should match scripted speed modified by endSpeedType
             ready = false;
@@ -1020,7 +1028,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
             float distToCmd = _currentCommand.getTrackSpeed() * _currentCommand.getTime();   // distance to next command
 
             int commandIndexLimit = getCommandIndexLimit(_endBlockIdx, _idxCurrentCommand);
-            if (log.isDebugEnabled()) 
+            if (log.isDebugEnabled())
                 log.debug("ThrottleRamp for \"{}\". At Cmd#{} limit#{}. rampLen= {} distToCmd= {}. useIndex= {}. on warrant {}",
                    _endSpeedType, _idxCurrentCommand+1, commandIndexLimit+1, rampLen, distToCmd, _useIndex, _warrant.getDisplayName());
 
@@ -1113,7 +1121,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                         ListIterator<Float> iter = _rampData.speedIterator(false);
                         float prevSpeed = iter.previous().floatValue();   // skip repeat of current throttle setting
                         float prevScriptSpeed;
- 
+
                         while (iter.hasPrevious()) {
                             if (stop) {
                                 break;
@@ -1125,11 +1133,11 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                                     // loco overran end block.  Set end speed and leave ramp
                                     speed = endSpeed;
                                     stop = true;
-                                } else if ( _warrant._idxCurrentOrder < _endBlockIdx && 
+                                } else if ( _warrant._idxCurrentOrder < _endBlockIdx &&
                                         _endSpeedType.equals(Warrant.Stop) && Math.abs(speed - endSpeed) <.001f) {
-                                    // At last speed change to set throttle to 0.0, but train has not 
+                                    // At last speed change to set throttle to 0.0, but train has not
                                     // reached the last block. Let loco creep to end block at current setting.
-                                    if (log.isDebugEnabled()) 
+                                    if (log.isDebugEnabled())
                                         log.debug("Extending ramp to reach block {}. speed= {}",
                                                 _warrant.getBlockAt(_endBlockIdx).getDisplayName(), speed);
                                     while (_endBlockIdx - _warrant._idxCurrentOrder > 0) {
@@ -1139,7 +1147,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                                         } catch (InterruptedException ie) {
                                             _lock.unlock();
                                             stop = true;
-                                        }   
+                                        }
                                     }
                                 }
                             }
@@ -1211,16 +1219,16 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                             }
                             advanceToCommandIndex(_idxCurrentCommand); // skip up to this command
 
-                            if (log.isDebugEnabled()) 
+                            if (log.isDebugEnabled())
                                 log.debug("End Blk= {}, Cmd Blk= {}, idxCurrentCommand={}, normalSpeed= {}",
                                         _warrant.getBlockAt(_endBlockIdx).getDisplayName(),
                                         _commands.get(_idxCurrentCommand).getNamedBeanHandle().getBean().getDisplayName(),
                                         _normalSpeed); // Note: command indexes biased from 0 to 1 to match Warrant display of commands.
                         }
-                        
+
                         _stopPending = false;
                     }
-                    
+
                 } finally {
                     _lock.unlock();
                     if (!_endSpeedType.equals(Warrant.Stop) &&

--- a/java/src/jmri/jmrit/logix/Engineer.java
+++ b/java/src/jmri/jmrit/logix/Engineer.java
@@ -399,7 +399,7 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
                     wait(20);
                     time += 20;
                 }
-                catch (InterruptedException ie) { // ignore
+                catch (InterruptedException ie) {
                     log.debug("InterruptedException during rampSpeedTo {}", ie);
                     Thread.currentThread().interrupt();
                     return;

--- a/java/test/jmri/implementation/MatrixSignalMastTest.java
+++ b/java/test/jmri/implementation/MatrixSignalMastTest.java
@@ -67,7 +67,7 @@ public class MatrixSignalMastTest {
             clear.append("0");
             stop.append("1");
         }
-        
+
         m.setBitstring("Clear", clear.toString());
         m.setBitstring("Stop", stop.toString());
         m.setBitstring("Unlit", stop.toString());
@@ -85,11 +85,11 @@ public class MatrixSignalMastTest {
 
         m.setLit(true);
         Assertions.assertTrue(m.getLit());
-        
+
         Assertions.assertEquals(10, m.getOutputs().size());
 
     }
-    
+
     @Test
     @SuppressWarnings("unused") // it11 etc. are indirectly used as NamedBeans IT11 etc.
     public void testLit() {
@@ -209,6 +209,10 @@ public class MatrixSignalMastTest {
 
     @AfterEach
     public void tearDown() {
+        // has dumpd a bunch of stuff to AWT thread
+        JUnitUtil.releaseThread(this, 20);
+
+        JUnitUtil.clearTurnoutThreads();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
+++ b/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
@@ -97,6 +97,11 @@ public class AddEntryExitPairPanelTest {
             panels.forEach((name, panel) -> JUnitUtil.dispose(panel));
         }
         panels = null;
+
+        JUnitUtil.clearTurnoutThreads();
+        JUnitUtil.clearRouteThreads();
+        JUnitUtil.removeMatchingThreads("Routing stabilising timer");
+
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/entryexit/DestinationPointsTest.java
+++ b/java/test/jmri/jmrit/entryexit/DestinationPointsTest.java
@@ -132,6 +132,9 @@ public class DestinationPointsTest {
 
     @AfterAll
     public static void tearDown() {
+        JUnitUtil.clearRouteThreads();
+        JUnitUtil.clearTurnoutThreads();
+        JUnitUtil.removeMatchingThreads("Routing stabilising timer");
         panels.forEach((name, panel) -> JUnitUtil.dispose(panel));
         tm = null;
         sm = null;

--- a/java/test/jmri/jmrit/entryexit/EntryExitPairsTest.java
+++ b/java/test/jmri/jmrit/entryexit/EntryExitPairsTest.java
@@ -122,6 +122,11 @@ public class EntryExitPairsTest {
         tm = null;
         panels = null;
         tools = null;
+
+        JUnitUtil.clearRouteThreads();
+        JUnitUtil.clearTurnoutThreads();
+        JUnitUtil.removeMatchingThreads("Routing stabilising timer");
+
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/entryexit/PointDetailsTest.java
+++ b/java/test/jmri/jmrit/entryexit/PointDetailsTest.java
@@ -89,6 +89,9 @@ public class PointDetailsTest {
     @AfterAll
     public static void tearDown() {
         panels.forEach((name, panel) -> JUnitUtil.dispose(panel));
+        JUnitUtil.clearRouteThreads();
+        JUnitUtil.clearTurnoutThreads();
+        JUnitUtil.removeMatchingThreads("Routing stabilising timer");
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/entryexit/SourceTest.java
+++ b/java/test/jmri/jmrit/entryexit/SourceTest.java
@@ -120,6 +120,9 @@ public class SourceTest {
 
     @AfterAll
     static public void tearDown() {
+        JUnitUtil.clearRouteThreads();
+        JUnitUtil.clearTurnoutThreads();
+        JUnitUtil.removeMatchingThreads("Routing stabilising timer");
         panels.forEach((name, panel) -> JUnitUtil.dispose(panel));
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();

--- a/java/test/jmri/jmrit/logix/LearnWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LearnWarrantTest.java
@@ -227,6 +227,7 @@ public class LearnWarrantTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("Engineer(");
         if (InstanceManager.containsDefault(ShutDownManager.class)) {
             List<ShutDownTask> list = new ArrayList<>();
             ShutDownManager sm = InstanceManager.getDefault(jmri.ShutDownManager.class);

--- a/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
@@ -359,6 +359,8 @@ public class LinkedWarrantTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("Engineer(");
+
         _warrantMgr.dispose();
         _warrantMgr = null;
         _OBlockMgr.dispose();

--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -464,6 +464,7 @@ public class NXFrameTest {
 
     @AfterEach
     public void tearDown() throws Exception {
+        JUnitUtil.removeMatchingThreads("Engineer(");
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
         InstanceManager.getDefault(WarrantManager.class).dispose();

--- a/java/test/jmri/jmrit/logix/PortalManagerTest.java
+++ b/java/test/jmri/jmrit/logix/PortalManagerTest.java
@@ -141,6 +141,7 @@ public class PortalManagerTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("Engineer(");
         _portalMgr = null;
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();

--- a/java/test/jmri/util/HelpUtilTest.java
+++ b/java/test/jmri/util/HelpUtilTest.java
@@ -16,7 +16,7 @@ public class HelpUtilTest {
     @Test
     public void testCTor() {
         Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
-        
+
         JMenuBar menuBar = new JMenuBar();
         int initialMenuCount = menuBar.getMenuCount();
         HelpUtil.helpMenu(menuBar,"test",true);
@@ -32,6 +32,7 @@ public class HelpUtilTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -313,7 +313,6 @@ public class JUnitUtil {
 
         for (int i = 0; i<max; i++) {
             Thread t = list[i];
-            Thread.State topState = t.getState();
             if (t.getState() == Thread.State.TERMINATED) { // going away, just not cleaned up yet
                 // don't want to prevent gc
                 continue;

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -287,6 +287,50 @@ public class JUnitUtil {
     }
 
     /**
+     * Silently remove any AbstractTurnout threads that are still running.
+     * A bit expensive, so only used when needed.
+     */
+    public static void clearTurnoutThreads(){
+        removeMatchingThreads("setCommandedStateAtInterval"); // must stay consistent with AbstractTurnout
+    }
+
+    /**
+     * Silently remove any DefaultRoute threads that are still running.
+     * A bit expensive, so only used when needed.
+     */
+    public static void clearRouteThreads(){
+        removeMatchingThreads("setRoute"); // must stay consistent with DefaultRoute
+    }
+
+    /**
+     * Utility to remove any threads with a matching name
+     */
+    public static void removeMatchingThreads(String nameContains) {
+        ThreadGroup main = Thread.currentThread().getThreadGroup();
+        while (main.getParent() != null ) {main = main.getParent(); }
+        Thread[] list = new Thread[main.activeCount()+2];  // space on end
+        int max = main.enumerate(list);
+
+        for (int i = 0; i<max; i++) {
+            Thread t = list[i];
+            Thread.State topState = t.getState();
+            if (t.getState() == Thread.State.TERMINATED) { // going away, just not cleaned up yet
+                // don't want to prevent gc
+                continue;
+            }
+            String name = t.getName();
+            if (name.contains(nameContains)) {
+                t.interrupt();
+                try {
+                    t.join(100); // give it a bit of time to end
+                } catch (InterruptedException e) {
+                    log.warn("join interrupted in removeMatchingThreads", e);
+                }
+            }
+        }
+    }
+
+    /**
      * Teardown from tests. This should be the last line in the {@code @After}
      * annotated method.
      */
@@ -903,55 +947,55 @@ public class JUnitUtil {
             InstanceManager.getDefault(ConfigureManager.class).registerConfig(m1, jmri.Manager.LOGIXNGS);
         }
         InstanceManager.setDefault(LogixNG_Manager.class, m1);
-        
+
         ConditionalNG_Manager m2 = new DefaultConditionalNGManager();
         if (InstanceManager.getNullableDefault(ConfigureManager.class) != null) {
             InstanceManager.getDefault(ConfigureManager.class).registerConfig(m2, jmri.Manager.LOGIXNG_CONDITIONALNGS);
         }
         InstanceManager.setDefault(ConditionalNG_Manager.class, m2);
-        
+
         AnalogActionManager m3 = new DefaultAnalogActionManager();
         if (InstanceManager.getNullableDefault(ConfigureManager.class) != null) {
             InstanceManager.getDefault(ConfigureManager.class).registerConfig(m3, jmri.Manager.LOGIXNG_ANALOG_ACTIONS);
         }
         InstanceManager.setDefault(AnalogActionManager.class, m3);
-        
+
         AnalogExpressionManager m4 = new DefaultAnalogExpressionManager();
         if (InstanceManager.getNullableDefault(ConfigureManager.class) != null) {
             InstanceManager.getDefault(ConfigureManager.class).registerConfig(m4, jmri.Manager.LOGIXNG_ANALOG_EXPRESSIONS);
         }
         InstanceManager.setDefault(AnalogExpressionManager.class, m4);
-        
+
         DigitalActionManager m5 = new DefaultDigitalActionManager();
         if (InstanceManager.getNullableDefault(ConfigureManager.class) != null) {
             InstanceManager.getDefault(ConfigureManager.class).registerConfig(m5, jmri.Manager.LOGIXNG_DIGITAL_ACTIONS);
         }
         InstanceManager.setDefault(DigitalActionManager.class, m5);
-        
+
         DigitalBooleanActionManager m6 = new DefaultDigitalBooleanActionManager();
         if (InstanceManager.getNullableDefault(ConfigureManager.class) != null) {
             InstanceManager.getDefault(ConfigureManager.class).registerConfig(m6, jmri.Manager.LOGIXNG_DIGITAL_BOOLEAN_ACTIONS);
         }
         InstanceManager.setDefault(DigitalBooleanActionManager.class, m6);
-        
+
         DigitalExpressionManager m7 = new DefaultDigitalExpressionManager();
         if (InstanceManager.getNullableDefault(ConfigureManager.class) != null) {
             InstanceManager.getDefault(ConfigureManager.class).registerConfig(m7, jmri.Manager.LOGIXNG_DIGITAL_EXPRESSIONS);
         }
         InstanceManager.setDefault(DigitalExpressionManager.class, m7);
-        
+
         StringActionManager m8 = new DefaultStringActionManager();
         if (InstanceManager.getNullableDefault(ConfigureManager.class) != null) {
             InstanceManager.getDefault(ConfigureManager.class).registerConfig(m8, jmri.Manager.LOGIXNG_STRING_ACTIONS);
         }
         InstanceManager.setDefault(StringActionManager.class, m8);
-        
+
         StringExpressionManager m9 = new DefaultStringExpressionManager();
         if (InstanceManager.getNullableDefault(ConfigureManager.class) != null) {
             InstanceManager.getDefault(ConfigureManager.class).registerConfig(m9, jmri.Manager.LOGIXNG_STRING_EXPRESSIONS);
         }
         InstanceManager.setDefault(StringExpressionManager.class, m9);
-        
+
         if (activate) m1.activateAllLogixNGs(false, false);
     }
 

--- a/java/test/jmri/util/PlaceWindowTest.java
+++ b/java/test/jmri/util/PlaceWindowTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
- * @author Pete Cressman 2020   
+ * @author Pete Cressman 2020
  */
 @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class PlaceWindowTest {
@@ -66,7 +66,7 @@ public class PlaceWindowTest {
 
         Point pt = pw.nextTo(w1,  null,  w2);
         // w2 position should be centered within a pixel and overlap from above
-        System.out.println(Math.abs((rect.width/2-100) - pt.x));
+        //System.out.println(Math.abs((rect.width/2-100) - pt.x));
         assertThat(Math.abs(((rect.width/2)-100) - pt.x))
                 .withFailMessage("pt.x at screen center")
                 .isLessThanOrEqualTo(tolerance);


### PR DESCRIPTION
 - Add utilities to interrupt running threads to JUnitUtil
 - Improve how interrupts are handled
 - Make sure threads are named for retrieval
 - Add handling of remaining threads to rsome) relevant tests

Goal is to avoid intermittent test failures due to actions by threads left running at end of tests.