### PR TITLE
Operations, automatically change font size to smallest when using text

### DIFF
--- a/java/src/jmri/jmrit/operations/setup/BuildReportOptionPanel.java
+++ b/java/src/jmri/jmrit/operations/setup/BuildReportOptionPanel.java
@@ -135,6 +135,10 @@ public class BuildReportOptionPanel extends OperationsPreferencesPanel {
     @Override
     protected void checkBoxActionPerformed(ActionEvent ae) {
         buildReportIndentCheckBox.setEnabled(buildReportCheckBox.isSelected());
+        // use the smallest font to create the longest lines in the build report
+        if (buildReportCheckBox.isSelected()) {
+            fontSizeComboBox.setSelectedItem(7);
+        }
     }
 
     @Override


### PR DESCRIPTION
editor for build reports. This increases line length for the build report making it more readable.  Font size is actually set by editor.