### PR TITLE
Don't resend loconet enquiry if negative acknowledgment received

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -73,7 +73,13 @@
         <h4>LocoNet</h4>
             <ul>
                 <li>Added Digitrax DCS210Plus command station</li>
-            </ul>
+                <li>A storm of LocoNet messages could result if certain command station models
+                    have track power turned off whem JMRI starts. The status enquiry messages would
+                    fail, and JMRI would repeat them in an effort to get complete information from the layout.
+                    This release no longer retries messages in that case. If you are not getting
+                    initial status from some devices on your layout, you should power up
+                    your LocoNet system, including track power, before starting JMRI.
+                </ul>
 
         <h4>Maple</h4>
             <ul>

--- a/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
+++ b/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
@@ -167,7 +167,7 @@ public class LnTurnoutManager extends AbstractTurnoutManager implements LocoNetL
                     int sw2 = lastSWREQ.getElement(2);
                     addr = address(sw1, sw2);
 
-                    if (addr < 1017) { // enquiries are above this
+                    if (addr < 1017 || addr > 1020) { // enquiries are above this
                         fastcontroller.sendLocoNetMessage(lastSWREQ);
                     }
                 }

--- a/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
+++ b/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
@@ -161,8 +161,15 @@ public class LnTurnoutManager extends AbstractTurnoutManager implements LocoNetL
             case LnConstants.OPC_LONG_ACK: {
                 // might have to resend, check 2nd byte
                 if (lastSWREQ != null && l.getElement(1) == 0x30 && l.getElement(2) == 0 && !mTurnoutNoRetry) {
-                    // received LONG_ACK reject msg, resend
-                    fastcontroller.sendLocoNetMessage(lastSWREQ);
+                    // received LONG_ACK reject msg, resend?
+                    // Skip if this is a status inquiry
+                    int sw1 = lastSWREQ.getElement(1);
+                    int sw2 = lastSWREQ.getElement(2);
+                    addr = address(sw1, sw2);
+
+                    if (addr < 1017) { // enquiries are above this
+                        fastcontroller.sendLocoNetMessage(lastSWREQ);
+                    }
                 }
 
                 // clear so can't resend recursively (we'll see
@@ -184,7 +191,7 @@ public class LnTurnoutManager extends AbstractTurnoutManager implements LocoNetL
             if (jmri.InstanceManager.lightManagerInstance().getBySystemName(sx) == null) {
                 // no light, create a turnout
                 LnTurnout t = (LnTurnout) provideTurnout(s);
-                
+
                 // process the message to put the turnout in the right state
                 t.messageFromManager(l);
             }

--- a/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
@@ -168,7 +168,7 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
         Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
         ((LnTurnoutManager)l).mTurnoutNoRetry=false;
 
-        Turnout t = ((LnTurnoutManager)l).provideTurnout("LT1018");   // This is effectively an enquiry command
+        ((LnTurnoutManager)l).provideTurnout("LT1018");   // This is effectively an enquiry command
         LocoNetMessage m = new LocoNetMessage(new int[] {0xb0, 0x79, 0x37, 0x01});
         lnis.sendTestMessage(m);
         Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());

--- a/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
@@ -125,7 +125,7 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
         Assert.assertNotNull(l.getByUserName("my name"));
     }
 
-        @Test
+    @Test
     public void testOpcLongAck() {
         Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
         ((LnTurnoutManager)l).mTurnoutNoRetry=false;
@@ -161,6 +161,35 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
         Assert.assertEquals("Check outbound message opcode", LnConstants.OPC_SW_REQ, lnis.outbound.get(0).getOpCode());
         Assert.assertEquals("Check outbound message byte 1", 0x00, lnis.outbound.get(0).getElement(1));
         Assert.assertEquals("Check outbound message byte 2", 0x20, lnis.outbound.get(0).getElement(2));
+    }
+
+    @Test
+    public void testOpcLongAckToEnquiry() {
+        Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
+        ((LnTurnoutManager)l).mTurnoutNoRetry=false;
+
+        Turnout t = ((LnTurnoutManager)l).provideTurnout("LT1018");   // This is effectively an enquiry command
+        LocoNetMessage m = new LocoNetMessage(new int[] {0xb0, 0x79, 0x37, 0x01});
+        lnis.sendTestMessage(m);
+        Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
+        Assert.assertNotNull(((LnTurnoutManager)l).lastSWREQ);
+        Assert.assertEquals(LnConstants.OPC_SW_REQ, ((LnTurnoutManager)l).lastSWREQ.getOpCode());
+        Assert.assertEquals(0x79, ((LnTurnoutManager)l).lastSWREQ.getElement(1));
+        Assert.assertEquals(0x37, ((LnTurnoutManager)l).lastSWREQ.getElement(2));
+
+        Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
+        Assert.assertEquals("Check that the turnout message was saved as 'last'",
+                m, ((LnTurnoutManager)l).lastSWREQ);
+        lnis.sendTestMessage(m);    // command station rejection of turnout command
+        m.setOpCode(0xB4);
+        m.setElement(1, 0x30);
+        m.setElement(2, 0x00);
+        m.setElement(3, 0x7b);
+        Assert.assertEquals("check sent message opcode", 0xb4, m.getOpCode());
+        lnis.sendTestMessage(m);    // command station rejection of turnout command
+        Assert.assertEquals("Check no outbound messages", 0, lnis.outbound.size());
+
+        Assert.assertFalse("check turnout manager retry mechanism setting", ((LnTurnoutManager)l).mTurnoutNoRetry);
     }
 
     private LocoNetInterfaceScaffold lnis;


### PR DESCRIPTION
Meant to avoid LocoNet storm if JMRI started with certain command stations while track power is off.