### PR TITLE
Add the LogixNG function hex2dec

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -394,7 +394,8 @@
     <h3>LogixNG</h3>
         <a id="LogixNG" name="LogixNG"></a>
         <ul>
-          <li></li>
+          <li>The LogixNG function hex2dec() has been added.
+          It converts a hexadecimal number to a decimal number.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/ConvertFunctions.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/ConvertFunctions.java
@@ -30,6 +30,7 @@ public class ConvertFunctions implements FunctionFactory {
         functionClasses.add(new IntFunction());
         functionClasses.add(new FloatFunction());
         functionClasses.add(new StrFunction());
+        functionClasses.add(new Hex2DecFunction());
         return functionClasses;
     }
 
@@ -159,6 +160,45 @@ public class ConvertFunctions implements FunctionFactory {
         @Override
         public String getDescription() {
             return Bundle.getMessage("Convert.str_Descr");
+        }
+        
+    }
+    
+    public static class Hex2DecFunction implements Function {
+        
+        @Override
+        public String getModule() {
+            return new ConvertFunctions().getModule();
+        }
+        
+        @Override
+        public String getConstantDescriptions() {
+            return new ConvertFunctions().getConstantDescription();
+        }
+        
+        @Override
+        public String getName() {
+            return "hex2dec";
+        }
+        
+        @Override
+        public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
+                throws JmriException {
+            
+            if (parameterList.size() != 1) {
+                throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters2", getName(), 1));
+            }
+            Object o = parameterList.get(0).calculate(symbolTable);
+            if (o != null) {
+                return Long.parseLong(o.toString(), 16);
+            } else {
+                throw new NullPointerException("value is null");
+            }
+        }
+        
+        @Override
+        public String getDescription() {
+            return Bundle.getMessage("Convert.hex2dec");
         }
         
     }

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle.properties
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle.properties
@@ -65,6 +65,13 @@ Converts <i>value</i> to a string and returns it. <i>do_i18n</i> is a boolean va
 </html>
 
 
+Convert.hex2dec                 = <html>                                                    \
+<h1>hex2dec()</h1>                                                                          \
+<h2>hex2dec(value)</h2>                                                                     \
+Converts <i>value</i> from a hexadecimal number to a decimal numner and returns it.         \
+</html>
+
+
 Math.ConstantDescriptions                 = <html>                          \
 <h1>Constants</h1>                                                          \
 <table>                                                                     \

--- a/java/test/jmri/jmrit/logixng/util/parser/functions/ConvertFunctionsTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/functions/ConvertFunctionsTest.java
@@ -11,6 +11,7 @@ import jmri.jmrit.logixng.implementation.DefaultConditionalNG;
 import jmri.jmrit.logixng.implementation.DefaultSymbolTable;
 import jmri.jmrit.logixng.util.LogixNG_Thread;
 import jmri.jmrit.logixng.util.parser.ExpressionNode;
+import jmri.jmrit.logixng.util.parser.ExpressionNodeIntegerNumber;
 import jmri.jmrit.logixng.util.parser.ExpressionNodeFloatingNumber;
 import jmri.jmrit.logixng.util.parser.ExpressionNodeString;
 import jmri.jmrit.logixng.util.parser.ExpressionNodeTrue;
@@ -40,8 +41,10 @@ public class ConvertFunctionsTest {
     ExpressionNode expr0_95 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "0.95", 0));
     ExpressionNode expr12_34 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "12.34", 0));
     ExpressionNode expr25_46 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "25.46", 0));
-    ExpressionNode expr12 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "12", 0));
-    ExpressionNode expr23 = new ExpressionNodeFloatingNumber(new Token(TokenType.NONE, "23", 0));
+    ExpressionNode expr12 = new ExpressionNodeIntegerNumber(new Token(TokenType.NONE, "12", 0));
+    ExpressionNode expr23 = new ExpressionNodeIntegerNumber(new Token(TokenType.NONE, "23", 0));
+    ExpressionNode expr2FA5 = new ExpressionNodeString(new Token(TokenType.NONE, "2FA5", 0));
+    ExpressionNode exprC352 = new ExpressionNodeString(new Token(TokenType.NONE, "c352", 0));
     
     
     private List<ExpressionNode> getParameterList(ExpressionNode... exprNodes) {
@@ -87,6 +90,39 @@ public class ConvertFunctionsTest {
         hasThrown.set(false);
         try {
             intFunction.calculate(symbolTable, getParameterList(expr12_34, expr25_46));
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+    }
+    
+    @Test
+    public void testHex2DecFunction() throws Exception {
+        ConvertFunctions.Hex2DecFunction hex2DecFunction = new ConvertFunctions.Hex2DecFunction();
+        Assert.assertEquals("strings matches", "hex2dec", hex2DecFunction.getName());
+        Assert.assertEquals("strings matches", "hex2dec", new ConvertFunctions.Hex2DecFunction().getName());
+        
+        AtomicBoolean hasThrown = new AtomicBoolean(false);
+        
+        SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
+        
+        // Test unsupported token type
+        hasThrown.set(false);
+        try {
+            hex2DecFunction.calculate(symbolTable, getParameterList());
+        } catch (WrongNumberOfParametersException e) {
+            hasThrown.set(true);
+        }
+        Assert.assertTrue("exception is thrown", hasThrown.get());
+        
+        Assert.assertEquals("numbers are equal", 18L, hex2DecFunction.calculate(symbolTable, getParameterList(expr12)));
+        Assert.assertEquals("numbers are equal", 35L, hex2DecFunction.calculate(symbolTable, getParameterList(expr23)));
+        Assert.assertEquals("numbers are equal", 12197L, hex2DecFunction.calculate(symbolTable, getParameterList(expr2FA5)));
+        Assert.assertEquals("numbers are equal", 50002L, hex2DecFunction.calculate(symbolTable, getParameterList(exprC352)));
+        
+        // Test unsupported token type
+        hasThrown.set(false);
+        try {
+            hex2DecFunction.calculate(symbolTable, getParameterList(expr12_34, expr25_46));
         } catch (WrongNumberOfParametersException e) {
             hasThrown.set(true);
         }


### PR DESCRIPTION
This PR adds the LogixNG function hex2dec() as requested by Nigel Cliffe:
https://groups.io/g/jmriusers/message/197386

It's not used unless explicity used by the user. So it's safe to add to 4.25.9.

There is a workaround by using scripts to do the hex->dec conversion. But there might be other users needing this feature as well, so it would be good to get it into 4.26.

---

A panel file that demonstrates this function:
[hex2dec.txt](https://github.com/JMRI/JMRI/files/7687473/hex2dec.txt)

Enter a hex value in the memory IM1. Both the hex value and the decimal value is printed to the log.