### PR TITLE
Use the turnout state for the control circle option

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -379,7 +379,8 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
-	        <li></li>
+          <li>Use the actual turnout state for the turnout circle when that option is used.  This
+          corrects the color for turnouts using the continuing route option when set to thrown.</li>
         </ul>
 
         <h4>NX - Entry/Exit Tool</h4>

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnoutView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnoutView.java
@@ -3025,18 +3025,19 @@ public class LayoutTurnoutView extends LayoutTrackView {
     protected void drawTurnoutControls(Graphics2D g2) {
         if (!isDisabled() && !(isDisabledWhenOccupied() && isOccupied())) {
             Color foregroundColor = g2.getColor();
-            // if turnout is not continuing state
-            if (getState() != getContinuingSense()) {
-                // then switch to background color
+
+            if (getState() != Turnout.CLOSED) {
+                // then switch to background (thrown) color
                 g2.setColor(g2.getBackground());
             }
+
             if (layoutEditor.isTurnoutFillControlCircles()) {
                 g2.fill(trackControlCircleAt(getCoordsCenter()));
             } else {
                 g2.draw(trackControlCircleAt(getCoordsCenter()));
             }
-            // if turnout is not continuing state
-            if (getState() != getContinuingSense()) {
+
+            if (getState() != Turnout.CLOSED) {
                 // then restore foreground color
                 g2.setColor(foregroundColor);
             }


### PR DESCRIPTION
When the continuing route option was set for thrown, the turnout control circle colors were inverted.  The turnout control circle colors are supposed to reflect the actual state of the turnout.