### PR TITLE
Fix bug in ActionBlock

### DIFF
--- a/java/src/jmri/jmrit/logixng/actions/ActionBlock.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionBlock.java
@@ -325,7 +325,7 @@ public class ActionBlock extends AbstractDigitalAction implements VetoableChange
         }
     }
 
-    private String getNewData() throws JmriException {
+    private Object getNewData() throws JmriException {
 
         switch (_dataAddressing) {
             case Direct:
@@ -337,14 +337,12 @@ public class ActionBlock extends AbstractDigitalAction implements VetoableChange
 
             case LocalVariable:
                 SymbolTable symbolTable = getConditionalNG().getSymbolTable();
-                return TypeConversionUtil
-                        .convertToString(symbolTable.getValue(_dataLocalVariable), false);
+                return symbolTable.getValue(_dataLocalVariable);
 
             case Formula:
                 return _dataExpressionNode != null
-                        ? TypeConversionUtil.convertToString(
-                                _dataExpressionNode.calculate(
-                                        getConditionalNG().getSymbolTable()), false)
+                        ? _dataExpressionNode.calculate(
+                                getConditionalNG().getSymbolTable())
                         : null;
 
             default:


### PR DESCRIPTION
Don't convert the value of a local variable or the result of a formula to a string before assignment.

When the value of a local variable or the result of a formula is to be assigned to a block, the value should not be converted to a string before doing the assignment.