### PR TITLE
J11 Remove deprecated JTable persistence from pre-4.6

### DIFF
--- a/java/src/jmri/swing/JmriJTablePersistenceManager.java
+++ b/java/src/jmri/swing/JmriJTablePersistenceManager.java
@@ -394,36 +394,6 @@ public class JmriJTablePersistenceManager extends AbstractPreferencesManager
     }
 
     /**
-     * Transition support for the standard {@link jmri.UserPreferencesManager}
-     * instance (a {@link jmri.managers.JmriUserPreferencesManager}) so it does not
-     * need to maintain separate knowledge of table column state.
-     *
-     * @param table  the table name
-     * @param column the column name
-     * @param order  order of the column
-     * @param width  column preferredWidth
-     * @param sort   how the column is sorted
-     * @param hidden true if column is hidden
-     * @throws NullPointerException if either name is null
-     * @deprecated since 4.5.2; not to be removed; used by
-     *             {@link jmri.managers.configurexml.DefaultUserMessagePreferencesXml}
-     *             to allow tabled preferences from JMRI 4.4 and earlier to be read
-     *             when a user is upgrading to a newer version; not to be used
-     *             elsewhere
-     */
-    @Deprecated
-    public void setTableColumnPreferences(String table, String column, int order, int width, SortOrder sort,
-            boolean hidden) {
-        Objects.requireNonNull(table, "table name must be nonnull");
-        if (sort != SortOrder.UNSORTED) {
-            List<SortKey> keys = new ArrayList<>();
-            keys.add(new SortKey(order, sort));
-            this.sortKeys.put(table, keys);
-        }
-        this.setPersistedState(table, column, order, width, sort, hidden);
-    }
-
-    /**
      * Set the persisted state for the given column in the given table. The
      * persisted state is not saved until
      * {@link #savePreferences(jmri.profile.Profile)} is called.

--- a/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
+++ b/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
@@ -520,31 +520,6 @@ public class JmriJTablePersistenceManagerTest {
     }
 
     /**
-     * Test of setTableColumnPreferences method, of class
-     * JmriJTablePersistenceManager.
-     */
-    @Test
-    public void testSetTableColumnPreferences() {
-        JTable table = testTable("test");
-        JmriJTablePersistenceManagerSpy instance = new JmriJTablePersistenceManagerSpy();
-        Assert.assertFalse("Not persisting table", instance.isPersisting(table));
-        Assert.assertFalse("Clean manager", instance.isDirty());
-        TableColumn c0 = table.getColumnModel().getColumn(0);
-        TableColumn c1 = table.getColumnModel().getColumn(1);
-        instance.setTableColumnPreferences(table.getName(), c0.getHeaderValue().toString(), 0, c0.getPreferredWidth(), SortOrder.UNSORTED, false);
-        instance.setTableColumnPreferences(table.getName(), c1.getHeaderValue().toString(), 0, c1.getPreferredWidth(), SortOrder.UNSORTED, false);
-        Assert.assertFalse("Persisting table", instance.isPersisting(table));
-        Assert.assertTrue("Dirty manager", instance.isDirty());
-        Assert.assertEquals("Column c1 is default width", c1.getWidth(), instance.getColumnsMap(table.getName()).get("c1").getPreferredWidth());
-        c1.setPreferredWidth(100);
-        Assert.assertNotEquals("Column c1 width not persisted width",
-                c1.getPreferredWidth(),
-                instance.getColumnsMap(table.getName()).get("c1").getPreferredWidth());
-        instance.setTableColumnPreferences(table.getName(), c1.getHeaderValue().toString(), 0, c1.getPreferredWidth(), SortOrder.UNSORTED, false);
-        Assert.assertEquals("Column c1 is 100 width", c1.getPreferredWidth(), instance.getColumnsMap(table.getName()).get("c1").getPreferredWidth());
-    }
-
-    /**
      * Test of isPersistenceDataRetained method, of class
      * JmriJTablePersistenceManager.
      */


### PR DESCRIPTION
Turns out this was no longer used in any case.