### PR TITLE
zsh options handling for ./runtest.csh

### DIFF
--- a/java/test/jmri/util/junit/TestClassMainMethod.java
+++ b/java/test/jmri/util/junit/TestClassMainMethod.java
@@ -48,7 +48,7 @@ public class TestClassMainMethod {
 
     // Main entry point
     static public void main(String[] args) {
-        String className = args[0];
+        String className = args[args.length-1];  // last argument is class name
 
         // as a convenience, allow file names and paths
         className = className.replace("//","/");


### PR DESCRIPTION
The `./runtest.csh` method of running individual tests can fail with zsh due to how options are handled.  This fixes that.