### PR TITLE
J11: rm deprecated methods from two misc files

### DIFF
--- a/java/src/jmri/jmrit/consisttool/ConsistFile.java
+++ b/java/src/jmri/jmrit/consisttool/ConsistFile.java
@@ -326,21 +326,12 @@ public class ConsistFile extends XmlFile implements PropertyChangeListener {
 
     /**
      * GetFile Location.
-     * 
-     * @return the preferences subdirectory in which Consist Files are kept 
-     * this is relative to the roster files location. 
+     *
+     * @return the preferences subdirectory in which Consist Files are kept
+     * this is relative to the roster files location.
      */
     public static String getFileLocation() {
         return Roster.getDefault().getRosterFilesLocation() + CONSIST + File.separator;
-    }
-
-    /**
-     * @param loc location.
-     * @deprecated since 4.17.3 file location is determined by roster location.
-     */
-    @Deprecated
-    public static void setFileLocation(String loc) {
-        // this method has been deprecated
     }
 
     /**

--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -290,16 +290,7 @@ public class SplitVariableValue extends VariableValue
         return retString;
     }
 
-    @Deprecated
-    public String getSecondCvNum() {
-        String retString = "";
-        if (cvCount > 1) {
-            retString = cvList.get(1).cvName;
-        }
-        return retString;
-    }
-
-    @Override
+   @Override
     public void setToolTipText(String t) {
         super.setToolTipText(t);   // do default stuff
         _textField.setToolTipText(t);  // set our value


### PR DESCRIPTION
 - SplitVariableValue#getSecondCvNum()
 - ConsistFile#setFileLocation

Neither was used.