### PR TITLE
Use both factory name and language name in bundle

### DIFF
--- a/java/src/jmri/script/Bundle.properties
+++ b/java/src/jmri/script/Bundle.properties
@@ -3,6 +3,7 @@ allScripts=All Script Files
 files=Files
 
 # The next lines map the name provided by the engine (left side) to a human readable file type (right side)
-ECMAScript=ECMAScript Files
-python=Jython Files
-Python=Python 3 Files
+# The left side is the factory name followed by the language name. All non letters are replaced by underscore.
+Oracle_Nashorn_ECMAScript       = ECMAScript Files
+jython_python                   = Jython Files
+GraalVM_Python                  = Python 3 Files

--- a/java/src/jmri/script/swing/ScriptFileChooser.java
+++ b/java/src/jmri/script/swing/ScriptFileChooser.java
@@ -42,7 +42,7 @@ public class ScriptFileChooser extends JFileChooser {
             if (version != null) {
                 List<String> extensions = factory.getExtensions();
                 allExtensions.addAll(extensions);
-                String name = this.fileForLanguage(factory.getLanguageName());
+                String name = this.fileForLanguage(factory.getEngineName() + "_" + factory.getLanguageName());
                 filterNames.add(name);
                 filters.put(name, new FileNameExtensionFilter(name, extensions.toArray(new String[extensions.size()])));
             }
@@ -57,6 +57,7 @@ public class ScriptFileChooser extends JFileChooser {
     }
 
     private String fileForLanguage(String language) {
+        language = language.replaceAll("\\W+", "_");
         try {
             return Bundle.getMessage(language);
         } catch (MissingResourceException ex) {


### PR DESCRIPTION
@bobjacobsen 
This is a small suggestion to https://github.com/JMRI/JMRI/pull/10549#discussion_r780555662 :
> What is this used for? My concern is that if Python and python stands for two different things, the risk of error is high.

Instead of using only the language name in the bundle, this PR uses both the factory name and the language name.

I don't know what factory name GraalVM has so that probably needs to be change.

Note:
This section of properties was both in `jmri.script.Bundle.properties` and in `jmri.script.swing.Bundle.properties`. I suppose it can be removed from the later one?
```
ECMAScript=ECMAScript Files
python=Jython Files
Python=Python 3 Files
```