### PR TITLE
Annotate some long-standing deprecation warnings

### DIFF
--- a/java/src/jmri/jmrit/ctc/editor/gui/FrmMainForm.java
+++ b/java/src/jmri/jmrit/ctc/editor/gui/FrmMainForm.java
@@ -81,6 +81,7 @@ public class FrmMainForm extends JFrame {
      * @param keycode The integer value for the key from KeyEvent
      * @return The key stroke with the platform's accelerator character
      */
+    @SuppressWarnings("deprecation")  // getMenuShortcutKeyMask()
     private KeyStroke getAccelerator(int keycode) {
         int modifier = Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
         return KeyStroke.getKeyStroke(keycode, modifier);

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -207,6 +207,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
         setMenuAcceleratorKey(mi, KeyEvent.VK_T);
     }
 
+    @SuppressWarnings("deprecation")  // META_MASK CTRL_MASK
     private void setMenuAcceleratorKey (JMenuItem mi,  int key) {
         if (SystemType.isMacOSX()) {
             mi.setAccelerator(KeyStroke.getKeyStroke(key, InputEvent.META_MASK));

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -480,6 +480,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         });
     }
 
+    @SuppressWarnings("deprecation")  // getMenuShortcutKeyMask()
     private void setupMenuBar() {
         // initialize menu bar
         JMenuBar menuBar = new JMenuBar();
@@ -809,6 +810,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
      * @param menuBar to add the option menu to
      * @return option menu that was added
      */
+    @SuppressWarnings("deprecation")  // getMenuShortcutKeyMask()
     private JMenu setupOptionMenu(@Nonnull JMenuBar menuBar) {
         assert menuBar != null;
 
@@ -1832,6 +1834,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     //
     //
     //
+    @SuppressWarnings("deprecation")  // getMenuShortcutKeyMask()
     private void setupZoomMenu(@Nonnull JMenuBar menuBar) {
         zoomMenu.setMnemonic(stringsToVTCodes.get(Bundle.getMessage("MenuZoomMnemonic")));
         menuBar.add(zoomMenu);

--- a/java/src/jmri/jmrit/throttle/ThrottlesPreferencesControlsSettingsPane.java
+++ b/java/src/jmri/jmrit/throttle/ThrottlesPreferencesControlsSettingsPane.java
@@ -13,12 +13,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A preferences panel to display and edit JMRI throttle keyboard shortcuts
- * 
+ *
  * @author Lionel Jeanson - 2021
- * 
+ *
  */
 public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
-    
+
     private ShortCutsField tfNextThrottleWindow;
     private ShortCutsField tfPrevThrottleWindow;
     private ShortCutsField tfNextThrottleFrame;
@@ -29,23 +29,23 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
     private ShortCutsField tfPrevThrottleInternalWindow;
     private ShortCutsField tfGotoControl;
     private ShortCutsField tfGotoFunctions;
-    private ShortCutsField tfGotoAddress;    
+    private ShortCutsField tfGotoAddress;
     private ShortCutsField tfForward;
     private ShortCutsField tfReverse;
     private ShortCutsField tfSwitchDir;
     private ShortCutsField tfSpeedIdle;
     private ShortCutsField tfSpeedStop;
     private ShortCutsField tfSpeedUp;
-    private ShortCutsField tfSpeedDown;        
+    private ShortCutsField tfSpeedDown;
     private ShortCutsField tfSpeedUpMore;
     private ShortCutsField tfSpeedDownMore;
-    
+
     private JTextField tfSpeedMultiplier;
     private float origSpeedMultiplier;
-    
+
     private ShortCutsField[] tfFunctionKeys;
     private ThrottlesPreferencesWindowKeyboardControls _tpwkc;
-        
+
     public ThrottlesPreferencesControlsSettingsPane(ThrottlesPreferences tp) {
         try {
             _tpwkc = tp.getThrottlesKeyboardControls().clone();
@@ -56,12 +56,12 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
     }
 
     private void initComponents() {
-        
+
         JPanel propertyPanel = new JPanel();
         propertyPanel.setLayout(new GridBagLayout());
         this.add(propertyPanel);
-        
-        GridBagConstraints constraintsL = new GridBagConstraints();        
+
+        GridBagConstraints constraintsL = new GridBagConstraints();
         constraintsL.fill = GridBagConstraints.HORIZONTAL;
         constraintsL.gridheight = 1;
         constraintsL.gridwidth = 1;
@@ -73,177 +73,177 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
         constraintsL.anchor = GridBagConstraints.WEST;
         constraintsL.gridx = 0;
         constraintsL.gridy = 0;
-        
-        GridBagConstraints constraintsR = (GridBagConstraints) constraintsL.clone();  
+
+        GridBagConstraints constraintsR = (GridBagConstraints) constraintsL.clone();
         constraintsR.anchor = GridBagConstraints.CENTER;
         constraintsR.gridx = 1;
-        
-        GridBagConstraints constraintsS = (GridBagConstraints) constraintsL.clone();  
+
+        GridBagConstraints constraintsS = (GridBagConstraints) constraintsL.clone();
         constraintsS.gridwidth = 2;
         constraintsS.insets = new Insets(18, 2, 2, 2);
-        
-        
+
+
         propertyPanel.add(new JTitledSeparator(Bundle.getMessage("ThrottleWindowControls")),constraintsS);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-        
+
         propertyPanel.add(new JLabel(Bundle.getMessage("NextThrottleWindow")), constraintsL);
         tfNextThrottleWindow = new ShortCutsField( _tpwkc.getNextThrottleWindowKeys());
-        propertyPanel.add(tfNextThrottleWindow, constraintsR);        
-        constraintsL.gridy++; 
+        propertyPanel.add(tfNextThrottleWindow, constraintsR);
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-        
+
         propertyPanel.add(new JLabel(Bundle.getMessage("PrevThrottleWindow")), constraintsL);
         tfPrevThrottleWindow = new ShortCutsField( _tpwkc.getPrevThrottleWindowKeys());
-        propertyPanel.add(tfPrevThrottleWindow, constraintsR);        
-        constraintsL.gridy++; 
+        propertyPanel.add(tfPrevThrottleWindow, constraintsR);
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-              
-        propertyPanel.add(new JLabel(Bundle.getMessage("NextThrottleFrame")), constraintsL);        
+
+        propertyPanel.add(new JLabel(Bundle.getMessage("NextThrottleFrame")), constraintsL);
         tfNextThrottleFrame = new ShortCutsField( _tpwkc.getNextThrottleFrameKeys());
-        propertyPanel.add(tfNextThrottleFrame, constraintsR);        
-        constraintsL.gridy++; 
+        propertyPanel.add(tfNextThrottleFrame, constraintsR);
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-              
+
         propertyPanel.add(new JLabel(Bundle.getMessage("PrevThrottleFrame")), constraintsL);
         tfPrevThrottleFrame = new ShortCutsField( _tpwkc.getPrevThrottleFrameKeys());
-        propertyPanel.add(tfPrevThrottleFrame, constraintsR);                
-        constraintsL.gridy++; 
+        propertyPanel.add(tfPrevThrottleFrame, constraintsR);
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-              
+
         propertyPanel.add(new JLabel(Bundle.getMessage("NextRunningThrottleFrame")), constraintsL);
         tfNextRunningThrottleFrame = new ShortCutsField( _tpwkc.getNextRunThrottleFrameKeys());
-        propertyPanel.add(tfNextRunningThrottleFrame, constraintsR);        
-        constraintsL.gridy++; 
+        propertyPanel.add(tfNextRunningThrottleFrame, constraintsR);
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-              
+
         propertyPanel.add(new JLabel(Bundle.getMessage("PrevRunningThrottleFrame")), constraintsL);
         tfPrevRunningThrottleFrame = new ShortCutsField( _tpwkc.getPrevRunThrottleFrameKeys());
-        propertyPanel.add(tfPrevRunningThrottleFrame, constraintsR);        
-        constraintsL.gridy++; 
+        propertyPanel.add(tfPrevRunningThrottleFrame, constraintsR);
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-              
+
         propertyPanel.add(new JLabel(Bundle.getMessage("NextThrottleInternalWindow")), constraintsL);
         tfNextThrottleInternalWindow = new ShortCutsField( _tpwkc.getNextThrottleInternalWindowKeys());
-        propertyPanel.add(tfNextThrottleInternalWindow, constraintsR);        
-        constraintsL.gridy++; 
+        propertyPanel.add(tfNextThrottleInternalWindow, constraintsR);
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-              
+
         propertyPanel.add(new JLabel(Bundle.getMessage("PrevThrottleInternalWindow")), constraintsL);
         tfPrevThrottleInternalWindow = new ShortCutsField( _tpwkc.getPrevThrottleInternalWindowKeys());
-        propertyPanel.add(tfPrevThrottleInternalWindow, constraintsR);        
-        constraintsL.gridy++; 
+        propertyPanel.add(tfPrevThrottleInternalWindow, constraintsR);
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-              
+
         propertyPanel.add(new JLabel(Bundle.getMessage("GotoControl")), constraintsL);
         tfGotoControl = new ShortCutsField( _tpwkc.getMoveToControlPanelKeys());
-        propertyPanel.add(tfGotoControl, constraintsR);        
-        constraintsL.gridy++; 
+        propertyPanel.add(tfGotoControl, constraintsR);
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-              
+
         propertyPanel.add(new JLabel(Bundle.getMessage("GotoFunctions")), constraintsL);
         tfGotoFunctions = new ShortCutsField( _tpwkc.getMoveToFunctionPanelKeys());
-        propertyPanel.add(tfGotoFunctions, constraintsR);        
-        constraintsL.gridy++; 
+        propertyPanel.add(tfGotoFunctions, constraintsR);
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-              
+
         propertyPanel.add(new JLabel(Bundle.getMessage("GotoAddress")), constraintsL);
         tfGotoAddress = new ShortCutsField( _tpwkc.getMoveToAddressPanelKeys());
         propertyPanel.add(tfGotoAddress, constraintsR);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
-        constraintsS.gridy++;                
+        constraintsS.gridy++;
 
         propertyPanel.add(new JTitledSeparator(Bundle.getMessage("ThrottleSpeedControls")),constraintsS);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
 
         propertyPanel.add(new JLabel(Bundle.getMessage("Forward")), constraintsL);
         tfForward = new ShortCutsField( _tpwkc.getForwardKeys());
         propertyPanel.add(tfForward, constraintsR);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
 
         propertyPanel.add(new JLabel(Bundle.getMessage("Backward")), constraintsL);
         tfReverse = new ShortCutsField( _tpwkc.getReverseKeys());
         propertyPanel.add(tfReverse, constraintsR);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-        
+
         propertyPanel.add(new JLabel(Bundle.getMessage("SwitchDirection")), constraintsL);
         tfSwitchDir = new ShortCutsField( _tpwkc.getSwitchDirectionKeys());
         propertyPanel.add(tfSwitchDir, constraintsR);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
-        constraintsS.gridy++;  
-    
+        constraintsS.gridy++;
+
         propertyPanel.add(new JLabel(Bundle.getMessage("SpeedIdle")), constraintsL);
         tfSpeedIdle = new ShortCutsField( _tpwkc.getIdleKeys());
         propertyPanel.add(tfSpeedIdle, constraintsR);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
 
         propertyPanel.add(new JLabel(Bundle.getMessage("SpeedStop")), constraintsL);
         tfSpeedStop = new ShortCutsField( _tpwkc.getStopKeys());
         propertyPanel.add(tfSpeedStop, constraintsR);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
 
         propertyPanel.add(new JLabel(Bundle.getMessage("SpeedUp")), constraintsL);
         tfSpeedUp = new ShortCutsField( _tpwkc.getAccelerateKeys());
         propertyPanel.add(tfSpeedUp, constraintsR);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
 
         propertyPanel.add(new JLabel(Bundle.getMessage("SpeedDown")), constraintsL);
         tfSpeedDown = new ShortCutsField( _tpwkc.getDecelerateKeys());
         propertyPanel.add(tfSpeedDown, constraintsR);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-        
+
         propertyPanel.add(new JLabel(Bundle.getMessage("SpeedUpMore")), constraintsL);
         tfSpeedUpMore = new ShortCutsField( _tpwkc.getAccelerateMoreKeys());
         propertyPanel.add(tfSpeedUpMore, constraintsR);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
 
         propertyPanel.add(new JLabel(Bundle.getMessage("SpeedDownMore")), constraintsL);
         tfSpeedDownMore = new ShortCutsField( _tpwkc.getDecelerateMoreKeys());
         propertyPanel.add(tfSpeedDownMore, constraintsR);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
-        
+
         propertyPanel.add(new JLabel(Bundle.getMessage("SpeedMultiplier")), constraintsL);
         origSpeedMultiplier = _tpwkc.getMoreSpeedMultiplier();
         tfSpeedMultiplier = new JTextField(""+origSpeedMultiplier);
         tfSpeedMultiplier.setColumns(5);
         propertyPanel.add(tfSpeedMultiplier, constraintsR);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
 
         propertyPanel.add(new JTitledSeparator(Bundle.getMessage("ThrottleFunctionsControls")),constraintsS);
-        constraintsL.gridy++; 
+        constraintsL.gridy++;
         constraintsR.gridy++;
         constraintsS.gridy++;
 
@@ -252,10 +252,10 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
             propertyPanel.add(new JLabel(Bundle.getMessage("Function")+" "+i), constraintsL);
             tfFunctionKeys[i] = new ShortCutsField( _tpwkc.getFunctionsKeys(i));
             propertyPanel.add(tfFunctionKeys[i], constraintsR);
-            constraintsL.gridy++; 
+            constraintsL.gridy++;
             constraintsR.gridy++;
             constraintsS.gridy++;
-        }        
+        }
     }
 
     public ThrottlesPreferences updateThrottlesPreferences(ThrottlesPreferences tp) {
@@ -326,7 +326,7 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
             }
         }
         try {
-            float sm = Float.parseFloat(tfSpeedMultiplier.getText());            
+            float sm = Float.parseFloat(tfSpeedMultiplier.getText());
             if (Math.abs(sm - tpwkc.getMoreSpeedMultiplier()) > 0.0001) {
                 tpwkc.setMoreSpeedMultiplier(sm);
             }
@@ -336,7 +336,7 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
         }
         return tp;
     }
-    
+
     void resetComponents(ThrottlesPreferences tp) {
         try {
             _tpwkc = tp.getThrottlesKeyboardControls().clone();
@@ -376,8 +376,8 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
             }
         }
         try {
-            float sm = Float.parseFloat(tfSpeedMultiplier.getText());            
-            ret = (Math.abs(sm - origSpeedMultiplier) > 0.0001) || ret; 
+            float sm = Float.parseFloat(tfSpeedMultiplier.getText());
+            ret = (Math.abs(sm - origSpeedMultiplier) > 0.0001) || ret;
         }
         catch (NumberFormatException e) {
             log.error("Speed multiplier must be a numerical float value.");
@@ -385,10 +385,10 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
         return ret;
     }
 
-    final private class ShortCutsField extends JPanel {        
+    final private class ShortCutsField extends JPanel {
         int[][] shortcuts;
         boolean isDirty = false;
-                
+
         ShortCutsField(int[][] values) {
             super();
             shortcuts = values;
@@ -398,36 +398,36 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
                     add(new ShortCutPanel( this, v));
                 }
             }
-            add(new ShortCutTextField( this));        
+            add(new ShortCutTextField( this));
         }
 
-        private void addValue(int[] values, Component cmp) {            
+        private void addValue(int[] values, Component cmp) {
             shortcuts = java.util.Arrays.copyOf(shortcuts, shortcuts.length+1);
             shortcuts[shortcuts.length-1]=values;
             add(new ShortCutPanel( this, shortcuts[shortcuts.length-1]));
             add(new ShortCutTextField( this));
             setDirty(true);
             remove(cmp);
-            revalidate();                                
+            revalidate();
         }
-        
+
         public boolean isDirty() {
             return isDirty;
         }
-        
+
         public void setDirty(boolean b) {
             isDirty = b;
         }
-        
+
         public int[][] getShortCuts() {
             return shortcuts;
         }
     }
-    
+
     final private class ShortCutPanel extends JPanel {
         ShortCutsField shortCutsField;
         int[] shortcut; // [0]:modifier , [1]: extended key code
-                
+
         ShortCutPanel(ShortCutsField scf, int[] sc) {
             super();
             shortCutsField = scf;
@@ -446,10 +446,11 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
             setBorder(BorderFactory.createEtchedBorder(EtchedBorder.RAISED));
         }
     }
-    
+
     final private class ShortCutTextField extends JTextField {
         ShortCutsField shortCutsField;
-        
+
+        @SuppressWarnings("deprecation")  // getKeyModifiersText()
         ShortCutTextField(int[] v) {
             super();
             setEditable(false);
@@ -459,16 +460,17 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
             }
             if (v[1]!=0) {
                 text += KeyEvent.getKeyText(v[1]);
-            }            
+            }
             super.setText(text);
         }
-        
+
         ShortCutTextField(ShortCutsField scf) {
             super();
             setEditable(false);
             shortCutsField = scf;
             addKeyListener(new KeyAdapter() {
                     @Override
+                    @SuppressWarnings("deprecation")  // getModifiers()
                     public void keyReleased(KeyEvent e){
                         int[] values = new int[2];
                         values[0] = e.getModifiersEx();
@@ -476,9 +478,9 @@ public class ThrottlesPreferencesControlsSettingsPane extends JPanel {
                         shortCutsField.addValue(values, e.getComponent());
                         log.debug("Key pressed: "+e.getKeyCode()+" / modifier: "+e.getModifiers()+" / ext. key code: "+e.getExtendedKeyCode()+" / location: "+e.getKeyLocation());
                     }
-                });        
-        }                          
+                });
+        }
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ThrottlesPreferencesControlsSettingsPane.class);        
+    private final static Logger log = LoggerFactory.getLogger(ThrottlesPreferencesControlsSettingsPane.class);
 }

--- a/java/src/jmri/jmrix/nce/NceClockControl.java
+++ b/java/src/jmri/jmrix/nce/NceClockControl.java
@@ -312,7 +312,7 @@ public class NceClockControl extends DefaultClockControl implements NceListener 
     /**
      * Set the time, the date part is ignored.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("deprecation") // getHours, getMinutes, getSeconds
     @Override
     public void setTime(Date now) {
         if (DEBUG_SHOW_PUBLIC_CALLS && log.isDebugEnabled()) {
@@ -324,7 +324,7 @@ public class NceClockControl extends DefaultClockControl implements NceListener 
     /**
      * Get the current Nce time, does not have a date component.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("deprecation") // getHours, getMinutes, getSeconds
     @Override
     public Date getTime() {
         issueReadOnlyRequest(); // go get the current time value
@@ -352,7 +352,7 @@ public class NceClockControl extends DefaultClockControl implements NceListener 
     /**
      * Set Nce clock and start clock.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("deprecation") // getHours, getMinutes, getSeconds
     @Override
     public void startHardwareClock(Date now) {
         if (DEBUG_SHOW_PUBLIC_CALLS && log.isDebugEnabled()) {

--- a/java/src/jmri/util/BusyGlassPane.java
+++ b/java/src/jmri/util/BusyGlassPane.java
@@ -103,6 +103,7 @@ public class BusyGlassPane extends JComponent {
             inDrag = false;
         }
 
+        @SuppressWarnings("deprecation")  // getMenuShortcutKeyMask()
         private void redispatchMouseEvent(MouseEvent e) {
             boolean inButton = false;
             Point glassPanePoint = e.getPoint();
@@ -145,21 +146,21 @@ public class BusyGlassPane extends JComponent {
                         glassPanePoint,
                         component);
                 parentFrame.setCursor(Cursor.getDefaultCursor());
-                
+
                 component.dispatchEvent(new MouseEvent(component,
                         eventID,
                         e.getWhen(),
-                        
-                        // The Java8 Javadoc 
+
+                        // The Java8 Javadoc
                         //  https://docs.oracle.com/javase/8/docs/api/java/awt/event/MouseEvent.html#MouseEvent-java.awt.Component-int-long-int-int-int-int-boolean-
                         // says the following should reference
                         // getModifiersEx()
                         // but that makes it impossible to cancel
                         // ReadAll, WriteAll etc in DecoderPro.
                         // When it fails, getModifier is 0x10 BUTTON1_MASK
-                        // and 
+                        // and
                         // getModifierEx is 0x400 BUTTON1_DOWN_MASK
-                        
+
                         e.getModifiers(),
                         componentPoint.x,
                         componentPoint.y,

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -90,7 +90,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         reuseFrameSavedSized = saveSize;
         initFrame();
     }
-    
+
     final void initFrame() {
         addWindowListener(this);
         addComponentListener(this);
@@ -155,7 +155,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         this(saveSize, savePosition);
         setFrameTitle(name);
     }
-    
+
     final void setFrameTitle(String name) {
         setTitle(name);
         generateWindowRef();
@@ -479,7 +479,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
 
     /**
      * Add a standard help menu, including window specific help item.
-     * 
+     *
      * Final because it defines the content of a standard help menu, not to be messed with individually
      *
      * @param ref    JHelp reference for the desired window-specific help page
@@ -502,6 +502,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
     /**
      * Adds a "Close Window" key shortcut to close window on op-W.
      */
+    @SuppressWarnings("deprecation")  // getMenuShortcutKeyMask()
     void addWindowCloseShortCut() {
         // modelled after code in JavaDev mailing list item by Bill Tschumy <bill@otherwise.com> 08 Dec 2004
         AbstractAction act = new AbstractAction() {
@@ -755,7 +756,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         List<T> result = new ArrayList<>();
         JmriJFrameManager m = getJmriJFrameManager();
         synchronized (m) {
-            m.stream().filter((f) -> (type.isInstance(f))).forEachOrdered((f) -> 
+            m.stream().filter((f) -> (type.isInstance(f))).forEachOrdered((f) ->
                 {
                     result.add((T)f);
                 });
@@ -933,7 +934,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * The JmriJFrame implementation calls {@link #handleModified()}.
      */
     @Override
@@ -993,7 +994,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * When window is finally destroyed, remove it from the list of windows.
      * <p>
      * Subclasses that over-ride this method must invoke this implementation
@@ -1062,7 +1063,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         return BeanUtil.getIntrospectedIndexedProperty(this, key, index);
     }
 
-    /** {@inheritDoc} 
+    /** {@inheritDoc}
      * Subclasses should override this method with something more direct and faster
      */
     @Override
@@ -1074,7 +1075,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         }
     }
 
-    /** {@inheritDoc} 
+    /** {@inheritDoc}
      * Subclasses should override this method with something more direct and faster
      */
     @Override
@@ -1172,5 +1173,5 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
     }
 
     private final static Logger log = LoggerFactory.getLogger(JmriJFrame.class);
-    
+
 }

--- a/java/src/jmri/util/swing/SearchBar.java
+++ b/java/src/jmri/util/swing/SearchBar.java
@@ -8,7 +8,7 @@ import javax.swing.*;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * Provides a standard "search bar" for addition to 
+ * Provides a standard "search bar" for addition to
  * other panels.  Actual search is via call-back.
  *
  * @author Bob Jacobsen
@@ -18,18 +18,18 @@ public class SearchBar extends javax.swing.JPanel {
     Runnable forward;
     Runnable backward;
     Runnable done;
-    
+
     JTextField textField = new JTextField();
     JButton rightButton = new JButton(">");
     JButton leftButton = new JButton("<");
     JButton doneButton = new JButton(Bundle.getMessage("ButtonDone"));
-    
+
     public SearchBar(Runnable forward, Runnable backward, Runnable done) {
         super();
         this.forward = forward;
         this.backward = backward;
         this.done = done;
-        
+
         // create GUI
         setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
         add(textField);
@@ -37,11 +37,11 @@ public class SearchBar extends javax.swing.JPanel {
         add(leftButton);
         add(rightButton);
         add(doneButton);
-        
+
         leftButton.setToolTipText("Search backwards");
         rightButton.setToolTipText("Search forwards");
         doneButton.setToolTipText("Close search bar");
-        
+
         // add actions
         doneButton.addActionListener(new java.awt.event.ActionListener() {
             @Override
@@ -55,7 +55,7 @@ public class SearchBar extends javax.swing.JPanel {
                 }
             }
         });
-        
+
         leftButton.addActionListener(new java.awt.event.ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -67,7 +67,7 @@ public class SearchBar extends javax.swing.JPanel {
                 }
             }
         });
-        
+
         rightButton.addActionListener(new java.awt.event.ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -94,33 +94,34 @@ public class SearchBar extends javax.swing.JPanel {
                 rightButton.requestFocusInWindow();
             }
         });
-        
+
     }
 
     public String getSearchString() {
         return textField.getText();
     }
-    
+
     /**
-     * A service routine to connect the SearchBar to 
+     * A service routine to connect the SearchBar to
      * the usual modifier keys
      * @param frame JFrame containing this search bar; used to set key maps
      */
+    @SuppressWarnings("deprecation")  // getMenuShortcutKeyMask()
     public void configureKeyModifiers(JFrame frame) {
         JRootPane rootPane = frame.getRootPane();
-        
+
         rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
             KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "openSearch");
-        
+
         rootPane.getActionMap().put("openSearch", new AbstractAction() {
             public void actionPerformed(ActionEvent e) {
-            
+
                 // don't retain last text?
                 textField.setText("");
-                
+
                 // alternate visible
                 SearchBar.this.setVisible(! SearchBar.this.isVisible());
-                
+
                 // if visible, move focus
                 if (SearchBar.this.isVisible()) {
                     SearchBar.this.textField.requestFocusInWindow();
@@ -130,10 +131,10 @@ public class SearchBar extends javax.swing.JPanel {
 
         rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
             KeyStroke.getKeyStroke(KeyEvent.VK_G, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()|java.awt.event.InputEvent.SHIFT_DOWN_MASK), "forwardSearch");
-        
+
         rootPane.getActionMap().put("forwardSearch", new AbstractAction() {
             public void actionPerformed(ActionEvent e) {
-            
+
                 // same as button
                 leftButton.doClick();
                 }
@@ -141,15 +142,15 @@ public class SearchBar extends javax.swing.JPanel {
 
         rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(
             KeyStroke.getKeyStroke(KeyEvent.VK_G, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "backwardSearch");
-        
+
         rootPane.getActionMap().put("backwardSearch", new AbstractAction() {
             public void actionPerformed(ActionEvent e) {
-            
+
                 // same as button
                 rightButton.doClick();
                 }
         });
     }
-    
+
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SearchBar.class);
 }

--- a/java/src/jmri/util/swing/ValidatedTextField.java
+++ b/java/src/jmri/util/swing/ValidatedTextField.java
@@ -498,6 +498,7 @@ public class ValidatedTextField extends javax.swing.JTextField {
     private class MyVerifier extends javax.swing.InputVerifier implements java.awt.event.ActionListener {
 
         @Override
+        @SuppressWarnings("deprecation")  // shouldYieldFocus()
         public boolean shouldYieldFocus(javax.swing.JComponent input) {
             if (input instanceof ValidatedTextField) {
 


### PR DESCRIPTION
A number of Java key-handling routines (getMenuShortcutKeyMask(), getKeyModifiersText(), shouldYieldFocus(), InputEvent.META_MASK and CTRL_MASK) were deprecated in Java 8.  This PR annotates our uses of them to remove the compilation warnings about them.  

Yes, we have to update them at some point but
 (1) our use of key modifiers is sufficiently non-standard that they update may break things subtly, so it should be done farther from a production release 
(2) these warnings are making it harder to see _new_ warnings, which might arise as we do the split j8/j11 development and
(3) we can easier fix these in Java 11.  

A later j11master PR will apply fixes on the j11master branch and remove these annotations.