### PR TITLE
ID tags now sorting properly

### DIFF
--- a/java/src/jmri/implementation/DefaultIdTag.java
+++ b/java/src/jmri/implementation/DefaultIdTag.java
@@ -52,7 +52,7 @@ public class DefaultIdTag extends AbstractIdTag {
         String o2 = n2.getSystemName();
         int p1len = Manager.getSystemPrefixLength(o1);
         int p2len = Manager.getSystemPrefixLength(o2);
-        int comp = o2.substring(0, p1len).compareTo(o2.substring(0, p2len));
+        int comp = o1.substring(0, p1len).compareTo(o2.substring(0, p2len));
         if (comp != 0) 
             return comp;
         comp = o1.compareTo(o2);

--- a/java/src/jmri/implementation/DefaultIdTag.java
+++ b/java/src/jmri/implementation/DefaultIdTag.java
@@ -4,6 +4,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Objects;
 
 import javax.annotation.CheckForNull;
 
@@ -42,6 +43,20 @@ public class DefaultIdTag extends AbstractIdTag {
     public DefaultIdTag(String systemName, String userName) {
         super(systemName, userName);
         setWhereLastSeen(null);
+    }
+
+    @Override
+    public int compareTo(NamedBean n2) {
+        Objects.requireNonNull(n2);
+        String o1 = this.getSystemName();
+        String o2 = n2.getSystemName();
+        int p1len = Manager.getSystemPrefixLength(o1);
+        int p2len = Manager.getSystemPrefixLength(o2);
+        int comp = o2.substring(0, p1len).compareTo(o2.substring(0, p2len));
+        if (comp != 0) 
+            return comp;
+        comp = o1.compareTo(o2);
+        return comp;
     }
 
     @Override


### PR DESCRIPTION
This PR adds a compareTo method to DefaultIdTag. The method compares the System Prefixes and, if they are different, the comparison of prefixes is returned. If the prefixes are the same, the string comparison of the System Names is returned. This causes tags to sort by ID. In the combo box, (on Edit Car), the RFID tags are sorted by System Name, except for those that have a User Name -- those tags sort after system names in alpha numeric order (doing the the standard number chunk sort).  In the PanelPro Table for ID tags, the System Name column sorts the same as the Tag ID column. 