### PR TITLE
Rename method

### DIFF
--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -707,7 +707,7 @@ public class DefaultConditional extends AbstractNamedBean
                         conditionalExecute.setBlockError(action, (OBlock) nb, actionCount, errorList);
                         break;
                     case CLEAR_BLOCK_ERROR:
-                        conditionalExecute.clearBlockValue(action, (OBlock) nb, errorList);
+                        conditionalExecute.clearBlockError(action, (OBlock) nb, errorList);
                         break;
                     case DEALLOCATE_BLOCK:
                         conditionalExecute.deallocateBlock(action, (OBlock) nb, actionCount, errorList);

--- a/java/src/jmri/implementation/DefaultConditionalExecute.java
+++ b/java/src/jmri/implementation/DefaultConditionalExecute.java
@@ -602,7 +602,7 @@ public class DefaultConditionalExecute {
         }
     }
 
-    void clearBlockValue(@Nonnull ConditionalAction action, OBlock b, @Nonnull List<String> errorList) {
+    void clearBlockError(@Nonnull ConditionalAction action, OBlock b, @Nonnull List<String> errorList) {
         if (b == null) {
             errorList.add("invalid Block name in action - " + action.getDeviceName());  // NOI18N
         } else {


### PR DESCRIPTION
@bobjacobsen 
When I looked thru the changes in #10522, I noticed a small error. The case `CLEAR_BLOCK_ERROR` called the method `clearBlockValue`. This PR fixes that.

This PR has no code change, it only renames the method.