### PR TITLE
Spotbugs update

### DIFF
--- a/.spotbugs-check.xml
+++ b/.spotbugs-check.xml
@@ -14,9 +14,7 @@
         <Confidence value="2" /> <!-- 3 is low priority, 2 is medium priority, 1 is high priority -->
         <Or>
            <Bug pattern="IS2_INCONSISTENT_SYNC" />
-           <Bug pattern="OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE" />
            <Bug pattern="OVERRIDING_METHODS_MUST_INVOKE_SUPER" />
-           <Bug pattern="STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE" />
            <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
            <Bug pattern="DCN_NULLPOINTER_EXCEPTION" /> <!-- 327 cases -->
         </Or>

--- a/java/src/jmri/profile/ProfileManager.java
+++ b/java/src/jmri/profile/ProfileManager.java
@@ -262,13 +262,13 @@ public class ProfileManager extends Bean {
         try {
             os = new FileOutputStream(config);
             p.storeToXML(os, "Active profile configuration (saved at " + (new Date()).toString() + ")"); // NOI18N
-            os.close();
         } catch (IOException ex) {
             log.error("While trying to save active profile {}", config, ex);
+            throw ex;
+        } finally {
             if (os != null) {
                 os.close();
             }
-            throw ex;
         }
 
     }


### PR DESCRIPTION
 - fixes a resource leak (OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE)
 - Add OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE and STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE to checks, as they're now at zero occurrences