### PR TITLE
LinkedWarrentTest threading

### DIFF
--- a/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LinkedWarrantTest.java
@@ -82,7 +82,7 @@ public class LinkedWarrantTest {
 
         assertThat(NXFrameTest.runtimes(route, _OBlockMgr).getDisplayName()).withFailMessage("LoopDeLoop after second leg").isEqualTo(block.getSensor().getDisplayName());
 
-        jmri.util.JUnitUtil.waitFor(() -> {
+        JUnitUtil.waitFor(() -> {
             String m = tableFrame.getStatus();
             return m.startsWith("Warrant");
         }, "LoopDeLoop finished second leg");
@@ -99,7 +99,9 @@ public class LinkedWarrantTest {
         jfo.requestClose();
         // we may want to use jemmy to close the panel as well.
         assert panel != null;
-        panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        jmri.util.ThreadingUtil.runOnGUI( () -> {
+            panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        });
     }
 
     // Tests warrant launching a different warrant with different address. Origin location cannot be destination of the other)
@@ -145,7 +147,7 @@ public class LinkedWarrantTest {
         // Run the train, then checks end location
         assertThat(NXFrameTest.runtimes(route1, _OBlockMgr).getDisplayName()).withFailMessage("Train after first leg").isEqualTo(block.getSensor().getDisplayName());
         // It takes 600+ milliseconds per block to execute NXFrameTest.runtimes()
-        
+
         // "Loop&Fred" links to "WestToEast". Get start for "WestToEast" occupied quickly
         NXFrameTest.setAndConfirmSensorAction(sensor1, Sensor.ACTIVE, _OBlockMgr.getBySystemName("OB1"));
 
@@ -167,7 +169,9 @@ public class LinkedWarrantTest {
         jfo.requestClose();
         // we may want to use jemmy to close the panel as well.
         assert panel != null;
-        panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        jmri.util.ThreadingUtil.runOnGUI( () -> {
+            panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        });
     }
 
     // tests a warrant running a train out and launching a return train
@@ -216,7 +220,7 @@ public class LinkedWarrantTest {
         assertThat(NXFrameTest.runtimes(routeOut, _OBlockMgr).getDisplayName()).withFailMessage("Train after first leg").isEqualTo(outEndSensorName);
         // It takes 600+ milliseconds per block to execute NXFrameTest.runtimes()
         // i.e. wait at least 600 * (route.length - 1) for return
-        
+
         jmri.util.JUnitUtil.waitFor(() -> {
             String m = tableFrame.getStatus();
             return m.startsWith("Warrant");
@@ -242,7 +246,7 @@ public class LinkedWarrantTest {
 
         assertThat(NXFrameTest.runtimes(routeOut, _OBlockMgr).getDisplayName()).withFailMessage("Train after third leg").isEqualTo(outEndSensorName);
         // It takes 600+ milliseconds per block to execute NXFrameTest.runtimes()
- 
+
         jmri.util.JUnitUtil.waitFor(() -> {
             String m = tableFrame.getStatus();
             return m.startsWith("Warrant");
@@ -261,7 +265,9 @@ public class LinkedWarrantTest {
             jfo.requestClose();
             // we may want to use jemmy to close the panel as well.
         assert panel != null;
-        panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        jmri.util.ThreadingUtil.runOnGUI( () -> {
+            panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        });
     }
 
 
@@ -363,7 +369,9 @@ public class LinkedWarrantTest {
         jfo.requestClose();
         // we may want to use jemmy to close the panel as well.
         assert panel != null;
-        panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        jmri.util.ThreadingUtil.runOnGUI( () -> {
+            panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        });
     }
 
     @BeforeEach


### PR DESCRIPTION
Finally got a back-trace that points to a concurrency problem during panel.dispose in LinkedWarrentTest.  This puts that operation on the GUI thread to avoid that.  It's a timing, very intermittent fault, so I don't have a consistent test case, but this seems to work better.