### PR TITLE
Logix copy: replace text system name field with editable combo box

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -402,7 +402,8 @@
     <h3>Logix</h3>
         <a id="Logix" name="Logix"></a>
         <ul>
-          <li></li>
+          <li>Change the system name input for the Copy command to use a combo box.  This makes it
+          easier to select an existing Logix as the copy destination.</li>
         </ul>
 
     <h3>LogixNG</h3>

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -733,6 +733,7 @@ LogixError10                         = New user name is already in use. Cannot u
 LogixError11                         = Cannot delete as requested.\nConditional "{0}" ({1}) is a Conditional Variable in the Conditional,\n"{2}" ({3}), of Logix, "{4}" ({5}).\nPlease remove that variable first.
 LogixError31                         = Copy of Logix "{0}" in progress.  Please complete and try again.
 LogixError32                         = Cannot edit two Logixs at the same time. Please complete edit of Logix "{0}" and try again.
+LogixError33                         = Add of a new Logix is in progress.  Please complete and try again.
 LogixWarn8                           = Conditionals in Logix "{0}" ({1}) cannot be edited.\nGo to the Sensor Group Table to edit sensor groups.
 # Messages prefs pane item
 DeleteLogix                          = When deleting the Logix

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -1031,7 +1031,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
         var name = "";
         var index = _copyCombo.getSelectedIndex();
         if (index > 0) {
-            var logix = _logixManager.getLogix((String) _copyCombo.getItemAt(index));
+            var logix = _logixManager.getLogix(_copyCombo.getItemAt(index));
             if (logix != null) {
                 var userName = logix.getUserName();
                 if (userName != null) {

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -678,6 +678,8 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
     JmriJFrame addLogixFrame = null;
     JTextField _systemName = new JTextField(20);
     JTextField _addUserName = new JTextField(20);
+    JComboBox<String> _copyCombo = new JComboBox<>();
+
     JCheckBox _autoSystemName = new JCheckBox(Bundle.getMessage("LabelAutoSysName"));   // NOI18N
     JLabel _sysNameLabel = new JLabel(Bundle.getMessage("BeanNameLogix") + " " + Bundle.getMessage("ColumnSystemName") + ":");  // NOI18N
     JLabel _userNameLabel = new JLabel(Bundle.getMessage("BeanNameLogix") + " " + Bundle.getMessage("ColumnUserName") + ":");   // NOI18N
@@ -790,7 +792,6 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
         addLogixFrame.setLocation(50, 30);
         Container contentPane = addLogixFrame.getContentPane();
         contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
-
         JPanel p;
         p = new JPanel();
         p.setLayout(new FlowLayout());
@@ -809,7 +810,11 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
         c.anchor = java.awt.GridBagConstraints.WEST;
         c.weightx = 1.0;
         c.fill = java.awt.GridBagConstraints.HORIZONTAL;  // text field will expand
-        p.add(_systemName, c);
+        if (titleId.equals("TitleCopyLogix")) {
+            p.add(_copyCombo, c);
+        } else {
+            p.add(_systemName, c);
+        }
         c.gridy = 1;
         p.add(_addUserName, c);
         c.gridx = 2;
@@ -912,6 +917,20 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
             return;
         }
         _showReminder = true;
+
+        // Refresh combo box Logix list
+        _copyCombo.removeActionListener(this::copyComboListener);
+        _copyCombo.removeAllItems();
+        _copyCombo.addItem("");
+        var logixList = InstanceManager.getDefault(LogixManager.class).getNamedBeanSet();
+        logixList.forEach((lgx) -> {
+            _copyCombo.addItem(lgx.getSystemName());
+        });
+        _copyCombo.setEditable(true);
+        _copyCombo.setSelectedIndex(0);
+        _copyCombo.addActionListener(this::copyComboListener);
+        jmri.util.swing.JComboBoxUtil.setupComboBoxMaxRows(_copyCombo);
+
         // make an Add Logix Frame
         if (addLogixFrame == null) {
             JPanel panel5 = makeAddLogixFrame("TitleCopyLogix", "CopyLogixMessage",
@@ -949,7 +968,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
      * @param lgxName Logix system name to be copied
      */
     private void copyLogixPressed(String lgxName) {
-        String sName = _systemName.getText();
+        _systemName.setText((String) _copyCombo.getSelectedItem());
         String uName = _addUserName.getText();
         if (uName.length() == 0) {
             uName = null;
@@ -961,6 +980,13 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
             }
             targetLogix = _logixManager.createNewLogix(uName);
         } else {
+            // Validate the system name
+            if (!checkLogixSysName()) {
+                cancelAddPressed(null);
+                return;
+            }
+            var sName = _systemName.getText();  // Use the validated, possibly changed, system name
+
             targetLogix = _logixManager.getBySystemName(sName);
             if (targetLogix == null && uName != null) {
                 targetLogix = _logixManager.getByUserName(uName);
@@ -976,10 +1002,6 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
                 }
             }
             if (targetLogix == null) {
-                if (!checkLogixSysName()) {
-                    return;
-                }
-                // Create the new Logix
                 targetLogix = _logixManager.createNewLogix(sName, uName);
                 if (targetLogix == null) {
                     // should never get here unless there is an assignment conflict
@@ -995,6 +1017,29 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
         _baseEdit.locateAt(getFrame());
         _inCopyMode = true;
         _baseEdit.addLogixEventListener(new ConditionalBaseListener(lgxName));
+    }
+
+    /**
+     * Set the user name input field.
+     * @param e The action event.
+     */
+    private void copyComboListener(ActionEvent e) {
+        if (!e.getActionCommand().equals("comboBoxChanged")) {
+            return;
+        }
+
+        var name = "";
+        var index = _copyCombo.getSelectedIndex();
+        if (index > 0) {
+            var logix = _logixManager.getLogix((String) _copyCombo.getItemAt(index));
+            if (logix != null) {
+                var userName = logix.getUserName();
+                if (userName != null) {
+                    name = userName;
+                }
+            }
+        }
+        _addUserName.setText(name);
     }
 
     /**
@@ -1036,7 +1081,6 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
                     JOptionPane.ERROR_MESSAGE);
             return false;
         }
-
         _systemName.setText(sName);
         return true;
     }
@@ -1070,7 +1114,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
         }
 
         if (_inCopyMode) {
-            // Already editing a Logix, ask for completion of that edit
+            // Already copying a Logix, ask for completion of that edit
             JOptionPane.showMessageDialog(getFrame(),
                     Bundle.getMessage("LogixError31", _curLogix.getSystemName()),
                     Bundle.getMessage("ErrorTitle"), // NOI18N


### PR DESCRIPTION
The **Select &rArr; Copy** action is used to copy one or more conditionals from the current Logix to another Logix.  The other Logix can either be a new one or an existing one.

An editable combo box is used to provide an input field for creating a new one along with a list of the existing Logix definitions to make selecting an existing one easier.