### PR TITLE
Add missing Bundle items jmri.util.startup.Bundle

### DIFF
--- a/java/src/jmri/util/startup/Bundle.properties
+++ b/java/src/jmri/util/startup/Bundle.properties
@@ -62,3 +62,11 @@ TriggerRouteModel.RouteNotDefined=Unable to set route "{0}". Route not defined.
 StartupPauseModel.Interrupted={0} second startup pause interrupted early.
 StartupActionsManager.RefusalToInitialize=Unable to run startup actions due to earlier failures.
 StartupActionsOverriddenClasses=<html>Startup action class {0} has been updated to {1}.<br>Please save preferences to make this permanent.</html>
+
+#Multiple errors in Startup Actions
+StartupActionsMultipleErrors=There are multiple errors running Startup Actions.
+#Startup Actions unable to create class
+StartupActionsCreationError=Unable to create loader "{0}" for Startup Action class "{1}".
+#Startup Actions unable to load created class
+StartupActionsLoadError=Unable to load Startup action "{1}" using "{0}".
+

--- a/java/src/jmri/util/startup/Bundle_ca.properties
+++ b/java/src/jmri/util/startup/Bundle_ca.properties
@@ -66,3 +66,11 @@ TriggerRouteModel.RouteNotDefined=No s'ha pogut activar la ruta "{0}". Ruta no d
 StartupPauseModel.Interrupted={0} la segona pausa d'inici es va interrompre prematurament.
 StartupActionsManager.RefusalToInitialize=No es poden executar accions d'inici per errors anteriors.
 StartupActionsOverriddenClasses=<html>Startup action class {0} has been updated to {1}.<br>Please save preferences to make this permanent.</html>
+
+#Multiple errors in Startup Actions
+StartupActionsMultipleErrors=Hi han diversos errors executant les Accions d'inici.
+#Startup Actions unable to create class
+StartupActionsCreationError=No s'ha pogut crear el carregador "{0}" per a la classe d'Acci\u00f3 d'inici "{1}".
+#Startup Actions unable to load created class
+StartupActionsLoadError=No s'ha pogut carregar l'Acci\u00f3 d'inici "{1}" utilitzant "{0}".
+

--- a/java/src/jmri/util/startup/Bundle_cs.properties
+++ b/java/src/jmri/util/startup/Bundle_cs.properties
@@ -65,3 +65,11 @@ AbstractActionModel.InvalidClass=Nemohu naj\u00edt t\u0159\u00eddu {0}
 AbstractActionModel.InvalidAction=Akce {0} nen\u00ed platn\u00e1
 StartupActionsManager.RefusalToInitialize=Nemohu spustit akce spou\u0161t\u011bn\u00ed z d\u016fvodu d\u0159\u00edv\u011bj\u0161\u00edch selh\u00e1n\u00ed.
 StartupActionsOverriddenClasses=<html>T\u0159\u00edda Akce po spu\u0161t\u011bn\u00ed {0} byla aktualizov\u00e1na na {1}.<br>Pros\u00edm ulo\u017ete p\u0159edvolby, aby se zm\u011bna ulo\u017eila.</html>
+
+#Multiple errors in Startup Actions
+StartupActionsMultipleErrors = P\u0159i b\u011bhu akc\u00ed po spu\u0161t\u011bn\u00ed se vyskytlo v\u00edce chyb.
+#Startup Actions unable to create class
+StartupActionsCreationError = Nelze vytvo\u0159it zavad\u011b\u010d "{0}" pro t\u0159\u00eddu Akce po spu\u0161t\u011bn\u00ed "{1}".
+#Startup Actions unable to load created class
+StartupActionsLoadError = Nelze na\u010d\u00edst Akci po spu\u0161t\u011bn\u00ed "{1}" s pou\u017eit\u00edm "{0}".
+

--- a/java/src/jmri/util/startup/Bundle_de.properties
+++ b/java/src/jmri/util/startup/Bundle_de.properties
@@ -41,3 +41,11 @@ TriggerRouteModel.RouteNotDefined=Unable to set route "{0}". Route not defined.
 StartupPauseModel.Interrupted={0} second startup pause interrupted early.
 StartupActionsManager.RefusalToInitialize=Durch Fehler werden die Aufstartverhalten nicht aktiviert.
 StartupActionsOverriddenClasses=<html>Aufstartverhalten {0} wurde \u00fcberarbeitet nach {1}.<br>Bitte die Voreinstellungen speichern um dauerhaft durch zu f\u00fchren.</html>
+
+#Multiple errors in Startup Actions
+StartupActionsMultipleErrors = Mehrere Fehler w\u00e4hrend des Programmstarts.
+#Startup Actions unable to create class
+StartupActionsCreationError = Kann Modul "{0}" f\u00fcr Aufstartverhalten "{1}" nicht erstellen.
+#Startup Actions unable to load created class
+StartupActionsLoadError = Kann Aufstartverhalten "{1}" mit "{0}" nicht einlesen.
+

--- a/java/src/jmri/util/startup/Bundle_fr.properties
+++ b/java/src/jmri/util/startup/Bundle_fr.properties
@@ -1,2 +1,10 @@
 StartupActionsManager.RefusalToInitialize=Impossible de lancer les actions au d\u00e9marrage du fait d'erreurs pr\u00e9c\u00e9dentes.
 StartupActionsOverriddenClasses=<html>La classe {0} d'action au d\u00e9marrage a \u00e9t\u00e9 actualis\u00e9e {1}.<br>SVP Sauvegarder les pr\u00e9f\u00e9rences pour les rendre permanentes.</html>
+
+#Multiple errors in Startup Actions
+StartupActionsMultipleErrors=Il existe plusieurs erreurs lors de l'ex\u00e9cution des Actions de D\u00e9marrage.
+#Startup Actions unable to create class
+StartupActionsCreationError=Impossible de cr\u00e9er le chargeur "{0}" pour Action de D\u00e9marrage class "{1}".
+#Startup Actions unable to load created class
+StartupActionsLoadError=Impossible de charger Action de D\u00e9marrage "{1}" utilisant "{0}".
+

--- a/java/src/jmri/util/startup/Bundle_nl.properties
+++ b/java/src/jmri/util/startup/Bundle_nl.properties
@@ -67,3 +67,11 @@ TriggerRouteModel.RouteNotDefined=Kan Route "{0}" niet instellen. Route niet ged
 StartupPauseModel.Interrupted=opstartpauze van {0} secondes is vroegtijdig afgebroken.
 StartupActionsManager.RefusalToInitialize=Door eerdere fouten kunnen de opstartacties niet worden uitgevoerd.
 StartupActionsOverriddenClasses=<html>Opstartactie type {0} is bijgewerkt naar {1}.<br>Bewaar je Voorkeuren om dit definitief te maken.</html>
+
+#Multiple errors in Startup Actions
+StartupActionsMultipleErrors = Tijdens het laden van Opstartacties zijn meerdere fouten opgetreden.
+#Startup Actions unable to create class
+StartupActionsCreationError = Kan ondersteuning "{0}" voor opstartactie type "{1}" niet aanmaken.
+#Startup Actions unable to load created class
+StartupActionsLoadError = Kan opstartactie "{1}" met "{0}" niet laden.
+


### PR DESCRIPTION
Console log in https://builds.jmri.org/jenkins/job/j11development/job/alltest/51/consoleFull
suggests missing Bundle items in jmri.util.startup.Bundle , eg.

```
java.lang.reflect.InvocationTargetException
     [java] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     [java] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
     [java] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
     [java] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
     [java] 	at apps.ApplicationTestAcceptanceSteps.lambda$new$2(ApplicationTestAcceptanceSteps.java:60)
     [java] 	at ✽.starting application apps.PanelPro.PanelPro with PanelPro(file:java/acceptancetest/features/apps/ApplicationStart.feature:6)
     [java] Caused by: java.util.MissingResourceException: Resource 'StartupActionsCreationError' not found
     [java] 	at jmri.Bundle.retry(Bundle.java:205)
     [java] 	at jmri.Bundle.handleGetMessage(Bundle.java:151)
     [java] 	at jmri.util.Bundle.retry(Bundle.java:94)
     [java] 	at jmri.Bundle.handleGetMessage(Bundle.java:151)
     [java] 	at jmri.util.startup.Bundle.retry(Bundle.java:94)
     [java] 	at jmri.Bundle.handleGetMessage(Bundle.java:151)
     [java] 	at jmri.Bundle.handleGetMessage(Bundle.java:186)
     [java] 	at jmri.util.startup.Bundle.getMessage(Bundle.java:77)
     [java] 	at jmri.util.startup.StartupActionsManager.initialize(StartupActionsManager.java:98)
     [java] 	at jmri.implementation.JmriConfigurationManager.initializeProvider(JmriConfigurationManager.java:456)
     [java] 	at jmri.implementation.JmriConfigurationManager.lambda$load$2(JmriConfigurationManager.java:216)
```