### PR TITLE
Some test improvements

### DIFF
--- a/java/test/jmri/VariableLightTest.java
+++ b/java/test/jmri/VariableLightTest.java
@@ -14,43 +14,49 @@ public class VariableLightTest {
     @Test
     public void testIsConsistentState() {
         MyVariableLight light = new MyVariableLight("IL1");
-        
+
         light.setState(VariableLight.ON);
         Assert.assertTrue("State is consistent", light.isConsistentState());
-        
+
         light.setState(VariableLight.OFF);
         Assert.assertTrue("State is consistent", light.isConsistentState());
-        
+
         light.setState(VariableLight.INTERMEDIATE);
         Assert.assertTrue("State is consistent", light.isConsistentState());
-        
+
         light.setState(VariableLight.TRANSITIONINGTOFULLON);
         Assert.assertFalse("State is not consistent", light.isConsistentState());
-        
+
         light.setState(VariableLight.TRANSITIONINGHIGHER);
         Assert.assertFalse("State is not consistent", light.isConsistentState());
-        
+
         light.setState(VariableLight.TRANSITIONINGLOWER);
         Assert.assertFalse("State is not consistent", light.isConsistentState());
-        
+
         light.setState(VariableLight.TRANSITIONINGTOFULLOFF);
         Assert.assertFalse("State is not consistent", light.isConsistentState());
-        
+
         light.setState(VariableLight.TRANSITIONING);
         Assert.assertFalse("State is not consistent", light.isConsistentState());
     }
-    
+
+
+    private jmri.Timebase clock;
+
     @Before
     public void setUp() {
-          jmri.util.JUnitUtil.setUp();
-    }
+        jmri.util.JUnitUtil.setUp();
+        clock = jmri.InstanceManager.getDefault(jmri.Timebase.class);
+        clock.setRun(false);
+        clock.setTime(java.time.Instant.EPOCH);  // just a specific time
+     }
 
     @After
     public void tearDown() {
           jmri.util.JUnitUtil.tearDown();
     }
 
-    
+
     private static class MyVariableLight extends AbstractVariableLight {
 
         public MyVariableLight(String systemName) {
@@ -61,7 +67,7 @@ public class VariableLightTest {
         public void setState(int newState) {
             mState = newState;
         }
-        
+
         @Override
         protected void sendIntensity(double intensity) {
             throw new UnsupportedOperationException("Not supported");
@@ -76,7 +82,7 @@ public class VariableLightTest {
         protected int getNumberOfSteps() {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/VariableLightTest.java
+++ b/java/test/jmri/VariableLightTest.java
@@ -54,6 +54,12 @@ public class VariableLightTest {
     @After
     public void tearDown() {
           jmri.util.JUnitUtil.tearDown();
+
+          // the light has registered a listener to the
+          // previous timebase, but we've stopped that.
+
+          // force a new default Timebase object
+          InstanceManager.reset(jmri.Timebase.class);
     }
 
 

--- a/java/test/jmri/VariableLightTest.java
+++ b/java/test/jmri/VariableLightTest.java
@@ -46,6 +46,7 @@ public class VariableLightTest {
     @Before
     public void setUp() {
         jmri.util.JUnitUtil.setUp();
+
         clock = jmri.InstanceManager.getDefault(jmri.Timebase.class);
         clock.setRun(false);
         clock.setTime(java.time.Instant.EPOCH);  // just a specific time

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorConnectivityTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorConnectivityTest.java
@@ -310,6 +310,7 @@ public class LayoutEditorConnectivityTest {
         cm = null;
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
+        jmri.jmrit.display.EditorFrameOperator.clearEditorFrameOperatorThreads();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackDrawingOptionsDialogTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackDrawingOptionsDialogTest.java
@@ -45,6 +45,7 @@ public class LayoutTrackDrawingOptionsDialogTest {
         }
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.deregisterEditorManagerShutdownTask();
+        jmri.jmrit.display.EditorFrameOperator.clearEditorFrameOperatorThreads();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logix/LearnControlPanelTest.java
+++ b/java/test/jmri/jmrit/logix/LearnControlPanelTest.java
@@ -37,6 +37,7 @@ public class LearnControlPanelTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logix/LearnFunctionPanelTest.java
+++ b/java/test/jmri/jmrit/logix/LearnFunctionPanelTest.java
@@ -38,6 +38,7 @@ public class LearnFunctionPanelTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/logix/LearnThrottleFrameTest.java
+++ b/java/test/jmri/jmrit/logix/LearnThrottleFrameTest.java
@@ -35,6 +35,7 @@ public class LearnThrottleFrameTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logix/WarrantTableFrameTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantTableFrameTest.java
@@ -33,6 +33,7 @@ public class WarrantTableFrameTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logix/WarrantTableModelTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantTableModelTest.java
@@ -34,6 +34,7 @@ public class WarrantTableModelTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
@@ -9,6 +9,7 @@ import jmri.jmrit.logixng.expressions.ExpressionSensor;
 import jmri.jmrit.logixng.expressions.True;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
 import jmri.util.JUnitUtil;
+import jmri.util.JUnitAppender;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -17,31 +18,31 @@ import org.junit.Test;
 
 /**
  * Test ActionSimpleScript
- * 
+ *
  * @author Daniel Bergqvist 2021
  */
 public class ActionScriptTest extends AbstractDigitalActionTestBase {
 
     private final String _scriptText = "lights.provideLight(\"IL1\").commandedState = ON";
-    
-    
+
+
     private LogixNG logixNG;
     private ConditionalNG conditionalNG;
     private IfThenElse ifThenElse;
     private ActionScript actionScript;
     private Sensor sensor;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         AnalogActionBean childAction = new AnalogActionMemory("IQAA999", null);
@@ -49,13 +50,13 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
                 InstanceManager.getDefault(AnalogActionManager.class).registerAction(childAction);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
                 "Execute simple script: Jython command. Script lights.provideLight(\"IL1\").commandedState = ON ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -70,33 +71,33 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ActionScript(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         ActionScript action2;
-        
+
         action2 = new ActionScript("IQDA321", null);
         action2.setScript(_scriptText);
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Execute simple script: Jython command. Script lights.provideLight(\"IL1\").commandedState = ON", action2.getLongDescription());
-        
+
         action2 = new ActionScript("IQDA321", "My action");
         action2.setScript(_scriptText);
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My action", action2.getUserName());
         Assert.assertEquals("String matches", "Execute simple script: Jython command. Script lights.provideLight(\"IL1\").commandedState = ON", action2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -105,7 +106,7 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -115,16 +116,16 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testGetChild() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Test without script
         actionScript.setScript(null);
         Assert.assertTrue("getChildCount() returns 0", 0 == actionScript.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             actionScript.getChild(0);
@@ -133,24 +134,24 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
             Assert.assertEquals("Error message is correct", "Not supported.", ex.getMessage());
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
-        
+
         // Test with script
         actionScript.setScript(_scriptText);
         Assert.assertTrue("getChildCount() returns 0", 0 == actionScript.getChildCount());
     }
-    
+
     @Test
     public void testDescription() {
         Assert.assertEquals("Script", actionScript.getShortDescription());
         Assert.assertEquals("Execute simple script: Jython command. Script lights.provideLight(\"IL1\").commandedState = ON", actionScript.getLongDescription());
     }
-    
+
     @Test
     public void testAction_JythonCommand() throws Exception {
         // Test action
         Light light = InstanceManager.getDefault(LightManager.class).provide("IL1");
         light.setCommandedState(Light.OFF);
-        
+
         // The action is not yet executed so the light should be off
         Assert.assertTrue("light is off", light.getState() == Light.OFF);
         // Enable the conditionalNG and all its children.
@@ -159,15 +160,15 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         sensor.setState(Sensor.ACTIVE);
         // The action should now be executed so the light should be on
         Assert.assertTrue("light is on", light.getState() == Light.ON);
-        
-        
+
+
         // Test action when triggered because the script is listening on the sensor IS2
         Sensor sensor2 = InstanceManager.getDefault(SensorManager.class).provide("IS2");
         sensor2.setCommandedState(Sensor.INACTIVE);
         light.setCommandedState(Light.OFF);
-        
+
         logixNG.unregisterListeners();
-        
+
         // Disconnect the expressionSensor and replace it with a True expression
         // since we always want the result "true" for this test.
         ifThenElse.getChild(0).disconnect();
@@ -175,9 +176,9 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         MaleSocket maleSocketTrue =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionTrue);
         ifThenElse.getChild(0).connect(maleSocketTrue);
-        
+
 //        actionScript.setScript(_scriptText);
-        
+
         // The action is not yet executed so the atomic boolean should be false
         Assert.assertEquals("light is off",Light.OFF,light.getState());
         // Activate the sensor. This should not execute the conditional.
@@ -195,7 +196,7 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         sensor2.setCommandedState(Sensor.ACTIVE);
         // The action should now be executed so the atomic boolean should be true
         Assert.assertEquals("light is on",Light.ON,light.getState());
-        
+
         // Unregister listeners
         actionScript.unregisterListeners();
         light.setState(Light.OFF);
@@ -205,23 +206,23 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         sensor2.setCommandedState(Sensor.ACTIVE);
         // Listerners are not registered so the atomic boolean should be false
         Assert.assertEquals("light is off",Light.OFF,light.getState());
-        
+
         // Test execute() without script. This shouldn't do anything but we
         // do it for coverage.
         actionScript.setScript("");
         actionScript.execute();
     }
-    
+
     @Test
     public void testAction_RunScript() throws Exception {
-        
+
         actionScript.setOperationType(ActionScript.OperationType.RunScript);
         actionScript.setScript("java/test/jmri/jmrit/logixng/actions/ActionScriptTest.py");
-        
+
         // Test action
         Light light = InstanceManager.getDefault(LightManager.class).provide("IL9");
         light.setCommandedState(Light.OFF);
-        
+
         // The action is not yet executed so the light should be off
         Assert.assertTrue("light is off", light.getState() == Light.OFF);
         // Enable the conditionalNG and all its children.
@@ -230,15 +231,15 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         sensor.setState(Sensor.ACTIVE);
         // The action should now be executed so the light should be on
         Assert.assertTrue("light is on", light.getState() == Light.ON);
-        
-        
+
+
         // Test action when triggered because the script is listening on the sensor IS2
         Sensor sensor2 = InstanceManager.getDefault(SensorManager.class).provide("IS2");
         sensor2.setCommandedState(Sensor.INACTIVE);
         light.setCommandedState(Light.OFF);
-        
+
         logixNG.unregisterListeners();
-        
+
         // Disconnect the expressionSensor and replace it with a True expression
         // since we always want the result "true" for this test.
         ifThenElse.getChild(0).disconnect();
@@ -246,7 +247,7 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         MaleSocket maleSocketTrue =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionTrue);
         ifThenElse.getChild(0).connect(maleSocketTrue);
-        
+
         // The action is not yet executed so the atomic boolean should be false
         Assert.assertEquals("light is off",Light.OFF,light.getState());
         // Activate the sensor. This should not execute the conditional.
@@ -264,7 +265,7 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         sensor2.setCommandedState(Sensor.ACTIVE);
         // The action should now be executed so the atomic boolean should be true
         Assert.assertEquals("light is on",Light.ON,light.getState());
-        
+
         // Unregister listeners
         actionScript.unregisterListeners();
         light.setState(Light.OFF);
@@ -274,28 +275,29 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         sensor2.setCommandedState(Sensor.ACTIVE);
         // Listerners are not registered so the atomic boolean should be false
         Assert.assertEquals("light is off",Light.OFF,light.getState());
-        
+
         // Test execute() without script. This shouldn't do anything but we
         // do it for coverage.
         actionScript.setScript("");
         actionScript.execute();
+        JUnitAppender.assertWarnMessage("cannot execute script \"\"");
     }
-    
+
     @Test
     public void testSetScript() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Test setScript() when listeners are registered
         Assert.assertNotNull("Script is not null", _scriptText);
         actionScript.setScript(_scriptText);
         Assert.assertNotNull("Script is not null", actionScript.getScript());
-        
+
         // Test bad script
         actionScript.setScript("This is a bad script");
         Assert.assertEquals("This is a bad script", actionScript.getScript());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -306,39 +308,39 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A logixNG");
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         logixNG.addConditionalNG(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         ifThenElse = new IfThenElse("IQDA321", null);
         ifThenElse.setType(IfThenElse.Type.AlwaysExecute);
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         sensor = InstanceManager.getDefault(SensorManager.class).provide("IS1");
-        
+
         ExpressionSensor expressionSensor = new ExpressionSensor("IQDE321", null);
         expressionSensor.setSensor(sensor);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionSensor);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         actionScript = new ActionScript(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
         actionScript.setScript(_scriptText);
         MaleSocket socketActionSimpleScript = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionScript);
         ifThenElse.getChild(1).connect(socketActionSimpleScript);
-        
+
         _base = actionScript;
         _baseMaleSocket = socketActionSimpleScript;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
         logixNG.setEnabled(true);
     }
@@ -349,5 +351,5 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/AnalogActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/AnalogActionManagerTest.java
@@ -17,32 +17,33 @@ import org.junit.Test;
 
 /**
  * Test AnalogActionManager
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class AnalogActionManagerTest extends AbstractManagerTestBase {
 
     private AnalogActionManager _m;
-    
+
     @Test
     public void testRegisterAction() {
         MyAction myAction = new MyAction(_m.getSystemNamePrefix()+"BadSystemName");
-        
+
         boolean hasThrown = false;
         try {
             _m.registerAction(myAction);
         } catch (IllegalArgumentException e) {
             hasThrown = true;
             Assert.assertEquals("Error message is correct", "System name is invalid: IQBadSystemName", e.getMessage());
+            JUnitAppender.assertWarnMessage("SystemName IQBadSystemName is not in the correct format");
         }
         Assert.assertTrue("Exception thrown", hasThrown);
-        
-        
+
+
         // We need a male socket to test with, so we register the action and then unregister the socket
         AnalogActionBean action = new AnalogActionMemory("IQAA321", null);
         MaleAnalogActionSocket maleSocket = _m.registerAction(action);
         _m.deregister(maleSocket);
-        
+
         hasThrown = false;
         try {
             _m.registerAction(maleSocket);
@@ -52,20 +53,20 @@ public class AnalogActionManagerTest extends AbstractManagerTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testGetBeanTypeHandled() {
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Analog action", _m.getBeanTypeHandled());
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Analog action", _m.getBeanTypeHandled(false));
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Analog actions", _m.getBeanTypeHandled(true));
     }
-    
+
     @Test
     public void testInstance() {
         Assert.assertNotNull("instance() is not null", DefaultAnalogActionManager.instance());
         JUnitAppender.assertWarnMessage("instance() called on wrong thread");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -76,7 +77,7 @@ public class AnalogActionManagerTest extends AbstractManagerTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _m = InstanceManager.getDefault(AnalogActionManager.class);
         _manager = _m;
     }
@@ -88,8 +89,8 @@ public class AnalogActionManagerTest extends AbstractManagerTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     private static class MyAction extends AbstractBase implements AnalogActionBean {
 
         public MyAction(String sys) throws BadSystemNameException {
@@ -180,7 +181,7 @@ public class AnalogActionManagerTest extends AbstractManagerTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/AnalogExpressionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/AnalogExpressionManagerTest.java
@@ -17,32 +17,33 @@ import org.junit.Test;
 
 /**
  * Test AnalogExpressionManager
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class AnalogExpressionManagerTest extends AbstractManagerTestBase {
 
     private AnalogExpressionManager _m;
-    
+
     @Test
     public void testRegisterExpression() {
         MyExpression myExpression = new MyExpression(_m.getSystemNamePrefix()+"BadSystemName");
-        
+
         boolean hasThrown = false;
         try {
             _m.registerExpression(myExpression);
         } catch (IllegalArgumentException e) {
             hasThrown = true;
             Assert.assertEquals("Error message is correct", "System name is invalid: IQBadSystemName", e.getMessage());
+            JUnitAppender.assertWarnMessage("SystemName IQBadSystemName is not in the correct format");
         }
         Assert.assertTrue("Exception thrown", hasThrown);
-        
-        
+
+
         // We need a male socket to test with, so we register the action and then unregister the socket
         AnalogExpressionBean action = new AnalogExpressionMemory("IQAE321", null);
         MaleAnalogExpressionSocket maleSocket = _m.registerExpression(action);
         _m.deregister(maleSocket);
-        
+
         hasThrown = false;
         try {
             _m.registerExpression(maleSocket);
@@ -52,30 +53,30 @@ public class AnalogExpressionManagerTest extends AbstractManagerTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testCreateFemaleSocket() {
         FemaleSocket socket;
         AnalogExpressionManagerTest.MyExpression myExpression = new AnalogExpressionManagerTest.MyExpression("IQSA1");
         FemaleSocketListener listener = new AnalogExpressionManagerTest.MyFemaleSocketListener();
-        
+
         socket = _m.createFemaleSocket(myExpression, listener, "E1");
         Assert.assertEquals("Class is correct", "jmri.jmrit.logixng.implementation.DefaultFemaleAnalogExpressionSocket", socket.getClass().getName());
     }
-    
+
     @Test
     public void testGetBeanTypeHandled() {
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Analog expression", _m.getBeanTypeHandled());
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Analog expression", _m.getBeanTypeHandled(false));
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Analog expressions", _m.getBeanTypeHandled(true));
     }
-    
+
     @Test
     public void testInstance() {
         Assert.assertNotNull("instance() is not null", DefaultAnalogExpressionManager.instance());
         JUnitAppender.assertWarnMessage("instance() called on wrong thread");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -86,7 +87,7 @@ public class AnalogExpressionManagerTest extends AbstractManagerTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _m = InstanceManager.getDefault(AnalogExpressionManager.class);
         _manager = _m;
     }
@@ -98,8 +99,8 @@ public class AnalogExpressionManagerTest extends AbstractManagerTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     private static class MyExpression extends AbstractBase implements AnalogExpressionBean {
 
         public MyExpression(String sys) throws BadSystemNameException {
@@ -200,10 +201,10 @@ public class AnalogExpressionManagerTest extends AbstractManagerTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
-    
+
+
     private static class MyFemaleSocketListener implements FemaleSocketListener {
         @Override
         public void connected(FemaleSocket socket) {
@@ -215,5 +216,5 @@ public class AnalogExpressionManagerTest extends AbstractManagerTestBase {
             // Do nothing
         }
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DigitalActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DigitalActionManagerTest.java
@@ -17,32 +17,33 @@ import org.junit.Test;
 
 /**
  * Test DigitalActionManager
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class DigitalActionManagerTest extends AbstractManagerTestBase {
 
     private DigitalActionManager _m;
-    
+
     @Test
     public void testRegisterAction() {
         MyAction myAction = new MyAction(_m.getSystemNamePrefix()+"BadSystemName");
-        
+
         boolean hasThrown = false;
         try {
             _m.registerAction(myAction);
         } catch (IllegalArgumentException e) {
             hasThrown = true;
             Assert.assertEquals("Error message is correct", "System name is invalid: IQBadSystemName", e.getMessage());
+            JUnitAppender.assertWarnMessage("SystemName IQBadSystemName is not in the correct format");
         }
         Assert.assertTrue("Exception thrown", hasThrown);
-        
-        
+
+
         // We need a male socket to test with, so we register the action and then unregister the socket
         DigitalActionBean action = new ActionMemory("IQDA321", null);
         MaleDigitalActionSocket maleSocket = _m.registerAction(action);
         _m.deregister(maleSocket);
-        
+
         hasThrown = false;
         try {
             _m.registerAction(maleSocket);
@@ -52,20 +53,20 @@ public class DigitalActionManagerTest extends AbstractManagerTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testGetBeanTypeHandled() {
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Digital action", _m.getBeanTypeHandled());
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Digital action", _m.getBeanTypeHandled(false));
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Digital actions", _m.getBeanTypeHandled(true));
     }
-    
+
     @Test
     public void testInstance() {
         Assert.assertNotNull("instance() is not null", DefaultDigitalActionManager.instance());
         JUnitAppender.assertWarnMessage("instance() called on wrong thread");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -76,7 +77,7 @@ public class DigitalActionManagerTest extends AbstractManagerTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _m = InstanceManager.getDefault(DigitalActionManager.class);
         _manager = _m;
     }
@@ -88,8 +89,8 @@ public class DigitalActionManagerTest extends AbstractManagerTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     private static class MyAction extends AbstractBase implements DigitalActionBean {
 
         public MyAction(String sys) throws BadSystemNameException {
@@ -180,7 +181,7 @@ public class DigitalActionManagerTest extends AbstractManagerTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DigitalBooleanActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DigitalBooleanActionManagerTest.java
@@ -17,32 +17,33 @@ import org.junit.Test;
 
 /**
  * Test DigitalActionManager
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class DigitalBooleanActionManagerTest extends AbstractManagerTestBase {
 
     private DigitalBooleanActionManager _m;
-    
+
     @Test
     public void testRegisterAction() {
         MyAction myAction = new MyAction(_m.getSystemNamePrefix()+"BadSystemName");
-        
+
         boolean hasThrown = false;
         try {
             _m.registerAction(myAction);
         } catch (IllegalArgumentException e) {
             hasThrown = true;
             Assert.assertEquals("Error message is correct", "System name is invalid: IQBadSystemName", e.getMessage());
+            JUnitAppender.assertWarnMessage("SystemName IQBadSystemName is not in the correct format");
         }
         Assert.assertTrue("Exception thrown", hasThrown);
-        
-        
+
+
         // We need a male socket to test with, so we register the action and then unregister the socket
         DigitalBooleanActionBean action = new DigitalBooleanOnChange("IQDB321", null, DigitalBooleanOnChange.Trigger.CHANGE);
         MaleDigitalBooleanActionSocket maleSocket = _m.registerAction(action);
         _m.deregister(maleSocket);
-        
+
         hasThrown = false;
         try {
             _m.registerAction(maleSocket);
@@ -52,20 +53,20 @@ public class DigitalBooleanActionManagerTest extends AbstractManagerTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testGetBeanTypeHandled() {
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Digital boolean action", _m.getBeanTypeHandled());
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Digital boolean action", _m.getBeanTypeHandled(false));
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Digital boolean actions", _m.getBeanTypeHandled(true));
     }
-    
+
     @Test
     public void testInstance() {
         Assert.assertNotNull("instance() is not null", DefaultDigitalBooleanActionManager.instance());
         JUnitAppender.assertWarnMessage("instance() called on wrong thread");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -76,7 +77,7 @@ public class DigitalBooleanActionManagerTest extends AbstractManagerTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _m = InstanceManager.getDefault(DigitalBooleanActionManager.class);
         _manager = _m;
     }
@@ -88,8 +89,8 @@ public class DigitalBooleanActionManagerTest extends AbstractManagerTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     private static class MyAction extends AbstractBase implements DigitalBooleanActionBean {
 
         public MyAction(String sys) throws BadSystemNameException {
@@ -180,7 +181,7 @@ public class DigitalBooleanActionManagerTest extends AbstractManagerTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DigitalExpressionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DigitalExpressionManagerTest.java
@@ -17,32 +17,33 @@ import org.junit.Test;
 
 /**
  * Test DigitalExpressionManager
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class DigitalExpressionManagerTest extends AbstractManagerTestBase {
 
     private DigitalExpressionManager _m;
-    
+
     @Test
     public void testRegisterExpression() {
         MyExpression myExpression = new MyExpression(_m.getSystemNamePrefix()+"BadSystemName");
-        
+
         boolean hasThrown = false;
         try {
             _m.registerExpression(myExpression);
         } catch (IllegalArgumentException e) {
             hasThrown = true;
             Assert.assertEquals("Error message is correct", "System name is invalid: IQBadSystemName", e.getMessage());
+            JUnitAppender.assertWarnMessage("SystemName IQBadSystemName is not in the correct format");
         }
         Assert.assertTrue("Exception thrown", hasThrown);
-        
-        
+
+
         // We need a male socket to test with, so we register the action and then unregister the socket
         DigitalExpressionBean action = new ExpressionMemory("IQDE321", null);
         MaleDigitalExpressionSocket maleSocket = _m.registerExpression(action);
         _m.deregister(maleSocket);
-        
+
         hasThrown = false;
         try {
             _m.registerExpression(maleSocket);
@@ -52,30 +53,30 @@ public class DigitalExpressionManagerTest extends AbstractManagerTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testCreateFemaleSocket() {
         FemaleSocket socket;
         MyExpression myExpression = new MyExpression("IQSA1");
         FemaleSocketListener listener = new MyFemaleSocketListener();
-        
+
         socket = _m.createFemaleSocket(myExpression, listener, "E1");
         Assert.assertEquals("Class is correct", "jmri.jmrit.logixng.implementation.DefaultFemaleDigitalExpressionSocket", socket.getClass().getName());
     }
-    
+
     @Test
     public void testGetBeanTypeHandled() {
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Digital expression", _m.getBeanTypeHandled());
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Digital expression", _m.getBeanTypeHandled(false));
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "Digital expressions", _m.getBeanTypeHandled(true));
     }
-    
+
     @Test
     public void testInstance() {
         Assert.assertNotNull("instance() is not null", DefaultDigitalExpressionManager.instance());
         JUnitAppender.assertWarnMessage("instance() called on wrong thread");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -86,7 +87,7 @@ public class DigitalExpressionManagerTest extends AbstractManagerTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _m = InstanceManager.getDefault(DigitalExpressionManager.class);
         _manager = _m;
     }
@@ -98,8 +99,8 @@ public class DigitalExpressionManagerTest extends AbstractManagerTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     private static class MyExpression extends AbstractBase implements DigitalExpressionBean {
 
         public MyExpression(String sys) throws BadSystemNameException {
@@ -196,10 +197,10 @@ public class DigitalExpressionManagerTest extends AbstractManagerTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
-    
+
+
     private static class MyFemaleSocketListener implements FemaleSocketListener {
         @Override
         public void connected(FemaleSocket socket) {
@@ -211,5 +212,5 @@ public class DigitalExpressionManagerTest extends AbstractManagerTestBase {
             // Do nothing
         }
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/StringActionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/StringActionManagerTest.java
@@ -17,32 +17,33 @@ import org.junit.Test;
 
 /**
  * Test StringActionManager
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class StringActionManagerTest extends AbstractManagerTestBase {
 
     private StringActionManager _m;
-    
+
     @Test
     public void testRegisterAction() {
         MyAction myAction = new MyAction(_m.getSystemNamePrefix()+"BadSystemName");
-        
+
         boolean hasThrown = false;
         try {
             _m.registerAction(myAction);
         } catch (IllegalArgumentException e) {
             hasThrown = true;
             Assert.assertEquals("Error message is correct", "System name is invalid: IQBadSystemName", e.getMessage());
+            JUnitAppender.assertWarnMessage("SystemName IQBadSystemName is not in the correct format");
         }
         Assert.assertTrue("Exception thrown", hasThrown);
-        
-        
+
+
         // We need a male socket to test with, so we register the action and then unregister the socket
         StringActionBean action = new StringActionMemory("IQSA321", null);
         MaleStringActionSocket maleSocket = _m.registerAction(action);
         _m.deregister(maleSocket);
-        
+
         hasThrown = false;
         try {
             _m.registerAction(maleSocket);
@@ -52,20 +53,20 @@ public class StringActionManagerTest extends AbstractManagerTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testGetBeanTypeHandled() {
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "String action", _m.getBeanTypeHandled());
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "String action", _m.getBeanTypeHandled(false));
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "String actions", _m.getBeanTypeHandled(true));
     }
-    
+
     @Test
     public void testInstance() {
         Assert.assertNotNull("instance() is not null", DefaultStringActionManager.instance());
         JUnitAppender.assertWarnMessage("instance() called on wrong thread");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -76,7 +77,7 @@ public class StringActionManagerTest extends AbstractManagerTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _m = InstanceManager.getDefault(StringActionManager.class);
         _manager = _m;
     }
@@ -88,8 +89,8 @@ public class StringActionManagerTest extends AbstractManagerTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     private static class MyAction extends AbstractBase implements StringActionBean {
 
         public MyAction(String sys) throws BadSystemNameException {
@@ -180,7 +181,7 @@ public class StringActionManagerTest extends AbstractManagerTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/StringExpressionManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/StringExpressionManagerTest.java
@@ -17,32 +17,33 @@ import org.junit.Test;
 
 /**
  * Test StringExpressionManager
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class StringExpressionManagerTest extends AbstractManagerTestBase {
 
     private StringExpressionManager _m;
-    
+
     @Test
     public void testRegisterExpression() {
         MyExpression myExpression = new MyExpression(_m.getSystemNamePrefix()+"BadSystemName");
-        
+
         boolean hasThrown = false;
         try {
             _m.registerExpression(myExpression);
         } catch (IllegalArgumentException e) {
             hasThrown = true;
             Assert.assertEquals("Error message is correct", "System name is invalid: IQBadSystemName", e.getMessage());
+            JUnitAppender.assertWarnMessage("SystemName IQBadSystemName is not in the correct format");
         }
         Assert.assertTrue("Exception thrown", hasThrown);
-        
-        
+
+
         // We need a male socket to test with, so we register the action and then unregister the socket
         StringExpressionBean action = new StringExpressionMemory("IQSE321", null);
         MaleStringExpressionSocket maleSocket = _m.registerExpression(action);
         _m.deregister(maleSocket);
-        
+
         hasThrown = false;
         try {
             _m.registerExpression(maleSocket);
@@ -52,30 +53,30 @@ public class StringExpressionManagerTest extends AbstractManagerTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testCreateFemaleSocket() {
         FemaleSocket socket;
         MyExpression myExpression = new MyExpression("IQSA1");
         FemaleSocketListener listener = new MyFemaleSocketListener();
-        
+
         socket = _m.createFemaleSocket(myExpression, listener, "E1");
         Assert.assertEquals("Class is correct", "jmri.jmrit.logixng.implementation.DefaultFemaleStringExpressionSocket", socket.getClass().getName());
     }
-    
+
     @Test
     public void testGetBeanTypeHandled() {
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "String expression", _m.getBeanTypeHandled());
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "String expression", _m.getBeanTypeHandled(false));
         Assert.assertEquals("getBeanTypeHandled() returns correct value", "String expressions", _m.getBeanTypeHandled(true));
     }
-    
+
     @Test
     public void testInstance() {
         Assert.assertNotNull("instance() is not null", DefaultStringExpressionManager.instance());
         JUnitAppender.assertWarnMessage("instance() called on wrong thread");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -86,7 +87,7 @@ public class StringExpressionManagerTest extends AbstractManagerTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _m = InstanceManager.getDefault(StringExpressionManager.class);
         _manager = _m;
     }
@@ -98,8 +99,8 @@ public class StringExpressionManagerTest extends AbstractManagerTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     private static class MyExpression extends AbstractBase implements StringExpressionBean {
 
         public MyExpression(String sys) throws BadSystemNameException {
@@ -200,10 +201,10 @@ public class StringExpressionManagerTest extends AbstractManagerTestBase {
         public Base deepCopyChildren(Base base, Map<String, String> map, Map<String, String> map1) throws JmriException {
             throw new UnsupportedOperationException("Not supported");
         }
-        
+
     }
-    
-    
+
+
     private static class MyFemaleSocketListener implements FemaleSocketListener {
         @Override
         public void connected(FemaleSocket socket) {
@@ -215,5 +216,5 @@ public class StringExpressionManagerTest extends AbstractManagerTestBase {
             // Do nothing
         }
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogExpressionManagerXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogExpressionManagerXmlTest.java
@@ -32,7 +32,7 @@ public class DefaultAnalogExpressionManagerXmlTest {
     @Test
     public void testLoad() {
         DefaultAnalogExpressionManagerXml b = new DefaultAnalogExpressionManagerXml();
-        
+
         Element e = new Element("logixngAnalogExpressions");
         Element e2 = new Element("missing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
@@ -40,7 +40,7 @@ public class DefaultAnalogExpressionManagerXmlTest {
         e.addContent(e2);
         b.loadExpressions(e);
         JUnitAppender.assertErrorMessage("cannot load class jmri.jmrit.logixng.this.class.does.not.exist.TestClassXml");
-/*        
+/*
         // Test loading the same class twice, in order to check field "xmlClasses"
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -49,7 +49,7 @@ public class DefaultAnalogExpressionManagerXmlTest {
         e2.addContent(new Element("systemName").addContent("IQAE1"));
         e2.addContent(new Element("maleSocket"));
         b.loadExpressions(e);
-        
+
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
         e2.setAttribute("class", "jmri.jmrit.logixng.expressions.configurexml.AnalogExpressionMemoryXml");
@@ -57,7 +57,7 @@ public class DefaultAnalogExpressionManagerXmlTest {
         e2.addContent(new Element("systemName").addContent("IQAE2"));
         e2.addContent(new Element("maleSocket"));
         b.loadExpressions(e);
-        
+
         // Test trying to load a class with private constructor
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -66,7 +66,7 @@ public class DefaultAnalogExpressionManagerXmlTest {
         e.addContent(e2);
         b.loadExpressions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-        
+
         // Test trying to load a class which throws an exception
         e = new Element("logixngAnalogExpressions");
         e2 = new Element("existing_class");
@@ -75,7 +75,7 @@ public class DefaultAnalogExpressionManagerXmlTest {
         e.addContent(e2);
         b.loadExpressions(e);
         JUnitAppender.assertErrorMessage("cannot create constructor");
-*/        
+*/
 //        System.out.format("Class name: %s%n", PrivateConstructorXml.class.getName());
     }
 
@@ -83,10 +83,10 @@ public class DefaultAnalogExpressionManagerXmlTest {
     @Test
     public void testStore() {
         DefaultAnalogExpressionManagerXml b = new DefaultAnalogExpressionManagerXml();
-        
+
         // If parameter is null, nothing should happen
         b.store(null);
-        
+
         // Test store a named bean that has no configurexml class
         AnalogExpressionManager manager = InstanceManager.getDefault(AnalogExpressionManager.class);
         manager.registerExpression(new DefaultAnalogExpressionManagerXmlTest.MyAnalogExpression());
@@ -94,10 +94,10 @@ public class DefaultAnalogExpressionManagerXmlTest {
         JUnitAppender.assertErrorMessage("Cannot load configuration adapter for jmri.jmrit.logixng.implementation.configurexml.DefaultAnalogExpressionManagerXmlTest$MyAnalogExpression");
         JUnitAppender.assertErrorMessage("Cannot store configuration for jmri.jmrit.logixng.implementation.configurexml.DefaultAnalogExpressionManagerXmlTest$MyAnalogExpression");
     }
-    
+
     @Test
     public void testReplaceActionManagerWithoutConfigManager() {
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.AnalogExpressionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -115,26 +115,26 @@ public class DefaultAnalogExpressionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_ANALOG_EXPRESSIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(AnalogExpressionManager.class)
                         instanceof DefaultAnalogExpressionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultAnalogExpressionManagerXml b = new DefaultAnalogExpressionManagerXml();
         b.replaceExpressionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(AnalogExpressionManager.class)
                         instanceof DefaultAnalogExpressionManagerXmlTest.MyManager);
     }
-    
+
 //    @Ignore("When debug is enabled, jmri.configurexml.ConfigXmlManager.registerConfig checks if the manager has a XML class, which our fake manager doesn't have")
     @Test
     public void testReplaceActionManagerWithConfigManager() {
-        
+
         JUnitUtil.initConfigureManager();
-        
+
         // if old manager exists, remove it from configuration process
         if (InstanceManager.getNullableDefault(jmri.jmrit.logixng.AnalogExpressionManager.class) != null) {
             ConfigureManager cmOD = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -152,20 +152,20 @@ public class DefaultAnalogExpressionManagerXmlTest {
         if (cmOD != null) {
             cmOD.registerConfig(pManager, jmri.Manager.LOGIXNG_ANALOG_EXPRESSIONS);
         }
-        
+
         Assert.assertTrue("manager is a MyManager",
                 InstanceManager.getDefault(AnalogExpressionManager.class)
                         instanceof DefaultAnalogExpressionManagerXmlTest.MyManager);
-        
+
         // Test replacing the manager
         DefaultAnalogExpressionManagerXml b = new DefaultAnalogExpressionManagerXml();
         b.replaceExpressionManager();
-        
+
         Assert.assertFalse("manager is not a MyManager",
                 InstanceManager.getDefault(AnalogExpressionManager.class)
                         instanceof DefaultAnalogExpressionManagerXmlTest.MyManager);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -181,25 +181,25 @@ public class DefaultAnalogExpressionManagerXmlTest {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
-    
-    
+
+
+
     private class MyAnalogExpression extends AnalogExpressionMemory {
-        
+
         MyAnalogExpression() {
             super("IQAE9999", null);
         }
-        
+
     }
-    
-    
+
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class PrivateConstructorXml extends AnalogExpressionMemoryXml {
         private PrivateConstructorXml() {
         }
     }
-    
+
     // This class is loaded by reflection. The class cannot be private since
     // Spotbugs will in that case flag it as "is never used locally"
     class ThrowExceptionXml extends AnalogExpressionMemoryXml {
@@ -208,9 +208,9 @@ public class DefaultAnalogExpressionManagerXmlTest {
             throw new JmriConfigureXmlException();
         }
     }
-    
-    
+
+
     class MyManager extends DefaultAnalogExpressionManager {
     }
-    
+
 }

--- a/java/test/jmri/jmrit/roster/swing/rostergroup/RosterGroupTableFrameTest.java
+++ b/java/test/jmri/jmrit/roster/swing/rostergroup/RosterGroupTableFrameTest.java
@@ -26,6 +26,7 @@ public class RosterGroupTableFrameTest extends jmri.util.JmriJFrameTestBase {
     @AfterEach
     @Override
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/simplelightctrl/SimpleLightCtrlFrameTest.java
+++ b/java/test/jmri/jmrit/simplelightctrl/SimpleLightCtrlFrameTest.java
@@ -1,7 +1,7 @@
 package jmri.jmrit.simplelightctrl;
 
 import java.awt.GraphicsEnvironment;
-
+import jmri.Timebase;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -17,6 +17,11 @@ public class SimpleLightCtrlFrameTest extends jmri.util.JmriJFrameTestBase {
     @Override
     public void setUp() {
         JUnitUtil.setUp();
+
+        Timebase clock = jmri.InstanceManager.getDefault(jmri.Timebase.class);
+        clock.setRun(false);
+        clock.setTime(java.time.Instant.EPOCH);  // just a specific time
+
         JUnitUtil.resetProfileManager();
         if (!GraphicsEnvironment.isHeadless()) {
             frame = new SimpleLightCtrlFrame();
@@ -26,6 +31,9 @@ public class SimpleLightCtrlFrameTest extends jmri.util.JmriJFrameTestBase {
     @AfterEach
     @Override
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
+        // force a new default Timebase object
+        jmri.InstanceManager.reset(jmri.Timebase.class);
         super.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/symbolicprog/PrintActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/PrintActionTest.java
@@ -45,6 +45,7 @@ public class PrintActionTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneOpsProgFrameTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneOpsProgFrameTest.java
@@ -43,6 +43,7 @@ public class PaneOpsProgFrameTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPaneTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPaneTest.java
@@ -432,6 +432,7 @@ public class PaneProgPaneTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneServiceProgFrameTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneServiceProgFrameTest.java
@@ -43,6 +43,7 @@ public class PaneServiceProgFrameTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneSetTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneSetTest.java
@@ -48,6 +48,7 @@ public class PaneSetTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/QualifiedVarTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/QualifiedVarTest.java
@@ -194,6 +194,7 @@ public class QualifiedVarTest {
 
     @AfterEach
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/throttle/ThrottleFramePropertyEditorTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottleFramePropertyEditorTest.java
@@ -37,6 +37,7 @@ public class ThrottleFramePropertyEditorTest {
     @AfterEach
     public void tearDown() {
         JUnitUtil.resetWindows(false,false);
+        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/throttle/ThrottleWindowTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottleWindowTest.java
@@ -28,6 +28,7 @@ public class ThrottleWindowTest extends jmri.util.JmriJFrameTestBase {
     @AfterEach
     @Override
     public void tearDown() {
+        JUnitUtil.clearShutDownManager();
         super.tearDown();
     }
 }


### PR DESCRIPTION
 - Stop the clock during some tests to prevent alarms from changing results
 - handle (instead of displaying) some messages emitted in normal operation
 - kill some Editor threads
 - clear some shut down items left behind at end.

Only test code changes.