### PR TITLE
VSDecoder test thread removal

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
@@ -19,14 +19,14 @@ import org.slf4j.LoggerFactory;
  * <hr>
  * This file is part of JMRI.
  * <p>
- * JMRI is free software; you can redistribute it and/or modify it under 
- * the terms of version 2 of the GNU General Public License as published 
+ * JMRI is free software; you can redistribute it and/or modify it under
+ * the terms of version 2 of the GNU General Public License as published
  * by the Free Software Foundation. See the "COPYING" file for a copy
  * of this license.
  * <p>
- * JMRI is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
  * for more details.
  *
  * @author Mark Underwood Copyright (C) 2011
@@ -56,6 +56,7 @@ class Diesel3Sound extends EngineSound {
 
     private void startThread() {
         _loopThread = new D3LoopThread(this, notch_sounds.get(current_notch), _soundName, true);
+        _loopThread.setName("Diesel3Sound.D3LoopThread");
         log.debug("Loop Thread Started.  Sound name: {}", _soundName);
     }
 

--- a/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
@@ -21,14 +21,14 @@ import org.slf4j.LoggerFactory;
  * <hr>
  * This file is part of JMRI.
  * <p>
- * JMRI is free software; you can redistribute it and/or modify it under 
- * the terms of version 2 of the GNU General Public License as published 
- * by the Free Software Foundation. See the "COPYING" file for a copy 
+ * JMRI is free software; you can redistribute it and/or modify it under
+ * the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation. See the "COPYING" file for a copy
  * of this license.
  * <p>
- * JMRI is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
  * for more details.
  *
  * @author Mark Underwood Copyright (C) 2011
@@ -73,6 +73,7 @@ class Steam1Sound extends EngineSound {
     private void startThread() {
         _loopThread = new S1LoopThread(this, _soundName, top_speed, top_speed_reverse,
                 driver_diameter_float, num_cylinders, decel_trigger_rpms, true);
+        _loopThread.setName("Steam1Sound.S1LoopThread");
         log.debug("Loop Thread Started.  Sound name: {}", _soundName);
     }
 
@@ -651,7 +652,7 @@ class Steam1Sound extends EngineSound {
         private int queue_limit;
         private int wait_loops;
 
-        private S1LoopThread(Steam1Sound d, String s, int ts, int tsr, float dd, 
+        private S1LoopThread(Steam1Sound d, String s, int ts, int tsr, float dd,
                 int nc, int dtr, boolean r) {
             super();
             _parent = d;
@@ -722,7 +723,7 @@ class Steam1Sound extends EngineSound {
                         _parent.accdectime = dec_time;
                         log.debug("decelerate from {} to {}", lastRpm, getRpmNominal());
 
-                        if ((getRpmNominal() < 23) && is_auto_coasting && (count_pre_arrival > 0) && 
+                        if ((getRpmNominal() < 23) && is_auto_coasting && (count_pre_arrival > 0) &&
                                 _parent.trigger_sounds.containsKey("pre_arrival") && (dec_time < 250)) {
                             _parent.trigger_sounds.get("pre_arrival").fadeIn();
                             count_pre_arrival--;
@@ -809,7 +810,7 @@ class Steam1Sound extends EngineSound {
         }
 
         private void getLocoDirection(int d) {
-            // If loco direction was changed we need to set topspeed of the loco to new value 
+            // If loco direction was changed we need to set topspeed of the loco to new value
             // (this is necessary, when topspeed-forward and topspeed-reverse differs)
             if (d == 1) {  // loco is going forward
                 topspeed = _top_speed;
@@ -835,7 +836,7 @@ class Steam1Sound extends EngineSound {
         private void setFunction(String event, boolean is_true, String name) {
             // This throttle function key handling differs to configurable sounds:
             // Do something following certain conditions, when a throttle function key is pressed.
-            // Note: throttle will send initial value(s) before thread is started! 
+            // Note: throttle will send initial value(s) before thread is started!
             log.debug("throttle function key pressed: {} is {}, function: {}", event, is_true, name);
             if (name.equals("COAST")) {
                 // Handle key-coasting on/off.
@@ -895,7 +896,7 @@ class Steam1Sound extends EngineSound {
             notch1 = _parent.getNotch(1);
             if (_parent.engine_pane != null) {
                 _parent.engine_pane.setThrottle(1); // Set EnginePane (DieselPane) notch
-            } 
+            }
             is_dynamic_gain = _parent.is_dynamic_gain;
             dynamic_volume = 1.0f;
             _sound.setReferenceDistance(_parent.engine_rd);
@@ -977,7 +978,8 @@ class Steam1Sound extends EngineSound {
                 }
                 _sound.stop();
             } catch (InterruptedException ie) {
-                log.error("execption", ie);
+                // kill thread
+                return;
             }
         }
 
@@ -1006,7 +1008,7 @@ class Steam1Sound extends EngineSound {
 
         private void changeNotch() {
             int new_notch = _notch.getNotch();
-            log.debug("changing notch ... rpm: {}, notch: {}, chuff index: {}", 
+            log.debug("changing notch ... rpm: {}, notch: {}, chuff index: {}",
                     getRpm(), _notch.getNotch(), chuff_index);
             if ((getRpm() > _notch.getMaxLimit()) && (new_notch < _parent.notch_sounds.size())) {
                 // Too fast. Need to go to next notch up
@@ -1045,7 +1047,7 @@ class Steam1Sound extends EngineSound {
                     setRpm(getRpm() + 1);
                 } else {
                     log.debug("actual rpm not increased. Value: {}", getRpm());
-                } 
+                }
                 log.debug("accel - nominal RPM: {}, actual RPM: {}", getRpmNominal(), getRpm());
             } else if (getRpmNominal() < getRpm()) {
                 setRpm(getRpm() - 1);
@@ -1081,7 +1083,7 @@ class Steam1Sound extends EngineSound {
                     }
                     log.debug("change from chuff or coast to idle.");
                     is_auto_coasting = false;
-                    stopBraking(); 
+                    stopBraking();
                     startIdling();
                 }
             } else {
@@ -1130,7 +1132,7 @@ class Steam1Sound extends EngineSound {
                     if (dynamic_volume + inc3 < 1.0f && high_volume < 1.0f) {
                         dynamic_volume += inc3;
                     } else if (dynamic_volume + inc2 < high_volume) {
-                        dynamic_volume += inc2; 
+                        dynamic_volume += inc2;
                     } else if (dynamic_volume - inc3 > 1.0f) {
                         dynamic_volume -= inc3;
                         high_volume -= inc2;
@@ -1182,7 +1184,7 @@ class Steam1Sound extends EngineSound {
         private int calcChuffInterval(int revpm) {
             //  chuff interval will be calculated based on revolutions per minute (revpm)
             //  note: interval time includes the sound duration!
-            //  chuffInterval = time in ms per revolution of the driver wheel: 
+            //  chuffInterval = time in ms per revolution of the driver wheel:
             //      60,000 ms / revpm / number of cylinders / 2 (because cylinders are double-acting)
             return (int) Math.round(60000.0 / revpm / _num_cylinders / 2.0);
         }
@@ -1255,7 +1257,7 @@ class Steam1Sound extends EngineSound {
                 }
             } else {
                 // Need to cut the SoundBite to new length of interval
-                log.debug("need to cut sound clip from {} to length {}", sbl, interval); 
+                log.debug("need to cut sound clip from {} to length {}", sbl, interval);
                 byte[] bbytes = new byte[bbufcount];
                 data.get(bbytes); // Same as: data.get(bbytes, 0, bbufcount);
                 data.rewind();

--- a/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
@@ -979,6 +979,7 @@ class Steam1Sound extends EngineSound {
                 _sound.stop();
             } catch (InterruptedException ie) {
                 // kill thread
+                log.debug("thread interrupted");
                 return;
             }
         }

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManagerThread.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManagerThread.java
@@ -6,14 +6,14 @@ package jmri.jmrit.vsdecoder;
  * <hr>
  * This file is part of JMRI.
  * <p>
- * JMRI is free software; you can redistribute it and/or modify it under 
- * the terms of version 2 of the GNU General Public License as published 
+ * JMRI is free software; you can redistribute it and/or modify it under
+ * the terms of version 2 of the GNU General Public License as published
  * by the Free Software Foundation. See the "COPYING" file for a copy
  * of this license.
  * <p>
- * JMRI is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
  * for more details.
  * <p>
  *
@@ -57,6 +57,8 @@ class VSDecoderManagerThread extends Thread {
             try {
                 sleep(20);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
             }
         }
         // all done.

--- a/java/test/jmri/jmrit/vsdecoder/Diesel3SoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/Diesel3SoundTest.java
@@ -28,6 +28,7 @@ public class Diesel3SoundTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/vsdecoder/DieselSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/DieselSoundTest.java
@@ -28,6 +28,7 @@ public class DieselSoundTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/vsdecoder/EngineSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/EngineSoundTest.java
@@ -25,8 +25,8 @@ public class EngineSoundTest {
     @AfterEach
     public void tearDown() {
         // this created an audio manager, clean that up
-        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
+        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/vsdecoder/EngineSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/EngineSoundTest.java
@@ -25,6 +25,7 @@ public class EngineSoundTest {
     @AfterEach
     public void tearDown() {
         // this created an audio manager, clean that up
+        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();

--- a/java/test/jmri/jmrit/vsdecoder/Steam1SoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/Steam1SoundTest.java
@@ -28,6 +28,7 @@ public class Steam1SoundTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/vsdecoder/SteamSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/SteamSoundTest.java
@@ -28,6 +28,7 @@ public class SteamSoundTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/vsdecoder/VSDecoderManagerThreadTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDecoderManagerThreadTest.java
@@ -26,6 +26,7 @@ public class VSDecoderManagerThreadTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/vsdecoder/VSDecoderTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDecoderTest.java
@@ -27,6 +27,7 @@ public class VSDecoderTest {
         jmri.util.JUnitAppender.suppressErrorMessage("Unhandled audio format type 0");
 
         // this created an an audio manager, clean that up
+        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
         JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/vsdecoder/VSDecoderTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDecoderTest.java
@@ -29,6 +29,9 @@ public class VSDecoderTest {
         // this created an an audio manager, clean that up
         JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
+
+        JUnitUtil.removeMatchingThreads("Steam1Sound.S1LoopThread");
+
         JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/vsdecoder/swing/VSDConfigDialogTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/swing/VSDConfigDialogTest.java
@@ -37,6 +37,7 @@ public class VSDConfigDialogTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         JUnitUtil.resetWindows(false,false);
         JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/vsdecoder/swing/VSDManagerFrameTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/swing/VSDManagerFrameTest.java
@@ -27,6 +27,7 @@ public class VSDManagerFrameTest extends jmri.util.JmriJFrameTestBase {
 
         // this created an audio manager, clean that up
         jmri.InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
+        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
         super.tearDown();

--- a/java/test/jmri/jmrit/vsdecoder/swing/VSDecoderPreferencesPaneTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/swing/VSDecoderPreferencesPaneTest.java
@@ -29,6 +29,7 @@ public class VSDecoderPreferencesPaneTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.removeMatchingThreads("VSDecoderManagerThread");
         JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1538,12 +1538,16 @@ public class JUnitUtil {
                         }
 
                         // for anonymous threads, show the traceback in hopes of finding what it is
-                        if (name.startsWith("Thread-")) {
-                            Exception ex = new Exception("traceback of numbered thread");
-                            ex.setStackTrace(Thread.getAllStackTraces().get(t));
-                            log.warn("{} remnant thread \"{}\" in group \"{}\" after {}", action, name, group, getTestClassName(), ex);
-                        } else {
-                            log.warn("{} remnant thread \"{}\" in group \"{}\" after {}", action, name, group, getTestClassName());
+                        try {
+                            if (name.startsWith("Thread-")) {
+                                Exception ex = new Exception("traceback of numbered thread");
+                                ex.setStackTrace(Thread.getAllStackTraces().get(t));
+                                log.warn("{} remnant thread \"{}\" in group \"{}\" after {}", action, name, group, getTestClassName(), ex);
+                            } else {
+                                log.warn("{} remnant thread \"{}\" in group \"{}\" after {}", action, name, group, getTestClassName());
+                            }
+                        } catch (NullPointerException e) {
+                            log.warn("NullPointerException while processing \"{}\" stack trace, thread may be gone", name);
                         }
                         if (kill) {
                             System.err.println(topState+" "+t.getState());

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1473,7 +1473,9 @@ public class JUnitUtil {
         "Multihomed mDNS.Timer",            // observed in JmDNS; clean shutdown takes time
         "Direct Clip",                      // observed in macOS JRE, associated with javax.sound.sampled.AudioSystem
         "Basic L&F File Loading Thread",
-        "dns.close in ZeroConfServiceManager#stopAll"
+        "dns.close in ZeroConfServiceManager#stopAll",
+        "Common-Cleaner",
+        "Batik CleanerThread"  // XML
     }));
     static List<Thread> threadsSeen = new ArrayList<>();
 
@@ -1510,22 +1512,24 @@ public class JUnitUtil {
                  || name.startsWith("AWT-EventQueue")
                  || name.startsWith("Aqua L&F")
                  || name.startsWith("junit-jupiter-")  // JUnit
-                 || name.startsWith("Batik CleanerThread")  // XML
                  || name.startsWith("Image Fetcher ")
                  || name.startsWith("Image Animator ")
                  || name.startsWith("JmDNS(")
                  || name.startsWith("JmmDNS pool")
-                 || name.startsWith("Common-Cleaner")
                  || name.startsWith("ForkJoinPool.commonPool-worker")
-                 || name.contains("SocketListener")
+                 || name.startsWith("SocketListener(")
                  || group.contains("FailOnTimeoutGroup") // JUnit timeouts
-                 || name.startsWith("SwingWorker-pool-1-thread-")
-                ) ) {
+                 || ( name.startsWith("SwingWorker-pool-1-thread-") &&
+                         ( group.contains("FailOnTimeoutGroup") || group.contains("main") )
+                    )
+                )) {
 
                         if (t.getState() == Thread.State.TERMINATED) {
                             // might have transitioned during above (logging slow)
                             continue;
                         }
+
+                        // This thread we have to deal with.
                         boolean kill = true;
                         String action = "Interrupt";
                         if (!killRemnantThreads) {
@@ -1538,16 +1542,25 @@ public class JUnitUtil {
                         }
 
                         // for anonymous threads, show the traceback in hopes of finding what it is
-                        try {
-                            if (name.startsWith("Thread-")) {
-                                Exception ex = new Exception("traceback of numbered thread");
-                                ex.setStackTrace(Thread.getAllStackTraces().get(t));
-                                log.warn("{} remnant thread \"{}\" in group \"{}\" after {}", action, name, group, getTestClassName(), ex);
+                        if (name.startsWith("Thread-")) {
+                            StackTraceElement[] traces = Thread.getAllStackTraces().get(t);
+                            if (traces == null) continue;  // thread went away, maybe terminated in parallel
+                            if (traces.length >7 && traces[7].getClassName().contains("org.netbeans.jemmy") ) {
+                                // empirically. jemmy leaves anonymous threads
+                                log.warn("Jemmy remnant thread running {}.{} [{}.{}]",
+                                        traces[7].getClassName(),
+                                        traces[7].getMethodName(),
+                                       traces[7].getFileName(),
+                                       traces[7].getLineNumber()
+                                    );
                             } else {
-                                log.warn("{} remnant thread \"{}\" in group \"{}\" after {}", action, name, group, getTestClassName());
+                                // anonymous thread that should be displayed
+                                Exception ex = new Exception("traceback of numbered thread");
+                                ex.setStackTrace(traces);
+                                log.warn("{} remnant thread \"{}\" in group \"{}\" after {}", action, name, group, getTestClassName(), ex);
                             }
-                        } catch (NullPointerException e) {
-                            log.warn("NullPointerException while processing \"{}\" stack trace, thread may be gone", name);
+                        } else {
+                            log.warn("{} remnant thread \"{}\" in group \"{}\" after {}", action, name, group, getTestClassName());
                         }
                         if (kill) {
                             System.err.println(topState+" "+t.getState());


### PR DESCRIPTION
 - kill threads left running at end of tests
 - improve JUnitUtil thread check to handle threads that complete part way through 