### PR TITLE
J11: rm Cucumber script

### DIFF
--- a/java/test/apps/PanelPro/profiles/Prevent_Init_Loop/profile/profile.xml
+++ b/java/test/apps/PanelPro/profiles/Prevent_Init_Loop/profile/profile.xml
@@ -14,7 +14,7 @@
         <perform xmlns="" class="jmri.util.startup.configurexml.PerformActionModelXml" name="apps.SystemConsoleAction" type="Action">
             <property name="systemPrefix" value=""/>
         </perform>
-        <perform xmlns="" class="jmri.util.startup.configurexml.PerformScriptModelXml" name="preference:jython/FollowJumpingPanel.py" type="ScriptFile"/>
+        <!-- <perform xmlns="" class="jmri.util.startup.configurexml.PerformScriptModelXml" name="preference:jython/FollowJumpingPanel.py" type="ScriptFile"/> -->
         <perform xmlns="" class="jmri.util.startup.configurexml.PerformFileModelXml" name="preference:Panels/jumping panels.xml" type="XmlFile"/>
     </startup>
 </auxiliary-configuration>


### PR DESCRIPTION
Cucumber is run headless in J11 Jenkins builds.  This particular Cucumber test profile includes a script that manipulates the screen.  Now that we have Cucumber running in the Jenkins builds, it's failing every time.