### PR TITLE
ProxyAnalogIO DefaultSelector Managers Tests Update

### DIFF
--- a/java/test/jmri/managers/ManagerDefaultSelectorTest.java
+++ b/java/test/jmri/managers/ManagerDefaultSelectorTest.java
@@ -14,7 +14,7 @@ import jmri.util.prefs.InitializationException;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of ManagerDefaultSelector
@@ -34,7 +34,6 @@ public class ManagerDefaultSelectorTest {
 
     @AfterEach
     public void tearDown() {
-        JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 
@@ -77,9 +76,9 @@ public class ManagerDefaultSelectorTest {
         return memo;
     }
 
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     public void testSingleSystemPreferencesValid() throws InitializationException {
-        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
 
         ManagerDefaultSelector mds = new ManagerDefaultSelector();
         // assert default state
@@ -126,13 +125,15 @@ public class ManagerDefaultSelectorTest {
         // loconet gone, auto internal is by itself, so OK
         Assert.assertTrue(mds.isPreferencesValid(profile));
 
+        loconet.getPowerManager().dispose();
+        loconet.getSensorManager().dispose();
         loconet.dispose();
 
     }
 
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     public void testAuxInternalPreferencesValid() throws InitializationException {
-        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
 
         ManagerDefaultSelector mds = new ManagerDefaultSelector();
         Profile profile = ProfileManager.getDefault().getActiveProfile();
@@ -193,12 +194,14 @@ public class ManagerDefaultSelectorTest {
         // loconet gone, auto internal is by itself, so OK
         Assert.assertTrue(mds.isPreferencesValid(profile));
 
+        loconet.getPowerManager().dispose();
+        loconet.getSensorManager().dispose();
         loconet.dispose();
     }
 
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     public void testTwoLoconetPreferencesValid() throws InitializationException {
-        Assume.assumeFalse(java.awt.GraphicsEnvironment.isHeadless());
 
         ManagerDefaultSelector mds = new ManagerDefaultSelector();
         Profile profile = ProfileManager.getDefault().getActiveProfile();
@@ -256,7 +259,12 @@ public class ManagerDefaultSelectorTest {
         // loconet and loconet2 gone, auto internal is by itself, so OK
         Assert.assertTrue(mds.isPreferencesValid(profile));
 
+        loconet.getPowerManager().dispose();
+        loconet.getSensorManager().dispose();
         loconet.dispose();
+
+        loconet2.getPowerManager().dispose();
+        loconet2.getSensorManager().dispose();
         loconet2.dispose();
     }
 

--- a/java/test/jmri/managers/ProxyAnalogIOManagerTest.java
+++ b/java/test/jmri/managers/ProxyAnalogIOManagerTest.java
@@ -43,6 +43,7 @@ public class ProxyAnalogIOManagerTest {
     @Test
     public void testDispose() {
         l.dispose();  // all we're really doing here is making sure the method exists
+        l = null; // save being re-disposed by afterEach
     }
 
     @Test
@@ -106,6 +107,8 @@ public class ProxyAnalogIOManagerTest {
         b = newAnalogIO("IV3", null);
         InstanceManager.getDefault(AnalogIOManager.class).register(b);
         Assert.assertNotNull(InstanceManager.getDefault(AnalogIOManager.class).getBySystemName("IV1"));
+
+        m.dispose();
     }
 
     @Test
@@ -234,6 +237,9 @@ public class ProxyAnalogIOManagerTest {
 
     @AfterEach
     public void tearDown() {
+        if ( l != null ) {
+            l.dispose();
+        }
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
DefaultSelectorManagerTest leaving remnant threads.
ProxyAnalogIOManagerTest leaving a Timer running, eg.
https://builds.jmri.org/jenkins/job/development/job/builds/1049/console

`Exception in thread "AWT-EventQueue-0" java.lang.UnsupportedOperationException: Not supported
     [java] 	at jmri.managers.ProxyAnalogIOManagerTest$MyVariableLight.getNumberOfSteps(ProxyAnalogIOManagerTest.java:341)
     [java] 	at jmri.implementation.AbstractVariableLight.newInternalMinute(AbstractVariableLight.java:309)
     [java] 	at jmri.implementation.AbstractVariableLight.lambda$0(AbstractVariableLight.java:295)
     [java] 	at java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:335)
     [java] 	at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:328)
     [java] 	at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:263)
     [java] 	at jmri.implementation.AbstractNamedBean.firePropertyChange(AbstractNamedBean.java:311)
     [java] 	at jmri.jmrit.simpleclock.SimpleTimebase.handleAlarm(SimpleTimebase.java:709)
     [java] 	at javax.swing.Timer.fireActionPerformed(Timer.java:313)
     [java] 	at javax.swing.Timer$DoPostEvent.run(Timer.java:245)
     [java] 	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)`