### PR TITLE
Don't restart unless we know preferences have been stored

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -585,5 +585,9 @@
                 scaling of JMRI to 100%. If this value is
                 <code>0</code>, Java uses the same scaling as the
                 system.</li>
+            <li>The setting for HighDPI scaling can be changed in
+                <i>Edit -> Preferences -> Display</i>. The checkbox
+                has the text <i>Force 100% scaling when the OS uses
+                higher scaling</i>.</li>
         </ul>
 

--- a/java/src/jmri/util/EarlyInitializationPreferences.java
+++ b/java/src/jmri/util/EarlyInitializationPreferences.java
@@ -82,11 +82,13 @@ public class EarlyInitializationPreferences {
         return startupPrefs;
     }
 
-    private void store() {
+    private boolean store() {
         try (OutputStream output = new FileOutputStream(FILENAME)) {
             preferences.store(output, null);
+            return true;
         } catch (IOException ex) {
             ex.printStackTrace(System.err);
+            return false;
         }
     }
 
@@ -129,9 +131,7 @@ public class EarlyInitializationPreferences {
             preferences.setProperty("sun.java2d.uiScale", Integer.toString(uiScale));
         }
 
-        store();
-
-        if (restartIsNeeded) {
+        if (store() && restartIsNeeded) {
             InstanceManager.getDefault(ShutDownManager.class).restart();
         }
     }


### PR DESCRIPTION
https://github.com/JMRI/JMRI/pull/10362#issuecomment-977988374 by @KenC57 

> I think a failure to read the file should default to something on the large size instead of small.

If the file doesn't exists and cannot be created by JMRI, the following happens:
- If Linux or Mac, a stack trace is printed and JMRI starts with normal scaling.
- If Windows Headless, a stack trace is printed and scaling doesn't matter since it's headless.
- If Windows and not headless, JMRI will restart, restart and restart. **This PR changes that so that JMRI doesn't restart unless properties have been saved.**

With this PR, if Windows and not headless, JMRI will try to read the preferences and store the setting. But if JMRI is unable to store the setting, JMRI will continue as usual. And JMRI will not override the scaling.

JMRI will not change the scaling unless it can store and load the file. The reason for that is that JMRI cannot change the scaling once AWT/Swing is started, and it needs to start AWT/Swing to try to read the current scaling.