### PR TITLE
Dispatcher Xcrossings

### DIFF
--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -15,8 +15,6 @@ import jmri.Sensor;
 import jmri.Transit;
 import jmri.TransitSection;
 import jmri.jmrit.dispatcher.TaskAllocateRelease.TaskAction;
-import jmri.jmrit.display.layoutEditor.ConnectivityUtil;
-import jmri.jmrit.display.layoutEditor.LevelXing;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,14 +89,12 @@ public class AutoAllocate implements Runnable {
             log.error("null LayoutEditor when constructing AutoAllocate");
             return;
         }
-        _conUtil = _dispatcher.getLayoutEditor().getConnectivityUtil();
         taskList = new LinkedBlockingQueue<>();
     }
 
     // operational variables
     private static final jmri.NamedBean.DisplayOptions USERSYS = jmri.NamedBean.DisplayOptions.USERNAME_SYSTEMNAME;
     private DispatcherFrame _dispatcher = null;
-    private ConnectivityUtil _conUtil = null;
     private final List<AllocationPlan> _planList = new ArrayList<>();
     private int nextPlanNum = 1;
     private final List<AllocationRequest> orderedRequests = new ArrayList<>();
@@ -403,59 +399,41 @@ public class AutoAllocate implements Runnable {
                                     }
                                 }
                             }
-                            if (neededByTrainList.size() <= 0) {
-                                // no other ActiveTrain needs this Section,
-                                // any LevelXings?
-                                if (containsLevelXing(ar.getSection())) {
-                                    // check if allocating this Section
-                                    // might block a higher priority train
-                                    for (int j = 0; j < activeTrainsList.size(); j++) {
-                                        ActiveTrain at = activeTrainsList.get(j);
-                                        if ((at != activeTrain) &&
-                                                (at.getPriority() > activeTrain.getPriority())) {
-                                            if (willLevelXingsBlockTrain(at)) {
+                            // requested Section (or alternate) is
+                            // needed by other active Active Train(s)
+                            for (int k = 0; k < neededByTrainList.size(); k++) {
+                                // section is also needed by this active
+                                // train
+                                ActiveTrain nt = neededByTrainList.get(k);
+                                // are trains moving in same direction
+                                // through the requested Section?
+                                if (sameDirection(ar, nt)) {
+                                    // trains will move in the same
+                                    // direction thru requested section
+                                    if (firstTrainLeadsSecond(activeTrain, nt) &&
+                                            (nt.getPriority() > activeTrain.getPriority())) {
+                                        // a higher priority train is
+                                        // trailing this train, can we
+                                        // let it pass?
+                                        if (checkForPassingPlan(ar, nt, neededByTrainList)) {
+                                            // PASSING_MEET plan created
+                                            if (!willAllocatingFollowPlan(ar,
+                                                    getPlanThisTrain(activeTrain))) {
                                                 okToAllocate = false;
                                             }
                                         }
                                     }
-                                }
-                            } else {
-                                // requested Section (or alternate) is
-                                // needed by other active Active Train(s)
-                                for (int k = 0; k < neededByTrainList.size(); k++) {
-                                    // section is also needed by this active
-                                    // train
-                                    ActiveTrain nt = neededByTrainList.get(k);
-                                    // are trains moving in same direction
-                                    // through the requested Section?
-                                    if (sameDirection(ar, nt)) {
-                                        // trains will move in the same
-                                        // direction thru requested section
-                                        if (firstTrainLeadsSecond(activeTrain, nt) &&
-                                                (nt.getPriority() > activeTrain.getPriority())) {
-                                            // a higher priority train is
-                                            // trailing this train, can we
-                                            // let it pass?
-                                            if (checkForPassingPlan(ar, nt, neededByTrainList)) {
-                                                // PASSING_MEET plan created
-                                                if (!willAllocatingFollowPlan(ar,
-                                                        getPlanThisTrain(activeTrain))) {
-                                                    okToAllocate = false;
-                                                }
-                                            }
-                                        }
-                                    } else {
-                                        // trains will move in opposite
-                                        // directions thru requested section
-                                        // explore possibility of an
-                                        // XING_MEET to avoid gridlock
-                                        if (willTrainsCross(activeTrain, nt)) {
-                                            if (checkForXingPlan(ar, nt, neededByTrainList)) {
-                                                // XING_MEET plan created
-                                                if (!willAllocatingFollowPlan(ar,
-                                                        getPlanThisTrain(activeTrain))) {
-                                                    okToAllocate = false;
-                                                }
+                                } else {
+                                    // trains will move in opposite
+                                    // directions thru requested section
+                                    // explore possibility of an
+                                    // XING_MEET to avoid gridlock
+                                    if (willTrainsCross(activeTrain, nt)) {
+                                        if (checkForXingPlan(ar, nt, neededByTrainList)) {
+                                            // XING_MEET plan created
+                                            if (!willAllocatingFollowPlan(ar,
+                                                    getPlanThisTrain(activeTrain))) {
+                                                okToAllocate = false;
                                             }
                                         }
                                     }
@@ -1602,57 +1580,6 @@ public class AutoAllocate implements Runnable {
         }
         return false;
     }
-
-    private boolean willLevelXingsBlockTrain(ActiveTrain at) {
-        // returns true if any LevelXings in _levelXingList will block the
-        // specified train
-        if (at == null) {
-            log.error("null argument on entry to 'willLevelXingsBlockTrain'");
-            return true; // returns true to be safe
-        }
-        if (_levelXingList.size() <= 0) {
-            return false;
-        }
-        for (int i = 0; i < _levelXingList.size(); i++) {
-            LevelXing lx = _levelXingList.get(i);
-            Block bAC = lx.getLayoutBlockAC().getBlock();
-            Block bBD = lx.getLayoutBlockBD().getBlock();
-            if (at.getTransit().containsBlock(bAC) || at.getTransit().containsBlock(bBD)) {
-                if (InstanceManager.getDefault(DispatcherFrame.class).getSignalType() == DispatcherFrame.SIGNALMAST) {
-                    return true;
-                } else {
-                    // temp - return false - continious trains always meet for
-                    // ever and no one moves...
-                    return false;
-                }
-                // return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean containsLevelXing(Section s) {
-        // returns true if Section contains one or more level crossings
-        // NOTE: changes _levelXingList!
-        _levelXingList.clear();
-        if (s == null) {
-            log.error("null argument to 'containsLevelCrossing'");
-            return false;
-        }
-        List<LevelXing> temLevelXingList = null;
-        List<Block> blockList = s.getBlockList();
-        for (int i = 0; i < blockList.size(); i++) {
-            temLevelXingList = _conUtil.getLevelCrossingsThisBlock(blockList.get(i));
-            if (temLevelXingList.size() > 0) {
-                for (int j = 0; j < temLevelXingList.size(); j++) {
-                    _levelXingList.add(temLevelXingList.get(j));
-                }
-            }
-        }
-        return _levelXingList.size() > 0;
-    }
-
-    List<LevelXing> _levelXingList = new ArrayList<>();
 
     private boolean isSignalHeldAtStartOfSection(AllocationRequest ar) {
 


### PR DESCRIPTION
#10600 
Currently, if using signal masts a transit cannot run if it will use an Xcrossing
    that conflicts anywhere along its path with a train of higher priority,
     it will run if it is not using SignalMasts.
    During the allocation process there is no check for whether the AC route conflicts with a BD route
    already running.
    This adds a check before allocating to ensure that and AC or BD will not conflict with a BD or AC as appropriate.
    It will allow the reserving of a section if running using "Safe Section", but will not allocate until clear.