### PR TITLE
JmriJFrameTestBase - update Headless Check

### DIFF
--- a/java/test/jmri/util/JmriJFrameTestBase.java
+++ b/java/test/jmri/util/JmriJFrameTestBase.java
@@ -15,13 +15,13 @@ abstract public class JmriJFrameTestBase {
 
     protected JmriJFrame frame = null;
 
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     public void testCTor() {
         Assert.assertNotNull("exists",frame);
     }
 
-    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     public void testShowAndClose() {
         frame.initComponents();

--- a/java/test/jmri/util/JmriJFrameTestBase.java
+++ b/java/test/jmri/util/JmriJFrameTestBase.java
@@ -1,10 +1,9 @@
 package jmri.util;
 
-import java.awt.GraphicsEnvironment;
-
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import org.netbeans.jemmy.operators.JFrameOperator;
 
 /**
@@ -16,15 +15,15 @@ abstract public class JmriJFrameTestBase {
 
     protected JmriJFrame frame = null;
 
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     @Test
     public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("exists",frame);
     }
 
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     @Test
     public void testShowAndClose() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         frame.initComponents();
         jmri.util.ThreadingUtil.runOnLayout(() -> {
             frame.setVisible(true);


### PR DESCRIPTION
Using DisabledIfSystemProperty Tag instead of Assume saves Headless Tests calling the BeforeEach / AfterEach methods.