### PR TITLE
MQTT reconnects if disconnected

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -95,6 +95,10 @@
                     Add protection against a concurrent-modification
                     error that can happen during very fast operations.
                 </li>
+                <li>
+                    If the connection is disconnected, JMRI tries to
+                    reconnect.
+                </li>
             </ul>
 
         <h4>MRC</h4>

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -257,7 +257,7 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
         return (mqttClient);
     }
 
-    private boolean tryToReconnect() {
+    private void tryToReconnect() {
         log.warn("Try to reconnect");
         try {
             if ( getOptionState(MQTT_USERNAME_OPTION) != null
@@ -272,12 +272,9 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
             for (String t : mqttEventListeners.keySet()) {
                 mqttClient.subscribe(t);
             }
-            return true;
-            
         } catch (MqttException ex) {
             log.error("Unable to reconnect", ex);
             scheduleReconnectTimer();
-            return false;
         }
     }
 
@@ -285,9 +282,7 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
         jmri.util.TimerUtil.scheduleOnLayoutThread(new java.util.TimerTask() {
             @Override
             public void run() {
-                if (tryToReconnect()) {
-                    cancel();
-                }
+                tryToReconnect();
             }
         }, 100);
     }

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -269,7 +269,8 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
             log.warn("Succeeded to reconnect");
 
             mqttClient.setCallback(this);
-            for (String t : mqttEventListeners.keySet()) {
+            Set<String> set = mqttEventListeners.keySet();
+            for (String t : set) {
                 mqttClient.subscribe(t);
             }
         } catch (MqttException ex) {
@@ -284,7 +285,7 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
             public void run() {
                 tryToReconnect();
             }
-        }, 100);
+        }, 500);
     }
 
     @Override

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -257,8 +257,8 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
         return (mqttClient);
     }
 
-    private void tryToReconnect() {
-        log.warn("Try to reconnect");
+    private void tryToReconnect(boolean showLogMessages) {
+        if (showLogMessages) log.warn("Try to reconnect");
         try {
             if ( getOptionState(MQTT_USERNAME_OPTION) != null
                     && ! getOptionState(MQTT_USERNAME_OPTION).isEmpty()) {
@@ -274,16 +274,16 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
                 mqttClient.subscribe(t);
             }
         } catch (MqttException ex) {
-            log.error("Unable to reconnect", ex);
-            scheduleReconnectTimer();
+            if (showLogMessages) log.error("Unable to reconnect", ex);
+            scheduleReconnectTimer(false);
         }
     }
 
-    private void scheduleReconnectTimer() {
+    private void scheduleReconnectTimer(boolean showLogMessages) {
         jmri.util.TimerUtil.scheduleOnLayoutThread(new java.util.TimerTask() {
             @Override
             public void run() {
-                tryToReconnect();
+                tryToReconnect(showLogMessages);
             }
         }, 500);
     }
@@ -293,8 +293,8 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
     public void connectionLost(Throwable thrwbl) {
         log.warn("Lost MQTT broker connection...");
         if (this.allowConnectionRecovery) {
-            log.info("...trying to reconnect");
-            scheduleReconnectTimer();
+            log.info("...trying to reconnect repeatedly");
+            scheduleReconnectTimer(true);
             return;
         }
         log.error("Won't reconnect");

--- a/java/src/jmri/jmrix/mqtt/MqttAdapter.java
+++ b/java/src/jmri/jmrix/mqtt/MqttAdapter.java
@@ -269,7 +269,7 @@ public class MqttAdapter extends jmri.jmrix.AbstractNetworkPortController implem
             log.warn("Succeeded to reconnect");
 
             mqttClient.setCallback(this);
-            Set<String> set = mqttEventListeners.keySet();
+            Set<String> set = new HashSet<>(mqttEventListeners.keySet());
             for (String t : set) {
                 mqttClient.subscribe(t);
             }


### PR DESCRIPTION
If the MQTT connection disconnects, it tries to reconnect. I have tested this with the Mosquitto broker and if I shut down Mosquitto, JMRI tries to reconnect until Mosquitto is restarted.

Comments are welcome. Maybe the log statements should be different?