### PR TITLE
J11: improve test synch

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -934,7 +934,6 @@
             >
             <javac-options>
                 <compilerarg value="@${basedir}/java/ecj.warning.options-ci"/>
-                <compilerarg value="@${basedir}/java/ecj.warning.options-test"/>
                 <compilerarg value="@${basedir}/java/ecj.warning.options-test-ci"/>
             </javac-options>
         </ecj-compile>
@@ -951,6 +950,7 @@
             >
             <javac-options>
                 <compilerarg value="@${basedir}/java/ecj.warning.options-ci"/>
+                <compilerarg value="@${basedir}/java/ecj.warning.options-test-ci"/>
                 <compilerarg value="@${basedir}/java/ecj.warning.options-test"/>
             </javac-options>
         </ecj-compile>

--- a/java/ecj.warning.options
+++ b/java/ecj.warning.options
@@ -21,32 +21,3 @@
 #
 
 
-#
-# Checks we plan to eventually put in place, but would be burdensome now
-#
-
-  # 211 cases; the common "if (debugFlag)" metaphor is flagged by these
--err:-allDeadCode
--err:+deadCode
-
-  # missing synch in synchronized method override
-  # 24 outstanding items
--err:-syncOverride
-
-  # 1270 "Empty block should be documented"
--err:-emptyBlock
-
-  # 291 cases of "Potential Resource Leak: '<unassigned Closeable value>' may not be closed"
--err:-resource
-
-
-
-  # this tags some NetBeans and FindBugs tokens in @SuppressWarnings
-  # Until that's fixed, useful to run occasionally to find "Unnecessary" annotations
--warn:-warningToken
-  # occasionally turn off @SuppressWarnings to see if there are occurrences to fix
-  #   Currently 370 cases
--err:+suppress
-
-
-

--- a/java/ecj.warning.options-ci
+++ b/java/ecj.warning.options-ci
@@ -171,7 +171,7 @@
 # Checks we plan to eventually put in place, but would be burdensome now
 #
 
-  # missing synch in synchronized method override
+  # missing synch in synchronized method override (enforced in tests-warnings)
   # 24 outstanding items
 -err:-syncOverride
 

--- a/java/ecj.warning.options-ci
+++ b/java/ecj.warning.options-ci
@@ -79,6 +79,7 @@
 # Individual Checks
 #
 
+-err:-allDeadCode
 -err:+allDeprecation
 -err:+allOver-ann
 -err:+assertIdentifier
@@ -86,6 +87,7 @@
 -err:+conditionAssign
 -err:+constructorName
 -err:+compareIdentical
+-err:+deadCode
 -err:+dep-ann
 -err:+deprecation
 -err:+discouraged
@@ -115,6 +117,7 @@
 -err:+semicolon
 -err:+specialParamHiding
 -err:+switchDefault
+-err:+syncOverride
 -err:+unavoidableGenericProblems
 -err:+unchecked
 -err:+uselessTypeCheck
@@ -163,11 +166,10 @@
 
 #
 # Checks we plan to eventually put in place, but would be burdensome now
-#
 
-  # 211 cases; the common "if (debugFlag)" metaphor is flagged by these
--err:-allDeadCode
--err:+deadCode
+#
+# Checks we plan to eventually put in place, but would be burdensome now
+#
 
   # missing synch in synchronized method override
   # 24 outstanding items
@@ -187,6 +189,4 @@
   # occasionally turn off @SuppressWarnings to see if there are occurrences to fix
   #   Currently 370 cases
 -err:+suppress
-
-
 

--- a/java/ecj.warning.options-test
+++ b/java/ecj.warning.options-test
@@ -16,19 +16,3 @@
 #   http://help.eclipse.org/galileo/index.jsp?topic=/org.eclipse.jdt.doc.isv/guide/jdt_api_compile.htm
 #
 
-#
-# Case counts here are as of 12/15/2021
-#
-
-
-# Allowing 56 un-annotated deprecations
--err:-dep-ann
--err:-deprecation
--err:-allDeprecation
-
-# 178 missing @Override annotations
--err:-allOver-ann
--err:-over-ann
-
-# 200 generic raw types
--err:-raw

--- a/java/ecj.warning.options-test-ci
+++ b/java/ecj.warning.options-test-ci
@@ -20,15 +20,17 @@
 # Case counts here are as of 12/15/2021
 #
 
+# Allow 14 missing synch in synchronized method override
+-err:+syncOverride
 
-# Allowing 56 un-annotated deprecations
+# Allowing 55 un-annotated deprecations
 -err:-dep-ann
 -err:-deprecation
 -err:-allDeprecation
 
-# 178 missing @Override annotations
+# 176 missing @Override annotations
 -err:-allOver-ann
 -err:-over-ann
 
-# 200 generic raw types
+# 179 generic raw types
 -err:-raw

--- a/java/ecj.warning.options-test-ci
+++ b/java/ecj.warning.options-test-ci
@@ -20,8 +20,10 @@
 # Case counts here are as of 12/15/2021
 #
 
-# Allow 14 missing synch in synchronized method override
+# Enforce missing synch in synchronized method override
 -err:+syncOverride
+
+
 
 # Allowing 55 un-annotated deprecations
 -err:-dep-ann

--- a/java/test/jmri/jmrit/withrottle/MultiThrottleControllerTest.java
+++ b/java/test/jmri/jmrit/withrottle/MultiThrottleControllerTest.java
@@ -28,7 +28,7 @@ public class MultiThrottleControllerTest {
 
     @Test
     public void testSetShortAddress() {
-        // tests setting the address from the input.  
+        // tests setting the address from the input.
         // Does not include the prefix.
         Assert.assertTrue("Continue after address", controller.sort("S1"));
         Assert.assertTrue("Address Found", tcls.hasAddressBeenFound());
@@ -36,7 +36,7 @@ public class MultiThrottleControllerTest {
 
     @Test
     public void testSetLongAddress() {
-        // tests setting the address from the input.  
+        // tests setting the address from the input.
         // Does not include the prefix.
         Assert.assertTrue("Continue after address", controller.sort("L1234"));
         Assert.assertTrue("Address Found", tcls.hasAddressBeenFound());
@@ -82,7 +82,7 @@ public class MultiThrottleControllerTest {
     public void testSetFunction() {
         jmri.DccThrottle t = new jmri.jmrix.debugthrottle.DebugThrottle(new jmri.DccLocoAddress(1, false), null);
         // before notifying the throttle is found, set a function on
-        // which runs a couple of additional lines of code in 
+        // which runs a couple of additional lines of code in
         // sendAllFunctionStates.
         t.setF6(true);
         controller.notifyThrottleFound(t);
@@ -204,13 +204,13 @@ public class MultiThrottleControllerTest {
     public void testVelocityChangeSequence() {
         jmri.DccThrottle t = new jmri.jmrix.debugthrottle.DebugThrottle(new jmri.DccLocoAddress(1, false), null) {
             @Override
-            public void setSpeedSetting(float s) {
+            public synchronized void setSpeedSetting(float s) {
                 // override so we can send property changes in sequence.
             }
         };
         controller.notifyThrottleFound(t);
         cis.reset();
-        // withrottle may actually sends more than one speed change when 
+        // withrottle may actually sends more than one speed change when
         // moving the slider.
         Assert.assertTrue("Continue after velocity", controller.sort("V7"));
         Assert.assertTrue("Continue after velocity", controller.sort("V15"));

--- a/java/test/jmri/jmrix/can/AbstractCanTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/AbstractCanTrafficControllerTest.java
@@ -12,11 +12,11 @@ import org.junit.jupiter.api.*;
  * @author Paul Bender Copyright (C) 2016
  */
 public class AbstractCanTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficControllerTest {
-    
+
     @Override
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp(); 
+        jmri.util.JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
         tc = new AbstractCanTrafficController(){
            @Override
@@ -48,9 +48,9 @@ public class AbstractCanTrafficControllerTest extends jmri.jmrix.AbstractMRTraff
            @Override
            public void sendCanMessage(CanMessage m, CanListener l) {}
            @Override
-           public void addCanListener(CanListener l) {}
+           public synchronized void addCanListener(CanListener l) {}
            @Override
-           public void removeCanListener(CanListener l) {}
+           public synchronized void removeCanListener(CanListener l) {}
 
         };
     }
@@ -61,7 +61,7 @@ public class AbstractCanTrafficControllerTest extends jmri.jmrix.AbstractMRTraff
        tc = null;
         JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
- 
+
     }
 
 }

--- a/java/test/jmri/jmrix/can/TrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/TrafficControllerTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.*;
  * @author Paul Bender Copyright (C) 2016
  */
 public class TrafficControllerTest extends AbstractCanTrafficControllerTest {
-   
+
     @Test
     public void testGetCanid(){
         Assert.assertEquals("default canid value",120,((TrafficController)tc).getCanid());
@@ -24,11 +24,11 @@ public class TrafficControllerTest extends AbstractCanTrafficControllerTest {
         ((TrafficController)tc).setCanId(240);
         Assert.assertEquals("canid value after set",240,((TrafficController)tc).getCanid());
     }
- 
+
     @Override
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp(); 
+        jmri.util.JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
         tc = new TrafficController(){
            @Override
@@ -60,9 +60,9 @@ public class TrafficControllerTest extends AbstractCanTrafficControllerTest {
            @Override
            public void sendCanMessage(CanMessage m, CanListener l) {}
            @Override
-           public void addCanListener(CanListener l) {}
+           public synchronized void addCanListener(CanListener l) {}
            @Override
-           public void removeCanListener(CanListener l) {}
+           public synchronized void removeCanListener(CanListener l) {}
 
         };
     }
@@ -73,7 +73,7 @@ public class TrafficControllerTest extends AbstractCanTrafficControllerTest {
        tc = null;
         JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
- 
+
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/XNetInterfaceScaffold.java
+++ b/java/test/jmri/jmrix/lenz/XNetInterfaceScaffold.java
@@ -37,7 +37,7 @@ public class XNetInterfaceScaffold extends XNetTrafficController {
     }
 
     @Override
-    public void sendHighPriorityXNetMessage(XNetMessage m, XNetListener replyTo) {
+    public synchronized void sendHighPriorityXNetMessage(XNetMessage m, XNetListener replyTo) {
         log.debug("sendXNetMessage [{}]", m);
         // save a copy
         outbound.addElement(m);
@@ -83,7 +83,7 @@ public class XNetInterfaceScaffold extends XNetTrafficController {
     /**
      * This is normal, don't log at ERROR level
      */
-    @Override 
+    @Override
     protected void reportReceiveLoopException(Exception e) {
         log.debug("run: Exception: {} in {} (considered normal in testing)", e.toString(), this.getClass().toString(), e);
         jmri.jmrix.ConnectionStatus.instance().setConnectionState(controller.getUserName(), controller.getCurrentPortName(), jmri.jmrix.ConnectionStatus.CONNECTION_DOWN);

--- a/java/test/jmri/jmrix/loconet/LnDeferProgrammerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnDeferProgrammerTest.java
@@ -219,7 +219,7 @@ public class LnDeferProgrammerTest {
                 startedShortTimer = true;
             }
             @Override
-            protected void stopTimer() {
+            protected synchronized void stopTimer() {
                 super.stopTimer();
                 stoppedTimer = true;
             }

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -1348,7 +1348,7 @@ public class SlotManagerTest {
                 startedShortTimer = true;
             }
             @Override
-            protected void stopTimer() {
+            protected synchronized void stopTimer() {
                 super.stopTimer();
                 stoppedTimer = true;
             }

--- a/java/test/jmri/jmrix/pricom/pockettester/StatusFrameTest.java
+++ b/java/test/jmri/jmrix/pricom/pockettester/StatusFrameTest.java
@@ -30,7 +30,7 @@ public class StatusFrameTest {
         f.setSource(new DataSource() {
 
             @Override
-            void sendBytes(byte[] bytes) {
+            synchronized void sendBytes(byte[] bytes) {
             }
         });
         f.asciiFormattedMessage(TestConstants.version);
@@ -54,7 +54,7 @@ public class StatusFrameTest {
         f.setVisible(true);
         f.setSource(new DataSource() {
             @Override
-            void sendBytes(byte[] bytes) {
+            synchronized void sendBytes(byte[] bytes) {
             }
         });
         f.asciiFormattedMessage(TestConstants.version);

--- a/java/test/jmri/jmrix/rfid/generic/standalone/StandaloneReporterManagerTest.java
+++ b/java/test/jmri/jmrix/rfid/generic/standalone/StandaloneReporterManagerTest.java
@@ -34,17 +34,17 @@ public class StandaloneReporterManagerTest extends jmri.managers.AbstractReporte
             }
 
             @Override
-            public void reply(jmri.jmrix.rfid.RfidReply m) {
+            public synchronized void reply(jmri.jmrix.rfid.RfidReply m) {
             }
 
         };
     }
-    
+
     // No test for manager-specific system name validation at present
     @Test
     @Override
     public void testMakeSystemNameWithNoPrefixNotASystemName() {}
-    
+
     // No test for manager-specific system name validation at present
     @Test
     @Override

--- a/java/test/jmri/jmrix/rfid/merg/concentrator/ConcentratorReporterManagerTest.java
+++ b/java/test/jmri/jmrix/rfid/merg/concentrator/ConcentratorReporterManagerTest.java
@@ -40,12 +40,12 @@ public class ConcentratorReporterManagerTest extends jmri.managers.AbstractRepor
     @NotApplicable("Not supported by this manager at this time")
     public void testReporterProvideByNumber() {
     }
-    
+
     // No test for manager-specific system name validation at present
     @Test
     @Override
     public void testMakeSystemNameWithNoPrefixNotASystemName() {}
-    
+
     // No test for manager-specific system name validation at present
     @Test
     @Override
@@ -71,7 +71,7 @@ public class ConcentratorReporterManagerTest extends jmri.managers.AbstractRepor
             }
 
             @Override
-            public void reply(jmri.jmrix.rfid.RfidReply m) {
+            public synchronized void reply(jmri.jmrix.rfid.RfidReply m) {
             }
 
         };

--- a/java/test/jmri/jmrix/rfid/merg/concentrator/ConcentratorSensorManagerTest.java
+++ b/java/test/jmri/jmrix/rfid/merg/concentrator/ConcentratorSensorManagerTest.java
@@ -27,19 +27,19 @@ public class ConcentratorSensorManagerTest extends jmri.managers.AbstractSensorM
     public void testCtor() {
         Assert.assertNotNull(l);
     }
-    
+
     @Test
     public void testAlphaSystemName() {
         Sensor t = l.provide("RSA");
         Assert.assertNotNull(t);
     }
-    
+
     // test not applicable as minimal validation
     @Test
     @Override
     public void testMakeSystemNameWithNoPrefixNotASystemName() {
-    } 
-    
+    }
+
     // test not applicable as minimal validation
     @Test
     @Override
@@ -64,7 +64,7 @@ public class ConcentratorSensorManagerTest extends jmri.managers.AbstractSensorM
             }
 
             @Override
-            public void reply(jmri.jmrix.rfid.RfidReply m) {
+            public synchronized void reply(jmri.jmrix.rfid.RfidReply m) {
             }
 
         };

--- a/java/test/jmri/jmrix/xpa/XpaTrafficControlScaffold.java
+++ b/java/test/jmri/jmrix/xpa/XpaTrafficControlScaffold.java
@@ -31,7 +31,7 @@ public class XpaTrafficControlScaffold extends XpaTrafficController {
     public ArrayList<XpaMessage> outbound = new ArrayList<>();  // public OK here, so long as this is a test class
 
     @Override
-    public void sendXpaMessage(XpaMessage m, XpaListener reply) {
+    public synchronized void sendXpaMessage(XpaMessage m, XpaListener reply) {
         if (log.isDebugEnabled()) {
             log.debug("sendXpaMessage [{}]", m);
         }


### PR DESCRIPTION
Fix the "missing synch on overridden method" errors in java/tests. More ecj control file cleanup.