### PR TITLE
Let digital actions choose socket prefix

### DIFF
--- a/java/src/jmri/jmrit/logixng/actions/AbstractDigitalAction.java
+++ b/java/src/jmri/jmrit/logixng/actions/AbstractDigitalAction.java
@@ -43,6 +43,10 @@ public abstract class AbstractDigitalAction extends AbstractBase
         _parent = parent;
     }
 
+    protected String getPreferredSocketPrefix() {
+        return "A";
+    }
+    
     public String getNewSocketName() {
         String[] names = new String[getChildCount()];
         for (int i=0; i < getChildCount(); i++) {
@@ -51,19 +55,21 @@ public abstract class AbstractDigitalAction extends AbstractBase
         return getNewSocketName(names);
     }
     
-    public static String getNewSocketName(String[] names) {
+    public String getNewSocketName(String[] names) {
+        String prefix = getPreferredSocketPrefix();
+        
         int x = 1;
         while (x < 10000) {     // Protect from infinite loop
             boolean validName = true;
             for (int i=0; i < names.length; i++) {
-                String name = "A" + Integer.toString(x);
+                String name = prefix + Integer.toString(x);
                 if (name.equals(names[i])) {
                     validName = false;
                     break;
                 }
             }
             if (validName) {
-                return "A" + Integer.toString(x);
+                return prefix + Integer.toString(x);
             }
             x++;
         }

--- a/java/src/jmri/jmrit/logixng/actions/DigitalFormula.java
+++ b/java/src/jmri/jmrit/logixng/actions/DigitalFormula.java
@@ -58,6 +58,11 @@ public class DigitalFormula extends AbstractDigitalAction implements FemaleSocke
     }
     
     @Override
+    protected String getPreferredSocketPrefix() {
+        return "E";
+    }
+    
+    @Override
     public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws JmriException {
         DigitalActionManager manager = InstanceManager.getDefault(DigitalActionManager.class);
         String sysName = systemNames.get(getSystemName());

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionTimerSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionTimerSwing.java
@@ -41,7 +41,7 @@ public class ActionTimerSwing extends AbstractDigitalActionSwing {
         for (int i=0; i < MAX_NUM_TIMERS; i++) {
             names[ActionTimer.NUM_STATIC_EXPRESSIONS + i] = _timerSocketNames[i].getText();
         }
-        return AbstractDigitalAction.getNewSocketName(names);
+        return action.getNewSocketName(names);
     }
     
     @Override


### PR DESCRIPTION
Many actions and expressions in LogixNG have children. A child is a female socket there the user can connect a matching action or expression. Each child socket has a name consisting of letters and digits. For actions, the socket names usually starts with "A" and for expressions, the socket names usually starts with "E". But this isn't mandatory and the user can rename the sockets if he wants to.

The `DigitalFormula` action, added in #10173, generates socket names that starts with "A", for example A1, A2, ..., A5. But it's children are expressions so this PR changes it so it instead generates socket names that starts with "E".

This is done by adding the overridable method `getPreferredSocketPrefix()` to its base class `AbstractDigitalAction` that's overridden in `DigitalFormula`. This new method is then used in the method `AbstractDigitalAction.getNewSocketName()` that generates the socket names.

To allow `AbstractDigitalAction.getNewSocketName()` to use the overridable method, it's not static anymore. This required a small change to `ActionTimerSwing`.

These changes are small and safe. It would be very good to get them into 4.25.9 if possible.