### PR TITLE
J11 CBUS swing Table Sorter Warnings

### DIFF
--- a/java/src/jmri/jmrit/cabsignals/CabSignalTableModel.java
+++ b/java/src/jmri/jmrit/cabsignals/CabSignalTableModel.java
@@ -335,9 +335,7 @@ public class CabSignalTableModel extends javax.swing.table.AbstractTableModel {
             log.debug(" direction found, setting reverse.");
             b.setDirection(Path.reverseDirection(olddirection));
         }
-        jmri.util.ThreadingUtil.runOnGUI( ()->{
-            fireTableDataChanged();
-        });
+        fireTableDataChanged();
         log.debug("block {} now has direction {}", b.getUserName(), b.getDirection());
     }
     

--- a/java/src/jmri/jmrix/can/cbus/eventtable/CbusBasicEventTableModel.java
+++ b/java/src/jmri/jmrix/can/cbus/eventtable/CbusBasicEventTableModel.java
@@ -248,7 +248,7 @@ public class CbusBasicEventTableModel extends javax.swing.table.AbstractTableMod
         // not existing so creating new
         CbusTableEvent newtabev = new CbusTableEvent(_memo,nn,en );
         _mainArray.add(newtabev);
-        ThreadingUtil.runOnGUIEventually(() -> fireTableDataChanged()); 
+        fireTableDataChanged();
         return newtabev;
     }
     

--- a/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeEvent.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeEvent.java
@@ -38,11 +38,9 @@ public class CbusBasicNodeEvent extends CbusEvent {
     }
     
     protected void notifyModel(){
-        jmri.util.ThreadingUtil.runOnGUI( ()->{
-            if ( eventDataModel != null ) {
-                eventDataModel.fireTableDataChanged();
-            }
-        });
+        if ( eventDataModel != null ) {
+            eventDataModel.fireTableDataChanged();
+        }
     }
     
     /**

--- a/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeTableOperations.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusBasicNodeTableOperations.java
@@ -37,7 +37,7 @@ public class CbusBasicNodeTableOperations extends CbusBasicNodeTable {
             setRequestNodeDisplay(node.getNodeNumber());
         }
         // notify the JTable object that a row has changed; do that in the Swing thread!
-        ThreadingUtil.runOnGUIEventually(() -> fireTableDataChanged() );
+        fireTableDataChanged();
     }
     
     /**

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeNVTableDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeNVTableDataModel.java
@@ -263,9 +263,7 @@ public class CbusNodeNVTableDataModel extends javax.swing.table.AbstractTableMod
         
         resetNewNvs();
         nodeOfInterest.addPropertyChangeListener(this);
-        ThreadingUtil.runOnGUIEventually( ()->{ 
-            fireTableDataChanged();
-        });
+        fireTableDataChanged();
         
     }
     

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeSingleEventTableDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeSingleEventTableDataModel.java
@@ -262,10 +262,7 @@ public class CbusNodeSingleEventTableDataModel extends javax.swing.table.Abstrac
     }
     
     public void updateFromNode( int arrayid, int col){
-        ThreadingUtil.runOnGUIEventually( ()->{
-            // fireTableCellUpdated(arrayid, col);
-            fireTableDataChanged();
-        });
+        fireTableDataChanged();
     }
     
     public boolean isTableLoaded(){

--- a/java/src/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModel.java
@@ -268,10 +268,7 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         CbusSlotMonitorSession newSession = new CbusSlotMonitorSession(addr);
         
         _mainArray.add(newSession);
-        
-        ThreadingUtil.runOnGUI( ()->{
-            fireTableRowsInserted((getRowCount()-1), (getRowCount()-1));
-        });
+        fireTableRowsInserted((getRowCount()-1), (getRowCount()-1));
         return getRowCount()-1;
     }
     

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeBackupTableModel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeBackupTableModel.java
@@ -44,9 +44,7 @@ public class CbusNodeBackupTableModel extends javax.swing.table.AbstractTableMod
     @Override
     public void propertyChange(PropertyChangeEvent ev){
         if (ev.getPropertyName().equals("BACKUPS")) {
-            jmri.util.ThreadingUtil.runOnGUIEventually( ()->{
-                fireTableDataChanged();
-            });
+            fireTableDataChanged();
         }
     }
 


### PR DESCRIPTION
Fixes warnings

`WARNING: row index is bigger than sorter's row count. Most likely this is a wrong sorter usage.`

in J11 Console logs.

eg. https://builds.jmri.org/jenkins/job/j11development/job/separate_tests/22/consoleFull jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePaneTest


