### PR TITLE
Set accessible context name on representation

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -347,7 +347,8 @@
     <h3>DecoderPro</h3>
         <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
-            <li></li>
+            <li>Added accessible names to the (simple)
+                variables displayed on programming panes.</li>
         </ul>
 
     <h3>CTC Tool</h3>

--- a/java/src/jmri/jmrit/symbolicprog/CompositeVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/CompositeVariableValue.java
@@ -57,7 +57,10 @@ public class CompositeVariableValue extends EnumVariableValue {
         super(name, comment, cvName, readOnly, infoOnly, writeOnly, opsOnly, cvNum, mask, minVal, maxVal, v, status, stdname);
         _maxVal = maxVal;
         _minVal = minVal;
+
         _value = new JComboBox<String>();
+        _value.getAccessibleContext().setAccessibleName(label());
+
         log.debug("New Composite named {}", name);
     }
 
@@ -67,6 +70,7 @@ public class CompositeVariableValue extends EnumVariableValue {
      */
     public CompositeVariableValue() {
         _value = new JComboBox<String>();
+        _value.getAccessibleContext().setAccessibleName(label());
     }
 
     @Override
@@ -219,7 +223,7 @@ public class CompositeVariableValue extends EnumVariableValue {
         _defaultColor = _value.getBackground();
         super.setState(READ);
 
-        // note that we don't set this to COLOR_UNKNOWN!  Rather, 
+        // note that we don't set this to COLOR_UNKNOWN!  Rather,
         // we check the current value
         findValue();
 

--- a/java/src/jmri/jmrit/symbolicprog/DecVarSlider.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVarSlider.java
@@ -19,6 +19,9 @@ public class DecVarSlider extends JSlider implements ChangeListener {
     DecVarSlider(DecVariableValue var, int min, int max) {
         super(new DefaultBoundedRangeModel(min, 0, min, max));
         _var = var;
+
+        this.getAccessibleContext().setAccessibleName(label());
+
         // get the original color right
         setBackground(_var.getColor());
         if (_var.getColor() == _var.getDefaultColor()) {

--- a/java/src/jmri/jmrit/symbolicprog/DecVarSlider.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVarSlider.java
@@ -20,7 +20,7 @@ public class DecVarSlider extends JSlider implements ChangeListener {
         super(new DefaultBoundedRangeModel(min, 0, min, max));
         _var = var;
 
-        this.getAccessibleContext().setAccessibleName(label());
+        this.getAccessibleContext().setAccessibleName(_var.label());
 
         // get the original color right
         setBackground(_var.getColor());

--- a/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
@@ -32,6 +32,7 @@ public class DecVariableValue extends VariableValue
         _maxVal = maxVal;
         _minVal = minVal;
         _value = new JTextField("0", fieldLength());
+        _value.getAccessibleContext().setAccessibleName(label());
         _defaultColor = _value.getBackground();
         _value.setBackground(COLOR_UNKNOWN);
         // connect to the JTextField value, cv
@@ -270,7 +271,7 @@ public class DecVariableValue extends VariableValue
     /**
      * Set a new value, including notification as needed.
      * <p>
-     * This does the conversion from string to int, so if the place where 
+     * This does the conversion from string to int, so if the place where
      * formatting needs to be applied.
      * @param value new value.
      */

--- a/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
@@ -104,6 +104,8 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
 
     public void lastItem() {
         _value = new JComboBox<>(java.util.Arrays.copyOf(_itemArray, _nstored));
+        _value.getAccessibleContext().setAccessibleName(label());
+
         // finish initialization
         _value.setActionCommand("");
         _defaultColor = _value.getBackground();
@@ -324,6 +326,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
             case "checkbox": {
                 // this only makes sense if there are exactly two options
                 ComboCheckBox b = new ComboCheckBox(_value, this);
+                b.getAccessibleContext().setAccessibleName(label());
                 comboCBs.add(b);
                 if (getReadOnly() || getInfoOnly()) {
                     b.setEnabled(false);
@@ -333,6 +336,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
             }
             case "radiobuttons": {
                 ComboRadioButtons b = new ComboRadioButtons(_value, this);
+                b.getAccessibleContext().setAccessibleName(label());
                 comboRBs.add(b);
                 if (getReadOnly() || getInfoOnly()) {
                     b.setEnabled(false);
@@ -342,6 +346,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
             }
             case "onradiobutton": {
                 ComboRadioButtons b = new ComboOnRadioButton(_value, this);
+                b.getAccessibleContext().setAccessibleName(label());
                 comboRBs.add(b);
                 if (getReadOnly() || getInfoOnly()) {
                     b.setEnabled(false);
@@ -351,6 +356,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
             }
             case "offradiobutton": {
                 ComboRadioButtons b = new ComboOffRadioButton(_value, this);
+                b.getAccessibleContext().setAccessibleName(label());
                 comboRBs.add(b);
                 if (getReadOnly() || getInfoOnly()) {
                     b.setEnabled(false);
@@ -398,10 +404,12 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
                     log.error("read only variables cannot use tree format: {}", item());
                 }
                 updateRepresentation(dScroll);
+                dScroll.getAccessibleContext().setAccessibleName(label());
                 return dScroll;
             default: {
                 // return a new JComboBox representing the same model
                 VarComboBox b = new VarComboBox(_value.getModel(), this);
+                b.getAccessibleContext().setAccessibleName(label());
                 comboVars.add(b);
                 if (getReadOnly() || getInfoOnly()) {
                     b.setEnabled(false);

--- a/java/src/jmri/jmrit/symbolicprog/LongAddrVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/LongAddrVariableValue.java
@@ -25,12 +25,15 @@ public class LongAddrVariableValue extends VariableValue
     public LongAddrVariableValue(@Nonnull String name, @Nonnull String comment, @Nonnull String cvName,
             boolean readOnly, boolean infoOnly, boolean writeOnly, boolean opsOnly,
             @Nonnull String cvNum, @Nonnull String mask, int minVal, int maxVal,
-            @Nonnull HashMap<String, CvValue> v, @Nonnull JLabel status, 
+            @Nonnull HashMap<String, CvValue> v, @Nonnull JLabel status,
             @Nonnull String stdname, @Nonnull CvValue mHighCV) {
         super(name, comment, cvName, readOnly, infoOnly, writeOnly, opsOnly, cvNum, mask, v, status, stdname);
         _maxVal = maxVal;
         _minVal = minVal;
+
         _value = new JTextField("0", 5);
+        _value.getAccessibleContext().setAccessibleName(label());
+
         _defaultColor = _value.getBackground();
         _value.setBackground(COLOR_UNKNOWN);
         // connect to the JTextField value, cv
@@ -212,7 +215,9 @@ public class LongAddrVariableValue extends VariableValue
 
     @Override
     public Component getNewRep(String format) {
-        return updateRepresentation(new VarTextField(_value.getDocument(), _value.getText(), 5, this));
+        var retval = updateRepresentation(new VarTextField(_value.getDocument(), _value.getText(), 5, this));
+        retval.getAccessibleContext().setAccessibleName(label());
+        return retval;
     }
     private int _progState = 0;
     private static final int IDLE = 0;


### PR DESCRIPTION
Does `_value.getAccessibleContext().setAccessibleName(label());` on the following DecoderPro variable representations:
```
CompositeVariableValue.java
DecVarSlider.java
DecVariableValue.java
EnumVariableValue.java
LongAddrVariableValue.java
```

This is (hopefully) a partial solution to #10606
