### PR TITLE
J11: fix cucumber tests

### DIFF
--- a/java/test/apps/PanelPro/profiles/Grapevine_Simulator/profile/profile.xml
+++ b/java/test/apps/PanelPro/profiles/Grapevine_Simulator/profile/profile.xml
@@ -17,7 +17,7 @@
         </connection>
     </connections>
     <startup xmlns="http://jmri.org/xml/schema/auxiliary-configuration/startup-4-3-5.xsd">
-        <perform xmlns="" class="apps.configurexml.PerformActionModelXml" name="apps.SystemConsoleAction" type="Action">
+        <perform xmlns="" class="jmri.util.startup.configurexml.PerformActionModelXml" name="apps.SystemConsoleAction" type="Action">
             <property name="systemPrefix" value=""/>
         </perform>
     </startup>

--- a/java/test/apps/PanelPro/profiles/LocoNet_Simulator/profile/profile.xml
+++ b/java/test/apps/PanelPro/profiles/LocoNet_Simulator/profile/profile.xml
@@ -11,7 +11,7 @@
         </connection>
     </connections>
     <startup xmlns="http://jmri.org/xml/schema/auxiliary-configuration/startup-4-3-5.xsd">
-        <perform xmlns="" class="apps.configurexml.PerformActionModelXml" name="apps.SystemConsoleAction" type="Action">
+        <perform xmlns="" class="jmri.util.startup.configurexml.PerformActionModelXml" name="apps.SystemConsoleAction" type="Action">
             <property name="systemPrefix" value=""/>
         </perform>
     </startup>

--- a/java/test/apps/PanelPro/profiles/Prevent_Init_Loop/profile/profile.xml
+++ b/java/test/apps/PanelPro/profiles/Prevent_Init_Loop/profile/profile.xml
@@ -11,10 +11,10 @@
         </connection>
     </connections>
     <startup xmlns="http://jmri.org/xml/schema/auxiliary-configuration/startup-4-3-5.xsd">
-        <perform xmlns="" class="apps.configurexml.PerformActionModelXml" name="apps.SystemConsoleAction" type="Action">
+        <perform xmlns="" class="jmri.util.startup.configurexml.PerformActionModelXml" name="apps.SystemConsoleAction" type="Action">
             <property name="systemPrefix" value=""/>
         </perform>
-        <perform xmlns="" class="apps.configurexml.PerformScriptModelXml" name="preference:jython/FollowJumpingPanel.py" type="ScriptFile"/>
-        <perform xmlns="" class="apps.configurexml.PerformFileModelXml" name="preference:Panels/jumping panels.xml" type="XmlFile"/>
+        <perform xmlns="" class="jmri.util.startup.configurexml.PerformScriptModelXml" name="preference:jython/FollowJumpingPanel.py" type="ScriptFile"/>
+        <perform xmlns="" class="jmri.util.startup.configurexml.PerformFileModelXml" name="preference:Panels/jumping panels.xml" type="XmlFile"/>
     </startup>
 </auxiliary-configuration>

--- a/java/test/apps/PanelPro/profiles/Sprog_Simulator/profile/profile.xml
+++ b/java/test/apps/PanelPro/profiles/Sprog_Simulator/profile/profile.xml
@@ -11,7 +11,7 @@
     </connection>
 </connections>
     <startup xmlns="http://jmri.org/xml/schema/auxiliary-configuration/startup-4-3-5.xsd">
-        <perform xmlns="" class="apps.configurexml.PerformActionModelXml" name="apps.SystemConsoleAction" type="Action">
+        <perform xmlns="" class="jmri.util.startup.configurexml.PerformActionModelXml" name="apps.SystemConsoleAction" type="Action">
             <property name="systemPrefix" value=""/>
         </perform>
     </startup>

--- a/java/test/apps/PanelPro/profiles/TMCC_Simulator/profile/profile.xml
+++ b/java/test/apps/PanelPro/profiles/TMCC_Simulator/profile/profile.xml
@@ -6,7 +6,7 @@
         </connection>
     </connections>
     <startup xmlns="http://jmri.org/xml/schema/auxiliary-configuration/startup-4-3-5.xsd">
-        <perform xmlns="" class="apps.configurexml.PerformActionModelXml" name="apps.SystemConsoleAction" type="Action">
+        <perform xmlns="" class="jmri.util.startup.configurexml.PerformActionModelXml" name="apps.SystemConsoleAction" type="Action">
             <property name="systemPrefix" value=""/>
         </perform>
     </startup>


### PR DESCRIPTION
This fixes the Cucumber tests on `j11master` that had been broken by a previous J11 migration.  Not clear why those failing Cucumber tests were not causing CI to fail....