### PR TITLE
Fix bugs in LogixNG when copy/paste

### DIFF
--- a/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
@@ -41,9 +41,10 @@ public class TreeEditor extends TreeViewer {
     public enum EnableExecuteEvaluate { EnableExecuteEvaluate, DisableExecuteEvaluate }
 
 
-    private final LogixNGPreferences _prefs = InstanceManager.getDefault(LogixNGPreferences.class);
+    // There should only be one clipboard editor open at any time so this is static
+    private static ClipboardEditor _clipboardEditor = null;
 
-    ClipboardEditor _clipboardEditor = null;
+    private final LogixNGPreferences _prefs = InstanceManager.getDefault(LogixNGPreferences.class);
 
     private JDialog _renameSocketDialog = null;
     private JDialog _selectItemTypeDialog = null;
@@ -1627,6 +1628,10 @@ public class TreeEditor extends TreeViewer {
                                         JOptionPane.ERROR_MESSAGE);
                             }
                             ThreadingUtil.runOnGUIEventually(() -> {
+                                _treePane._femaleRootSocket.forEntireTree((Base b) -> {
+                                    b.removePropertyChangeListener(_treePane);
+                                    b.addPropertyChangeListener(_clipboardEditor._treePane);
+                                });
                                 _treePane._femaleRootSocket.registerListeners();
                                 _treePane.updateTree(_currentFemaleSocket, _currentPath.getPath());
                             });
@@ -1668,6 +1673,12 @@ public class TreeEditor extends TreeViewer {
                                             JOptionPane.ERROR_MESSAGE);
                                 });
                             }
+                            ThreadingUtil.runOnGUIEventually(() -> {
+                                _treePane._femaleRootSocket.forEntireTree((Base b) -> {
+                                    b.removePropertyChangeListener(_treePane);
+                                    b.addPropertyChangeListener(_clipboardEditor._treePane);
+                                });
+                            });
                         });
 
                         _treePane._femaleRootSocket.registerListeners();

--- a/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
@@ -1700,6 +1700,13 @@ public class TreeEditor extends TreeViewer {
                                 log.error("item cannot be connected", ex);
                             }
                             ThreadingUtil.runOnGUIEventually(() -> {
+                                _treePane._femaleRootSocket.forEntireTree((Base b) -> {
+                                    // Remove the listener if it is already
+                                    // added so we don't end up with duplicate
+                                    // listeners.
+                                    b.removePropertyChangeListener(_treePane);
+                                    b.addPropertyChangeListener(_treePane);
+                                });
                                 _treePane._femaleRootSocket.registerListeners();
                                 _treePane.updateTree(_currentFemaleSocket, _currentPath.getPath());
                             });

--- a/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
@@ -41,7 +41,8 @@ public class TreeEditor extends TreeViewer {
     public enum EnableExecuteEvaluate { EnableExecuteEvaluate, DisableExecuteEvaluate }
 
 
-    // There should only be one clipboard editor open at any time so this is static
+    // There should only be one clipboard editor open at any time so this is static.
+    // This field must only be accessed on the GUI thread.
     private static ClipboardEditor _clipboardEditor = null;
 
     private final LogixNGPreferences _prefs = InstanceManager.getDefault(LogixNGPreferences.class);


### PR DESCRIPTION
This PR fixes three bugs:
- It was possible to open the clipboard twice, both from the ConditionalNG editor and the LogixNG Module editor.
- @jerryg2003 found a bug in the ConditionalNG editor: https://github.com/JMRI/JMRI/issues/10428#issuecomment-997142062
- The same bug that @jerryg2003 found is also in the clipboard