### PR TITLE
Restore JmriUserPreferencesManager

### DIFF
--- a/java/src/jmri/managers/JmriUserPreferencesManager.java
+++ b/java/src/jmri/managers/JmriUserPreferencesManager.java
@@ -1,5 +1,7 @@
 package jmri.managers;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.Toolkit;
@@ -1066,7 +1068,8 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
         }
     }
 
-    @SuppressWarnings("DMI_ENTRY_SETS_MAY_REUSE_ENTRY_OBJECTS")
+    @SuppressFBWarnings(value = "DMI_ENTRY_SETS_MAY_REUSE_ENTRY_OBJECTS",
+            justification = "needs to copy the items of the hashmap windowDetails")
     private void saveWindowDetails() {
         this.setChangeMade(false);
         if (this.allowSave) {

--- a/java/src/jmri/managers/JmriUserPreferencesManager.java
+++ b/java/src/jmri/managers/JmriUserPreferencesManager.java
@@ -1066,6 +1066,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
         }
     }
 
+    @SuppressWarnings("DMI_ENTRY_SETS_MAY_REUSE_ENTRY_OBJECTS")
     private void saveWindowDetails() {
         this.setChangeMade(false);
         if (this.allowSave) {

--- a/java/src/jmri/managers/JmriUserPreferencesManager.java
+++ b/java/src/jmri/managers/JmriUserPreferencesManager.java
@@ -1073,7 +1073,8 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
                 Element element = new Element(WINDOWS_ELEMENT, WINDOWS_NAMESPACE);
                 // Copy the entries before iterate over them since
                 // ConcurrentModificationException may happen otherwise
-                for (Entry<String, WindowLocations> entry : windowDetails.entrySet()) {
+                Set<Entry<String, WindowLocations>> entries = new HashSet<>(windowDetails.entrySet());
+                for (Entry<String, WindowLocations> entry : entries) {
                     Element window = new Element("window");
                     window.setAttribute(CLASS, entry.getKey());
                     if (entry.getValue().getSaveLocation()) {


### PR DESCRIPTION
@bobjacobsen 
A year ago, I tried to fix a problem with preferences by changing JmriUserPreferencesManager: https://github.com/JMRI/JMRI/commit/11ae1f1822bad0eda62e2d2464ee5e68aeb9f184

That change was obviously wrong and I apologize for it. This PR restores JmriUserPreferencesManager.

`/jmri/jmrit/logix/PortalManagerTest` is currently the most common failure of Separate tests and this seems to be the cause of that.
```
2021-11-20T08:43:55.5316630Z Failures (1):
2021-11-20T08:43:55.5318750Z   JUnit Jupiter:PortalManagerTest:testChangeNames()
2021-11-20T08:43:55.5321310Z     MethodSource [className = 'jmri.jmrit.logix.PortalManagerTest', methodName = 'testChangeNames', methodParameterTypes = '']
2021-11-20T08:43:55.5322750Z     => java.util.ConcurrentModificationException
2021-11-20T08:43:55.5323730Z        java.util.HashMap$HashIterator.nextNode(HashMap.java:1469)
2021-11-20T08:43:55.5324560Z        java.util.HashMap$EntryIterator.next(HashMap.java:1503)
2021-11-20T08:43:55.5325360Z        java.util.HashMap$EntryIterator.next(HashMap.java:1501)
2021-11-20T08:43:55.5331160Z        jmri.managers.JmriUserPreferencesManager.saveWindowDetails(JmriUserPreferencesManager.java:1076)
2021-11-20T08:43:55.5333590Z        jmri.managers.JmriUserPreferencesManager.setWindowLocation(JmriUserPreferencesManager.java:531)
2021-11-20T08:43:55.5335930Z        jmri.util.JmriJFrame.lambda$dispose$7(JmriJFrame.java:1008)
2021-11-20T08:43:55.5336800Z        java.util.Optional.ifPresent(Optional.java:159)
2021-11-20T08:43:55.5337650Z        jmri.util.JmriJFrame.dispose(JmriJFrame.java:1006)
2021-11-20T08:43:55.5338990Z        jmri.jmrit.display.Editor.dispose(Editor.java:2621)
2021-11-20T08:43:55.5340380Z        jmri.jmrit.logix.PortalManagerTest.testChangeNames(PortalManagerTest.java:123)
2021-11-20T08:43:55.5341390Z        [...]
```