### PR TITLE
Fix NX cancel and LE Edit block permissive

### DIFF
--- a/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
+++ b/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
@@ -1357,14 +1357,14 @@
 
       <p>Turnout, level crossing, and track segment edit dialogs provide access to the Create/Edit
       Block dialog where information specific to a block may be entered or edited. The
-      <strong>Occupancy Sensor:</strong> field in the Create/Edit Block dialog shows the name of
+      <strong>Sensor:</strong> field in the <strong>Sensor</strong> tab shows the name of
       the occupancy sensor currently assigned to the block, if there is one. To enter or change the
-      occupancy sensor, enter the name (system name or user name) of a sensor in the Sensor Table
-      in the <strong>Occupancy Sensor:</strong> field. A sensor may be assigned as the occupancy
+      occupancy sensor, select the name (system name or user name) of a sensor in the Sensor Table
+      in the <strong>Sensor:</strong> field. A sensor may be assigned as the occupancy
       sensor of only one block; attempting to do otherwise will result in an error message.
       Normally, the state of an occupancy sensor is "Active" when a block is occupied, so "Active"
       for occupied sense is the automatic default. This can be changed by selecting "Inactive" in
-      the <strong>Occupied Sense:</strong> selection box.</p>
+      the <strong>Occupied Sense:</strong> selection box in the <strong>Layout Editor</strong> tab.</p>
 
       <p>Block track colors are used instead of the default track color if a section of track is in
       a block. The track items in a block are drawn with different track colors for occupied and

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -601,7 +601,7 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
                 block.setNamedSensor(occupancyNamedSensor);
             }
         }
-        
+
         Sensor s = getOccupancySensor();
         if ( s == null) {
             return UNKNOWN;
@@ -917,8 +917,6 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
 
     private final JComboBox<String> senseBox = new JComboBox<>();
 
-    private final JCheckBox permissiveCheck = new JCheckBox("Permissive Working Allowed");
-
     // TODO I18N in Bundle.properties
     private int senseActiveIndex;
     private int senseInactiveIndex;
@@ -1051,7 +1049,6 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
         if (m != metric) {
             setBlockMetric(m);
         }
-        block.setPermissiveWorking(permissiveCheck.isSelected());
         if (neighbourDir != null) {
             for (int i = 0; i < neighbourDir.size(); i++) {
                 int neigh = neighbourDir.get(i).getSelectedIndex();
@@ -1270,7 +1267,6 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
                     if (m != metric) {
                         setBlockMetric(m);
                     }
-                    block.setPermissiveWorking(permissiveCheck.isSelected());
                     if (neighbourDir != null) {
                         for (int i = 0; i < neighbourDir.size(); i++) {
                             int neigh = neighbourDir.get(i).getSelectedIndex();
@@ -4263,7 +4259,7 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
             length = len;
             init();
         }
-        
+
         final void init() {
             validCurrentRoute = checkIsRouteOnValidThroughPath(this);
             firePropertyChange("length", null, null);

--- a/java/src/jmri/jmrit/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/entryexit/DestinationPoints.java
@@ -823,7 +823,13 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean {
             return;
         }
 
+        boolean facing = true;
         for (LayoutBlock blk : routeDetails) {
+            if (facing) {
+                // skip facing Block
+                facing = false;
+                continue;
+            }
             if ((getEntryExitType() == EntryExitPairs.FULLINTERLOCK)) {
                 blk.setUseExtraColor(false);
             }


### PR DESCRIPTION
- The NX cancel process was also releasing the facing block.  This is an issue when the facing block is part of another active NX route.
- Old code in LayoutBlock was forcing a block to be non-permissive regardless of the change requested in the LE Edit dialog.