### PR TITLE
More test threadicide

### DIFF
--- a/java/src/jmri/jmrix/loconet/LocoNetThrottledTransmitter.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottledTransmitter.java
@@ -169,9 +169,10 @@ public class LocoNetThrottledTransmitter implements LocoNetInterface {
                     }
                     controller.sendLocoNetMessage(m.getMessage());
                     // and go round again
-                } catch (Exception e) {
-                    // just report error and continue
-                    log.error("Exception in ServiceThread: ", e);
+                } catch (InterruptedException e) {
+                    // request to terminate
+                    this.interrupt();
+                    break;
                 }
             }
             running = false;

--- a/java/test/jmri/jmrit/beantable/IdTagTableDataModelTest.java
+++ b/java/test/jmri/jmrit/beantable/IdTagTableDataModelTest.java
@@ -15,17 +15,26 @@ import static org.junit.Assert.assertEquals;
  * @author Steve Young (C) 2021
  */
 public class IdTagTableDataModelTest extends AbstractBeanTableDataModelBase<IdTag>{
-    
+
     @Test
     public void testCTor() {
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Override
     public int getModelColumnCount(){
         return 8;
     }
-    
+
+    /**
+     * Test in superclass doesn't make sense for this class under test,
+     * as it's sensitive to run order. Suppress it.
+     */
+    @Override
+    @Test
+    public void testGetRowCount(){
+    }
+
     @Test
     @Override
     public void testGetBaseColumnNames() {
@@ -34,7 +43,7 @@ public class IdTagTableDataModelTest extends AbstractBeanTableDataModelBase<IdTa
         assertEquals("Column2 - Bean value",Bundle.getMessage("ColumnIdTagID"), t.getColumnName(2));
         assertEquals("Column3 - User Comment",Bundle.getMessage("ColumnComment"), t.getColumnName(3));
         assertEquals("Column4 - Delete button","", t.getColumnName(4));
-        
+
     }
 
     @BeforeEach
@@ -55,5 +64,5 @@ public class IdTagTableDataModelTest extends AbstractBeanTableDataModelBase<IdTa
         InstanceManager.getDefault(IdTagManager.class).dispose(); // kills shutdown task
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/display/EditorFrameOperator.java
+++ b/java/test/jmri/jmrit/display/EditorFrameOperator.java
@@ -90,7 +90,6 @@ public class EditorFrameOperator extends JFrameOperator {
 
         for (int i = 0; i<max; i++) {
             Thread t = list[i];
-            Thread.State topState = t.getState();
             if (t.getState() == Thread.State.TERMINATED) { // going away, just not cleaned up yet
                 continue;
             }

--- a/java/test/jmri/jmrit/display/EditorFrameOperator.java
+++ b/java/test/jmri/jmrit/display/EditorFrameOperator.java
@@ -23,6 +23,10 @@ public class EditorFrameOperator extends JFrameOperator {
        super(frame);
     }
 
+    private static final String hideThreadName = "EditorFrameOperator: Hide Dialog Close Thread";
+    private static final String deleteThreadName = "EditorFrameOperator: Delete Dialog Close Thread";
+    private static final int joinDelayMillis = 100;
+
     public void closeFrameWithConfirmations(){
         // if OK to here, close window
         this.requestClose();
@@ -54,7 +58,7 @@ public class EditorFrameOperator extends JFrameOperator {
                 // exceptions in this thread are not considered an error.
             }
         });
-        t.setName("Hide Dialog Close Thread");
+        t.setName(hideThreadName);
         t.start();
 
         Thread t2 = new Thread( () -> {
@@ -69,9 +73,38 @@ public class EditorFrameOperator extends JFrameOperator {
                 // exceptions in this thread are not considered an error.
             }
         });
-        t2.setName("Delete Dialog Close Thread");
+        t2.setName(deleteThreadName);
         t2.start();
 
     }
 
+    /**
+     * Call this at the end of tests that have invoked dismissClosingDialogs
+     * to clean up any threads that have been left hanging.
+     */
+    public static void clearEditorFrameOperatorThreads() {
+        ThreadGroup main = Thread.currentThread().getThreadGroup();
+        while (main.getParent() != null ) {main = main.getParent(); }
+        Thread[] list = new Thread[main.activeCount()+2];  // space on end
+        int max = main.enumerate(list);
+
+        for (int i = 0; i<max; i++) {
+            Thread t = list[i];
+            Thread.State topState = t.getState();
+            if (t.getState() == Thread.State.TERMINATED) { // going away, just not cleaned up yet
+                continue;
+            }
+            String name = t.getName();
+            if (name.equals(hideThreadName) || name.equals(deleteThreadName)) {
+                try {
+                    // give it a chance to end
+                    t.join(joinDelayMillis);
+                    // then interrupt it to end it
+                    t.interrupt();
+                } catch (InterruptedException e) {
+                    // not an error, not recorded
+                }
+            }
+        }
+    }
 }

--- a/java/test/jmri/jmrit/display/SensorIconWindowTest.java
+++ b/java/test/jmri/jmrit/display/SensorIconWindowTest.java
@@ -71,6 +71,7 @@ public class SensorIconWindowTest {
         // close the panel target frame.
         EditorFrameOperator to = new EditorFrameOperator(panel.getTargetFrame());
         to.closeFrameWithConfirmations();
+        EditorFrameOperator.clearEditorFrameOperatorThreads();
     }
 
     @Test
@@ -129,6 +130,7 @@ public class SensorIconWindowTest {
         // close the panel editor frame
         EditorFrameOperator to = new EditorFrameOperator(panel);
         to.closeFrameWithConfirmations();
+        EditorFrameOperator.clearEditorFrameOperatorThreads();
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/display/SignalSystemTest.java
+++ b/java/test/jmri/jmrit/display/SignalSystemTest.java
@@ -94,6 +94,7 @@ public class SignalSystemTest {
 
         EditorFrameOperator efo = new EditorFrameOperator("DB1969 Control Panel Editor");
         efo.closeFrameWithConfirmations();
+        EditorFrameOperator.clearEditorFrameOperatorThreads();
 
     }
 
@@ -160,7 +161,7 @@ public class SignalSystemTest {
 
         EditorFrameOperator efo = new EditorFrameOperator("AA1UPtest Layout");
         efo.closeFrameWithConfirmations();
-
+        EditorFrameOperator.clearEditorFrameOperatorThreads();
     }
 
     void checkAspect(String mastName, String aspect) {

--- a/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
+++ b/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
@@ -78,6 +78,7 @@ public class TurnoutIconWindowTest {
         // close the panel target frame.
         EditorFrameOperator to = new EditorFrameOperator(panel.getTargetFrame());
         to.closeFrameWithConfirmations();
+        EditorFrameOperator.clearEditorFrameOperatorThreads();
     }
 
     @Test
@@ -136,6 +137,7 @@ public class TurnoutIconWindowTest {
         // close the panel editor frame
         EditorFrameOperator to = new EditorFrameOperator(panel);
         to.closeFrameWithConfirmations();
+        EditorFrameOperator.clearEditorFrameOperatorThreads();
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackEditorTest.java
@@ -52,10 +52,10 @@ public class LayoutTrackEditorTest {
 
         layoutTrackEditor.sensorList.add("Test");
         assertThat(layoutTrackEditor.sensorList).isNotEmpty();
-        
+
         layoutTrackEditor.showSensorMessage();
     }
-    
+
     @BeforeEach
     @OverridingMethodsMustInvokeSuper  // invoke first
     public void setUp() {
@@ -65,13 +65,14 @@ public class LayoutTrackEditorTest {
     @AfterEach
     @OverridingMethodsMustInvokeSuper  // invoke last
     public void tearDown()  {
+        jmri.jmrit.display.EditorFrameOperator.clearEditorFrameOperatorThreads();
         JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 
     protected Turnout turnout0 = null;
     protected Turnout turnout1 = null;
-    
+
     /*
      * This is used to find a component by matching against its tooltip
      */

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
@@ -658,12 +658,14 @@ public class LayoutEditorToolsTest {
             EditorFrameOperator operator = new EditorFrameOperator(layoutEditor);
             operator.closeFrameWithConfirmations();
             JUnitUtil.dispose(layoutEditor);
+            EditorFrameOperator.clearEditorFrameOperatorThreads();
         }
+
         InstanceManager.getDefault(LayoutBlockManager.class).dispose();
         InstanceManager.getDefault(SignalHeadManager.class).dispose();
         InstanceManager.getDefault(TurnoutManager.class).dispose();
         InstanceManager.getDefault(SensorManager.class).dispose();
-        
+
         let = null;
         layoutEditor = null;
         layoutBlocks = null;

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorWindowTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorWindowTest.java
@@ -32,6 +32,9 @@ public class LayoutEditorWindowTest {
         // It's up at this point, and can be manipulated
         // Ask to close window
         to.closeFrameWithConfirmations();
+
+        EditorFrameOperator.clearEditorFrameOperatorThreads();
+
     }
 
     // Setup for log4J

--- a/java/test/jmri/jmrit/display/palette/ColorDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/ColorDialogTest.java
@@ -176,6 +176,8 @@ public class ColorDialogTest {
     public void tearDown() {
         EditorFrameOperator efo = new EditorFrameOperator(_cpe.getTargetFrame());
         efo.closeFrameWithConfirmations();
+        EditorFrameOperator.clearEditorFrameOperatorThreads();
+
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
+++ b/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
@@ -242,6 +242,8 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase<SwitchboardEdi
             jfo.deleteViaFileMenuWithConfirmations();
             e = null;
         }
+        EditorFrameOperator.clearEditorFrameOperatorThreads();
+
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/loconet/LnCabSignalIT.java
+++ b/java/test/jmri/jmrix/loconet/LnCabSignalIT.java
@@ -71,6 +71,8 @@ public class LnCabSignalIT extends jmri.implementation.DefaultCabSignalIT {
     public void tearDown() {
         cs.dispose(); // verify no exceptions
         cs = null;
+
+        jmri.jmrit.display.EditorFrameOperator.clearEditorFrameOperatorThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/loconet/LnClockControlTest.java
+++ b/java/test/jmri/jmrix/loconet/LnClockControlTest.java
@@ -21,17 +21,17 @@ public class LnClockControlTest {
 
         LnClockControl t = new LnClockControl(c);
         Assert.assertNotNull("exists",t);
-        
+
         c.dispose();
     }
-    
+
     @Test
     public void testCtorTwoArg() {
         LnTrafficController lnis = new LocoNetInterfaceScaffold();
         SlotManager slotmanager = new SlotManager(lnis);
- 
+
         LnClockControl t = new LnClockControl(slotmanager, lnis, null);
- 
+
         Assert.assertNotNull("exists",t);
         slotmanager.dispose();
     }
@@ -51,19 +51,19 @@ public class LnClockControlTest {
         lnis.outbound.removeAllElements();
 
         LnClockControl t = new LnClockControl(c);
-        
+
         // configure, hence write
         Date testDate = new Date(2018, 12, 1);  // deprecated, but OK for test
         t.initializeHardwareClock(1.0, testDate, false);
-        
+
         // expect two messages
         Assert.assertEquals("sent", 2, lnis.outbound.size());
         Assert.assertEquals("message 1", "EF 0E 7B 01 7B 78 43 07 68 01 00 00 00 00", lnis.outbound.get(0).toString());
-        Assert.assertEquals("message 2", "BB 7B 00 00", lnis.outbound.get(1).toString());     
-        
+        Assert.assertEquals("message 2", "BB 7B 00 00", lnis.outbound.get(1).toString());
+
         c.dispose();
     }
-    
+
     @Test
     public void testPowerBit() throws jmri.JmriException {
         // a brute-force approach to testing that the power bit follows
@@ -78,18 +78,18 @@ public class LnClockControlTest {
         c.getPowerManager().setPower(jmri.PowerManager.OFF);
         c.getPowerManager().message(lnis.outbound.get(0));
         lnis.outbound.removeAllElements();
-                
+
         LnClockControl t = new LnClockControl(c);
-        
+
         // configure, hence write
         Date testDate = new Date(2018, 12, 1);  // deprecated, but OK for test
         t.initializeHardwareClock(1.0, testDate, false);
-        
+
         // expect two messages
         Assert.assertEquals("sent", 2, lnis.outbound.size());
         Assert.assertEquals("message 1", "EF 0E 7B 01 7B 78 43 06 68 01 00 00 00 00", lnis.outbound.get(0).toString());
-        Assert.assertEquals("message 2", "BB 7B 00 00", lnis.outbound.get(1).toString());     
-        
+        Assert.assertEquals("message 2", "BB 7B 00 00", lnis.outbound.get(1).toString());
+
         c.dispose();
     }
 
@@ -100,6 +100,8 @@ public class LnClockControlTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("LnPowerManager LnTrackStatusUpdateThread");
+        JUnitUtil.removeMatchingThreads("LnSensorUpdateThread");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/LnSystemConnectionMemoTestBase.java
+++ b/java/test/jmri/jmrix/loconet/LnSystemConnectionMemoTestBase.java
@@ -1,0 +1,35 @@
+package jmri.jmrix.loconet;
+
+import jmri.jmrix.SystemConnectionMemoTestBase;
+import jmri.jmrix.DefaultSystemConnectionMemo;
+import jmri.util.JUnitUtil;
+
+import javax.annotation.OverridingMethodsMustInvokeSuper;
+
+import org.junit.jupiter.api.*;
+
+/**
+ * Abstract base class for SystemConnectionMemo objects.
+ *
+ * @author Paul Bender Copyright (C) 2017
+ * @param <M> the supported memo class
+ */
+abstract public class LnSystemConnectionMemoTestBase<M extends DefaultSystemConnectionMemo>
+            extends SystemConnectionMemoTestBase<M> {
+
+    @BeforeEach
+    @OverridingMethodsMustInvokeSuper  // invoke first
+    public void setUp() {
+       JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    @OverridingMethodsMustInvokeSuper  // invoke last
+    public void tearDown() {
+        JUnitUtil.removeMatchingThreads("LnPowerManager LnTrackStatusUpdateThread");
+        JUnitUtil.removeMatchingThreads("LnSensorUpdateThread");
+
+        JUnitUtil.tearDown();
+    }
+
+}

--- a/java/test/jmri/jmrix/loconet/LocoNetSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetSystemConnectionMemoTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.loconet;
 
-import jmri.jmrix.SystemConnectionMemoTestBase;
+import jmri.jmrix.loconet.LnSystemConnectionMemoTestBase;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.*;
  *
  * @author Paul Bender Copyright (C) 2016
  */
-public class LocoNetSystemConnectionMemoTest extends SystemConnectionMemoTestBase<LocoNetSystemConnectionMemo> {
+public class LocoNetSystemConnectionMemoTest extends LnSystemConnectionMemoTestBase<LocoNetSystemConnectionMemo> {
 
     @Override
     @BeforeEach
     public void setUp() {
-        JUnitUtil.setUp();
+        super.setUp();
         scm = new LocoNetSystemConnectionMemo();
         LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold(scm);
         scm.setLnTrafficController(lnis);
@@ -27,7 +27,7 @@ public class LocoNetSystemConnectionMemoTest extends SystemConnectionMemoTestBas
     @AfterEach
     public void tearDown() {
         scm.dispose();
-        JUnitUtil.tearDown();
+        super.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/loconet/LocoNetSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetSystemConnectionMemoTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.loconet;
 
-import jmri.jmrix.loconet.LnSystemConnectionMemoTestBase;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;

--- a/java/test/jmri/jmrix/loconet/configurexml/LoadAndStoreTest.java
+++ b/java/test/jmri/jmrix/loconet/configurexml/LoadAndStoreTest.java
@@ -41,13 +41,13 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
         super(SaveType.Config, false);
     }
 
-    
+
     LocoNetSystemConnectionMemo memo1;
     LocoNetInterfaceScaffold lnis1;
-    
+
     LocoNetSystemConnectionMemo memo2;
     LocoNetInterfaceScaffold lnis2;
-    
+
     /**
      * {@inheritDoc}
      * Ensure that a LocoNet connection is available
@@ -65,7 +65,7 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
         memo1.configureCommandStation(LnCommandStationType.COMMAND_STATION_DCS100,false,false,false);
         memo1.configureManagers(); // Does this generate autonomous loconet traffic? Needs a wait?
         jmri.InstanceManager.store(memo1,LocoNetSystemConnectionMemo.class);
-        
+
         // 2nd LocoNet connection L2
         memo2 = new LocoNetSystemConnectionMemo();
         lnis2 = new LocoNetInterfaceScaffold(memo1);
@@ -74,7 +74,7 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
         memo2.configureCommandStation(LnCommandStationType.COMMAND_STATION_DCS100,false,false,false);
         memo2.configureManagers(); // Does this generate autonomous loconet traffic? Needs a wait?
         jmri.InstanceManager.store(memo2,LocoNetSystemConnectionMemo.class);
-        
+
         jmri.InstanceManager.setDefault(jmri.jmrix.loconet.LnTrafficController.class, lnis1);
     }
 
@@ -87,6 +87,8 @@ public class LoadAndStoreTest extends jmri.configurexml.LoadAndStoreTestBase {
     public void tearDown() {
         memo1.dispose();
         memo2.dispose();
+        jmri.util.JUnitUtil.removeMatchingThreads("LnPowerManager LnTrackStatusUpdateThread");
+        jmri.util.JUnitUtil.removeMatchingThreads("LnSensorUpdateThread");
         super.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementationTest.java
+++ b/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementationTest.java
@@ -330,10 +330,10 @@ public class LnIPLImplementationTest {
 
             Assert.assertTrue  ("IplIdentity device "+dev+" check is specific IPL host device ",
                     LnIPLImplementation.isIplSpecificIdentityReportMessage(m, mfg|0x80, dev));
-            
+
             Assert.assertTrue  ("IplIdentity device "+dev+" check is specific IPL host device ",
                     LnIPLImplementation.isIplSpecificIdentityReportMessage(m, mfg, dev|0x80));
-            
+
             Assert.assertEquals("IplIdentity device "+dev+" check is UR92 device", dev == 92,
                     LnIPLImplementation.isIplUr92IdentityReportMessage(m));
             Assert.assertEquals("IplIdentity device "+dev+" check is DT402 device", dev == 42,
@@ -592,7 +592,7 @@ public class LnIPLImplementationTest {
                 case 28:
                    Assert.assertEquals ("Ipl Extract host name from device "+dev, "Digitrax DCS240",
                            LnIPLImplementation.extractInterpretedIplHostDevice(m));
-                   Assert.assertEquals("extracting slave device from DCS240 IPL report", 
+                   Assert.assertEquals("extracting slave device from DCS240 IPL report",
                            "Digitrax (unknown Slave Device)",
                            LnIPLImplementation.extractInterpretedIplSlaveDevice(m));
                    break;
@@ -662,7 +662,7 @@ public class LnIPLImplementationTest {
                 case 4:
                    Assert.assertEquals ("Ipl Extract host name from device "+dev+", slave=24", "Digitrax UT4D",
                            LnIPLImplementation.extractInterpretedIplHostDevice(m));
-                   Assert.assertEquals("extracting slave device from DCS240 IPL report", 
+                   Assert.assertEquals("extracting slave device from DCS240 IPL report",
                            "Digitrax RF24",
                            LnIPLImplementation.extractInterpretedIplSlaveDevice(m));
                    break;
@@ -1062,7 +1062,7 @@ public class LnIPLImplementationTest {
                 LnIPLImplementation.isIplIdentityReportMessage(msg));
 
     }
-    
+
     @Test
     public void checkInterpretHostManufacturerDevice() {
         for (int dev = 0; dev < 128; ++dev) {
@@ -1587,7 +1587,7 @@ public class LnIPLImplementationTest {
         propChangeFlag = false;
         propChangeReportFlag = false;
         propChangeQueryFlag = false;
-        
+
         m = new LocoNetMessage(2);
         m.setElement(0, 0x81); m.setElement(1, 0);
         iplImplementation.message(m);
@@ -1653,6 +1653,8 @@ public class LnIPLImplementationTest {
     @AfterEach
     public void tearDown() {
         memo.dispose();
+        JUnitUtil.removeMatchingThreads("LnPowerManager LnTrackStatusUpdateThread");
+        JUnitUtil.removeMatchingThreads("LnSensorUpdateThread");
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/loconet/hexfile/HexFileFrameTest.java
+++ b/java/test/jmri/jmrix/loconet/hexfile/HexFileFrameTest.java
@@ -17,7 +17,7 @@ public class HexFileFrameTest {
     public void testCTor() throws InterruptedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LnHexFilePort p = new LnHexFilePort();
-        
+
         HexFileFrame f = new HexFileFrame();
 
         ThreadingUtil.runOnGUI( ()-> {
@@ -29,11 +29,11 @@ public class HexFileFrameTest {
         ThreadingUtil.runOnGUI( ()-> {
             f.dispose();
        });
-            
+
         p.dispose();
         f.sourceThread.stop();
         f.sourceThread.join();
-        f.dispose();   
+        f.dispose();
  }
 
     @BeforeEach
@@ -45,6 +45,8 @@ public class HexFileFrameTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("LnPowerManager LnTrackStatusUpdateThread");
+        JUnitUtil.removeMatchingThreads("LnSensorUpdateThread");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/hexfile/HexFileSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/hexfile/HexFileSystemConnectionMemoTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.loconet.hexfile;
 
-import jmri.jmrix.SystemConnectionMemoTestBase;
+import jmri.jmrix.loconet.LnSystemConnectionMemoTestBase;
 import jmri.jmrix.loconet.LocoNetInterfaceScaffold;
 import jmri.util.JUnitUtil;
 
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.*;
  *
  * @author Paul Bender Copyright (C) 2017
  */
-public class HexFileSystemConnectionMemoTest extends SystemConnectionMemoTestBase<HexFileSystemConnectionMemo> {
+public class HexFileSystemConnectionMemoTest extends LnSystemConnectionMemoTestBase<HexFileSystemConnectionMemo> {
 
     @Override
     @BeforeEach
     public void setUp() {
-        JUnitUtil.setUp();
+        super.setUp();
         scm = new HexFileSystemConnectionMemo();
         LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold(scm);
         scm.setLnTrafficController(lnis);
@@ -27,7 +27,7 @@ public class HexFileSystemConnectionMemoTest extends SystemConnectionMemoTestBas
     @AfterEach
     public void tearDown() {
         scm.dispose();
-        JUnitUtil.tearDown();
+        super.tearDown();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(LocoNetSystemConnectionMemoTest.class);

--- a/java/test/jmri/jmrix/loconet/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrix/loconet/logixng/configurexml/StoreAndLoadTest.java
@@ -341,6 +341,11 @@ public class StoreAndLoadTest {
     @After
     public void tearDown() {
         // JUnitAppender.clearBacklog();    // REMOVE THIS!!!
+
+        JUnitUtil.removeMatchingThreads("LnPowerManager LnTrackStatusUpdateThread");
+        JUnitUtil.removeMatchingThreads("LnSensorUpdateThread");
+        JUnitUtil.removeMatchingThreads("LocoNetThrottledTransmitter");
+
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemoTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.loconet.pr3;
 
-import jmri.jmrix.SystemConnectionMemoTestBase;
+import jmri.jmrix.loconet.LnSystemConnectionMemoTestBase;
 import jmri.jmrix.loconet.LocoNetInterfaceScaffold;
 import jmri.util.JUnitUtil;
 
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.*;
  *
  * @author Paul Bender Copyright (C) 2017
  */
-public class PR3SystemConnectionMemoTest extends SystemConnectionMemoTestBase<PR3SystemConnectionMemo> {
+public class PR3SystemConnectionMemoTest extends LnSystemConnectionMemoTestBase<PR3SystemConnectionMemo> {
 
     @Override
     @BeforeEach
     public void setUp() {
-        JUnitUtil.setUp();
+        super.setUp();
         scm = new PR3SystemConnectionMemo();
         LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold(scm);
         scm.setLnTrafficController(lnis);
@@ -27,7 +27,7 @@ public class PR3SystemConnectionMemoTest extends SystemConnectionMemoTestBase<PR
     @AfterEach
     public void tearDown() {
         scm.dispose();
-        JUnitUtil.tearDown();
+        super.tearDown();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(PR3SystemConnectionMemoTest.class);

--- a/java/test/jmri/jmrix/loconet/pr4/PR4SystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/pr4/PR4SystemConnectionMemoTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.loconet.pr4;
 
-import jmri.jmrix.SystemConnectionMemoTestBase;
+import jmri.jmrix.loconet.LnSystemConnectionMemoTestBase;
 import jmri.jmrix.loconet.LocoNetInterfaceScaffold;
 import jmri.util.JUnitUtil;
 
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.*;
  *
  * @author Paul Bender Copyright (C) 2017
  */
-public class PR4SystemConnectionMemoTest extends SystemConnectionMemoTestBase<PR4SystemConnectionMemo> {
+public class PR4SystemConnectionMemoTest extends LnSystemConnectionMemoTestBase<PR4SystemConnectionMemo> {
 
     @Override
     @BeforeEach
     public void setUp() {
-        JUnitUtil.setUp();
+        super.setUp();
         scm = new PR4SystemConnectionMemo();
         LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold(scm);
         scm.setLnTrafficController(lnis);
@@ -27,7 +27,7 @@ public class PR4SystemConnectionMemoTest extends SystemConnectionMemoTestBase<PR
     @AfterEach
     public void tearDown() {
         scm.dispose();
-        JUnitUtil.tearDown();
+        super.tearDown();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(PR4SystemConnectionMemoTest.class);

--- a/java/test/jmri/jmrix/loconet/sdfeditor/EditorFrameTest.java
+++ b/java/test/jmri/jmrix/loconet/sdfeditor/EditorFrameTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.*;
  * @author Paul Bender Copyright (C) 2017
  */
 public class EditorFrameTest extends jmri.util.JmriJFrameTestBase {
-           
+
     private SdfBuffer b;
 
     @BeforeEach
@@ -35,6 +35,7 @@ public class EditorFrameTest extends jmri.util.JmriJFrameTestBase {
     @Override
     public void tearDown() {
         b = null;
+        JUnitUtil.clearShutDownManager();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/sdfeditor/EditorPaneTest.java
+++ b/java/test/jmri/jmrix/loconet/sdfeditor/EditorPaneTest.java
@@ -34,6 +34,7 @@ public class EditorPaneTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/uhlenbrock/UhlenbrockSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/uhlenbrock/UhlenbrockSystemConnectionMemoTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.loconet.uhlenbrock;
 
-import jmri.jmrix.SystemConnectionMemoTestBase;
+import jmri.jmrix.loconet.LnSystemConnectionMemoTestBase;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -11,12 +11,12 @@ import jmri.jmrix.loconet.LocoNetInterfaceScaffold;
  *
  * @author Paul Bender Copyright (C) 2017
  */
-public class UhlenbrockSystemConnectionMemoTest extends SystemConnectionMemoTestBase<UhlenbrockSystemConnectionMemo> {
+public class UhlenbrockSystemConnectionMemoTest extends LnSystemConnectionMemoTestBase<UhlenbrockSystemConnectionMemo> {
 
     @Override
     @BeforeEach
     public void setUp() {
-        JUnitUtil.setUp();
+        super.setUp();
         scm = new UhlenbrockSystemConnectionMemo();
         LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold(scm);
         scm.setLnTrafficController(lnis);
@@ -28,7 +28,7 @@ public class UhlenbrockSystemConnectionMemoTest extends SystemConnectionMemoTest
     @AfterEach
     public void tearDown() {
         scm.dispose();
-        JUnitUtil.tearDown();
+        super.tearDown();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(UhlenbrockSystemConnectionMemoTest.class);

--- a/java/test/jmri/jmrix/loconet/usb_dcs240/UsbDcs240SystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/usb_dcs240/UsbDcs240SystemConnectionMemoTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.loconet.usb_dcs240;
 
-import jmri.jmrix.SystemConnectionMemoTestBase;
+import jmri.jmrix.loconet.LnSystemConnectionMemoTestBase;
 import jmri.jmrix.loconet.LnCommandStationType;
 import jmri.jmrix.loconet.LocoNetInterfaceScaffold;
 import jmri.util.JUnitUtil;
@@ -11,12 +11,12 @@ import org.junit.jupiter.api.*;
  *
  * @author Paul Bender Copyright (C) 2017
  */
-public class UsbDcs240SystemConnectionMemoTest extends SystemConnectionMemoTestBase<UsbDcs240SystemConnectionMemo> {
+public class UsbDcs240SystemConnectionMemoTest extends LnSystemConnectionMemoTestBase<UsbDcs240SystemConnectionMemo> {
 
     @Override
     @BeforeEach
     public void setUp() {
-        JUnitUtil.setUp();
+        super.setUp();
         scm = new UsbDcs240SystemConnectionMemo();
         LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold(scm);
         scm.setLnTrafficController(lnis);
@@ -28,7 +28,7 @@ public class UsbDcs240SystemConnectionMemoTest extends SystemConnectionMemoTestB
     @AfterEach
     public void tearDown() {
         scm.dispose();
-        JUnitUtil.tearDown();
+        super.tearDown();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(SBDCS240SystemConnectionMemoTest.class);

--- a/java/test/jmri/jmrix/loconet/usb_dcs52/UsbDcs52SystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/usb_dcs52/UsbDcs52SystemConnectionMemoTest.java
@@ -1,7 +1,7 @@
 package jmri.jmrix.loconet.usb_dcs52;
 
-import jmri.jmrix.SystemConnectionMemoTestBase;
 import jmri.jmrix.loconet.LocoNetInterfaceScaffold;
+import jmri.jmrix.loconet.LnSystemConnectionMemoTestBase;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.*;
  *
  * @author Paul Bender Copyright (C) 2017
  */
-public class UsbDcs52SystemConnectionMemoTest extends SystemConnectionMemoTestBase<UsbDcs52SystemConnectionMemo> {
+public class UsbDcs52SystemConnectionMemoTest extends LnSystemConnectionMemoTestBase<UsbDcs52SystemConnectionMemo> {
 
     @Override
     @BeforeEach
     public void setUp() {
-       JUnitUtil.setUp();
+       super.setUp();
        scm = new UsbDcs52SystemConnectionMemo();
        LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold(scm);
        scm.setLnTrafficController(lnis);
@@ -27,7 +27,7 @@ public class UsbDcs52SystemConnectionMemoTest extends SystemConnectionMemoTestBa
     @AfterEach
     public void tearDown() {
         scm.dispose();
-        JUnitUtil.tearDown();
+        super.tearDown();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(UsbDcs52SystemConnectionMemoTest.class);

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1502,22 +1502,24 @@ public class JUnitUtil {
             ThreadGroup g = t.getThreadGroup();
             String group = (g != null) ?  g.getName() : "<null group>";
 
-            if (! (threadNames.contains(name)
+            if (! (
+                    threadNames.contains(name)
                  || group.equals("system")
                  || name.startsWith("Timer-")  // we separately scan for JMRI-resident timers
                  || name.startsWith("RMI TCP Accept")
                  || name.startsWith("AWT-EventQueue")
                  || name.startsWith("Aqua L&F")
+                 || name.startsWith("junit-jupiter-")  // JUnit
+                 || name.startsWith("Batik CleanerThread")  // XML
                  || name.startsWith("Image Fetcher ")
                  || name.startsWith("Image Animator ")
                  || name.startsWith("JmDNS(")
                  || name.startsWith("JmmDNS pool")
+                 || name.startsWith("Common-Cleaner")
                  || name.startsWith("ForkJoinPool.commonPool-worker")
-                 || name.startsWith("SocketListener(")
-                 || group.contains("FailOnTimeoutGroup")) // JUnit timeouts
-                 || name.startsWith("SocketListener(")
-                 || name.startsWith("junit-jupiter-timeout-watcher")  // JUnit
-                 || (name.startsWith("SwingWorker-pool-1-thread-")
+                 || name.contains("SocketListener")
+                 || group.contains("FailOnTimeoutGroup") // JUnit timeouts
+                 || name.startsWith("SwingWorker-pool-1-thread-")
                 ) ) {
 
                         if (t.getState() == Thread.State.TERMINATED) {

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1516,8 +1516,9 @@ public class JUnitUtil {
                  || name.startsWith("SocketListener(")
                  || group.contains("FailOnTimeoutGroup")) // JUnit timeouts
                  || name.startsWith("SocketListener(")
-                 || (name.startsWith("SwingWorker-pool-1-thread-") && ( group.contains("FailOnTimeoutGroup") || group.contains("main") )
-                )) {
+                 || name.startsWith("junit-jupiter-timeout-watcher")  // JUnit
+                 || (name.startsWith("SwingWorker-pool-1-thread-")
+                ) ) {
 
                         if (t.getState() == Thread.State.TERMINATED) {
                             // might have transitioned during above (logging slow)
@@ -1582,6 +1583,7 @@ public class JUnitUtil {
                             }
                             e.dispose();
                         }));
+        EditorFrameOperator.clearEditorFrameOperatorThreads();
     }
 
     /* GraphicsEnvironment utility methods */


### PR DESCRIPTION
The `EditorFrameOperator` is meant to click on any Close or Delete dialogs left behind.  It's quite ruthless about this, leaving around threads that are still trying to accomplish their goal.  This PR provides a routine that removes those, and invokes it in multiple classes that have left threads around.