### PR TITLE
J11: move certain openlcb tests to the "run separately" list

### DIFF
--- a/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
@@ -60,6 +60,7 @@ public class OlcbClockControlTest {
 
     @BeforeAll
     static public void checkSeparate() {
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
     }
 

--- a/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
@@ -58,6 +58,10 @@ public class OlcbClockControlTest {
         }
     }
 
+    @BeforeAll
+    static public void checkSeparate() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    }
 
     @BeforeEach
     public void setUp() {

--- a/java/test/jmri/jmrix/openlcb/OlcbConfigurationManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbConfigurationManagerTest.java
@@ -63,6 +63,7 @@ public class OlcbConfigurationManagerTest {
     @BeforeAll
     public static void preClassInit() {
         JUnitUtil.setUp();
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         scm = new OlcbSystemConnectionMemo();
         TestTrafficController tc = new TestTrafficController();

--- a/java/test/jmri/jmrix/openlcb/OlcbConfigurationManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbConfigurationManagerTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertEquals;
  * @author Paul Bender Copyright (C) 2017
  */
 public class OlcbConfigurationManagerTest {
-        
+
     private static OlcbSystemConnectionMemo scm;
 
     @Test
@@ -30,7 +30,7 @@ public class OlcbConfigurationManagerTest {
     public void testConfigureManagers() {
         OlcbConfigurationManager t = new OlcbConfigurationManager(scm);
         // this tet verifies this does not throw an exception
-        t.configureManagers(); 
+        t.configureManagers();
     }
 
     @Test
@@ -63,6 +63,7 @@ public class OlcbConfigurationManagerTest {
     @BeforeAll
     public static void preClassInit() {
         JUnitUtil.setUp();
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         scm = new OlcbSystemConnectionMemo();
         TestTrafficController tc = new TestTrafficController();
         scm.setTrafficController(tc);
@@ -70,11 +71,13 @@ public class OlcbConfigurationManagerTest {
 
     @AfterAll
     public static void postClassTearDown() {
-        if(scm != null && scm.getInterface() !=null ) {
-            scm.getTrafficController().terminateThreads();
-            scm.getInterface().dispose();
+        if (Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning") == false ) {
+            if (scm != null && scm.getInterface() !=null ) {
+                scm.getTrafficController().terminateThreads();
+                scm.getInterface().dispose();
+            }
+            scm = null;
         }
-        scm = null;
         jmri.util.JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
 

--- a/java/test/jmri/jmrix/openlcb/OlcbLightManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbLightManagerTest.java
@@ -143,6 +143,7 @@ public class OlcbLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
     @BeforeAll
     @SuppressWarnings("deprecated") // OlcbInterface(NodeID, Connection)
     static public void preClassInit() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         JUnitUtil.setUp();
         JUnitUtil.initInternalTurnoutManager();
         nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
@@ -169,6 +170,7 @@ public class OlcbLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
 
     @AfterAll
     public static void postClassTearDown() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         if(memo != null && memo.getInterface() !=null ) {
            memo.getInterface().dispose();
         }

--- a/java/test/jmri/jmrix/openlcb/OlcbLightManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbLightManagerTest.java
@@ -143,6 +143,7 @@ public class OlcbLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
     @BeforeAll
     @SuppressWarnings("deprecated") // OlcbInterface(NodeID, Connection)
     static public void preClassInit() {
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         JUnitUtil.setUp();
         JUnitUtil.initInternalTurnoutManager();

--- a/java/test/jmri/jmrix/openlcb/OlcbLightTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbLightTest.java
@@ -44,6 +44,7 @@ public class OlcbLightTest {
 
     @BeforeAll
     static public void checkSeparate() {
+        // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
     }
 

--- a/java/test/jmri/jmrix/openlcb/OlcbLightTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbLightTest.java
@@ -42,6 +42,11 @@ public class OlcbLightTest {
 
     OlcbTestInterface t;
 
+    @BeforeAll
+    static public void checkSeparate() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
@@ -408,6 +408,7 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public void setUp() {
         JUnitUtil.setUp();
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+       // this test is run separately because it leaves a lot of threads behind
         l = new PropertyChangeListenerScaffold();
         // load dummy TrafficController
         ti = new OlcbTestInterface();

--- a/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
@@ -46,7 +46,7 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public void checkInactiveMsgSent() {
         Assert.assertTrue(new OlcbAddress("1.2.3.4.5.6.7.9").match(ti.tc.rcvMessage));
     }
-    
+
     @org.junit.jupiter.api.Disabled("Test requires further setup")
     @jmri.util.junit.annotations.ToDo("Check checkActiveMsgSent() producing correct result")
     @Test
@@ -58,7 +58,7 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
     @Test
     @Override
     public void testCommandSentInactive() {}
-    
+
     @Override
     public void checkStatusRequestMsgSent() {
         ti.flush();
@@ -407,6 +407,7 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
     @Override
     public void setUp() {
         JUnitUtil.setUp();
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         l = new PropertyChangeListenerScaffold();
         // load dummy TrafficController
         ti = new OlcbTestInterface();
@@ -418,10 +419,14 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
     @AfterEach
     @Override
     public void tearDown() {
-        t.dispose();
-        l.resetPropertyChanged();
-        l = null;
-        ti.dispose();
+        if (Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning") == false) {
+            t.dispose();
+            t = null;
+            l.resetPropertyChanged();
+            l = null;
+            ti.dispose();
+            ti = null;
+        }
         JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
 

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutInheritedTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutInheritedTest.java
@@ -19,12 +19,13 @@ import org.junit.jupiter.api.*;
 public class OlcbTurnoutInheritedTest extends AbstractTurnoutTestBase {
     OlcbTestInterface tif;
     int baselineListeners;
-    protected PropertyChangeListenerScaffold l; 
+    protected PropertyChangeListenerScaffold l;
 
     @Override
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         tif = new OlcbTestInterface();
         tif.waitForStartup();
         baselineListeners = tif.iface.numMessageListeners();
@@ -36,10 +37,12 @@ public class OlcbTurnoutInheritedTest extends AbstractTurnoutTestBase {
 
     @AfterEach
     public void tearDown() {
-        tif.dispose();
+        if (Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning") == false) {
+            tif.dispose();
+            tif = null;
+        }
         JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
-
     }
 
     @Override

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutInheritedTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutInheritedTest.java
@@ -25,6 +25,7 @@ public class OlcbTurnoutInheritedTest extends AbstractTurnoutTestBase {
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         tif = new OlcbTestInterface();
         tif.waitForStartup();

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
@@ -378,6 +378,7 @@ public class OlcbTurnoutTest {
 
     @BeforeAll
     static public void checkSeparate() {
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
     }
 

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
@@ -26,7 +26,7 @@ import jmri.util.ThreadingUtil;
 public class OlcbTurnoutTest {
     private final static Logger log = LoggerFactory.getLogger(OlcbTurnoutTest.class);
 
-    protected PropertyChangeListenerScaffold l; 
+    protected PropertyChangeListenerScaffold l;
 
     @Test
     public void testIncomingChange() {
@@ -53,7 +53,7 @@ public class OlcbTurnoutTest {
         Assert.assertEquals(s.getCommandedState(), Turnout.UNKNOWN);
 
         t.sendMessage(mActive);
-      
+
         JUnitUtil.waitFor( () -> l.getPropertyChanged());
         Assert.assertEquals("called twice",2,l.getCallCount());
         Assert.assertEquals(s.getCommandedState(), Turnout.THROWN);
@@ -360,14 +360,14 @@ public class OlcbTurnoutTest {
 
         // test by putting into a tree set, then extracting and checking order
         TreeSet<Turnout> set = new TreeSet<>(new NamedBeanComparator<>());
-        
+
         set.add(new OlcbTurnout("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface));
         set.add(new OlcbTurnout("M", "X0501010114FF2000;X0501010114FF2011", t.iface));
         set.add(new OlcbTurnout("M", "X0501010114FF2000;X0501010114FF2001", t.iface));
         set.add(new OlcbTurnout("M", "1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.9", t.iface));
-        
+
         Iterator<Turnout> it = set.iterator();
-        
+
         Assert.assertEquals("MT1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", it.next().getSystemName());
         Assert.assertEquals("MT1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.9", it.next().getSystemName());
         Assert.assertEquals("MTX0501010114FF2000;X0501010114FF2001", it.next().getSystemName());
@@ -375,6 +375,11 @@ public class OlcbTurnoutTest {
     }
 
     private OlcbTestInterface t;
+
+    @BeforeAll
+    static public void checkSeparate() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    }
 
     @BeforeEach
     public void setUp() {

--- a/java/test/jmri/jmrix/openlcb/configurexml/OlcbLightManagerXmlTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/OlcbLightManagerXmlTest.java
@@ -69,6 +69,11 @@ public class OlcbLightManagerXmlTest {
     OlcbTestInterface t;
     private final static Logger log = LoggerFactory.getLogger(OlcbLightManagerXmlTest.class);
 
+    @BeforeAll
+    static public void checkSeparate() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/jmrix/openlcb/configurexml/OlcbLightManagerXmlTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/OlcbLightManagerXmlTest.java
@@ -71,6 +71,7 @@ public class OlcbLightManagerXmlTest {
 
     @BeforeAll
     static public void checkSeparate() {
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
     }
 

--- a/java/test/jmri/jmrix/openlcb/configurexml/OlcbSensorManagerXmlTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/OlcbSensorManagerXmlTest.java
@@ -101,6 +101,11 @@ public class OlcbSensorManagerXmlTest {
     OlcbTestInterface t;
     private final static Logger log = LoggerFactory.getLogger(OlcbSensorManagerXmlTest.class);
 
+    @BeforeAll
+    static public void checkSeparate() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/jmrix/openlcb/configurexml/OlcbSensorManagerXmlTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/OlcbSensorManagerXmlTest.java
@@ -103,6 +103,7 @@ public class OlcbSensorManagerXmlTest {
 
     @BeforeAll
     static public void checkSeparate() {
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
     }
 

--- a/java/test/jmri/jmrix/openlcb/configurexml/OlcbSignalMastXmlTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/OlcbSignalMastXmlTest.java
@@ -61,6 +61,7 @@ public class OlcbSignalMastXmlTest {
     @SuppressWarnings("deprecated") // OlcbInterface(NodeID, Connection)
     static public void preClassInit() {
         JUnitUtil.setUp();
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         JUnitUtil.initInternalTurnoutManager();
         nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});

--- a/java/test/jmri/jmrix/openlcb/configurexml/OlcbSignalMastXmlTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/OlcbSignalMastXmlTest.java
@@ -61,6 +61,7 @@ public class OlcbSignalMastXmlTest {
     @SuppressWarnings("deprecated") // OlcbInterface(NodeID, Connection)
     static public void preClassInit() {
         JUnitUtil.setUp();
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         JUnitUtil.initInternalTurnoutManager();
         nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
 
@@ -91,12 +92,14 @@ public class OlcbSignalMastXmlTest {
 
     @AfterAll
     public static void postClassTearDown() {
-        if(memo != null && memo.getInterface() !=null ) {
-           memo.getInterface().dispose();
+        if (Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning") == false) {
+            if(memo != null && memo.getInterface() !=null ) {
+               memo.getInterface().dispose();
+            }
+            memo = null;
+            connection = null;
+            nodeID = null;
         }
-        memo = null;
-        connection = null;
-        nodeID = null;
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/openlcb/configurexml/ProtocolOptionsPersistenceTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/ProtocolOptionsPersistenceTest.java
@@ -36,6 +36,7 @@ public class ProtocolOptionsPersistenceTest {
 
     @BeforeAll
     static public void checkSeparate() {
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
     }
 

--- a/java/test/jmri/jmrix/openlcb/configurexml/ProtocolOptionsPersistenceTest.java
+++ b/java/test/jmri/jmrix/openlcb/configurexml/ProtocolOptionsPersistenceTest.java
@@ -34,6 +34,11 @@ public class ProtocolOptionsPersistenceTest {
     private String profileId;
     private PortAdapter adapter;
 
+    @BeforeAll
+    static public void checkSeparate() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    }
+
     @BeforeEach
     public void setUp() {
         jmri.util.JUnitUtil.setUp();

--- a/java/test/jmri/jmrix/openlcb/swing/hub/HubPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/hub/HubPaneTest.java
@@ -27,6 +27,7 @@ public class HubPaneTest {
 
     @BeforeAll
     static public void checkSeparate() {
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
     }
 

--- a/java/test/jmri/jmrix/openlcb/swing/hub/HubPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/hub/HubPaneTest.java
@@ -25,6 +25,11 @@ public class HubPaneTest {
         //hub.initContext(memo);
     }
 
+    @BeforeAll
+    static public void checkSeparate() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/jmrix/openlcb/swing/networktree/CdiPanelDemo.java
+++ b/java/test/jmri/jmrix/openlcb/swing/networktree/CdiPanelDemo.java
@@ -105,6 +105,11 @@ public class CdiPanelDemo {
         return f;
     }
 
+    @BeforeAll
+    static public void checkSeparate() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    }
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/jmrix/openlcb/swing/networktree/CdiPanelDemo.java
+++ b/java/test/jmri/jmrix/openlcb/swing/networktree/CdiPanelDemo.java
@@ -107,6 +107,7 @@ public class CdiPanelDemo {
 
     @BeforeAll
     static public void checkSeparate() {
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
     }
 

--- a/java/test/jmri/jmrix/openlcb/swing/networktree/TreePaneDemo.java
+++ b/java/test/jmri/jmrix/openlcb/swing/networktree/TreePaneDemo.java
@@ -55,6 +55,11 @@ public class TreePaneDemo {
 
     MimicNodeStore store;
 
+    @BeforeAll
+    static public void checkSeparate() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+    }
+
     @BeforeEach
     public void setUp() {
         store = new MimicNodeStore(connection, nid1);

--- a/java/test/jmri/jmrix/openlcb/swing/networktree/TreePaneDemo.java
+++ b/java/test/jmri/jmrix/openlcb/swing/networktree/TreePaneDemo.java
@@ -57,6 +57,7 @@ public class TreePaneDemo {
 
     @BeforeAll
     static public void checkSeparate() {
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
     }
 

--- a/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPaneTest.java
@@ -18,18 +18,21 @@ public class OpenLcbCanSendPaneTest extends jmri.util.swing.JmriPanelTest {
     @Test
     @Override
     public void testInitComponents() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         // for now, just makes ure there isn't an exception.
         ((OpenLcbCanSendPane)panel).initComponents(memo);
     }
 
     @Test
     public void testInitContext() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         // for now, just makes ure there isn't an exception.
         panel.initContext(memo);
     }
 
     @Test
     public void testEventId() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         OpenLcbCanSendPane p = (OpenLcbCanSendPane) panel;
 
         p.sendEventField.setText("05 01 01 01 14 FF 01 02");
@@ -39,6 +42,7 @@ public class OpenLcbCanSendPaneTest extends jmri.util.swing.JmriPanelTest {
 
     @Test
     public void testEventIdDotted() {
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         OpenLcbCanSendPane p = (OpenLcbCanSendPane) panel;
 
         p.sendEventField.setText("05.01.01.01.14.FF.01.02");
@@ -51,6 +55,7 @@ public class OpenLcbCanSendPaneTest extends jmri.util.swing.JmriPanelTest {
     @Override
     public void setUp() {
         JUnitUtil.setUp();
+        org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         JUnitUtil.resetProfileManager();
         memo = new jmri.jmrix.can.CanSystemConnectionMemo();
         tc = new jmri.jmrix.can.TestTrafficController();
@@ -65,14 +70,15 @@ public class OpenLcbCanSendPaneTest extends jmri.util.swing.JmriPanelTest {
     @AfterEach
     @Override
     public void tearDown() {
-        memo.dispose();
-        memo = null;
-        tc.terminateThreads();
-        tc = null;
-        panel = null;
-        helpTarget = null;
-        title = null;
+        if (Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning") == false) {
+            memo.dispose();
+            memo = null;
+            tc.terminateThreads();
+            tc = null;
+            panel = null;
+            helpTarget = null;
+            title = null;
+        }
         JUnitUtil.tearDown();
-
     }
 }

--- a/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPaneTest.java
@@ -55,6 +55,7 @@ public class OpenLcbCanSendPaneTest extends jmri.util.swing.JmriPanelTest {
     @Override
     public void setUp() {
         JUnitUtil.setUp();
+       // this test is run separately because it leaves a lot of threads behind
         org.junit.Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         JUnitUtil.resetProfileManager();
         memo = new jmri.jmrix.can.CanSystemConnectionMemo();

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1516,10 +1516,6 @@ public class JUnitUtil {
                             action = "Found";
                             kill = false;
                         }
-                        if (name.toUpperCase().startsWith("OLCB") || name.toUpperCase().startsWith("OPENLCB")) { // ugly special case
-                            action = "Skipping";
-                            kill = false;
-                        }
 
                         // for anonymous threads, show the traceback in hopes of finding what it is
                         if (name.startsWith("Thread-")) {


### PR DESCRIPTION
See Issue #10490 for background.  

This moves only those test classes that leave behind threads, leaving the others to run as part of AllTest/HeadLessTest.