### PR TITLE
Update Z21LocoNet Tunnel + Test

### DIFF
--- a/java/src/jmri/jmrix/roco/z21/Z21LocoNetTunnel.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21LocoNetTunnel.java
@@ -292,16 +292,16 @@ public class Z21LocoNetTunnel implements Z21Listener, LocoNetListener , Runnable
 
     @SuppressWarnings("deprecation") // Thread.stop
     public void dispose(){
-        Z21TrafficController tc = _memo.getTrafficController();
-        if ( tc != null ) {
-            tc.removez21Listener(this);
-        }
        if(lsc != null){
           lsc.dispose();
        }
-       if(_memo != null){
-          _memo.dispose();
-       }
+        if( _memo != null ) {
+            Z21TrafficController tc = _memo.getTrafficController();
+            if ( tc != null ) {
+                tc.removez21Listener(this);
+            }
+           _memo.dispose();
+        }
        sourceThread.stop();
        try {
           sourceThread.join();

--- a/java/src/jmri/jmrix/roco/z21/Z21LocoNetTunnel.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21LocoNetTunnel.java
@@ -292,7 +292,10 @@ public class Z21LocoNetTunnel implements Z21Listener, LocoNetListener , Runnable
 
     @SuppressWarnings("deprecation") // Thread.stop
     public void dispose(){
-        _memo.getTrafficController().removez21Listener(this);
+        Z21TrafficController tc = _memo.getTrafficController();
+        if ( tc != null ) {
+            tc.removez21Listener(this);
+        }
        if(lsc != null){
           lsc.dispose();
        }

--- a/java/src/jmri/jmrix/roco/z21/Z21LocoNetTunnel.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21LocoNetTunnel.java
@@ -37,10 +37,13 @@ public class Z21LocoNetTunnel implements Z21Listener, LocoNetListener , Runnable
      * Build a new LocoNet tunnel.
      * @param memo system connection.
      */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value="SC_START_IN_CTOR", justification="done at end, waits for data")
     public Z21LocoNetTunnel(Z21SystemConnectionMemo memo) {
         // save the SystemConnectionMemo.
         _memo = memo;
+        init();
+    }
+
+    private void init() {
 
         // configure input and output pipes to use for
         // the communication with the LocoNet implementation.
@@ -289,6 +292,7 @@ public class Z21LocoNetTunnel implements Z21Listener, LocoNetListener , Runnable
 
     @SuppressWarnings("deprecation") // Thread.stop
     public void dispose(){
+        _memo.getTrafficController().removez21Listener(this);
        if(lsc != null){
           lsc.dispose();
        }

--- a/java/test/jmri/jmrix/roco/z21/Z21LocoNetTunnelTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21LocoNetTunnelTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.roco.z21;
 
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -21,11 +22,6 @@ public class Z21LocoNetTunnelTest {
         Assert.assertNotNull(tunnel);
     }
 
-    @Test
-    public void testGetStreamPortController() {
-        Assert.assertNotNull(tunnel.getStreamPortController());
-    }
-
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
@@ -45,10 +41,14 @@ public class Z21LocoNetTunnelTest {
 
     @AfterEach
     public void tearDown() {
+        jmri.jmrix.loconet.streamport.LnStreamPortController lnspc = tunnel.getStreamPortController();
+        Assert.assertNotNull(lnspc);
         tunnel.dispose();
+        memo.getTrafficController().terminateThreads();
+        JUnitUtil.waitFor(() -> {  return !lnspc.status(); });
+        JUnitAppender.assertWarnMessage("sendLocoNetMessage: IOException: java.io.IOException: Read end dead");
         tunnel = null;
         tc = null;
-        memo.getTrafficController().terminateThreads();
         memo = null;
         JUnitUtil.tearDown();
     }


### PR DESCRIPTION
Improve constructor.
Remove tc listener on dispose.

Assert LnStreamPortController not null in teardown, not single test.
Wait for LnStreamPortController to terminate.
Asserts Warn message present in build warnings
`sendLocoNetMessage: IOException: java.io.IOException: Read end dead`