### PR TITLE
First step in jython directory reorg

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -467,7 +467,7 @@
     <h3>Scripting</h3>
         <a id="Scripting" name="Scripting"></a>
         <ul>
-            <li></li>
+            <li>Example scripts related to MQTT moved from jython directory to jython\MQTT directory.</li>
         </ul>
 
     <h3>Signals</h3>

--- a/help/en/releasenotes/current-draft-warnings.shtml
+++ b/help/en/releasenotes/current-draft-warnings.shtml
@@ -1,7 +1,8 @@
 
     <!-- contains new warnings for the release under development -->
     <li>
-        None yet
+        Example scripts related to MQTT moved from jython directory to jython\MQTT directory.  This will require 
+        an update to any start-up actions that reference their location.
     </li>
     <li>
     </li>

--- a/jython/MQTT/README.md
+++ b/jython/MQTT/README.md
@@ -1,0 +1,20 @@
+JMRI Jython Example Scripts for Using MQTT
+======================================================
+
+This folder contains user-constributed [scripts][1] written in Jython, a Java-based
+variant of Python, available in the JMRI application.
+
+Further information on some scripts may also be found here:
+ - [Script-based help][2]
+ 
+## Copying and License 
+
+See [the COPYING file][3] for the license terms for using these files.  See also the [JMRI Copyright page][4]
+
+
+[1]: https://www.jmri.org/help/en/html/tools/scripting/index.shtml
+[2]: https://www.jmri.org/help/en/html/scripthelp/
+[3]: https://www.jmri.org/jython/COPYING
+[4]: https://www.jmri.org/Copyright.html
+
+

--- a/jython/MQTT/index.php
+++ b/jython/MQTT/index.php
@@ -43,7 +43,7 @@ function showSubdirs() {
 
         sort($list);
         foreach ($list as $entry) {
-            echo '<img src="https://www.jmri.org/icons/folder.gif"> <a href="'.$entry.'">'.$entry.'</a></td><p>'."\n";
+            echo '<img src="https://www.jmri.org/icons/folder.gif"> <a href="'.$entry.'">'.$entry.'</a><p>'."\n";
         }
     }
 }

--- a/jython/MQTT/index.php
+++ b/jython/MQTT/index.php
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>JMRI Jython Example Files (Topic Subdirectory)</title>
+</head>
+<body>
+<h2>JMRI Jython Example Files (Topic Subdirectory)</h2>
+
+
+<?php
+
+//Based on two php files in the resources directory: index, showIcons
+
+function startswith($string, $test) {
+    $strlen = strlen($string);
+    $testlen = strlen($test);
+    if ($testlen > $strlen) return false;
+    return substr($string, 0, strlen($test)) == $test;
+}
+
+function endswith($string, $test) {
+    $strlen = strlen($string);
+    $testlen = strlen($test);
+    if ($testlen > $strlen) return false;
+    return substr_compare(strtolower($string), strtolower($test), -$testlen) === 0;
+}
+
+function showSubdirs() {
+
+    // show subdirectories
+    $list = array();
+
+    $d = dir(".");
+    while (false !== ($entry = $d->read())) {
+       if (is_dir($entry) && substr($entry,0,1) != '.') {
+         $list[] = $entry;
+       }
+    }
+    $d->close();
+
+    if (sizeof($list)> 0) {
+        echo "<h3>Subdirectories</h3>\n";
+
+        sort($list);
+        foreach ($list as $entry) {
+            echo '<img src="https://www.jmri.org/icons/folder.gif"> <a href="'.$entry.'">'.$entry.'</a></td><p>'."\n";
+        }
+    }
+}
+
+function showFilesAndIcons() {
+
+    $listIcon = array();
+    $listOther = array();
+    $listPy = array();
+
+    $d = dir(".");
+    while (false !== ($entry = $d->read())) {
+       if (endswith($entry, ".py")) {
+         $listPy[] = $entry;
+       }
+       elseif (endswith($entry, ".gif")
+            || endswith($entry, ".jpg")
+            || endswith($entry, ".png")
+            || endswith($entry, ".EPS")
+            || endswith($entry, ".PSD")
+            )   {
+         $listIcon[] = $entry;
+       }
+       elseif (! (startswith($entry, ".") || is_dir($entry) || endswith($entry, ".php")) ) {
+         $listOther[] = $entry;
+       }
+    }
+    $d->close();
+
+    // now show the files
+    if (sizeof($listPy)> 0) {
+
+        echo "<h3>Sample Scripts</h3>\n";
+        echo '<table border="1">';
+
+        sort($listPy);
+
+        foreach ($listPy as $entry) {
+            echo '<tr>'."\n";
+            echo     '<td><a href="'.$entry.'">'.$entry.' </a></td>'."\n";
+            echo     '<td bgcolor="#C0C0C0"><a href="'.$entry.'" download="'.$entry.'">(download)</a></tr>'."\n";
+            echo '</tr>'."\n";
+        }
+
+        echo "</table>\n";
+    }
+
+    // Show any icons
+    if (sizeof($listIcon)> 0) {
+
+        echo "<h3>Icons</h3>\n";
+        echo '<table border="1">';
+
+        sort($listIcon);
+
+        foreach ($listIcon as $entry) {
+            echo '<tr>'."\n";
+            echo     '<td><a href="'.$entry.'">'.$entry.' </a></td>'."\n";
+            if (endswith($entry, ".gif") || endswith($entry, ".jpg") || endswith($entry, ".png")) {
+                // display as image
+                //   would be good to add a limiting size here
+                echo     '<td bgcolor="#C0C0C0"><a href="'.$entry.'"><img src="'.$entry.'" style="max-width:500px;max-height:500px;"></a></tr>'."\n";
+            }
+            else {
+                // link without display
+                echo     '<td bgcolor="#C0C0C0"><a href="'.$entry.'" download="'.$entry.'">(download)</a></tr>'."\n";
+            }
+            echo '</tr>'."\n";
+        }
+
+        echo "</table>\n";
+    }
+
+    // now show the rest of the files
+    if (sizeof($listOther)> 0) {
+
+        echo "<h3>Other Files</h3>\n";
+        echo '<table border="1">';
+
+        sort($listOther);
+
+        foreach ($listOther as $entry) {
+            echo '<tr>'."\n";
+            echo     '<td><a href="'.$entry.'">'.$entry.' </a></td>'."\n";
+            echo     '<td bgcolor="#C0C0C0"><a href="'.$entry.'" download="'.$entry.'">(download)</a></tr>'."\n";
+            echo '</tr>'."\n";
+        }
+
+        echo "</table>\n";
+    }
+
+}
+
+//MAINLINE
+
+// show README if present
+if (file_exists("README.md")) {
+    echo "<pre>\n";
+    echo file_get_contents( "README.md" );
+    echo "</pre>\n";
+}
+elseif (file_exists("README")) {
+    echo "<pre>\n";
+    echo file_get_contents( "README" );
+    echo "</pre>\n";
+}
+elseif (file_exists("README.txt")) {
+    echo "<pre>\n";
+    echo file_get_contents( "README.txt" );
+    echo "</pre>\n";
+}
+
+
+showFilesAndIcons();
+showSubdirs();
+
+?>
+
+
+</body>
+</html>

--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -50,9 +50,8 @@
 ; -------------------------------------------------------------------------
 ; - Version History
 ; -------------------------------------------------------------------------
-; - Version 4.99.1
-; - Updated "-CleanUp" so that old files are removed before installation 
-; - to allow restructuring of jython directory
+; - Version 0.1.27.0
+; - Updated "-CleanUp" so that old/error files are removed before installation in jython directory
 ; -------------------------------------------------------------------------
 ; - Version 0.1.26.1
 ; - Remove Tools start menu items
@@ -320,7 +319,7 @@
   ; -- usually, this will be determined by the build.xml ant script
   !define JRE_VER   "1.8"                       ; Required JRE version
 !endif
-!define INST_VER  "0.1.26.1"                    ; Installer version
+!define INST_VER  "0.1.27.0"                    ; Installer version
 !define PNAME     "${APP}.${JMRI_VER}"          ; Name of installer.exe
 !define SRCDIR    "."                           ; Path to head of sources
 InstallDir        "$PROGRAMFILES\JMRI"          ; Default install directory
@@ -512,13 +511,13 @@ SectionGroup "JMRI Core Files" SEC_CORE
     Delete "$OUTDIR\jh.jar"
     Delete "$OUTDIR\jdom-jdk11.jar"
  
-    ; -- Delete certain jython files that have been moved, as of JMRI 4.99.1
-    ; -- [List will increase as files are moved]
+    ; -- Delete certain jython files that have been moved, or were entered erroneously, as of JMRI 4.21.3
     Delete "$OUTDIR\jython\SetMqttOptions.py"
     Delete "$OUTDIR\jython\SetMqttParser.py"
     Delete "$OUTDIR\jython\SetMqttPrefix.py"
     Delete "$OUTDIR\jython\ReceiveMqttMessage.py"
     Delete "$OUTDIR\jython\SendMqttMessage.py"
+    Delete "$OUTDIR\jython\CmriBitsToBytes.jy"    
 
     ; -- Delete XmlIO-related files, as of JMRI 3.11.3
     Delete "$OUTDIR\help\en\package\jmri\jmrit\inControl\images\2Throttles.png"

--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -50,6 +50,10 @@
 ; -------------------------------------------------------------------------
 ; - Version History
 ; -------------------------------------------------------------------------
+; - Version 4.99.1
+; - Updated "-CleanUp" so that old files are removed before installation 
+; - to allow restructuring of jython directory
+; -------------------------------------------------------------------------
 ; - Version 0.1.26.1
 ; - Remove Tools start menu items
 ; - Add support for Open JDK 8 Registry Keys
@@ -508,6 +512,14 @@ SectionGroup "JMRI Core Files" SEC_CORE
     Delete "$OUTDIR\jh.jar"
     Delete "$OUTDIR\jdom-jdk11.jar"
  
+    ; -- Delete certain jython files that have been moved, as of JMRI 4.99.1
+    ; -- [List will increase as files are moved]
+    Delete "$OUTDIR\jython\SetMqttOptions.py"
+    Delete "$OUTDIR\jython\SetMqttParser.py"
+    Delete "$OUTDIR\jython\SetMqttPrefix.py"
+    Delete "$OUTDIR\jython\ReceiveMqttMessage.py"
+    Delete "$OUTDIR\jython\SendMqttMessage.py"
+
     ; -- Delete XmlIO-related files, as of JMRI 3.11.3
     Delete "$OUTDIR\help\en\package\jmri\jmrit\inControl\images\2Throttles.png"
     Delete "$OUTDIR\help\en\package\jmri\jmrit\inControl\images\AnalogClock.png"
@@ -609,6 +621,7 @@ SectionGroup "JMRI Core Files" SEC_CORE
     Delete "$OUTDIR\resources\GreenPowerLED.gif"
     Delete "$OUTDIR\resources\RedPowerLED.gif"
     Delete "$OUTDIR\resources\YellowPowerLED.gif"
+        
 
     ; -- If the current install Start Menu folder exists, remove any
     ; --        predictably-named JMRI-related contents.


### PR DESCRIPTION
This PR can be implemented now as it deals with files previously moved to a subdirectory.

installJMRI.nsi: Add list of jython files to delete from main directory (because moved to subdirectory).  [Initial list is files previously moved but never deleted.]

Add Readme.md and index.php to jython\MQTT as a first example of how things will look when all done.