### PR TITLE
Remove warnings from DP extra menu item execution

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/ExtraMenuTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/ExtraMenuTableModel.java
@@ -327,21 +327,7 @@ public class ExtraMenuTableModel extends AbstractTableModel implements ActionLis
      * @return true if user says to continue
      */
     boolean badModeOk(String currentMode, String resetModes, String availableModes) {
-        String resetWarning
-                = ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn1")
-                + "\n\n"
-                + java.text.MessageFormat.format(ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn2"), resetModes)
-                + "\n"
-                + java.text.MessageFormat.format(ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn3"), availableModes)
-                + "\n"
-                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn4")
-                + "\n\n"
-                + java.text.MessageFormat.format(ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn5"), currentMode);
-        return (JOptionPane.YES_OPTION
-                == JOptionPane.showConfirmDialog(null,
-                        resetWarning,
-                        ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetTitle"),
-                        JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE));
+        return true;
     }
 
     /**
@@ -351,25 +337,7 @@ public class ExtraMenuTableModel extends AbstractTableModel implements ActionLis
      * @return true if user says to continue
      */
     boolean opsResetOk() {
-        String resetWarning
-                = ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn1")
-                + "\n\n"
-                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn2")
-                + "\n"
-                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn3")
-                + "\n"
-                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn4")
-                + "\n\n"
-                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn5")
-                + "\n"
-                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn6")
-                + "\n\n"
-                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn7");
-        return (JOptionPane.YES_OPTION
-                == JOptionPane.showConfirmDialog(null,
-                        resetWarning,
-                        ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsTitle"),
-                        JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE));
+        return true;
     }
 
     public void dispose() {

--- a/java/src/jmri/jmrit/symbolicprog/ResetTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/ResetTableModel.java
@@ -1,6 +1,9 @@
 package jmri.jmrit.symbolicprog;
 
+import java.util.ResourceBundle;
+
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 
 import jmri.Programmer;
 
@@ -28,5 +31,62 @@ public class ResetTableModel extends ExtraMenuTableModel {
     public String getIndividualElementName() {
         return "factReset";
     }
+
+    /**
+     * Can provide some mechanism to prompt for user for one last chance to
+     * change his/her mind
+     * @param currentMode current programming mode
+     * @param resetModes representation of reset modes available
+     * @param availableModes representation of available modes
+     * @return true if user says to continue
+     */
+    @Override
+    boolean badModeOk(String currentMode, String resetModes, String availableModes) {
+        String resetWarning
+                = ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn1")
+                + "\n\n"
+                + java.text.MessageFormat.format(ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn2"), resetModes)
+                + "\n"
+                + java.text.MessageFormat.format(ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn3"), availableModes)
+                + "\n"
+                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn4")
+                + "\n\n"
+                + java.text.MessageFormat.format(ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn5"), currentMode);
+        return (JOptionPane.YES_OPTION
+                == JOptionPane.showConfirmDialog(null,
+                        resetWarning,
+                        ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetTitle"),
+                        JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE));
+    }
+
+    /**
+     * Can provide some mechanism to prompt for user for one last chance to
+     * change his/her mind
+     *
+     * @return true if user says to continue
+     */
+    @Override
+    boolean opsResetOk() {
+        String resetWarning
+                = ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn1")
+                + "\n\n"
+                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn2")
+                + "\n"
+                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn3")
+                + "\n"
+                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn4")
+                + "\n\n"
+                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn5")
+                + "\n"
+                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn6")
+                + "\n\n"
+                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsWarn7");
+        return (JOptionPane.YES_OPTION
+                == JOptionPane.showConfirmDialog(null,
+                        resetWarning,
+                        ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetOpsTitle"),
+                        JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE));
+    }
+
 
 }


### PR DESCRIPTION
 - refactor warning method from ExtraMenuTableModel to ResetTableModel