### PR TITLE
WIP Move Throttle DTD to Schema

### DIFF
--- a/java/src/jmri/configurexml/ConfigXmlManager.java
+++ b/java/src/jmri/configurexml/ConfigXmlManager.java
@@ -491,7 +491,7 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
         XmlAdapter adapter = null;
         try {
             adapter = (XmlAdapter) Class.forName(adapterName(object)).getDeclaredConstructor().newInstance();
-        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException 
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException
                     | NoSuchMethodException | java.lang.reflect.InvocationTargetException ex) {
             log.error("Cannot load configuration adapter for {}", object.getClass().getName(), ex);
         }
@@ -503,7 +503,7 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
         }
     }
 
-    private void storeVersion(Element root) {
+    public static void storeVersion(Element root) {
         // add version at front
         root.addContent(0,
                 new Element("jmriversion")
@@ -572,10 +572,10 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
     @Override
     public boolean load(URL url, boolean registerDeferred) throws JmriConfigureXmlException {
         log.trace("starting load({}, {})", url, registerDeferred);
-        
+
         // we do the actual load on the Swing thread in case it changes visible windows
         Boolean retval = jmri.util.ThreadingUtil.runOnGUIwithReturn(() -> {
-            try { 
+            try {
                 Boolean ret = loadOnSwingThread(url, registerDeferred);
                 return ret;
             } catch (Exception e) {
@@ -583,7 +583,7 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
                 throw new RuntimeException(e);
             }
         });
-        
+
         log.trace("  ending load({}, {} with {})", url, registerDeferred, retval);
         return retval;
     }

--- a/java/src/jmri/jmrit/XmlFile.java
+++ b/java/src/jmri/jmrit/XmlFile.java
@@ -204,7 +204,7 @@ public abstract class XmlFile {
      * @param doc  Document to be written out. This should never be null.
      * @throws FileNotFoundException if file not found
      */
-    public static void writeXML(File file, Document doc) throws IOException, FileNotFoundException {
+    public void writeXML(File file, Document doc) throws IOException, FileNotFoundException {
         // ensure parent directory exists
         if (file.getParent() != null) {
             FileUtil.createDirectory(file.getParent());

--- a/java/src/jmri/jmrit/XmlFile.java
+++ b/java/src/jmri/jmrit/XmlFile.java
@@ -204,7 +204,7 @@ public abstract class XmlFile {
      * @param doc  Document to be written out. This should never be null.
      * @throws FileNotFoundException if file not found
      */
-    public void writeXML(File file, Document doc) throws IOException, FileNotFoundException {
+    public static void writeXML(File file, Document doc) throws IOException, FileNotFoundException {
         // ensure parent directory exists
         if (file.getParent() != null) {
             FileUtil.createDirectory(file.getParent());

--- a/java/src/jmri/jmrit/throttle/LoadXmlThrottlesLayoutAction.java
+++ b/java/src/jmri/jmrit/throttle/LoadXmlThrottlesLayoutAction.java
@@ -90,6 +90,7 @@ public class LoadXmlThrottlesLayoutAction extends AbstractAction {
     public boolean loadThrottlesLayout(java.io.File f) throws java.io.IOException {
         try {
             ThrottlePrefs prefs = new ThrottlePrefs();
+            prefs.setValidate(XmlFile.Validate.RequireSchema);
             Element root = prefs.rootFromFile(f);
             List<Element> throttles = root.getChildren("ThrottleFrame");
             ThrottleFrameManager tfManager = InstanceManager.getDefault(ThrottleFrameManager.class);

--- a/java/src/jmri/jmrit/throttle/StoreXmlThrottlesLayoutAction.java
+++ b/java/src/jmri/jmrit/throttle/StoreXmlThrottlesLayoutAction.java
@@ -3,7 +3,6 @@ package jmri.jmrit.throttle;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Iterator;
 
@@ -14,12 +13,9 @@ import jmri.InstanceManager;
 import jmri.configurexml.ConfigXmlManager;
 import jmri.configurexml.StoreXmlConfigAction;
 import jmri.jmrit.XmlFile;
-import static jmri.jmrit.XmlFile.writeXML;
 
 import org.jdom2.Document;
 import org.jdom2.Element;
-import org.jdom2.output.Format;
-import org.jdom2.output.XMLOutputter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,7 +103,8 @@ public class StoreXmlThrottlesLayoutAction extends AbstractAction {
             }
             root.setContent(children);
 
-            writeXML(f, doc);
+            XmlFile xf = new XmlFile() {};
+            xf.writeXML(f, doc);
         } catch (FileNotFoundException ex) {
             log.warn("Exception in storing throttle xml", ex);
         } catch (IOException ex) {

--- a/java/src/jmri/jmrit/throttle/StoreXmlThrottlesLayoutAction.java
+++ b/java/src/jmri/jmrit/throttle/StoreXmlThrottlesLayoutAction.java
@@ -74,7 +74,7 @@ public class StoreXmlThrottlesLayoutAction extends AbstractAction {
         try {
             Element root = new Element("throttle-layout-config");
             root.setAttribute("noNamespaceSchemaLocation",
-                    "http://jmri.org/xml/schema/layout" + schemaVersion + ".xsd",
+                    "http://jmri.org/xml/schema/throttle-layout" + schemaVersion + ".xsd",
                     org.jdom2.Namespace.getNamespace("xsi",
                             "http://www.w3.org/2001/XMLSchema-instance"));
             Document doc = XmlFile.newDocument(root);

--- a/xml/schema/throttle-layout-4-99-5.xsd
+++ b/xml/schema/throttle-layout-4-99-5.xsd
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2022                      -->
+
+<!-- Not in Venetian blind form                                       -->
+<!-- 'operation' element not complete                                 -->
+<!-- Need annotations                                                 -->
+<!-- Attributes need to get types right esp. for enumerated           -->
+<!-- Attributes need REQUIRED/IMPLIED                                 -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:xi="http://www.w3.org/2001/XInclude"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+        >
+
+    <xs:include schemaLocation="http://jmri.org/xml/schema/types/general.xsd"/>
+    <xs:import namespace='http://docbook.org/ns/docbook' schemaLocation='http://jmri.org/xml/schema/docbook/docbook.xsd'/>
+
+    <xs:annotation>
+        <xs:documentation>
+          This is the schema representing throttle layout files, including.
+          <p/>
+          This version of the schema is for files created by JMRI
+          version 4.99.5 and later.
+        </xs:documentation>
+    </xs:annotation>
+<!--
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/connection.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/userpreferences.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/turnouts-4-19-2.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/sensors-4-19-2.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/lights-4-19-2.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/reporters-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/memories-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/blocks-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/oblocks-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/sections-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/transits-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/timebase.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/signalheads-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/signalmasts-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/signalgroups-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/signalmastlogics.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/layoutblocks-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/signalelements.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/audio-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/routes-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/warrants-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/logix-2-9-6.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/editors.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/layouteditor.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/paneleditor.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/switchboardeditor.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/entryexitpair.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/meters.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/meterframes.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/ctcdata.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/filehistory.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/logixng-4.23.1.xsd"/>
+-->
+  <xs:element name="throttle-lay11out-config">
+    <xs:complexType>
+      <xs:sequence minOccurs="0" maxOccurs="unbounded" >
+
+        <xs:element name="jmriversion" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+                <xs:documentation>
+                  Automatically added to contain JMRI version writing the file
+                </xs:documentation>
+                <xs:appinfo>
+                    <jmri:usingclass configurexml="yes">jmri.configurexml.ConfigXmlManager</jmri:usingclass>
+                </xs:appinfo>
+            </xs:annotation>
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="major" type="xs:int" minOccurs="1" maxOccurs="1" />
+                <xs:element name="minor" type="xs:int" minOccurs="1" maxOccurs="1" />
+                <xs:element name="test" type="xs:int" minOccurs="0" maxOccurs="1" />
+                <xs:element name="modifier" type="xs:string" minOccurs="0" maxOccurs="1" />
+              </xs:sequence>
+            </xs:complexType>
+        </xs:element>
+<!--
+        <xs:element name="gui" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+                <xs:documentation>
+                  Defines options for the GUI configuration
+                </xs:documentation>
+                <xs:appinfo>
+                    <jmri:usingclass configurexml="yes">jmri.configurexml.GuiLafConfigPaneXml</jmri:usingclass>
+                </xs:appinfo>
+            </xs:annotation>
+            <xs:complexType>
+                <xs:attribute name="LAFclass" type="xs:string"/>
+                <xs:attribute name="class" type="classType" use="required" />
+                <xs:attribute name="fontsize" type="xs:integer" />
+                <xs:attribute name="LocaleLanguage" type="xs:string"/>
+                <xs:attribute name="LocaleCountry" type="xs:string"/>
+                <xs:attribute name="LocaleVariant" type="xs:string"/>
+                <xs:attribute name="nonStandardMouseEvent" type="yesNoType"/>
+            </xs:complexType>
+        </xs:element>
+
+        <xs:element name="console" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines options for the JMRI System Console
+                </xs:documentation>
+                <xs:appinfo>
+                    <jmri:usingclass configurexml="yes">apps.configurexml.SystemConsoleConfigPanelXml</jmri:usingclass>
+                </xs:appinfo>
+            </xs:annotation>
+            <xs:complexType>
+                <xs:sequence>
+                    <xs:element name="position" minOccurs="0" maxOccurs="1">
+                        <xs:complexType>
+                            <xs:attribute name="x" type="xs:integer" use="required" />
+                            <xs:attribute name="y" type="xs:integer" use="required" />
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="size" minOccurs="0" maxOccurs="1">
+                        <xs:complexType>
+                            <xs:attribute name="width" type="xs:integer" use="required" />
+                            <xs:attribute name="height" type="xs:integer" use="required" />
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="class" type="classType" use="required" />
+                <xs:attribute name="scheme" type="xs:integer" />
+                <xs:attribute name="fontfamily" type="xs:string" />
+                <xs:attribute name="fontsize" type="xs:integer" />
+                <xs:attribute name="fontstyle" type="xs:integer" />
+                <xs:attribute name="wrapstyle" type="xs:integer" />
+            </xs:complexType>
+        </xs:element>
+
+        <xs:element name="fileLocations" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+                <xs:documentation>
+                  Defines the default locations for user file locations.
+                </xs:documentation>
+                <xs:appinfo>
+                    <jmri:usingclass configurexml="yes">apps.configurexml.FileLocationPaneXml</jmri:usingclass>
+                </xs:appinfo>
+            </xs:annotation>
+            <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="fileLocation" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                      <xs:attribute name="defaultScriptLocation" type="xs:string"/>
+                      <xs:attribute name="defaultUserLocation" type="xs:string"/>
+                      <xs:attribute name="defaultThrottleLocation" type="xs:string"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="defaultScriptLocation" type="xs:string"/>
+                <xs:attribute name="class" type="classType" use="required" />
+                <xs:attribute name="defaultUserLocation" type="xs:string"/>
+                <xs:attribute name="defaultThrottleLocation" type="xs:string"/>
+            </xs:complexType>
+        </xs:element>
+
+        <xs:element name="managerdefaults" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>
+              Defines which manager is to be used for various operations.
+            </xs:documentation>
+            <xs:appinfo>
+                <jmri:usingclass configurexml="yes">jmri.managers.configurexml.DefaultUserMessagePreferencesXml</jmri:usingclass>
+            </xs:appinfo>
+          </xs:annotation>
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="setting" minOccurs="0" maxOccurs="unbounded">
+                  <xs:complexType>
+                    <xs:sequence>
+                      <xs:element name="key" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+                      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+                    </xs:sequence>
+                  </xs:complexType>
+                </xs:element>
+              </xs:sequence>
+              <xs:attribute name="class" type="classType" use="required" />
+            </xs:complexType>
+        </xs:element>
+        <xs:element name="programmer" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+                <xs:documentation>
+                  Defines DecoderPro configuration options
+                </xs:documentation>
+                <xs:appinfo>
+                    <jmri:usingclass configurexml="yes">jmri.jmrit.symbolicprog.configurexml.ProgrammerConfigPaneXml</jmri:usingclass>
+                </xs:appinfo>
+            </xs:annotation>
+            <xs:complexType>
+                <xs:attribute name="class" type="classType" use="required"/>
+                <xs:attribute name="verifyBeforeWrite" type="yesNoType" default="no"/>
+                <xs:attribute name="showEmptyPanes" type="yesNoType" default="yes" />
+                <xs:attribute name="canCacheDefault" type="yesNoType" default="yes">
+                  <xs:annotation>
+                    <xs:documentation>
+                      Defines default for whether to cache index CV writes,
+                      which can be overridden in a decoder definition file if desired.
+                    </xs:documentation>
+                    <xs:appinfo>
+                      <jmri:usingclass configurexml="yes">jmri.jmrit.symbolicprog.configurexml.ProgrammerConfigPaneXml</jmri:usingclass>
+                      <jmri:usingclass configurexml="no">jmri.jmrix.AbstractProgrammerFacade</jmri:usingclass>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="doConfirmWrite" type="yesNoType" default="yes">
+                  <xs:annotation>
+                    <xs:documentation>
+                      Defines default for whether index CVs should be read for confirmation after being written,
+                      which can be overridden in a decoder definition file if desired.
+                    </xs:documentation>
+                    <xs:appinfo>
+                      <jmri:usingclass configurexml="yes">jmri.jmrit.symbolicprog.configurexml.ProgrammerConfigPaneXml</jmri:usingclass>
+                      <jmri:usingclass configurexml="no">jmri.jmrix.AbstractProgrammerFacade</jmri:usingclass>
+                    </xs:appinfo>
+                  </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="defaultFile" type="xs:string" default="Basic.xml"/>
+            </xs:complexType>
+        </xs:element>
+
+        <xs:element name="roster" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+                <xs:documentation>
+                  Defines DecoderPro roster applications re location, default owner
+                </xs:documentation>
+                <xs:appinfo>
+                    <jmri:usingclass configurexml="yes">jmri.jmrit.roster.configurexml.RosterConfigPaneXml</jmri:usingclass>
+                </xs:appinfo>
+            </xs:annotation>
+            <xs:complexType>
+                <xs:attribute name="class" type="classType" use="required"/>
+                <xs:attribute name="directory" type="xs:string" />
+                <xs:attribute name="ownerDefault" type="xs:string" />
+            </xs:complexType>
+        </xs:element>
+
+        <xs:element name="perform" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+                <xs:documentation>
+                  Defines things to do when the file is loaded (usually when the app starts up, as this is in config file)
+                </xs:documentation>
+                <xs:appinfo>
+                    <jmri:usingclass configurexml="yes">apps.configurexml.PerformActionModelXml</jmri:usingclass>
+                    <jmri:usingclass configurexml="yes">apps.configurexml.CreateButtonModelXml</jmri:usingclass>
+                    <jmri:usingclass configurexml="yes">apps.configurexml.PerformFileModelXml</jmri:usingclass>
+                </xs:appinfo>
+            </xs:annotation>
+            <xs:complexType>
+                <xs:attribute name="class" type="classType" use="required"/>
+                <xs:attribute name="type" default="Action">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:token">
+                      <xs:enumeration value="Action"/>
+                      <xs:enumeration value="ScriptFile"/>
+                      <xs:enumeration value="XmlFile"/>
+                      <xs:enumeration value="Button"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+            </xs:complexType>
+        </xs:element>
+
+        <xs:element name="connection"   type="ConnectionType" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="UserMessagePreferences"   type="UserPrefsType" minOccurs="0" maxOccurs="unbounded" />
+
+        <xs:element name="turnouts"     type="TurnoutManagerType" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="sensors"      type="SensorManagerType" minOccurs="0" maxOccurs="unbounded" />
+
+        <xs:element name="lights"       type="LightManagerType" minOccurs="0" maxOccurs="unbounded" >
+          <xs:key name="lightSystemName">
+            <xs:annotation><xs:documentation>Insist that the system name is unique</xs:documentation></xs:annotation>
+            <xs:selector xpath="./light/systemName"/>
+            <xs:field xpath="."/>
+          </xs:key>
+          <xs:unique name="lightUserName">
+            <xs:annotation><xs:documentation>Insist that the user name is unique</xs:documentation></xs:annotation>
+            <xs:selector xpath="./light/userName"/>
+            <xs:field xpath="."/>
+          </xs:unique>
+        </xs:element>
+-->
+
+      </xs:sequence>
+    </xs:complexType>
+
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
As part of  #10697, move Throttle DTD to Schema.

One of the reasons for this PR is to improve the validity check of the xml files.