### PR TITLE
Remove unused RetryRules from JUnit5 Tests

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -818,7 +818,7 @@ TemporaryDir</a>.
     @Rule
     public final TemporaryFolder tempFolder = new TemporaryFolder();
 </pre>
-      <p>Some standard JUnit rules you might find useful:</p>
+      <p>Some standard JUnit4 rules you might find useful:</p>
 
       <ul>
         <li>
@@ -851,14 +851,14 @@ TemporaryDir</a>.
 </pre>will put a 2 second (2,000 milliseconds) timeout on that test. If you use both the rule and
 the option, the option will control the behavior. For a bit more info, see the <a href=
 "https://github.com/junit-team/junit4/wiki/Timeout-for-tests">JUnit Timeouts for Tests page</a>.
-      <h4 id="RetryRule">RetryRule - run test several times</h4>
+      <h4 id="RetryRule">RetryRule - run test several times ( JUnit4 Only )</h4>
       JMRI has <code><a href=
       "https://github.com/JMRI/JMRI/tree/master/java/test/jmri/util/junit/rules/RetryRule.java">jmri.util.junit.rules.RetryRule</a></code>
       which can rerun a test multiple times until it reaches a limit or finally passes. Although
       it's better to write reliable tests, this can be a way to make the CI system more reliable
       while you try to find out why a test isn't reliable.
       <p>For a working example, see <a href=
-      "https://github.com/JMRI/JMRI/tree/master/java/test/jmri/jmrit/logix/LearnWarrantTest.java">java/test/jmri/jmrit/logix/LearnWarrantTest.java</a></p>
+      "https://github.com/JMRI/JMRI/blob/master/java/test/jmri/util/junit/rules/RetryRuleTest.java">java/test/jmri/util/junit/rules/RetryRuleTest.java</a></p>
 
       <p>Briefly, you just add the lines</p>
 
@@ -867,7 +867,7 @@ the option, the option will control the behavior. For a bit more info, see the <
 
     @Rule
     public RetryRule retryRule = new RetryRule(3);  // allow 3 retries
-</pre>to your test class. This will modify how JUnit handles errors during all of the tests in that
+</pre>to your test class. This will modify how JUnit4 handles errors during all of the tests in that
 class.
       <h3 id="control">Tools for Controlling JUnit tests</h3>
 

--- a/java/test/jmri/jmrit/beantable/LogixNGModuleTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixNGModuleTableActionTest.java
@@ -16,32 +16,24 @@ import jmri.jmrit.logixng.Module;
 import jmri.jmrit.logixng.tools.swing.ConditionalNGEditor;
 
 import jmri.util.*;
-import jmri.util.junit.rules.*;
 
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Rule;
 import org.junit.jupiter.api.*;
-import org.junit.rules.Timeout;
 
 import org.netbeans.jemmy.operators.*;
 
 
-/*
+/**
 * Tests for the LogixNGModuleTableAction Class
-* Re-created using JUnit4 with support for the new conditional editors
+* Re-created using JUnit5 with support for the new conditional editors
 * @author Dave Sand Copyright (C) 2017 (for the LogixTableActionTest class)
 * @author Daniel Bergqvist Copyright (C) 2019
 */
+@Timeout(10) // 10 second timeout for methods in this test class.
 public class LogixNGModuleTableActionTest extends AbstractTableActionBase<Module> {
 
     static final ResourceBundle rbxLogixNGSwing = ResourceBundle.getBundle("jmri.jmrit.logixng.tools.swing.LogixNGSwingBundle");
-
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(10); // 10 second timeout for methods in this test class.
-
-    @Rule
-    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     @Test
     public void testCtor() {
@@ -103,7 +95,7 @@ public class LogixNGModuleTableActionTest extends AbstractTableActionBase<Module
 
         // Menu AutoCreate
         JMenuItem findMenuItem = (JMenuItem) jpm.getComponent(0);
-        Assert.assertEquals(findMenuItem.getText(), "Close window");
+        Assert.assertEquals( "Close window", findMenuItem.getText());
         new JMenuItemOperator(findMenuItem).doClick();
 /*
         // Test that we can open the LogixNGEdtior window twice
@@ -707,7 +699,7 @@ public class LogixNGModuleTableActionTest extends AbstractTableActionBase<Module
     @Test
     public void testDeleteModule() throws InterruptedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction moduleTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> moduleTable = (AbstractLogixNGTableAction) a;
 
         moduleTable.actionPerformed(null); // show table
         JFrame moduleFrame = JFrameOperator.waitJFrame(Bundle.getMessage("TitleLogixNGModuleTable"), true, true);  // NOI18N
@@ -733,7 +725,7 @@ public class LogixNGModuleTableActionTest extends AbstractTableActionBase<Module
     @Test
     public void testDeleteModuleWithDigitalAction() throws InterruptedException, SocketAlreadyConnectedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction moduleTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> moduleTable = (AbstractLogixNGTableAction) a;
 
         Module module102 = InstanceManager.getDefault(ModuleManager.class).getBySystemName("IQM102");   // NOI18N
         jmri.jmrit.logixng.actions.DigitalMany digitalMany_102 =
@@ -777,7 +769,7 @@ public class LogixNGModuleTableActionTest extends AbstractTableActionBase<Module
     @Test
     public void testDeleteModuleWithTwoDigitalActions() throws InterruptedException, SocketAlreadyConnectedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction moduleTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> moduleTable = (AbstractLogixNGTableAction) a;
 
         Module module102 = InstanceManager.getDefault(ModuleManager.class).getBySystemName("IQM102");   // NOI18N
         jmri.jmrit.logixng.actions.DigitalMany digitalMany_102 =
@@ -835,7 +827,7 @@ public class LogixNGModuleTableActionTest extends AbstractTableActionBase<Module
     @Test
     public void testDeleteModuleWithDigitalActionWithListenerRef() throws InterruptedException, SocketAlreadyConnectedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction moduleTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> moduleTable = (AbstractLogixNGTableAction) a;
 
         PropertyChangeListener pcl = (PropertyChangeEvent evt) -> {
             // Do nothing

--- a/java/test/jmri/jmrit/beantable/LogixNGTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixNGTableActionTest.java
@@ -17,31 +17,23 @@ import jmri.jmrit.logixng.expressions.ExpressionSensor;
 import jmri.jmrit.logixng.tools.swing.ConditionalNGEditor;
 
 import jmri.util.*;
-import jmri.util.junit.rules.*;
 
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Rule;
 import org.junit.jupiter.api.*;
-import org.junit.rules.Timeout;
 
 import org.netbeans.jemmy.operators.*;
 
-/*
+/**
 * Tests for the LogixNGTableAction Class
-* Re-created using JUnit4 with support for the new conditional editors
+* Re-created using JUnit5 with support for the new conditional editors
 * @author Dave Sand Copyright (C) 2017 (for the LogixTableActionTest class)
 * @author Daniel Bergqvist Copyright (C) 2019
 */
+@Timeout(10) // 10 second timeout for methods in this test class.
 public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
 
     static final ResourceBundle rbxLogixNGSwing = ResourceBundle.getBundle("jmri.jmrit.logixng.tools.swing.LogixNGSwingBundle");
-
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(10); // 10 second timeout for methods in this test class.
-
-    @Rule
-    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     @Test
     public void testCtor() {
@@ -85,7 +77,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     @Override
     public void testAddThroughDialog() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> logixNGTable = (AbstractLogixNGTableAction) a;
         a.actionPerformed(null);
         JFrame f = JFrameOperator.waitJFrame(getTableFrameName(), true, true);
 
@@ -134,7 +126,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     @Override
     public void testEditButton() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> logixNGTable = (AbstractLogixNGTableAction) a;
 
         LogixNG logixNG = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ101");
         Assert.assertNotNull("LogixNG exists", logixNG);
@@ -165,7 +157,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     @Test
     public void testLogixNGBrowser() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> logixNGTable = (AbstractLogixNGTableAction) a;
 
         logixNGTable.browserPressed("IQ101");  // NOI18N
 
@@ -180,7 +172,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
         InstanceManager.getDefault(jmri.UserPreferencesManager.class).
                 setProperty("jmri.jmrit.beantable.LogixNGTableAction", "Edit Mode", "TREEEDIT");  // NOI18N
         a.actionPerformed(null);
-        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> logixNGTable = (AbstractLogixNGTableAction) a;
         JFrameOperator logixNGFrame = new JFrameOperator(Bundle.getMessage("TitleLogixNGTable"));  // NOI18N
         Assert.assertNotNull(logixNGFrame);
 
@@ -194,7 +186,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     @Test
     public void testAddLogixNGAutoName() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> logixNGTable = (AbstractLogixNGTableAction) a;
 
         logixNGTable.actionPerformed(null); // show table
         JFrame logixNGFrame = JFrameOperator.waitJFrame(Bundle.getMessage("TitleLogixNGTable"), true, true);  // NOI18N
@@ -220,7 +212,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     @Test
     public void testAddLogixNG() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> logixNGTable = (AbstractLogixNGTableAction) a;
 
         logixNGTable.actionPerformed(null); // show table
         JFrame logixNGFrame = JFrameOperator.waitJFrame(Bundle.getMessage("TitleLogixNGTable"), true, true);  // NOI18N
@@ -250,7 +242,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     @Test
     public void testDeleteLogixNG() throws InterruptedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> logixNGTable = (AbstractLogixNGTableAction) a;
 
         logixNGTable.actionPerformed(null); // show table
         JFrame logixNGFrame = JFrameOperator.waitJFrame(Bundle.getMessage("TitleLogixNGTable"), true, true);  // NOI18N
@@ -276,7 +268,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     @Test
     public void testDeleteLogixNGWithConditionalNG() throws InterruptedException, SocketAlreadyConnectedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> logixNGTable = (AbstractLogixNGTableAction) a;
 
         LogixNG logixNG_102 = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ102");   // NOI18N
         InstanceManager.getDefault(ConditionalNG_Manager.class).createConditionalNG(logixNG_102, "IQC102", null);   // NOI18N
@@ -312,7 +304,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     @Test
     public void testDeleteLogixNGWithDigitalAction() throws InterruptedException, SocketAlreadyConnectedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> logixNGTable = (AbstractLogixNGTableAction) a;
 
         LogixNG logixNG_102 = InstanceManager.getDefault(LogixNG_Manager.class).getBySystemName("IQ102");   // NOI18N
         ConditionalNG conditionalNG_102 = InstanceManager.getDefault(ConditionalNG_Manager.class).createConditionalNG(logixNG_102, "IQC102", null);   // NOI18N
@@ -362,7 +354,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
     @Test
     public void testDeleteLogixNGWithDigitalActionWithListenerRef() throws InterruptedException, SocketAlreadyConnectedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> logixNGTable = (AbstractLogixNGTableAction) a;
 
         PropertyChangeListener pcl = (PropertyChangeEvent evt) -> {
             throw new UnsupportedOperationException("Not supported");
@@ -489,7 +481,7 @@ public class LogixNGTableActionTest extends AbstractTableActionBase<LogixNG> {
         Turnout turnout1 = InstanceManager.getDefault(TurnoutManager.class).provide("IT1");
 
         // * Add a LogixNG
-        AbstractLogixNGTableAction logixNGTable = (AbstractLogixNGTableAction) a;
+        AbstractLogixNGTableAction<?> logixNGTable = (AbstractLogixNGTableAction) a;
 
         logixNGTable.actionPerformed(null); // show table
         JFrameOperator logixNGFrameOperator = new JFrameOperator(Bundle.getMessage("TitleLogixNGTable"));  // NOI18N

--- a/java/test/jmri/jmrit/beantable/LogixNGTableTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixNGTableTableActionTest.java
@@ -13,32 +13,24 @@ import jmri.jmrit.logixng.expressions.ExpressionSensor;
 import jmri.jmrit.logixng.tools.swing.ConditionalNGEditor;
 
 import jmri.util.*;
-import jmri.util.junit.rules.*;
 
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Rule;
 import org.junit.jupiter.api.*;
-import org.junit.rules.Timeout;
 
 import org.netbeans.jemmy.operators.*;
 
 
-/*
+/**
 * Tests for the NamedTableTableAction Class
-* Re-created using JUnit4 with support for the new conditional editors
+* Re-created using JUnit5 with support for the new conditional editors
 * @author Dave Sand Copyright (C) 2017 (for the LogixTableActionTest class)
 * @author Daniel Bergqvist Copyright (C) 2019
 */
+@Timeout(10)
 public class LogixNGTableTableActionTest extends AbstractTableActionBase<NamedTable> {
 
     static final ResourceBundle rbxNamedTableSwing = ResourceBundle.getBundle("jmri.jmrit.logixng.tools.swing.LogixNGSwingBundle");
-
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(10); // 10 second timeout for methods in this test class.
-
-    @Rule
-    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     @Test
     public void testCtor() {

--- a/java/test/jmri/jmrit/beantable/LogixTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixTableActionTest.java
@@ -8,7 +8,6 @@ import jmri.InstanceManager;
 import jmri.Logix;
 
 import jmri.util.*;
-import jmri.util.junit.rules.RetryRule;
 import jmri.util.swing.JemmyUtil;
 
 import org.junit.Assert;
@@ -20,17 +19,13 @@ import org.netbeans.jemmy.operators.JCheckBoxOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JTextFieldOperator;
 
-
-/*
+/**
 * Tests for the LogixTableAction Class
-* Re-created using JUnit4 with support for the new conditional editors
+* Re-created using JUnit5 with support for the new conditional editors
 * @author Dave Sand Copyright (C) 2017
  */
 @Timeout(10)
 public class LogixTableActionTest extends AbstractTableActionBase<Logix> {
-
-    //@Rule
-    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     @Test
     public void testCtor() {

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -8,7 +8,6 @@ import java.io.File;
 import jmri.*;
 import jmri.jmrit.display.*;
 import jmri.util.*;
-import jmri.util.junit.rules.*;
 import jmri.util.swing.JemmyUtil;
 
 import org.junit.Assert;
@@ -29,8 +28,6 @@ import org.netbeans.jemmy.operators.JMenuOperator;
 public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
 
     private EditorFrameOperator jfo;
-
-    public RetryRule retryRule = new RetryRule(3); // allow 3 retries
 
     @BeforeEach
     @Override

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
@@ -11,15 +11,13 @@ import jmri.*;
 import jmri.implementation.*;
 import jmri.jmrit.display.EditorFrameOperator;
 import jmri.util.*;
-import jmri.util.junit.rules.RetryRule;
 import jmri.util.swing.JemmyUtil;
 
 import org.junit.jupiter.api.*;
 
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
+
 import org.netbeans.jemmy.QueueTool;
 import org.netbeans.jemmy.operators.*;
 
@@ -29,14 +27,8 @@ import org.netbeans.jemmy.operators.*;
  * @author Paul Bender Copyright (C) 2016
  * @author George Warner Copyright (C) 2019
  */
+@Timeout(10)
 public class LayoutEditorToolsTest {
-
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(10); //10 second timeout for methods in this test class.
-
-    //allow 2 retries of intermittent tests
-    @Rule
-    public RetryRule retryRule = new RetryRule(2); //allow 2 retries
 
     private LayoutEditor layoutEditor = null;
     private LayoutEditorTools let = null;

--- a/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
+++ b/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import jmri.util.JUnitUtil;
-import jmri.util.junit.rules.RetryRule;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
@@ -25,9 +24,6 @@ public class AddEntryExitPairPanelTest {
     static EntryExitTestTools tools;
     static HashMap<String, LayoutEditor> panels = new HashMap<>();
     static EntryExitPairs eep;
-
-    //@Rule
-    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     @Test
     public void testCTor() {

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/CarEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/CarEditFrameTest.java
@@ -18,7 +18,6 @@ import jmri.jmrit.operations.setup.Control;
 import jmri.jmrit.operations.setup.Setup;
 import jmri.util.JUnitOperationsUtil;
 import jmri.util.JUnitUtil;
-import jmri.util.junit.rules.RetryRule;
 import jmri.util.swing.JemmyUtil;
 
 /**
@@ -28,8 +27,6 @@ import jmri.util.swing.JemmyUtil;
  */
 @Timeout(10)
 public class CarEditFrameTest extends OperationsTestCase {
-
-    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     @Test
     public void testClearRoadNumber() {

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/EngineEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/EngineEditFrameTest.java
@@ -21,7 +21,6 @@ import jmri.jmrit.operations.setup.Control;
 import jmri.jmrit.operations.setup.Setup;
 import jmri.util.JUnitOperationsUtil;
 import jmri.util.JUnitUtil;
-import jmri.util.junit.rules.RetryRule;
 import jmri.util.swing.JemmyUtil;
 
 /**
@@ -32,8 +31,6 @@ import jmri.util.swing.JemmyUtil;
  */
 @Timeout(10)
 public class EngineEditFrameTest extends OperationsTestCase {
-
-    public RetryRule retryRule = new RetryRule(2); // allow 2 retries      
 
     @Test
     public void testClearRoadNumber() {

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/tools/ImportRosterEngineActionTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/tools/ImportRosterEngineActionTest.java
@@ -21,7 +21,6 @@ import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.util.FileUtil;
 import jmri.util.JUnitUtil;
-import jmri.util.junit.rules.RetryRule;
 import jmri.util.swing.JemmyUtil;
 
 /**
@@ -30,8 +29,6 @@ import jmri.util.swing.JemmyUtil;
  */
 @Timeout(20)
 public class ImportRosterEngineActionTest extends OperationsTestCase {
-
-    public RetryRule retryRule = new RetryRule(3); // allow 3 retries
     
     ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrit.roster.JmritRosterBundle");
 

--- a/java/test/jmri/jmrit/operations/trains/TrainsTableFrameTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainsTableFrameTest.java
@@ -23,7 +23,6 @@ import jmri.jmrit.operations.setup.Setup;
 import jmri.util.JUnitOperationsUtil;
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
-import jmri.util.junit.rules.RetryRule;
 import jmri.util.swing.JemmyUtil;
 
 /**
@@ -32,8 +31,6 @@ import jmri.util.swing.JemmyUtil;
  */
 @Timeout(10)
 public class TrainsTableFrameTest extends OperationsTestCase {
-
-    public RetryRule retryRule = new RetryRule(3); // first, plus three retries
 
     @Test
     public void testCTor() {

--- a/java/test/jmri/jmrit/operations/trains/tools/PrintTrainManifestActionTest.java
+++ b/java/test/jmri/jmrit/operations/trains/tools/PrintTrainManifestActionTest.java
@@ -17,7 +17,6 @@ import jmri.jmrit.operations.trains.TrainManager;
 import jmri.util.JUnitOperationsUtil;
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
-import jmri.util.junit.rules.RetryRule;
 import jmri.util.swing.JemmyUtil;
 
 /**
@@ -25,8 +24,6 @@ import jmri.util.swing.JemmyUtil;
  */
 @Timeout(20)
 public class PrintTrainManifestActionTest extends OperationsTestCase {
-
-    public RetryRule retryRule = new RetryRule(3); // allow 3 retries
 
     @Test
     public void testCTor() {

--- a/java/test/jmri/jmrit/throttle/ThrottlesPreferencesWindowTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottlesPreferencesWindowTest.java
@@ -6,8 +6,6 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
 
-import jmri.util.junit.rules.RetryRule;
-
 /**
  * Test simple functioning of ThrottlesPreferencesWindow
  *
@@ -15,9 +13,6 @@ import jmri.util.junit.rules.RetryRule;
  */
 public class ThrottlesPreferencesWindowTest {
 
-    public RetryRule retryRule = new RetryRule(2);  // allow 2 retries
-                                                    // because of possible IndexOutOfBoundsException
-                                                    // in Swing during tearDown
     @Test
     public void testCtor() {
         try {
@@ -25,7 +20,7 @@ public class ThrottlesPreferencesWindowTest {
             ThrottlesPreferencesWindow w = new ThrottlesPreferencesWindow("ThrottlesPreferencesWindowTest");
             Assert.assertNotNull("exists", w);
         } catch (IndexOutOfBoundsException e) {
-            Assert.fail("IndexOutOfBoundsException, fail to retry\n"+e);
+            Assert.fail("IndexOutOfBoundsException\n"+e);
         }
     }
 

--- a/java/test/jmri/jmrix/dccpp/dccppovertcp/DCCppOverTcpPacketizerTest.java
+++ b/java/test/jmri/jmrix/dccpp/dccppovertcp/DCCppOverTcpPacketizerTest.java
@@ -2,7 +2,6 @@ package jmri.jmrix.dccpp.dccppovertcp;
 
 import jmri.util.JUnitUtil;
 import org.junit.jupiter.api.*;
-import jmri.util.junit.rules.RetryRule;
 
 /**
  * <p>
@@ -12,8 +11,6 @@ import jmri.util.junit.rules.RetryRule;
  * @author Paul Bender Copyright (C) 2009
  */
 public class DCCppOverTcpPacketizerTest extends jmri.jmrix.dccpp.DCCppPacketizerTest {
-
-    public RetryRule retryRule = new RetryRule(3);  // allow 3 retries
 
     @Test
     @Override

--- a/java/test/jmri/jmrix/easydcc/EasyDccTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccTrafficControllerTest.java
@@ -9,7 +9,6 @@ import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import jmri.util.junit.rules.RetryRule;
 
 /**
  * JUnit tests for the EasyDccTrafficController class
@@ -18,8 +17,6 @@ import jmri.util.junit.rules.RetryRule;
  */
 @Timeout(90)
 public class EasyDccTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficControllerTest {
-
-    public RetryRule retryRule = new RetryRule(3);  // allow 3 retries
 
     @Test
     public void testSendThenRcvReply() throws Exception {

--- a/java/test/jmri/jmrix/easydcc/simulator/EasyDccSimulatorTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/easydcc/simulator/EasyDccSimulatorTrafficControllerTest.java
@@ -14,7 +14,6 @@ import jmri.jmrix.easydcc.EasyDccPortController;
 import jmri.jmrix.easydcc.EasyDccSystemConnectionMemo;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import jmri.util.junit.rules.RetryRule;
 
 /**
  * JUnit tests for the EasyDccSimulatorTrafficController class
@@ -23,8 +22,6 @@ import jmri.util.junit.rules.RetryRule;
  */
 @Timeout(90)
 public class EasyDccSimulatorTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficControllerTest {
-
-    public RetryRule retryRule = new RetryRule(3);  // allow 3 retries
 
     @Test
     public void testSendThenRcvReply() throws Exception {

--- a/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
@@ -4,7 +4,6 @@ import jmri.util.JUnitUtil;
 import jmri.SpeedStepMode;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import jmri.util.junit.rules.RetryRule;
 
 /**
  * Test for the jmri.jmrix.lenz.XNetThrottle class
@@ -13,8 +12,6 @@ import jmri.util.junit.rules.RetryRule;
  */
 @Timeout(1)
 public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
-
-    public RetryRule retryRule = new RetryRule(3);  // allow 3 retries
 
     protected XNetInterfaceScaffold tc = null;
     protected XNetSystemConnectionMemo memo = null;

--- a/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
@@ -18,7 +18,6 @@ import jmri.util.JUnitUtil;
 import jmri.util.NamedBeanComparator;
 import jmri.util.PropertyChangeListenerScaffold;
 import jmri.util.ThreadingUtil;
-import jmri.util.junit.rules.RetryRule;
 
 /**
  * Tests for the jmri.jmrix.openlcb.OlcbSensor class.
@@ -26,8 +25,6 @@ import jmri.util.junit.rules.RetryRule;
  * @author Bob Jacobsen Copyright 2008, 2010
  */
 public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
-
-    public RetryRule retryRule = new RetryRule(3);  // allow 3 retries of tests
 
     private final static Logger log = LoggerFactory.getLogger(OlcbSensorTest.class);
     protected PropertyChangeListenerScaffold l;
@@ -81,13 +78,13 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
         mInactive.setExtended(true);
 
         // check states
-        Assert.assertEquals(t.getKnownState(), Sensor.UNKNOWN);
+        Assert.assertEquals(Sensor.UNKNOWN, t.getKnownState());
 
         ti.sendMessage(mActive);
-        Assert.assertEquals(t.getKnownState(), Sensor.ACTIVE);
+        Assert.assertEquals(Sensor.ACTIVE,t.getKnownState());
 
         ti.sendMessage(mInactive);
-        Assert.assertEquals(t.getKnownState(), Sensor.INACTIVE);
+        Assert.assertEquals(Sensor.INACTIVE, t.getKnownState());
 
     }
 
@@ -115,13 +112,13 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
         mStateInactive.setExtended(true);
 
         // check states
-        Assert.assertEquals(t.getKnownState(), Sensor.UNKNOWN);
+        Assert.assertEquals(Sensor.UNKNOWN, t.getKnownState());
 
         ti.sendMessage(mStateActive);
-        Assert.assertEquals(t.getKnownState(), Sensor.ACTIVE);
+        Assert.assertEquals(Sensor.ACTIVE,t.getKnownState());
 
         ti.sendMessage(mStateInactive);
-        Assert.assertEquals(t.getKnownState(), Sensor.INACTIVE);
+        Assert.assertEquals(Sensor.INACTIVE, t.getKnownState());
     }
 
     @Test
@@ -136,10 +133,10 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
         mActive.setExtended(true);
 
         // check states
-        Assert.assertEquals(s.getKnownState(), Sensor.UNKNOWN);
+        Assert.assertEquals(Sensor.UNKNOWN, s.getKnownState());
 
         ti.sendMessage(mActive);
-        Assert.assertEquals(s.getKnownState(), Sensor.ACTIVE);
+        Assert.assertEquals(Sensor.ACTIVE,s.getKnownState());
 
         JUnitUtil.waitFor( ()-> (s.getKnownState() != Sensor.ACTIVE));
 
@@ -147,7 +144,7 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
 
         // local flip
         s.setKnownState(Sensor.ACTIVE);
-        Assert.assertEquals(s.getKnownState(), Sensor.ACTIVE);
+        Assert.assertEquals(Sensor.ACTIVE,s.getKnownState());
 
         JUnitUtil.waitFor( ()-> (s.getKnownState() != Sensor.ACTIVE));
 

--- a/java/test/jmri/util/junit/rules/RetryRule.java
+++ b/java/test/jmri/util/junit/rules/RetryRule.java
@@ -2,6 +2,8 @@ package jmri.util.junit.rules;
 
 /**
  * Retries a failing test.
+ * <p>Works with org.junit.Test (JUnit4)
+ * <p>Does NOT work with org.junit.jupiter.api.Test (JUnit5)
  * <ul>
  * <li>If a test passes on the first time, this rule does nothing; the test is marked as passed
  * <li>If a test fails at first, a warning is logged, and the test is retries up to "retryCount" times.

--- a/java/test/jmri/util/junit/rules/RetryRuleTest.java
+++ b/java/test/jmri/util/junit/rules/RetryRuleTest.java
@@ -4,7 +4,8 @@ import jmri.util.*;
 import org.junit.*;
 
 /**
- * Test the RetryRule
+ * Test the RetryRule.
+ * <p>Note RetryRule only works with JUnit4 Tests.
  * @author Bob Jacobsen Copyright 2018
  */
 public class RetryRuleTest {


### PR DESCRIPTION
While developing some tests, I've realised that jmri.util.junit.rules.RetryRule does NOT work with JUnit5 tests, just JUnit4.

This PR updates documentation and removes the RetryRule from JUnit5 tests for clarity.

The JUnit4 / JUnit5 discrepancy was confirmed by locally tweaking RetryRule to throw an exception on each Test called, as per image below.
The exception was thrown for JUnit4 Tests whereas the JUnit 5 Tests passed with no exception called, JUnit 5 tests do not call the same methods.

![retryrule-junit5](https://user-images.githubusercontent.com/39652002/145739791-87cb7c3f-be4a-4a5f-871a-ca215929f77e.png)
 