### PR TITLE
Suppress a warning message that happens often but not always

### DIFF
--- a/java/test/jmri/jmrix/roco/z21/Z21LocoNetTunnelTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21LocoNetTunnelTest.java
@@ -46,8 +46,7 @@ public class Z21LocoNetTunnelTest {
         tunnel.dispose();
         memo.getTrafficController().terminateThreads();
         JUnitUtil.waitFor(() -> {  return !lnspc.status(); });
-        // The assertWarnMessage() below often fails on Windows CI. Disable it for now. It was added in PR #10773.
-//        JUnitAppender.assertWarnMessage("sendLocoNetMessage: IOException: java.io.IOException: Read end dead");
+        JUnitAppender.suppressWarnMessage("sendLocoNetMessage: IOException: java.io.IOException: Read end dead");
         tunnel = null;
         tc = null;
         memo = null;

--- a/java/test/jmri/jmrix/roco/z21/Z21LocoNetTunnelTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21LocoNetTunnelTest.java
@@ -46,7 +46,8 @@ public class Z21LocoNetTunnelTest {
         tunnel.dispose();
         memo.getTrafficController().terminateThreads();
         JUnitUtil.waitFor(() -> {  return !lnspc.status(); });
-        JUnitAppender.assertWarnMessage("sendLocoNetMessage: IOException: java.io.IOException: Read end dead");
+        // The assertWarnMessage() below often fails on Windows CI. Disable it for now. It was added in PR #10773.
+//        JUnitAppender.assertWarnMessage("sendLocoNetMessage: IOException: java.io.IOException: Read end dead");
         tunnel = null;
         tc = null;
         memo = null;


### PR DESCRIPTION
PR #10773 added:
`JUnitAppender.assertWarnMessage("sendLocoNetMessage: IOException: java.io.IOException: Read end dead");`

But this line often fails on Windows CI. This PR changes it to `suppressWarnMessage()` instead of `assertWarnMessage()`.