### PR TITLE
fix Error message if RFID tag is not found

### DIFF
--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStock.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStock.java
@@ -850,7 +850,7 @@ public abstract class RollingStock extends PropertyChangeSupport implements Iden
             _rfid = id;
             if (!id.equals(NONE)) {
                 try {
-                    IdTag tag = InstanceManager.getDefault(IdTagManager.class).getIdTag(id);
+                    IdTag tag = InstanceManager.getDefault(IdTagManager.class).provideIdTag(id);
                     if (tag != null) {
                         log.debug("Tag {} found", tag);
                         setIdTag(tag);


### PR DESCRIPTION
Change getIdTag to provideIdTag in RollingStock method for setRfid(). This will create the tag in the PanelPro tag table, rather than giving an error message. If data is moved to OperationsPro from another JMRI, the tag may not be present. This change will create it, instead of giving an error message. Existing tags are left unchanged.