### PR TITLE
Issue 10285 - fix bad image link in CCOR-1967 signal system

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -473,7 +473,8 @@
         </ul>
         <h4>Signal Systems</h4>
             <ul>
-                <li></li>
+                <li>Fixed a bug in the CCOR-1967 set that kept one
+                    aspect from displaying properly.</li>
             </ul>
 
         <h4>Signal Heads</h4>

--- a/xml/signals/CCOR-1967/appearance-SL-1-dwarf.xml
+++ b/xml/signals/CCOR-1967/appearance-SL-1-dwarf.xml
@@ -73,6 +73,12 @@
         <authorinitials>MKZ</authorinitials>
         <revremark>fix imagelink directory</revremark>
     </revision>
+        <revision>
+        <revnumber>2.1</revnumber>
+        <date>2021-11-10</date>
+        <authorinitials>MKZ</authorinitials>
+        <revremark>fix imagelink for Held aspect</revremark>
+    </revision>
   </revhistory>
 
   <aspecttable>CCOR-1967</aspecttable>
@@ -134,7 +140,7 @@
     </permissive>
     <held>
       <aspect>Stop</aspect>
-      <imagelink>preference:resources/icons/smallschematics/aspects/CCOR-1967/SL-1-dwarf/rule-240A-held.gif</imagelink>
+      <imagelink>../../../resources/icons/smallschematics/aspects/CCOR-1967/SL-1-dwarf/rule-240A-held.gif</imagelink>
     </held>
   </specificappearances>
 


### PR DESCRIPTION
Commits the file contributed in Issue #10285 