### PR TITLE
Update remaining Ipocs Tests to Junit5

### DIFF
--- a/java/src/jmri/jmrix/ipocs/IpocsSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/ipocs/IpocsSystemConnectionMemo.java
@@ -1,8 +1,6 @@
 package jmri.jmrix.ipocs;
 
-import jmri.LightManager;
-import jmri.SensorManager;
-import jmri.TurnoutManager;
+import jmri.*;
 
 /**
  *
@@ -12,18 +10,23 @@ import jmri.TurnoutManager;
 public class IpocsSystemConnectionMemo extends jmri.jmrix.DefaultSystemConnectionMemo implements jmri.jmrix.ConfiguringSystemConnectionMemo {
   private IpocsPortController portController;
 
-  public IpocsSystemConnectionMemo() {
-    super("P", "IPOCS");
-    jmri.InstanceManager.store(this, IpocsSystemConnectionMemo.class);
-  }
+    public IpocsSystemConnectionMemo() {
+        super("P", "IPOCS");
+        storeThisInstance();
+    }
+    
+    private void storeThisInstance(){
+        InstanceManager.store(this, IpocsSystemConnectionMemo.class);
+    }
 
-  @Override
-  public void configureManagers() {
-    jmri.InstanceManager.setTurnoutManager(getTurnoutManager());
-    jmri.InstanceManager.setLightManager(getLightManager());
-    jmri.InstanceManager.setSensorManager(getSensorManager());
-    register();
-  }
+    @Override
+    public void configureManagers() {
+        InstanceManager.setSensorManager(getSensorManager());
+        InstanceManager.setTurnoutManager(getTurnoutManager());
+        InstanceManager.setLightManager(getLightManager());
+    
+        register();
+    }
 
   @Override
   public <B extends jmri.NamedBean> java.util.Comparator<B> getNamedBeanComparator(final Class<B> type) {

--- a/java/test/jmri/jmrix/ipocs/IpocsClientHandlerTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsClientHandlerTest.java
@@ -10,14 +10,10 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousSocketChannel;
 
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+
+import org.junit.jupiter.api.*;
 
 import jmri.jmrix.ipocs.protocol.Message;
 import jmri.jmrix.ipocs.protocol.packets.ConnectionRequestPacket;
@@ -25,11 +21,7 @@ import jmri.jmrix.ipocs.protocol.packets.SignOfLifePacket;
 
 public class IpocsClientHandlerTest {
 
-  @Mock
-  public AsynchronousSocketChannel client;
-
-  @Rule
-  public MockitoRule mockitoRule = MockitoJUnit.rule();
+  private AsynchronousSocketChannel client;
 
   private final IpocsClientListener listener = new IpocsClientListener() {
     @Override
@@ -68,6 +60,8 @@ public class IpocsClientHandlerTest {
 
     doThrow(new IOException()).when(client).close();
     ch.completed(-1, null);
+    
+    JUnitAppender.assertErrorMessage("Unable to close client: null");
   }
 
   @Test
@@ -141,14 +135,16 @@ public class IpocsClientHandlerTest {
     ch.send(msg);
   }
 
-  @BeforeEach
-  public void setUp() {
-    jmri.util.JUnitUtil.setUp();
-  }
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        client = mock(AsynchronousSocketChannel.class);
+    }
 
-  @AfterEach
-  public void tearDown() {
-    JUnitUtil.tearDown();
-  }
+    @AfterEach
+    public void tearDown() {
+        client = null;
+        JUnitUtil.tearDown();
+    }
 
 }

--- a/java/test/jmri/jmrix/ipocs/IpocsConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsConnectionConfigTest.java
@@ -9,7 +9,9 @@ import static org.mockito.Mockito.when;
 
 import javax.swing.JOptionPane;
 
-import org.junit.Test;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
 import org.mockito.MockedStatic;
 
 public class IpocsConnectionConfigTest {
@@ -128,4 +130,15 @@ public class IpocsConnectionConfigTest {
     cc.setDisabled(true);
     assertEquals(true, cc.getDisabled());
   }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrix/ipocs/IpocsConnectionTypeListTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsConnectionTypeListTest.java
@@ -1,8 +1,6 @@
 package jmri.jmrix.ipocs;
 
-import org.junit.Test;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
 
 import jmri.util.JUnitUtil;
 import org.junit.Assert;
@@ -16,17 +14,6 @@ import org.junit.Assert;
  */
 public class IpocsConnectionTypeListTest {
 
-    @BeforeEach        
-    public void setUp() {
-        JUnitUtil.setUp();
-        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
-    }
-
-    @AfterEach
-    public void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
     @Test
     public void ConstructorTest() {
         Assert.assertNotNull("constructor", new IpocsConnectionTypeList());
@@ -34,11 +21,22 @@ public class IpocsConnectionTypeListTest {
 
     @Test
     public void GetManufacturersTest() {
-      new IpocsConnectionTypeList().getManufacturers();
+        new IpocsConnectionTypeList().getManufacturers();
     }
 
     @Test
     public void GetAvailableProtocolClassesTest() {
-      new IpocsConnectionTypeList().getAvailableProtocolClasses();
+        new IpocsConnectionTypeList().getAvailableProtocolClasses();
     }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrix/ipocs/IpocsLightManagerTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsLightManagerTest.java
@@ -1,13 +1,31 @@
 package jmri.jmrix.ipocs;
 
+import jmri.util.JUnitUtil;
+
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
-public class IpocsLightManagerTest {
+public class IpocsLightManagerTest extends jmri.managers.AbstractLightMgrTestBase {
+
+    @Override
+    protected int getNumToTest1() {
+        return 10;
+    }
+
+    @Override
+    protected int getNumToTest2() {
+        return 56517;
+    }
+
+    @Override
+    public String getSystemName(int i) {
+        return "PL" + i;
+    }
+
   @Test
   public void constructorTest() {
     IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
@@ -28,4 +46,38 @@ public class IpocsLightManagerTest {
     IpocsLightManager manager = new IpocsLightManager(memo);
     assertNotNull(manager.createNewLight("AL33", "Li91"));
   }
+
+    @Disabled("Test requires further development")
+    @Test
+    @Override
+    public void testMakeSystemNameWithNoPrefixNotASystemName() {}
+
+    @Disabled("Test requires further development")
+    @Test
+    @Override
+    public void testMakeSystemNameWithPrefixNotASystemName() {}
+
+    @Disabled("Test requires further development")
+    @Test
+    @Override
+    public void testRegisterDuplicateSystemName() {}
+  
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
+        IpocsPortController portController = mock(IpocsPortController.class);
+        when(memo.getPortController()).thenReturn(portController);
+        when(memo.getSystemPrefix()).thenReturn("P");
+        l = new IpocsLightManager(memo);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        l.dispose();
+        l = null;
+        JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrix/ipocs/IpocsLightTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsLightTest.java
@@ -5,14 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 import org.apache.log4j.Level;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 import jmri.Light;
 import jmri.jmrix.ipocs.protocol.Message;
 import jmri.jmrix.ipocs.protocol.enums.RqOutputState;
 import jmri.jmrix.ipocs.protocol.packets.OutputStatusPacket;
+import jmri.util.JUnitUtil;
 
-public class IpocsLightTest {
+public class IpocsLightTest extends jmri.implementation.AbstractLightTestBase {
   @Test
   public void constructorTest() {
     IpocsPortController portController = mock(IpocsPortController.class);
@@ -73,4 +74,35 @@ public class IpocsLightTest {
     pkt.setState(RqOutputState.On);
     light.onMessage(client, msg);
   }
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        IpocsPortController portController = mock(IpocsPortController.class);
+        t  = new IpocsLight(portController, "EL33", "Light9F1");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        t.dispose();
+        t = null;
+        JUnitUtil.tearDown();
+    }
+
+    @Override
+    public int numListeners() {
+        return 0;
+    }
+
+    // Test requires further development
+    @Override
+    public void checkOnMsgSent() {
+    }
+
+    // Test requires further development
+    @Override
+    public void checkOffMsgSent() {
+    }
+
 }

--- a/java/test/jmri/jmrix/ipocs/IpocsPortControllerTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsPortControllerTest.java
@@ -12,11 +12,12 @@ import java.net.InetSocketAddress;
 import java.nio.channels.AsynchronousServerSocketChannel;
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import jmri.jmrix.ipocs.protocol.Message;
+import jmri.util.JUnitUtil;
 import jmri.util.zeroconf.ZeroConfService;
 
 public class IpocsPortControllerTest {
@@ -171,4 +172,14 @@ public class IpocsPortControllerTest {
     pc.onMessage(client, msg);
     assertNotNull(pc.getLastStatus("Vx91"));
   }
+
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
 }

--- a/java/test/jmri/jmrix/ipocs/IpocsSensorManagerTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsSensorManagerTest.java
@@ -1,25 +1,64 @@
 package jmri.jmrix.ipocs;
 
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
+public class IpocsSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
-public class IpocsSensorManagerTest {
-  @Test
-  public void constructorTest() {
-    final IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
-    assertNotNull(new IpocsSensorManager(memo));
-  }
+    @Test
+    public void constructorTest() {
+        final IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
+        assertNotNull(new IpocsSensorManager(memo));
+    }
   
-  @Test
-  public void createNewSensorTest() {
-    final IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
-    final IpocsPortController portController = mock(IpocsPortController.class);
-    when(memo.getPortController()).thenReturn(portController);
-    final IpocsSensorManager manager = new IpocsSensorManager(memo);
-    assertNotNull(manager.createNewSensor("AS33", "Li91"));
-  }
+    @Test
+    public void createNewSensorTest() {
+        final IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
+        final IpocsPortController portController = mock(IpocsPortController.class);
+        when(memo.getPortController()).thenReturn(portController);
+        final IpocsSensorManager manager = new IpocsSensorManager(memo);
+        assertNotNull(manager.createNewSensor("AS33", "Li91"));
+    }
+
+    @Override
+    public String getSystemName(int i) {
+        return "PS" + i;
+    }
+
+    @Disabled("Test requires further development")
+    @Test
+    @Override
+    public void testMakeSystemNameWithNoPrefixNotASystemName() {}
+
+    @Disabled("Test requires further development")
+    @Test
+    @Override
+    public void testMakeSystemNameWithPrefixNotASystemName() {}
+
+    @Disabled("Test requires further development")
+    @Test
+    @Override
+    public void testRegisterDuplicateSystemName() {}
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        final IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
+        final IpocsPortController portController = mock(IpocsPortController.class);
+        when(memo.getPortController()).thenReturn(portController);
+        when(memo.getSystemPrefix()).thenReturn("P");
+        l = new IpocsSensorManager(memo);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
 
 }

--- a/java/test/jmri/jmrix/ipocs/IpocsSensorTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsSensorTest.java
@@ -3,13 +3,14 @@ package jmri.jmrix.ipocs;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
-
 import jmri.jmrix.ipocs.protocol.Message;
 import jmri.jmrix.ipocs.protocol.enums.RqInputState;
 import jmri.jmrix.ipocs.protocol.packets.InputStatusPacket;
+import jmri.util.JUnitUtil;
 
-public class IpocsSensorTest {
+import org.junit.jupiter.api.*;
+
+public class IpocsSensorTest extends jmri.implementation.AbstractSensorTestBase {
 
   @Test
   public void constructorTest() {
@@ -57,5 +58,41 @@ public class IpocsSensorTest {
     pkt.setState(RqInputState.Undefined);
     sensor.onMessage(client, msg);
   }
+
+    @Override
+    public int numListeners() {
+        return 0;
+    }
+
+    @Disabled("Test requires further development")
+    @Override
+    public void checkActiveMsgSent() {
+    }
+
+    @Disabled("Test requires further development")
+    @Override
+    public void checkInactiveMsgSent() {
+    }
+
+    @Disabled("Test requires further development")
+    @Override
+    public void checkStatusRequestMsgSent() {
+    }
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        IpocsPortController portController = mock(IpocsPortController.class);
+        t  = new IpocsSensor(portController, "ES33", "Li91");
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        t.dispose();
+        t = null;
+        JUnitUtil.tearDown();
+    }
 
 }

--- a/java/test/jmri/jmrix/ipocs/IpocsSocketAdapterTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsSocketAdapterTest.java
@@ -6,7 +6,9 @@ import static org.mockito.Mockito.mock;
 import java.nio.channels.AsynchronousServerSocketChannel;
 import java.nio.channels.AsynchronousSocketChannel;
 
-import org.junit.Test;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
 
 public class IpocsSocketAdapterTest {
   
@@ -36,4 +38,13 @@ public class IpocsSocketAdapterTest {
     jmri.util.JUnitAppender.suppressErrorMessage("Unable to accept socket");
   }
 
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
 }

--- a/java/test/jmri/jmrix/ipocs/IpocsSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsSystemConnectionMemoTest.java
@@ -5,14 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import jmri.SensorManager;
 import jmri.jmrix.SystemConnectionMemoManager;
+import jmri.jmrix.SystemConnectionMemoTestBase;
 
-public class IpocsSystemConnectionMemoTest {
+import jmri.util.JUnitUtil;
+
+public class IpocsSystemConnectionMemoTest extends SystemConnectionMemoTestBase<IpocsSystemConnectionMemo> {
 
   @Test
   public void constructorTest() {
@@ -21,6 +25,7 @@ public class IpocsSystemConnectionMemoTest {
       when(scmm.isSystemPrefixAvailable("P")).thenReturn(true);
       when(scmm.isUserNameAvailable("IPOCS")).thenReturn(true);
       imMock.when(() -> jmri.InstanceManager.getDefault(SystemConnectionMemoManager.class)).thenReturn(scmm);
+
       IpocsSystemConnectionMemo memo = new IpocsSystemConnectionMemo();
       assertNotNull(memo);
 
@@ -37,6 +42,7 @@ public class IpocsSystemConnectionMemoTest {
       when(scmm.isUserNameAvailable("IPOCS")).thenReturn(true);
       imMock.when(() -> jmri.InstanceManager.getDefault(SystemConnectionMemoManager.class)).thenReturn(scmm);
       imMock.when(() -> jmri.InstanceManager.sensorManagerInstance()).thenReturn(sm);
+
       IpocsSystemConnectionMemo memo = new IpocsSystemConnectionMemo();
       assertNotNull(memo);
       memo.configureManagers();
@@ -54,6 +60,7 @@ public class IpocsSystemConnectionMemoTest {
       when(scmm.isUserNameAvailable("IPOCS")).thenReturn(true);
       imMock.when(() -> jmri.InstanceManager.getDefault(SystemConnectionMemoManager.class)).thenReturn(scmm);
       imMock.when(() -> jmri.InstanceManager.sensorManagerInstance()).thenReturn(sm);
+
       IpocsSystemConnectionMemo memo = new IpocsSystemConnectionMemo();
       memo.setDisabled(true);
       assertNotNull(memo);
@@ -70,6 +77,7 @@ public class IpocsSystemConnectionMemoTest {
       when(scmm.isSystemPrefixAvailable("P")).thenReturn(true);
       when(scmm.isUserNameAvailable("IPOCS")).thenReturn(true);
       imMock.when(() -> jmri.InstanceManager.getDefault(SystemConnectionMemoManager.class)).thenReturn(scmm);
+
       IpocsSystemConnectionMemo memo = new IpocsSystemConnectionMemo();
       assertNotNull(memo);
       assertNull(memo.getActionModelResourceBundle());
@@ -85,6 +93,7 @@ public class IpocsSystemConnectionMemoTest {
       when(scmm.isSystemPrefixAvailable("P")).thenReturn(true);
       when(scmm.isUserNameAvailable("IPOCS")).thenReturn(true);
       imMock.when(() -> jmri.InstanceManager.getDefault(SystemConnectionMemoManager.class)).thenReturn(scmm);
+
       IpocsSystemConnectionMemo memo = new IpocsSystemConnectionMemo();
       assertNotNull(memo);
       assertNull(memo.getPortController());
@@ -94,5 +103,20 @@ public class IpocsSystemConnectionMemoTest {
       memo.dispose();
     }
   }
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        scm = new IpocsSystemConnectionMemo();
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        scm.dispose();
+        scm = null;
+        JUnitUtil.tearDown();
+    }
 
 }

--- a/java/test/jmri/jmrix/ipocs/IpocsTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsTurnoutManagerTest.java
@@ -1,26 +1,76 @@
 package jmri.jmrix.ipocs;
 
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
 
-public class IpocsTurnoutManagerTest {
+public class IpocsTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
-  @Test
-  public void constructorTest() {
-    final IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
-    assertNotNull(new IpocsTurnoutManager(memo));
-  }
-  
-  @Test
-  public void createNewTurnoutTest() {
-    final IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
-    final IpocsPortController portController = mock(IpocsPortController.class);
-    when(memo.getPortController()).thenReturn(portController);
-    final IpocsTurnoutManager manager = new IpocsTurnoutManager(memo);
-    assertNotNull(manager.createNewTurnout("AT33", "Li91"));
-  }
+    @Test
+    public void constructorTest() {
+        final IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
+        assertNotNull(new IpocsTurnoutManager(memo));
+    }
+
+    @Test
+    public void createNewTurnoutTest() {
+        final IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
+        final IpocsPortController portController = mock(IpocsPortController.class);
+        when(memo.getPortController()).thenReturn(portController);
+        final IpocsTurnoutManager manager = new IpocsTurnoutManager(memo);
+        assertNotNull(manager.createNewTurnout("AT33", "Li91"));
+    }
+
+    @Override
+    public String getSystemName(int i) {
+        return "PT" + i;
+    }
+
+    @Disabled("Test requires further development")
+    @Test
+    @Override
+    public void testMakeSystemNameWithNoPrefixNotASystemName() {}
+
+    @Disabled("Test requires further development")
+    @Test
+    @Override
+    public void testMakeSystemNameWithPrefixNotASystemName() {}
+
+    @Disabled("Test requires further development")
+    @Test
+    @Override
+    public void testSetAndGetOutputInterval() {}
+
+    @Disabled("Test requires further development")
+    @Test
+    @Override
+    public void testRegisterDuplicateSystemName() {}
+
+    @Test
+    @Override
+    public void testAutoSystemNames() {
+    }
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        final IpocsPortController portController = mock(IpocsPortController.class);
+        final IpocsSystemConnectionMemo memo = mock(IpocsSystemConnectionMemo.class);
+        when(memo.getPortController()).thenReturn(portController);
+        when(memo.getSystemPrefix()).thenReturn("P");
+        l = new IpocsTurnoutManager(memo);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        l = null;
+        JUnitUtil.tearDown();
+    }
 
 }

--- a/java/test/jmri/jmrix/ipocs/IpocsTurnoutTest.java
+++ b/java/test/jmri/jmrix/ipocs/IpocsTurnoutTest.java
@@ -2,8 +2,7 @@ package jmri.jmrix.ipocs;
 
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -18,18 +17,6 @@ public class IpocsTurnoutTest extends AbstractTurnoutTestBase {
 
   @Mock
   IpocsPortController portController;
-
-  @BeforeEach
-  public void setUp() {
-    JUnitUtil.initDefaultUserMessagePreferences();
-    MockitoAnnotations.openMocks(this);
-    // when(portController..send())
-    t = new IpocsTurnout(portController, "PT2", "Vx2");
-    // t.client
-    super.setUp();
-  }
-
-  // no special actions during teardown?
 
   @Override
   public int numListeners() {
@@ -113,5 +100,15 @@ public class IpocsTurnoutTest extends AbstractTurnoutTestBase {
     final IpocsClientHandler client = mock(IpocsClientHandler.class);
     ((IpocsTurnout)t).clientDisconnected(client);
   }
+
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        MockitoAnnotations.openMocks(this);
+        // when(portController..send())
+        t = new IpocsTurnout(portController, "PT2", "Vx2");
+        // t.client
+    }
 
 }

--- a/java/test/jmri/jmrix/ipocs/configurexml/IpocsConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/ipocs/configurexml/IpocsConnectionConfigXmlTest.java
@@ -5,43 +5,40 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.jdom2.Element;
-import org.junit.Test;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
 
 import jmri.jmrix.ipocs.IpocsConnectionConfig;
 import jmri.jmrix.ipocs.IpocsPortController;
+import jmri.util.JUnitUtil;
 
 public class IpocsConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractConnectionConfigXmlTestBase {
 
-  private IpocsPortController portController;
-  private IpocsConnectionConfig connConfig;
+    @BeforeEach
+    @Override
+    public void setUp() {
+        JUnitUtil.setUp();
+        xmlAdapter = new IpocsConnectionConfigXml();
+        
+        IpocsPortController portController = mock(IpocsPortController.class);
+        when(portController.getOptions()).thenReturn(new String[]{});
+        when(portController.getDisabled()).thenReturn(true);
+        cc = mock(IpocsConnectionConfig.class);
+        when(cc.getAdapter()).thenReturn(portController);
 
-  @BeforeEach
-  @Override
-  public void setUp() {
-    jmri.util.JUnitUtil.setUp();
-    jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
-    xmlAdapter = new IpocsConnectionConfigXml();
-    portController = mock(IpocsPortController.class);
-    when(portController.getOptions()).thenReturn(new String[]{});
-    when(portController.getDisabled()).thenReturn(true);
-    connConfig = mock(IpocsConnectionConfig.class);
-    when(connConfig.getAdapter()).thenReturn(portController);
-    cc = connConfig;
-  }
+    }
 
-  @AfterEach
-  @Override
-  public void tearDown() {
-    jmri.util.JUnitUtil.tearDown();
-    xmlAdapter = null;
-    cc = null;
-  }
+    @AfterEach
+    @Override
+    public void tearDown() {
+        cc.dispose();
+        xmlAdapter = null;
+        cc = null;
+        JUnitUtil.tearDown();
+    }
 
-  @Test
-  public void specificLoadTest() {
-    assertThrows(NullPointerException.class, () -> xmlAdapter.load(null));
-    assertThrows(NullPointerException.class, () -> xmlAdapter.load(new Element("connection")));
-  }
+    @Test
+    public void specificLoadTest() {
+        assertThrows(UnsupportedOperationException.class, () -> xmlAdapter.load(null));
+        assertThrows(UnsupportedOperationException.class, () -> xmlAdapter.load(new Element("connection")));
+    }
 }

--- a/java/test/jmri/jmrix/ipocs/configurexml/IpocsLightManagerXmlTest.java
+++ b/java/test/jmri/jmrix/ipocs/configurexml/IpocsLightManagerXmlTest.java
@@ -2,40 +2,40 @@ package jmri.jmrix.ipocs.configurexml;
 
 import static org.mockito.Mockito.mock;
 
+import jmri.util.JUnitUtil;
+
 import org.jdom2.Element;
 
 import org.junit.Assert;
-import org.junit.Test;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
 
 public class IpocsLightManagerXmlTest {
 
-  @Test
-  public void ConstructorTest() {
-    Assert.assertNotNull("IpocsLightManagerXml constructor", new IpocsLightManagerXml());
-  }
-
-  @BeforeEach
-  public void setUp() {
-    jmri.util.JUnitUtil.setUp();
-    jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
-  }
-
-  @AfterEach
-  public void tearDown() {
-    jmri.util.JUnitUtil.tearDown();
-  }
+    @Test
+    public void ConstructorTest() {
+        Assert.assertNotNull("IpocsLightManagerXml constructor", new IpocsLightManagerXml());
+    }
   
-  @Test
-  public void loadTest() {
-    Element element = mock(Element.class);
-    new IpocsLightManagerXml().load(element, null);
-   }
+    @Test
+    public void loadTest() {
+        Element element = mock(Element.class);
+        new IpocsLightManagerXml().load(element, null);
+    }
 
-   @Test
-   public void setStoreelementClassTest() {
-    Element element = mock(Element.class);
-    new IpocsLightManagerXml().setStoreElementClass(element);
-   }
+    @Test
+    public void setStoreelementClassTest() {
+        Element element = mock(Element.class);
+        new IpocsLightManagerXml().setStoreElementClass(element);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrix/ipocs/configurexml/IpocsSensorManagerXmlTest.java
+++ b/java/test/jmri/jmrix/ipocs/configurexml/IpocsSensorManagerXmlTest.java
@@ -3,38 +3,40 @@ package jmri.jmrix.ipocs.configurexml;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 
+import jmri.util.JUnitUtil;
+
 import org.jdom2.Element;
 import org.junit.Assert;
-import org.junit.Test;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+
+import org.junit.jupiter.api.*;
 
 public class IpocsSensorManagerXmlTest {
 
-  @Test
-  public void testCtor() {
-    Assert.assertNotNull("IpocsSensorManagerXml constructor", new IpocsSensorManagerXml());
-  }
+    @Test
+    public void testCtor() {
+        Assert.assertNotNull("IpocsSensorManagerXml constructor", new IpocsSensorManagerXml());
+    }
 
-  @BeforeEach
-  public void setUp() {
-    jmri.util.JUnitUtil.setUp();
-  }
+    @Test
+    public void loadTest() {
+        Element element = mock(Element.class);
+        assertDoesNotThrow(() -> new IpocsSensorManagerXml().load(element, null));
+    }
 
-  @AfterEach
-  public void tearDown() {
-    jmri.util.JUnitUtil.tearDown();
-  }
+    @Test
+    public void setStoreelementClassTest() {
+        Element element = mock(Element.class);
+        new IpocsSensorManagerXml().setStoreElementClass(element);
+    }
 
-  @Test
-  public void loadTest() {
-    Element element = mock(Element.class);
-    assertDoesNotThrow(() -> new IpocsSensorManagerXml().load(element, null));
-   }
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
 
-   @Test
-   public void setStoreelementClassTest() {
-    Element element = mock(Element.class);
-    new IpocsSensorManagerXml().setStoreElementClass(element);
-   }
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrix/ipocs/configurexml/IpocsTurnoutManagerXmlTest.java
+++ b/java/test/jmri/jmrix/ipocs/configurexml/IpocsTurnoutManagerXmlTest.java
@@ -2,38 +2,40 @@ package jmri.jmrix.ipocs.configurexml;
 
 import static org.mockito.Mockito.mock;
 
+import jmri.util.JUnitUtil;
+
 import org.jdom2.Element;
+
 import org.junit.Assert;
-import org.junit.Test;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.*;
 
 public class IpocsTurnoutManagerXmlTest {
 
-  @Test
-  public void testCtor() {
-    Assert.assertNotNull("IpocsSensorManagerXml constructor", new IpocsTurnoutManagerXml());
-  }
+    @Test
+    public void testCtor() {
+        Assert.assertNotNull("IpocsSensorManagerXml constructor", new IpocsTurnoutManagerXml());
+    }
 
-  @BeforeEach
-  public void setUp() {
-    jmri.util.JUnitUtil.setUp();
-  }
+    @Test
+    public void loadTest() {
+        Element element = mock(Element.class);
+        new IpocsTurnoutManagerXml().load(element, null);
+    }
 
-  @AfterEach
-  public void tearDown() {
-    jmri.util.JUnitUtil.tearDown();
-  }
+    @Test
+    public void setStoreelementClassTest() {
+        Element element = mock(Element.class);
+        new IpocsTurnoutManagerXml().setStoreElementClass(element);
+    }
 
-  @Test
-  public void loadTest() {
-    Element element = mock(Element.class);
-    new IpocsTurnoutManagerXml().load(element, null);
-   }
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
 
-   @Test
-   public void setStoreelementClassTest() {
-    Element element = mock(Element.class);
-    new IpocsTurnoutManagerXml().setStoreElementClass(element);
-   }
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
 }


### PR DESCRIPTION
Missing setUp / tearDown methods added.

Some tests now extend from Abstract classes
IpocsLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
IpocsLightTest extends jmri.implementation.AbstractLightTestBase
IpocsSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase
IpocsSensorTest extends jmri.implementation.AbstractSensorTestBase
IpocsSystemConnectionMemoTest extends SystemConnectionMemoTestBase<IpocsSystemConnectionMemo> 
IpocsTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase