### PR TITLE
Add -T/-t options for Jemmy testing on Mac

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -789,7 +789,7 @@
             <sysproperty key="wdm.forceCache" value="true"/>
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
-            <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
+            <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
@@ -826,7 +826,7 @@
             <sysproperty key="wdm.forceCache" value="true"/>
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
-            <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
+            <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
@@ -1414,7 +1414,7 @@
           fork="yes" >
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
-            <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
+            <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
@@ -1439,7 +1439,7 @@
           fork="yes" >
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
-            <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
+            <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
@@ -1470,7 +1470,7 @@
             <sysproperty key="wdm.forceCache" value="true"/>
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
-            <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
+            <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
@@ -1561,7 +1561,7 @@
                 <fileset refid="junitfileset"/>
                 <fork>
                     <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
-                    <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
+                    <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
                     <sysproperty key="log4j.ignoreTCL" path="true/"/>
                     <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
                     <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
@@ -1588,7 +1588,7 @@
           fork="yes" >
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
-            <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
+            <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
@@ -1616,7 +1616,7 @@
             <sysproperty key="wdm.forceCache" value="true"/>
 
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
-            <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
+            <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
@@ -1655,7 +1655,7 @@
 
                    <sysproperty key="cucumber.options" value="--tags 'not @Ignore'"/>
                     <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
-                    <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
+                    <!-- <sysproperty key="apple.laf.useScreenMenuBar" value="false"/> causes problems with Jemmy access to menus on Mac -->
                     <sysproperty key="log4j.ignoreTCL" path="true/"/>
                     <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
                     <sysproperty key="jmri.prefsdir" path="${tempdir}"/>

--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -177,10 +177,16 @@ recompiled everything, you may want to do <code>ant clean</code> first)<br>
 
       <pre style="font-family: monospace;">
    ant tests
-   ./runtest.csh -T jmri.jmrit.powerpanel.PowerPanelTest
+   ./runtest.csh jmri.jmrit.powerpanel.PowerPanelTest
 </pre>The first line compiles all the test code, and the second runs a specific test or test
 suite.<br>
       (See also how to set this up <a href="IntelliJ.shtml#test">using IntelliJ</a>)
+
+      If you're running on Mac, there's a <a href="StartUpScripts.shtml#parameters"><code>-t</code> option</a>
+      to put the menu on the main-screen menu bar, which makes JMRI apps look more like a
+      Mac application.  This will interfere with
+      <a href="#jemmy">Jemmy</a> based tests of the GUI.
+
       <p>There is also a PowerShell (Core) script available to help running tests with maven,</p>
 
       <pre style="font-family: monospace;">./java/runtests.ps1</pre>. Its main features are:

--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -177,7 +177,7 @@ recompiled everything, you may want to do <code>ant clean</code> first)<br>
 
       <pre style="font-family: monospace;">
    ant tests
-   ./runtest.csh jmri.jmrit.powerpanel.PowerPanelTest
+   ./runtest.csh -T jmri.jmrit.powerpanel.PowerPanelTest
 </pre>The first line compiles all the test code, and the second runs a specific test or test
 suite.<br>
       (See also how to set this up <a href="IntelliJ.shtml#test">using IntelliJ</a>)

--- a/help/en/html/doc/Technical/StartUpScripts.shtml
+++ b/help/en/html/doc/Technical/StartUpScripts.shtml
@@ -139,7 +139,7 @@
       DecoderPro, PanelPro, etc. These are all identical except for application name and main Java
       class.</p>
 
-      <h3>Parameters</h3>
+      <h3 id="parameters">Parameters</h3>
 
       <p>The JMRI shell scripts take the following parameters:</p>
 
@@ -229,10 +229,12 @@
         <dt><code>-t</code>
         </dt>
 
-        <dd>JMRI normally (-t case) configures itself to use the
+        <dd>JMRI applications normally (-t case) configures itself to use the
             main menu bar on Apple Mac systems.  This interferes with
             Jemmy screen-based tests.  The -T option forces standard
-            (on window) Java menus which allows Jemmy tests to run properly.</dd>
+            (on window) Java menus which allows Jemmy tests to run properly.
+            -T is the default when running tests with
+            <code>./runtest.csh</code> or from <code>ant</code>.</dd>
 
         <dt><code>--help</code>
         </dt>

--- a/help/en/html/doc/Technical/StartUpScripts.shtml
+++ b/help/en/html/doc/Technical/StartUpScripts.shtml
@@ -223,6 +223,17 @@
           </dl>
         </dd>
 
+        <dt><code>-T</code>
+        </dt>
+
+        <dt><code>-t</code>
+        </dt>
+
+        <dd>JMRI normally (-t case) configures itself to use the
+            main menu bar on Apple Mac systems.  This interferes with
+            Jemmy screen-based tests.  The -T option forces standard
+            (on window) Java menus which allows Jemmy tests to run properly.</dd>
+
         <dt><code>--help</code>
         </dt>
 

--- a/runtest.csh
+++ b/runtest.csh
@@ -12,7 +12,7 @@
 #
 # If there is no main() method found in the named class, an
 # org.junit.runner.JUnitCore runner is asked to try to run the
-# class as JUnit4 tests. 
+# class as JUnit4 tests.
 #
 # This works by calling .run.sh, which is generated from the JMRI POSIX launcher
 # by running 'ant run-sh'
@@ -35,11 +35,11 @@
 #  jmri.skipscripttests     Skip tests of Jython scripts if true
 #  jmri.log4jconfigfilename Specify replacement for details tests.lcf file (tests only)
 #
-# E.g.: 
+# E.g.:
 # setenv JMRI_OPTIONS -Djmri.skipschematests=true
 #
 # You can run separate instances of the program with their
-# own preferences and setup if you provide the name of a configuration file 
+# own preferences and setup if you provide the name of a configuration file
 # as the 1st argument
 #
 # If you are getting X11 warnings about meta keys, uncomment the next line
@@ -93,4 +93,4 @@ fi
 # tests to the classpaths
 testclasspath="--cp:a=${dirname}/target/test-classes"
 
-"${dirname}/.run.sh" "${settingsdir}" "${prefsdir}" "${testclasspath}" $@
+"${dirname}/.run.sh" -T "${settingsdir}" "${prefsdir}" "${testclasspath}" $@

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -63,6 +63,8 @@ Usage: $( basename $0 ) [--help] [OPTIONS] [--] [ARGUMENTS]
   --serial-ports=SERIAL_PORTS    Use the serial ports in SERIAL_PORTS by name
                                  Multiple names are separated with commas (,)
   --settingsdir=SETTINGS_DIR     Use SETTINGS_DIR as the settings directory
+  -T                             Running Jemmy tests, set options appropriately
+  -t                             Not running Jemmy tests, use regular menu options
   --                             Do not process anything following as an option,
                                  even if it matches one of the above options
 EOM
@@ -118,6 +120,8 @@ function parse_args() {
             --settingsdir=*) ;;
             # ignore and do not pass a ProcessSerialNumber argument (from the open command on macOS)
             -psn_*) ;;
+            -T)  JEMMY="yes" ;;
+            -t)  JEMMY="" ;;
             # everything after this is to be passed to JMRI
             --) ARGS="${ARGS} $@" ; break ;;
             # pass anything else on to JMRI
@@ -205,6 +209,9 @@ ARGS=
 
 # set DEBUG to any non-empty string to see debugging output
 DEBUG=${DEBUG:-}
+
+# set JEMMY to any non-empty string to configure for Jemmy testing
+JEMMY=${JEMMY:-}
 
 # set default classpaths additions
 pre_classpath=""
@@ -517,8 +524,12 @@ fi
 if [ "$OS" = "macosx" ] ; then
     # since bash mangles the application name and icon in $OPTIONS,
     # these are not stored in $OPTIONS
-    OS_OPTIONS="-Dapple.laf.useScreenMenuBar=true"
-    OS_OPTIONS="${OS_OPTIONS} -Dcom.apple.macos.useScreenMenuBar=true"
+    OS_OPTIONS=""
+        # omit custom menu bar if running Jemmy tests
+        if [ "$JEMMY" = "" ] ; then
+        OS_OPTIONS="${OS_OPTIONS} -Dapple.laf.useScreenMenuBar=true"
+        OS_OPTIONS="${OS_OPTIONS} -Dcom.apple.macos.useScreenMenuBar=true"
+    fi
     OS_OPTIONS="${OS_OPTIONS} -Dfile.encoding=UTF-8"
     if [ -f "${BUNDLEDIR}/Contents/Resources/@ICON@.icns" ] ; then
         APPICON="${BUNDLEDIR}/Contents/Resources/@ICON@.icns"


### PR DESCRIPTION
By default, we've had the startup scripts use Mac menu bars when running on Mac:  Menu bar at the top of the screen, not at the top of the window.

This makes Jemmy testing intermittent with the older Jemmy library, and very intermittent with the new Jemmy library.

This adds a -T option(_T_esting)  to force regular Java menu bars on the top of each window, which makes Jemmy tests much much more consistent on Mac.