### PR TITLE
Load and set system properties at startup

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -575,8 +575,9 @@
             <li>Users that have HighDPI scaling set to something
                 different than 100% can now select whenether or not
                 to force Java to use 100% scaling. It's set in the
-                file <code>settings:JMRI_InitPreferences.ini</code>
-                with the setting <code>sun.java2d.uiScale</code>.
+                file <code>JMRI_InitPreferences.properties</code>
+                in the JMRI system preferences directory with the
+                setting <code>sun.java2d.uiScale</code>.
                 If this value is <code>1</code>, Java forces the
                 scaling of JMRI to 100%. If this value is
                 <code>0</code>, Java uses the same scaling as the

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -572,5 +572,14 @@
         <ul>
             <li>Basic support for TypeScript has been added to the
                 webserver file system.</li>
+            <li>Users that have HighDPI scaling set to something
+                different than 100% can now select whenether or not
+                to force Java to use 100% scaling. It's set in the
+                file <code>settings:JMRI_InitPreferences.ini</code>
+                with the setting <code>sun.java2d.uiScale</code>.
+                If this value is <code>1</code>, Java forces the
+                scaling of JMRI to 100%. If this value is
+                <code>0</code>, Java uses the same scaling as the
+                system.</li>
         </ul>
 

--- a/java/src/apps/DecoderPro/DecoderPro.java
+++ b/java/src/apps/DecoderPro/DecoderPro.java
@@ -141,7 +141,7 @@ public class DecoderPro extends Apps {
     public static void main(String args[]) {
 
         // Set up system properties that needs to be loaded early
-        new jmri.util.EarlyInitializationPreferences().loadAndSetPreferences();
+        jmri.util.EarlyInitializationPreferences.getInstance().loadAndSetPreferences();
 
         // show splash screen early
         splash(true);

--- a/java/src/apps/DecoderPro/DecoderPro.java
+++ b/java/src/apps/DecoderPro/DecoderPro.java
@@ -140,6 +140,9 @@ public class DecoderPro extends Apps {
     // Main entry point
     public static void main(String args[]) {
 
+        // Set up system properties that needs to be loaded early
+        new jmri.util.EarlyInitializationPreferences().loadAndSetPreferences();
+
         // show splash screen early
         splash(true);
 

--- a/java/src/apps/DispatcherPro/DispatcherPro.java
+++ b/java/src/apps/DispatcherPro/DispatcherPro.java
@@ -111,6 +111,9 @@ public class DispatcherPro extends Apps {
     // Main entry point
     public static void main(String args[]) {
 
+        // Set up system properties that needs to be loaded early
+        new jmri.util.EarlyInitializationPreferences().loadAndSetPreferences();
+
         // show splash screen early
         splash(true);
 

--- a/java/src/apps/DispatcherPro/DispatcherPro.java
+++ b/java/src/apps/DispatcherPro/DispatcherPro.java
@@ -112,7 +112,7 @@ public class DispatcherPro extends Apps {
     public static void main(String args[]) {
 
         // Set up system properties that needs to be loaded early
-        new jmri.util.EarlyInitializationPreferences().loadAndSetPreferences();
+        jmri.util.EarlyInitializationPreferences.getInstance().loadAndSetPreferences();
 
         // show splash screen early
         splash(true);

--- a/java/src/apps/InstallTest/InstallTest.java
+++ b/java/src/apps/InstallTest/InstallTest.java
@@ -107,7 +107,7 @@ public class InstallTest extends Apps {
     public static void main(String args[]) {
 
         // Set up system properties that needs to be loaded early
-        new jmri.util.EarlyInitializationPreferences().loadAndSetPreferences();
+        jmri.util.EarlyInitializationPreferences.getInstance().loadAndSetPreferences();
 
         // show splash screen early
         splash(true);

--- a/java/src/apps/InstallTest/InstallTest.java
+++ b/java/src/apps/InstallTest/InstallTest.java
@@ -106,6 +106,9 @@ public class InstallTest extends Apps {
     // Main entry point
     public static void main(String args[]) {
 
+        // Set up system properties that needs to be loaded early
+        new jmri.util.EarlyInitializationPreferences().loadAndSetPreferences();
+
         // show splash screen early
         splash(true);
 

--- a/java/src/apps/PanelPro/PanelPro.java
+++ b/java/src/apps/PanelPro/PanelPro.java
@@ -112,7 +112,7 @@ public class PanelPro extends Apps {
     public static void main(String args[]) {
 
         // Set up system properties that needs to be loaded early
-        new jmri.util.EarlyInitializationPreferences().loadAndSetPreferences();
+        jmri.util.EarlyInitializationPreferences.getInstance().loadAndSetPreferences();
 
         // show splash screen early
         splash(true);

--- a/java/src/apps/PanelPro/PanelPro.java
+++ b/java/src/apps/PanelPro/PanelPro.java
@@ -111,6 +111,9 @@ public class PanelPro extends Apps {
     // Main entry point
     public static void main(String args[]) {
 
+        // Set up system properties that needs to be loaded early
+        new jmri.util.EarlyInitializationPreferences().loadAndSetPreferences();
+
         // show splash screen early
         splash(true);
 

--- a/java/src/apps/SoundPro/SoundPro.java
+++ b/java/src/apps/SoundPro/SoundPro.java
@@ -118,6 +118,9 @@ public class SoundPro extends Apps {
     // Main entry point
     public static void main(String args[]) {
 
+        // Set up system properties that needs to be loaded early
+        new jmri.util.EarlyInitializationPreferences().loadAndSetPreferences();
+
         // show splash screen early
         splash(true);
 

--- a/java/src/apps/SoundPro/SoundPro.java
+++ b/java/src/apps/SoundPro/SoundPro.java
@@ -119,7 +119,7 @@ public class SoundPro extends Apps {
     public static void main(String args[]) {
 
         // Set up system properties that needs to be loaded early
-        new jmri.util.EarlyInitializationPreferences().loadAndSetPreferences();
+        jmri.util.EarlyInitializationPreferences.getInstance().loadAndSetPreferences();
 
         // show splash screen early
         splash(true);

--- a/java/src/jmri/jmrit/mailreport/ReportContext.java
+++ b/java/src/jmri/jmrit/mailreport/ReportContext.java
@@ -47,6 +47,9 @@ public class ReportContext {
     public String getReport(boolean reportNetworkInfo) {
 
         addString("JMRI Version: " + jmri.Version.name() + "   ");
+
+        addEarlyInitializationPreferences();
+
         addString("JMRI configuration file name: "
                 + System.getProperty("org.jmri.apps.Apps.configFilename") + "   (from org.jmri.apps.Apps.configFilename system property)");
         if (!jmri.util.JmriJFrame.getFrameList().isEmpty() && jmri.util.JmriJFrame.getFrameList().get(0) != null) {
@@ -166,6 +169,15 @@ public class ReportContext {
 
     void addProperty(String prop) {
         addString(prop + ": " + System.getProperty(prop) + "   ");
+    }
+
+    void addEarlyInitializationPreferences() {
+        jmri.util.EarlyInitializationPreferences eip =
+                jmri.util.EarlyInitializationPreferences.getInstance();
+
+        for (String pref : eip.getStartupPreferences()) {
+            addString(pref + "   ");
+        }
     }
 
     /**

--- a/java/src/jmri/util/EarlyInitializationPreferences.java
+++ b/java/src/jmri/util/EarlyInitializationPreferences.java
@@ -1,0 +1,60 @@
+package jmri.util;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Properties;
+
+/**
+ * Allow the user to configure properties that needs to be setup very early
+ * when JMRI starts, for example before Swing starts up.
+ * 
+ * @author Daniel Bergqvist Copyright (C) 2021
+ */
+public class EarlyInitializationPreferences {
+
+    private static final String FILENAME = jmri.util.FileUtil
+            .getExternalFilename("settings:JMRI_InitPreferences.ini");
+
+    private final Properties preferences = new Properties();
+
+
+    /**
+     * Load the preferences at startup and set them.
+     */
+    public void loadAndSetPreferences() {
+        load();
+        for (String pref : preferences.stringPropertyNames()) {
+            System.setProperty(pref, preferences.getProperty(pref));
+        }
+    }
+
+    private void store() {
+        try (OutputStream output = new FileOutputStream(FILENAME)) {
+
+//            log.warn("Store startup preferences to {}", FILENAME);
+            preferences.store(output, null);
+
+        } catch (IOException ex) {
+//            log.warn("Storing startup preferences to {} failed", FILENAME, ex);
+            ex.printStackTrace();
+        }
+    }
+
+    private void load() {
+        try (InputStream input = new FileInputStream(FILENAME)) {
+
+//            log.warn("Load startup preferences from {}", FILENAME);
+            preferences.load(input);
+
+        } catch (IOException ex) {
+//            log.warn("Loading startup preferences from {} failed", FILENAME);
+            preferences.setProperty("sun.java2d.uiScale", "1");
+            store();
+        }
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(EarlyInitializationPreferences.class);
+}

--- a/java/src/jmri/util/EarlyInitializationPreferences.java
+++ b/java/src/jmri/util/EarlyInitializationPreferences.java
@@ -14,7 +14,7 @@ import java.util.Properties;
 public class EarlyInitializationPreferences {
 
     private static final String FILENAME = jmri.util.FileUtil
-            .getExternalFilename("settings:JMRI_InitPreferences.ini");
+            .getExternalFilename("settings:JMRI_InitPreferences.properties");
     
     private static final EarlyInitializationPreferences instance =
             new EarlyInitializationPreferences();

--- a/java/src/jmri/util/EarlyInitializationPreferences.java
+++ b/java/src/jmri/util/EarlyInitializationPreferences.java
@@ -1,10 +1,8 @@
 package jmri.util;
 
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -17,9 +15,24 @@ public class EarlyInitializationPreferences {
 
     private static final String FILENAME = jmri.util.FileUtil
             .getExternalFilename("settings:JMRI_InitPreferences.ini");
+    
+    private static final EarlyInitializationPreferences instance =
+            new EarlyInitializationPreferences();
 
     private final Properties preferences = new Properties();
+    
+    // The preferences might have been changed after startup, but we want to
+    // keep a list of the preferences used at startup for the JMRI Context.
+    private final List<String> startupPrefs = new ArrayList<>();
 
+
+    private EarlyInitializationPreferences() {
+        // Private constructor to protect singleton pattern.
+    }
+
+    public static EarlyInitializationPreferences getInstance() {
+        return instance;
+    }
 
     /**
      * Load the preferences at startup and set them.
@@ -28,7 +41,16 @@ public class EarlyInitializationPreferences {
         load();
         for (String pref : preferences.stringPropertyNames()) {
             System.setProperty(pref, preferences.getProperty(pref));
+            startupPrefs.add(pref + ": " + preferences.getProperty(pref));
         }
+    }
+
+    /**
+     * Return the preferences set at startup.
+     * @return the preferences
+     */
+    public List<String> getStartupPreferences() {
+        return startupPrefs;
     }
 
     private void store() {

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -6,7 +6,6 @@ import com.tngtech.archunit.lang.*;
 import com.tngtech.archunit.junit.*;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import com.tngtech.archunit.library.freeze.FreezingArchRule;
 
 /**
  * Check the architecture of the JMRI library
@@ -56,6 +55,7 @@ public class ArchitectureTest {
                                 .doNotHaveFullyQualifiedName("jmri.util.GetJavaProperty").and()
                                 .doNotHaveFullyQualifiedName("jmri.Version").and()
                                 .doNotHaveFullyQualifiedName("jmri.util.JTextPaneAppender").and()
+                                .doNotHaveFullyQualifiedName("jmri.util.EarlyInitializationPreferences").and()
                                 // generated code that we don't have enough control over
                                 .resideOutsideOfPackage("jmri.jmris.simpleserver..").and()
                                 .resideOutsideOfPackage("jmri.jmris.srcp..").and()


### PR DESCRIPTION
This PR gives the user the option to enable or disable the property `sun.java2d.uiScale` as well as other system properties during JMRI startup.

The logger is not initialized when this code is executed and I'm not sure what to do about that. Try to initialize the logger earlier or to use standard output here?