### PR TITLE
Update dccpp programmer tests

### DIFF
--- a/java/src/jmri/jmrix/AbstractProgrammer.java
+++ b/java/src/jmri/jmrix/AbstractProgrammer.java
@@ -71,7 +71,7 @@ public abstract class AbstractProgrammer extends PropertyChangeSupport implement
         }
 
         String retval = sbuf.toString();
-        if (retval.equals("")) {
+        if (retval.isEmpty()) {
             return "unknown status code: " + code;
         } else {
             return retval;
@@ -119,7 +119,7 @@ public abstract class AbstractProgrammer extends PropertyChangeSupport implement
         List<ProgrammingMode> validModes = getSupportedModes();
 
         if (m == null) {
-            if (validModes.size()>0) {
+            if (!validModes.isEmpty()) {
                 // null can only be set if there are no valid modes
                 throw new IllegalArgumentException("Cannot set null mode when modes are present");
             } else {

--- a/java/src/jmri/jmrix/dccpp/DCCppProgrammer.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppProgrammer.java
@@ -34,17 +34,17 @@ public class DCCppProgrammer extends AbstractProgrammer implements DCCppListener
     // response to a request to a programming request. 
     protected boolean _service_mode = false;  // TODO: Is this even meaningful for DCC++?
 
-    public DCCppProgrammer(DCCppTrafficController tc) {
+    static protected final int LISTENER_MASK = DCCppInterface.CS_INFO | DCCppInterface.COMMINFO | DCCppInterface.INTERFACE;
+
+    public DCCppProgrammer(@Nonnull DCCppTrafficController tc) {
         // error if more than one constructed?
-
         _controller = tc;
+        init();
+    }
 
+    private void init() {
         // connect to listen
-        controller().addDCCppListener(DCCppInterface.CS_INFO
-                | DCCppInterface.COMMINFO
-                | DCCppInterface.INTERFACE,
-                this);
-
+        controller().addDCCppListener(LISTENER_MASK, this);
         setMode(ProgrammingMode.DIRECTBYTEMODE);
     }
 
@@ -93,9 +93,7 @@ public class DCCppProgrammer extends AbstractProgrammer implements DCCppListener
      */
     @Override
     public boolean getCanWrite(String addr) {
-        if (log.isDebugEnabled()) {
-            log.debug("check CV {}", addr);
-        }
+        log.debug("check CV {}", addr);
         log.debug("cs Type: {} CS Build: {}", controller().getCommandStation().getStationType(), controller().getCommandStation().getBuild());
         if (!getCanWrite()) {
             return false; // check basic implementation first
@@ -293,10 +291,14 @@ public class DCCppProgrammer extends AbstractProgrammer implements DCCppListener
         notifyProgListenerEnd(temp,value,status);
     }
 
-    DCCppTrafficController _controller;
+    private final DCCppTrafficController _controller;
 
     protected DCCppTrafficController controller() {
         return _controller;
+    }
+
+    public void dispose() {
+        controller().removeDCCppListener(LISTENER_MASK, this);
     }
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DCCppProgrammer.class);

--- a/java/test/jmri/ProgrammerTestBase.java
+++ b/java/test/jmri/ProgrammerTestBase.java
@@ -54,7 +54,8 @@ abstract public class ProgrammerTestBase {
     
     @Test
     public void testSetModeNull() {
-        Assert.assertThrows(IllegalArgumentException.class, () -> programmer.setMode(null));
+        Throwable throwable = Assert.assertThrows(IllegalArgumentException.class, () -> programmer.setMode(null));
+        Assertions.assertNotNull(throwable.getMessage());
     }
 
     @Test

--- a/java/test/jmri/jmrix/AbstractProgrammerTest.java
+++ b/java/test/jmri/jmrix/AbstractProgrammerTest.java
@@ -1,9 +1,10 @@
 package jmri.jmrix;
 
 import java.util.List;
-import jmri.ProgListener;
-import jmri.ProgrammingMode;
+
+import jmri.*;
 import jmri.util.JUnitUtil;
+
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
@@ -17,7 +18,7 @@ import javax.annotation.Nonnull;
  *
  * @author Bob Jacobsen
  */
-public class AbstractProgrammerTest extends jmri.ProgrammerTestBase {
+public class AbstractProgrammerTest extends ProgrammerTestBase {
 
     @Test
     public void testDefaultViaBestMode() {
@@ -47,7 +48,7 @@ public class AbstractProgrammerTest extends jmri.ProgrammerTestBase {
                     abstractprogrammer.registerFromCV(cv1 = 7));
             Assert.assertEquals("test CV 8", 8,
                     abstractprogrammer.registerFromCV(cv1 = 8));
-        } catch (Exception e) {
+        } catch (ProgrammerException e) {
             Assert.fail("unexpected exception while cv = " + cv1);
         }
 
@@ -59,7 +60,7 @@ public class AbstractProgrammerTest extends jmri.ProgrammerTestBase {
             try {
                 abstractprogrammer.registerFromCV(cv1); // should assert
                 Assert.fail("did not throw as expected for cv = " + cv1);
-            } catch (Exception e) {
+            } catch (ProgrammerException e) {
                 jmri.util.JUnitAppender.assertWarnMessage("Unhandled register from cv:  "+cv1);
             }
         }
@@ -75,7 +76,7 @@ public class AbstractProgrammerTest extends jmri.ProgrammerTestBase {
             @Nonnull
             @Override
             public List<ProgrammingMode> getSupportedModes() {
-                java.util.ArrayList<ProgrammingMode> retval = new java.util.ArrayList<ProgrammingMode>();
+                java.util.ArrayList<ProgrammingMode> retval = new java.util.ArrayList<>();
                 
                 retval.add(ProgrammingMode.DIRECTMODE);
                 retval.add(ProgrammingMode.PAGEMODE);

--- a/java/test/jmri/jmrix/dccpp/DCCppProgrammerManagerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppProgrammerManagerTest.java
@@ -19,9 +19,13 @@ public class DCCppProgrammerManagerTest {
     public void testCtor() {
         // infrastructure objects
         DCCppInterfaceScaffold tc = new DCCppInterfaceScaffold(new DCCppCommandStation());
+        DCCppProgrammer dccprogrammer = new DCCppProgrammer(tc);
 
-        DCCppProgrammerManager t = new DCCppProgrammerManager(new DCCppProgrammer(tc), new DCCppSystemConnectionMemo(tc));
-        Assert.assertNotNull(t);
+        DCCppProgrammerManager t = new DCCppProgrammerManager(dccprogrammer, new DCCppSystemConnectionMemo(tc));
+        Assertions.assertNotNull(t, "exists");
+
+        dccprogrammer.dispose();
+        tc.terminateThreads();
     }
 
     @BeforeEach
@@ -31,9 +35,7 @@ public class DCCppProgrammerManagerTest {
 
     @AfterEach
     public void tearDown() {
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
-
     }
 
 }

--- a/java/test/jmri/jmrix/dccpp/DCCppProgrammerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppProgrammerTest.java
@@ -8,8 +8,7 @@
  */
 package jmri.jmrix.dccpp;
 
-import jmri.JmriException;
-import jmri.ProgrammingMode;
+import jmri.*;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -20,7 +19,7 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     static final int RESTART_TIME = 20;
 
     private DCCppInterfaceScaffold t = null;
-    private jmri.ProgListenerScaffold l = null;
+    private ProgListenerScaffold l = null;
     private DCCppProgrammer p = null;
 
     @Test
@@ -40,7 +39,8 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     @Test
     @Override
     public void testSetGetMode() {
-        Assert.assertThrows(IllegalArgumentException.class, () -> programmer.setMode(ProgrammingMode.REGISTERMODE));
+        Throwable throwable = Assert.assertThrows(IllegalArgumentException.class, () -> programmer.setMode(ProgrammingMode.REGISTERMODE));
+        Assertions.assertNotNull(throwable.getMessage());
     }
 
     @Override
@@ -52,7 +52,7 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     @Override
     @Test
     public void testGetWriteConfirmMode() {
-        Assert.assertEquals("Write Confirm Mode", jmri.Programmer.WriteConfirmMode.DecoderReply,
+        Assert.assertEquals("Write Confirm Mode", Programmer.WriteConfirmMode.DecoderReply,
                 programmer.getWriteConfirmMode("1234"));
     }
 
@@ -73,9 +73,8 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
-
-        //failure in this test occurs with the next line.
+        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
+        
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
         Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
     }
@@ -128,7 +127,7 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
+        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
 
         //failure in this test occurs with the next line.
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
@@ -136,18 +135,9 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         Assert.assertEquals("Register mode received value", 12, l.getRcvdValue());
          */
     }
+
     @Test
     public void testReadCvSequence() throws JmriException {
-        // infrastructure objects
-        DCCppInterfaceScaffold t = new DCCppInterfaceScaffold(new DCCppCommandStation());
-        jmri.ProgListenerScaffold l = new jmri.ProgListenerScaffold();
-
-        DCCppProgrammer p = new DCCppProgrammer(t) {
-            @Override
-            protected synchronized void restartTimer(int delay) {
-                super.restartTimer(RESTART_TIME);
-            }
-        };
 
         // and do the read
         p.readCV("29", l);
@@ -165,9 +155,8 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
-
-        //failure in this test occurs with the next line.
+        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
+        
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
 
         Assert.assertEquals("Register mode received value", 12, l.getRcvdValue());
@@ -176,14 +165,17 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
 
     @Test
     public void testReadCvWithStartValSequence() throws JmriException {
+        
+        t.terminateThreads();
+        p.dispose();
+        
         // infrastructure objects
         DCCppCommandStation cs = new DCCppCommandStation();
         cs.setVersion("3.0.0"); //set the version to support startVal
         Assert.assertTrue(cs.getVersion().equals("3.0.0"));
-        DCCppInterfaceScaffold t = new DCCppInterfaceScaffold(cs);
-        jmri.ProgListenerScaffold l = new jmri.ProgListenerScaffold();
-
-        DCCppProgrammer p = new DCCppProgrammer(t) {
+        t = new DCCppInterfaceScaffold(cs);
+        l = new ProgListenerScaffold();
+        p = new DCCppProgrammer(t) {
             @Override
             protected synchronized void restartTimer(int delay) {
                 super.restartTimer(RESTART_TIME);
@@ -206,7 +198,7 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
+        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
 
         //failure in this test occurs with the next line.
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
@@ -261,7 +253,7 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
+        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
 
         //failure in this test occurs with the next line.
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
@@ -274,16 +266,6 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     // different XpressNet commands.
     @Test
     public void testWriteHighCvSequence() throws JmriException {
-        // infrastructure objects
-        DCCppInterfaceScaffold t = new DCCppInterfaceScaffold(new DCCppCommandStation());
-        jmri.ProgListenerScaffold l = new jmri.ProgListenerScaffold();
-
-        DCCppProgrammer p = new DCCppProgrammer(t) {
-            @Override
-            protected synchronized void restartTimer(int delay) {
-                super.restartTimer(RESTART_TIME);
-            }
-        };
 
         // and do the write
         p.writeCV("300", 34, l);
@@ -300,9 +282,8 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
+        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
 
-        //failure in this test occurs with the next line.
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
         Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
     }
@@ -312,16 +293,6 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     // different XpressNet commands.
     @Test
     public void testReadCvHighSequence() throws JmriException {
-        // infrastructure objects
-        DCCppInterfaceScaffold t = new DCCppInterfaceScaffold(new DCCppCommandStation());
-        jmri.ProgListenerScaffold l = new jmri.ProgListenerScaffold();
-
-        DCCppProgrammer p = new DCCppProgrammer(t) {
-            @Override
-            protected synchronized void restartTimer(int delay) {
-                super.restartTimer(RESTART_TIME);
-            }
-        };
 
         // and do the read
         p.readCV("300", l);
@@ -339,9 +310,8 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
+        JUnitUtil.waitFor(() -> { return !(l.getRcvdInvoked() == 0); });
 
-        //failure in this test occurs with the next line.
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
 
         Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
@@ -420,7 +390,7 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         JUnitUtil.setUp();
         // infrastructure objects
         t = new DCCppInterfaceScaffold(new DCCppCommandStation());
-        l = new jmri.ProgListenerScaffold();
+        l = new ProgListenerScaffold();
 
         p = new DCCppProgrammer(t) {
             @Override
@@ -434,10 +404,11 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     @Override
     @AfterEach
     public void tearDown() {
+        p.dispose();
+        t.terminateThreads();
         t = null;
         l = null;
         p = null;
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/dccpp/DCCppProgrammerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppProgrammerTest.java
@@ -162,12 +162,14 @@ public class DCCppProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         Assert.assertEquals("Register mode received value", 12, l.getRcvdValue());
     }
 
-
     @Test
     public void testReadCvWithStartValSequence() throws JmriException {
         
         t.terminateThreads();
         p.dispose();
+        l =  null;
+        t = null;
+        p = null;
         
         // infrastructure objects
         DCCppCommandStation cs = new DCCppCommandStation();


### PR DESCRIPTION
Update dccpp programmer tests to mainly use connection in startup, not created each test.
Other minor tweaks.
Recent test failures, eg. https://builds.jmri.org/jenkins/job/development/job/builds/1099/