### PR TITLE
Remove releaseThread() and replace it with waitFor()

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -599,5 +599,8 @@
         <a id="Misc" name="Misc"></a>
         <ul>
             <li>Add a search feature to the JmriHelp local web page.</li>
+            <li>The method JUnitUtil.releaseThread(this) and JUnitUtil.releaseThread(this, delay)
+            has been removed. Use JUnitUtil.waitFor(int time) instead. Replace the call
+            JUnitUtil.releaseThread(this) with JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY);</li>
         </ul>
 

--- a/java/acceptancetest/step_definitions/apps/ApplicationTestAcceptanceSteps.java
+++ b/java/acceptancetest/step_definitions/apps/ApplicationTestAcceptanceSteps.java
@@ -89,7 +89,7 @@ public class ApplicationTestAcceptanceSteps implements En {
                 }
             } finally {
                 // wait for threads, etc
-                jmri.util.JUnitUtil.releaseThread(this, 5000);
+                JUnitUtil.waitFor(5000);
             }
             FileUtils.deleteDirectory(tempFolder);
             System.clearProperty("org.jmri.profile");

--- a/java/test/apps/LaunchJmriAppBase.java
+++ b/java/test/apps/LaunchJmriAppBase.java
@@ -26,7 +26,7 @@ abstract public class LaunchJmriAppBase {
 
     /**
      * Run one application.
-     * 
+     *
      * @param profileName       Name of the Profile folder to copy from
      *                          java/test/apps/PanelPro/profiles/
      * @param frameName         Application (frame) title
@@ -70,7 +70,7 @@ abstract public class LaunchJmriAppBase {
 
         } finally {
             // wait for threads, etc
-            jmri.util.JUnitUtil.releaseThread(this, 40);
+            JUnitUtil.waitFor(40);
         }
     }
 

--- a/java/test/jmri/implementation/MatrixSignalMastTest.java
+++ b/java/test/jmri/implementation/MatrixSignalMastTest.java
@@ -207,7 +207,7 @@ public class MatrixSignalMastTest {
     @AfterEach
     public void tearDown() {
         // has dumpd a bunch of stuff to AWT thread
-        JUnitUtil.releaseThread(this, 20);
+        JUnitUtil.waitFor(20);
 
         JUnitUtil.clearTurnoutThreads();
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/logix/SCWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/SCWarrantTest.java
@@ -88,7 +88,7 @@ public class SCWarrantTest extends WarrantTest {
             String m = warrant.getRunningMessage();
             return m.endsWith("IH1 showing appearance 16");
         }, "Train starts to move after 2nd command");
-        jmri.util.JUnitUtil.releaseThread(this, 100); // What should we specifically waitFor?
+        JUnitUtil.waitFor(100); // What should we specifically waitFor?
 
         // confirm one message logged
         //jmri.util.JUnitAppender.assertWarnMessage("Path NorthToWest in block North has length zero. Cannot run NXWarrants or ramp speeds through blocks with zero length.");
@@ -99,7 +99,7 @@ public class SCWarrantTest extends WarrantTest {
                 Assert.fail("Unexpected Exception: " + e);
             }
         });
-        jmri.util.JUnitUtil.releaseThread(this, 100); // What should we specifically waitFor?
+        JUnitUtil.waitFor(100); // What should we specifically waitFor?
 
         jmri.util.ThreadingUtil.runOnLayout(() -> {
             try {
@@ -108,7 +108,7 @@ public class SCWarrantTest extends WarrantTest {
                 Assert.fail("Unexpected Exception: " + e);
             }
         });
-        jmri.util.JUnitUtil.releaseThread(this, 100); // What should we specifically waitFor?
+        JUnitUtil.waitFor(100); // What should we specifically waitFor?
 
         jmri.util.ThreadingUtil.runOnLayout(() -> {
             try {
@@ -117,7 +117,7 @@ public class SCWarrantTest extends WarrantTest {
                 Assert.fail("Unexpected Exception: " + e);
             }
         });
-        jmri.util.JUnitUtil.releaseThread(this, 100); // What should we specifically waitFor?
+        JUnitUtil.waitFor(100); // What should we specifically waitFor?
 
         // wait for done
         jmri.util.JUnitUtil.waitFor(() -> {

--- a/java/test/jmri/jmrit/logix/WarrantTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantTest.java
@@ -194,7 +194,7 @@ public class WarrantTest {
             String m = warrant.getRunningMessage();
             return m.endsWith("Cmd #2.") || m.endsWith("Cmd #3.");
         }, "Train starts to move after 2nd command");
-        jmri.util.JUnitUtil.releaseThread(this, 100); // What should we specifically waitFor?
+        JUnitUtil.waitFor(100); // What should we specifically waitFor?
 
         jmri.util.ThreadingUtil.runOnLayout(() -> {
             try {
@@ -203,7 +203,7 @@ public class WarrantTest {
                 Assert.fail("Unexpected Exception: " + e);
             }
         });
-        jmri.util.JUnitUtil.releaseThread(this, 100); // What should we specifically waitFor?
+        JUnitUtil.waitFor(100); // What should we specifically waitFor?
 
         jmri.util.ThreadingUtil.runOnLayout(() -> {
             try {
@@ -212,7 +212,7 @@ public class WarrantTest {
                 Assert.fail("Unexpected Exception: " + e);
             }
         });
-        jmri.util.JUnitUtil.releaseThread(this, 100);
+        JUnitUtil.waitFor(100);
 
         // wait for done
         jmri.util.JUnitUtil.waitFor(() -> {

--- a/java/test/jmri/jmrix/dccpp/DCCppPacketizerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppPacketizerTest.java
@@ -58,7 +58,7 @@ public class DCCppPacketizerTest extends DCCppTrafficControllerTest {
         m.setTimeout(1);  // don't want to wait a long time
         c.sendDCCppMessage(m, null);
         log.debug("Message = {} length = {}", m.toString(), m.getNumDataElements());
-        JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY); // Allow time for other threads to send 4 characters
+        JUnitUtil.waitFor(JUnitUtil.WAITFOR_DEFAULT_DELAY); // Allow time for other threads to send 4 characters
         //Assert.assertEquals("total length ", 8, p.tostream.available());
         Assert.assertEquals("Char 0", '<', p.tostream.readByte() & 0xff);
         Assert.assertEquals("Char 1", 'T', p.tostream.readByte() & 0xff);
@@ -113,7 +113,7 @@ public class DCCppPacketizerTest extends DCCppTrafficControllerTest {
         // wait for reply (normally, done by callback; will check that later)
         int i = 0;
         while (l.rcvdRply == null && i++ < 100) {
-            JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY);
+            JUnitUtil.waitFor(JUnitUtil.WAITFOR_DEFAULT_DELAY);
         }
         if (log.isDebugEnabled()) {
             log.debug("past loop, i={} reply={}", i, l.rcvdRply);

--- a/java/test/jmri/jmrix/dccpp/DCCppPacketizerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppPacketizerTest.java
@@ -58,7 +58,7 @@ public class DCCppPacketizerTest extends DCCppTrafficControllerTest {
         m.setTimeout(1);  // don't want to wait a long time
         c.sendDCCppMessage(m, null);
         log.debug("Message = {} length = {}", m.toString(), m.getNumDataElements());
-        jmri.util.JUnitUtil.releaseThread(this); // Allow time for other threads to send 4 characters
+        JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY); // Allow time for other threads to send 4 characters
         //Assert.assertEquals("total length ", 8, p.tostream.available());
         Assert.assertEquals("Char 0", '<', p.tostream.readByte() & 0xff);
         Assert.assertEquals("Char 1", 'T', p.tostream.readByte() & 0xff);
@@ -113,7 +113,7 @@ public class DCCppPacketizerTest extends DCCppTrafficControllerTest {
         // wait for reply (normally, done by callback; will check that later)
         int i = 0;
         while (l.rcvdRply == null && i++ < 100) {
-            jmri.util.JUnitUtil.releaseThread(this);
+            JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY);
         }
         if (log.isDebugEnabled()) {
             log.debug("past loop, i={} reply={}", i, l.rcvdRply);
@@ -123,7 +123,7 @@ public class DCCppPacketizerTest extends DCCppTrafficControllerTest {
         }
         return i < 100;
     }
-    
+
     @Test
     @Override
     public void testPortReadyToSendNullController() {

--- a/java/test/jmri/jmrix/lenz/XNetPortControllerScaffold.java
+++ b/java/test/jmri/jmrix/lenz/XNetPortControllerScaffold.java
@@ -4,13 +4,16 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+
+import jmri.util.JUnitUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of XNetPortController that eases
  * checking whether data was forwarded or not.
- * 
+ *
  * @author Bob Jacobsen Copyright (C) 2006, 2015
  */
 public class XNetPortControllerScaffold extends XNetSimulatorPortController {
@@ -48,10 +51,10 @@ public class XNetPortControllerScaffold extends XNetSimulatorPortController {
 
     PipedInputStream otempIPipe;
     PipedOutputStream otempOPipe;
-    
+
     PipedInputStream itempIPipe;
     PipedOutputStream itempOPipe;
-    
+
     public XNetPortControllerScaffold() throws Exception {
         otempIPipe = new PipedInputStream(200);
         tostream = new DataInputStream(otempIPipe);
@@ -65,20 +68,20 @@ public class XNetPortControllerScaffold extends XNetSimulatorPortController {
     }
 
     public void flush() {
-        try { 
+        try {
             ostream.flush();
             otempOPipe.flush();
-        
+
             tistream.flush();
             itempOPipe.flush();
 
-            jmri.util.JUnitUtil.releaseThread(this);
+            JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY);
 
         } catch (Exception e) {
             log.error("Exception during flush", e);
         }
     }
-    
+
     /**
      * Returns the InputStream from the port.
      */

--- a/java/test/jmri/jmrix/lenz/XNetPortControllerScaffold.java
+++ b/java/test/jmri/jmrix/lenz/XNetPortControllerScaffold.java
@@ -75,7 +75,7 @@ public class XNetPortControllerScaffold extends XNetSimulatorPortController {
             tistream.flush();
             itempOPipe.flush();
 
-            JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY);
+            JUnitUtil.waitFor(JUnitUtil.WAITFOR_DEFAULT_DELAY);
 
         } catch (Exception e) {
             log.error("Exception during flush", e);

--- a/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
@@ -75,7 +75,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // now we're going to wait and verify the throttle eventually has
         // its status set to idle.
-        JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY);  // give the messages
+        JUnitUtil.waitFor(JUnitUtil.WAITFOR_DEFAULT_DELAY);  // give the messages
         // some time to process;
 
         jmri.util.JUnitAppender.assertErrorMessage("Unsupported Command Sent to command station");

--- a/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
@@ -75,7 +75,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // now we're going to wait and verify the throttle eventually has
         // its status set to idle.
-        jmri.util.JUnitUtil.releaseThread(this);  // give the messages
+        JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY);  // give the messages
         // some time to process;
 
         jmri.util.JUnitAppender.assertErrorMessage("Unsupported Command Sent to command station");

--- a/java/test/jmri/jmrix/lenz/xntcp/XnTcpPortControllerScaffold.java
+++ b/java/test/jmri/jmrix/lenz/xntcp/XnTcpPortControllerScaffold.java
@@ -4,13 +4,16 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+
+import jmri.util.JUnitUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of XnTcpAdapter that eases
  * checking whether data was forwarded or not
- * 
+ *
  * @author Bob Jacobsen Copyright (C) 2006, 2015
  */
 class XnTcpPortControllerScaffold extends XnTcpAdapter {
@@ -39,10 +42,10 @@ class XnTcpPortControllerScaffold extends XnTcpAdapter {
 
     PipedInputStream otempIPipe;
     PipedOutputStream otempOPipe;
-    
+
     PipedInputStream itempIPipe;
     PipedOutputStream itempOPipe;
-    
+
     protected XnTcpPortControllerScaffold() throws Exception {
         otempIPipe = new PipedInputStream(200);
         tostream = new DataInputStream(otempIPipe);
@@ -56,20 +59,20 @@ class XnTcpPortControllerScaffold extends XnTcpAdapter {
     }
 
     public void flush() {
-        try { 
+        try {
             ostream.flush();
             otempOPipe.flush();
-        
+
             tistream.flush();
             itempOPipe.flush();
 
-            jmri.util.JUnitUtil.releaseThread(this);
+            JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY);
 
         } catch (Exception e) {
             log.error("Exception during flush", e);
         }
     }
-    
+
     /**
      * Returns the InputStream from the port.
      */

--- a/java/test/jmri/jmrix/lenz/xntcp/XnTcpPortControllerScaffold.java
+++ b/java/test/jmri/jmrix/lenz/xntcp/XnTcpPortControllerScaffold.java
@@ -66,7 +66,7 @@ class XnTcpPortControllerScaffold extends XnTcpAdapter {
             tistream.flush();
             itempOPipe.flush();
 
-            JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY);
+            JUnitUtil.waitFor(JUnitUtil.WAITFOR_DEFAULT_DELAY);
 
         } catch (Exception e) {
             log.error("Exception during flush", e);

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -413,7 +413,7 @@ public class SlotManagerTest {
         log.debug("send CS check back");
         slotmanager.message(new LocoNetMessage(new int[]{0xBB, 0x7F, 0x00, 0x3B}));
         // not clear what to wait for here; status doesn't change
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         Assert.assertEquals("post-CS-check status", -999, status);
 
         // read received back (DCS240 sequence)
@@ -421,7 +421,7 @@ public class SlotManagerTest {
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
         Assert.assertEquals("no immediate reply", -999, status);
         // not clear what to wait for here; content doesn't change
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         log.debug("checking..");
         Assert.assertEquals("reply status", 0, status);
         Assert.assertEquals("reply value", -1, value);
@@ -500,7 +500,7 @@ public class SlotManagerTest {
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started short timer", startedShortTimer);
         Assert.assertFalse("didn't start long timer", startedLongTimer);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        JUnitUtil.waitFor(releaseTestDelay);  // wait for slow reply
         Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
         Assert.assertEquals("initial status", -999, status);
 
@@ -508,7 +508,7 @@ public class SlotManagerTest {
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
         Assert.assertEquals("no immediate reply", -999, status);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         Assert.assertEquals("initial status", -999, status);
 
         // check that SI write happened
@@ -527,14 +527,14 @@ public class SlotManagerTest {
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started short timer", startedShortTimer);
         Assert.assertFalse("didn't start long timer", startedLongTimer);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        JUnitUtil.waitFor(releaseTestDelay);  // wait for slow reply
         Assert.assertEquals("still two messages sent", 2, lnis.outbound.size());
 
         // completion received back (DCS240 sequence) to SI write
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x0F, 0x02, 0x7F, 0x7F, 0x4A}));
         Assert.assertEquals("no immediate reply", -999, status);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         Assert.assertEquals("initial status", -999, status);
 
         // check that final CV write happened
@@ -553,14 +553,14 @@ public class SlotManagerTest {
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started short timer", startedShortTimer);
         Assert.assertFalse("didn't start long timer", startedLongTimer);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        JUnitUtil.waitFor(releaseTestDelay);  // wait for slow reply
         Assert.assertEquals("three messages sent", 3, lnis.outbound.size());
 
         // completion received back (DCS240 sequence)
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x10, 0x00, 0x37, 0x7F, 0x7F, 0x4A}));
         Assert.assertEquals("no immediate reply", -999, status);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         log.debug("checking..");
         Assert.assertEquals("reply status", 0, status);
         Assert.assertEquals("reply value", -1, value);
@@ -610,11 +610,11 @@ public class SlotManagerTest {
         startedShortTimer = false;
         startedLongTimer = false;
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started short timer", startedShortTimer);
         Assert.assertFalse("didn't start long timer", startedLongTimer);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        JUnitUtil.waitFor(releaseTestDelay);  // wait for slow reply
         Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
         Assert.assertEquals("initial status", -999, status);
 
@@ -622,7 +622,7 @@ public class SlotManagerTest {
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
         Assert.assertEquals("no immediate reply", -999, status);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         Assert.assertEquals("initial status", -999, status);
 
         // check that SI write happened
@@ -640,11 +640,11 @@ public class SlotManagerTest {
         startedShortTimer = false;
         startedLongTimer = false;
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started short timer", startedShortTimer);
         Assert.assertFalse("didn't start long timer", startedLongTimer);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        JUnitUtil.waitFor(releaseTestDelay);  // wait for slow reply
 
         JUnitUtil.waitFor(() -> {
             return 2 == lnis.outbound.size();
@@ -654,7 +654,7 @@ public class SlotManagerTest {
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x0F, 0x02, 0x7F, 0x7F, 0x4A}));
         Assert.assertEquals("no immediate reply", -999, status);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         Assert.assertEquals("initial status", -999, status);
 
         // check that final CV write happened
@@ -669,18 +669,18 @@ public class SlotManagerTest {
         startedShortTimer = false;
         startedLongTimer = false;
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started long timer", startedLongTimer);
         Assert.assertFalse("didn't start short timer", startedShortTimer);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        JUnitUtil.waitFor(releaseTestDelay);  // wait for slow reply
         Assert.assertEquals("three messages sent", 3, lnis.outbound.size());
 
         // completion received back (DCS240 sequence)
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x10, 0x00, 0x37, 0x7F, 0x7F, 0x4A}));
         Assert.assertEquals("no immediate reply", -999, status);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         log.debug("checking..");
         Assert.assertEquals("reply status", 0, status);
         Assert.assertEquals("reply value", 55, value);
@@ -733,11 +733,11 @@ public class SlotManagerTest {
         startedShortTimer = false;
         startedLongTimer = false;
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x0, 0x24}));
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(releaseTestDelay);
         Assert.assertEquals("post-LACK status is fail", 4, status);
         Assert.assertFalse("didn't start short timer", startedShortTimer);
         Assert.assertFalse("didn't start long timer", startedLongTimer);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        JUnitUtil.waitFor(releaseTestDelay);  // wait for slow reply
         Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
 
         log.debug(".... end testReadThroughFacadeFail ...");

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -88,7 +88,7 @@ public class JUnitUtil {
      * <p>
      * Public in case modification is needed from a test or script.
      */
-    static final public int DEFAULT_RELEASETHREAD_DELAY = 50;
+    static final public int WAITFOR_DEFAULT_DELAY = 50;
 
     /**
      * Default standard time step (in mSec) when looping in a waitFor operation.

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -52,7 +52,7 @@ import org.netbeans.jemmy.operators.*;
  * Common utility methods for working with JUnit.
  * <p>
  * To release the current thread and allow other listeners to execute:  <code><pre>
- * JUnitUtil.releaseThread(this);
+ * JUnitUtil.waitFor(int time);
  * </pre></code> Note that this is not appropriate for Swing objects; you need
  * to use Jemmy for that.
  * <p>
@@ -82,6 +82,9 @@ public class JUnitUtil {
     /**
      * Standard time (in mSec) to wait when releasing
      * a thread during a test.
+     * <p>
+     * The method releaseThread() is removed but this constant is still used
+     * by some tests when calling waitFor(int time).
      * <p>
      * Public in case modification is needed from a test or script.
      */
@@ -422,51 +425,6 @@ public class JUnitUtil {
         // Optionally, check that the Swing queue is idle
         //new org.netbeans.jemmy.QueueTool().waitEmpty(250);
 
-    }
-
-    /**
-     * Release the current thread, allowing other threads to process. Waits for
-     * {@value #DEFAULT_RELEASETHREAD_DELAY} milliseconds.
-     * <p>
-     * This cannot be used on the Swing or AWT event threads. For those, please
-     * use Jemmy's wait routine.
-     * <p>
-     * The various waitFor(..) methods are much preferred to using this.
-     * They're faster and more reliable.  This is retained only for
-     * cases where there's nothing accessible to wait for.
-     *
-     * @param self currently ignored
-     */
-    public static void releaseThread(Object self) {
-        releaseThread(self, DEFAULT_RELEASETHREAD_DELAY);
-    }
-
-    /**
-     * Release the current thread, allowing other threads to process.
-     * <p>
-     * This cannot be used on the Swing or AWT event threads. For those, please
-     * use Jemmy's wait routine.
-     * <p>
-     * The various waitFor(..) methods are much preferred to using this.
-     * They're faster and more reliable.  This is retained only for
-     * cases where there's nothing accessible to wait for.
-     *
-     * @param self  currently ignored
-     * @param delay milliseconds to wait
-     */
-    public static void releaseThread(Object self, int delay) {
-        if (javax.swing.SwingUtilities.isEventDispatchThread()) {
-            log.error("Cannot use releaseThread on Swing thread", new Exception());
-            return;
-        }
-        try {
-            int priority = Thread.currentThread().getPriority();
-            Thread.currentThread().setPriority(Thread.MIN_PRIORITY);
-            Thread.sleep(delay);
-            Thread.currentThread().setPriority(priority);
-        } catch (InterruptedException e) {
-            Assert.fail("failed due to InterruptedException");
-        }
     }
 
     /**

--- a/java/test/jmri/util/exceptionhandler/UncaughtExceptionHandlerTest.java
+++ b/java/test/jmri/util/exceptionhandler/UncaughtExceptionHandlerTest.java
@@ -1,6 +1,7 @@
 package jmri.util.exceptionhandler;
 
 import jmri.util.JUnitAppender;
+import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
 
@@ -25,7 +26,7 @@ public class UncaughtExceptionHandlerTest {
         });
         t.setName("Uncaught Exception Handler Test Thread");
         t.start();
-        jmri.util.JUnitUtil.releaseThread(this);
+        JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY);
         JUnitAppender.assertErrorMessage("Uncaught Exception caught by jmri.util.exceptionhandler.UncaughtExceptionHandler");
     }
 

--- a/java/test/jmri/util/exceptionhandler/UncaughtExceptionHandlerTest.java
+++ b/java/test/jmri/util/exceptionhandler/UncaughtExceptionHandlerTest.java
@@ -26,7 +26,7 @@ public class UncaughtExceptionHandlerTest {
         });
         t.setName("Uncaught Exception Handler Test Thread");
         t.start();
-        JUnitUtil.waitFor(JUnitUtil.DEFAULT_RELEASETHREAD_DELAY);
+        JUnitUtil.waitFor(JUnitUtil.WAITFOR_DEFAULT_DELAY);
         JUnitAppender.assertErrorMessage("Uncaught Exception caught by jmri.util.exceptionhandler.UncaughtExceptionHandler");
     }
 


### PR DESCRIPTION
@bobjacobsen 
I noticed in the Javadoc for `releaseThread()` that `The various waitFor(..) methods are much preferred to using this`. Also the name `waitFor(time)` explains much better what it does in comparision to `releaseThread()`.

So this PR removes `releaseThread()` and replaces all the calls to it to `waitFor(time)`. I wasn't sure if I could remove it or should have deprecated it, but if I remember correctly, we decided to remove deprecated methods in 4.99.x?

I'm not sure what to do with `JUnitUtil.DEFAULT_RELEASETHREAD_DELAY`. There are a `JUnitUtil.WAITFOR_MAX_DELAY` but it's 10000 ms instead of 50 ms. But I'm happy to rename `DEFAULT_RELEASETHREAD_DELAY` if there is a better name for it.

----

An unrelated issue:

There are some labels I think can be removed. What do you think about these?
* `From SourceForge` - Is this useful now?
* `java 11`

The label `Future Java` should have a better comment. Maybe `Item needed for Java 17+ compatibility`