### PR TITLE
SprogII UpdateFrame / Sprog Version Frame, Improve Dispose

### DIFF
--- a/java/src/jmri/jmrix/sprog/update/SprogIIUpdateFrame.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogIIUpdateFrame.java
@@ -41,19 +41,6 @@ public class SprogIIUpdateFrame
         // Get the SPROG version
         _memo.getSprogVersionQuery().requestVersion(this);
     }
-    
-    
-    /** 
-     * {@inheritDoc}
-     * Also ensures timers are no longer running
-     */
-    @Override
-    public void dispose() {
-        // kill any timers still running 
-        stopTimer();
-            
-        super.dispose();
-    }
 
     int bootVer = 0;
 
@@ -395,6 +382,19 @@ public class SprogIIUpdateFrame
         tc.resetTimeout();
         tc.sendSprogMessage(msg, this);
         startLongTimer();
+    }
+
+    /**
+     * Removes SprogVersionListener.
+     * Calls Super to stop Timer.
+     * {@inheritDoc}
+     */
+    @Override
+    public void dispose(){
+        if (_memo !=null) {
+            _memo.getSprogVersionQuery().removeSprogVersionListener(this);
+        }
+        super.dispose();
     }
 
     private final static Logger log = LoggerFactory

--- a/java/src/jmri/jmrix/sprog/update/SprogUpdateFrame.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogUpdateFrame.java
@@ -91,11 +91,13 @@ abstract public class SprogUpdateFrame
         tc.setSprogState(SprogState.NORMAL);
     }
 
-    /** 
+    /**
+     * Stops Timer.
      * {@inheritDoc}
      */
     @Override
     public void dispose() {
+        stopTimer();
         tc = null;
         _memo = null;
         super.dispose();

--- a/java/src/jmri/jmrix/sprog/update/SprogVersionFrame.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogVersionFrame.java
@@ -46,5 +46,15 @@ public class SprogVersionFrame extends jmri.util.JmriJFrame implements SprogVers
         dispose();
     }
 
+    /**
+     * Removes SprogVersionListener.
+     * {@inheritDoc}
+     */
+    @Override
+    public void dispose() {
+        _memo.getSprogVersionQuery().removeSprogVersionListener(this);
+        super.dispose();
+    }
+
     private final static Logger log = LoggerFactory.getLogger(SprogVersionFrame.class);
 }

--- a/java/src/jmri/jmrix/sprog/update/SprogVersionQuery.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogVersionQuery.java
@@ -62,9 +62,17 @@ public class SprogVersionQuery implements SprogListener {
         }
     }
 
+    /**
+     * Remove a SprogVersionListener.
+     * Stops Timer ( if running ), when no further Listeners are present.
+     * @param l the Listener to remove.
+     */
     public synchronized void removeSprogVersionListener(SprogVersionListener l) {
         if (versionListeners.contains(l)) {
             versionListeners.removeElement(l);
+        }
+        if (versionListeners.size() == 0 ) {
+            stopTimer();
         }
     }
 

--- a/java/test/jmri/jmrix/sprog/update/SprogIIUpdateFrameTest.java
+++ b/java/test/jmri/jmrix/sprog/update/SprogIIUpdateFrameTest.java
@@ -33,15 +33,17 @@ public class SprogIIUpdateFrameTest extends jmri.util.JmriJFrameTestBase {
     @AfterEach
     @Override
     public void tearDown() {
-        if (frame!=null) ((SprogIIUpdateFrame)frame).stopTimer();
-        // frame.dispose() called in super class
+        // we need to close window before the Traffic Controller.
+        if(frame!=null) {
+           JUnitUtil.dispose(frame); // frame dispose stops Update timer.
+        }
+        frame = null;
         m.getSlotThread().interrupt();
         JUnitUtil.waitFor(() -> {return m.getSlotThread().getState() == Thread.State.TERMINATED;}, "Slot thread failed to stop");
         m.dispose();
         stcs.dispose();
         m = null;
         stcs = null;
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         super.tearDown();
     }
 


### PR DESCRIPTION
Remove SprogVersionListeners on dispose.
Stops SprogVersionQuery Timer if all Listeners removed.

Prevents
 ` [java] WARN  - requestBoot with null tc, ignored [AWT-EventQueue-1] jmrix.sprog.update.SprogIIUpdateFrame.requestBoot()`

in Test Console logs, eg https://builds.jmri.org/jenkins/job/j11development/job/alltest/77/console