### PR TITLE
Refactor DefaultConditional.takeActionIfNeeded()

### DIFF
--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -1,40 +1,19 @@
 package jmri.implementation;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.Date;
 import java.util.List;
 
 import javax.annotation.Nonnull;
-import javax.script.ScriptException;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JPanel;
-import javax.swing.Timer;
+import javax.swing.*;
 
 import jmri.*;
-import jmri.jmrit.Sound;
-import jmri.jmrit.audio.AudioListener;
-import jmri.jmrit.audio.AudioSource;
-import jmri.jmrit.entryexit.DestinationPoints;
 import jmri.jmrit.logix.OBlock;
 import jmri.jmrit.logix.Warrant;
-import jmri.script.JmriScriptEngineManager;
-import jmri.script.ScriptOutput;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Class providing the basic logic of the Conditional interface.
@@ -49,12 +28,16 @@ public class DefaultConditional extends AbstractNamedBean
 
     static final java.util.ResourceBundle rbx = java.util.ResourceBundle.getBundle("jmri.jmrit.conditional.ConditionalBundle");  // NOI18N
 
+    private final DefaultConditionalExecute conditionalExecute;
+
     public DefaultConditional(String systemName, String userName) {
         super(systemName, userName);
+        conditionalExecute = new DefaultConditionalExecute(this);
     }
 
     public DefaultConditional(String systemName) {
         super(systemName);
+        conditionalExecute = new DefaultConditionalExecute(this);
     }
 
     @Override
@@ -550,19 +533,17 @@ public class DefaultConditional extends AbstractNamedBean
      * Only get here if a change in state has occurred when calculating this
      * Conditional
      */
-    @SuppressWarnings({"deprecation", "fallthrough"})
-    @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH")
-    // it's unfortunate that this is such a huge method, because these annotations
-    // have to apply to more than 500 lines of code - jake
+//    @SuppressWarnings({"deprecation", "fallthrough"})
+//    @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH")
+//    // it's unfortunate that this is such a huge method, because these annotations
+//    // have to apply to more than 500 lines of code - jake
     private void takeActionIfNeeded() {
         if (log.isTraceEnabled()) {
             log.trace("takeActionIfNeeded starts for {}", getSystemName());  // NOI18N
         }
-        int actionCount = 0;
+        Reference<Integer> actionCount = new Reference<>(0);
         int actionNeeded = 0;
-        int act = 0;
-        int state = 0;
-        ArrayList<String> errorList = new ArrayList<>();
+        List<String> errorList = new ArrayList<>();
         // Use a local copy of state to guarantee the entire list of actions will be fired off
         // before a state change occurs that may block their completion.
         int currentState = _currentState;
@@ -578,17 +559,10 @@ public class DefaultConditional extends AbstractNamedBean
                     || (option == ACTION_OPTION_ON_CHANGE)) {
                 // need to take this action
                 actionNeeded++;
-                SignalHead h = null;
-                SignalMast f = null;
-                Logix x = null;
-                Light lgt = null;
-                Warrant w = null;
                 NamedBean nb = null;
                 if (action.getNamedBean() != null) {
                     nb = action.getNamedBean().getBean();
                 }
-                int value = 0;
-                Timer timer = null;
                 Conditional.Action type = action.getType();
                 String devName = getDeviceName(action);
                 if (devName == null) {
@@ -602,633 +576,160 @@ public class DefaultConditional extends AbstractNamedBean
                     case NONE:
                         break;
                     case SET_TURNOUT:
-                        Turnout t = (Turnout) nb;
-                        if (t == null) {
-                            errorList.add("invalid turnout name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            act = action.getActionData();
-                            if (act == Route.TOGGLE) {
-                                state = t.getKnownState();
-                                if (state == Turnout.CLOSED) {
-                                    act = Turnout.THROWN;
-                                } else {
-                                    act = Turnout.CLOSED;
-                                }
-                            }
-                            t.setCommandedState(act);
-                            actionCount++;
-                        }
+                        conditionalExecute.setTurnout(action, (Turnout) nb, actionCount, errorList);
                         break;
                     case RESET_DELAYED_TURNOUT:
-                        action.stopTimer();
-                    // fall through
+                        conditionalExecute.delayedTurnout(action, actionCount, new TimeTurnout(i), true, devName);
+                        break;
                     case DELAYED_TURNOUT:
-                        if (!action.isTimerActive()) {
-                            // Create a timer if one does not exist
-                            timer = action.getTimer();
-                            if (timer == null) {
-                                action.setListener(new TimeTurnout(i));
-                                timer = new Timer(2000, action.getListener());
-                                timer.setRepeats(true);
-                            }
-                            // Start the Timer to set the turnout
-                            value = getMillisecondValue(action);
-                            if (value < 0) {
-                                break;
-                            }
-                            timer.setInitialDelay(value);
-                            action.setTimer(timer);
-                            action.startTimer();
-                            actionCount++;
-                        } else {
-                            log.warn("timer already active on request to start delayed turnout action - {}", devName);
-                        }
+                        conditionalExecute.delayedTurnout(action, actionCount, new TimeTurnout(i), false, devName);
                         break;
                     case CANCEL_TURNOUT_TIMERS:
-                        ConditionalManager cmg = jmri.InstanceManager.getDefault(jmri.ConditionalManager.class);
-                        java.util.Iterator<Conditional> iter = cmg.getNamedBeanSet().iterator();
-                        while (iter.hasNext()) {
-                            String sname = iter.next().getSystemName();
-                            
-                            Conditional c = cmg.getBySystemName(sname);
-                            if (c == null) {
-                                errorList.add("Conditional null during cancel turnout timers for "  // NOI18N
-                                        + action.getDeviceName());
-                                continue; // no more processing of this one
-                            }
-                            
-                            c.cancelTurnoutTimer(devName);
-                            actionCount++;
-                        }
+                        conditionalExecute.cancelTurnoutTimers(action, actionCount, errorList, devName);
                         break;
                     case LOCK_TURNOUT:
-                        Turnout tl = (Turnout) nb;
-                        if (tl == null) {
-                            errorList.add("invalid turnout name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            act = action.getActionData();
-                            if (act == Route.TOGGLE) {
-                                if (tl.getLocked(Turnout.CABLOCKOUT)) {
-                                    act = Turnout.UNLOCKED;
-                                } else {
-                                    act = Turnout.LOCKED;
-                                }
-                            }
-                            if (act == Turnout.LOCKED) {
-                                tl.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, true);
-                            } else if (act == Turnout.UNLOCKED) {
-                                tl.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, false);
-                            }
-                            actionCount++;
-                        }
+                        conditionalExecute.lockTurnout(action, (Turnout) nb, actionCount, errorList);
                         break;
                     case SET_SIGNAL_APPEARANCE:
-                        h = (SignalHead) nb;
-                        if (h == null) {
-                            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            h.setAppearance(action.getActionData());
-                            actionCount++;
-                        }
+                        conditionalExecute.setSignalAppearance(action, (SignalHead) nb, actionCount, errorList);
                         break;
                     case SET_SIGNAL_HELD:
-                        h = (SignalHead) nb;
-                        if (h == null) {
-                            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            h.setHeld(true);
-                            actionCount++;
-                        }
+                        conditionalExecute.setSignalHeld(action, (SignalHead) nb, actionCount, errorList);
                         break;
                     case CLEAR_SIGNAL_HELD:
-                        h = (SignalHead) nb;
-                        if (h == null) {
-                            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            h.setHeld(false);
-                            actionCount++;
-                        }
+                        conditionalExecute.clearSignalHeld(action, (SignalHead) nb, actionCount, errorList);
                         break;
                     case SET_SIGNAL_DARK:
-                        h = (SignalHead) nb;
-                        if (h == null) {
-                            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            h.setLit(false);
-                            actionCount++;
-                        }
+                        conditionalExecute.setSignalDark(action, (SignalHead) nb, actionCount, errorList);
                         break;
                     case SET_SIGNAL_LIT:
-                        h = (SignalHead) nb;
-                        if (h == null) {
-                            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            h.setLit(true);
-                            actionCount++;
-                        }
+                        conditionalExecute.setSignalLit(action, (SignalHead) nb, actionCount, errorList);
                         break;
                     case TRIGGER_ROUTE:
-                        Route r = (Route) nb;
-                        if (r == null) {
-                            errorList.add("invalid Route name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            r.setRoute();
-                            actionCount++;
-                        }
+                        conditionalExecute.triggerRoute(action, (Route) nb, actionCount, errorList);
                         break;
                     case SET_SENSOR:
-                        Sensor sn = (Sensor) nb;
-                        if (sn == null) {
-                            errorList.add("invalid Sensor name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            act = action.getActionData();
-                            if (act == Route.TOGGLE) {
-                                state = sn.getState();
-                                if (state == Sensor.ACTIVE) {
-                                    act = Sensor.INACTIVE;
-                                } else {
-                                    act = Sensor.ACTIVE;
-                                }
-                            }
-                            try {
-                                sn.setKnownState(act);
-                                actionCount++;
-                            } catch (JmriException e) {
-                                log.warn("Exception setting Sensor {} in action", devName);  // NOI18N
-                            }
-                        }
+                        conditionalExecute.setSensor(action, (Sensor) nb, actionCount, errorList, devName);
                         break;
                     case RESET_DELAYED_SENSOR:
-                        action.stopTimer();
-                    // fall through
+                        conditionalExecute.delayedSensor(action, actionCount, new TimeSensor(i), getMillisecondValue(action), true, devName);
+                        break;
                     case DELAYED_SENSOR:
-                        if (!action.isTimerActive()) {
-                            // Create a timer if one does not exist
-                            timer = action.getTimer();
-                            if (timer == null) {
-                                action.setListener(new TimeSensor(i));
-                                timer = new Timer(2000, action.getListener());
-                                timer.setRepeats(true);
-                            }
-                            // Start the Timer to set the turnout
-                            value = getMillisecondValue(action);
-                            if (value < 0) {
-                                break;
-                            }
-                            timer.setInitialDelay(value);
-                            action.setTimer(timer);
-                            action.startTimer();
-                            actionCount++;
-                        } else {
-                            log.warn("timer already active on request to start delayed sensor action - {}", devName);
-                        }
+                        conditionalExecute.delayedSensor(action, actionCount, new TimeSensor(i), getMillisecondValue(action), false, devName);
                         break;
                     case CANCEL_SENSOR_TIMERS:
-                        ConditionalManager cm = jmri.InstanceManager.getDefault(jmri.ConditionalManager.class);
-                        java.util.Iterator<Conditional> itr = cm.getNamedBeanSet().iterator();
-                        while (itr.hasNext()) {
-                            String sname = itr.next().getSystemName();
-                            Conditional c = cm.getBySystemName(sname);
-                            if (c == null) {
-                                errorList.add("Conditional null during cancel sensor timers for "  // NOI18N
-                                        + action.getDeviceName());
-                                continue; // no more processing of this one
-                            }
-                            
-                            c.cancelSensorTimer(devName);
-                            actionCount++;
-                        }
+                        conditionalExecute.cancelSensorTimers(action, actionCount, errorList, devName);
                         break;
                     case SET_LIGHT:
-                        lgt = (Light) nb;
-                        if (lgt == null) {
-                            errorList.add("invalid light name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            act = action.getActionData();
-                            if (act == Route.TOGGLE) {
-                                state = lgt.getState();
-                                if (state == Light.ON) {
-                                    act = Light.OFF;
-                                } else {
-                                    act = Light.ON;
-                                }
-                            }
-                            lgt.setState(act);
-                            actionCount++;
-                        }
+                        conditionalExecute.setLight(action, (Light) nb, actionCount, errorList);
                         break;
                     case SET_LIGHT_INTENSITY:
-                        lgt = (Light) nb;
-                        if (lgt == null) {
-                            errorList.add("invalid light name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            try {
-                                value = getIntegerValue(action);
-                                if (value < 0) {
-                                    break;
-                                }
-                                if (lgt instanceof VariableLight) {
-                                    ((VariableLight)lgt).setTargetIntensity((value) / 100.0);
-                                } else {
-                                    lgt.setState(value > 0.5 ? Light.ON : Light.OFF);
-                                }
-                                actionCount++;
-                            } catch (IllegalArgumentException e) {
-                                errorList.add("Exception in set light intensity action - " + action.getDeviceName());  // NOI18N
-                            }
-                        }
+                        conditionalExecute.setLightIntensity(action, (Light) nb, getIntegerValue(action), actionCount, errorList);
                         break;
                     case SET_LIGHT_TRANSITION_TIME:
-                        lgt = (Light) nb;
-                        if (lgt == null) {
-                            errorList.add("invalid light name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            try {
-                                value = getIntegerValue(action);
-                                if (value < 0) {
-                                    break;
-                                }
-                                if (lgt instanceof VariableLight) {
-                                    ((VariableLight)lgt).setTransitionTime(value);
-                                }
-                                actionCount++;
-                            } catch (IllegalArgumentException e) {
-                                errorList.add("Exception in set light transition time action - " + action.getDeviceName());  // NOI18N
-                            }
-                        }
+                        conditionalExecute.setLightTransitionTime(action, (Light) nb, getIntegerValue(action), actionCount, errorList);
                         break;
                     case SET_MEMORY:
-                        Memory m = (Memory) nb;
-                        if (m == null) {
-                            errorList.add("invalid memory name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            m.setValue(action.getActionString());
-                            actionCount++;
-                        }
+                        conditionalExecute.setMemory(action, (Memory) nb, actionCount, errorList);
                         break;
                     case COPY_MEMORY:
-                        Memory mFrom = (Memory) nb;
-                        if (mFrom == null) {
-                            errorList.add("invalid memory name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            Memory mTo = getMemory(action.getActionString());
-                            if (mTo == null) {
-                                errorList.add("invalid memory name in action - " + action.getActionString());  // NOI18N
-                            } else {
-                                mTo.setValue(mFrom.getValue());
-                                actionCount++;
-                            }
-                        }
+                        conditionalExecute.copyMemory(action, (Memory) nb, getMemory(action.getActionString()), getActionString(action), actionCount, errorList);
                         break;
                     case ENABLE_LOGIX:
-                        x = InstanceManager.getDefault(jmri.LogixManager.class).getLogix(devName);
-                        if (x == null) {
-                            errorList.add("invalid logix name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            x.setEnabled(true);
-                            actionCount++;
-                        }
+                        conditionalExecute.enableLogix(action, actionCount, errorList, devName);
                         break;
                     case DISABLE_LOGIX:
-                        x = InstanceManager.getDefault(jmri.LogixManager.class).getLogix(devName);
-                        if (x == null) {
-                            errorList.add("invalid logix name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            x.setEnabled(false);
-                            actionCount++;
-                        }
+                        conditionalExecute.disableLogix(action, actionCount, errorList, devName);
                         break;
                     case PLAY_SOUND:
-                        String path = getActionString(action);
-                        if (!path.equals("")) {
-                            Sound sound = action.getSound();
-                            if (sound == null) {
-                                try {
-                                    sound = new Sound(path);
-                                } catch (NullPointerException ex) {
-                                    errorList.add("invalid path to sound: " + path);  // NOI18N
-                                }
-                            }
-                            if (sound != null) {
-                                sound.play();
-                            }
-                            actionCount++;
-                        }
+                        conditionalExecute.playSound(action, getActionString(action), actionCount, errorList);
                         break;
                     case RUN_SCRIPT:
-                        if (!(getActionString(action).equals(""))) {
-                            JmriScriptEngineManager.getDefault().runScript(new File(jmri.util.FileUtil.getExternalFilename(getActionString(action))));
-                            actionCount++;
-                        }
+                        conditionalExecute.runScript(action, getActionString(action), actionCount);
                         break;
                     case SET_FAST_CLOCK_TIME:
-                        Date date = InstanceManager.getDefault(jmri.Timebase.class).getTime();
-                        date.setHours(action.getActionData() / 60);
-                        date.setMinutes(action.getActionData() - ((action.getActionData() / 60) * 60));
-                        date.setSeconds(0);
-                        InstanceManager.getDefault(jmri.Timebase.class).userSetTime(date);
-                        actionCount++;
+                        conditionalExecute.setFastClockTime(action, actionCount);
                         break;
                     case START_FAST_CLOCK:
-                        InstanceManager.getDefault(jmri.Timebase.class).setRun(true);
-                        actionCount++;
+                        conditionalExecute.startFastClock(actionCount);
                         break;
                     case STOP_FAST_CLOCK:
-                        InstanceManager.getDefault(jmri.Timebase.class).setRun(false);
-                        actionCount++;
+                        conditionalExecute.stopFastClock(actionCount);
                         break;
                     case CONTROL_AUDIO:
-                        Audio audio = InstanceManager.getDefault(jmri.AudioManager.class).getAudio(devName);
-                        if (audio == null) {
-                            break;
-                        }
-                        if (audio.getSubType() == Audio.SOURCE) {
-                            AudioSource audioSource = (AudioSource) audio;
-                            switch (action.getActionData()) {
-                                case Audio.CMD_PLAY:
-                                    audioSource.play();
-                                    break;
-                                case Audio.CMD_STOP:
-                                    audioSource.stop();
-                                    break;
-                                case Audio.CMD_PLAY_TOGGLE:
-                                    audioSource.togglePlay();
-                                    break;
-                                case Audio.CMD_PAUSE:
-                                    audioSource.pause();
-                                    break;
-                                case Audio.CMD_RESUME:
-                                    audioSource.resume();
-                                    break;
-                                case Audio.CMD_PAUSE_TOGGLE:
-                                    audioSource.togglePause();
-                                    break;
-                                case Audio.CMD_REWIND:
-                                    audioSource.rewind();
-                                    break;
-                                case Audio.CMD_FADE_IN:
-                                    audioSource.fadeIn();
-                                    break;
-                                case Audio.CMD_FADE_OUT:
-                                    audioSource.fadeOut();
-                                    break;
-                                case Audio.CMD_RESET_POSITION:
-                                    audioSource.resetCurrentPosition();
-                                    break;
-                                default:
-                                    break;
-                            }
-                        } else if (audio.getSubType() == Audio.LISTENER) {
-                            AudioListener audioListener = (AudioListener) audio;
-                            switch (action.getActionData()) {
-                                case Audio.CMD_RESET_POSITION:
-                                    audioListener.resetCurrentPosition();
-                                    break;
-                                default:
-                                    break; // nothing needed for others
-                            }
-                        }
+                        conditionalExecute.controlAudio(action, devName);
                         break;
                     case JYTHON_COMMAND:
-                        if (!(getActionString(action).isEmpty())) {
-                            // add the text to the output frame
-                            ScriptOutput.writeScript(getActionString(action));
-                            // and execute
-                            
-                            javax.script.ScriptEngine se =  JmriScriptEngineManager.getDefault().getEngine(JmriScriptEngineManager.PYTHON);
-                            if (se!=null) {
-                                try {
-                                    JmriScriptEngineManager.getDefault().eval(getActionString(action), se);
-                                } catch (ScriptException ex) {
-                                    log.error("Error executing script:", ex);  // NOI18N
-                                }
-                            } else {
-                                log.error("Error getting default ScriptEngine");
-                            }
-                            actionCount++;
-                        }
+                        conditionalExecute.jythonCommand(action, getActionString(action), actionCount);
                         break;
                     case ALLOCATE_WARRANT_ROUTE:
-                        w = (Warrant) nb;
-                        if (w == null) {
-                            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            String msg = w.allocateRoute(false, null);
-                            if (msg != null) {
-                                log.info("Warrant {} - {}", action.getDeviceName(), msg);  // NOI18N
-                            }
-                            actionCount++;
-                        }
+                        conditionalExecute.allocateWarrantRoute(action, (Warrant) nb, actionCount, errorList);
                         break;
                     case DEALLOCATE_WARRANT_ROUTE:
-                        w = (Warrant) nb;
-                        if (w == null) {
-                            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            w.deAllocate();
-                            actionCount++;
-                        }
+                        conditionalExecute.deallocateWarrantRoute(action, (Warrant) nb, actionCount, errorList);
                         break;
                     case SET_ROUTE_TURNOUTS:
-                        w = (Warrant) nb;
-                        if (w == null) {
-                            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            String msg = w.setRoute(false, null);
-                            if (msg != null) {
-                                log.info("Warrant {} unable to Set Route - {}", action.getDeviceName(), msg);  // NOI18N
-                            }
-                            actionCount++;
-                        }
+                        conditionalExecute.setRouteTurnouts(action, (Warrant) nb, actionCount, errorList);
                         break;
                     case THROTTLE_FACTOR:
                         log.info("Set warrant Throttle Factor deprecated - Use Warrrant Preferences");  // NOI18N
                         break;
                     case SET_TRAIN_ID:
-                        w = (Warrant) nb;
-                        if (w == null) {
-                            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            if(!w.getSpeedUtil().setAddress(getActionString(action))) {
-                                errorList.add("invalid train ID in action - " + action.getDeviceName());  // NOI18N
-                            }
-                            actionCount++;
-                        }
+                        conditionalExecute.setTrainId(action, (Warrant) nb, getActionString(action), actionCount, errorList);
                         break;
                     case SET_TRAIN_NAME:
-                        w = (Warrant) nb;
-                        if (w == null) {
-                            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            w.setTrainName(getActionString(action));
-                            actionCount++;
-                        }
+                        conditionalExecute.setTrainName(action, (Warrant) nb, getActionString(action), actionCount, errorList);
                         break;
                     case AUTO_RUN_WARRANT:
-                        w = (Warrant) nb;
-                        if (w == null) {
-                            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            jmri.jmrit.logix.WarrantTableFrame frame = jmri.jmrit.logix.WarrantTableFrame.getDefault();
-                            String err = frame.runTrain(w, Warrant.MODE_RUN);
-                            if (err != null) {
-                                errorList.add("runAutoTrain error - " + err);  // NOI18N
-                                w.stopWarrant(true, true);
-                            }
-                            actionCount++;
-                        }
+                        conditionalExecute.autoRunWarrant(action, (Warrant) nb, actionCount, errorList);
                         break;
                     case MANUAL_RUN_WARRANT:
-                        w = (Warrant) nb;
-                        if (w == null) {
-                            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            String err = w.setRoute(false, null);
-                            if (err == null) {
-                                err = w.setRunMode(Warrant.MODE_MANUAL, null, null, null, false);
-                            }
-                            if (err != null) {
-                                errorList.add("runManualTrain error - " + err);  // NOI18N
-                            }
-                            actionCount++;
-                        }
+                        conditionalExecute.manualRunWarrant(action, (Warrant) nb, actionCount, errorList);
                         break;
                     case CONTROL_TRAIN:
-                        w = (Warrant) nb;
-                        if (w == null) {
-                            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            if (!w.controlRunTrain(action.getActionData())) {
-                                log.info("Train {} not running  - {}", w.getSpeedUtil().getRosterId(), devName);  // NOI18N
-                            }
-                            actionCount++;
-                        }
+                        conditionalExecute.controlTrain(action, (Warrant) nb, actionCount, errorList, devName);
                         break;
                     case SET_SIGNALMAST_ASPECT:
-                        f = (SignalMast) nb;
-                        if (f == null) {
-                            errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            f.setAspect(getActionString(action));
-                            actionCount++;
-                        }
+                        conditionalExecute.setSignalMastAspect(action, (SignalMast) nb, getActionString(action), actionCount, errorList);
                         break;
                     case SET_SIGNALMAST_HELD:
-                        f = (SignalMast) nb;
-                        if (f == null) {
-                            errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            f.setHeld(true);
-                            actionCount++;
-                        }
+                        conditionalExecute.setSignalMastHeld(action, (SignalMast) nb, actionCount, errorList);
                         break;
                     case CLEAR_SIGNALMAST_HELD:
-                        f = (SignalMast) nb;
-                        if (f == null) {
-                            errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            f.setHeld(false);
-                            actionCount++;
-                        }
+                        conditionalExecute.clearSignalMastHeld(action, (SignalMast) nb, actionCount, errorList);
                         break;
                     case SET_SIGNALMAST_DARK:
-                        f = (SignalMast) nb;
-                        if (f == null) {
-                            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            f.setLit(false);
-                            actionCount++;
-                        }
+                        conditionalExecute.setSignalMastDark(action, (SignalMast) nb, actionCount, errorList);
                         break;
                     case SET_SIGNALMAST_LIT:
-                        f = (SignalMast) nb;
-                        if (f == null) {
-                            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            f.setLit(true);
-                            actionCount++;
-                        }
+                        conditionalExecute.setSignalMastLit(action, (SignalMast) nb, actionCount, errorList);
                         break;
                     case SET_BLOCK_VALUE:
-                        OBlock b = (OBlock) nb;
-                        if (b == null) {
-                            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            b.setValue(getActionString(action));
-                            actionCount++;
-                        }
+                        conditionalExecute.setBlockValue(action, (OBlock) nb, getActionString(action), actionCount, errorList);
                         break;
                     case SET_BLOCK_ERROR:
-                        b = (OBlock) nb;
-                        if (b == null) {
-                            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            b.setError(true);
-                            actionCount++;
-                        }
+                        conditionalExecute.setBlockError(action, (OBlock) nb, actionCount, errorList);
                         break;
                     case CLEAR_BLOCK_ERROR:
-                        b = (OBlock) nb;
-                        if (b == null) {
-                            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            b.setError(false);
-                        }
+                        conditionalExecute.clearBlockValue(action, (OBlock) nb, errorList);
                         break;
                     case DEALLOCATE_BLOCK:
-                        b = (OBlock) nb;
-                        if (b == null) {
-                            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            b.deAllocate(null);
-                            actionCount++;
-                        }
+                        conditionalExecute.deallocateBlock(action, (OBlock) nb, actionCount, errorList);
                         break;
                     case SET_BLOCK_OUT_OF_SERVICE:
-                        b = (OBlock) nb;
-                        if (b == null) {
-                            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            b.setOutOfService(true);
-                            actionCount++;
-                        }
+                        conditionalExecute.setBlockOutOfService(action, (OBlock) nb, actionCount, errorList);
                         break;
                     case SET_BLOCK_IN_SERVICE:
-                        b = (OBlock) nb;
-                        if (b == null) {
-                            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            b.setOutOfService(false);
-                            actionCount++;
-                        }
+                        conditionalExecute.setBlockInService(action, (OBlock) nb, actionCount, errorList);
                         break;
                     case SET_NXPAIR_ENABLED:
-                        DestinationPoints dp = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(devName);
-                        if (dp == null) {
-                            errorList.add("Invalid NX Pair name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            dp.setEnabled(true);
-                            actionCount++;
-                        }
+                        conditionalExecute.setNXPairEnabled(action, actionCount, errorList, devName);
                         break;
                     case SET_NXPAIR_DISABLED:
-                        dp = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(devName);
-                        if (dp == null) {
-                            errorList.add("Invalid NX Pair name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            dp.setEnabled(false);
-                            actionCount++;
-                        }
+                        conditionalExecute.setNXPairDisabled(action, actionCount, errorList, devName);
                         break;
                     case SET_NXPAIR_SEGMENT:
-                        dp = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(devName);
-                        if (dp == null) {
-                            errorList.add("Invalid NX Pair name in action - " + action.getDeviceName());  // NOI18N
-                        } else {
-                            jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
-                                    setSingleSegmentRoute(devName);
-                            actionCount++;
-                        }
+                        conditionalExecute.setNXPairSegment(action, actionCount, errorList, devName);
                         break;
                     default:
                         log.warn("takeActionIfNeeded drops through switch statement for action {} of {}", i, getSystemName());  // NOI18N
@@ -1576,5 +1077,5 @@ public class DefaultConditional extends AbstractNamedBean
         }
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DefaultConditional.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultConditional.class);
 }

--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -533,10 +533,6 @@ public class DefaultConditional extends AbstractNamedBean
      * Only get here if a change in state has occurred when calculating this
      * Conditional
      */
-//    @SuppressWarnings({"deprecation", "fallthrough"})
-//    @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH")
-//    // it's unfortunate that this is such a huge method, because these annotations
-//    // have to apply to more than 500 lines of code - jake
     private void takeActionIfNeeded() {
         if (log.isTraceEnabled()) {
             log.trace("takeActionIfNeeded starts for {}", getSystemName());  // NOI18N

--- a/java/src/jmri/implementation/DefaultConditionalExecute.java
+++ b/java/src/jmri/implementation/DefaultConditionalExecute.java
@@ -1,0 +1,671 @@
+package jmri.implementation;
+
+import java.io.File;
+import java.util.Date;
+import java.util.List;
+
+import javax.script.ScriptException;
+import javax.swing.Timer;
+
+import jmri.*;
+import jmri.implementation.DefaultConditional.TimeSensor;
+import jmri.implementation.DefaultConditional.TimeTurnout;
+import jmri.jmrit.Sound;
+import jmri.jmrit.audio.AudioListener;
+import jmri.jmrit.audio.AudioSource;
+import jmri.jmrit.entryexit.DestinationPoints;
+import jmri.jmrit.logix.OBlock;
+import jmri.jmrit.logix.Warrant;
+import jmri.script.JmriScriptEngineManager;
+import jmri.script.ScriptOutput;
+
+/**
+ * Helper class for DefaultConditional that executes the  actions of a
+ * DefaultConditional.
+ * @author Daniel Bergqvist (C) 2021
+ */
+public class DefaultConditionalExecute {
+
+    private final DefaultConditional conditional;
+
+    DefaultConditionalExecute(DefaultConditional conditional) {
+        this.conditional = conditional;
+    }
+
+    void setTurnout(ConditionalAction action, Turnout t, Reference<Integer> actionCount, List<String> errorList) {
+        if (t == null) {
+            errorList.add("invalid turnout name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            int act = action.getActionData();
+            if (act == Route.TOGGLE) {
+                int state = t.getKnownState();
+                if (state == Turnout.CLOSED) {
+                    act = Turnout.THROWN;
+                } else {
+                    act = Turnout.CLOSED;
+                }
+            }
+            t.setCommandedState(act);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+    
+    void delayedTurnout(ConditionalAction action, Reference<Integer> actionCount, TimeTurnout timeTurnout, boolean reset, String devName) {
+        if (reset) action.stopTimer();
+        if (!action.isTimerActive()) {
+            // Create a timer if one does not exist
+            Timer timer = action.getTimer();
+            if (timer == null) {
+                action.setListener(timeTurnout);
+                timer = new Timer(2000, action.getListener());
+                timer.setRepeats(true);
+            }
+            // Start the Timer to set the turnout
+            int value = conditional.getMillisecondValue(action);
+            if (value < 0) {
+                return;
+            }
+            timer.setInitialDelay(value);
+            action.setTimer(timer);
+            action.startTimer();
+            actionCount.set(actionCount.get() + 1);
+        } else {
+            log.warn("timer already active on request to start delayed turnout action - {}", devName);
+        }
+    }
+    
+    void cancelTurnoutTimers(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+        ConditionalManager cmg = jmri.InstanceManager.getDefault(jmri.ConditionalManager.class);
+        java.util.Iterator<Conditional> iter = cmg.getNamedBeanSet().iterator();
+        while (iter.hasNext()) {
+            String sname = iter.next().getSystemName();
+
+            Conditional c = cmg.getBySystemName(sname);
+            if (c == null) {
+                errorList.add("Conditional null during cancel turnout timers for "  // NOI18N
+                        + action.getDeviceName());
+                continue; // no more processing of this one
+            }
+
+            c.cancelTurnoutTimer(devName);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+    
+    void lockTurnout(ConditionalAction action, Turnout tl, Reference<Integer> actionCount, List<String> errorList) {
+        if (tl == null) {
+            errorList.add("invalid turnout name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            int act = action.getActionData();
+            if (act == Route.TOGGLE) {
+                if (tl.getLocked(Turnout.CABLOCKOUT)) {
+                    act = Turnout.UNLOCKED;
+                } else {
+                    act = Turnout.LOCKED;
+                }
+            }
+            if (act == Turnout.LOCKED) {
+                tl.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, true);
+            } else if (act == Turnout.UNLOCKED) {
+                tl.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, false);
+            }
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+    
+    void setSignalAppearance(ConditionalAction action, SignalHead h, Reference<Integer> actionCount, List<String> errorList) {
+        if (h == null) {
+            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            h.setAppearance(action.getActionData());
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setSignalHeld(ConditionalAction action, SignalHead h, Reference<Integer> actionCount, List<String> errorList) {
+        if (h == null) {
+            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            h.setHeld(true);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void clearSignalHeld(ConditionalAction action, SignalHead h, Reference<Integer> actionCount, List<String> errorList) {
+        if (h == null) {
+            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            h.setHeld(false);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setSignalDark(ConditionalAction action, SignalHead h, Reference<Integer> actionCount, List<String> errorList) {
+        if (h == null) {
+            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            h.setLit(false);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setSignalLit(ConditionalAction action, SignalHead h, Reference<Integer> actionCount, List<String> errorList) {
+        if (h == null) {
+            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            h.setLit(true);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void triggerRoute(ConditionalAction action, Route r, Reference<Integer> actionCount, List<String> errorList) {
+        if (r == null) {
+            errorList.add("invalid Route name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            r.setRoute();
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setSensor(ConditionalAction action, Sensor sn, Reference<Integer> actionCount, List<String> errorList, String devName) {
+        if (sn == null) {
+            errorList.add("invalid Sensor name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            int act = action.getActionData();
+            if (act == Route.TOGGLE) {
+                int state = sn.getState();
+                if (state == Sensor.ACTIVE) {
+                    act = Sensor.INACTIVE;
+                } else {
+                    act = Sensor.ACTIVE;
+                }
+            }
+            try {
+                sn.setKnownState(act);
+                actionCount.set(actionCount.get() + 1);
+            } catch (JmriException e) {
+                log.warn("Exception setting Sensor {} in action", devName);  // NOI18N
+            }
+        }
+    }
+
+    void delayedSensor(ConditionalAction action, Reference<Integer> actionCount, TimeSensor timeSensor, int delay, boolean reset, String devName) {
+        if (reset) action.stopTimer();
+        if (!action.isTimerActive()) {
+            // Create a timer if one does not exist
+            Timer timer = action.getTimer();
+            if (timer == null) {
+                action.setListener(timeSensor);
+                timer = new Timer(2000, action.getListener());
+                timer.setRepeats(true);
+            }
+            // Start the Timer to set the sensor
+            if (delay < 0) {
+                return;
+            }
+            timer.setInitialDelay(delay);
+            action.setTimer(timer);
+            action.startTimer();
+            actionCount.set(actionCount.get() + 1);
+        } else {
+            log.warn("timer already active on request to start delayed sensor action - {}", devName);
+        }
+    }
+
+    void cancelSensorTimers(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+        ConditionalManager cm = jmri.InstanceManager.getDefault(jmri.ConditionalManager.class);
+        java.util.Iterator<Conditional> itr = cm.getNamedBeanSet().iterator();
+        while (itr.hasNext()) {
+            String sname = itr.next().getSystemName();
+            Conditional c = cm.getBySystemName(sname);
+            if (c == null) {
+                errorList.add("Conditional null during cancel sensor timers for "  // NOI18N
+                        + action.getDeviceName());
+                continue; // no more processing of this one
+            }
+
+            c.cancelSensorTimer(devName);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setLight(ConditionalAction action, Light lgt, Reference<Integer> actionCount, List<String> errorList) {
+        if (lgt == null) {
+            errorList.add("invalid light name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            int act = action.getActionData();
+            if (act == Route.TOGGLE) {
+                int state = lgt.getState();
+                if (state == Light.ON) {
+                    act = Light.OFF;
+                } else {
+                    act = Light.ON;
+                }
+            }
+            lgt.setState(act);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setLightIntensity(ConditionalAction action, Light lgt, int intensity, Reference<Integer> actionCount, List<String> errorList) {
+        if (lgt == null) {
+            errorList.add("invalid light name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            try {
+                if (intensity < 0) {
+                    return;
+                }
+                if (lgt instanceof VariableLight) {
+                    ((VariableLight)lgt).setTargetIntensity((intensity) / 100.0);
+                } else {
+                    lgt.setState(intensity > 0.5 ? Light.ON : Light.OFF);
+                }
+                actionCount.set(actionCount.get() + 1);
+            } catch (IllegalArgumentException e) {
+                errorList.add("Exception in set light intensity action - " + action.getDeviceName());  // NOI18N
+            }
+        }
+    }
+
+    void setLightTransitionTime(ConditionalAction action, Light lgt, int time, Reference<Integer> actionCount, List<String> errorList) {
+        if (lgt == null) {
+            errorList.add("invalid light name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            try {
+                if (time  < 0) {
+                    return;
+                }
+                if (lgt instanceof VariableLight) {
+                    ((VariableLight)lgt).setTransitionTime(time );
+                }
+                actionCount.set(actionCount.get() + 1);
+            } catch (IllegalArgumentException e) {
+                errorList.add("Exception in set light transition time action - " + action.getDeviceName());  // NOI18N
+            }
+        }
+    }
+
+    void setMemory(ConditionalAction action, Memory m, Reference<Integer> actionCount, List<String> errorList) {
+        if (m == null) {
+            errorList.add("invalid memory name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            m.setValue(action.getActionString());
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void copyMemory(ConditionalAction action, Memory mFrom, Memory mTo, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+        if (mFrom == null) {
+            errorList.add("invalid memory name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            if (mTo == null) {
+                errorList.add("invalid memory name in action - " + action.getActionString());  // NOI18N
+            } else {
+                mTo.setValue(mFrom.getValue());
+                actionCount.set(actionCount.get() + 1);
+            }
+        }
+    }
+
+    void enableLogix(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+        Logix x = InstanceManager.getDefault(jmri.LogixManager.class).getLogix(devName);
+        if (x == null) {
+            errorList.add("invalid logix name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            x.setEnabled(true);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void disableLogix(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+        Logix x = InstanceManager.getDefault(jmri.LogixManager.class).getLogix(devName);
+        if (x == null) {
+            errorList.add("invalid logix name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            x.setEnabled(false);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void playSound(ConditionalAction action, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+        String path = actionStr;
+        if (!path.equals("")) {
+            Sound sound = action.getSound();
+            if (sound == null) {
+                try {
+                    sound = new Sound(path);
+                } catch (NullPointerException ex) {
+                    errorList.add("invalid path to sound: " + path);  // NOI18N
+                }
+            }
+            if (sound != null) {
+                sound.play();
+            }
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void runScript(ConditionalAction action, String actionStr, Reference<Integer> actionCount) {
+        if (!(actionStr.equals(""))) {
+            JmriScriptEngineManager.getDefault().runScript(new File(jmri.util.FileUtil.getExternalFilename(actionStr)));
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    @SuppressWarnings({"deprecation"})  // date.setHours, date.setMinutes, date.setSeconds
+    void setFastClockTime(ConditionalAction action, Reference<Integer> actionCount) {
+        Date date = InstanceManager.getDefault(jmri.Timebase.class).getTime();
+        date.setHours(action.getActionData() / 60);
+        date.setMinutes(action.getActionData() - ((action.getActionData() / 60) * 60));
+        date.setSeconds(0);
+        InstanceManager.getDefault(jmri.Timebase.class).userSetTime(date);
+        actionCount.set(actionCount.get() + 1);
+    }
+
+    void startFastClock(Reference<Integer> actionCount) {
+        InstanceManager.getDefault(jmri.Timebase.class).setRun(true);
+        actionCount.set(actionCount.get() + 1);
+    }
+
+    void stopFastClock(Reference<Integer> actionCount) {
+        InstanceManager.getDefault(jmri.Timebase.class).setRun(false);
+        actionCount.set(actionCount.get() + 1);
+    }
+
+    void controlAudio(ConditionalAction action, String devName) {
+        Audio audio = InstanceManager.getDefault(jmri.AudioManager.class).getAudio(devName);
+        if (audio == null) {
+            return;
+        }
+        if (audio.getSubType() == Audio.SOURCE) {
+            AudioSource audioSource = (AudioSource) audio;
+            switch (action.getActionData()) {
+                case Audio.CMD_PLAY:
+                    audioSource.play();
+                    break;
+                case Audio.CMD_STOP:
+                    audioSource.stop();
+                    break;
+                case Audio.CMD_PLAY_TOGGLE:
+                    audioSource.togglePlay();
+                    break;
+                case Audio.CMD_PAUSE:
+                    audioSource.pause();
+                    break;
+                case Audio.CMD_RESUME:
+                    audioSource.resume();
+                    break;
+                case Audio.CMD_PAUSE_TOGGLE:
+                    audioSource.togglePause();
+                    break;
+                case Audio.CMD_REWIND:
+                    audioSource.rewind();
+                    break;
+                case Audio.CMD_FADE_IN:
+                    audioSource.fadeIn();
+                    break;
+                case Audio.CMD_FADE_OUT:
+                    audioSource.fadeOut();
+                    break;
+                case Audio.CMD_RESET_POSITION:
+                    audioSource.resetCurrentPosition();
+                    break;
+                default:
+                    break;
+            }
+        } else if (audio.getSubType() == Audio.LISTENER) {
+            AudioListener audioListener = (AudioListener) audio;
+            switch (action.getActionData()) {
+                case Audio.CMD_RESET_POSITION:
+                    audioListener.resetCurrentPosition();
+                    break;
+                default:
+                    break; // nothing needed for others
+            }
+        }
+    }
+
+    void jythonCommand(ConditionalAction action, String actionStr, Reference<Integer> actionCount) {
+        if (!(actionStr.isEmpty())) {
+            // add the text to the output frame
+            ScriptOutput.writeScript(actionStr);
+            // and execute
+
+            javax.script.ScriptEngine se =  JmriScriptEngineManager.getDefault().getEngine(JmriScriptEngineManager.PYTHON);
+            if (se!=null) {
+                try {
+                    JmriScriptEngineManager.getDefault().eval(actionStr, se);
+                } catch (ScriptException ex) {
+                    log.error("Error executing script:", ex);  // NOI18N
+                }
+            } else {
+                log.error("Error getting default ScriptEngine");
+            }
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void allocateWarrantRoute(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList) {
+        if (w == null) {
+            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            String msg = w.allocateRoute(false, null);
+            if (msg != null) {
+                log.info("Warrant {} - {}", action.getDeviceName(), msg);  // NOI18N
+            }
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void deallocateWarrantRoute(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList) {
+        if (w == null) {
+            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            w.deAllocate();
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setRouteTurnouts(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList) {
+        if (w == null) {
+            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            String msg = w.setRoute(false, null);
+            if (msg != null) {
+                log.info("Warrant {} unable to Set Route - {}", action.getDeviceName(), msg);  // NOI18N
+            }
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setTrainId(ConditionalAction action, Warrant w, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+        if (w == null) {
+            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            if(!w.getSpeedUtil().setAddress(actionStr)) {
+                errorList.add("invalid train ID in action - " + action.getDeviceName());  // NOI18N
+            }
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setTrainName(ConditionalAction action, Warrant w, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+        if (w == null) {
+            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            w.setTrainName(actionStr);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void autoRunWarrant(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList) {
+        if (w == null) {
+            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            jmri.jmrit.logix.WarrantTableFrame frame = jmri.jmrit.logix.WarrantTableFrame.getDefault();
+            String err = frame.runTrain(w, Warrant.MODE_RUN);
+            if (err != null) {
+                errorList.add("runAutoTrain error - " + err);  // NOI18N
+                w.stopWarrant(true, true);
+            }
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void manualRunWarrant(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList) {
+        if (w == null) {
+            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            String err = w.setRoute(false, null);
+            if (err == null) {
+                err = w.setRunMode(Warrant.MODE_MANUAL, null, null, null, false);
+            }
+            if (err != null) {
+                errorList.add("runManualTrain error - " + err);  // NOI18N
+            }
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void controlTrain(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList, String devName) {
+        if (w == null) {
+            errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            if (!w.controlRunTrain(action.getActionData())) {
+                log.info("Train {} not running  - {}", w.getSpeedUtil().getRosterId(), devName);  // NOI18N
+            }
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setSignalMastAspect(ConditionalAction action, SignalMast f, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+        if (f == null) {
+            errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            f.setAspect(actionStr);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setSignalMastHeld(ConditionalAction action, SignalMast f, Reference<Integer> actionCount, List<String> errorList) {
+        if (f == null) {
+            errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            f.setHeld(true);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void clearSignalMastHeld(ConditionalAction action, SignalMast f, Reference<Integer> actionCount, List<String> errorList) {
+        if (f == null) {
+            errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            f.setHeld(false);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setSignalMastDark(ConditionalAction action, SignalMast f, Reference<Integer> actionCount, List<String> errorList) {
+        if (f == null) {
+            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            f.setLit(false);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setSignalMastLit(ConditionalAction action, SignalMast f, Reference<Integer> actionCount, List<String> errorList) {
+        if (f == null) {
+            errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            f.setLit(true);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setBlockValue(ConditionalAction action, OBlock b, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+        if (b == null) {
+            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            b.setValue(actionStr);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setBlockError(ConditionalAction action, OBlock b, Reference<Integer> actionCount, List<String> errorList) {
+        if (b == null) {
+            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            b.setError(true);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void clearBlockValue(ConditionalAction action, OBlock b, List<String> errorList) {
+        if (b == null) {
+            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            b.setError(false);
+        }
+    }
+
+    void deallocateBlock(ConditionalAction action, OBlock b, Reference<Integer> actionCount, List<String> errorList) {
+        if (b == null) {
+            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            b.deAllocate(null);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setBlockOutOfService(ConditionalAction action, OBlock b, Reference<Integer> actionCount, List<String> errorList) {
+        if (b == null) {
+            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            b.setOutOfService(true);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setBlockInService(ConditionalAction action, OBlock b, Reference<Integer> actionCount, List<String> errorList) {
+        if (b == null) {
+            errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            b.setOutOfService(false);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setNXPairEnabled(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+        DestinationPoints dp = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(devName);
+        if (dp == null) {
+            errorList.add("Invalid NX Pair name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            dp.setEnabled(true);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setNXPairDisabled(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+        DestinationPoints dp = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(devName);
+        if (dp == null) {
+            errorList.add("Invalid NX Pair name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            dp.setEnabled(false);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    void setNXPairSegment(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+        DestinationPoints dp = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(devName);
+        if (dp == null) {
+            errorList.add("Invalid NX Pair name in action - " + action.getDeviceName());  // NOI18N
+        } else {
+            jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
+                    setSingleSegmentRoute(devName);
+            actionCount.set(actionCount.get() + 1);
+        }
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultConditionalExecute.class);
+}

--- a/java/src/jmri/implementation/DefaultConditionalExecute.java
+++ b/java/src/jmri/implementation/DefaultConditionalExecute.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Date;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.script.ScriptException;
 import javax.swing.Timer;
 
@@ -28,11 +29,11 @@ public class DefaultConditionalExecute {
 
     private final DefaultConditional conditional;
 
-    DefaultConditionalExecute(DefaultConditional conditional) {
+    DefaultConditionalExecute(@Nonnull DefaultConditional conditional) {
         this.conditional = conditional;
     }
 
-    void setTurnout(ConditionalAction action, Turnout t, Reference<Integer> actionCount, List<String> errorList) {
+    void setTurnout(@Nonnull ConditionalAction action, Turnout t, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (t == null) {
             errorList.add("invalid turnout name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -50,7 +51,7 @@ public class DefaultConditionalExecute {
         }
     }
     
-    void delayedTurnout(ConditionalAction action, Reference<Integer> actionCount, TimeTurnout timeTurnout, boolean reset, String devName) {
+    void delayedTurnout(@Nonnull ConditionalAction action, @Nonnull Reference<Integer> actionCount, @Nonnull TimeTurnout timeTurnout, boolean reset, String devName) {
         if (reset) action.stopTimer();
         if (!action.isTimerActive()) {
             // Create a timer if one does not exist
@@ -74,7 +75,7 @@ public class DefaultConditionalExecute {
         }
     }
     
-    void cancelTurnoutTimers(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+    void cancelTurnoutTimers(@Nonnull ConditionalAction action, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList, String devName) {
         ConditionalManager cmg = jmri.InstanceManager.getDefault(jmri.ConditionalManager.class);
         java.util.Iterator<Conditional> iter = cmg.getNamedBeanSet().iterator();
         while (iter.hasNext()) {
@@ -92,7 +93,7 @@ public class DefaultConditionalExecute {
         }
     }
     
-    void lockTurnout(ConditionalAction action, Turnout tl, Reference<Integer> actionCount, List<String> errorList) {
+    void lockTurnout(@Nonnull ConditionalAction action, Turnout tl, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (tl == null) {
             errorList.add("invalid turnout name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -113,7 +114,7 @@ public class DefaultConditionalExecute {
         }
     }
     
-    void setSignalAppearance(ConditionalAction action, SignalHead h, Reference<Integer> actionCount, List<String> errorList) {
+    void setSignalAppearance(@Nonnull ConditionalAction action, SignalHead h, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (h == null) {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -122,7 +123,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setSignalHeld(ConditionalAction action, SignalHead h, Reference<Integer> actionCount, List<String> errorList) {
+    void setSignalHeld(@Nonnull ConditionalAction action, SignalHead h, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (h == null) {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -131,7 +132,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void clearSignalHeld(ConditionalAction action, SignalHead h, Reference<Integer> actionCount, List<String> errorList) {
+    void clearSignalHeld(@Nonnull ConditionalAction action, SignalHead h, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (h == null) {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -140,7 +141,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setSignalDark(ConditionalAction action, SignalHead h, Reference<Integer> actionCount, List<String> errorList) {
+    void setSignalDark(@Nonnull ConditionalAction action, SignalHead h, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (h == null) {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -149,7 +150,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setSignalLit(ConditionalAction action, SignalHead h, Reference<Integer> actionCount, List<String> errorList) {
+    void setSignalLit(@Nonnull ConditionalAction action, SignalHead h, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (h == null) {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -158,7 +159,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void triggerRoute(ConditionalAction action, Route r, Reference<Integer> actionCount, List<String> errorList) {
+    void triggerRoute(@Nonnull ConditionalAction action, Route r, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (r == null) {
             errorList.add("invalid Route name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -167,7 +168,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setSensor(ConditionalAction action, Sensor sn, Reference<Integer> actionCount, List<String> errorList, String devName) {
+    void setSensor(@Nonnull ConditionalAction action, Sensor sn, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList, String devName) {
         if (sn == null) {
             errorList.add("invalid Sensor name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -189,7 +190,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void delayedSensor(ConditionalAction action, Reference<Integer> actionCount, TimeSensor timeSensor, int delay, boolean reset, String devName) {
+    void delayedSensor(@Nonnull ConditionalAction action, @Nonnull Reference<Integer> actionCount, @Nonnull TimeSensor timeSensor, int delay, boolean reset, String devName) {
         if (reset) action.stopTimer();
         if (!action.isTimerActive()) {
             // Create a timer if one does not exist
@@ -212,7 +213,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void cancelSensorTimers(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+    void cancelSensorTimers(@Nonnull ConditionalAction action, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList, String devName) {
         ConditionalManager cm = jmri.InstanceManager.getDefault(jmri.ConditionalManager.class);
         java.util.Iterator<Conditional> itr = cm.getNamedBeanSet().iterator();
         while (itr.hasNext()) {
@@ -229,7 +230,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setLight(ConditionalAction action, Light lgt, Reference<Integer> actionCount, List<String> errorList) {
+    void setLight(@Nonnull ConditionalAction action, Light lgt, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (lgt == null) {
             errorList.add("invalid light name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -247,7 +248,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setLightIntensity(ConditionalAction action, Light lgt, int intensity, Reference<Integer> actionCount, List<String> errorList) {
+    void setLightIntensity(@Nonnull ConditionalAction action, Light lgt, int intensity, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (lgt == null) {
             errorList.add("invalid light name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -267,7 +268,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setLightTransitionTime(ConditionalAction action, Light lgt, int time, Reference<Integer> actionCount, List<String> errorList) {
+    void setLightTransitionTime(@Nonnull ConditionalAction action, Light lgt, int time, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (lgt == null) {
             errorList.add("invalid light name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -285,7 +286,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setMemory(ConditionalAction action, Memory m, Reference<Integer> actionCount, List<String> errorList) {
+    void setMemory(@Nonnull ConditionalAction action, Memory m, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (m == null) {
             errorList.add("invalid memory name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -294,7 +295,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void copyMemory(ConditionalAction action, Memory mFrom, Memory mTo, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+    void copyMemory(@Nonnull ConditionalAction action, Memory mFrom, Memory mTo, String actionStr, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (mFrom == null) {
             errorList.add("invalid memory name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -307,7 +308,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void enableLogix(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+    void enableLogix(@Nonnull ConditionalAction action, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList, String devName) {
         Logix x = InstanceManager.getDefault(jmri.LogixManager.class).getLogix(devName);
         if (x == null) {
             errorList.add("invalid logix name in action - " + action.getDeviceName());  // NOI18N
@@ -317,7 +318,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void disableLogix(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+    void disableLogix(@Nonnull ConditionalAction action, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList, String devName) {
         Logix x = InstanceManager.getDefault(jmri.LogixManager.class).getLogix(devName);
         if (x == null) {
             errorList.add("invalid logix name in action - " + action.getDeviceName());  // NOI18N
@@ -327,7 +328,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void playSound(ConditionalAction action, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+    void playSound(@Nonnull ConditionalAction action, String actionStr, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         String path = actionStr;
         if (!path.equals("")) {
             Sound sound = action.getSound();
@@ -345,7 +346,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void runScript(ConditionalAction action, String actionStr, Reference<Integer> actionCount) {
+    void runScript(@Nonnull ConditionalAction action, String actionStr, @Nonnull Reference<Integer> actionCount) {
         if (!(actionStr.equals(""))) {
             JmriScriptEngineManager.getDefault().runScript(new File(jmri.util.FileUtil.getExternalFilename(actionStr)));
             actionCount.set(actionCount.get() + 1);
@@ -353,7 +354,7 @@ public class DefaultConditionalExecute {
     }
 
     @SuppressWarnings({"deprecation"})  // date.setHours, date.setMinutes, date.setSeconds
-    void setFastClockTime(ConditionalAction action, Reference<Integer> actionCount) {
+    void setFastClockTime(@Nonnull ConditionalAction action, @Nonnull Reference<Integer> actionCount) {
         Date date = InstanceManager.getDefault(jmri.Timebase.class).getTime();
         date.setHours(action.getActionData() / 60);
         date.setMinutes(action.getActionData() - ((action.getActionData() / 60) * 60));
@@ -362,17 +363,17 @@ public class DefaultConditionalExecute {
         actionCount.set(actionCount.get() + 1);
     }
 
-    void startFastClock(Reference<Integer> actionCount) {
+    void startFastClock(@Nonnull Reference<Integer> actionCount) {
         InstanceManager.getDefault(jmri.Timebase.class).setRun(true);
         actionCount.set(actionCount.get() + 1);
     }
 
-    void stopFastClock(Reference<Integer> actionCount) {
+    void stopFastClock(@Nonnull Reference<Integer> actionCount) {
         InstanceManager.getDefault(jmri.Timebase.class).setRun(false);
         actionCount.set(actionCount.get() + 1);
     }
 
-    void controlAudio(ConditionalAction action, String devName) {
+    void controlAudio(@Nonnull ConditionalAction action, String devName) {
         Audio audio = InstanceManager.getDefault(jmri.AudioManager.class).getAudio(devName);
         if (audio == null) {
             return;
@@ -425,7 +426,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void jythonCommand(ConditionalAction action, String actionStr, Reference<Integer> actionCount) {
+    void jythonCommand(@Nonnull ConditionalAction action, String actionStr, @Nonnull Reference<Integer> actionCount) {
         if (!(actionStr.isEmpty())) {
             // add the text to the output frame
             ScriptOutput.writeScript(actionStr);
@@ -445,7 +446,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void allocateWarrantRoute(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList) {
+    void allocateWarrantRoute(@Nonnull ConditionalAction action, Warrant w, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (w == null) {
             errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -457,7 +458,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void deallocateWarrantRoute(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList) {
+    void deallocateWarrantRoute(@Nonnull ConditionalAction action, Warrant w, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (w == null) {
             errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -466,7 +467,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setRouteTurnouts(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList) {
+    void setRouteTurnouts(@Nonnull ConditionalAction action, Warrant w, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (w == null) {
             errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -478,7 +479,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setTrainId(ConditionalAction action, Warrant w, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+    void setTrainId(@Nonnull ConditionalAction action, Warrant w, String actionStr, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (w == null) {
             errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -489,7 +490,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setTrainName(ConditionalAction action, Warrant w, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+    void setTrainName(@Nonnull ConditionalAction action, Warrant w, String actionStr, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (w == null) {
             errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -498,7 +499,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void autoRunWarrant(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList) {
+    void autoRunWarrant(@Nonnull ConditionalAction action, Warrant w, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (w == null) {
             errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -512,7 +513,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void manualRunWarrant(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList) {
+    void manualRunWarrant(@Nonnull ConditionalAction action, Warrant w, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (w == null) {
             errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -527,7 +528,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void controlTrain(ConditionalAction action, Warrant w, Reference<Integer> actionCount, List<String> errorList, String devName) {
+    void controlTrain(@Nonnull ConditionalAction action, Warrant w, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList, String devName) {
         if (w == null) {
             errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -538,7 +539,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setSignalMastAspect(ConditionalAction action, SignalMast f, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+    void setSignalMastAspect(@Nonnull ConditionalAction action, SignalMast f, String actionStr, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (f == null) {
             errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -547,7 +548,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setSignalMastHeld(ConditionalAction action, SignalMast f, Reference<Integer> actionCount, List<String> errorList) {
+    void setSignalMastHeld(@Nonnull ConditionalAction action, SignalMast f, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (f == null) {
             errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -556,7 +557,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void clearSignalMastHeld(ConditionalAction action, SignalMast f, Reference<Integer> actionCount, List<String> errorList) {
+    void clearSignalMastHeld(@Nonnull ConditionalAction action, SignalMast f, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (f == null) {
             errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -565,7 +566,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setSignalMastDark(ConditionalAction action, SignalMast f, Reference<Integer> actionCount, List<String> errorList) {
+    void setSignalMastDark(@Nonnull ConditionalAction action, SignalMast f, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (f == null) {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -574,7 +575,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setSignalMastLit(ConditionalAction action, SignalMast f, Reference<Integer> actionCount, List<String> errorList) {
+    void setSignalMastLit(@Nonnull ConditionalAction action, SignalMast f, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (f == null) {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -583,7 +584,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setBlockValue(ConditionalAction action, OBlock b, String actionStr, Reference<Integer> actionCount, List<String> errorList) {
+    void setBlockValue(@Nonnull ConditionalAction action, OBlock b, String actionStr, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (b == null) {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -592,7 +593,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setBlockError(ConditionalAction action, OBlock b, Reference<Integer> actionCount, List<String> errorList) {
+    void setBlockError(@Nonnull ConditionalAction action, OBlock b, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (b == null) {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -601,7 +602,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void clearBlockValue(ConditionalAction action, OBlock b, List<String> errorList) {
+    void clearBlockValue(@Nonnull ConditionalAction action, OBlock b, @Nonnull List<String> errorList) {
         if (b == null) {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -609,7 +610,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void deallocateBlock(ConditionalAction action, OBlock b, Reference<Integer> actionCount, List<String> errorList) {
+    void deallocateBlock(@Nonnull ConditionalAction action, OBlock b, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (b == null) {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -618,7 +619,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setBlockOutOfService(ConditionalAction action, OBlock b, Reference<Integer> actionCount, List<String> errorList) {
+    void setBlockOutOfService(@Nonnull ConditionalAction action, OBlock b, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (b == null) {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -627,7 +628,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setBlockInService(ConditionalAction action, OBlock b, Reference<Integer> actionCount, List<String> errorList) {
+    void setBlockInService(@Nonnull ConditionalAction action, OBlock b, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList) {
         if (b == null) {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {
@@ -636,7 +637,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setNXPairEnabled(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+    void setNXPairEnabled(@Nonnull ConditionalAction action, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList, String devName) {
         DestinationPoints dp = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(devName);
         if (dp == null) {
             errorList.add("Invalid NX Pair name in action - " + action.getDeviceName());  // NOI18N
@@ -646,7 +647,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setNXPairDisabled(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+    void setNXPairDisabled(@Nonnull ConditionalAction action, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList, String devName) {
         DestinationPoints dp = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(devName);
         if (dp == null) {
             errorList.add("Invalid NX Pair name in action - " + action.getDeviceName());  // NOI18N
@@ -656,7 +657,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void setNXPairSegment(ConditionalAction action, Reference<Integer> actionCount, List<String> errorList, String devName) {
+    void setNXPairSegment(@Nonnull ConditionalAction action, @Nonnull Reference<Integer> actionCount, @Nonnull List<String> errorList, String devName) {
         DestinationPoints dp = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(devName);
         if (dp == null) {
             errorList.add("Invalid NX Pair name in action - " + action.getDeviceName());  // NOI18N

--- a/java/src/jmri/implementation/DefaultConditionalExecute.java
+++ b/java/src/jmri/implementation/DefaultConditionalExecute.java
@@ -47,7 +47,7 @@ public class DefaultConditionalExecute {
                 }
             }
             t.setCommandedState(act);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
     
@@ -69,7 +69,7 @@ public class DefaultConditionalExecute {
             timer.setInitialDelay(value);
             action.setTimer(timer);
             action.startTimer();
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         } else {
             log.warn("timer already active on request to start delayed turnout action - {}", devName);
         }
@@ -89,7 +89,7 @@ public class DefaultConditionalExecute {
             }
 
             c.cancelTurnoutTimer(devName);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
     
@@ -110,7 +110,7 @@ public class DefaultConditionalExecute {
             } else if (act == Turnout.UNLOCKED) {
                 tl.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, false);
             }
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
     
@@ -119,7 +119,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
             h.setAppearance(action.getActionData());
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -128,7 +128,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
             h.setHeld(true);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -137,7 +137,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
             h.setHeld(false);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -146,7 +146,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
             h.setLit(false);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -155,7 +155,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
             h.setLit(true);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -164,7 +164,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Route name in action - " + action.getDeviceName());  // NOI18N
         } else {
             r.setRoute();
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -183,7 +183,7 @@ public class DefaultConditionalExecute {
             }
             try {
                 sn.setKnownState(act);
-                actionCount.set(actionCount.get() + 1);
+                increaseCounter(actionCount);
             } catch (JmriException e) {
                 log.warn("Exception setting Sensor {} in action", devName);  // NOI18N
             }
@@ -207,7 +207,7 @@ public class DefaultConditionalExecute {
             timer.setInitialDelay(delay);
             action.setTimer(timer);
             action.startTimer();
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         } else {
             log.warn("timer already active on request to start delayed sensor action - {}", devName);
         }
@@ -226,7 +226,7 @@ public class DefaultConditionalExecute {
             }
 
             c.cancelSensorTimer(devName);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -244,7 +244,7 @@ public class DefaultConditionalExecute {
                 }
             }
             lgt.setState(act);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -261,7 +261,7 @@ public class DefaultConditionalExecute {
                 } else {
                     lgt.setState(intensity > 0.5 ? Light.ON : Light.OFF);
                 }
-                actionCount.set(actionCount.get() + 1);
+                increaseCounter(actionCount);
             } catch (IllegalArgumentException e) {
                 errorList.add("Exception in set light intensity action - " + action.getDeviceName());  // NOI18N
             }
@@ -279,7 +279,7 @@ public class DefaultConditionalExecute {
                 if (lgt instanceof VariableLight) {
                     ((VariableLight)lgt).setTransitionTime(time );
                 }
-                actionCount.set(actionCount.get() + 1);
+                increaseCounter(actionCount);
             } catch (IllegalArgumentException e) {
                 errorList.add("Exception in set light transition time action - " + action.getDeviceName());  // NOI18N
             }
@@ -291,7 +291,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid memory name in action - " + action.getDeviceName());  // NOI18N
         } else {
             m.setValue(action.getActionString());
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -303,7 +303,7 @@ public class DefaultConditionalExecute {
                 errorList.add("invalid memory name in action - " + action.getActionString());  // NOI18N
             } else {
                 mTo.setValue(mFrom.getValue());
-                actionCount.set(actionCount.get() + 1);
+                increaseCounter(actionCount);
             }
         }
     }
@@ -314,7 +314,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid logix name in action - " + action.getDeviceName());  // NOI18N
         } else {
             x.setEnabled(true);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -324,7 +324,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid logix name in action - " + action.getDeviceName());  // NOI18N
         } else {
             x.setEnabled(false);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -342,14 +342,14 @@ public class DefaultConditionalExecute {
             if (sound != null) {
                 sound.play();
             }
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
     void runScript(@Nonnull ConditionalAction action, String actionStr, @Nonnull Reference<Integer> actionCount) {
         if (!(actionStr.equals(""))) {
             JmriScriptEngineManager.getDefault().runScript(new File(jmri.util.FileUtil.getExternalFilename(actionStr)));
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -360,17 +360,17 @@ public class DefaultConditionalExecute {
         date.setMinutes(action.getActionData() - ((action.getActionData() / 60) * 60));
         date.setSeconds(0);
         InstanceManager.getDefault(jmri.Timebase.class).userSetTime(date);
-        actionCount.set(actionCount.get() + 1);
+        increaseCounter(actionCount);
     }
 
     void startFastClock(@Nonnull Reference<Integer> actionCount) {
         InstanceManager.getDefault(jmri.Timebase.class).setRun(true);
-        actionCount.set(actionCount.get() + 1);
+        increaseCounter(actionCount);
     }
 
     void stopFastClock(@Nonnull Reference<Integer> actionCount) {
         InstanceManager.getDefault(jmri.Timebase.class).setRun(false);
-        actionCount.set(actionCount.get() + 1);
+        increaseCounter(actionCount);
     }
 
     void controlAudio(@Nonnull ConditionalAction action, String devName) {
@@ -442,7 +442,7 @@ public class DefaultConditionalExecute {
             } else {
                 log.error("Error getting default ScriptEngine");
             }
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -454,7 +454,7 @@ public class DefaultConditionalExecute {
             if (msg != null) {
                 log.info("Warrant {} - {}", action.getDeviceName(), msg);  // NOI18N
             }
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -463,7 +463,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
         } else {
             w.deAllocate();
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -475,7 +475,7 @@ public class DefaultConditionalExecute {
             if (msg != null) {
                 log.info("Warrant {} unable to Set Route - {}", action.getDeviceName(), msg);  // NOI18N
             }
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -486,7 +486,7 @@ public class DefaultConditionalExecute {
             if(!w.getSpeedUtil().setAddress(actionStr)) {
                 errorList.add("invalid train ID in action - " + action.getDeviceName());  // NOI18N
             }
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -495,7 +495,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Warrant name in action - " + action.getDeviceName());  // NOI18N
         } else {
             w.setTrainName(actionStr);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -509,7 +509,7 @@ public class DefaultConditionalExecute {
                 errorList.add("runAutoTrain error - " + err);  // NOI18N
                 w.stopWarrant(true, true);
             }
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -524,7 +524,7 @@ public class DefaultConditionalExecute {
             if (err != null) {
                 errorList.add("runManualTrain error - " + err);  // NOI18N
             }
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -535,7 +535,7 @@ public class DefaultConditionalExecute {
             if (!w.controlRunTrain(action.getActionData())) {
                 log.info("Train {} not running  - {}", w.getSpeedUtil().getRosterId(), devName);  // NOI18N
             }
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -544,7 +544,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
         } else {
             f.setAspect(actionStr);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -553,7 +553,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
         } else {
             f.setHeld(true);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -562,7 +562,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Signal Mast name in action - " + action.getDeviceName());  // NOI18N
         } else {
             f.setHeld(false);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -571,7 +571,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
             f.setLit(false);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -580,7 +580,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Signal Head name in action - " + action.getDeviceName());  // NOI18N
         } else {
             f.setLit(true);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -589,7 +589,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {
             b.setValue(actionStr);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -598,7 +598,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {
             b.setError(true);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -615,7 +615,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {
             b.deAllocate(null);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -624,7 +624,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {
             b.setOutOfService(true);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -633,7 +633,7 @@ public class DefaultConditionalExecute {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {
             b.setOutOfService(false);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -643,7 +643,7 @@ public class DefaultConditionalExecute {
             errorList.add("Invalid NX Pair name in action - " + action.getDeviceName());  // NOI18N
         } else {
             dp.setEnabled(true);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -653,7 +653,7 @@ public class DefaultConditionalExecute {
             errorList.add("Invalid NX Pair name in action - " + action.getDeviceName());  // NOI18N
         } else {
             dp.setEnabled(false);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
     }
 
@@ -664,8 +664,14 @@ public class DefaultConditionalExecute {
         } else {
             jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
                     setSingleSegmentRoute(devName);
-            actionCount.set(actionCount.get() + 1);
+            increaseCounter(actionCount);
         }
+    }
+
+    private void increaseCounter(@Nonnull Reference<Integer> actionCount) {
+        // actionCount.get() is never null, but Spotbugs doesn't know that
+        Integer value = actionCount.get();
+        actionCount.set(value != null ? value+1 : 0);
     }
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultConditionalExecute.class);


### PR DESCRIPTION
I have got a feature request to trigger a LRoute from LogixNG. To solve that, I need to be able to trigger the execution of a Logix Conditional from LogixNG.

But in order to do that, I need to change `DefaultConditional.takeActionIfNeeded()`. But that method is 700 lines long with a switch case statement that's 636 lines long.

To be able to do the desired changes, I have refactored `takeActionIfNeeded()` and moved most of the code to methods in `DefaultConditionalExecute`. So now, takeActionIfNeeded() is 218 lines long and the switch-case statement is 163 lines long.