### PR TITLE
CAN TrafficController related tests / tweaks

### DIFF
--- a/java/src/jmri/jmrix/AbstractNetworkConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractNetworkConnectionConfig.java
@@ -4,8 +4,6 @@ import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import javax.swing.JButton;
@@ -140,7 +138,7 @@ abstract public class AbstractNetworkConnectionConfig extends AbstractConnection
             }
         });
 
-        for (Map.Entry<String, Option> entry : options.entrySet()) {
+        options.entrySet().forEach(entry -> {
             final String item = entry.getKey();
             if (entry.getValue().getComponent() instanceof JComboBox) {
                 ((JComboBox<?>) entry.getValue().getComponent()).addActionListener((ActionEvent e) -> {
@@ -169,7 +167,7 @@ abstract public class AbstractNetworkConnectionConfig extends AbstractConnection
                     }
                 });
             }
-        }
+        });
 
         addNameEntryCheckers(adapter);
 
@@ -183,15 +181,15 @@ abstract public class AbstractNetworkConnectionConfig extends AbstractConnection
     public void updateAdapter() {
         if (adapter.getMdnsConfigure()) {
             // set the hostname if it is not blank
-            if (!(hostNameField.getText().equals(""))) {
+            if (!(hostNameField.getText().isEmpty())) {
                 adapter.setHostName(hostNameField.getText());
             }
             // set the advertisement name if it is not blank
-            if (!(adNameField.getText().equals(""))) {
+            if (!(adNameField.getText().isEmpty())) {
                 adapter.setAdvertisementName(adNameField.getText());
             }
             // set the Service Type if it is not blank.
-            if (!(serviceTypeField.getText().equals(""))) {
+            if (!(serviceTypeField.getText().isEmpty())) {
                 adapter.setServiceType(serviceTypeField.getText());
             }
             // and get the host IP and port number
@@ -201,9 +199,9 @@ abstract public class AbstractNetworkConnectionConfig extends AbstractConnection
             adapter.setHostName(hostNameField.getText());
             adapter.setPort(Integer.parseInt(portField.getText()));
         }
-        for (Map.Entry<String, Option> entry : options.entrySet()) {
+        options.entrySet().forEach(entry -> {
             adapter.setOptionState(entry.getKey(), entry.getValue().getItem());
-        }
+        });
         if (adapter.getSystemConnectionMemo() != null && !adapter.getSystemConnectionMemo().setSystemPrefix(systemPrefixField.getText())) {
             systemPrefixField.setText(adapter.getSystemConnectionMemo().getSystemPrefix());
             connectionNameField.setText(adapter.getSystemConnectionMemo().getUserName());
@@ -302,7 +300,7 @@ abstract public class AbstractNetworkConnectionConfig extends AbstractConnection
         hostNameField.setText(adapter.getHostName());
         hostNameFieldLabel = new JLabel(Bundle.getMessage("HostFieldLabel"));
         hostNameField.setToolTipText(Bundle.getMessage("HostFieldToolTip"));
-        if (adapter.getHostName() == null || adapter.getHostName().equals("")) {
+        if (adapter.getHostName() == null || adapter.getHostName().isEmpty()) {
             hostNameField.setText(p.getComboBoxLastSelection(adapter.getClass().getName() + ".hostname"));
             adapter.setHostName(hostNameField.getText());
         }
@@ -499,6 +497,12 @@ abstract public class AbstractNetworkConnectionConfig extends AbstractConnection
         return false;
     }
 
+    /**
+     * Determine whether to display port in Advanced options.
+     * <p>
+     * Default in Abstract Net Conn Config. Abstract True.
+     * @return true to display port in advanced options.
+     */
     public boolean isPortAdvanced() {
         return true;
     }

--- a/java/src/jmri/jmrix/can/CanMessage.java
+++ b/java/src/jmri/jmrix/can/CanMessage.java
@@ -42,12 +42,12 @@ public class CanMessage extends AbstractMRMessage implements CanMutableFrame {
     
     /**
      * Create a new CanMessage of given length
-     * @param i number of CAN Frame data bytes, max 8
+     * @param numDataBytes number of CAN Frame data bytes, max 8
      * @param header The CAN Frame header value
      */
-    public CanMessage(int i, int header) {
+    public CanMessage(int numDataBytes, int header) {
         this(header);
-        _nDataChars = (i <= 8) ? i : 8;
+        _nDataChars = (numDataBytes <= 8) ? numDataBytes : 8;
     }
     
     /**

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/GcTrafficController.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/GcTrafficController.java
@@ -127,8 +127,7 @@ public class GcTrafficController extends TrafficController {
     @Override
     protected AbstractMRMessage newMessage() {
         log.debug("New GridConnectMessage created");
-        GridConnectMessage msg = new GridConnectMessage();
-        return msg;
+        return new GridConnectMessage();
     }
 
     /**
@@ -155,9 +154,7 @@ public class GcTrafficController extends TrafficController {
     @Override
     public AbstractMRMessage encodeForHardware(CanMessage m) {
         //log.debug("Encoding for hardware");
-        GridConnectMessage ret = new GridConnectMessage(m);
-
-        return ret;
+        return new GridConnectMessage(m);
     }
 
     /**
@@ -167,8 +164,7 @@ public class GcTrafficController extends TrafficController {
     @Override
     protected AbstractMRReply newReply() {
         log.debug("New GridConnectReply created");
-        GridConnectReply reply = new GridConnectReply();
-        return reply;
+        return new GridConnectReply();
     }
 
     /*
@@ -187,7 +183,7 @@ public class GcTrafficController extends TrafficController {
     /**
      * Detect if the reply buffer ends with ";".
      * @param r Reply
-     * @return true if contais end, else false.
+     * @return true if contains end, else false.
      */
     boolean endNormalReply(AbstractMRReply r) {
         int num = r.getNumDataElements() - 1;

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/GridConnectMessage.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/GridConnectMessage.java
@@ -27,7 +27,7 @@ public class GridConnectMessage extends AbstractMRMessage {
     public GridConnectMessage() {
         _nDataChars = 28;
         _dataChars = new int[_nDataChars];
-        setElement(0, ':');
+        GridConnectMessage.this.setElement(0, ':');
     }
 
     /**
@@ -36,7 +36,10 @@ public class GridConnectMessage extends AbstractMRMessage {
      */
     public GridConnectMessage(CanMessage m) {
         this();
+        addCanMessage(m);
+    }
 
+    private void addCanMessage(CanMessage m) {
         // Standard or extended frame
         setExtended(m.isExtended());
 

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/GridConnectReply.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/GridConnectReply.java
@@ -167,9 +167,7 @@ public class GridConnectReply extends AbstractMRReply {
      */
     public void setData(int[] d) {
         int len = (d.length <= MAXLEN) ? d.length : MAXLEN;
-        for (int i = 0; i < len; i++) {
-            _dataChars[i] = d[i];
-        }
+        System.arraycopy(d, 0, _dataChars, 0, len);
     }
 
     // pointer to the N or R character
@@ -229,8 +227,7 @@ public class GridConnectReply extends AbstractMRReply {
 
     // Get a single hex digit. returns 0 if digit is invalid
     private int getHexDigit(int index) {
-        int b = 0;
-        b = _dataChars[index];
+        int b = _dataChars[index];
         if ((b >= '0') && (b <= '9')) {
             b = b - '0';
         } else if ((b >= 'A') && (b <= 'F')) {

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/can2usbino/GridConnectDoubledMessage.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/can2usbino/GridConnectDoubledMessage.java
@@ -25,12 +25,15 @@ public class GridConnectDoubledMessage extends GridConnectMessage {
     public GridConnectDoubledMessage() {
         _nDataChars = 28;
         _dataChars = new int[_nDataChars];
-        setElement(0, '!');
+        GridConnectDoubledMessage.this.setElement(0, '!');
     }
 
     public GridConnectDoubledMessage(CanMessage m) {
         this();
+        addCanMessage(m);
+    }
 
+    private void addCanMessage(CanMessage m) {
         // Standard or extended frame
         setExtended(m.isExtended());
 
@@ -75,9 +78,7 @@ public class GridConnectDoubledMessage extends GridConnectMessage {
     @Override
     public void setData(int[] d) {
         int len = (d.length <= 24) ? d.length : 24;
-        for (int i = 0; i < len; i++) {
-            _dataChars[i] = d[i];
-        }
+        System.arraycopy(d, 0, _dataChars, 0, len);
     }
 
     @Override
@@ -91,7 +92,7 @@ public class GridConnectDoubledMessage extends GridConnectMessage {
         }
     }
 
-    boolean extended;
+    private boolean extended;
 
     @Override
     public boolean isExtended() {

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/canrs/MergTrafficController.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/canrs/MergTrafficController.java
@@ -24,19 +24,19 @@ public class MergTrafficController extends GcTrafficController {
 
     public MergTrafficController() {
         super();
-        setCanId(CbusConstants.DEFAULT_STANDARD_ID);
+        super.setCanId(CbusConstants.DEFAULT_STANDARD_ID);
     }
 
     // New message for hardware protocol
     @Override
     protected AbstractMRMessage newMessage() {
         log.debug("New MergMessage created");
-        MergMessage msg = new MergMessage();
-        return msg;
+        return new MergMessage();
     }
 
     /**
-     * Make a CanReply from a MergReply reply
+     * Make a CanReply from a MergReply reply.
+     * {@inheritDoc}
      */
     @Override
     public CanReply decodeFromHardware(AbstractMRReply m) {
@@ -53,22 +53,22 @@ public class MergTrafficController extends GcTrafficController {
     }
 
     /**
-     * Encode a CanMessage for the hardware
+     * Encode a CanMessage for the hardware.
+     * {@inheritDoc}
      */
     @Override
     public AbstractMRMessage encodeForHardware(CanMessage m) {
         //log.debug("Encoding for hardware");
-        MergMessage ret = new MergMessage(m);
-
-        return ret;
+        return new MergMessage(m);
     }
 
-    // New reply from hardware
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected AbstractMRReply newReply() {
         log.debug("New MergReply created");
-        MergReply reply = new MergReply();
-        return reply;
+        return new MergReply();
     }
 
     private final static Logger log = LoggerFactory.getLogger(MergTrafficController.class);

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/net/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/net/ConnectionConfig.java
@@ -1,7 +1,6 @@
 package jmri.jmrix.can.adapters.gridconnect.net;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.ResourceBundle;
 import javax.swing.JComboBox;
 import javax.swing.JPanel;
@@ -70,11 +69,8 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
 
         updateUserNameField();
 
-        ((JComboBox<Option>) options.get("Protocol").getComponent()).addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                updateUserNameField();
-            }
+        ((JComboBox<Option>) options.get("Protocol").getComponent()).addActionListener((ActionEvent e) -> {
+            updateUserNameField();
         });
     }
 
@@ -101,11 +97,8 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     }
 
     /**
-     * Access to current selected command station mode
+     * {@inheritDoc}
      */
-    /*public String getMode() {
-     return opt2Box.getSelectedItem().toString();
-     }*/
     @Override
     public boolean isPortAdvanced() {
         return false;

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/net/MergConnectionConfig.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/net/MergConnectionConfig.java
@@ -10,11 +10,11 @@ import java.util.ResourceBundle;
  */
 public class MergConnectionConfig extends ConnectionConfig {
 
-    public final static String NAME = "CAN via MERG Network Interface";
+    public final static String MERG_NAME = "CAN via MERG Network Interface";
 
     /**
-     * Create a connection configuration with a preexisting adapter. This is
-     * used principally when loading a configuration that defines this
+     * Create a connection configuration with a preexisting adapter.
+     * This is used principally when loading a configuration that defines this
      * connection.
      *
      * @param p the adapter to create a connection configuration for
@@ -25,7 +25,7 @@ public class MergConnectionConfig extends ConnectionConfig {
 
     @Override
     public String name() {
-        return NAME;
+        return MERG_NAME;
     }
 
     /**

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/net/MergNetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/net/MergNetworkDriverAdapter.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.can.adapters.gridconnect.net;
 
-
 /**
  * Implements NetworkDriverAdapter for the MERG system network connection.
  * <p>
@@ -14,7 +13,7 @@ public class MergNetworkDriverAdapter extends NetworkDriverAdapter {
     public MergNetworkDriverAdapter() {
         super();
         options.put("CANID", new Option("CAN ID for CAN-USB", new String[]{"127", "126", "125", "124", "123", "122", "121", "120"}));
-        setManufacturer(jmri.jmrix.merg.MergConnectionTypeList.MERG);
+        super.setManufacturer(jmri.jmrix.merg.MergConnectionTypeList.MERG);
     }
 
 }

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/net/NetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/net/NetworkDriverAdapter.java
@@ -24,7 +24,7 @@ public class NetworkDriverAdapter extends jmri.jmrix.AbstractNetworkPortControll
         options.put(option1Name, new Option(Bundle.getMessage("ConnectionGateway"), new String[]{"Pass All", "Filtering"}));
         option2Name = "Protocol"; // NOI18N
         options.put(option2Name, new Option(Bundle.getMessage("ConnectionProtocol"), jmri.jmrix.can.ConfigurationManager.getSystemOptions(), false));
-        setManufacturer(jmri.jmrix.openlcb.OlcbConnectionTypeList.OPENLCB);
+        super.setManufacturer(jmri.jmrix.openlcb.OlcbConnectionTypeList.OPENLCB); // overriden by MERG Connections.
         allowConnectionRecovery = true;
     }
 
@@ -35,26 +35,21 @@ public class NetworkDriverAdapter extends jmri.jmrix.AbstractNetworkPortControll
     @Override
     public void configure() {
         TrafficController tc;
-        if (getOptionState(option2Name).equals(ConfigurationManager.MERGCBUS)) {
-            // Register the CAN traffic controller being used for this connection
-            tc = new MergTrafficController();
-            try {
-                tc.setCanId(Integer.parseInt(getOptionState("CANID")));
-            } catch (Exception e) {
-                log.error("Cannot parse CAN ID - check your preference settings {}", e);
-                log.error("Now using default CAN ID");
-            }
-        } else if (getOptionState(option2Name).equals(ConfigurationManager.SPROGCBUS)) {
-            // Register the CAN traffic controller being used for this connection
-            tc = new MergTrafficController();
-            try {
-                tc.setCanId(Integer.parseInt(getOptionState("CANID")));
-            } catch (Exception e) {
-                log.error("Cannot parse CAN ID - check your preference settings {}", e);
-                log.error("Now using default CAN ID");
-            }
-        } else {
-            tc = new GcTrafficController();
+        switch (getOptionState(option2Name)) {
+            case ConfigurationManager.MERGCBUS:
+            case ConfigurationManager.SPROGCBUS:
+                // Register the CAN traffic controller being used for this connection
+                tc = new MergTrafficController();
+                 try {
+                    tc.setCanId(Integer.parseInt(getOptionState("CANID")));
+                } catch (NumberFormatException e) {
+                    log.error("Cannot parse CAN ID \"{}\" - check your preference settings", getOptionState("CANID"), e);
+                    log.error("Now using default CAN ID {}",tc.getCanid());
+                }
+                break;
+            default:
+                tc = new GcTrafficController();
+                break;
         }
         this.getSystemConnectionMemo().setTrafficController(tc);
 
@@ -66,7 +61,9 @@ public class NetworkDriverAdapter extends jmri.jmrix.AbstractNetworkPortControll
         // do central protocol-specific configuration    
         this.getSystemConnectionMemo().configureManagers();
         if (socketConn != null) {
-            log.info("Connection complete with {}", socketConn.getInetAddress());
+            log.info("{} Connection via {} complete with {}",
+                this.getSystemConnectionMemo().getUserName(),
+                getOptionState(option2Name), socketConn.getInetAddress());
         }
     }
 

--- a/java/src/jmri/jmrix/can/adapters/lawicell/LawicellTrafficController.java
+++ b/java/src/jmri/jmrix/can/adapters/lawicell/LawicellTrafficController.java
@@ -36,6 +36,7 @@ public class LawicellTrafficController extends jmri.jmrix.can.TrafficController 
 
     /**
      * Forward a CanReply to all registered CanInterface listeners.
+     * {@inheritDoc}
      */
     @Override
     protected void forwardReply(AbstractMRListener client, AbstractMRReply r) {
@@ -61,6 +62,7 @@ public class LawicellTrafficController extends jmri.jmrix.can.TrafficController 
 
     /**
      * Forward a preformatted message to the actual interface.
+     * {@inheritDoc}
      */
     @Override
     public void sendCanMessage(CanMessage m, CanListener reply) {
@@ -70,6 +72,7 @@ public class LawicellTrafficController extends jmri.jmrix.can.TrafficController 
 
     /**
      * Forward a preformatted reply to the actual interface.
+     * {@inheritDoc}
      */
     @Override
     public void sendCanReply(CanReply r, CanListener reply) {
@@ -85,7 +88,6 @@ public class LawicellTrafficController extends jmri.jmrix.can.TrafficController 
      */
     @Override
     protected void addTrailerToOutput(byte[] msg, int offset, AbstractMRMessage m) {
-        return;
     }
 
     /**
@@ -109,7 +111,8 @@ public class LawicellTrafficController extends jmri.jmrix.can.TrafficController 
     }
 
     /**
-     * Make a CanReply from a system-specific reply
+     * Make a CanReply from a Lawicell-specific reply.
+     * {@inheritDoc}
      */
     @Override
     public CanReply decodeFromHardware(AbstractMRReply m) {
@@ -126,7 +129,8 @@ public class LawicellTrafficController extends jmri.jmrix.can.TrafficController 
     }
 
     /**
-     * Encode a CanMessage for the hardware
+     * Encode a CanMessage into Lawicell format for the hardware.
+     * {@inheritDoc}
      */
     @Override
     public AbstractMRMessage encodeForHardware(CanMessage m) {
@@ -143,15 +147,13 @@ public class LawicellTrafficController extends jmri.jmrix.can.TrafficController 
         return reply;
     }
 
-    /*
-     * Normal Lawicall replies will end with CR; errors are BELL
+    /**
+     * Normal Lawicell replies will end with CR; errors are BELL.
+     * {@inheritDoc}
      */
     @Override
     protected boolean endOfMessage(AbstractMRReply r) {
-        if (endNormalReply(r)) {
-            return true;
-        }
-        return false;
+        return endNormalReply(r);
     }
 
     boolean endNormalReply(AbstractMRReply r) {
@@ -160,10 +162,7 @@ public class LawicellTrafficController extends jmri.jmrix.can.TrafficController 
         if (r.getElement(num) == 0x0D) {
             return true;
         }
-        if (r.getElement(num) == 0x07) {
-            return true;
-        }
-        return false;
+        return r.getElement(num) == 0x07;
     }
 
     private int gcState;

--- a/java/src/jmri/jmrix/can/adapters/loopback/LoopbackTrafficController.java
+++ b/java/src/jmri/jmrix/can/adapters/loopback/LoopbackTrafficController.java
@@ -134,7 +134,6 @@ public class LoopbackTrafficController extends jmri.jmrix.can.TrafficController 
 
     /**
      * Dummy; loopback doesn't parse serial messages.
-     * {@inheritDoc}
      */
     boolean endNormalReply(AbstractMRReply r) {
         log.error("endNormalReply unexpected");

--- a/java/src/jmri/jmrix/can/adapters/loopback/LoopbackTrafficController.java
+++ b/java/src/jmri/jmrix/can/adapters/loopback/LoopbackTrafficController.java
@@ -24,6 +24,7 @@ public class LoopbackTrafficController extends jmri.jmrix.can.TrafficController 
 
     /**
      * Forward a CanMessage to all registered CanInterface listeners.
+     * {@inheritDoc}
      */
     @Override
     protected void forwardMessage(AbstractMRListener client, AbstractMRMessage m) {
@@ -32,6 +33,7 @@ public class LoopbackTrafficController extends jmri.jmrix.can.TrafficController 
 
     /**
      * Forward a CanReply to all registered CanInterface listeners.
+     * {@inheritDoc}
      */
     @Override
     protected void forwardReply(AbstractMRListener client, AbstractMRReply r) {
@@ -44,6 +46,7 @@ public class LoopbackTrafficController extends jmri.jmrix.can.TrafficController 
 
     /**
      * Forward a preformatted message to the actual interface.
+     * {@inheritDoc}
      */
     @Override
     public void sendCanMessage(CanMessage m, CanListener reply) {
@@ -53,6 +56,7 @@ public class LoopbackTrafficController extends jmri.jmrix.can.TrafficController 
 
     /**
      * Forward a preformatted reply to the actual interface.
+     * {@inheritDoc}
      */
     @Override
     public void sendCanReply(CanReply r, CanListener reply) {
@@ -68,7 +72,6 @@ public class LoopbackTrafficController extends jmri.jmrix.can.TrafficController 
      */
     @Override
     protected void addTrailerToOutput(byte[] msg, int offset, AbstractMRMessage m) {
-        return;
     }
 
     /**
@@ -87,37 +90,24 @@ public class LoopbackTrafficController extends jmri.jmrix.can.TrafficController 
     @Override
     protected AbstractMRMessage newMessage() {
         log.debug("New CanMessage created");
-        CanMessage msg = new CanMessage(getCanid());
-        return msg;
+        return new CanMessage(getCanid());
     }
 
     /**
-     * Make a CanReply from a system-specific reply
+     * Make a CanReply from a system-specific reply.
+     * loop back returns null.
+     * {@inheritDoc}
      */
     @Override
     public CanReply decodeFromHardware(AbstractMRReply m) {
         log.error("decodeFromHardware unexpected");
         return null;
-
-        /*         if (log.isDebugEnabled()) log.debug("Decoding from hardware: '"+m+"'\n"); */
-        /*      CanReply gc = (CanReply)m; */
-        /*         CanReply ret = new CanReply(); */
-        /*  */
-        /*      // Get the ID */
-        /*         ret.setId(gc.getID()); */
-        /*          */
-        /*         // Get the data */
-        /*         for (int i = 0; i < gc.getNumBytes(); i++) { */
-        /*             ret.setElement(i, gc.getByte(i)); */
-        /*         } */
-        /*         ret.setNumDataElements(gc.getNumBytes()); */
-        /*         if (log.isDebugEnabled()) log.debug("Decoded as "+ret); */
-        /*          */
-        /*         return ret; */
     }
 
     /**
-     * Encode a CanMessage for the hardware
+     * Encode a CanMessage for the hardware.
+     * loop back returns null.
+     * {@inheritDoc}
      */
     @Override
     public AbstractMRMessage encodeForHardware(CanMessage m) {
@@ -129,21 +119,22 @@ public class LoopbackTrafficController extends jmri.jmrix.can.TrafficController 
     @Override
     protected AbstractMRReply newReply() {
         log.debug("New CanReply created");
-        CanReply reply = new CanReply();
-        return reply;
+        return new CanReply();
     }
 
-    /*
-     * Dummy; loopback doesn't parse serial messages
+    /**
+     * Dummy; loopback doesn't parse serial messages.
+     * {@inheritDoc}
      */
     @Override
     protected boolean endOfMessage(AbstractMRReply r) {
-        log.error("endNormalReply unexpected");
+        log.error("endOfMessage unexpected");
         return true;
     }
 
-    /*
-     * Dummy; loopback doesn't parse serial messages
+    /**
+     * Dummy; loopback doesn't parse serial messages.
+     * {@inheritDoc}
      */
     boolean endNormalReply(AbstractMRReply r) {
         log.error("endNormalReply unexpected");

--- a/java/src/jmri/jmrix/can/adapters/loopback/LoopbackTrafficController.java
+++ b/java/src/jmri/jmrix/can/adapters/loopback/LoopbackTrafficController.java
@@ -132,14 +132,6 @@ public class LoopbackTrafficController extends jmri.jmrix.can.TrafficController 
         return true;
     }
 
-    /**
-     * Dummy; loopback doesn't parse serial messages.
-     */
-    boolean endNormalReply(AbstractMRReply r) {
-        log.error("endNormalReply unexpected");
-        return true;
-    }
-
     private final static Logger log = LoggerFactory.getLogger(LoopbackTrafficController.class);
 
 }

--- a/java/src/jmri/jmrix/can/adapters/loopback/Port.java
+++ b/java/src/jmri/jmrix/can/adapters/loopback/Port.java
@@ -76,14 +76,9 @@ public class Port extends AbstractSerialPortController {
 
     @Override
     public java.util.Vector<String> getPortNames() {
-        java.util.Vector<String> v = new java.util.Vector<String>();
+        java.util.Vector<String> v = new java.util.Vector<>();
         v.addElement(Bundle.getMessage("none"));
         return v;
-    }
-
-    @Override
-    public void dispose() {
-        super.dispose();
     }
 
     @Override

--- a/java/test/jmri/jmrix/AbstractPortControllerScaffold.java
+++ b/java/test/jmri/jmrix/AbstractPortControllerScaffold.java
@@ -1,9 +1,6 @@
 package jmri.jmrix;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
+import java.io.*;
 
 import jmri.SystemConnectionMemo;
 
@@ -15,11 +12,9 @@ import jmri.SystemConnectionMemo;
 
 public class AbstractPortControllerScaffold extends AbstractPortController {
 
-    DataOutputStream ostream;  // Traffic controller writes to this
-    DataInputStream tostream; // so we can read it from this
-
-    DataOutputStream tistream; // tests write to this
-    DataInputStream istream;  // so the traffic controller can read from this
+    private final DataOutputStream ostream;  // Traffic controller writes to this
+    private final DataOutputStream tistream; // tests write to this
+    private final DataInputStream istream;  // so the traffic controller can read from this
    
     @Override
     public void configure() {
@@ -27,7 +22,7 @@ public class AbstractPortControllerScaffold extends AbstractPortController {
 
     @Override
     public String getCurrentPortName() {
-         return("testport");
+        return("testport");
     }
 
     @Override
@@ -38,11 +33,9 @@ public class AbstractPortControllerScaffold extends AbstractPortController {
     public void connect(){
     }
 
-    public AbstractPortControllerScaffold(SystemConnectionMemo connectionMemo) throws Exception {
+    public AbstractPortControllerScaffold(SystemConnectionMemo connectionMemo) throws IOException {
         super(connectionMemo);
-        PipedInputStream tempPipe;
-        tempPipe = new PipedInputStream();
-        tostream = new DataInputStream(tempPipe);
+        PipedInputStream tempPipe = new PipedInputStream();
         ostream = new DataOutputStream(new PipedOutputStream(tempPipe));
         tempPipe = new PipedInputStream();
         istream = new DataInputStream(tempPipe);
@@ -52,19 +45,28 @@ public class AbstractPortControllerScaffold extends AbstractPortController {
     // returns the InputStream from the port
     @Override
     public DataInputStream getInputStream() {
-       return istream;
+        return istream;
     }
 
     // returns the outputStream to the port
     @Override
     public DataOutputStream getOutputStream() {
-       return ostream;
+        return ostream;
+    }
+    
+    /**
+     * Get the redirect stream.
+     * Data sent to this output stream will appear in the DataInputStream.
+     * @return the stream which redirects to the input stream.
+     */
+    public DataOutputStream getRedirectedToInputStream() {
+        return tistream;
     }
 
     // check that this object is ready to operate
     @Override
     public boolean status() {
-       return true;
+        return true;
     }
 }
 

--- a/java/test/jmri/jmrix/can/AbstractCanTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/AbstractCanTrafficControllerTest.java
@@ -58,10 +58,9 @@ public class AbstractCanTrafficControllerTest extends jmri.jmrix.AbstractMRTraff
     @Override
     @AfterEach
     public void tearDown(){
-       tc = null;
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
+        tc.terminateThreads();
+        tc = null;
         JUnitUtil.tearDown();
- 
     }
 
 }

--- a/java/test/jmri/jmrix/can/DummyCanListener.java
+++ b/java/test/jmri/jmrix/can/DummyCanListener.java
@@ -1,0 +1,65 @@
+package jmri.jmrix.can;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Basic CanListener for use in testing.
+ * @author Steve Young Copyright (C) 2022
+ */
+public class DummyCanListener implements CanListener {
+    
+    private final TrafficController tc;
+    private final List<CanMessage> m_list;
+    private final List<CanReply> r_list;
+
+    public DummyCanListener(TrafficController tcToAdd) {
+        tc = tcToAdd;
+        m_list = new CopyOnWriteArrayList<>();
+        r_list = new CopyOnWriteArrayList<>();
+        addTc(tc);
+    }
+
+    /**
+     * Trigger for Outgoing CanMessage.
+     * @param m Outgoing CanMessage
+     */
+    @Override
+    public void message(CanMessage m) {
+        m_list.add(m);
+    }
+
+    /**
+     * Trigger for Incoming CanReply.
+     * @param r Incoming CanReply
+     */
+    @Override
+    public void reply(CanReply r) {
+        r_list.add(r);
+    }
+
+    /**
+     * Get List of outgoing messages.
+     * @return list of CanMessage.
+     */
+    public List<CanMessage> getMessages() {
+        return Collections.unmodifiableList(m_list);
+    }
+
+    /**
+     * Get List of incoming replies.
+     * @return list of CanReply.
+     */
+    public List<CanReply> getReplies() {
+        return Collections.unmodifiableList(r_list);
+    }
+
+    /**
+     * Remove CanListener.
+     */
+    public void dispose() {
+        removeTc(tc);
+    }
+    
+}

--- a/java/test/jmri/jmrix/can/TrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/TrafficControllerTest.java
@@ -28,7 +28,7 @@ public class TrafficControllerTest extends AbstractCanTrafficControllerTest {
     @Override
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp(); 
+        JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new TrafficController(){
            @Override
@@ -70,10 +70,9 @@ public class TrafficControllerTest extends AbstractCanTrafficControllerTest {
     @Override
     @AfterEach
     public void tearDown(){
-       tc = null;
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
+        tc.terminateThreads();
+        tc = null;
         JUnitUtil.tearDown();
- 
     }
 
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/GcTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/GcTrafficControllerTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.can.adapters.gridconnect;
 
+import jmri.jmrix.AbstractPortControllerScaffold;
+import jmri.jmrix.can.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -9,11 +11,37 @@ import org.junit.jupiter.api.*;
  * @author Paul Bender Copyright (C) 2016
  */
 public class GcTrafficControllerTest extends jmri.jmrix.can.TrafficControllerTest {
-   
+
+    @Timeout(10)
+    @Test
+    public void testIncomingRtr() throws java.io.IOException {
+        
+        DummyCanListener listener = new DummyCanListener((GcTrafficController)tc);
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        
+        AbstractPortControllerScaffold pcs = new AbstractPortControllerScaffold(memo);
+        tc.connectPort(pcs);
+        pcs.getRedirectedToInputStream().writeBytes(":SB0F0R;"); // RTR CanFrame SB0F0R
+        
+        JUnitUtil.waitFor(() -> {
+            return !listener.getReplies().isEmpty();
+        },"rtr reply did not happen");
+        
+        CanReply reply = listener.getReplies().get(0);
+        Assertions.assertNotNull(reply, "CanReply generated and not null");
+        Assertions.assertEquals(0,reply.getNumDataElements(),"no data elements");
+        Assertions.assertTrue(reply.isRtr(),"rtr flag set");
+        
+        listener.dispose();
+        tc.disconnectPort(pcs);
+        pcs.dispose();
+        
+    }
+
     @Override
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp(); 
+        JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new GcTrafficController();
     }
@@ -21,8 +49,8 @@ public class GcTrafficControllerTest extends jmri.jmrix.can.TrafficControllerTes
     @Override
     @AfterEach
     public void tearDown(){
-       tc = null;
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
+        tc.terminateThreads();
+        tc = null;
         JUnitUtil.tearDown();
  
     }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/GridConnectReplyTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/GridConnectReplyTest.java
@@ -132,6 +132,7 @@ public class GridConnectReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         m = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergReplyTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergReplyTest.java
@@ -110,6 +110,28 @@ public class MergReplyTest extends jmri.jmrix.AbstractMessageTestBase {
         Assert.assertEquals("el 1", 0x63, r.getElement(0));
     }
 
+    @Test
+    public void testZeroLengthRtr() {
+        MergReply g = new MergReply(":SB0F0R;");
+        CanReply r = g.createReply();
+        
+        Assert.assertEquals("rtr", true, r.isRtr());
+        Assert.assertEquals("extended", false, r.isExtended());
+        Assert.assertEquals("header", 1415, r.getHeader());
+        Assert.assertEquals("num elements", 0, r.getNumDataElements());
+    }
+
+    @Test
+    public void testZeroLengthStandard() {
+        MergReply g = new MergReply(":SB180N;");
+        CanReply r = g.createReply();
+        
+        Assert.assertEquals("rtr", false, r.isRtr());
+        Assert.assertEquals("extended", false, r.isExtended());
+        Assert.assertEquals("header", 1420, r.getHeader());
+        Assert.assertEquals("num elements", 0, r.getNumDataElements());
+    }
+    
     // Left shift a standard header from CBUS specific format
     public int unMungeStdHeader(int h) {
         return (h >> 5);
@@ -128,6 +150,7 @@ public class MergReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         m = null;
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergTrafficControllerTest.java
@@ -1,5 +1,9 @@
 package jmri.jmrix.can.adapters.gridconnect.canrs;
 
+import java.io.*;
+
+import jmri.jmrix.*;
+import jmri.jmrix.can.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -8,6 +12,7 @@ import org.junit.jupiter.api.*;
 /**
  * Tests for MergTrafficController.
  * @author Paul Bender Copyright (C) 2016
+ * @author Steve Young Copyright (C) 2022
  */
 public class MergTrafficControllerTest extends jmri.jmrix.can.adapters.gridconnect.GcTrafficControllerTest {
 
@@ -17,7 +22,94 @@ public class MergTrafficControllerTest extends jmri.jmrix.can.adapters.gridconne
         Assert.assertEquals("default canid value",122,((MergTrafficController)tc).getCanid());
     }
 
-   
+    @Test
+    public void testRtrDecodeFromHardware() {
+
+        MergReply g = new MergReply(":SB0F0R;");
+        CanReply r = ((MergTrafficController)tc).decodeFromHardware(g);
+
+        Assertions.assertNotNull(r);
+        Assertions.assertTrue(r.isRtr(),"is RtR");
+        Assertions.assertFalse(r.isExtended(),"not extended");
+        Assertions.assertTrue(r.getNumDataElements()==0,"0 data elements");
+        Assertions.assertEquals("[587]", r.toString(),"CanReply toString ok");
+    }
+
+    @Test
+    public void testRtrEncodeForHardware() {
+        
+        CanMessage m = new CanMessage(0,0xB0F0); // header
+        m.setRtr(true);
+        m.setNumDataElements(0);
+        
+        AbstractMRMessage g = ((MergTrafficController)tc).encodeForHardware(m);
+        Assertions.assertEquals(":S1E00R;", g.toString(),"Gridconnect toString ok");
+        
+    }
+    
+    @Test
+    public void testdecodeFromHardwareRtr() {
+        
+        MergReply g = new MergReply(":SB0F0R;");
+        CanReply r = ((MergTrafficController)tc).decodeFromHardware(g);
+        
+        Assertions.assertNotNull(r);
+        Assertions.assertTrue(r.isRtr(),"is RtR");
+        Assertions.assertFalse(r.isExtended(),"not extended");
+        Assertions.assertTrue(r.getNumDataElements()==0,"0 data elements");
+        
+        Assertions.assertEquals("[587]", r.toString(),"CanReply toString ok");
+        
+    }
+    
+    @Test
+    public void testFailDecodeForHardware() {
+        
+        MergReply g = new MergReply("NOT A MERG REPLY");
+        CanReply r = ((MergTrafficController)tc).decodeFromHardware(g);
+        Assertions.assertNotNull(r);
+        Assertions.assertTrue(r.getNumDataElements()==0,"0 data elements");
+        Assertions.assertEquals("[0]", r.toString(),"CanReply toString zero value");
+        
+    }
+
+    @Test
+    @SuppressWarnings("AssertEqualsBetweenInconvertibleTypes") // CanReply and CanMessage can be tested via Equals
+    public void sendRtrAsCanReplyCanMessageTest() throws IOException {
+        MergTrafficController ltc = (MergTrafficController)tc;
+        
+        DummyCanListener listener = new DummyCanListener(ltc);
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        
+        AbstractPortControllerScaffold pcs = new AbstractPortControllerScaffold(memo);
+        ltc.connectPort(pcs);
+        
+        MergReply g = new MergReply(":SB0F0R;");
+        CanReply r = g.createReply();
+        ltc.sendCanReply(r, null);
+        JUnitUtil.waitFor(() -> {
+            return !listener.getReplies().isEmpty();
+        },"rtr reply did not happen");
+        
+        CanReply rr = listener.getReplies().get(0);
+        Assertions.assertEquals(r,rr,"CanReply matches");
+        
+        ltc.sendCanMessage(new CanMessage(r), null);
+        JUnitUtil.waitFor(() -> {
+            return !listener.getMessages().isEmpty();
+        },"rtr message did not happen");
+        
+        CanMessage mm = listener.getMessages().get(0);
+        Assertions.assertEquals(r,mm,"CanMessage matches");
+        
+        Assertions.assertEquals(g.getNumDataElements(),pcs.getOutputStream().size(),"dos size matches, message sent.");
+        
+        listener.dispose();
+        ltc.disconnectPort(pcs);
+        memo.dispose();
+
+    }
+
     @Override
     @BeforeEach
     public void setUp() {
@@ -29,8 +121,8 @@ public class MergTrafficControllerTest extends jmri.jmrix.can.adapters.gridconne
     @Override
     @AfterEach
     public void tearDown(){
-       tc = null;
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
+        tc.terminateThreads();
+        tc = null;
         JUnitUtil.tearDown();
  
     }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/net/MergConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/net/MergConnectionConfigTest.java
@@ -2,7 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.net;
 
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -14,7 +13,15 @@ public class MergConnectionConfigTest extends jmri.jmrix.AbstractConnectionConfi
     @Test
     public void testCTor() {
         MergConnectionConfig t = new MergConnectionConfig();
-        Assert.assertNotNull("exists",t);
+        Assertions.assertNotNull(t, "exists");
+        t.dispose();
+    }
+
+    @Test
+    public void testMergName() {
+        MergConnectionConfig t = new MergConnectionConfig();
+        Assertions.assertEquals("CAN via MERG Network Interface", t.name(),"MERG name");
+        t.dispose();
     }
 
     @BeforeEach

--- a/java/test/jmri/jmrix/can/adapters/lawicell/LawicellTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/lawicell/LawicellTrafficControllerTest.java
@@ -1,5 +1,9 @@
 package jmri.jmrix.can.adapters.lawicell;
 
+import java.io.IOException;
+
+import jmri.jmrix.AbstractPortControllerScaffold;
+import jmri.jmrix.can.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -7,9 +11,71 @@ import org.junit.jupiter.api.*;
 /**
  * Tests for LawicellTrafficController.
  * @author Paul Bender Copyright (C) 2016
+ * @author Steve Young Copyright (C) 2022
  */
+@Timeout(10)
 public class LawicellTrafficControllerTest extends jmri.jmrix.can.TrafficControllerTest {
    
+    @Test
+    @SuppressWarnings("AssertEqualsBetweenInconvertibleTypes") // CanReply and CanMessage can be tested via Equals
+    public void sendRtrAsCanReplyCanMessageTest() throws IOException {
+        LawicellTrafficController ltc = (LawicellTrafficController)tc;
+
+        DummyCanListener listener = new DummyCanListener(ltc);
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+
+        AbstractPortControllerScaffold pcs = new AbstractPortControllerScaffold(memo);
+        ltc.connectPort(pcs);
+
+        Reply g = new Reply("r1230\r");
+        CanReply r = g.createReply();
+        ltc.sendCanReply(r, null);
+        JUnitUtil.waitFor(() -> {
+            return !listener.getReplies().isEmpty();
+        },"rtr reply did not happen");
+
+        CanReply rr = listener.getReplies().get(0);
+        Assertions.assertEquals(r,rr,"CanReply matches");
+
+        ltc.sendCanMessage(new CanMessage(r), null);
+        JUnitUtil.waitFor(() -> {
+            return !listener.getMessages().isEmpty();
+        },"rtr message did not happen");
+
+        CanMessage mm = listener.getMessages().get(0);
+        Assertions.assertEquals(r,mm,"CanMessage matches");
+        Assertions.assertEquals(g.getNumDataElements(),pcs.getOutputStream().size(),"dos size matches, message sent.");
+
+        listener.dispose();
+        ltc.disconnectPort(pcs);
+        pcs.dispose();
+    }
+
+    @Test
+    public void testIncomingRtr() throws IOException {
+
+        DummyCanListener listener = new DummyCanListener((LawicellTrafficController)tc);
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+
+        AbstractPortControllerScaffold pcs = new AbstractPortControllerScaffold(memo);
+        tc.connectPort(pcs);
+        pcs.getRedirectedToInputStream().writeBytes("r1230\r"); // RTR CanFrame
+
+        JUnitUtil.waitFor(() -> {
+            return !listener.getReplies().isEmpty();
+        },"rtr reply did not happen");
+
+        CanReply reply = listener.getReplies().get(0);
+        Assertions.assertNotNull(reply, "CanReply generated and not null");
+        Assertions.assertEquals(0,reply.getNumDataElements(),"no data elements");
+        Assertions.assertTrue(reply.isRtr(),"rtr flag set");
+
+        listener.dispose();
+        tc.disconnectPort(pcs);
+        pcs.dispose();
+
+    }
+
     @Override
     @BeforeEach
     public void setUp() {
@@ -21,8 +87,8 @@ public class LawicellTrafficControllerTest extends jmri.jmrix.can.TrafficControl
     @Override
     @AfterEach
     public void tearDown(){
+        tc.terminateThreads();
         tc = null;
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
  
     }

--- a/java/test/jmri/jmrix/can/adapters/loopback/LoopbackTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/loopback/LoopbackTrafficControllerTest.java
@@ -40,9 +40,6 @@ public class LoopbackTrafficControllerTest extends jmri.jmrix.can.TrafficControl
     public void testInterfaceMethods() {
         LoopbackTrafficController ltc = (LoopbackTrafficController)tc;
         
-        Assertions.assertTrue(ltc.endNormalReply(null),"always end of reply");
-        JUnitAppender.assertErrorMessage("endNormalReply unexpected");
-        
         Assertions.assertTrue(ltc.endOfMessage(null),"always end of message");
         JUnitAppender.assertErrorMessage("endOfMessage unexpected");
         

--- a/java/test/jmri/jmrix/can/adapters/loopback/LoopbackTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/loopback/LoopbackTrafficControllerTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.can.adapters.loopback;
 
+import jmri.jmrix.can.*;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -7,13 +9,64 @@ import org.junit.jupiter.api.*;
 /**
  * Tests for LoopbackTrafficController.
  * @author Paul Bender Copyright (C) 2016
+ * @author Steve Young Copyright (C) 2022
  */
 public class LoopbackTrafficControllerTest extends jmri.jmrix.can.TrafficControllerTest {
-   
+
+    @Test
+    public void sendRtrAsCanReplyCanMessageTest() {
+        LoopbackTrafficController ltc = (LoopbackTrafficController)tc;
+        DummyCanListener listener = new DummyCanListener(ltc);
+        
+        CanReply r = new CanReply();
+        r.setRtr(true);
+        r.setNumDataElements(0);
+        r.setHeader(0xB0F0);
+        
+        ltc.sendCanReply(r, null);
+        JUnitUtil.waitFor(() -> {
+            return !listener.getReplies().isEmpty();
+        },"rtr reply did not happen");
+        
+        ltc.sendCanMessage(new CanMessage(r), null);
+        JUnitUtil.waitFor(() -> {
+            return !listener.getMessages().isEmpty();
+        },"rtr message did not happen");
+        
+        listener.dispose();
+    }
+    
+    @Test
+    public void testInterfaceMethods() {
+        LoopbackTrafficController ltc = (LoopbackTrafficController)tc;
+        
+        Assertions.assertTrue(ltc.endNormalReply(null),"always end of reply");
+        JUnitAppender.assertErrorMessage("endNormalReply unexpected");
+        
+        Assertions.assertTrue(ltc.endOfMessage(null),"always end of message");
+        JUnitAppender.assertErrorMessage("endOfMessage unexpected");
+        
+        Assertions.assertNotNull(ltc.newReply(),"new reply created");
+        Assertions.assertNotNull(ltc.newMessage(),"new message created");
+        
+        Assertions.assertEquals(8, ltc.lengthOfByteStream(new CanMessage(4)),"byte tsream length");
+        
+        Assertions.assertFalse(ltc.isBootMode(),"always false");
+        
+        Assertions.assertNull(ltc.encodeForHardware(null),"does not encode");
+        JUnitAppender.assertErrorMessage("encodeForHardware unexpected");
+        
+        Assertions.assertNull(ltc.decodeFromHardware(null),"does not decode");
+        JUnitAppender.assertErrorMessage("decodeFromHardware unexpected");
+        
+        ltc.addTrailerToOutput(null, 0, null);
+        
+    }
+
     @Override
     @BeforeEach
     public void setUp() {
-        jmri.util.JUnitUtil.setUp(); 
+        JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new LoopbackTrafficController();
     }
@@ -21,10 +74,9 @@ public class LoopbackTrafficControllerTest extends jmri.jmrix.can.TrafficControl
     @Override
     @AfterEach
     public void tearDown(){
-       tc = null;
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
+        tc.terminateThreads();
+        tc = null;
         JUnitUtil.tearDown();
- 
     }
 
 }

--- a/java/test/jmri/jmrix/can/adapters/loopback/PortTest.java
+++ b/java/test/jmri/jmrix/can/adapters/loopback/PortTest.java
@@ -1,8 +1,8 @@
 package jmri.jmrix.can.adapters.loopback;
 
+import jmri.jmrix.can.*;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
 
 /**
@@ -13,17 +13,55 @@ public class PortTest {
 
     @Test
     public void testCTor() {
-        Port t = new Port();
-        Assert.assertNotNull("exists",t);
+        Assertions.assertNotNull(t, "exists");
     }
+
+    @Test
+    public void testInterfaceMethods() {
+        Assertions.assertTrue(t.status(),"port always connected");
+        Assertions.assertNull(t.getInputStream(),"no input stream as loopback");
+        Assertions.assertNull(t.getOutputStream(),"no output stream as loopback");
+        Assertions.assertEquals("invalid request", t.openPort("portName", "appName"),"open port invalid request");
+    }
+
+    @Test
+    public void testPortName() {
+        Assertions.assertEquals(1, t.getPortNames().size(),"none is only option");
+        Assertions.assertEquals("(none)", t.getPortNames().firstElement(),"none option");
+    }
+
+    @Test
+    public void testBaudRates() {
+        Assertions.assertEquals(t.validBaudNumbers().length, t.validBaudRates().length,"array lengths match");
+        Assertions.assertEquals(1, t.validBaudNumbers().length,"only 1 option");
+        Assertions.assertEquals(0,t.validBaudNumbers()[0],"0 baud");
+    }
+
+    @Test
+    public void testConfigure() {
+        CanSystemConnectionMemo memo = t.getSystemConnectionMemo();
+        Assertions.assertNotNull(memo);
+        
+        t.configure();
+        
+        TrafficController tc = memo.getTrafficController();
+        Assertions.assertNotNull(tc,"trafficcontroller not null and attatched to memo");
+        Assertions.assertNotNull(jmri.InstanceManager.getNullableDefault(jmri.SensorManager.class),"memo configure managers called");
+        
+        tc.terminateThreads();
+    }
+
+    private Port t;
 
     @BeforeEach
     public void setUp() {
+        t = new Port();
         JUnitUtil.setUp();
     }
 
     @AfterEach
     public void tearDown() {
+        t.dispose(); // closes the CanSystemConnectionMemo created by the Port
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsolePaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/console/CbusConsolePaneTest.java
@@ -1,7 +1,5 @@
 package jmri.jmrix.can.cbus.swing.console;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
@@ -9,9 +7,12 @@ import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.jmrix.can.cbus.CbusConstants;
 import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
 import jmri.util.JUnitUtil;
+import jmri.util.JmriJFrame;
 
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+import org.netbeans.jemmy.operators.*;
 
 /**
  * Test simple functioning of CbusConsolePane
@@ -28,8 +29,8 @@ public class CbusConsolePaneTest extends jmri.util.swing.JmriPanelTest {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true" )
     public void testInitComponentsNoArgs() throws Exception{
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // for now, just makes ure there isn't an exception.
         ((CbusConsolePane) panel).initComponents();
     }
@@ -41,21 +42,108 @@ public class CbusConsolePaneTest extends jmri.util.swing.JmriPanelTest {
     }
     
     @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true" )
     public void testSendCanMessageCanReply() throws Exception{
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         
         cbPanel.initComponents(memo);
+        JFrameOperator jfo = createNewFrameWithPanel( cbPanel );
         
         CanMessage m = new CanMessage(tc.getCanid());
         m.setNumDataElements(1);
         m.setElement(0, CbusConstants.CBUS_RTON);
         cbPanel.decodePane.message(m);
-        
+        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); });
+
+        Assertions.assertTrue( getCbusPaneText(jfo).contains("RTON"), 
+            "RTON logged in console");
+        Assertions.assertTrue( getCbusPaneText(jfo).contains("Request Track On"), 
+            "Request Track On logged in console");
+
         CanReply r = new CanReply(tc.getCanid());
-        m.setNumDataElements(1);
-        m.setElement(0, CbusConstants.CBUS_TON);
+        r.setNumDataElements(1);
+        r.setElement(0, CbusConstants.CBUS_TON);
+        clearCbusPaneText(jfo);
         cbPanel.decodePane.reply(r);
+        Assertions.assertTrue( getCbusPaneText(jfo).contains(" TON"), 
+            "TON logged in console");
+        Assertions.assertTrue( getCbusPaneText(jfo).contains("Track On"), 
+            "Track On logged in console");
+
+        // new JButtonOperator(jfo, "Not a Button").doClick();  // NOI18N
+        jfo.requestClose();
     
+    }
+
+    @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true" )
+    public void testDisplayRtrFrame() {
+    
+        cbPanel.initComponents(memo);
+        JFrameOperator jfo = createNewFrameWithPanel( cbPanel );
+        
+        // click to display rtr info
+        new JCheckBoxOperator(jfo, Bundle.getMessage("RtrCheckbox")).setSelected(true);
+        
+        CanReply r = new CanReply();
+        r.setRtr(true);
+        cbPanel.decodePane.reply(r);
+        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); });
+        Assertions.assertTrue( getCbusPaneText(jfo).contains("RTR:R"), 
+            "RTR CanReply logged in console");
+        
+        r.setRtr(false);
+        clearCbusPaneText(jfo);
+        
+        cbPanel.decodePane.reply(r);
+        
+        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); });
+        Assertions.assertTrue( getCbusPaneText(jfo).contains("RTR:N"), 
+            "Non-RTR CanReply logged in console");
+        
+        r.setRtr(true);
+        r.setNumDataElements(0);
+        clearCbusPaneText(jfo);
+        
+        cbPanel.decodePane.reply(r);
+        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); });
+        Assertions.assertTrue( getCbusPaneText(jfo).contains("RTR:R"), 
+            "RTR CanReply 0 length logged in console");
+        
+        
+        // now check CanMessage
+        CanMessage m = new CanMessage(r);
+        Assertions.assertTrue(m.getNumDataElements()==0);
+        Assertions.assertTrue(m.isRtr());
+        clearCbusPaneText(jfo);
+        
+        cbPanel.decodePane.message(m);
+        JUnitUtil.waitFor(() ->{ return !getCbusPaneText(jfo).isEmpty(); });
+        Assertions.assertTrue( getCbusPaneText(jfo).contains("RTR:R"), 
+            "RTR CanMessage 0 length logged in console");
+        
+        m.setRtr(false);
+        clearCbusPaneText(jfo);
+        
+        // new JButtonOperator(jfo, "Not a Button").doClick();  // NOI18N
+        jfo.requestClose();
+    }
+
+    private JFrameOperator createNewFrameWithPanel(CbusConsolePane p){
+        JmriJFrame f = new JmriJFrame();
+        f.add(p);
+        f.setTitle(p.getName());
+        f.pack();
+        f.setVisible(true);
+        return new JFrameOperator( p.getName() );
+    }
+
+    private void clearCbusPaneText(JFrameOperator jfoo){
+        new JTextAreaOperator(jfoo,1).setText("");
+        JUnitUtil.waitFor(() ->{ return getCbusPaneText(jfoo).isEmpty(); });
+    }
+
+    private String getCbusPaneText(JFrameOperator jfoo){
+        return new JTextAreaOperator(jfoo,1).getText().replaceAll("\\r\\n|\\r|\\n", "");
     }
 
     private CanSystemConnectionMemo memo;
@@ -91,6 +179,5 @@ public class CbusConsolePaneTest extends jmri.util.swing.JmriPanelTest {
         
         JUnitUtil.tearDown();
     }
-
 
 }


### PR DESCRIPTION
Increased testing for the jmrix.can.adapter classes.
Ensures zero length and RTR CAN Frames are passed through interfaces as expected.

Minor code tweaks, no change in functionality.

Adds DummyCanListener for use by CAN interface tests.
Updates AbstractPortControllerScaffold for access to the loop IO stream.
