### PR TITLE
Script-friendly InstanceManager accessors

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -465,6 +465,8 @@
         <a id="Scripting" name="Scripting"></a>
         <ul>
             <li>Example scripts related to MQTT moved from jython directory to jython\MQTT directory.</li>
+            <li>Added simpler accessors to InstanceManager for use in scripts. See
+                jython/test/InstanceManagerTest.py</li>
         </ul>
 
     <h3>Signals</h3>

--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -149,6 +149,23 @@ public final class InstanceManager {
     }
 
     /**
+     * Retrieve a list of all objects of a specific type that were registered with
+     * {@link #store}.
+     *
+     * Intended for use with i.e. scripts where access to the class type is inconvenient.
+     * In Java code where typing is enforced, use {@link getList(Class)}.
+     *
+     * @param className Fully qualified class name
+     * @return A list of type Objects registered with the manager or an empty
+     *         list.
+     */
+    @Nonnull
+    public static List<Object> getList(@Nonnull String className) {
+        return getDefault().getInstances(className);
+    }
+
+
+    /**
      * Deregister all objects of a particular type.
      *
      * @param <T>  The type of the class
@@ -239,6 +256,42 @@ public final class InstanceManager {
     }
 
     /**
+     * Retrieve the last object of specific type that was registered with
+     * {@link #store(java.lang.Object, java.lang.Class) }.
+     *
+     * Intended for use with i.e. scripts where access to the class type is inconvenient.
+     * In Java code where typing is enforced, use {@link getDefault(Class)}.
+     *
+     * <p>
+     * Unless specifically set, the default is the last object stored, see the
+     * {@link #setDefault(java.lang.Class, java.lang.Object) } method.
+     * <p>
+     * In some cases, InstanceManager can create the object the first time it's
+     * requested. For more on that, see the class comment.
+     * <p>
+     * In most cases, system configuration assures the existence of a default
+     * object, so this method will log and throw an exception if one doesn't
+     * exist. Use {@link #getNullableDefault(java.lang.Class)} or
+     * {@link #getOptionalDefault(java.lang.Class)} if the default is not
+     * guaranteed to exist.
+     *
+     * @param className Fully qualified class name
+     * @return The default object for type
+     * @throws NullPointerException if no default object for type exists
+     * @see #getNullableDefault(java.lang.Class)
+     * @see #getOptionalDefault(java.lang.Class)
+     */
+    @Nonnull
+    public static Object getDefault(@Nonnull String className) {
+        log.trace("getDefault of type {}", className);
+        Object object = InstanceManager.getNullableDefault(className);
+        if (object == null) {
+            throw new NullPointerException("Required nonnull default for " + className + " does not exist.");
+        }
+        return object;
+    }
+
+    /**
      * Retrieve the last object of type T that was registered with
      * {@link #store(java.lang.Object, java.lang.Class) }.
      * <p>
@@ -260,6 +313,40 @@ public final class InstanceManager {
      */
     @CheckForNull
     public static <T> T getNullableDefault(@Nonnull Class<T> type) {
+        return getDefault().getInstance(type);
+    }
+
+    /**
+     * Retrieve the last object of type T that was registered with
+     * {@link #store(java.lang.Object, java.lang.Class) }.
+     *
+     * Intended for use with i.e. scripts where access to the class type is inconvenient.
+     * In Java code where typing is enforced, use {@link getNullableDefault(Class)}.
+     * <p>
+     * Unless specifically set, the default is the last object stored, see the
+     * {@link #setDefault(java.lang.Class, java.lang.Object) } method.
+     * <p>
+     * In some cases, InstanceManager can create the object the first time it's
+     * requested. For more on that, see the class comment.
+     * <p>
+     * In most cases, system configuration assures the existence of a default
+     * object, but this method also handles the case where one doesn't exist.
+     * Use {@link #getDefault(java.lang.Class)} when the object is guaranteed to
+     * exist.
+     *
+     * @param className Fully qualified class name
+     * @return The default object for type.
+     * @see #getOptionalDefault(java.lang.Class)
+     */
+    @CheckForNull
+    public static Object getNullableDefault(@Nonnull String className) {
+        Class<?> type;
+        try {
+            type = Class.forName(className);
+        } catch (ClassNotFoundException ex) {
+            log.error("No class found: {}", className);
+            throw new IllegalArgumentException(ex);
+        }
         return getDefault().getInstance(type);
     }
 
@@ -772,6 +859,38 @@ public final class InstanceManager {
             return (List<T>) managerLists.get(type);
         }
     }
+
+
+    /**
+     * Get a list of all registered objects of a specific type.
+     *
+     * Intended for use with i.e. scripts where access to the class type is inconvenient.
+     *
+     * @param <T>  type of the class
+     * @param className Fully qualified class name
+     * @return a list of registered instances with the manager or an empty
+     *         list
+     */
+    @SuppressWarnings("unchecked") // the cast here is protected by the structure of the managerLists
+    @Nonnull
+    public <T> List<T> getInstances(@Nonnull String className) {
+        Class<?> type;
+        try {
+            type = Class.forName(className);
+        } catch (ClassNotFoundException ex) {
+            log.error("No class found: {}", className);
+            throw new IllegalArgumentException(ex);
+        }
+        log.trace("Get list of type {}", type.getName());
+        synchronized (type) {
+            if (managerLists.get(type) == null) {
+                managerLists.put(type, new ArrayList<>());
+                pcs.fireIndexedPropertyChange(getListPropertyName(type), 0, null, null);
+            }
+            return (List<T>) managerLists.get(type);
+        }
+    }
+
 
     /**
      * Call {@link jmri.Disposable#dispose()} on the passed in Object if and

--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -158,6 +158,7 @@ public final class InstanceManager {
      * @param className Fully qualified class name
      * @return A list of type Objects registered with the manager or an empty
      *         list.
+     * @throws IllegalArgumentException if the named class doesn't exist
      */
     @Nonnull
     public static List<Object> getList(@Nonnull String className) {
@@ -278,6 +279,7 @@ public final class InstanceManager {
      * @param className Fully qualified class name
      * @return The default object for type
      * @throws NullPointerException if no default object for type exists
+     * @throws IllegalArgumentException if the named class doesn't exist
      * @see #getNullableDefault(java.lang.Class)
      * @see #getOptionalDefault(java.lang.Class)
      */
@@ -336,6 +338,7 @@ public final class InstanceManager {
      *
      * @param className Fully qualified class name
      * @return The default object for type.
+     * @throws IllegalArgumentException if the named class doesn't exist
      * @see #getOptionalDefault(java.lang.Class)
      */
     @CheckForNull
@@ -870,6 +873,7 @@ public final class InstanceManager {
      * @param className Fully qualified class name
      * @return a list of registered instances with the manager or an empty
      *         list
+     * @throws IllegalArgumentException if the named class doesn't exist
      */
     @SuppressWarnings("unchecked") // the cast here is protected by the structure of the managerLists
     @Nonnull

--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -153,7 +153,7 @@ public final class InstanceManager {
      * {@link #store}.
      *
      * Intended for use with i.e. scripts where access to the class type is inconvenient.
-     * In Java code where typing is enforced, use {@link getList(Class)}.
+     * In Java code where typing is enforced, use {@link #getList(Class)}.
      *
      * @param className Fully qualified class name
      * @return A list of type Objects registered with the manager or an empty
@@ -260,7 +260,7 @@ public final class InstanceManager {
      * {@link #store(java.lang.Object, java.lang.Class) }.
      *
      * Intended for use with i.e. scripts where access to the class type is inconvenient.
-     * In Java code where typing is enforced, use {@link getDefault(Class)}.
+     * In Java code where typing is enforced, use {@link #getDefault(Class)}.
      *
      * <p>
      * Unless specifically set, the default is the last object stored, see the
@@ -321,7 +321,7 @@ public final class InstanceManager {
      * {@link #store(java.lang.Object, java.lang.Class) }.
      *
      * Intended for use with i.e. scripts where access to the class type is inconvenient.
-     * In Java code where typing is enforced, use {@link getNullableDefault(Class)}.
+     * In Java code where typing is enforced, use {@link #getNullableDefault(Class)}.
      * <p>
      * Unless specifically set, the default is the last object stored, see the
      * {@link #setDefault(java.lang.Class, java.lang.Object) } method.

--- a/java/test/jmri/InstanceManagerTest.java
+++ b/java/test/jmri/InstanceManagerTest.java
@@ -116,6 +116,11 @@ public class InstanceManagerTest {
                 InstanceManager.getList(PowerManager.class).get(0));
         Assert.assertEquals("retrieved 2nd PowerManager", m2,
                 InstanceManager.getList(PowerManager.class).get(1));
+
+        Assert.assertEquals("access by string",
+                InstanceManager.getList(PowerManager.class),
+                InstanceManager.getList("jmri.PowerManager")
+            );
     }
 
     @Test
@@ -132,6 +137,22 @@ public class InstanceManagerTest {
 
         Assert.assertEquals("retrieved same PowerManager", m1, m2);
         Assert.assertEquals("retrieved same TurnoutManager", t1, t2);
+
+        Assert.assertEquals("access by string",
+                InstanceManager.getDefault(PowerManager.class),
+                InstanceManager.getDefault("jmri.PowerManager")
+            );
+
+    }
+
+    @Test
+    public void testGetInstance() throws ClassNotFoundException {
+        // first check a predicate - Class.forName returns same object always
+        Assert.assertTrue("access by string",
+                Class.forName("jmri.PowerManager") == Class.forName("jmri.PowerManager")
+            );
+
+
     }
 
     @Test

--- a/java/test/jmri/InstanceManagerTest.java
+++ b/java/test/jmri/InstanceManagerTest.java
@@ -147,11 +147,12 @@ public class InstanceManagerTest {
 
     @Test
     public void testGetInstance() throws ClassNotFoundException {
-        // first check a predicate - Class.forName returns same object always
+        // for sync usage, check a predicate - Class.forName returns same object always
         Assert.assertTrue("access by string",
                 Class.forName("jmri.PowerManager") == Class.forName("jmri.PowerManager")
             );
-
+        // the rest of the checks are done via calls to getInstance
+        // embedded in various other tests
 
     }
 

--- a/jython/test/InstanceManagerTest.py
+++ b/jython/test/InstanceManagerTest.py
@@ -1,0 +1,8 @@
+# Test the InstanceManager accessor forms
+import jmri
+
+m1 = jmri.InstanceManager.getDefault(jmri.TurnoutManager)
+m2 = jmri.InstanceManager.getDefault("jmri.TurnoutManager")
+
+if (m1 != m2) : raise AssertionError("accessor results don't match")
+

--- a/jython/test/LoggingTest.py
+++ b/jython/test/LoggingTest.py
@@ -1,0 +1,5 @@
+# a quick check of logging from Jython
+import org.slf4j
+
+log = org.slf4j.LoggerFactory.getLogger("LoggingTest.py")
+log.warn("This WARN is OK, it's emitted from LoggingTest.py on purpose")


### PR DESCRIPTION
Adds string-based accessors to InstanceManager to allow easier access from .py and particularly from .py3 script files. Includes tests and a test sample script.

Also adds a logging sample test script.