### PR TITLE
Implement a viewOnly attribute for the pane 'display' element.

### DIFF
--- a/help/en/html/apps/DecoderPro/Programmer.shtml
+++ b/help/en/html/apps/DecoderPro/Programmer.shtml
@@ -57,6 +57,9 @@
             e.g. the text box. Possible values are "left", "above", "below", "right" with a default
             of "right".</li>
 
+            <li><dfn>viewOnly</dfn> - Present the variable but do not allow the user to change
+            its value in this place. Possible values are "yes" or "no", with a default of "no".</li>
+
             <li>
               <dfn>format</dfn> -
               <p>How the variable should be presented. Numeric variables can be presented as</p>

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
@@ -2351,6 +2351,9 @@ public class PaneProgPane extends javax.swing.JPanel
             format = attr.getValue();
         }
 
+        boolean viewOnly = var.getAttribute("viewOnly") != null
+                ? var.getAttribute("viewOnly").getValue().equals("yes") : false;
+
         if (i >= 0) {
             rep = getRep(i, format);
             rep.setMaximumSize(rep.getPreferredSize());
@@ -2360,6 +2363,9 @@ public class PaneProgPane extends javax.swing.JPanel
                 tip = rep.getToolTipText();
             }
             rep.setToolTipText(modifyToolTipText(tip, variable));
+            if (viewOnly) {
+            rep.setEnabled(false);
+            }
         }
         return rep;
     }

--- a/xml/decoders/ESU_SwitchPilot.xml
+++ b/xml/decoders/ESU_SwitchPilot.xml
@@ -360,19 +360,19 @@
                                 <label>
                                     <text> </text>
                                 </label>
-                                <display item="Primary_Address_1">
+                                <display item="Primary_Address_1" viewOnly="yes">
                                     <label>Output 1 Address</label>
                                     <label xml:lang="de">Ausgang 1 Adresse</label>
                                 </display>
-                                <display item="Primary_Address_2">
+                                <display item="Primary_Address_2" viewOnly="yes">
                                     <label>Output 2 Address</label>
                                     <label xml:lang="de">Ausgang 2 Adresse</label>
                                 </display>
-                                <display item="Primary_Address_3">
+                                <display item="Primary_Address_3" viewOnly="yes">
                                     <label>Output 3 Address</label>
                                     <label xml:lang="de">Ausgang 3 Adresse</label>
                                 </display>
-                                <display item="Primary_Address_4">
+                                <display item="Primary_Address_4" viewOnly="yes">
                                     <label>Output 4 Address</label>
                                     <label xml:lang="de">Ausgang 4 Adresse</label>
                                 </display>
@@ -387,19 +387,19 @@
                                 <label>
                                     <text> </text>
                                 </label>
-                                <display item="Primary_Address_1">
+                                <display item="Primary_Address_1" viewOnly="yes">
                                     <label>Servo 1 Address</label>
                                     <label xml:lang="de">Servo 1 Adresse</label>
                                 </display>
-                                <display item="Primary_Address_2">
+                                <display item="Primary_Address_2" viewOnly="yes">
                                     <label>Servo 2 Address</label>
                                     <label xml:lang="de">Servo 2 Adresse</label>
                                 </display>
-                                <display item="Primary_Address_3">
+                                <display item="Primary_Address_3" viewOnly="yes">
                                     <label>Servo 3 Address</label>
                                     <label xml:lang="de">Servo 3 Adresse</label>
                                 </display>
-                                <display item="Primary_Address_4">
+                                <display item="Primary_Address_4" viewOnly="yes">
                                     <label>Servo 4 Address</label>
                                     <label xml:lang="de">Servo 4 Adresse</label>
                                 </display>
@@ -420,19 +420,19 @@
                                 <label>
                                     <text> </text>
                                 </label>
-                                <display item="Secondary_Address_1">
+                                <display item="Secondary_Address_1" viewOnly="yes">
                                     <label>Servo 1 Address</label>
                                     <label xml:lang="de">Servo 1 Adresse</label>
                                 </display>
-                                <display item="Secondary_Address_2">
+                                <display item="Secondary_Address_2" viewOnly="yes">
                                     <label>Servo 2 Address</label>
                                     <label xml:lang="de">Servo 2 Adresse</label>
                                 </display>
-                                <display item="Secondary_Address_3">
+                                <display item="Secondary_Address_3" viewOnly="yes">
                                     <label>Servo 3 Address</label>
                                     <label xml:lang="de">Servo 3 Adresse</label>
                                 </display>
-                                <display item="Secondary_Address_4">
+                                <display item="Secondary_Address_4" viewOnly="yes">
                                     <label>Servo 4 Address</label>
                                     <label xml:lang="de">Servo 4 Adresse</label>
                                 </display>
@@ -448,19 +448,19 @@
                                 <label>
                                     <text> </text>
                                 </label>
-                                <display item="Secondary_Address_1">
+                                <display item="Secondary_Address_1" viewOnly="yes">
                                     <label>Servo 1 Address for position C and D</label>
                                     <label xml:lang="de">Servo 1 Adresse für Position C und D</label>
                                 </display>
-                                <display item="Secondary_Address_2">
+                                <display item="Secondary_Address_2" viewOnly="yes">
                                     <label>Servo 2 Address for position C and D</label>
                                     <label xml:lang="de">Servo 2 Adresse für Position C und D</label>
                                 </display>
-                                <display item="Secondary_Address_3">
+                                <display item="Secondary_Address_3" viewOnly="yes">
                                     <label>Servo 3 Address for position C and D</label>
                                     <label xml:lang="de">Servo 3 Adresse für Position C und D</label>
                                 </display>
-                                <display item="Secondary_Address_4">
+                                <display item="Secondary_Address_4" viewOnly="yes">
                                     <label>Servo 4 Address for position C and D</label>
                                     <label xml:lang="de">Servo 4 Adresse für Position C und D</label>
                                 </display>

--- a/xml/schema/types/panetype.xsd
+++ b/xml/schema/types/panetype.xsd
@@ -378,6 +378,7 @@
         </xs:simpleType>
     </xs:attribute>
     <xs:attribute name="tooltip" type="xs:string"/>
+    <xs:attribute name="viewOnly" type="yesNoType" default="no" />
   </xs:complexType>
 
   <xs:element name="pane" type="PaneType">


### PR DESCRIPTION
This was prompted by a query to me by @n3ix:

>  I have a CV that users can edit.  The CV efit is intended to happen on one specific tab.  However the value needs to be shown on multiple tabs (in forms like value+1, value+2,...) to help the user keep track of where they are.  It would be great if I could make the displayed value read only on all but the first tab.  Is there anything like a read only property for a display control as opposed to the read only setting for the CV itself?

I realised I could immediately benefit by use of it in accessory decoder definitions with derived output addresses.
