### PR TITLE
WIP Improve the support for tables in LogixNG

### DIFF
--- a/java/src/jmri/jmrit/logixng/LogixNGBundle.properties
+++ b/java/src/jmri/jmrit/logixng/LogixNGBundle.properties
@@ -75,6 +75,7 @@ NamedBeanAddressing_Direct          = Direct
 NamedBeanAddressing_Reference       = Reference
 NamedBeanAddressing_LocalVariable   = Local variable
 NamedBeanAddressing_Formula         = Formula
+NamedBeanAddressing_Table           = Table
 
 ErrorHandling_Default               = Use default
 ErrorHandling_ShowDialogBox         = Show dialog box
@@ -94,3 +95,4 @@ AddressByDirect                 = {0}
 AddressByReference              = by reference "{0}"
 AddressByLocalVariable          = by local variable "{0}"
 AddressByFormula                = by formula "{0}"
+AddressByTable                  = by table {0}, row {1}, column {2}

--- a/java/src/jmri/jmrit/logixng/NamedBeanAddressing.java
+++ b/java/src/jmri/jmrit/logixng/NamedBeanAddressing.java
@@ -2,31 +2,36 @@ package jmri.jmrit.logixng;
 
 /**
  * How should a named bean be addressed by an action or expression?
- * 
+ *
  * @author Daniel Bergqvist Copyright 2020
  */
 public enum NamedBeanAddressing {
-    
+
     /**
      * Direct addressing, by entering the name of the named bean
      */
     Direct(Bundle.getMessage("NamedBeanAddressing_Direct")),
-    
+
     /**
      * Addresssing by reference, by entering a reference that points to the named bean.
      */
     Reference(Bundle.getMessage("NamedBeanAddressing_Reference")),
-    
+
     /**
      * Addresssing by local variable, by entering a local variable that points to the named bean.
      */
     LocalVariable(Bundle.getMessage("NamedBeanAddressing_LocalVariable")),
-    
+
     /**
      * Addresssing by formula, by entering a formula that points to the named bean.
      */
-    Formula(Bundle.getMessage("NamedBeanAddressing_Formula"));
-    
+    Formula(Bundle.getMessage("NamedBeanAddressing_Formula")),
+
+    /**
+     * Addresssing by formula, by entering a formula that points to the named bean.
+     */
+    Table(Bundle.getMessage("NamedBeanAddressing_Table"));
+
     private final String _text;
 
     private NamedBeanAddressing(String text) {
@@ -37,5 +42,5 @@ public enum NamedBeanAddressing {
     public String toString() {
         return _text;
     }
-    
+
 }

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionTurnoutSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionTurnoutSwing.java
@@ -24,10 +24,11 @@ import jmri.jmrit.logixng.util.swing.LogixNG_SelectEnumSwing;
 public class ActionTurnoutSwing extends AbstractDigitalActionSwing {
 
     private final LogixNG_SelectNamedBeanSwing<Turnout> _selectNamedBeanSwing =
-            new LogixNG_SelectNamedBeanSwing<>(InstanceManager.getDefault(TurnoutManager.class));
+            new LogixNG_SelectNamedBeanSwing<>(
+                    InstanceManager.getDefault(TurnoutManager.class), getJDialog(), this);
 
     private final LogixNG_SelectEnumSwing<TurnoutState> _selectEnumSwing =
-            new LogixNG_SelectEnumSwing<>();
+            new LogixNG_SelectEnumSwing<>(getJDialog(), this);
 
 
     @Override
@@ -97,6 +98,7 @@ public class ActionTurnoutSwing extends AbstractDigitalActionSwing {
     @Override
     public void dispose() {
         _selectNamedBeanSwing.dispose();
+        _selectEnumSwing.dispose();
     }
 
 

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionTurnoutSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionTurnoutSwing.java
@@ -23,17 +23,25 @@ import jmri.jmrit.logixng.util.swing.LogixNG_SelectEnumSwing;
  */
 public class ActionTurnoutSwing extends AbstractDigitalActionSwing {
 
-    private final LogixNG_SelectNamedBeanSwing<Turnout> _selectNamedBeanSwing =
-            new LogixNG_SelectNamedBeanSwing<>(
-                    InstanceManager.getDefault(TurnoutManager.class), getJDialog(), this);
+    private LogixNG_SelectNamedBeanSwing<Turnout> _selectNamedBeanSwing;
+    private LogixNG_SelectEnumSwing<TurnoutState> _selectEnumSwing;
 
-    private final LogixNG_SelectEnumSwing<TurnoutState> _selectEnumSwing =
-            new LogixNG_SelectEnumSwing<>(getJDialog(), this);
 
+    public ActionTurnoutSwing() {
+    }
+
+    public ActionTurnoutSwing(JDialog dialog) {
+        super.setJDialog(dialog);
+    }
 
     @Override
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
         ActionTurnout action = (ActionTurnout)object;
+
+        _selectNamedBeanSwing = new LogixNG_SelectNamedBeanSwing<>(
+                InstanceManager.getDefault(TurnoutManager.class), getJDialog(), this);
+
+        _selectEnumSwing = new LogixNG_SelectEnumSwing<>(getJDialog(), this);
 
         panel = new JPanel();
 

--- a/java/src/jmri/jmrit/logixng/util/InUse.java
+++ b/java/src/jmri/jmrit/logixng/util/InUse.java
@@ -1,0 +1,11 @@
+package jmri.jmrit.logixng.util;
+
+/**
+ * Is this item in use?
+ * @author Daniel Bergqvist (C) 2022
+ */
+public interface InUse {
+
+    public boolean isInUse();
+
+}

--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectTable.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectTable.java
@@ -85,10 +85,12 @@ public class LogixNG_SelectTable implements VetoableChangeListener {
         }
     }
 
-    public synchronized void setTableNameAddressing(@Nonnull NamedBeanAddressing addressing) {
+    public void setTableNameAddressing(@Nonnull NamedBeanAddressing addressing) {
         this._tableNameAddressing = addressing;
-        if ((_tableNameAddressing == NamedBeanAddressing.Table) && (_tableNameSelectTable == null)) {
-            _tableNameSelectTable = new LogixNG_SelectTable(_base, _inUse);
+        synchronized(this) {
+            if ((_tableNameAddressing == NamedBeanAddressing.Table) && (_tableNameSelectTable == null)) {
+                _tableNameSelectTable = new LogixNG_SelectTable(_base, _inUse);
+            }
         }
     }
 
@@ -159,17 +161,21 @@ public class LogixNG_SelectTable implements VetoableChangeListener {
         }
     }
 
-    public synchronized LogixNG_SelectTable getSelectTableName() {
-        if (_tableNameSelectTable == null) {
-            _tableNameSelectTable = new LogixNG_SelectTable(_base, _inUse);
+    public LogixNG_SelectTable getSelectTableName() {
+        synchronized(this) {
+            if (_tableNameSelectTable == null) {
+                _tableNameSelectTable = new LogixNG_SelectTable(_base, _inUse);
+            }
         }
         return _tableNameSelectTable;
     }
 
-    public synchronized void setTableRowAddressing(@Nonnull NamedBeanAddressing addressing) {
+    public void setTableRowAddressing(@Nonnull NamedBeanAddressing addressing) {
         this._tableRowAddressing = addressing;
-        if ((_tableRowAddressing == NamedBeanAddressing.Table) && (_tableRowSelectTable == null)) {
-            _tableRowSelectTable = new LogixNG_SelectTable(_base, _inUse);
+        synchronized(this) {
+            if ((_tableRowAddressing == NamedBeanAddressing.Table) && (_tableRowSelectTable == null)) {
+                _tableRowSelectTable = new LogixNG_SelectTable(_base, _inUse);
+            }
         }
     }
 
@@ -232,17 +238,21 @@ public class LogixNG_SelectTable implements VetoableChangeListener {
         }
     }
 
-    public synchronized LogixNG_SelectTable getSelectTableRow() {
-        if (_tableRowSelectTable == null) {
-            _tableRowSelectTable = new LogixNG_SelectTable(_base, _inUse);
+    public LogixNG_SelectTable getSelectTableRow() {
+        synchronized(this) {
+            if (_tableRowSelectTable == null) {
+                _tableRowSelectTable = new LogixNG_SelectTable(_base, _inUse);
+            }
         }
         return _tableRowSelectTable;
     }
 
-    public synchronized void setTableColumnAddressing(@Nonnull NamedBeanAddressing addressing) {
+    public void setTableColumnAddressing(@Nonnull NamedBeanAddressing addressing) {
         this._tableColumnAddressing = addressing;
-        if ((_tableColumnAddressing == NamedBeanAddressing.Table) && (_tableColumnSelectTable == null)) {
-            _tableColumnSelectTable = new LogixNG_SelectTable(_base, _inUse);
+        synchronized(this) {
+            if ((_tableColumnAddressing == NamedBeanAddressing.Table) && (_tableColumnSelectTable == null)) {
+                _tableColumnSelectTable = new LogixNG_SelectTable(_base, _inUse);
+            }
         }
     }
 
@@ -305,9 +315,11 @@ public class LogixNG_SelectTable implements VetoableChangeListener {
         _tableColumnName = columnName;
     }
 
-    public synchronized LogixNG_SelectTable getSelectTableColumn() {
-        if (_tableColumnSelectTable == null) {
-            _tableColumnSelectTable = new LogixNG_SelectTable(_base, _inUse);
+    public LogixNG_SelectTable getSelectTableColumn() {
+        synchronized(this) {
+            if (_tableColumnSelectTable == null) {
+                _tableColumnSelectTable = new LogixNG_SelectTable(_base, _inUse);
+            }
         }
         return _tableColumnSelectTable;
     }

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectEnumXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectEnumXml.java
@@ -24,22 +24,29 @@ public class LogixNG_SelectEnumXml<E extends Enum<?>> {
      * @return Element containing the complete info
      */
     public Element store(LogixNG_SelectEnum<E> selectEnum, String tagName) {
-//        Element tableElement = new Element("enum");
-        Element tableElement = new Element(tagName);
 
-        tableElement.addContent(new Element("addressing").addContent(selectEnum.getAddressing().name()));
-        tableElement.addContent(new Element("enum").addContent(selectEnum.getEnum().name()));
-        tableElement.addContent(new Element("reference").addContent(selectEnum.getReference()));
-        tableElement.addContent(new Element("localVariable").addContent(selectEnum.getLocalVariable()));
-        tableElement.addContent(new Element("formula").addContent(selectEnum.getFormula()));
+        LogixNG_SelectTableXml selectTableXml = new LogixNG_SelectTableXml();
 
-        return tableElement;
+        Element enumElement = new Element(tagName);
+
+        enumElement.addContent(new Element("addressing").addContent(selectEnum.getAddressing().name()));
+        enumElement.addContent(new Element("enum").addContent(selectEnum.getEnum().name()));
+        enumElement.addContent(new Element("reference").addContent(selectEnum.getReference()));
+        enumElement.addContent(new Element("localVariable").addContent(selectEnum.getLocalVariable()));
+        enumElement.addContent(new Element("formula").addContent(selectEnum.getFormula()));
+
+        enumElement.addContent(selectTableXml.store(selectEnum.getSelectTable(), "table"));
+
+        return enumElement;
     }
 
     public void load(Element enumElement, LogixNG_SelectEnum<E> selectEnum)
             throws JmriConfigureXmlException {
 
         if (enumElement != null) {
+
+            LogixNG_SelectTableXml selectTableXml = new LogixNG_SelectTableXml();
+
             try {
                 Element elem = enumElement.getChild("addressing");
                 if (elem != null) {
@@ -59,6 +66,8 @@ public class LogixNG_SelectEnumXml<E extends Enum<?>> {
 
                 elem = enumElement.getChild("formula");
                 if (elem != null) selectEnum.setFormula(elem.getTextTrim());
+
+                selectTableXml.load(enumElement.getChild("table"), selectEnum.getSelectTable());
 
             } catch (ParserException e) {
                 throw new JmriConfigureXmlException(e);

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectEnumXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectEnumXml.java
@@ -35,7 +35,9 @@ public class LogixNG_SelectEnumXml<E extends Enum<?>> {
         enumElement.addContent(new Element("localVariable").addContent(selectEnum.getLocalVariable()));
         enumElement.addContent(new Element("formula").addContent(selectEnum.getFormula()));
 
-        enumElement.addContent(selectTableXml.store(selectEnum.getSelectTable(), "table"));
+        if (selectEnum.getAddressing() == NamedBeanAddressing.Table) {
+            enumElement.addContent(selectTableXml.store(selectEnum.getSelectTable(), "table"));
+        }
 
         return enumElement;
     }
@@ -67,7 +69,9 @@ public class LogixNG_SelectEnumXml<E extends Enum<?>> {
                 elem = enumElement.getChild("formula");
                 if (elem != null) selectEnum.setFormula(elem.getTextTrim());
 
-                selectTableXml.load(enumElement.getChild("table"), selectEnum.getSelectTable());
+                if (enumElement.getChild("table") != null) {
+                    selectTableXml.load(enumElement.getChild("table"), selectEnum.getSelectTable());
+                }
 
             } catch (ParserException e) {
                 throw new JmriConfigureXmlException(e);

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectNamedBeanXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectNamedBeanXml.java
@@ -38,7 +38,9 @@ public class LogixNG_SelectNamedBeanXml<E extends NamedBean> {
         namedBeanElement.addContent(new Element("localVariable").addContent(selectNamedBean.getLocalVariable()));
         namedBeanElement.addContent(new Element("formula").addContent(selectNamedBean.getFormula()));
 
-        namedBeanElement.addContent(selectTableXml.store(selectNamedBean.getSelectTable(), "table"));
+        if (selectNamedBean.getAddressing() == NamedBeanAddressing.Table) {
+            namedBeanElement.addContent(selectTableXml.store(selectNamedBean.getSelectTable(), "table"));
+        }
 
         return namedBeanElement;
     }
@@ -71,7 +73,9 @@ public class LogixNG_SelectNamedBeanXml<E extends NamedBean> {
                 elem = namedBeanElement.getChild("formula");
                 if (elem != null) selectNamedBean.setFormula(elem.getTextTrim());
 
-                selectTableXml.load(namedBeanElement.getChild("table"), selectNamedBean.getSelectTable());
+                if (namedBeanElement.getChild("table") != null) {
+                    selectTableXml.load(namedBeanElement.getChild("table"), selectNamedBean.getSelectTable());
+                }
 
             } catch (ParserException e) {
                 throw new JmriConfigureXmlException(e);

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectNamedBeanXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectNamedBeanXml.java
@@ -25,23 +25,30 @@ public class LogixNG_SelectNamedBeanXml<E extends NamedBean> {
      * @return Element containing the complete info
      */
     public Element store(LogixNG_SelectNamedBean<E> selectNamedBean, String tagName) {
-        Element tableElement = new Element(tagName);
+        Element namedBeanElement = new Element(tagName);
 
-        tableElement.addContent(new Element("addressing").addContent(selectNamedBean.getAddressing().name()));
+        LogixNG_SelectTableXml selectTableXml = new LogixNG_SelectTableXml();
+
+        namedBeanElement.addContent(new Element("addressing").addContent(selectNamedBean.getAddressing().name()));
         NamedBeanHandle<E> table = selectNamedBean.getNamedBean();
         if (table != null) {
-            tableElement.addContent(new Element("name").addContent(table.getName()));
+            namedBeanElement.addContent(new Element("name").addContent(table.getName()));
         }
-        tableElement.addContent(new Element("reference").addContent(selectNamedBean.getReference()));
-        tableElement.addContent(new Element("localVariable").addContent(selectNamedBean.getLocalVariable()));
-        tableElement.addContent(new Element("formula").addContent(selectNamedBean.getFormula()));
+        namedBeanElement.addContent(new Element("reference").addContent(selectNamedBean.getReference()));
+        namedBeanElement.addContent(new Element("localVariable").addContent(selectNamedBean.getLocalVariable()));
+        namedBeanElement.addContent(new Element("formula").addContent(selectNamedBean.getFormula()));
 
-        return tableElement;
+        namedBeanElement.addContent(selectTableXml.store(selectNamedBean.getSelectTable(), "table"));
+
+        return namedBeanElement;
     }
 
     public void load(Element namedBeanElement, LogixNG_SelectNamedBean<E> selectNamedBean) throws JmriConfigureXmlException {
 
         if (namedBeanElement != null) {
+
+            LogixNG_SelectTableXml selectTableXml = new LogixNG_SelectTableXml();
+
             try {
                 Element elem = namedBeanElement.getChild("addressing");
                 if (elem != null) {
@@ -63,6 +70,8 @@ public class LogixNG_SelectNamedBeanXml<E extends NamedBean> {
 
                 elem = namedBeanElement.getChild("formula");
                 if (elem != null) selectNamedBean.setFormula(elem.getTextTrim());
+
+                selectTableXml.load(namedBeanElement.getChild("table"), selectNamedBean.getSelectTable());
 
             } catch (ParserException e) {
                 throw new JmriConfigureXmlException(e);

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectTableXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectTableXml.java
@@ -26,6 +26,8 @@ public class LogixNG_SelectTableXml {
     public Element store(LogixNG_SelectTable selectTable, String tagName) {
         Element tableElement = new Element(tagName);
 
+        LogixNG_SelectTableXml selectTableXml = new LogixNG_SelectTableXml();
+
         Element tableNameElement = new Element("tableName");
         tableNameElement.addContent(new Element("addressing").addContent(selectTable.getTableNameAddressing().name()));
         NamedBeanHandle<NamedTable> table = selectTable.getTable();
@@ -35,6 +37,9 @@ public class LogixNG_SelectTableXml {
         tableNameElement.addContent(new Element("reference").addContent(selectTable.getTableNameReference()));
         tableNameElement.addContent(new Element("localVariable").addContent(selectTable.getTableNameLocalVariable()));
         tableNameElement.addContent(new Element("formula").addContent(selectTable.getTableNameFormula()));
+        if (selectTable.getTableNameAddressing() == NamedBeanAddressing.Table) {
+            tableNameElement.addContent(selectTableXml.store(selectTable.getSelectTableName(), "table"));
+        }
         tableElement.addContent(tableNameElement);
 
         Element tableRowElement = new Element("row");
@@ -43,6 +48,9 @@ public class LogixNG_SelectTableXml {
         tableRowElement.addContent(new Element("reference").addContent(selectTable.getTableRowReference()));
         tableRowElement.addContent(new Element("localVariable").addContent(selectTable.getTableRowLocalVariable()));
         tableRowElement.addContent(new Element("formula").addContent(selectTable.getTableRowFormula()));
+        if (selectTable.getTableRowAddressing() == NamedBeanAddressing.Table) {
+            tableRowElement.addContent(selectTableXml.store(selectTable.getSelectTableRow(), "table"));
+        }
         tableElement.addContent(tableRowElement);
 
         Element tableColumnElement = new Element("column");
@@ -51,6 +59,9 @@ public class LogixNG_SelectTableXml {
         tableColumnElement.addContent(new Element("reference").addContent(selectTable.getTableColumnReference()));
         tableColumnElement.addContent(new Element("localVariable").addContent(selectTable.getTableColumnLocalVariable()));
         tableColumnElement.addContent(new Element("formula").addContent(selectTable.getTableColumnFormula()));
+        if (selectTable.getTableColumnAddressing() == NamedBeanAddressing.Table) {
+            tableColumnElement.addContent(selectTableXml.store(selectTable.getSelectTableColumn(), "table"));
+        }
         tableElement.addContent(tableColumnElement);
 
         return tableElement;
@@ -59,6 +70,9 @@ public class LogixNG_SelectTableXml {
     public void load(Element tableElement, LogixNG_SelectTable selectTable) throws JmriConfigureXmlException {
 
         if (tableElement != null) {
+
+            LogixNG_SelectTableXml selectTableXml = new LogixNG_SelectTableXml();
+
             try {
                 Element tableName = tableElement.getChild("tableName");
 
@@ -85,6 +99,11 @@ public class LogixNG_SelectTableXml {
                 elem = tableName.getChild("formula");
                 if (elem != null) selectTable.setTableNameFormula(elem.getTextTrim());
 
+                elem = tableName.getChild("table");
+                if (elem != null) {
+                    selectTableXml.load(elem, selectTable.getSelectTableName());
+                }
+
 
                 // Table row
 
@@ -108,6 +127,11 @@ public class LogixNG_SelectTableXml {
                 elem = tableRow.getChild("formula");
                 if (elem != null) selectTable.setTableRowFormula(elem.getTextTrim());
 
+                elem = tableRow.getChild("table");
+                if (elem != null) {
+                    selectTableXml.load(elem, selectTable.getSelectTableRow());
+                }
+
 
                 // Table column
 
@@ -130,6 +154,11 @@ public class LogixNG_SelectTableXml {
 
                 elem = tableColumn.getChild("formula");
                 if (elem != null) selectTable.setTableColumnFormula(elem.getTextTrim());
+
+                elem = tableColumn.getChild("table");
+                if (elem != null) {
+                    selectTableXml.load(elem, selectTable.getSelectTableColumn());
+                }
 
             } catch (ParserException e) {
                 throw new JmriConfigureXmlException(e);

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectEnumSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectEnumSwing.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import javax.swing.*;
 
 import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
 import jmri.jmrit.logixng.util.LogixNG_SelectEnum;
 import jmri.jmrit.logixng.util.parser.ParserException;
 import jmri.util.swing.JComboBoxUtil;
@@ -20,16 +21,27 @@ import jmri.util.swing.JComboBoxUtil;
  */
 public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
 
+    private final JDialog _dialog;
+    private final LogixNG_SelectTableSwing _selectTableSwing;
+
     private JTabbedPane _tabbedPane;
     private JComboBox<E> _enumComboBox;
     private JPanel _panelDirect;
     private JPanel _panelReference;
     private JPanel _panelLocalVariable;
     private JPanel _panelFormula;
+    private JPanel _panelTable;
     private JTextField _referenceTextField;
     private JTextField _localVariableTextField;
     private JTextField _formulaTextField;
 
+
+    public LogixNG_SelectEnumSwing(
+            @Nonnull JDialog dialog,
+            @Nonnull SwingConfiguratorInterface swi) {
+        _dialog = dialog;
+        _selectTableSwing = new LogixNG_SelectTableSwing(_dialog, swi);
+    }
 
     public JPanel createPanel(
             @CheckForNull LogixNG_SelectEnum<E> selectEnum, E[] enumArray) {
@@ -41,11 +53,13 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
         _panelReference = new javax.swing.JPanel();
         _panelLocalVariable = new javax.swing.JPanel();
         _panelFormula = new javax.swing.JPanel();
+        _panelTable = new javax.swing.JPanel();
 
         _tabbedPane.addTab(NamedBeanAddressing.Direct.toString(), _panelDirect);
         _tabbedPane.addTab(NamedBeanAddressing.Reference.toString(), _panelReference);
         _tabbedPane.addTab(NamedBeanAddressing.LocalVariable.toString(), _panelLocalVariable);
         _tabbedPane.addTab(NamedBeanAddressing.Formula.toString(), _panelFormula);
+        _tabbedPane.addTab(NamedBeanAddressing.Table.toString(), _panelTable);
 
         _enumComboBox = new JComboBox<>();
         for (E e : enumArray) {
@@ -66,6 +80,12 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
         _formulaTextField.setColumns(30);
         _panelFormula.add(_formulaTextField);
 
+        if (selectEnum != null) {
+            _panelTable = _selectTableSwing.createPanel(selectEnum.getSelectTable());
+        } else {
+            _panelTable = _selectTableSwing.createPanel(null);
+        }
+
 
         if (selectEnum != null) {
             switch (selectEnum.getAddressing()) {
@@ -73,6 +93,7 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
                 case Reference: _tabbedPane.setSelectedComponent(_panelReference); break;
                 case LocalVariable: _tabbedPane.setSelectedComponent(_panelLocalVariable); break;
                 case Formula: _tabbedPane.setSelectedComponent(_panelFormula); break;
+                case Table: _tabbedPane.setSelectedComponent(_panelTable); break;
                 default: throw new IllegalArgumentException("invalid _addressing state: " + selectEnum.getAddressing().name());
             }
             if (selectEnum.getEnum() != null) {
@@ -117,7 +138,9 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
             return false;
         }
 
-        return true;
+        _selectTableSwing.validate(selectEnum.getSelectTable(), errorMessages);
+
+        return errorMessages.isEmpty();
     }
 
     public void updateObject(@Nonnull LogixNG_SelectEnum<E> selectEnum) {
@@ -144,6 +167,12 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
         } catch (ParserException e) {
             throw new RuntimeException("ParserException: "+e.getMessage(), e);
         }
+
+        _selectTableSwing.updateObject(selectEnum.getSelectTable());
+    }
+
+    public void dispose() {
+        _selectTableSwing.dispose();
     }
 
 }

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectNamedBeanSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectNamedBeanSwing.java
@@ -8,6 +8,7 @@ import javax.swing.*;
 
 import jmri.*;
 import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
 import jmri.jmrit.logixng.util.LogixNG_SelectNamedBean;
 import jmri.jmrit.logixng.util.parser.ParserException;
 import jmri.util.swing.BeanSelectPanel;
@@ -22,6 +23,8 @@ import jmri.util.swing.BeanSelectPanel;
 public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
 
     private final @Nonnull Manager<E> _manager;
+    private final JDialog _dialog;
+    private final LogixNG_SelectTableSwing _selectTableSwing;
 
     private JTabbedPane _tabbedPane;
     private BeanSelectPanel<E> _namedBeanPanel;
@@ -29,13 +32,19 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
     private JPanel _panelReference;
     private JPanel _panelLocalVariable;
     private JPanel _panelFormula;
+    private JPanel _panelTable;
     private JTextField _referenceTextField;
     private JTextField _localVariableTextField;
     private JTextField _formulaTextField;
 
 
-    public LogixNG_SelectNamedBeanSwing(@Nonnull Manager<E> manager) {
+    public LogixNG_SelectNamedBeanSwing(
+            @Nonnull Manager<E> manager,
+            @Nonnull JDialog dialog,
+            @Nonnull SwingConfiguratorInterface swi) {
         _manager = manager;
+        _dialog = dialog;
+        _selectTableSwing = new LogixNG_SelectTableSwing(_dialog, swi);
     }
 
     public JPanel createPanel(
@@ -48,11 +57,13 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
         _panelReference = new javax.swing.JPanel();
         _panelLocalVariable = new javax.swing.JPanel();
         _panelFormula = new javax.swing.JPanel();
+        _panelTable = new javax.swing.JPanel();
 
         _tabbedPane.addTab(NamedBeanAddressing.Direct.toString(), _panelDirect);
         _tabbedPane.addTab(NamedBeanAddressing.Reference.toString(), _panelReference);
         _tabbedPane.addTab(NamedBeanAddressing.LocalVariable.toString(), _panelLocalVariable);
         _tabbedPane.addTab(NamedBeanAddressing.Formula.toString(), _panelFormula);
+        _tabbedPane.addTab(NamedBeanAddressing.Table.toString(), _panelTable);
 
         _namedBeanPanel = new BeanSelectPanel<>(_manager, null);
         _panelDirect.add(_namedBeanPanel);
@@ -69,6 +80,12 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
         _formulaTextField.setColumns(30);
         _panelFormula.add(_formulaTextField);
 
+        if (selectNamedBean != null) {
+            _panelTable = _selectTableSwing.createPanel(selectNamedBean.getSelectTable());
+        } else {
+            _panelTable = _selectTableSwing.createPanel(null);
+        }
+
 
         if (selectNamedBean != null) {
             switch (selectNamedBean.getAddressing()) {
@@ -76,6 +93,7 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
                 case Reference: _tabbedPane.setSelectedComponent(_panelReference); break;
                 case LocalVariable: _tabbedPane.setSelectedComponent(_panelLocalVariable); break;
                 case Formula: _tabbedPane.setSelectedComponent(_panelFormula); break;
+                case Table: _tabbedPane.setSelectedComponent(_panelTable); break;
                 default: throw new IllegalArgumentException("invalid _addressing state: " + selectNamedBean.getAddressing().name());
             }
             if (selectNamedBean.getNamedBean() != null) {
@@ -120,7 +138,9 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
             return false;
         }
 
-        return true;
+        _selectTableSwing.validate(selectNamedBean.getSelectTable(), errorMessages);
+
+        return errorMessages.isEmpty();
     }
 
     public void updateObject(@Nonnull LogixNG_SelectNamedBean<E> selectNamedBean) {
@@ -157,12 +177,15 @@ public class LogixNG_SelectNamedBeanSwing<E extends NamedBean> {
         } catch (ParserException e) {
             throw new RuntimeException("ParserException: "+e.getMessage(), e);
         }
+
+        _selectTableSwing.updateObject(selectNamedBean.getSelectTable());
     }
 
     public void dispose() {
         if (_namedBeanPanel != null) {
             _namedBeanPanel.dispose();
         }
+        _selectTableSwing.dispose();
     }
 
 }

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectTableSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectTableSwing.java
@@ -151,11 +151,6 @@ public class LogixNG_SelectTableSwing {
     }
 
     private void selectTableNameFinished() {
-        boolean enable =
-                (_tableNameAddressing != NamedBeanAddressing.Direct)
-                || (_compareToTableBeanPanel.getNamedBean() != null);
-        _selectRowNameButton.setEnabled(enable);
-        _selectColumnNameButton.setEnabled(enable);
         _tableNameAddressing = _logixNG_DataDialog.getAddressing();
         _tableNameLabel.setText(getTableNameDescription());
     }
@@ -426,7 +421,7 @@ public class LogixNG_SelectTableSwing {
             String columnName =
                     _tableNameAddressing == NamedBeanAddressing.Direct
                     ? _tableColumnNameComboBox.getItemAt(_tableColumnNameComboBox.getSelectedIndex())
-                    : _tableRowNameTextField.getText();
+                    : _tableColumnNameTextField.getText();
             switch (_tableColumnAddressing) {
                 case Direct: selectTable.setTableColumnName(columnName); break;
                 case Reference: selectTable.setTableColumnReference(_tableColumnReferenceTextField.getText()); break;
@@ -477,7 +472,7 @@ public class LogixNG_SelectTableSwing {
             String columnName =
                     _tableNameAddressing == NamedBeanAddressing.Direct
                     ? _tableColumnNameComboBox.getItemAt(_tableColumnNameComboBox.getSelectedIndex())
-                    : _tableRowNameTextField.getText();
+                    : _tableColumnNameTextField.getText();
             switch (_tableColumnAddressing) {
                 case Direct: selectTable.setTableColumnName(columnName); break;
                 case Reference: selectTable.setTableColumnReference(_tableColumnReferenceTextField.getText()); break;

--- a/java/test/jmri/jmrit/logixng/ActionsAndExpressionsTest.java
+++ b/java/test/jmri/jmrit/logixng/ActionsAndExpressionsTest.java
@@ -66,7 +66,8 @@ public class ActionsAndExpressionsTest {
 
     }
 
-    private void checkFolder(Path path, String packageName, Map<Category, List<Class<? extends Base>>> registeredClasses, String[] classesToIgnore) {
+    private void checkFolder(Path path, String packageName, Map<Category, List<Class<? extends Base>>> registeredClasses, String[] classesToIgnore)
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException, NoSuchMethodException, java.lang.reflect.InvocationTargetException {
 
         JDialog dialog = new JDialog();
 
@@ -136,38 +137,37 @@ public class ActionsAndExpressionsTest {
             SwingConfiguratorInterface configureSwing = null;
             fullConfigName = packageName + ".swing." + file + "Swing";
             log.debug("getAdapter looks for {}", fullConfigName);
-            try {
-                Class<?> configClass = Class.forName(fullConfigName);
-                configureSwing = (SwingConfiguratorInterface)configClass.getDeclaredConstructor().newInstance();
-                configureSwing.setJDialog(dialog);
-                configureSwing.getConfigPanel(new JPanel());
 
-                MaleSocket socket = configureSwing.createNewObject(configureSwing.getAutoSystemName(), null);
-                MaleSocket lastMaleSocket = socket;
-                Base base = socket;
-                while ((base != null) && (base instanceof MaleSocket)) {
-                    lastMaleSocket = (MaleSocket) base;
-                    base = ((MaleSocket)base).getObject();
-                }
-                Assert.assertNotNull(base);
-                Assert.assertEquals("SwingConfiguratorInterface creates an object of correct type", base.getClass().getName(), packageName+"."+file);
+            Class<?> configClass = Class.forName(fullConfigName);
+            configureSwing = (SwingConfiguratorInterface)configClass.getDeclaredConstructor().newInstance();
+            configureSwing.setJDialog(dialog);
+            configureSwing.getConfigPanel(new JPanel());
+
+            MaleSocket socket = configureSwing.createNewObject(configureSwing.getAutoSystemName(), null);
+            MaleSocket lastMaleSocket = socket;
+            Base base = socket;
+            while ((base != null) && (base instanceof MaleSocket)) {
+                lastMaleSocket = (MaleSocket) base;
+                base = ((MaleSocket)base).getObject();
+            }
+            Assert.assertNotNull(base);
+            Assert.assertEquals("SwingConfiguratorInterface creates an object of correct type", base.getClass().getName(), packageName+"."+file);
 //                System.out.format("Swing: %s, Class: %s, class: %s%n", configureSwing.toString(), socket.getShortDescription(), socket.getObject().getClass().getName());
-                Assert.assertEquals("Swing class has correct name", socket.getShortDescription(), configureSwing.toString());
+            Assert.assertEquals("Swing class has correct name", socket.getShortDescription(), configureSwing.toString());
 //                System.out.format("MaleSocket class: %s, socket class: %s%n",
 //                        configureSwing.getManager().getMaleSocketClass().getName(),
 //                        socket.getClass().getName());
-                Assert.assertTrue(configureSwing.getManager().getMaleSocketClass().isAssignableFrom(lastMaleSocket.getClass()));
+            Assert.assertTrue(configureSwing.getManager().getMaleSocketClass().isAssignableFrom(lastMaleSocket.getClass()));
 
-                // Test all locales. This mainly tests that the female socket
-                // names are valid for each locale, for example that the name
-                // doesn't contain any spaces.
-                for (Locale locale : locales) {
-                    Locale.setDefault(locale);
-                    configureSwing.createNewObject(configureSwing.getAutoSystemName(), null);
-                }
-                Locale.setDefault(DEFAULT_LOCALE);
-            } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException | java.lang.reflect.InvocationTargetException e) {
+            // Test all locales. This mainly tests that the female socket
+            // names are valid for each locale, for example that the name
+            // doesn't contain any spaces.
+            for (Locale locale : locales) {
+                Locale.setDefault(locale);
+                configureSwing.createNewObject(configureSwing.getAutoSystemName(), null);
             }
+            Locale.setDefault(DEFAULT_LOCALE);
+
 //            if (configureSwing == null) {
 //                System.out.format("Class %s.%s has no swing class%n", packageName, file);
 //                errorsFound = true;
@@ -248,7 +248,9 @@ public class ActionsAndExpressionsTest {
 
     @Test
     @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
-    public void testGetBeanType() {
+    public void testGetBeanType()
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException, NoSuchMethodException, java.lang.reflect.InvocationTargetException {
+
         Map<Category, List<Class<? extends Base>>> classes = new HashMap<>();
         for (Category category : Category.values()) {
             classes.put(category, new ArrayList<>());

--- a/java/test/jmri/jmrit/logixng/actions/swing/ActionTurnoutSwingTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/swing/ActionTurnoutSwingTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.logixng.actions.swing;
 
 import java.awt.GraphicsEnvironment;
 
+import javax.swing.JDialog;
 import javax.swing.JPanel;
 
 import jmri.InstanceManager;
@@ -31,7 +32,7 @@ public class ActionTurnoutSwingTest extends SwingConfiguratorInterfaceTestBase {
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
-        ActionTurnoutSwing t = new ActionTurnoutSwing();
+        ActionTurnoutSwing t = new ActionTurnoutSwing(new JDialog());
         Assert.assertNotNull("exists",t);
     }
 
@@ -39,10 +40,12 @@ public class ActionTurnoutSwingTest extends SwingConfiguratorInterfaceTestBase {
     public void testCreatePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
+        JDialog dialog = new JDialog();
+
         Assert.assertTrue("panel is not null",
-            null != new ActionTurnoutSwing().getConfigPanel(new JPanel()));
+            null != new ActionTurnoutSwing(dialog).getConfigPanel(new JPanel()));
         Assert.assertTrue("panel is not null",
-            null != new ActionTurnoutSwing().getConfigPanel(new ActionTurnout("IQDA1", null), new JPanel()));
+            null != new ActionTurnoutSwing(dialog).getConfigPanel(new ActionTurnout("IQDA1", null), new JPanel()));
     }
 
     @org.junit.Ignore("Fails in Java 11 testing")

--- a/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
@@ -1512,10 +1512,14 @@ public class StoreAndLoadTest {
         actionTurnout.getSelectNamedBean().setFormula("\"IT\"+index");
         actionTurnout.getSelectNamedBean().setLocalVariable("index");
         actionTurnout.getSelectNamedBean().setReference("{IM1}");
+        set_LogixNG_SelectTable_Data(csvTable, actionTurnout.getSelectNamedBean().getSelectTable(),
+                NamedBeanAddressing.Direct);
         actionTurnout.getSelectEnum().setAddressing(NamedBeanAddressing.LocalVariable);
         actionTurnout.getSelectEnum().setFormula("\"IT\"+index2");
         actionTurnout.getSelectEnum().setLocalVariable("index2");
         actionTurnout.getSelectEnum().setReference("{IM2}");
+        set_LogixNG_SelectTable_Data(csvTable, actionTurnout.getSelectEnum().getSelectTable(),
+                NamedBeanAddressing.Formula);
         maleSocket = digitalActionManager.registerAction(actionTurnout);
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
@@ -1527,10 +1531,14 @@ public class StoreAndLoadTest {
         actionTurnout.getSelectNamedBean().setFormula("\"IT\"+index");
         actionTurnout.getSelectNamedBean().setLocalVariable("index");
         actionTurnout.getSelectNamedBean().setReference("{IM1}");
+        set_LogixNG_SelectTable_Data(csvTable, actionTurnout.getSelectNamedBean().getSelectTable(),
+                NamedBeanAddressing.Formula);
         actionTurnout.getSelectEnum().setAddressing(NamedBeanAddressing.Formula);
         actionTurnout.getSelectEnum().setFormula("\"IT\"+index2");
         actionTurnout.getSelectEnum().setLocalVariable("index2");
         actionTurnout.getSelectEnum().setReference("{IM2}");
+        set_LogixNG_SelectTable_Data(csvTable, actionTurnout.getSelectEnum().getSelectTable(),
+                NamedBeanAddressing.LocalVariable);
         maleSocket = digitalActionManager.registerAction(actionTurnout);
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
@@ -1542,10 +1550,14 @@ public class StoreAndLoadTest {
         actionTurnout.getSelectNamedBean().setFormula("\"IT\"+index");
         actionTurnout.getSelectNamedBean().setLocalVariable("index");
         actionTurnout.getSelectNamedBean().setReference("{IM1}");
+        set_LogixNG_SelectTable_Data(csvTable, actionTurnout.getSelectNamedBean().getSelectTable(),
+                NamedBeanAddressing.LocalVariable);
         actionTurnout.getSelectEnum().setAddressing(NamedBeanAddressing.Reference);
         actionTurnout.getSelectEnum().setFormula("\"IT\"+index2");
         actionTurnout.getSelectEnum().setLocalVariable("index2");
         actionTurnout.getSelectEnum().setReference("{IM2}");
+        set_LogixNG_SelectTable_Data(csvTable, actionTurnout.getSelectEnum().getSelectTable(),
+                NamedBeanAddressing.Reference);
         maleSocket = digitalActionManager.registerAction(actionTurnout);
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
@@ -1557,16 +1569,24 @@ public class StoreAndLoadTest {
         actionTurnout.getSelectNamedBean().setFormula("\"IT\"+index");
         actionTurnout.getSelectNamedBean().setLocalVariable("index");
         actionTurnout.getSelectNamedBean().setReference("{IM1}");
+        set_LogixNG_SelectTable_Data(csvTable, actionTurnout.getSelectNamedBean().getSelectTable(),
+                NamedBeanAddressing.Reference);
         actionTurnout.getSelectEnum().setAddressing(NamedBeanAddressing.Direct);
         actionTurnout.getSelectEnum().setFormula("\"IT\"+index2");
         actionTurnout.getSelectEnum().setLocalVariable("index2");
         actionTurnout.getSelectEnum().setReference("{IM2}");
+        set_LogixNG_SelectTable_Data(csvTable, actionTurnout.getSelectEnum().getSelectTable(),
+                NamedBeanAddressing.Table);
         maleSocket = digitalActionManager.registerAction(actionTurnout);
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
         actionTurnout = new ActionTurnout(digitalActionManager.getAutoSystemName(), null);
         actionTurnout.getSelectNamedBean().setNamedBean(turnout1);
+        set_LogixNG_SelectTable_Data(csvTable, actionTurnout.getSelectNamedBean().getSelectTable(),
+                NamedBeanAddressing.Table);
         actionTurnout.getSelectEnum().setEnum(ActionTurnout.TurnoutState.Inconsistent);
+        set_LogixNG_SelectTable_Data(csvTable, actionTurnout.getSelectEnum().getSelectTable(),
+                NamedBeanAddressing.Direct);
         maleSocket = digitalActionManager.registerAction(actionTurnout);
         maleSocket.setEnabled(false);
         actionManySocket.getChild(indexAction++).connect(maleSocket);
@@ -4016,10 +4036,18 @@ public class StoreAndLoadTest {
             throws ParserException {
 
         int next1 = nameAddressing.ordinal() + 1;
+        if ((next1 < NamedBeanAddressing.values().length)
+                && (NamedBeanAddressing.values()[next1] == NamedBeanAddressing.Table)) {
+            next1++;
+        }
         if (next1 >= NamedBeanAddressing.values().length) next1 = 0;
         NamedBeanAddressing rowAddressing = NamedBeanAddressing.values()[next1];
 
         int next2 = next1 + 1;
+        if ((next2 < NamedBeanAddressing.values().length)
+                && (NamedBeanAddressing.values()[next2] == NamedBeanAddressing.Table)) {
+            next2++;
+        }
         if (next2 >= NamedBeanAddressing.values().length) next2 = 0;
         NamedBeanAddressing colAddressing = NamedBeanAddressing.values()[next2];
 

--- a/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
@@ -85,7 +85,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <memory>
       <systemName>IM3</systemName>
     </memory>
-    <memory value="1:28 AM">
+    <memory value="2:03 AM">
       <systemName>IMCURRENTTIME</systemName>
     </memory>
     <memory value="1.0">
@@ -155,7 +155,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <userName>First conditional</userName>
     </conditional>
   </conditionals>
-  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Wed Feb 23 01:28:32 CET 2022" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Thu Feb 24 02:03:54 CET 2022" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <LogixNGs class="jmri.jmrit.logixng.implementation.configurexml.DefaultLogixNGManagerXml">
     <Thread>
       <id>0</id>
@@ -18188,6 +18188,28 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference />
         <localVariable />
         <formula />
+        <table>
+          <tableName>
+            <addressing>Direct</addressing>
+            <reference />
+            <localVariable />
+            <formula />
+          </tableName>
+          <row>
+            <addressing>Direct</addressing>
+            <name />
+            <reference />
+            <localVariable />
+            <formula />
+          </row>
+          <column>
+            <addressing>Direct</addressing>
+            <name />
+            <reference />
+            <localVariable />
+            <formula />
+          </column>
+        </table>
       </namedBean>
       <state>
         <addressing>Direct</addressing>
@@ -18195,6 +18217,28 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference />
         <localVariable />
         <formula />
+        <table>
+          <tableName>
+            <addressing>Direct</addressing>
+            <reference />
+            <localVariable />
+            <formula />
+          </tableName>
+          <row>
+            <addressing>Direct</addressing>
+            <name />
+            <reference />
+            <localVariable />
+            <formula />
+          </row>
+          <column>
+            <addressing>Direct</addressing>
+            <name />
+            <reference />
+            <localVariable />
+            <formula />
+          </column>
+        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -18262,6 +18306,29 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM1}</reference>
         <localVariable>index</localVariable>
         <formula>"IT"+index</formula>
+        <table>
+          <tableName>
+            <addressing>Direct</addressing>
+            <name>IQT1</name>
+            <reference>{tableRef}</reference>
+            <localVariable>tableVariable</localVariable>
+            <formula>"IT"+str(index)</formula>
+          </tableName>
+          <row>
+            <addressing>Reference</addressing>
+            <name>The row</name>
+            <reference>{rowRef}</reference>
+            <localVariable>rowVariable</localVariable>
+            <formula>"Row "+str(index)</formula>
+          </row>
+          <column>
+            <addressing>LocalVariable</addressing>
+            <name>The column</name>
+            <reference>{columnRef}</reference>
+            <localVariable>columnVariable</localVariable>
+            <formula>"Column "+str(index)</formula>
+          </column>
+        </table>
       </namedBean>
       <state>
         <addressing>LocalVariable</addressing>
@@ -18269,6 +18336,29 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM2}</reference>
         <localVariable>index2</localVariable>
         <formula>"IT"+index2</formula>
+        <table>
+          <tableName>
+            <addressing>Formula</addressing>
+            <name>IQT1</name>
+            <reference>{tableRef}</reference>
+            <localVariable>tableVariable</localVariable>
+            <formula>"IT"+str(index)</formula>
+          </tableName>
+          <row>
+            <addressing>Direct</addressing>
+            <name>The row</name>
+            <reference>{rowRef}</reference>
+            <localVariable>rowVariable</localVariable>
+            <formula>"Row "+str(index)</formula>
+          </row>
+          <column>
+            <addressing>Reference</addressing>
+            <name>The column</name>
+            <reference>{columnRef}</reference>
+            <localVariable>columnVariable</localVariable>
+            <formula>"Column "+str(index)</formula>
+          </column>
+        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -18336,6 +18426,29 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM1}</reference>
         <localVariable>index</localVariable>
         <formula>"IT"+index</formula>
+        <table>
+          <tableName>
+            <addressing>Formula</addressing>
+            <name>IQT1</name>
+            <reference>{tableRef}</reference>
+            <localVariable>tableVariable</localVariable>
+            <formula>"IT"+str(index)</formula>
+          </tableName>
+          <row>
+            <addressing>Direct</addressing>
+            <name>The row</name>
+            <reference>{rowRef}</reference>
+            <localVariable>rowVariable</localVariable>
+            <formula>"Row "+str(index)</formula>
+          </row>
+          <column>
+            <addressing>Reference</addressing>
+            <name>The column</name>
+            <reference>{columnRef}</reference>
+            <localVariable>columnVariable</localVariable>
+            <formula>"Column "+str(index)</formula>
+          </column>
+        </table>
       </namedBean>
       <state>
         <addressing>Formula</addressing>
@@ -18343,6 +18456,29 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM2}</reference>
         <localVariable>index2</localVariable>
         <formula>"IT"+index2</formula>
+        <table>
+          <tableName>
+            <addressing>LocalVariable</addressing>
+            <name>IQT1</name>
+            <reference>{tableRef}</reference>
+            <localVariable>tableVariable</localVariable>
+            <formula>"IT"+str(index)</formula>
+          </tableName>
+          <row>
+            <addressing>Formula</addressing>
+            <name>The row</name>
+            <reference>{rowRef}</reference>
+            <localVariable>rowVariable</localVariable>
+            <formula>"Row "+str(index)</formula>
+          </row>
+          <column>
+            <addressing>Direct</addressing>
+            <name>The column</name>
+            <reference>{columnRef}</reference>
+            <localVariable>columnVariable</localVariable>
+            <formula>"Column "+str(index)</formula>
+          </column>
+        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -18410,6 +18546,29 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM1}</reference>
         <localVariable>index</localVariable>
         <formula>"IT"+index</formula>
+        <table>
+          <tableName>
+            <addressing>LocalVariable</addressing>
+            <name>IQT1</name>
+            <reference>{tableRef}</reference>
+            <localVariable>tableVariable</localVariable>
+            <formula>"IT"+str(index)</formula>
+          </tableName>
+          <row>
+            <addressing>Formula</addressing>
+            <name>The row</name>
+            <reference>{rowRef}</reference>
+            <localVariable>rowVariable</localVariable>
+            <formula>"Row "+str(index)</formula>
+          </row>
+          <column>
+            <addressing>Direct</addressing>
+            <name>The column</name>
+            <reference>{columnRef}</reference>
+            <localVariable>columnVariable</localVariable>
+            <formula>"Column "+str(index)</formula>
+          </column>
+        </table>
       </namedBean>
       <state>
         <addressing>Reference</addressing>
@@ -18417,6 +18576,29 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM2}</reference>
         <localVariable>index2</localVariable>
         <formula>"IT"+index2</formula>
+        <table>
+          <tableName>
+            <addressing>Reference</addressing>
+            <name>IQT1</name>
+            <reference>{tableRef}</reference>
+            <localVariable>tableVariable</localVariable>
+            <formula>"IT"+str(index)</formula>
+          </tableName>
+          <row>
+            <addressing>LocalVariable</addressing>
+            <name>The row</name>
+            <reference>{rowRef}</reference>
+            <localVariable>rowVariable</localVariable>
+            <formula>"Row "+str(index)</formula>
+          </row>
+          <column>
+            <addressing>Formula</addressing>
+            <name>The column</name>
+            <reference>{columnRef}</reference>
+            <localVariable>columnVariable</localVariable>
+            <formula>"Column "+str(index)</formula>
+          </column>
+        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -18484,6 +18666,29 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM1}</reference>
         <localVariable>index</localVariable>
         <formula>"IT"+index</formula>
+        <table>
+          <tableName>
+            <addressing>Reference</addressing>
+            <name>IQT1</name>
+            <reference>{tableRef}</reference>
+            <localVariable>tableVariable</localVariable>
+            <formula>"IT"+str(index)</formula>
+          </tableName>
+          <row>
+            <addressing>LocalVariable</addressing>
+            <name>The row</name>
+            <reference>{rowRef}</reference>
+            <localVariable>rowVariable</localVariable>
+            <formula>"Row "+str(index)</formula>
+          </row>
+          <column>
+            <addressing>Formula</addressing>
+            <name>The column</name>
+            <reference>{columnRef}</reference>
+            <localVariable>columnVariable</localVariable>
+            <formula>"Column "+str(index)</formula>
+          </column>
+        </table>
       </namedBean>
       <state>
         <addressing>Direct</addressing>
@@ -18491,6 +18696,29 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM2}</reference>
         <localVariable>index2</localVariable>
         <formula>"IT"+index2</formula>
+        <table>
+          <tableName>
+            <addressing>Table</addressing>
+            <name>IQT1</name>
+            <reference>{tableRef}</reference>
+            <localVariable>tableVariable</localVariable>
+            <formula>"IT"+str(index)</formula>
+          </tableName>
+          <row>
+            <addressing>Direct</addressing>
+            <name>The row</name>
+            <reference>{rowRef}</reference>
+            <localVariable>rowVariable</localVariable>
+            <formula>"Row "+str(index)</formula>
+          </row>
+          <column>
+            <addressing>Reference</addressing>
+            <name>The column</name>
+            <reference>{columnRef}</reference>
+            <localVariable>columnVariable</localVariable>
+            <formula>"Column "+str(index)</formula>
+          </column>
+        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -18557,6 +18785,29 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference />
         <localVariable />
         <formula />
+        <table>
+          <tableName>
+            <addressing>Table</addressing>
+            <name>IQT1</name>
+            <reference>{tableRef}</reference>
+            <localVariable>tableVariable</localVariable>
+            <formula>"IT"+str(index)</formula>
+          </tableName>
+          <row>
+            <addressing>Direct</addressing>
+            <name>The row</name>
+            <reference>{rowRef}</reference>
+            <localVariable>rowVariable</localVariable>
+            <formula>"Row "+str(index)</formula>
+          </row>
+          <column>
+            <addressing>Reference</addressing>
+            <name>The column</name>
+            <reference>{columnRef}</reference>
+            <localVariable>columnVariable</localVariable>
+            <formula>"Column "+str(index)</formula>
+          </column>
+        </table>
       </namedBean>
       <state>
         <addressing>Direct</addressing>
@@ -18564,6 +18815,29 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference />
         <localVariable />
         <formula />
+        <table>
+          <tableName>
+            <addressing>Direct</addressing>
+            <name>IQT1</name>
+            <reference>{tableRef}</reference>
+            <localVariable>tableVariable</localVariable>
+            <formula>"IT"+str(index)</formula>
+          </tableName>
+          <row>
+            <addressing>Reference</addressing>
+            <name>The row</name>
+            <reference>{rowRef}</reference>
+            <localVariable>rowVariable</localVariable>
+            <formula>"Row "+str(index)</formula>
+          </row>
+          <column>
+            <addressing>LocalVariable</addressing>
+            <name>The column</name>
+            <reference>{columnRef}</reference>
+            <localVariable>columnVariable</localVariable>
+            <formula>"Column "+str(index)</formula>
+          </column>
+        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -26905,9 +27179,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
   <filehistory>
     <operation>
       <type>Store</type>
-      <date>Wed Feb 23 01:28:36 CET 2022</date>
+      <date>Thu Feb 24 02:03:57 CET 2022</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.99.3plus+daniel+2022-02-23T00:28:14Z+R6639734 on Wed Feb 23 01:28:36 CET 2022-->
+  <!--Written by JMRI version 4.99.3plus+daniel+2022-02-24T01:03:36Z+Rc470b46 on Thu Feb 24 02:03:57 CET 2022-->
 </layout-config>

--- a/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
+++ b/java/test/jmri/jmrit/logixng/configurexml/load/LogixNG.xml
@@ -85,7 +85,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
     <memory>
       <systemName>IM3</systemName>
     </memory>
-    <memory value="2:03 AM">
+    <memory value="3:13 AM">
       <systemName>IMCURRENTTIME</systemName>
     </memory>
     <memory value="1.0">
@@ -155,7 +155,7 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
       <userName>First conditional</userName>
     </conditional>
   </conditionals>
-  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Thu Feb 24 02:03:54 CET 2022" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Thu Feb 24 03:13:31 CET 2022" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <LogixNGs class="jmri.jmrit.logixng.implementation.configurexml.DefaultLogixNGManagerXml">
     <Thread>
       <id>0</id>
@@ -18188,28 +18188,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference />
         <localVariable />
         <formula />
-        <table>
-          <tableName>
-            <addressing>Direct</addressing>
-            <reference />
-            <localVariable />
-            <formula />
-          </tableName>
-          <row>
-            <addressing>Direct</addressing>
-            <name />
-            <reference />
-            <localVariable />
-            <formula />
-          </row>
-          <column>
-            <addressing>Direct</addressing>
-            <name />
-            <reference />
-            <localVariable />
-            <formula />
-          </column>
-        </table>
       </namedBean>
       <state>
         <addressing>Direct</addressing>
@@ -18217,28 +18195,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference />
         <localVariable />
         <formula />
-        <table>
-          <tableName>
-            <addressing>Direct</addressing>
-            <reference />
-            <localVariable />
-            <formula />
-          </tableName>
-          <row>
-            <addressing>Direct</addressing>
-            <name />
-            <reference />
-            <localVariable />
-            <formula />
-          </row>
-          <column>
-            <addressing>Direct</addressing>
-            <name />
-            <reference />
-            <localVariable />
-            <formula />
-          </column>
-        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -18306,29 +18262,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM1}</reference>
         <localVariable>index</localVariable>
         <formula>"IT"+index</formula>
-        <table>
-          <tableName>
-            <addressing>Direct</addressing>
-            <name>IQT1</name>
-            <reference>{tableRef}</reference>
-            <localVariable>tableVariable</localVariable>
-            <formula>"IT"+str(index)</formula>
-          </tableName>
-          <row>
-            <addressing>Reference</addressing>
-            <name>The row</name>
-            <reference>{rowRef}</reference>
-            <localVariable>rowVariable</localVariable>
-            <formula>"Row "+str(index)</formula>
-          </row>
-          <column>
-            <addressing>LocalVariable</addressing>
-            <name>The column</name>
-            <reference>{columnRef}</reference>
-            <localVariable>columnVariable</localVariable>
-            <formula>"Column "+str(index)</formula>
-          </column>
-        </table>
       </namedBean>
       <state>
         <addressing>LocalVariable</addressing>
@@ -18336,29 +18269,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM2}</reference>
         <localVariable>index2</localVariable>
         <formula>"IT"+index2</formula>
-        <table>
-          <tableName>
-            <addressing>Formula</addressing>
-            <name>IQT1</name>
-            <reference>{tableRef}</reference>
-            <localVariable>tableVariable</localVariable>
-            <formula>"IT"+str(index)</formula>
-          </tableName>
-          <row>
-            <addressing>Direct</addressing>
-            <name>The row</name>
-            <reference>{rowRef}</reference>
-            <localVariable>rowVariable</localVariable>
-            <formula>"Row "+str(index)</formula>
-          </row>
-          <column>
-            <addressing>Reference</addressing>
-            <name>The column</name>
-            <reference>{columnRef}</reference>
-            <localVariable>columnVariable</localVariable>
-            <formula>"Column "+str(index)</formula>
-          </column>
-        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -18426,29 +18336,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM1}</reference>
         <localVariable>index</localVariable>
         <formula>"IT"+index</formula>
-        <table>
-          <tableName>
-            <addressing>Formula</addressing>
-            <name>IQT1</name>
-            <reference>{tableRef}</reference>
-            <localVariable>tableVariable</localVariable>
-            <formula>"IT"+str(index)</formula>
-          </tableName>
-          <row>
-            <addressing>Direct</addressing>
-            <name>The row</name>
-            <reference>{rowRef}</reference>
-            <localVariable>rowVariable</localVariable>
-            <formula>"Row "+str(index)</formula>
-          </row>
-          <column>
-            <addressing>Reference</addressing>
-            <name>The column</name>
-            <reference>{columnRef}</reference>
-            <localVariable>columnVariable</localVariable>
-            <formula>"Column "+str(index)</formula>
-          </column>
-        </table>
       </namedBean>
       <state>
         <addressing>Formula</addressing>
@@ -18456,29 +18343,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM2}</reference>
         <localVariable>index2</localVariable>
         <formula>"IT"+index2</formula>
-        <table>
-          <tableName>
-            <addressing>LocalVariable</addressing>
-            <name>IQT1</name>
-            <reference>{tableRef}</reference>
-            <localVariable>tableVariable</localVariable>
-            <formula>"IT"+str(index)</formula>
-          </tableName>
-          <row>
-            <addressing>Formula</addressing>
-            <name>The row</name>
-            <reference>{rowRef}</reference>
-            <localVariable>rowVariable</localVariable>
-            <formula>"Row "+str(index)</formula>
-          </row>
-          <column>
-            <addressing>Direct</addressing>
-            <name>The column</name>
-            <reference>{columnRef}</reference>
-            <localVariable>columnVariable</localVariable>
-            <formula>"Column "+str(index)</formula>
-          </column>
-        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -18546,29 +18410,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM1}</reference>
         <localVariable>index</localVariable>
         <formula>"IT"+index</formula>
-        <table>
-          <tableName>
-            <addressing>LocalVariable</addressing>
-            <name>IQT1</name>
-            <reference>{tableRef}</reference>
-            <localVariable>tableVariable</localVariable>
-            <formula>"IT"+str(index)</formula>
-          </tableName>
-          <row>
-            <addressing>Formula</addressing>
-            <name>The row</name>
-            <reference>{rowRef}</reference>
-            <localVariable>rowVariable</localVariable>
-            <formula>"Row "+str(index)</formula>
-          </row>
-          <column>
-            <addressing>Direct</addressing>
-            <name>The column</name>
-            <reference>{columnRef}</reference>
-            <localVariable>columnVariable</localVariable>
-            <formula>"Column "+str(index)</formula>
-          </column>
-        </table>
       </namedBean>
       <state>
         <addressing>Reference</addressing>
@@ -18576,29 +18417,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM2}</reference>
         <localVariable>index2</localVariable>
         <formula>"IT"+index2</formula>
-        <table>
-          <tableName>
-            <addressing>Reference</addressing>
-            <name>IQT1</name>
-            <reference>{tableRef}</reference>
-            <localVariable>tableVariable</localVariable>
-            <formula>"IT"+str(index)</formula>
-          </tableName>
-          <row>
-            <addressing>LocalVariable</addressing>
-            <name>The row</name>
-            <reference>{rowRef}</reference>
-            <localVariable>rowVariable</localVariable>
-            <formula>"Row "+str(index)</formula>
-          </row>
-          <column>
-            <addressing>Formula</addressing>
-            <name>The column</name>
-            <reference>{columnRef}</reference>
-            <localVariable>columnVariable</localVariable>
-            <formula>"Column "+str(index)</formula>
-          </column>
-        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -18666,29 +18484,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM1}</reference>
         <localVariable>index</localVariable>
         <formula>"IT"+index</formula>
-        <table>
-          <tableName>
-            <addressing>Reference</addressing>
-            <name>IQT1</name>
-            <reference>{tableRef}</reference>
-            <localVariable>tableVariable</localVariable>
-            <formula>"IT"+str(index)</formula>
-          </tableName>
-          <row>
-            <addressing>LocalVariable</addressing>
-            <name>The row</name>
-            <reference>{rowRef}</reference>
-            <localVariable>rowVariable</localVariable>
-            <formula>"Row "+str(index)</formula>
-          </row>
-          <column>
-            <addressing>Formula</addressing>
-            <name>The column</name>
-            <reference>{columnRef}</reference>
-            <localVariable>columnVariable</localVariable>
-            <formula>"Column "+str(index)</formula>
-          </column>
-        </table>
       </namedBean>
       <state>
         <addressing>Direct</addressing>
@@ -18696,29 +18491,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference>{IM2}</reference>
         <localVariable>index2</localVariable>
         <formula>"IT"+index2</formula>
-        <table>
-          <tableName>
-            <addressing>Table</addressing>
-            <name>IQT1</name>
-            <reference>{tableRef}</reference>
-            <localVariable>tableVariable</localVariable>
-            <formula>"IT"+str(index)</formula>
-          </tableName>
-          <row>
-            <addressing>Direct</addressing>
-            <name>The row</name>
-            <reference>{rowRef}</reference>
-            <localVariable>rowVariable</localVariable>
-            <formula>"Row "+str(index)</formula>
-          </row>
-          <column>
-            <addressing>Reference</addressing>
-            <name>The column</name>
-            <reference>{columnRef}</reference>
-            <localVariable>columnVariable</localVariable>
-            <formula>"Column "+str(index)</formula>
-          </column>
-        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -18785,29 +18557,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference />
         <localVariable />
         <formula />
-        <table>
-          <tableName>
-            <addressing>Table</addressing>
-            <name>IQT1</name>
-            <reference>{tableRef}</reference>
-            <localVariable>tableVariable</localVariable>
-            <formula>"IT"+str(index)</formula>
-          </tableName>
-          <row>
-            <addressing>Direct</addressing>
-            <name>The row</name>
-            <reference>{rowRef}</reference>
-            <localVariable>rowVariable</localVariable>
-            <formula>"Row "+str(index)</formula>
-          </row>
-          <column>
-            <addressing>Reference</addressing>
-            <name>The column</name>
-            <reference>{columnRef}</reference>
-            <localVariable>columnVariable</localVariable>
-            <formula>"Column "+str(index)</formula>
-          </column>
-        </table>
       </namedBean>
       <state>
         <addressing>Direct</addressing>
@@ -18815,29 +18564,6 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
         <reference />
         <localVariable />
         <formula />
-        <table>
-          <tableName>
-            <addressing>Direct</addressing>
-            <name>IQT1</name>
-            <reference>{tableRef}</reference>
-            <localVariable>tableVariable</localVariable>
-            <formula>"IT"+str(index)</formula>
-          </tableName>
-          <row>
-            <addressing>Reference</addressing>
-            <name>The row</name>
-            <reference>{rowRef}</reference>
-            <localVariable>rowVariable</localVariable>
-            <formula>"Row "+str(index)</formula>
-          </row>
-          <column>
-            <addressing>LocalVariable</addressing>
-            <name>The column</name>
-            <reference>{columnRef}</reference>
-            <localVariable>columnVariable</localVariable>
-            <formula>"Column "+str(index)</formula>
-          </column>
-        </table>
       </state>
       <MaleSocket>
         <AbstractDebuggerMaleSocket class="jmri.jmrit.logixng.tools.debugger.configurexml.DebuggerMaleDigitalActionSocketXml" />
@@ -27179,9 +26905,9 @@ to the folder java/test/jmri/jmrit/logixng/configurexml/load
   <filehistory>
     <operation>
       <type>Store</type>
-      <date>Thu Feb 24 02:03:57 CET 2022</date>
+      <date>Thu Feb 24 03:13:35 CET 2022</date>
       <filename />
     </operation>
   </filehistory>
-  <!--Written by JMRI version 4.99.3plus+daniel+2022-02-24T01:03:36Z+Rc470b46 on Thu Feb 24 02:03:57 CET 2022-->
+  <!--Written by JMRI version 4.99.3plus+daniel+2022-02-24T02:10:31Z+R33b35c2 on Thu Feb 24 03:13:35 CET 2022-->
 </layout-config>

--- a/xml/schema/logixng/common-types-4.23.1.xsd
+++ b/xml/schema/logixng/common-types-4.23.1.xsd
@@ -38,6 +38,7 @@
         <xs:enumeration value="Reference"/>
         <xs:enumeration value="LocalVariable"/>
         <xs:enumeration value="Formula"/>
+        <xs:enumeration value="Table"/>
       </xs:restriction>
     </xs:simpleType>
 
@@ -65,6 +66,7 @@
          <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="1" />
          <xs:element name="localVariable" type="xs:string" minOccurs="0" maxOccurs="1" />
          <xs:element name="formula" type="xs:string" minOccurs="0" maxOccurs="1" />
+         <xs:element name="table" type="LogixNG_SelectTableType" minOccurs="0" maxOccurs="1"/>
        </xs:sequence>
      </xs:complexType>
 
@@ -76,11 +78,9 @@
          <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="1" />
          <xs:element name="localVariable" type="xs:string" minOccurs="0" maxOccurs="1" />
          <xs:element name="formula" type="xs:string" minOccurs="0" maxOccurs="1" />
+         <xs:element name="table" type="LogixNG_SelectTableType" minOccurs="0" maxOccurs="1"/>
        </xs:sequence>
      </xs:complexType>
-
-
-
 
 
      <xs:complexType name="LogixNG_SelectTableType">
@@ -94,6 +94,7 @@
                <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="1" />
                <xs:element name="localVariable" type="xs:string" minOccurs="0" maxOccurs="1" />
                <xs:element name="formula" type="xs:string" minOccurs="0" maxOccurs="1" />
+               <xs:element name="table" type="LogixNG_SelectTableType" minOccurs="0" maxOccurs="1"/>
              </xs:sequence>
            </xs:complexType>
          </xs:element>
@@ -106,6 +107,7 @@
                <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="1" />
                <xs:element name="localVariable" type="xs:string" minOccurs="0" maxOccurs="1" />
                <xs:element name="formula" type="xs:string" minOccurs="0" maxOccurs="1" />
+               <xs:element name="table" type="LogixNG_SelectTableType" minOccurs="0" maxOccurs="1"/>
              </xs:sequence>
            </xs:complexType>
          </xs:element>
@@ -118,6 +120,7 @@
                <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="1" />
                <xs:element name="localVariable" type="xs:string" minOccurs="0" maxOccurs="1" />
                <xs:element name="formula" type="xs:string" minOccurs="0" maxOccurs="1" />
+               <xs:element name="table" type="LogixNG_SelectTableType" minOccurs="0" maxOccurs="1"/>
              </xs:sequence>
            </xs:complexType>
          </xs:element>


### PR DESCRIPTION
This PR lets the user use a table reference when selecting a named bean or an enum. See https://github.com/JMRI/JMRI/pull/10734#issuecomment-1048380432.

For now, this is only supported in the LogixNG action Turnout, but once the rest of the actions and expressions are refactored, all of them will support tables as well.