### PR TITLE
Update command station type for Loconet over TCP

### DIFF
--- a/help/en/html/hardware/digirails/index.shtml
+++ b/help/en/html/hardware/digirails/index.shtml
@@ -63,7 +63,7 @@
 
         <li>Enter the IP address for your DR5000 unit</li>
 
-        <li>Select whatever as Command station type (DB150 Empire Builder on my side)</li>
+        <li>Select whatever as Command station type (DCS210 Evolution Command Station)</li>
 
         <li>Under Additional Connection settings, set port to 5550</li>
       </ul>


### PR DESCRIPTION
Pull request to update the command station type for Loconet over TCP.

Using the DB150 Empire Builder locks out programming with a programming track in Decoder Pro as the DB150 does not have that capability. Using one of the other command stations like the DCS210 does.