### PR TITLE
Logging Startup - FileUtilSupport

### DIFF
--- a/java/src/jmri/util/FileUtilSupport.java
+++ b/java/src/jmri/util/FileUtilSupport.java
@@ -925,32 +925,37 @@ public class FileUtilSupport extends Bean {
     }
 
     /**
-     * Get the JMRI program directory. If the program directory has not been
-     * previously sets, first sets the program directory to the value specified
-     * in the Java System property <code>jmri.path.program</code>, or
-     * <code>.</code> if that property is not set.
+     * Get the JMRI program directory.
+     * <p>
+     * If the program directory has not been
+     * previously set, first sets the program directory to the value specified
+     * in the Java System property <code>jmri.path.program</code>
+     * <p>
+     * If this property is unset, finds from jar or class files location.
+     * <p>
+     * If this fails, returns <code>.</code> .
      *
      * @return JMRI program directory as a String.
      */
     @Nonnull
     @CheckReturnValue
     public String getProgramPath() {
+        // As this method is called in Log4J setup, should not
+        // contain standard logging statements.
         if (programPath == null) {
             if (System.getProperty("jmri.path.program") == null) {
-                log.debug("jmri.path.program property not set");
                 // find from jar or class files location
                 String path1 = this.getClass().getProtectionDomain().getCodeSource().getLocation().getPath();
                 String path2 = (new File(path1)).getParentFile().getPath();
                 path2 = path2.replaceAll("\\+", "%2B"); // convert + chars to UTF-8 to get through the decode
                 try {
                     String loadingDir = java.net.URLDecoder.decode(path2, "UTF-8");
-                    log.trace("Program location from Classloader: {}", loadingDir);
                     if (loadingDir.endsWith("target")) {
                         loadingDir = loadingDir.substring(0, loadingDir.length()-6);
                     }
                      this.setProgramPath(loadingDir); // NOI18N
                } catch (java.io.UnsupportedEncodingException e) {
-                    log.error("Unsupported URL when trying to locate program directory: {}", path2);
+                    System.out.println("Unsupported URL when trying to locate program directory: " + path2 );
                     // best guess
                     this.setProgramPath("."); // NOI18N
                 }

--- a/java/src/jmri/util/FileUtilSupport.java
+++ b/java/src/jmri/util/FileUtilSupport.java
@@ -1791,6 +1791,8 @@ public class FileUtilSupport extends Bean {
      * @since 2.7.2
      */
     private String pathFromPortablePath(@CheckForNull Profile profile, @Nonnull String path) {
+        // As this method is called in Log4J setup, should not
+        // contain standard logging statements.
         if (path.startsWith(PROGRAM)) {
             if (new File(path.substring(PROGRAM.length())).isAbsolute()) {
                 path = path.substring(PROGRAM.length());
@@ -1832,10 +1834,9 @@ public class FileUtilSupport extends Bean {
         }
         try {
             // if path cannot be converted into a canonical path, return null
-            log.debug("Using {}", path);
             return new File(path.replace(SEPARATOR, File.separatorChar)).getCanonicalPath();
         } catch (IOException ex) {
-            log.warn("Cannot convert {} into a usable filename.", path, ex);
+            System.err.println("Cannot convert " + path + " into a usable filename. " + ex.getMessage());
             return null;
         }
     }

--- a/java/src/jmri/util/FileUtilSupport.java
+++ b/java/src/jmri/util/FileUtilSupport.java
@@ -955,7 +955,7 @@ public class FileUtilSupport extends Bean {
                     }
                      this.setProgramPath(loadingDir); // NOI18N
                } catch (java.io.UnsupportedEncodingException e) {
-                    System.out.println("Unsupported URL when trying to locate program directory: " + path2 );
+                    System.err.println("Unsupported URL when trying to locate program directory: " + path2 );
                     // best guess
                     this.setProgramPath("."); // NOI18N
                 }

--- a/java/test/jmri/ArchitectureTest.java
+++ b/java/test/jmri/ArchitectureTest.java
@@ -51,6 +51,7 @@ public class ArchitectureTest {
                                 .doNotHaveFullyQualifiedName("apps.JavaVersionCheckWindow").and()
                                 .doNotHaveFullyQualifiedName("apps.gui3.paned.QuitAction").and()
                                 .doNotHaveFullyQualifiedName("apps.jmrit.decoderdefn.DecoderIndexBuilder").and()
+                                .doNotHaveFullyQualifiedName("jmri.util.FileUtilSupport").and() // used in log4j init
                                 .doNotHaveFullyQualifiedName("jmri.util.GetArgumentList").and()
                                 .doNotHaveFullyQualifiedName("jmri.util.GetClassPath").and()
                                 .doNotHaveFullyQualifiedName("jmri.util.GetJavaProperty").and()


### PR DESCRIPTION
Remove standard log statements from methods used in Logging Setup.

Removes log warning
`log4j:WARN No appenders could be found for logger (jmri.util.FileUtilSupport)` on program / test startup.