### PR TITLE
Fix Program Directory Paths containing +

### DIFF
--- a/java/src/jmri/util/FileUtilSupport.java
+++ b/java/src/jmri/util/FileUtilSupport.java
@@ -941,6 +941,7 @@ public class FileUtilSupport extends Bean {
                 // find from jar or class files location
                 String path1 = this.getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
                 String path2 = (new File(path1)).getParentFile().getPath();
+                path2 = path2.replaceAll("\\+", "%2B"); // convert + chars to UTF-8 to get through the decode
                 try {
                     String loadingDir = java.net.URLDecoder.decode(path2, "UTF-8");
                     log.trace("Program location from Classloader: {}", loadingDir);


### PR DESCRIPTION
Parse + characters in core program directory path lookup.

URLDecoder , https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/URLDecoder.html
converts + signs into spaces by default.

This PR converts any + signs to UTF-8 before the decode, preserving them in the path.

Reported at https://groups.io/g/jmriusers/message/201271