### PR TITLE
General Updates - ECoS

### DIFF
--- a/java/src/jmri/jmrix/ecos/EcosLocoAddressManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosLocoAddressManager.java
@@ -49,11 +49,15 @@ public class EcosLocoAddressManager extends AbstractManager<NamedBean> implement
     private String rosterAttribute;
     private EcosTrafficController tc;
     private Thread waitPrefLoad;
-    private Hashtable<String, EcosLocoAddress> _tecos = new Hashtable<String, EcosLocoAddress>();   // stores known Ecos Object ids to DCC
-    private Hashtable<Integer, EcosLocoAddress> _tdcc = new Hashtable<Integer, EcosLocoAddress>();  // stores known DCC Address to Ecos Object ids
+    private Hashtable<String, EcosLocoAddress> _tecos = new Hashtable<>();   // stores known Ecos Object ids to DCC
+    private Hashtable<Integer, EcosLocoAddress> _tdcc = new Hashtable<>();  // stores known DCC Address to Ecos Object ids
 
     public EcosLocoAddressManager(@Nonnull EcosSystemConnectionMemo memo) {
         super(memo);
+        init();
+    }
+
+    private void init() {
         locoToRoster = new EcosLocoToRoster(getMemo());
         tc = getMemo().getTrafficController();
         p = getMemo().getPreferenceManager();
@@ -183,7 +187,7 @@ public class EcosLocoAddressManager extends AbstractManager<NamedBean> implement
 
     public List<String> getEcosObjectList() {
         String[] arr = new String[_tecos.size()];
-        List<String> out = new ArrayList<String>();
+        List<String> out = new ArrayList<>();
         Enumeration<String> en = _tecos.keys();
         int i = 0;
         while (en.hasMoreElements()) {
@@ -328,6 +332,10 @@ public class EcosLocoAddressManager extends AbstractManager<NamedBean> implement
         if (waitPrefLoad != null) {
             waitPrefLoad.interrupt();
         }
+    }
+    
+    protected boolean threadsRunning() {
+        return ( waitPrefLoad != null ? waitPrefLoad.isAlive() : false );
     }
 
     public boolean shutdownDispose() {

--- a/java/src/jmri/jmrix/ecos/EcosPowerManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosPowerManager.java
@@ -13,12 +13,16 @@ import org.slf4j.LoggerFactory;
  */
 public class EcosPowerManager extends AbstractPowerManager<EcosSystemConnectionMemo> implements EcosListener {
 
-    EcosTrafficController tc;
+    private EcosTrafficController tc;
 
     public EcosPowerManager(EcosTrafficController etc) {
         super(etc.adaptermemo);
         // connect to the TrafficManager
         tc = etc;
+        init();
+    }
+
+    private void init() {
         tc.addEcosListener(this);
 
         // ask to be notified

--- a/java/src/jmri/jmrix/ecos/EcosSensorManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosSensorManager.java
@@ -18,9 +18,13 @@ import org.slf4j.LoggerFactory;
 public class EcosSensorManager extends jmri.managers.AbstractSensorManager
         implements EcosListener {
 
-    public EcosSensorManager(EcosSystemConnectionMemo memo) {
+    public EcosSensorManager(@Nonnull EcosSystemConnectionMemo memo) {
         super(memo);
         tc = memo.getTrafficController();
+        init();
+    }
+        
+    private void init() {
         // listen for sensor creation
         // connect to the TrafficManager
         tc.addEcosListener(this);
@@ -34,10 +38,10 @@ public class EcosSensorManager extends jmri.managers.AbstractSensorManager
         tc.sendEcosMessage(m, this);
     }
 
-    private EcosTrafficController tc;
+    private final EcosTrafficController tc;
     //The hash table simply holds the object number against the EcosSensor ref.
-    private Hashtable<Integer, EcosSensor> _tecos = new Hashtable<Integer, EcosSensor>();   // stores known Ecos Object ids to DCC
-    private Hashtable<Integer, Integer> _sport = new Hashtable<Integer, Integer>();   // stores known Ecos Object ids to DCC
+    private final Hashtable<Integer, EcosSensor> _tecos = new Hashtable<>();   // stores known Ecos Object ids to DCC
+    private final Hashtable<Integer, Integer> _sport = new Hashtable<>();   // stores known Ecos Object ids to DCC
 
     /**
      * {@inheritDoc}
@@ -229,6 +233,12 @@ public class EcosSensorManager extends jmri.managers.AbstractSensorManager
     @Nonnull
     public String validateSystemNameFormat(@Nonnull String name, @Nonnull java.util.Locale locale) throws jmri.NamedBean.BadSystemNameException {
         return validateTrimmedMin1NumberSystemNameFormat(name,locale);
+    }
+
+    @Override
+    public void dispose() {
+        tc.removeEcosListener(this);
+        super.dispose();
     }
 
     private final static Logger log = LoggerFactory.getLogger(EcosSensorManager.class);

--- a/java/src/jmri/jmrix/ecos/EcosSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/ecos/EcosSystemConnectionMemo.java
@@ -6,7 +6,6 @@ import java.util.ResourceBundle;
 import jmri.*;
 import jmri.managers.DefaultProgrammerManager;
 import jmri.util.NamedBeanComparator;
-import org.python.antlr.op.Pow;
 
 
 /**
@@ -23,23 +22,23 @@ public class EcosSystemConnectionMemo extends jmri.jmrix.DefaultSystemConnection
     public EcosSystemConnectionMemo(EcosTrafficController et) {
         super("U", "ECoS");
         this.et = et;
-        et.setAdapterMemo(this);
-        InstanceManager.store(this, EcosSystemConnectionMemo.class); // also register as specific type
-        InstanceManager.store(cf = new jmri.jmrix.ecos.swing.EcosComponentFactory(this),
-                jmri.jmrix.swing.ComponentFactory.class);
-        store(new EcosPreferences(this), EcosPreferences.class);
+        et.setAdapterMemo(EcosSystemConnectionMemo.this);
+        init();
     }
 
     public EcosSystemConnectionMemo() {
         super("U", "ECoS");
+        init();
+    }
+
+    private void init() {
         InstanceManager.store(this, EcosSystemConnectionMemo.class); // also register as specific type
-        //Needs to be implemented
         InstanceManager.store(cf = new jmri.jmrix.ecos.swing.EcosComponentFactory(this),
                 jmri.jmrix.swing.ComponentFactory.class);
         store(new EcosPreferences(this), EcosPreferences.class);
     }
 
-    jmri.jmrix.swing.ComponentFactory cf = null;
+    private jmri.jmrix.swing.ComponentFactory cf = null;
 
     /**
      * Provides access to the TrafficController for this particular connection.
@@ -60,34 +59,34 @@ public class EcosSystemConnectionMemo extends jmri.jmrix.DefaultSystemConnection
      */
     public void configureManagers() {
 
+        SensorManager sensorManager = new EcosSensorManager(this);
+        InstanceManager.setSensorManager(sensorManager);
+        store(sensorManager, SensorManager.class);
+        
         PowerManager powerManager = new EcosPowerManager(getTrafficController());
-        jmri.InstanceManager.store(powerManager, PowerManager.class);
+        InstanceManager.store(powerManager, PowerManager.class);
         store(powerManager, PowerManager.class);
 
         TurnoutManager turnoutManager = new EcosTurnoutManager(this);
-        jmri.InstanceManager.setTurnoutManager(turnoutManager);
+        InstanceManager.setTurnoutManager(turnoutManager);
         store(turnoutManager,TurnoutManager.class);
 
         EcosLocoAddressManager locoManager = new EcosLocoAddressManager(this);
         store(locoManager,EcosLocoAddressManager.class);
 
         ThrottleManager throttleManager = new EcosDccThrottleManager(this);
-        jmri.InstanceManager.setThrottleManager(throttleManager);
+        InstanceManager.setThrottleManager(throttleManager);
         store(throttleManager,ThrottleManager.class);
 
         ReporterManager reporterManager = new EcosReporterManager(this);
-        jmri.InstanceManager.setReporterManager(reporterManager);
+        InstanceManager.setReporterManager(reporterManager);
         store(reporterManager,ReporterManager.class);
 
-        SensorManager sensorManager = new jmri.jmrix.ecos.EcosSensorManager(this);
-        jmri.InstanceManager.setSensorManager(sensorManager);
-        store(sensorManager, SensorManager.class);
-
-        jmri.InstanceManager.store(getProgrammerManager(), GlobalProgrammerManager.class);
+        InstanceManager.store(getProgrammerManager(), GlobalProgrammerManager.class);
         store(getProgrammerManager(), GlobalProgrammerManager.class);
 
-        jmri.InstanceManager.store(getProgrammerManager(), jmri.AddressedProgrammerManager.class);
-        store(getProgrammerManager(), jmri.AddressedProgrammerManager.class);
+        InstanceManager.store(getProgrammerManager(), AddressedProgrammerManager.class);
+        store(getProgrammerManager(), AddressedProgrammerManager.class);
 
         register(); // registers general type
     }

--- a/java/src/jmri/jmrix/ecos/EcosTurnoutManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosTurnoutManager.java
@@ -36,6 +36,10 @@ public class EcosTurnoutManager extends jmri.managers.AbstractTurnoutManager
 
     public EcosTurnoutManager(EcosSystemConnectionMemo memo) {
         super(memo);
+        init();
+    }
+    
+    private void init() {
         tc = getMemo().getTrafficController();
 
         // listen for turnout creation
@@ -55,7 +59,7 @@ public class EcosTurnoutManager extends jmri.managers.AbstractTurnoutManager
     EcosTrafficController tc;
 
     // The hash table simply holds the object number against the EcosTurnout ref.
-    private Hashtable<Integer, EcosTurnout> _tecos = new Hashtable<Integer, EcosTurnout>(); // stores known Ecos Object ids to DCC
+    private final Hashtable<Integer, EcosTurnout> _tecos = new Hashtable<>(); // stores known Ecos Object ids to DCC
 
     /**
      * {@inheritDoc}
@@ -631,10 +635,12 @@ public class EcosTurnoutManager extends jmri.managers.AbstractTurnoutManager
             tc.sendEcosMessage(em, this);
         }
 
-        if (jmri.InstanceManager.getNullableDefault(ConfigureManager.class) != null) {
-            jmri.InstanceManager.getDefault(ConfigureManager.class).deregister(this);
+        if (InstanceManager.getNullableDefault(ConfigureManager.class) != null) {
+            InstanceManager.getDefault(ConfigureManager.class).deregister(this);
         }
         _tecos.clear();
+        tc.removeEcosListener(this); // disconnect from tc
+        super.dispose(); // remove SensorManager and SystemConnectionMemo change listeners
     }
 
     public List<String> getEcosObjectList() {

--- a/java/src/jmri/jmrix/ecos/EcosTurnoutManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosTurnoutManager.java
@@ -36,10 +36,10 @@ public class EcosTurnoutManager extends jmri.managers.AbstractTurnoutManager
 
     public EcosTurnoutManager(EcosSystemConnectionMemo memo) {
         super(memo);
-        init();
+        initEtm();
     }
     
-    private void init() {
+    private void initEtm() {
         tc = getMemo().getTrafficController();
 
         // listen for turnout creation

--- a/java/test/jmri/jmrix/ecos/EcosLocoAddressManagerTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosLocoAddressManagerTest.java
@@ -1,12 +1,10 @@
 package jmri.jmrix.ecos;
 
-import java.awt.GraphicsEnvironment;
-
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  *
@@ -14,9 +12,9 @@ import org.junit.Assume;
  */
 public class EcosLocoAddressManagerTest {
 
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         EcosTrafficController tc = new EcosInterfaceScaffold();
         EcosSystemConnectionMemo memo = new EcosSystemConnectionMemo(tc){
            @Override
@@ -31,6 +29,9 @@ public class EcosLocoAddressManagerTest {
         };
         EcosLocoAddressManager t = new EcosLocoAddressManager(memo);
         Assert.assertNotNull("exists",t);
+
+        t.dispose();
+        tc.terminateThreads();
     }
 
     @Test

--- a/java/test/jmri/jmrix/ecos/EcosPowerManagerTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosPowerManagerTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.ecos;
 
+import jmri.jmrix.AbstractPowerManagerTestBase;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -12,10 +13,13 @@ import org.junit.jupiter.api.*;
 public class EcosPowerManagerTest {
 
     @Test
-    public void testCTor() {
+    public void testCTor() throws Exception {
         EcosTrafficController tc = new EcosInterfaceScaffold();
         EcosPowerManager t = new EcosPowerManager(tc);
         Assert.assertNotNull("exists",t);
+
+        t.dispose();
+        tc.terminateThreads();
     }
 
     @BeforeEach
@@ -25,7 +29,6 @@ public class EcosPowerManagerTest {
 
     @AfterEach
     public void tearDown() {
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/ecos/EcosSensorManagerTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosSensorManagerTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.ecos;
 
+import jmri.InstanceManager;
+import jmri.ShutDownManager;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -18,7 +20,7 @@ public class EcosSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         return "US" + i;
     }
 
-    EcosTrafficController tc = null;
+    private EcosTrafficController tc;
 
     @BeforeEach
     @Override
@@ -30,14 +32,16 @@ public class EcosSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         tc = new EcosInterfaceScaffold();
         EcosSystemConnectionMemo memo = new EcosSystemConnectionMemo(tc);
         l = new EcosSensorManager(memo);
+        InstanceManager.getDefault(ShutDownManager.class).deregister(memo.getPreferenceManager().ecosPreferencesShutDownTask);
     }
 
     @AfterEach
     public void tearDown() {
+        l.dispose();
+        tc.terminateThreads();
+        l = null;
         tc = null;
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
     }
-
 
 }


### PR DESCRIPTION
Improved constructors
Adds method boolean EcosLocoAddressManager.threadsRunning()
Removes various tc listeners on dispose
EcosTurnoutManager calls super on dispose
EcosSystemConnectionMemo sets SensorManager as 1st InstanceManager manager
Resolves a few remnant threads in tests