### PR TITLE
Speed up ESU function map loading #1

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
+++ b/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
@@ -450,7 +450,7 @@ public final class FnMapPanelESU extends JPanel {
                             thisVar = null;
                         }
 
-                        int iVar = varModel.findVarIndex(name);  // now pick up the varModel entry we just created
+                        int iVar = varModel.findVarIndex(name, true);  // now pick up the varModel entry we just created
 
                         // hopefully we found it!
                         if (iVar >= 0) {

--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -1186,12 +1186,36 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         return null;
     }
 
+    /**
+     * Returns the index of the first variable that matches a given name string.
+     * <p>
+     * Checks the search string against every variable's "item", the true name, 
+     * then against their "label" (default language only) and finally the
+     * CV name before moving on to the next variable if none of those match.
+     *
+     * @param name search string.
+     * @return index of the first matching variable found.
+     */
     public int findVarIndex(String name) {
 	return findVarIndex(name, false);
     }
     
-    public int findVarIndex(String name, boolean reverse) {
-        if(reverse) {
+    /**
+     * Returns the index of a variable that matches a given name string.
+     * <p>
+     * Checks the search string against every variable's "item", the true name, 
+     * then against their "label" (default language only) and finally the
+     * CV name before moving on to the next variable if none of those match.
+     *
+     * Depending on the second parameter, it will return the index of the first
+     * or last variable in our internal rowVector that matches the given string.
+     *
+     * @param name search string.
+     * @param searchFromEnd If true, will start searching from the end.
+     * @return index of the first matching variable found.
+     */
+    public int findVarIndex(String name, boolean searchFromEnd) {
+        if(searchFromEnd) {
 	    for (int i = getRowCount() - 1; i >= 0; i--) {
 		if (name.equals(getItem(i))) {
 		    return i;

--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -1187,18 +1187,36 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
     }
 
     public int findVarIndex(String name) {
-        for (int i = 0; i < getRowCount(); i++) {
-            if (name.equals(getItem(i))) {
-                return i;
-            }
-            if (name.equals(getLabel(i))) {
-                return i;
-            }
-            if (name.equals("CV" + getCvName(i))) {
-                return i;
-            }
-        }
-        return -1;
+	return findVarIndex(name, false);
+    }
+    
+    public int findVarIndex(String name, boolean reverse) {
+        if(reverse) {
+	    for (int i = getRowCount() - 1; i >= 0; i--) {
+		if (name.equals(getItem(i))) {
+		    return i;
+		}
+		if (name.equals(getLabel(i))) {
+		    return i;
+		}
+		if (name.equals("CV" + getCvName(i))) {
+		    return i;
+		}
+	    }
+	} else {
+	    for (int i = 0; i < getRowCount(); i++) {
+		if (name.equals(getItem(i))) {
+		    return i;
+		}
+		if (name.equals(getLabel(i))) {
+		    return i;
+		}
+		if (name.equals("CV" + getCvName(i))) {
+		    return i;
+		}
+	    }
+	}
+	return -1;
     }
 
     public void dispose() {

--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -1197,7 +1197,7 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
      * @return index of the first matching variable found.
      */
     public int findVarIndex(String name) {
-	return findVarIndex(name, false);
+        return findVarIndex(name, false);
     }
     
     /**
@@ -1216,31 +1216,31 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
      */
     public int findVarIndex(String name, boolean searchFromEnd) {
         if(searchFromEnd) {
-	    for (int i = getRowCount() - 1; i >= 0; i--) {
-		if (name.equals(getItem(i))) {
-		    return i;
-		}
-		if (name.equals(getLabel(i))) {
-		    return i;
-		}
-		if (name.equals("CV" + getCvName(i))) {
-		    return i;
-		}
-	    }
-	} else {
-	    for (int i = 0; i < getRowCount(); i++) {
-		if (name.equals(getItem(i))) {
-		    return i;
-		}
-		if (name.equals(getLabel(i))) {
-		    return i;
-		}
-		if (name.equals("CV" + getCvName(i))) {
-		    return i;
-		}
-	    }
-	}
-	return -1;
+            for (int i = getRowCount() - 1; i >= 0; i--) {
+                if (name.equals(getItem(i))) {
+                    return i;
+                }
+                if (name.equals(getLabel(i))) {
+                    return i;
+                }
+                if (name.equals("CV" + getCvName(i))) {
+                    return i;
+                }
+            }
+        } else {
+            for (int i = 0; i < getRowCount(); i++) {
+                if (name.equals(getItem(i))) {
+                    return i;
+                }
+                if (name.equals(getLabel(i))) {
+                    return i;
+                }
+                if (name.equals("CV" + getCvName(i))) {
+                    return i;
+                }
+            }
+        }
+        return -1;
     }
 
     public void dispose() {

--- a/java/test/jmri/jmrit/symbolicprog/VariableTableModelTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/VariableTableModelTest.java
@@ -120,6 +120,10 @@ public class VariableTableModelTest {
         Assert.assertEquals("find variable two ", 1, t.findVarIndex("two"));
         Assert.assertEquals("find nonexistant variable ", -1, t.findVarIndex("not there, eh?"));
 
+	// check reverse finding
+        Assert.assertEquals("find variable two ", 1, t.findVarIndex("two", true));
+        Assert.assertEquals("find variable one ", 0, t.findVarIndex("really two", true));
+        Assert.assertEquals("find nonexistant variable ", -1, t.findVarIndex("not there, eh?", true));	
     }
 
     // Check creating a longaddr type, walk through its programming

--- a/java/test/jmri/jmrit/symbolicprog/VariableTableModelTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/VariableTableModelTest.java
@@ -120,10 +120,10 @@ public class VariableTableModelTest {
         Assert.assertEquals("find variable two ", 1, t.findVarIndex("two"));
         Assert.assertEquals("find nonexistant variable ", -1, t.findVarIndex("not there, eh?"));
 
-	// check reverse finding
+        // check reverse finding
         Assert.assertEquals("find variable two ", 1, t.findVarIndex("two", true));
         Assert.assertEquals("find variable one ", 0, t.findVarIndex("really two", true));
-        Assert.assertEquals("find nonexistant variable ", -1, t.findVarIndex("not there, eh?", true));	
+        Assert.assertEquals("find nonexistant variable ", -1, t.findVarIndex("not there, eh?", true));
     }
 
     // Check creating a longaddr type, walk through its programming


### PR DESCRIPTION
As you may have seen on the jmri-users-list, I was a bit puzzled by how long it took to load the programmer for ESU LokSound v5 decoders.

Profiling showed the method taking the largest share of the time was VariableTableModel.findVarIndex, when called from FnMapPanelESU.<init>

This is because it searches the Vector inside VariableTableModel from the start for a VariableValue that has just a single line before been added to the end of that Vector. A couple of hundred times at least.

So I added a parameter to VariableTableModel.findVarIndex to optionally starts the search at the end, along with some documentation and Tests, and changed FnMapPanelESU.<init> to call that method.

Decreases load time from 25s to 17s on my machine.

I have not tested this extensively on other decoders. I did profile loading a Digitrax decoder programmer, which basically didn't change, and also still has the correct results.

Heiko

P.S: I have one more idea regarding the load time: Don't create all the GUI elements (JComboBoxes) at load time but defer creation until they are actually needed (which might be never for the FnMapPanelESU). I'll see how far I'll get with that.