### PR TITLE
TCS Pivotted to using industry standard CVs for extended decoder iden…

### DIFF
--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * {@link #setOptionalCv(boolean flag) setOptionalCv()} and
  * {@link #isOptionalCv() isOptionalCv()} as documented below.)</li>
  * <li>TCS: (mfgID == 153) CV249 is physical hardware id, V5 and above use
- * CV253, CV254, CV255, and CV256 to identify specific sound sets and 
+ * CV110 and CV111 to identify specific sound sets and
  * features. New productID process triggers if (CV249 &gt; 175).</li>
  * <li>Zimo: (mfgID == 145) CV250 is ID</li>
  * <li>SoundTraxx: (mfgID == 141, modelID == 70 or 71) CV253 is high byte, CV256
@@ -154,8 +154,8 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             writeCV("50", 4);
             return false;
         } else if (mfgID == 153) {  // TCS
+            productID = value;
             if(value < 175){ //check for pre-version 5 sound decoders
-                productID = value;
                 return true;
             }
             else{
@@ -265,7 +265,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             return false;
         } else if (mfgID == 153) {  // TCS
             productIDhigh = value;
-            productID = (productIDhigh*256) + productIDlow;
+            productID = (productIDhigh*256*256*256) + (productIDlow*256*256) + (productID*256);
             return true;
         }
         log.error("unexpected step 6 reached with value: {}", value);
@@ -287,7 +287,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             productIDlowest = value;
             productID = (((((productIDhighest << 8) | productIDhigh) << 8) | productIDlow) << 8) | productIDlowest;
             return true;
-        } 
+        }
         log.error("unexpected step 7 reached with value: {}", value);
         return true;
     }

--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -154,13 +154,14 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             writeCV("50", 4);
             return false;
         } else if (mfgID == 153) {  // TCS
-            productID = value;
-            if(value < 175){ //check for pre-version 5 sound decoders
+            if(value < 129){ //check for mobile decoders
+                productID = value;
                 return true;
             }
             else{
-                statusUpdate("Read decoder extended Version ID Low Byte");
-                readCV("111");
+                productIDlowest = value;
+                statusUpdate("Read decoder sound version number");
+                readCV("248");
                 return false;
             }
         } else if (mfgID == 48) {  // Hornby
@@ -239,7 +240,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
         } else if (mfgID == 153) {  // TCS
             productIDlow = value;
             statusUpdate("Read decoder extended Version ID Low Byte");
-            readCV("110");
+            readCV("111");
             return false;
         }
         log.error("unexpected step 5 reached with value: {}", value);
@@ -265,8 +266,9 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             return false;
         } else if (mfgID == 153) {  // TCS
             productIDhigh = value;
-            productID = (productIDhigh*256*256*256) + (productIDlow*256*256) + (productID*256);
-            return true;
+            statusUpdate("Read decoder extended Version ID High Byte");
+            readCV("110");
+            return false;
         }
         log.error("unexpected step 6 reached with value: {}", value);
         return true;
@@ -286,6 +288,15 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
         } else if (mfgID == 13) {  // DIY
             productIDlowest = value;
             productID = (((((productIDhighest << 8) | productIDhigh) << 8) | productIDlow) << 8) | productIDlowest;
+            return true;
+        } else if (mfgID == 153) {  // TCS
+            productIDhighest = value;
+            if (((productIDlowest >= 129 && productIDlowest <= 135) && (productIDlow == 5))||(modelID >= 5)){
+                productID = productIDlowest+(productIDlow*256)+(productIDhigh*256*256)+(productIDhighest*256*256*256);
+            }
+            else{
+                productID = productIDlowest;
+            }
             return true;
         }
         log.error("unexpected step 7 reached with value: {}", value);

--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -24,8 +24,8 @@ import org.slf4j.LoggerFactory;
  * {@link #setOptionalCv(boolean flag) setOptionalCv()} and
  * {@link #isOptionalCv() isOptionalCv()} as documented below.)</li>
  * <li>TCS: (mfgID == 153) CV249 is physical hardware id, V5 and above use
- * CV110 and CV111 to identify specific sound sets and
- * features. New productID process triggers if (CV249 &gt; 175).</li>
+ * CV248, CV110 and CV111 to identify specific sound sets and
+ * features. New productID process triggers if (CV249 &gt; 128).</li>
  * <li>Zimo: (mfgID == 145) CV250 is ID</li>
  * <li>SoundTraxx: (mfgID == 141, modelID == 70 or 71) CV253 is high byte, CV256
  * is low byte of ID</li>

--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -159,8 +159,8 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
                 return true;
             }
             else{
-                statusUpdate("Read decoder product hash #1 CV 253");
-                readCV("253");
+                statusUpdate("Read decoder extended Version ID Low Byte");
+                readCV("111");
                 return false;
             }
         } else if (mfgID == 48) {  // Hornby
@@ -237,9 +237,9 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             readCV("49");
             return false;
         } else if (mfgID == 153) {  // TCS
-            productIDlowest = value;
-            statusUpdate("Read decoder product hash #2 CV 254");
-            readCV("254");
+            productIDlow = value;
+            statusUpdate("Read decoder extended Version ID Low Byte");
+            readCV("110");
             return false;
         }
         log.error("unexpected step 5 reached with value: {}", value);
@@ -264,10 +264,9 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             readCV("50");
             return false;
         } else if (mfgID == 153) {  // TCS
-            productIDlow = value;
-            statusUpdate("Read decoder product hash #3 CV 255");
-            readCV("255");
-            return false;
+            productIDhigh = value;
+            productID = (productIDhigh*256) + productIDlow;
+            return true;
         }
         log.error("unexpected step 6 reached with value: {}", value);
         return true;
@@ -288,12 +287,7 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             productIDlowest = value;
             productID = (((((productIDhighest << 8) | productIDhigh) << 8) | productIDlow) << 8) | productIDlowest;
             return true;
-        } else if (mfgID == 153) {  // TCS
-            productIDhigh = value;
-            statusUpdate("Read decoder product hash #4 CV 256");
-            readCV("256");
-            return false;
-        }
+        } 
         log.error("unexpected step 7 reached with value: {}", value);
         return true;
     }
@@ -309,10 +303,6 @@ public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             statusUpdate("Read productID Byte 4");
             readCV("264");
             return false;
-        } else if (mfgID == 153) {  // TCS
-            productIDhighest = value;
-            productID = (productIDhighest*256*256*256) + (productIDhigh*256*256) + (productIDlow*256) + productIDlowest;
-            return true;
         }
         log.error("unexpected step 8 reached with value: {}", value);
         return true;

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -488,12 +488,70 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("found product ID ", 33620400, i.productID);
     }
     
-        /**
-     * Test TCS decoder with single byte, CV249 productID.
+    /**
+     * Test TCS decoder with single byte, CV249 productID. Sound decoders pre V5
      * Should pass
      */
     @Test
     public void testIdentifyTCSV4() {
+        // create our test object
+        IdentifyDecoder i = new IdentifyDecoder(p) {
+            @Override
+            public void done(int mfgID, int modelID, int productID) {
+            }
+
+            @Override
+            public void message(String m) {
+            }
+
+            @Override
+            public void error() {
+            }
+        };
+
+        i.start();
+        Assert.assertEquals("step 1 reads CV ", 8, cvRead);
+        Assert.assertEquals("running after 1 ", true, i.isRunning());
+
+        // simulate CV read complete on CV8, start 7
+        i.programmingOpReply(153, 0);
+        Assert.assertEquals("step 2 reads CV ", 7, cvRead);
+        Assert.assertEquals("running after 2 ", true, i.isRunning());
+
+        // simulate CV read complete on CV7, start 249
+        i.programmingOpReply(4, 0);
+        Assert.assertEquals("step 3 reads CV ", 249, cvRead);
+        Assert.assertEquals("running after 3 ", true, i.isRunning());
+
+        // simulate CV read complete on CV249, start 248
+        i.programmingOpReply(176, 0);
+        Assert.assertEquals("step 4 reads CV ", 248, cvRead);
+        Assert.assertEquals("running after 4 ", true, i.isRunning());
+        
+        // simulate CV read complete on CV248, start 111
+        i.programmingOpReply(1, 0);
+        Assert.assertEquals("step 5 reads CV 111", 111, cvRead);
+        Assert.assertEquals("running after 5 ", true, i.isRunning());
+        
+        // simulate CV read complete on CV111, start 110
+        i.programmingOpReply(1, 0);
+        Assert.assertEquals("step 6 reads CV ", 110, cvRead);
+        Assert.assertEquals("running after 6 ", true, i.isRunning());
+        
+        // simulate CV read complete on CV110, start end
+        i.programmingOpReply(2, 0);
+
+        Assert.assertEquals("found mfg ID ", 153, i.mfgID);
+        Assert.assertEquals("found model ID ", 4, i.modelID);
+        Assert.assertEquals("found product ID ", 176, i.productID);
+    }
+    
+    /**
+     * Test TCS decoder with single byte, CV249 productID. Non-sound decoders only).
+     * Should pass
+     */
+    @Test
+    public void testIdentifyTCSMobile() {
         // create our test object
         IdentifyDecoder i = new IdentifyDecoder(p) {
             @Override

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -465,22 +465,27 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("step 3 reads CV ", 249, cvRead);
         Assert.assertEquals("running after 3 ", true, i.isRunning());
 
-        // simulate CV read complete on CV249, start 111
+        // simulate CV read complete on CV249, start 248
         i.programmingOpReply(176, 0);
-        Assert.assertEquals("step 4 reads CV ", 111, cvRead);
+        Assert.assertEquals("step 4 reads CV ", 248, cvRead);
         Assert.assertEquals("running after 4 ", true, i.isRunning());
         
-        // simulate CV read complete on CV253, start 110
+        // simulate CV read complete on CV248, start 111
         i.programmingOpReply(1, 0);
-        Assert.assertEquals("step 5 reads CV ", 110, cvRead);
+        Assert.assertEquals("step 5 reads CV 111", 111, cvRead);
         Assert.assertEquals("running after 5 ", true, i.isRunning());
+        
+        // simulate CV read complete on CV111, start 110
+        i.programmingOpReply(1, 0);
+        Assert.assertEquals("step 6 reads CV ", 110, cvRead);
+        Assert.assertEquals("running after 6 ", true, i.isRunning());
         
         // simulate CV read complete on CV110, start end
         i.programmingOpReply(2, 0);
 
         Assert.assertEquals("found mfg ID ", 153, i.mfgID);
         Assert.assertEquals("found model ID ", 5, i.modelID);
-        Assert.assertEquals("found product ID ", 33665024, i.productID);
+        Assert.assertEquals("found product ID ", 33620400, i.productID);
     }
     
         /**

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -465,22 +465,22 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("step 3 reads CV ", 249, cvRead);
         Assert.assertEquals("running after 3 ", true, i.isRunning());
 
-        // simulate CV read complete on CV249, start 253
+        // simulate CV read complete on CV249, start 111
         i.programmingOpReply(176, 0);
         Assert.assertEquals("step 4 reads CV ", 111, cvRead);
         Assert.assertEquals("running after 4 ", true, i.isRunning());
         
-        // simulate CV read complete on CV253, start 254
+        // simulate CV read complete on CV253, start 110
         i.programmingOpReply(1, 0);
-        Assert.assertEquals("step 6 reads CV ", 110, cvRead);
-        Assert.assertEquals("running after 6 ", true, i.isRunning());
+        Assert.assertEquals("step 5 reads CV ", 110, cvRead);
+        Assert.assertEquals("running after 5 ", true, i.isRunning());
         
-        // simulate CV read complete on CV254, start end
+        // simulate CV read complete on CV110, start end
         i.programmingOpReply(2, 0);
 
         Assert.assertEquals("found mfg ID ", 153, i.mfgID);
         Assert.assertEquals("found model ID ", 5, i.modelID);
-        Assert.assertEquals("found product ID ", 513, i.productID);
+        Assert.assertEquals("found product ID ", 33665024, i.productID);
     }
     
         /**

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -467,30 +467,20 @@ public class IdentifyDecoderTest {
 
         // simulate CV read complete on CV249, start 253
         i.programmingOpReply(176, 0);
-        Assert.assertEquals("step 5 reads CV ", 253, cvRead);
-        Assert.assertEquals("running after 5 ", true, i.isRunning());
+        Assert.assertEquals("step 4 reads CV ", 111, cvRead);
+        Assert.assertEquals("running after 4 ", true, i.isRunning());
         
         // simulate CV read complete on CV253, start 254
         i.programmingOpReply(1, 0);
-        Assert.assertEquals("step 6 reads CV ", 254, cvRead);
+        Assert.assertEquals("step 6 reads CV ", 110, cvRead);
         Assert.assertEquals("running after 6 ", true, i.isRunning());
         
-        // simulate CV read complete on CV254, start 255
+        // simulate CV read complete on CV254, start end
         i.programmingOpReply(2, 0);
-        Assert.assertEquals("step 7 reads CV ", 255, cvRead);
-        Assert.assertEquals("running after 7 ", true, i.isRunning());
-        
-        // simulate CV read complete on CV255, start 256
-        i.programmingOpReply(3, 0);
-        Assert.assertEquals("step 8 reads CV ", 256, cvRead);
-        Assert.assertEquals("running after 8 ", true, i.isRunning());
-        
-        // simulate CV read complete on CV256, end
-        i.programmingOpReply(4, 0);
 
         Assert.assertEquals("found mfg ID ", 153, i.mfgID);
         Assert.assertEquals("found model ID ", 5, i.modelID);
-        Assert.assertEquals("found product ID ", 67305985, i.productID);
+        Assert.assertEquals("found product ID ", 513, i.productID);
     }
     
         /**


### PR DESCRIPTION
…tification

After continuing to review products at a rapid rate TCS has chosen not to use a software hash, but rather a manufacturer controlled value in CV's 110 and 111 to handle advanced identification for our expanding sound products.

We will likely tweak software frequently, but rarely change the sound set for a given decoder. By locking this number to a manually controlled value we can insure minor bug changes dont require new JMRI definitions reducing the overall size of TCS product definitions in JMRI.