### PR TITLE
Fix provideSignalMast

### DIFF
--- a/java/src/jmri/implementation/SignalHeadSignalMast.java
+++ b/java/src/jmri/implementation/SignalHeadSignalMast.java
@@ -18,14 +18,14 @@ import org.slf4j.LoggerFactory;
  * <p>
  * System name specifies the creation information:
  * <pre>
- * IF$shsm:basic:one-searchlight:(IH1)(IH2)
+ * IF$shsm:basic:one-searchlight(IH1)(IH2)
  * </pre>
  * The name is a colon-separated series of terms:
  * <ul>
  * <li>IF$shsm - defines signal masts of this type
  * <li>basic - name of the signaling system
  * <li>one-searchlight - name of the particular aspect map
- * <li>(IH1)(IH2) - colon-separated list of names for SignalHeads
+ * <li>(IH1)(IH2) - List of signal head names in parentheses.  Note: There is no colon between the mast name and the head names.
  * </ul>
  * There was an older form where the SignalHead names were also colon separated:
  * IF$shsm:basic:one-searchlight:IH1:IH2 This was deprecated because colons appear in

--- a/java/src/jmri/managers/DefaultSignalMastManager.java
+++ b/java/src/jmri/managers/DefaultSignalMastManager.java
@@ -29,7 +29,7 @@ public class DefaultSignalMastManager extends AbstractManager<SignalMast>
         repeaterList = new ArrayList<>();
         addListeners();
     }
-    
+
     final void addListeners(){
         InstanceManager.getDefault(SignalHeadManager.class).addVetoableChangeListener(this);
         InstanceManager.getDefault(TurnoutManager.class).addVetoableChangeListener(this);
@@ -47,8 +47,8 @@ public class DefaultSignalMastManager extends AbstractManager<SignalMast>
         return 'F';
     }
 
-    /** 
-     * {@inheritDoc} 
+    /**
+     * {@inheritDoc}
      * Searches by UserName then SystemName.
      */
     @Override
@@ -72,6 +72,7 @@ public class DefaultSignalMastManager extends AbstractManager<SignalMast>
         name.append(":");
         name.append(signalSystem);
         name.append(":");
+        name.append(mastName);
         for (String s : heads) {
             name.append("(");
             name.append(StringUtil.parenQuote(s));
@@ -86,8 +87,8 @@ public class DefaultSignalMastManager extends AbstractManager<SignalMast>
     public SignalMast provideSignalMast(@Nonnull String name) throws IllegalArgumentException {
         SignalMast m = getSignalMast(name);
         if (m == null) {
-            // this should be replaced by a Service based approach, 
-            // perhaps along the lines of SignalMastAddPane, but 
+            // this should be replaced by a Service based approach,
+            // perhaps along the lines of SignalMastAddPane, but
             // for now we manually check types
             if (name.startsWith("IF$shsm")) {
                 m = new SignalHeadSignalMast(name);
@@ -225,7 +226,7 @@ public class DefaultSignalMastManager extends AbstractManager<SignalMast>
     public SignalMast provide(String name) throws IllegalArgumentException {
         return provideSignalMast(name);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void dispose(){


### PR DESCRIPTION
The `mastName` parameter was not being added to the system name string.