### PR TITLE
New workflow action to check proper headless testing

### DIFF
--- a/.github/workflows/headless-test.yml
+++ b/.github/workflows/headless-test.yml
@@ -1,0 +1,27 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Headless CI Tests
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Cache Maven packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Run HeadLessTest with Maven
+      run: |
+        # run 'ant headlesstest' using maven
+        mvn antrun:run -Danttarget=headlesstest

--- a/.github/workflows/headless-test.yml
+++ b/.github/workflows/headless-test.yml
@@ -23,5 +23,5 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
     - name: Run HeadLessTest with Maven
       run: |
-        # run 'ant headlesstest' using maven
-        mvn antrun:run -Danttarget=headlesstest
+        # run tests using maven with graphics suppressed
+        mvn test "-Djmri.skipTestsRequiringSeparateRunning=true"  "-Djava.awt.headless=true"

--- a/java/test/jmri/HeadLessTest.java
+++ b/java/test/jmri/HeadLessTest.java
@@ -29,7 +29,7 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPacka
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
+ *
  * @author Bob Jacobsen, Copyright (C) 2001, 2002, 2007
  */
 @SuiteDisplayName("Headless Tests")
@@ -42,6 +42,7 @@ public class HeadLessTest {
 
         // start tests
         run();
+        System.exit(0);
     }
 
     /**

--- a/java/test/jmri/profile/ProfileTest.java
+++ b/java/test/jmri/profile/ProfileTest.java
@@ -27,7 +27,7 @@ public class ProfileTest {
 
     /**
      * Test of constructor with extension for Profile path.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -54,7 +54,7 @@ public class ProfileTest {
 
     /**
      * Test of getName method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -66,7 +66,7 @@ public class ProfileTest {
 
     /**
      * Test of setName method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -79,7 +79,7 @@ public class ProfileTest {
 
     /**
      * Test of getId method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -92,7 +92,7 @@ public class ProfileTest {
 
     /**
      * Test of getPath method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -106,7 +106,7 @@ public class ProfileTest {
 
     /**
      * Test of toString method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -118,7 +118,7 @@ public class ProfileTest {
 
     /**
      * Test of hashCode method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -131,7 +131,7 @@ public class ProfileTest {
 
     /**
      * Test of equals method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -151,13 +151,12 @@ public class ProfileTest {
         Assert.assertFalse(instance.equals(null));
         Assert.assertFalse(instance.equals(new String()));
         Assert.assertFalse(instance.equals(instance2));
-        System.out.println("Should be the same:");
         Assert.assertTrue(instance.equals(instance3));
     }
 
     /**
      * Test of isComplete method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -169,7 +168,7 @@ public class ProfileTest {
 
     /**
      * Test of getUniqueId method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -183,7 +182,7 @@ public class ProfileTest {
 
     /**
      * Test of containsProfile method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -200,7 +199,7 @@ public class ProfileTest {
 
     /**
      * Test of inProfile method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -218,7 +217,7 @@ public class ProfileTest {
 
     /**
      * Test of isProfile method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test
@@ -235,7 +234,7 @@ public class ProfileTest {
 
     /**
      * Test of compareTo method, of class Profile.
-     * 
+     *
      * @throws IOException if unexpected in context of test error occurs
      */
     @Test


### PR DESCRIPTION
This adds another workflow action to check that 'ant headlesstest' runs OK. (@danielb987 gets the credit for thinking of this)

Notes:
 - Note that this new check won't pass until #10701 is merged.
 - Once this is merged and confirmed OK, I intend to add it to the list of required checks
