### PR TITLE
TamValleyDepot QuadLN_S decoder update

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -45,14 +45,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="target/generated-sources/annotations">
-		<attributes>
-			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="m2e-apt" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="java/template">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
@@ -65,12 +57,14 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
 			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="m2e-apt" value="true"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -291,7 +291,12 @@
 		<li>TSU Genesis Steam - N Challenger add CV and change some default value per user request</li>
             </ul>
 
-        <h4>TAMS</h4>
+        <h4>Tam Valley Depot</h4>
+            <ul>
+                <li>QuadLN_S - added support for new firmware version 3.1 features</li>
+            </ul>
+            
+       <h4>TAMS</h4>
             <ul>
                 <li></li>
             </ul>

--- a/xml/decoders/TamValleyDepot_QuadLn_S_11.xml
+++ b/xml/decoders/TamValleyDepot_QuadLn_S_11.xml
@@ -11,7 +11,7 @@
 <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
-<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" showEmptyPanes="no">
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd" showEmptyPanes="no">
    <version author="robin@n3ix.com" version="3.01.3" lastUpdated="20220328"/>
    <decoder>
         <family name="Quad-LN_S" mfg="Tam Valley Depot" type="stationary" comment="The Quad-LN_S is programmed in OPs mode except for the device address.">

--- a/xml/decoders/TamValleyDepot_QuadLn_S_11.xml
+++ b/xml/decoders/TamValleyDepot_QuadLn_S_11.xml
@@ -12,7 +12,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" showEmptyPanes="no">
-   <version author="robin@n3ix.com" version="3.00.1" lastUpdated="20200902"/>
+   <version author="robin@n3ix.com" version="3.01.3" lastUpdated="20220328"/>
    <decoder>
         <family name="Quad-LN_S" mfg="Tam Valley Depot" type="stationary" comment="The Quad-LN_S is programmed in OPs mode except for the device address.">
             <model model="Quad-LN_S_v1" comment="4 or 8 Servo Driver with Signaling and Detection options" lowVersionID="6"/>
@@ -23,155 +23,6 @@
         </programming>
       
         <variables>
-            <variable item="Expansion" CV="11" mask="XXXXXXVV" default="0">
-                <enumVal>
-                    <enumChoice choice="Relay"/>
-                    <enumChoice choice="Signaling"/>
-                    <enumChoice choice="Servo"/>
-                </enumVal>
-            </variable>
-            <variable item="ServoExp" CV="11" mask="XXXXXXVX" default="0">
-                <decVal/>
-             </variable>
-         
-            <variable item="IO Mode" CV="11" mask="XXVVXXXX" default="0" include="Quad-LN_S_v3">
-                <enumVal>
-                    <enumChoice choice="Both IO"/>
-                    <enumChoice choice="Main IO, Aux Servo"/>
-                    <enumChoice choice="Both Servo" value="3"/>
-                </enumVal>
-            </variable>
-            <variable item="ServoMain" CV="11" mask="XXVXXXXX" default="0" include="Quad-LN_S_v3">
-                <decVal/>
-            </variable>
-            <variable item="ServoAux" CV="11" mask="XXXVXXXX" default="0" include="Quad-LN_S_v3">
-                <decVal/>
-            </variable>
-            <variable item="Servo16" CV="11" mask="XXVVXXVX" default="0" include="Quad-LN_S_v3">
-                <decVal/>
-            </variable>
-            <variable item="Send Output Off" CV="11" mask="XXXVXXXX" default="1" exclude="Quad-LN_S_v3">
-                <enumVal>
-                    <enumChoice choice="Disable"/>
-                    <enumChoice choice="Enable"/>
-                </enumVal>
-            </variable>
-            <variable item="Local Actions" CV="11" mask="XXVXXXXX" default="1" exclude="Quad-LN_S_v3">
-                <enumVal>
-                    <enumChoice choice="Perform Internally"/>
-                    <enumChoice choice="Visible on Loconet"/>
-                </enumVal>
-            </variable>
-             <variable item="IO Mode" CV="11" mask="XXXXXXXX" default="0" exclude="Quad-LN_S_v3">
-                <enumVal>
-                    <enumChoice choice="Both IO"/>
-                </enumVal>
-            </variable>
-           <variable item="ServoMain" CV="11" mask="XXXXXXXX" default="0" exclude="Quad-LN_S_v3">
-                <decVal/>
-            </variable>
-            <variable item="ServoAux" CV="11" mask="XXXXXXXX" default="0" exclude="Quad-LN_S_v3">
-                <decVal/>
-            </variable>
-            <variable item="Servo16" CV="11" mask="XXXXXXVX" default="0" exclude="Quad-LN_S_v3">
-                <decVal/>
-            </variable>
-         
-            <variable item="Signaling" CV="11" mask="XXXXXXXV" default="0">
-                <decVal/>
-            </variable>
-            <variable item="Servo State Memory" CV="11" mask="XXXXXVXX" default="1">
-                <enumVal>
-                    <enumChoice choice="Disable"/>
-                    <enumChoice choice="Enable"/>
-                </enumVal>
-            </variable>
-            <variable item="Signal State Memory" CV="11" mask="XXXXVXXX" default="0">
-                <qualifier>
-                    <variableref>Signaling</variableref>
-                    <relation>eq</relation>
-                    <value>1</value>
-                </qualifier>
-                <enumVal>
-                    <enumChoice choice="Disable"/>
-                    <enumChoice choice="Enable"/>
-                </enumVal>
-            </variable>
-            <variable item="Lock Indicator" CV="11" mask="XVXXXXXX" default="0">
-                <enumVal>
-                    <enumChoice choice="Blink when Locked"/>
-                    <enumChoice choice="Blink when Unlocked"/>
-                </enumVal>
-            </variable>
-            <variable item="DCC Busy Retry" CV="11" mask="VXXXXXXX" default="1">
-                <enumVal>
-                    <enumChoice choice="Disable"/>
-                    <enumChoice choice="Enable"/>
-                </enumVal>
-            </variable>
-
-            <variable item="Sensor Input Polarity" CV="12" mask="XXXXXXXV" default="0">
-                <enumVal>
-                    <enumChoice choice="Normal"/>
-                    <enumChoice choice="Inverted"/>
-                </enumVal>
-            </variable>
-            <variable item="Servo Drive" CV="12" mask="XXXXXXVX" default="0">
-                <qualifier>
-                    <variableref>Servo16</variableref>
-                    <relation>le</relation>
-                    <value>8</value>
-                </qualifier>
-                <enumVal>
-                    <enumChoice choice="Always On"/>
-                    <enumChoice choice="Off when Stopped"/>
-                </enumVal>
-            </variable>
-            <variable item="No CS" CV="12" mask="XXXXXVXX" default="0">
-                <enumVal>
-                    <enumChoice choice="Disable"/>
-                    <enumChoice choice="Enable"/>
-                </enumVal>
-            </variable>
-            <variable item="Local Actions" CV="12" mask="XXXXVXXX" default="1" include="Quad-LN_S_v3">
-                <enumVal>
-                    <enumChoice choice="Perform Internally"/>
-                    <enumChoice choice="Visible on Loconet"/>
-                </enumVal>
-            </variable>
-            <variable item="Route Delay" CV="12" mask="XXVVXXXX" default="0">
-                <enumVal>
-                    <enumChoice choice="1 Sec"/>
-                    <enumChoice choice="2 Sec"/>
-                    <enumChoice choice="4 Sec"/>
-                    <enumChoice choice="8 Sec"/>
-                </enumVal>
-            </variable>
-            <variable item="Disable Interrogate" CV="12" mask="XVXXXXXX" default="0">
-                <enumVal>
-                    <enumChoice choice="Normal"/>
-                    <enumChoice choice="Disable"/>
-                </enumVal>
-            </variable>
-            <variable item="Switch State Request" CV="12" mask="VXXXXXXX" default="0">
-                <enumVal>
-                    <enumChoice choice="Ignore"/>
-                    <enumChoice choice="Respond"/>
-                </enumVal>
-            </variable>
-
-            <variable item="Long Address" CV="17" default="11000" comment="Range 1-16383">
-                <longAddressVal/>
-            </variable>
-
-            <variable item="Lock Start Address" CV="13" mask="VVVVVVVV" default="100">
-                <splitVal highCV="14" upperMask="XXXXXVVV" offset="1" /> 
-            </variable>
-
-            <variable item="Servo Start Address" CV="2" mask="VVVVVVVV" default="0">
-                <splitVal highCV="3" upperMask="XXXXXVVV" offset="1" />
-            </variable>
-
             <variable item="Major Version" CV="4" mask="VVVVXXXX" readOnly="no" default="1">
                 <decVal/>
             </variable>
@@ -191,22 +42,198 @@
                 <decVal/>
             </variable>
 
-            <variable item="Main IO Start Address" CV="9" mask="VVVVVVVV" default="0">
+            <variable item="Expansion" CV="11" mask="XXXXXXVV" default="0">
+                <enumVal>
+                    <enumChoice choice="Relay"/>
+                    <enumChoice choice="Signaling"/>
+                    <enumChoice choice="Servo" include="Quad-LN_S_v1" />
+                    <enumChoice choice="Turnout" include="Quad-LN_S_v3" />
+                </enumVal>
+            </variable>
+            <variable item="ServoExp" CV="11" mask="XXXXXXVX" default="0">
+                <decVal/>
+             </variable>
+         
+            <variable item="IO Mode" CV="11" mask="XXVVXXXX" default="0" include="Quad-LN_S_v3">
+                <enumVal>
+                    <enumChoice choice="Both IO"/>
+                    <enumChoice choice="Main IO, Aux Servo" include="Quad-LN_S_v1" />
+                    <enumChoice choice="Main IO, Aux Turnout" include="Quad-LN_S_v3" />
+                    <enumChoice choice="Both Servo" value="3" include="Quad-LN_S_v1" />
+                    <enumChoice choice="Both Turnout" value="3" include="Quad-LN_S_v3" />
+                </enumVal>
+            </variable>
+            <variable item="ServoMain" CV="11" mask="XXVXXXXX" default="0" include="Quad-LN_S_v3">
+                <decVal/>
+            </variable>
+            <variable item="ServoAux" CV="11" mask="XXXVXXXX" default="0" include="Quad-LN_S_v3">
+                <decVal/>
+            </variable>
+            <variable item="ServoMain" CV="11" mask="XXXXXXXX" default="0" include="Quad-LN_S_v1">
+                <decVal/>
+            </variable>
+            <variable item="ServoAux" CV="11" mask="XXXXXXXX" default="0" include="Quad-LN_S_v1">
+                <decVal/>
+            </variable>
+            <variable item="Servo16" CV="11" mask="XXVVXXVX" default="0" include="Quad-LN_S_v3">
+                <decVal/>
+            </variable>
+            <variable item="Servo16" CV="11" mask="XXXXXXVX" default="0" include="Quad-LN_S_v1">
+                <decVal/>
+            </variable>
+            <variable item="Send Output Off" CV="11" mask="XXXVXXXX" default="1" exclude="Quad-LN_S_v3">
+                <enumVal>
+                    <enumChoice choice="Disable"/>
+                    <enumChoice choice="Enable"/>
+                </enumVal>
+            </variable>
+            <variable item="Local Actions" CV="11" mask="XXVXXXXX" default="1" exclude="Quad-LN_S_v3">
+                <enumVal>
+                    <enumChoice choice="Perform Internally"/>
+                    <enumChoice choice="Visible on Loconet"/>
+                </enumVal>
+            </variable>
+             <variable item="IO Mode" CV="11" mask="XXXXXXXX" default="0" exclude="Quad-LN_S_v3">
+                <enumVal>
+                    <enumChoice choice="Both IO"/>
+                </enumVal>
+            </variable>
+         
+            <variable item="Signaling" CV="11" mask="XXXXXXXV" default="0">
+                <decVal/>
+            </variable>
+            <variable item="Servo State Memory" CV="11" mask="XXXXXVXX" default="1" include="Quad-LN_S_v1">
+                <enumVal>
+                    <enumChoice choice="Disable"/>
+                    <enumChoice choice="Enable"/>
+                </enumVal>
+            </variable>
+            <variable item="Turnout State Memory" CV="11" mask="XXXXXVXX" default="1" include="Quad-LN_S_v3">
+                <enumVal>
+                    <enumChoice choice="Disable"/>
+                    <enumChoice choice="Enable"/>
+                </enumVal>
+            </variable>
+            <variable item="Signal State Memory" CV="11" mask="XXXXVXXX" default="0">
+                <qualifier>
+                    <variableref>Signaling</variableref>
+                    <relation>eq</relation>
+                    <value>1</value>
+                </qualifier>
+                <enumVal>
+                    <enumChoice choice="Disable"/>
+                    <enumChoice choice="Enable"/>
+                </enumVal>
+            </variable>
+            <variables>
+                <qualifier>
+                    <variableref>Servo16</variableref>
+                    <relation>lt</relation>
+                    <value>24</value>
+                </qualifier>
+                <variable item="Lock Indicator" CV="11" mask="XVXXXXXX" default="0">
+                   <enumVal>
+                        <enumChoice choice="Blink when Locked"/>
+                        <enumChoice choice="Blink when Unlocked"/>
+                    </enumVal>
+                </variable>
+                <variable item="Sensor Input Polarity" CV="12" mask="XXXXXXXV" default="0">
+                   <enumVal>
+                        <enumChoice choice="Normal"/>
+                        <enumChoice choice="Inverted"/>
+                    </enumVal>
+                </variable>
+                <variable item="Local Actions" CV="12" mask="XXXXVXXX" default="1" include="Quad-LN_S_v3">
+                    <enumVal>
+                        <enumChoice choice="Perform Internally"/>
+                        <enumChoice choice="Visible on Loconet"/>
+                    </enumVal>
+                </variable>
+            </variables>
+            <variable item="DCC Busy Retry" CV="11" mask="VXXXXXXX" default="1">
+                <enumVal>
+                    <enumChoice choice="Disable"/>
+                    <enumChoice choice="Enable"/>
+                </enumVal>
+            </variable>
+            <variables>
+                <qualifier>
+                    <variableref>Minor Version</variableref>
+                    <relation>ge</relation>
+                    <value>1</value>
+                </qualifier>
+                <variable item="Lock Scope" CV="12" mask="XXXXXXVX" default="0" include="Quad-LN_S_v3">
+                    <enumVal>
+                        <enumChoice choice="Local IO Only"/>
+                        <enumChoice choice="Local and LocoNet"/>
+                    </enumVal>
+                </variable>
+                <variable item="CV7 Interrogate" CV="12" mask="VXXXXXXX" default="0" include="Quad-LN_S_v3">
+                    <enumVal>
+                        <enumChoice choice="Ignore"/>
+                        <enumChoice choice="Respond"/>
+                    </enumVal>
+                </variable>
+            </variables>
+            <variable item="Servo Drive" CV="12" mask="XXXXXXVX" default="0" include="Quad-LN_S_v1">
+                <enumVal>
+                    <enumChoice choice="Always On"/>
+                    <enumChoice choice="Off when Stopped"/>
+                </enumVal>
+            </variable>
+
+            <variable item="No CS" CV="12" mask="XXXXXVXX" default="0">
+                <enumVal>
+                    <enumChoice choice="Disable"/>
+                    <enumChoice choice="Enable"/>
+                </enumVal>
+            </variable>
+            <variable item="Route Delay" CV="12" mask="XXVVXXXX" default="0">
+                <enumVal>
+                    <enumChoice choice="1 Sec"/>
+                    <enumChoice choice="2 Sec"/>
+                    <enumChoice choice="4 Sec"/>
+                    <enumChoice choice="8 Sec"/>
+                </enumVal>
+            </variable>
+            <variable item="Disable Interrogate" CV="12" mask="XVXXXXXX" default="0">
+                <enumVal>
+                    <enumChoice choice="Normal"/>
+                    <enumChoice choice="Disable"/>
+                </enumVal>
+            </variable>
+
+            <variable item="Long Address" CV="17" default="11000" comment="Range 1-16383">
+                <longAddressVal/>
+            </variable>
+
+            <variable item="Lock Start Address" CV="13,14" mask="VVVVVVVV XXXXXVVV" default="100">
+                <splitVal offset="1" /> 
+            </variable>
+
+            <variable item="Servo Start Address" CV="2,3" mask="VVVVVVVV XXXXXVVV" default="0" include="Quad-LN_S_v1">
+                <splitVal offset="1" />
+            </variable>
+            <variable item="Turnout Start Address" CV="2,3" mask="VVVVVVVV XXXXXVVV" default="0" include="Quad-LN_S_v3">
+                <splitVal offset="1" />
+            </variable>
+
+            <variable item="Main IO Start Address" CV="9,10" mask="VVVVVVVV XXXXVVVV" default="0">
                 <qualifier>
                     <variableref>ServoMain</variableref>
                     <relation>eq</relation>
                     <value>0</value>
                 </qualifier>
-                <splitVal highCV="10" upperMask="XXXXVVVV" offset="1" /> 
+                <splitVal offset="1" /> 
             </variable>
 
-            <variable item="Aux IO Start Address" CV="15" mask="VVVVVVVV" default="4">
+            <variable item="Aux IO Start Address" CV="15,16" mask="VVVVVVVV XXXXVVVV" default="4">
                 <qualifier>
                     <variableref>ServoAux</variableref>
                     <relation>eq</relation>
                     <value>0</value>
                 </qualifier>
-                <splitVal highCV="16" upperMask="XXXXVVVV" offset="1" /> 
+                <splitVal offset="1" /> 
             </variable>
             
             <variable item="One Choice Enum" CV="1" mask="XXXXXXXX">
@@ -243,6 +270,9 @@
                     <label label=" "/>
                     <display item="Servo Start Address" tooltip="Address of first servo: 1-2045. Recommend not using 1017-1020 for any servo.">
                         <label>Servo Start Address</label>
+                    </display>
+                    <display item="Turnout Start Address" tooltip="Address of first turnout: 1-2045. Recommend not using 1017-1020 for any turnout.">
+                        <label>Turnout Start Address</label>
                     </display>
                     <display item="Lock Start Address" tooltip="Address of first lock: 1-2045. Recommend not using 1017-1020 for any lock.">
                         <label>Lock Start Address</label>
@@ -290,6 +320,9 @@
                     <display item="Servo State Memory" format="checkbox" tooltip="Retain servo states when powered down">
                         <label>Servo State Memory</label>
                     </display>
+                    <display item="Turnout State Memory" format="checkbox" tooltip="Retain turnout states when powered down">
+                        <label>Turnout State Memory</label>
+                    </display>
                     <display item="Signal State Memory" format="checkbox" tooltip="Retain signal states when powered down">
                         <label>Signal State Memory</label>
                     </display>
@@ -308,14 +341,17 @@
                     <display item="Lock Indicator" format="checkbox" tooltip="LED blink indicates Unlock state rather than Lock state">
                         <label>Blink indicates Unlock</label>
                     </display>
+                    <display item="Lock Scope" format="checkbox" tooltip="Disable LocoNet turnout command when Locked">
+                        <label>Lock Disables LocoNet Control</label>
+                    </display>
                     <display item="Local Actions" format="checkbox" tooltip="Provide visibililty on Loconet for local actions">
                         <label>Broadcast Local Actions</label>
                     </display>
-                    <display item="Switch State Request" format="checkbox" tooltip="Respond to Switch State request with servo, lock and sensor states">
-                        <label>Switch State Request</label>
-                    </display>
                     <display item="Disable Interrogate" format="checkbox" tooltip="Ignore Stationary Decoder Interrogation messages">
-                        <label>Disable Interrogate</label>
+                        <label>Disable Statonary Interrogate</label>
+                    </display>
+                    <display item="CV7 Interrogate" format="checkbox" tooltip="Treat a write to CV7 as an Interrogate">
+                        <label>Enable CV7 Interrogate</label>
                     </display>
                     <label label=" "/>
                 </column>
@@ -411,10 +447,10 @@
                     </group>
                     <label label=" "/>
                     <label>
-                        <text>Decoder Template File Version: 3.00.1</text>
+                        <text>Decoder Template File Version: 3.01.3</text>
                     </label>
                     <label>
-                        <text>Decoder Transform File Version: x.xx</text>
+                        <text>Decoder Transform File Version: x.xx.x</text>
                     </label>
                 </column>
             </row>

--- a/xml/decoders/TamValleyDepot_QuadLn_S_11.xsl
+++ b/xml/decoders/TamValleyDepot_QuadLn_S_11.xsl
@@ -7,7 +7,7 @@
 <xsl:output method="xml" encoding="utf-8"/>
 
 <!-- for QUAD-LN_S -->
-<!-- v3.01  -->
+<!-- v3.01.3  -->
 
 <!--  Variables ............................................................................. -->
 <!--                  ............................................................................ -->
@@ -62,8 +62,8 @@
         <xi:include href="http://jmri.org/xml/decoders/tvd/AspectMode.xml"/>
     </variable>
 
-    <variable item="Aspect{$index} Addr" CV="{$CV3}" mask="VVVVVVVV" default="0">
-        <splitVal highCV="{$CV3 +1}" upperMask="XXXXXVVV" offset="1" />
+    <variable item="Aspect{$index} Addr" CV="{$CV3},{$CV3 +1}" mask="VVVVVVVV XXXXXVVV" default="0">
+        <splitVal offset="1" />
     </variable>
     <variables>
         <qualifier>
@@ -200,22 +200,108 @@
     <xsl:param name="CV5"/>
     <xsl:param name="index"/>
     
-    <variable item="Servo{$index} Addr" CV="2" mask="VVVVVVVV" default="0">
-        <splitVal highCV="3" upperMask="XXXXXVVV" offset="{$index}" /> 
+    <variable item="Servo{$index} Addr" CV="2,3" mask="VVVVVVVV XXXXXVVV" default="0">
+        <splitVal offset="{$index}" /> 
     </variable>
-    <variable item="Lock{$index} Addr" CV="13" mask="VVVVVVVV" default="100">
-        <splitVal highCV="14" upperMask="XXXXXVVV" offset="{$index}" />
+    <variable item="Lock{$index} Addr" CV="13,14" mask="VVVVVVVV XXXXXVVV" default="100">
+        <splitVal offset="{$index}" />
     </variable>
 
-    <variable item="Servo{$index} RapidStart" CV="{$CV1}" mask="VVXXXXXX" default="0">
+    <variable item="Servo{$index} RapidStart" CV="{$CV1}" mask="VVXXXXXX" default="0" include="Quad-LN_S_v1">
         <xi:include href="http://jmri.org/xml/decoders/tvd/RapidStart.xml"/>
     </variable>
-    <variable item="Servo{$index} Speed" CV="{$CV1}" mask="XXVVVVVV" default="4">
-        <decVal/>
+    <variable item="Servo{$index} DriveType" CV="{$CV1}" mask="VXXXXXXX" default="0" include="Quad-LN_S_v3">
+        <xi:include href="http://jmri.org/xml/decoders/tvd/DriveType.xml"/>
     </variable>
+    <variable item="Servo{$index} DriveType" CV="{$CV1}" mask="XXXXXXXX" default="0" include="Quad-LN_S_v1">
+        <enumVal xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+            <enumChoice choice="Servo"/>
+        </enumVal>
+    </variable>
+    <variables>
+        <qualifier>
+            <variableref>Servo<xsl:value-of select="$index"/> DriveType</variableref>
+            <relation>eq</relation>
+            <value>0</value>
+        </qualifier>
+        <variable item="One Choice Enum Servo{$index} Qual" CV="1" mask="XXXXXXXX">
+            <enumVal>
+                <enumChoice choice="" />
+            </enumVal>
+        </variable>
+        <variable item="Servo{$index} JumpStart" CV="{$CV1}" mask="XVXXXXXX" default="0" include="Quad-LN_S_v3">
+            <xi:include href="http://jmri.org/xml/decoders/tvd/JumpStart.xml"/>
+        </variable>
+        <variable item="Servo{$index} JumpStart" CV="{$CV1}" mask="XXXXXXXX" default="0" include="Quad-LN_S_v1">
+            <enumVal xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+                <enumChoice choice="Use Speed Setting"/>
+            </enumVal>
+        </variable>
+        <variables>
+            <qualifier>
+                <variableref>Servo<xsl:value-of select="$index"/> JumpStart</variableref>
+                <relation>eq</relation>
+                <value>0</value>
+            </qualifier>
+            <variable item="Servo{$index} Speed" CV="{$CV1}" mask="XXVVVVVV" default="4">
+                <decVal/>
+            </variable>
+        </variables>
+        <variable item="Servo{$index} DriveOff" CV="{$CV2}" mask="VXXXXXXX" default="0" include="Quad-LN_S_v3">
+            <xi:include href="http://jmri.org/xml/decoders/tvd/DriveOff.xml"/>
+        </variable>
 
-    <variable item="Servo{$index} Closed" CV="{$CV3}" default="1260" comment="range 0-2400">
-        <splitVal highCV="{$CV3 +1}" upperMask="XXXXVVVV"/>
+        <variable item="Servo{$index} Closed" CV="{$CV3},{$CV3 +1}" mask="VVVVVVVV XXXXVVVV" default="1260" comment="range 0-2400">
+            <splitVal/>
+        </variable>
+        <variable item="Servo{$index} Directional Speed" CV="{$CV3 +1}" mask="VXXXXXXX" default="0">
+            <xi:include href="http://jmri.org/xml/decoders/tvd/DirectionalSpeed.xml"/>
+        </variable>
+        <variable item="Servo{$index} Thrown" CV="{$CV4},{$CV4 +1}" mask="VVVVVVVV XXXXVVVV" default="1140" comment="range 0-2400">
+            <splitVal/>
+        </variable>
+        <variables>
+            <qualifier>
+                <variableref>Servo<xsl:value-of select="$index"/> Directional Speed</variableref>
+                <relation>eq</relation>
+                <value>1</value>
+            </qualifier>
+             <variable item="Servo{$index} Thrown RapidStart" CV="{$CV2}" mask="VVXXXXXX" default="0" include="Quad-LN_S_v1">
+                <xi:include href="http://jmri.org/xml/decoders/tvd/RapidStart.xml"/>
+            </variable>
+            <variable item="Servo{$index} Thrown JumpStart" CV="{$CV2}" mask="XVXXXXXX" default="0" include="Quad-LN_S_v3">
+                <xi:include href="http://jmri.org/xml/decoders/tvd/JumpStart.xml"/>
+            </variable>
+            <variable item="Servo{$index} Thrown JumpStart" CV="{$CV2}" mask="XXXXXXXX" default="0" include="Quad-LN_S_v1">
+                <enumVal xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+                    <enumChoice choice="Use Speed Setting"/>
+                </enumVal>
+            </variable>
+            <variables>
+                <qualifier>
+                    <variableref>Servo<xsl:value-of select="$index"/> Thrown JumpStart</variableref>
+                    <relation>eq</relation>
+                    <value>0</value>
+                </qualifier>
+                <variable item="Servo{$index} Thrown Speed" CV="{$CV2}" mask="XXVVVVVV" default="4">
+                    <decVal/>
+                </variable>
+            </variables>
+        </variables>
+    </variables>
+    <variables>
+        <qualifier>
+            <variableref>Servo<xsl:value-of select="$index"/> DriveType</variableref>
+            <relation>gt</relation>
+            <value>0</value>
+        </qualifier>
+        <variable item="Servo{$index} SwitchPoint" CV="{$CV3+1}" mask="VXXXXXXX" default="0" include="Quad-LN_S_v3">
+            <xi:include href="http://jmri.org/xml/decoders/tvd/SwitchPoint.xml"/>
+        </variable>
+    </variables>
+        
+    <variable item="Servo{$index} Dodeca Action" CV="{$CV4 +1}" mask="VVVVXXXX" default="0">
+       <xi:include href="http://jmri.org/xml/decoders/tvd/InputAction.xml"/>
     </variable>
     <variable item="Servo{$index} Output Message" CV="{$CV3 +1}" mask="XXXVXXXX" default="0">
         <xi:include href="http://jmri.org/xml/decoders/tvd/ServoMessage.xml"/>
@@ -223,33 +309,9 @@
     <variable item="Servo{$index} Lock" CV="{$CV3 +1}" mask="XVVXXXXX" default="0">
         <xi:include href="http://jmri.org/xml/decoders/tvd/ServoLock.xml"/>
     </variable>
-    <variable item="Servo{$index} Directional Speed" CV="{$CV3 +1}" mask="VXXXXXXX" default="0">
-        <xi:include href="http://jmri.org/xml/decoders/tvd/DirectionalSpeed.xml"/>
-    </variable>
 
-    <variables>
-        <qualifier>
-            <variableref>Servo<xsl:value-of select="$index"/> Directional Speed</variableref>
-            <relation>eq</relation>
-            <value>1</value>
-        </qualifier>
-        <variable item="Servo{$index} Thrown RapidStart" CV="{$CV2}" mask="VVXXXXXX" default="0">
-            <xi:include href="http://jmri.org/xml/decoders/tvd/RapidStart.xml"/>
-        </variable>
-        <variable item="Servo{$index} Thrown Speed" CV="{$CV2}" mask="XXVVVVVV" default="4">
-            <decVal/>
-        </variable>
-    </variables>
-
-    <variable item="Servo{$index} Thrown" CV="{$CV4}" default="1140" comment="range 0-2400">
-        <splitVal highCV="{$CV4 +1}" upperMask="XXXXVVVV"/>
-    </variable>
-    <variable item="Servo{$index} Dodeca Action" CV="{$CV4 +1}" mask="VVVVXXXX" default="0">
-       <xi:include href="http://jmri.org/xml/decoders/tvd/InputAction.xml"/>
-    </variable>
-
-    <variable item="Servo{$index} Cascade Turnout" CV="{$CV5}" default="0">
-        <splitVal highCV="{$CV5 +1}" upperMask="XXXXXVVV" offset="1" />
+    <variable item="Servo{$index} Cascade Turnout" CV="{$CV5},{$CV5 +1}" mask="VVVVVVVV XXXXXVVV" default="0">
+        <splitVal offset="1" />
     </variable>
     <variable item="Servo{$index} Cascade Trigger" CV="{$CV5 +1}" mask="VVXXXXXX" default="0">
         <xi:include href="http://jmri.org/xml/decoders/tvd/CascadeTrigger.xml"/>
@@ -329,11 +391,11 @@
     <xsl:param name="CV7"/>
     <xsl:param name="index"/>
     
-    <variable item="Main IO{$Offset} Addr" CV="9" mask="VVVVVVVV" default="0">
-        <splitVal highCV="10" upperMask="XXXXVVVV" offset="{$Offset}" /> 
+    <variable item="Main IO{$Offset} Addr" CV="9,10" mask="VVVVVVVV XXXXVVVV" default="0">
+        <splitVal offset="{$Offset}" /> 
    </variable>
-    <variable item="Aux IO{$Offset} Addr" CV="15" mask="VVVVVVVV" default="4">
-        <splitVal highCV="16" upperMask="XXXXVVVV" offset="{$Offset}" /> 
+    <variable item="Aux IO{$Offset} Addr" CV="15,16" mask="VVVVVVVV XXXXVVVV" default="4">
+        <splitVal offset="{$Offset}" /> 
     </variable>
 
 <!-- Aux IO .................................................................. -->
@@ -368,8 +430,8 @@
         <xi:include href="http://jmri.org/xml/decoders/tvd/LedSense.xml"/>
     </variable>
 
-    <variable item="GPIO{$index} Msg2 Addr" CV="{$CV4}" default="0">
-        <splitVal highCV="{$CV4 +1}" upperMask="XXXXVVVV" offset="1" />
+    <variable item="GPIO{$index} Msg2 Addr" CV="{$CV4},{$CV4 +1}" mask="VVVVVVVV XXXXVVVV" default="0">
+        <splitVal offset="1" />
     </variable>
     <variable item="GPIO{$index} Msg2 Condition" CV="{$CV4 +1}" mask="XXVVXXXX" default="0">
         <xi:include href="http://jmri.org/xml/decoders/tvd/InputMessageCondition.xml"/>
@@ -466,8 +528,8 @@
         </enumVal>
     </variable>
 
-    <variable item="GPIO{$index +1} Msg2 Addr" CV="{$CV5}" default="0">
-        <splitVal highCV="{$CV5 +1}" upperMask="XXXXVVVV" offset="1" />
+    <variable item="GPIO{$index +1} Msg2 Addr" CV="{$CV5},{$CV5 +1}" mask="VVVVVVVV XXXXVVVV" default="0">
+        <splitVal offset="1" />
     </variable>
     <variable item="GPIO{$index +1} Msg2 Condition" CV="{$CV5 +1}" mask="XXVVXXXX" default="0">
         <xi:include href="http://jmri.org/xml/decoders/tvd/InputMessageCondition.xml"/>
@@ -564,26 +626,26 @@
     <xsl:param name="CV2"/>
     <xsl:param name="index"/>
 
-    <variable item="Route{$index} Turnout1" CV="{$CV1}" mask="VVVVVVVV" default="0">
-        <splitVal highCV="{$CV1 +1}" upperMask="XXXXVVVV" offset="1" />
+    <variable item="Route{$index} Turnout1" CV="{$CV1},{$CV1 +1}" mask="VVVVVVVV XXXXVVVV" default="0">
+        <splitVal offset="1" />
     </variable>
     <variable item="Route{$index} Turnout1 Action" CV="{$CV1 +1}" mask="VVVVXXXX" default="0">
         <xi:include href="http://jmri.org/xml/decoders/tvd/RouteEntry.xml"/>
     </variable>
-    <variable item="Route{$index} Turnout2" CV="{$CV1 +2}" mask="VVVVVVVV" default="0">
-        <splitVal highCV="{$CV1 +3}" upperMask="XXXXVVVV" offset="1" />
+    <variable item="Route{$index} Turnout2" CV="{$CV1 +2},{$CV1 +3}" mask="VVVVVVVV XXXXVVVV" default="0">
+        <splitVal offset="1" />
     </variable>
     <variable item="Route{$index} Turnout2 Action" CV="{$CV1 +3}" mask="VVVVXXXX" default="0">
         <xi:include href="http://jmri.org/xml/decoders/tvd/RouteEntry.xml"/>
     </variable>
-    <variable item="Route{$index} Turnout3" CV="{$CV1 +4}" mask="VVVVVVVV" default="0">
-        <splitVal highCV="{$CV1 +5}" upperMask="XXXXVVVV" offset="1" />
+    <variable item="Route{$index} Turnout3" CV="{$CV1 +4},{$CV1 +5}" mask="VVVVVVVV XXXXVVVV" default="0">
+        <splitVal offset="1" />
     </variable>
     <variable item="Route{$index} Turnout3 Action" CV="{$CV1 +5}" mask="VVVVXXXX" default="0">
         <xi:include href="http://jmri.org/xml/decoders/tvd/RouteEntry.xml"/>
     </variable>
-    <variable item="Route{$index} Turnout4" CV="{$CV1 +6}" mask="VVVVVVVV" default="0">
-        <splitVal highCV="{$CV1 +7}" upperMask="XXXXVVVV" offset="1" />
+    <variable item="Route{$index} Turnout4" CV="{$CV1 +6},{$CV1 +7}" mask="VVVVVVVV XXXXVVVV" default="0">
+        <splitVal offset="1" />
     </variable>
     <variable item="Route{$index} Turnout4 Action" CV="{$CV1 +7}" mask="VVVVXXXX" default="0">
         <xi:include href="http://jmri.org/xml/decoders/tvd/RouteEntry.xml"/>
@@ -631,7 +693,7 @@
       <xsl:when test="4 >= $index">
          <column>
             <display item="One Choice Enum" format="onradiobutton" layout="right">
-               <label>SERVO <xsl:value-of select="$index"/></label>
+               <label>SERVO <xsl:value-of select="$index"/>  TURNOUT</label>
             </display>
             <xsl:call-template name="ServoParams">
                <xsl:with-param name="index" select="$index"/>
@@ -646,7 +708,7 @@
                <value>0</value>
             </qualifier>
             <display item="One Choice Enum" format="onradiobutton" layout="right">
-               <label>MAIN <xsl:value-of select="$index - 4"/> SERVO</label>
+               <label>MAIN <xsl:value-of select="$index - 4"/>  TURNOUT</label>
             </display>
             <xsl:call-template name="ServoParams">
                <xsl:with-param name="index" select="$index"/>
@@ -659,7 +721,7 @@
                <value>1</value>
             </qualifier>
             <display item="One Choice Enum" format="onradiobutton" layout="right">
-               <label>AUX <xsl:value-of select="$index - 4"/> SERVO</label>
+               <label>AUX <xsl:value-of select="$index - 4"/>  TURNOUT</label>
             </display>
             <xsl:call-template name="ServoParams">
                <xsl:with-param name="index" select="$index"/>
@@ -672,7 +734,7 @@
                <value>1</value>
             </qualifier>
             <display item="One Choice Enum" format="onradiobutton" layout="right">
-               <label>EXP <xsl:value-of select="$index - 4"/> SERVO</label>
+               <label>EXP <xsl:value-of select="$index - 4"/>  TURNOUT </label>
             </display>
             <xsl:call-template name="ServoParams">
                <xsl:with-param name="index" select="$index"/>
@@ -687,7 +749,7 @@
                <value>0</value>
             </qualifier>
             <display item="One Choice Enum" format="onradiobutton" layout="right">
-               <label>AUX <xsl:value-of select="$index - 8"/> SERVO</label>
+               <label>AUX <xsl:value-of select="$index - 8"/>  TURNOUT</label>
             </display>
             <xsl:call-template name="ServoParams">
                <xsl:with-param name="index" select="$index"/>
@@ -700,7 +762,7 @@
                <value>0</value>
             </qualifier>
             <display item="One Choice Enum" format="onradiobutton" layout="right">
-               <label>EXP <xsl:value-of select="$index - 8"/> SERVO</label>
+               <label>EXP <xsl:value-of select="$index - 8"/>  TURNOUT</label>
             </display>
             <xsl:call-template name="ServoParams">
                <xsl:with-param name="index" select="$index"/>
@@ -710,7 +772,7 @@
       <xsl:otherwise>
          <column>
             <display item="One Choice Enum" format="onradiobutton" layout="right">
-               <label>EXP <xsl:value-of select="$index - 12"/> SERVO</label>
+               <label>EXP <xsl:value-of select="$index - 12"/>  TURNOUT</label>
             </display>
             <xsl:call-template name="ServoParams">
                <xsl:with-param name="index" select="$index"/>
@@ -723,16 +785,32 @@
 <xsl:template name="ServoParams">
     <xsl:param name="index"/>
    <label label=" "/>   
-   <display  item="Servo{$index} Addr">
-      <tooltip>To change, adjust Servo Base Addr on Quad-LN pane</tooltip>
+   <display  item="Servo{$index} Addr" viewOnly="yes">
+      <tooltip>To change, adjust Turnout Base Addr on Quad-LN_S pane</tooltip>
       <label>Address  LT</label>
    </display>
-   <display  item="Lock{$index} Addr">
-      <tooltip>To change, adjust Lock Base Addr on Quad-LN pane</tooltip>
+   <display  item="Lock{$index} Addr" viewOnly="yes">
+      <tooltip>To change, adjust Lock Base Addr on Quad-LN_S pane</tooltip>
       <label>Lock  LT</label>
    </display>
    <label label=" "/>   
    <display item="One Choice Enum" format="onradiobutton" layout="right">
+      <label>DRIVE</label>
+   </display>
+   <display item="Servo{$index} DriveType">
+      <tooltip>select the type of connected device</tooltip>
+      <label>Type</label>
+   </display>
+   <display item="Servo{$index} DriveOff" >
+      <tooltip>set whether the servo drive turns off when the servo stops moving</tooltip>
+      <label>Turn Off</label>
+   </display>
+   <display item="Servo{$index} SwitchPoint">
+      <tooltip>select when the output drive changes state after the turnout state is changed</tooltip>
+      <label>Change Point</label>
+   </display>
+   <label label=" "/>   
+   <display item="One Choice Enum Servo{$index} Qual" format="onradiobutton" layout="right">
       <label>TRAVEL</label>
    </display>
    <display item="Servo{$index} Closed">
@@ -742,6 +820,10 @@
    <display item="Servo{$index} Thrown">
       <tooltip>0=full CCW, 2400=full CW</tooltip>
       <label>Thrown Position</label>
+   </display>
+   <display item="Servo{$index} JumpStart">
+      <tooltip>jump directly to setpoint for use with animation effects</tooltip>
+      <label>Speed Or Jump</label>
    </display>
    <display item="Servo{$index} Speed">
       <tooltip>0-63: 0=very slow, 4=normal, 63=very fast</tooltip>
@@ -754,6 +836,10 @@
    <display item="Servo{$index} Directional Speed">
       <tooltip>enables separate speed setting for travel in the Thrown direction</tooltip>
       <label>Directional Speed</label>
+   </display>
+   <display item="Servo{$index} Thrown JumpStart">
+      <tooltip>increases speed during initial movement</tooltip>
+      <label>Thrown Speed Or Jump</label>
    </display>
    <display item="Servo{$index} Thrown Speed">
       <tooltip>0-63: 0=very slow, 4=normal, 63=very fast</tooltip>
@@ -768,7 +854,7 @@
       <label>LOCK</label>
    </display>
    <display item="Servo{$index} Lock">
-      <tooltip>Controls Lock via Turnout at addr of servo + 4</tooltip>
+      <tooltip>Turnout at the Lock address controls this mode</tooltip>
       <label>Mode</label>
    </display>
    <label label=" "/>   
@@ -792,7 +878,7 @@
    </display>
    <display item="Servo{$index} Cascade Turnout">
       <tooltip>Cascade turnout number</tooltip>
-      <label>Turnout</label>
+      <label>Number</label>
    </display>
 </xsl:template>
 
@@ -812,8 +898,8 @@
             <label>MAIN IO <xsl:value-of select="$index"/></label>
          </display>
          <label label=" "/>   
-         <display  item="Main IO{$index} Addr">
-            <tooltip>To change, adjust Main IO Base Addr on Quad-LN pane</tooltip>
+         <display  item="Main IO{$index} Addr" viewOnly="yes">
+            <tooltip>To change, adjust Main IO Base Addr on Quad-LN_S pane</tooltip>
             <label>Address   LS</label>
          </display>
          <label label=" "/>   
@@ -847,7 +933,7 @@
          <label label=" "/>   
          <!-- use 2 qualified labels to maintain consistent column height -->
          <display item="Non-TVD Det GPIO{$io} Qual" format="onradiobutton" layout="right">
-            <label>SERVO <xsl:value-of select="$servo"/> INDICATION</label>
+            <label>TURNOUT <xsl:value-of select="$servo"/> INDICATION</label>
          </display>
          <display item="TVD Det GPIO{$io} Qual" format="onradiobutton" layout="right">
             <label>&lt;html&gt;&lt;/html&gt;</label>
@@ -877,8 +963,8 @@
             <label>AUX IO <xsl:value-of select="$index"/></label>
          </display>
          <label label=" "/>   
-         <display  item="Aux IO{$index} Addr">
-            <tooltip>To change, adjust Aux IO Base Addr on Quad-LN pane</tooltip>
+         <display  item="Aux IO{$index} Addr" viewOnly="yes">
+            <tooltip>To change, adjust Aux IO Base Addr on Quad-LN_S pane</tooltip>
             <label>Address   LS</label>
          </display>
          <label label=" "/>   
@@ -903,7 +989,7 @@
          </display>
          <label label=" "/>   
          <display item="One Choice Enum" format="onradiobutton" layout="right">
-            <label>SERVO <xsl:value-of select="$servo"/> INDICATION</label>
+            <label>TURNOUT <xsl:value-of select="$servo"/> INDICATION</label>
          </display>
          <xsl:call-template name="IOColumn">
             <xsl:with-param name="io" select="$io"/>
@@ -932,20 +1018,20 @@
          <label>ACTION</label>
       </display>
       <display item="GPIO{$io} Action: Servo1">
-         <tooltip>Servo 1 action</tooltip>
-         <label>Servo 1</label>
+         <tooltip>Turnout 1 action</tooltip>
+         <label>Turnout 1</label>
       </display>
       <display item="GPIO{$io} Action: Servo2">
-         <tooltip>Servo 2 action</tooltip>
-         <label>Servo 2</label>
+         <tooltip>Turnout 2 action</tooltip>
+         <label>Turnout 2</label>
       </display>
       <display item="GPIO{$io} Action: Servo3">
-         <tooltip>Servo 3 action</tooltip>
-         <label>Servo 3</label>
+         <tooltip>Turnout 3 action</tooltip>
+         <label>Turnout 3</label>
       </display>
       <display item="GPIO{$io} Action: Servo4">
-         <tooltip>Servo 4 action</tooltip>
-         <label>Servo 4</label>
+         <tooltip>Turnout 4 action</tooltip>
+         <label>Turnout 4</label>
       </display>
       <label label=" "/>
    </xsl:if>
@@ -1038,56 +1124,56 @@
          <label>ACTION</label>
       </display>
       <display item="GPIO{$io} Action: Servo1">
-         <tooltip>Servo 1 action</tooltip>
-         <label>Servo 1</label>
+         <tooltip>Turnout 1 action</tooltip>
+         <label>Turnout 1</label>
       </display>
       <display item="GPIO{$io} Action: Servo2">
-         <tooltip>Servo 2 action</tooltip>
-         <label>Servo 2</label>
+         <tooltip>Turnout 2 action</tooltip>
+         <label>Turnout 2</label>
       </display>
       <display item="GPIO{$io} Action: Servo3">
-         <tooltip>Servo 3 action</tooltip>
-         <label>Servo 3</label>
+         <tooltip>Turnout 3 action</tooltip>
+         <label>Turnout 3</label>
       </display>
       <display item="GPIO{$io} Action: Servo4">
-         <tooltip>Servo 4 action</tooltip>
-         <label>Servo 4</label>
+         <tooltip>Turnout 4 action</tooltip>
+         <label>Turnout 4</label>
       </display>
       <display item="GPIO{$io} Action: Servo5">
-         <tooltip>Servo 5 action</tooltip>
-         <label>Servo 5</label>
+         <tooltip>Turnout 5 action</tooltip>
+         <label>Turnout 5</label>
       </display>
       <display item="GPIO{$io} Action: Servo6">
-         <tooltip>Servo 6 action</tooltip>
-         <label>Servo 6</label>
+         <tooltip>Turnout 6 action</tooltip>
+         <label>Turnout 6</label>
       </display>
       <display item="GPIO{$io} Action: Servo7">
-         <tooltip>Servo 7 action</tooltip>
-         <label>Servo 7</label>
+         <tooltip>Turnout 7 action</tooltip>
+         <label>Turnout 7</label>
       </display>
       <display item="GPIO{$io} Action: Servo8">
-         <tooltip>Servo 8 action</tooltip>
-         <label>Servo 8</label>
+         <tooltip>Turnout 8 action</tooltip>
+         <label>Turnout 8</label>
       </display>
 </xsl:template>
 
 <xsl:template name="DodecaActionColumn">
     <xsl:param name="index"/>
       <display item="Servo{$index} Dodeca Action">
-         <tooltip>Servo 9 action</tooltip>
-         <label>Servo 9</label>
+         <tooltip>Turnout 9 action</tooltip>
+         <label>Turnout 9</label>
       </display>
       <display item="Servo{$index + 1} Dodeca Action">
-         <tooltip>Servo 10 action</tooltip>
-         <label>Servo 10</label>
+         <tooltip>Turnout 10 action</tooltip>
+         <label>Turnout 10</label>
       </display>
       <display item="Servo{$index + 2} Dodeca Action">
-         <tooltip>Servo 11 action</tooltip>
-         <label>Servo 11</label>
+         <tooltip>Turnout 11 action</tooltip>
+         <label>Turnout 11</label>
       </display>
       <display item="Servo{$index + 3} Dodeca Action">
-         <tooltip>Servo 12 action</tooltip>
-         <label>Servo 12</label>
+         <tooltip>Turnout 12 action</tooltip>
+         <label>Turnout 12</label>
       </display>
 </xsl:template>
 
@@ -1459,9 +1545,9 @@
  </xsl:template>
 
  <!--install panes -->
- <xsl:template match="label[text='Decoder Transform File Version: x.xx']">
+ <xsl:template match="label[text='Decoder Transform File Version: x.xx.x']">
     <label>
-        <text>Decoder Transform File Version: 3.01</text>
+        <text>Decoder Transform File Version: 3.01.3</text>
     </label>
  </xsl:template>
 

--- a/xml/decoders/tvd/DriveOff.xml
+++ b/xml/decoders/tvd/DriveOff.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<!-- Copyright (C) JMRI 2005, 2011 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- include for QUAD-LN_S -->
+<!-- drive type  v1.0  -->
+<enumVal xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+    <enumChoice choice="Always Driven"/>
+    <enumChoice choice="Off When Stopped"/>
+</enumVal>

--- a/xml/decoders/tvd/DriveType.xml
+++ b/xml/decoders/tvd/DriveType.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<!-- Copyright (C) JMRI 2005, 2011 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- include for QUAD-LN_S -->
+<!-- drive type  v1.0  -->
+<enumVal xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+    <enumChoice choice="Servo"/>
+    <enumChoice choice="Stall/Relay"/>
+</enumVal>

--- a/xml/decoders/tvd/JumpStart.xml
+++ b/xml/decoders/tvd/JumpStart.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<!-- Copyright (C) JMRI 2005, 2011 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- include for QUAD-LN_S -->
+<!-- jump start  v3.0  -->
+<enumVal xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+    <enumChoice choice="Use Speed Setting"/>
+    <enumChoice choice="Jump to Setpoint"/>
+</enumVal>

--- a/xml/decoders/tvd/SwitchPoint.xml
+++ b/xml/decoders/tvd/SwitchPoint.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<!-- Copyright (C) JMRI 2005, 2011 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- include for QUAD-LN_S -->
+<!-- drive type  v1.0  -->
+<enumVal xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+    <enumChoice choice="Immediate (stall)"/>
+    <enumChoice choice="Delayed (relay)"/>
+</enumVal>


### PR DESCRIPTION
Update QuadLN_S decoder template for new features in QuadLN_S firmware version 3.1 including support for configuring any mix of up to 16 servo and steady drive (stall motor) outputs, enabling optional LocoNet lockout of outputs and enabling optional direct interrogate using CV7.  Template uses new viewOnly Display attribute to limit editing of some vars to a specific tab.  All splitVal vars updated to use new method for specifying CVs and masks.