### PR TITLE
CbusOpCodes - Translate Loco Speed / Direction messages

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -21,7 +21,7 @@
 
         <h4>CBUS</h4>
             <ul>
-                <li></li>
+                <li>Console - Added Throttle speed / direction translations.</li>
             </ul>
 
         <h4>C/MRI</h4>

--- a/java/src/jmri/jmrix/can/CanListener.java
+++ b/java/src/jmri/jmrix/can/CanListener.java
@@ -1,14 +1,22 @@
 package jmri.jmrix.can;
 
 /**
- * Defines the interface for listening to CAN messages
+ * Defines the interface for listening to CAN messages.
  *
  * @author Andrew Crosland Copyright (C) 2008
  */
 public interface CanListener extends jmri.jmrix.AbstractMRListener {
 
+    /**
+     * Called when an outgoing message is sent to the CAN Network.
+     * @param m the CanMessage being sent.
+     */
     public void message(CanMessage m);
 
+    /**
+     * Called when an incoming CanFrame is received from the CAN Network.
+     * @param m the CanReply being received.
+     */
     public void reply(CanReply m);
     
     /**
@@ -27,7 +35,7 @@ public interface CanListener extends jmri.jmrix.AbstractMRListener {
      * Add a Traffic Controller Listener.
      * Adding here, rather than in a class construction header
      * avoids Leaking Constructor errors.
-     * @param memoToAdd The CAN system Connection
+     * @param memoToAdd The CAN system Connection.
      */
     public default void addTc(CanSystemConnectionMemo memoToAdd) {
         if (memoToAdd != null) {
@@ -37,7 +45,7 @@ public interface CanListener extends jmri.jmrix.AbstractMRListener {
     
     /**
      * Remove a Traffic Controller Listener.
-     * @param tcToRemove The system memo CAN Traffic Controller
+     * @param tcToRemove The system memo CAN Traffic Controller.
      */
     public default void removeTc(TrafficController tcToRemove) {
         if (tcToRemove != null) {
@@ -47,7 +55,7 @@ public interface CanListener extends jmri.jmrix.AbstractMRListener {
     
     /**
      * Remove a Traffic Controller Listener.
-     * @param memoToRemove The CAN system Connection
+     * @param memoToRemove The CAN system Connection.
      */
     public default void removeTc(CanSystemConnectionMemo memoToRemove) {
         if (memoToRemove != null) {

--- a/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
@@ -493,7 +493,7 @@ SigDataCol    = Signal Data Columns
 SigDataOn     = Signal Data On
 SigDataOff    = Signal Data Off
 
-FWD           = Forwards
+FWD           = Forward
 REV           = Reverse
 ResetBlocks   = Reload Blocks
 NoBlocks      = No blocks found to import into Command Station. Cabdata unavailable.

--- a/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
@@ -212,7 +212,7 @@ public class CbusOpCodes {
      * @return localised Forward or Reverse String.
      */
     public static String getDirectionFromByte( int speed ) {
-        return Bundle.getMessage(( speed << ~7 < 0 ? "FWD" : "REV"));
+        return Bundle.getMessage( ( speed >> 7 ) == 1 ? "FWD" : "REV");
     }
 
     /**

--- a/java/test/jmri/jmrix/can/cbus/CbusOpCodesTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusOpCodesTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 
 import jmri.jmrix.can.CanMessage;
+import jmri.jmrix.can.CanReply;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
@@ -66,11 +67,36 @@ public class CbusOpCodesTest {
         m.setElement(3, 0x09);
         Assert.assertEquals("CBUS_ERR 9","",CbusOpCodes.decode(m));
     }
+
+    @Test
+    public void testLocoSessionSpeedDirMsg() {
+        CanMessage m = new CanMessage( 3, 0x12 );
+        m.setElement(0, CbusConstants.CBUS_DSPD);
+        m.setElement(1, 0x01);
+        m.setElement(2, 0x02);
+        Assert.assertEquals("CBUS_DSPD Translate","Session: 1 Speed 1 Reverse ",CbusOpCodes.decode(m));
+    }
+
+    @Test
+    public void testTimeFromClock() {
+        CanReply send = new CanReply(1);
+        send.setNumDataElements(7);
+        send.setElement(0, CbusConstants.CBUS_FCLK);
+        send.setElement(1, 41 ); // mins
+        send.setElement(2, 13 ); // hrs
+        send.setElement(3, 0b001010000 ); // month 5
+        send.setElement(4,  2); // time divider, 0 is stpeed, 1 is real time, 2 twice real, 3 thrice real
+        send.setElement(5, 27); // day of month, 0-31
+        send.setElement(6, 0xDB ); // Temperature as twos complement -127 to +127
+        
+        String testStr = CbusOpCodes.decode(send);
+        Assertions.assertTrue(testStr.startsWith("Speed: x2 13:41"),"CBUS_FCLK Translate");
+    }
     
     @Test
     public void testNodeEventMessage() {
     
-        CanMessage m = new CanMessage( 0x12 );
+        CanMessage m = new CanMessage( 1 );
         m.setElement(0, CbusConstants.CBUS_ACON);
         m.setElement(1, 0x01);
         m.setElement(2, 0x02);
@@ -438,7 +464,28 @@ public class CbusOpCodesTest {
             }
         }
     }
-    
+
+    @Test
+    public void testGetSpeedFromInt(){
+        Assert.assertEquals("speed 0","0",CbusOpCodes.getSpeedFromByte(0) );
+        Assert.assertEquals("speed 1","0 E Stop ",CbusOpCodes.getSpeedFromByte(1) );
+        Assert.assertEquals("speed 2","1",CbusOpCodes.getSpeedFromByte(2) );
+        Assert.assertEquals("speed 10","9",CbusOpCodes.getSpeedFromByte(10) );
+        Assert.assertEquals("speed 126","125",CbusOpCodes.getSpeedFromByte(126) );
+        Assert.assertEquals("speed 127","126",CbusOpCodes.getSpeedFromByte(127) );
+        Assert.assertEquals("speed 128","0",CbusOpCodes.getSpeedFromByte(128) );
+        Assert.assertEquals("speed 129","0 E Stop ",CbusOpCodes.getSpeedFromByte(129) );
+        Assert.assertEquals("speed 130","1",CbusOpCodes.getSpeedFromByte(130) );
+        Assert.assertEquals("speed 131","2",CbusOpCodes.getSpeedFromByte(131) );
+        Assert.assertEquals("speed 182","53",CbusOpCodes.getSpeedFromByte(182) );
+        Assert.assertEquals("speed 255","126",CbusOpCodes.getSpeedFromByte(255) );
+    }
+
+    @Test
+    public void testSpeedDirFromByte() {
+        Assert.assertEquals("speed 0"," Speed 0 Reverse ",CbusOpCodes.speedDirFromByte(0) );
+        Assert.assertEquals("speed 131"," Speed 2 Forward ",CbusOpCodes.speedDirFromByte(131) );
+    }
     
     private static final Set<Integer> eventOpcodes = createEventOPC();
     

--- a/java/test/jmri/jmrix/can/cbus/CbusOpCodesTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusOpCodesTest.java
@@ -482,6 +482,18 @@ public class CbusOpCodesTest {
     }
 
     @Test
+    public void testGetDirectionFromByte() {
+        Assert.assertTrue("0 rev",CbusOpCodes.getDirectionFromByte(0).contains("Rev"));
+        Assert.assertTrue("1 rev",CbusOpCodes.getDirectionFromByte(1).contains("Rev"));
+        Assert.assertTrue("77 rev",CbusOpCodes.getDirectionFromByte(77).contains("Rev"));
+        Assert.assertTrue("128 rev",CbusOpCodes.getDirectionFromByte(127).contains("Rev"));
+        Assert.assertTrue("128 rev",CbusOpCodes.getDirectionFromByte(128).contains("For"));
+        Assert.assertTrue("129 rev",CbusOpCodes.getDirectionFromByte(129).contains("For"));
+        Assert.assertTrue("211 rev",CbusOpCodes.getDirectionFromByte(211).contains("For"));
+        Assert.assertTrue("255 rev",CbusOpCodes.getDirectionFromByte(255).contains("For"));
+    }
+
+    @Test
     public void testSpeedDirFromByte() {
         Assert.assertEquals("speed 0"," Speed 0 Reverse ",CbusOpCodes.speedDirFromByte(0) );
         Assert.assertEquals("speed 131"," Speed 2 Forward ",CbusOpCodes.speedDirFromByte(131) );

--- a/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModelTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModelTest.java
@@ -226,9 +226,8 @@ public class CbusSlotMonitorDataModelTest {
         Assert.assertFalse("Not Long", (boolean) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_ID_LONG_COLUMN) );
         Assert.assertEquals("No consist",0, (int) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_CONSIST_COLUMN) );
         Assert.assertEquals("Flags","", t.getValueAt(0,CbusSlotMonitorDataModel.FLAGS_COLUMN) );
-        Assert.assertEquals("speed 38","38",
-            (String) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
-        
+        Assert.assertEquals("speed 38","38", t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
+
         t.setValueAt("do button Click",0,CbusSlotMonitorDataModel.ESTOP_COLUMN);
         Assert.assertEquals("table sends estop session 1", "[5f8] 47 01 81",
             tcis.outbound.elementAt(tcis.outbound.size() - 1).toString());
@@ -241,9 +240,8 @@ public class CbusSlotMonitorDataModelTest {
         r.setElement(2, 77); // integer speed 77
         t.reply(r);
         
-        Assert.assertEquals("speed 76","76",
-            (String) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
-        
+        Assert.assertEquals("speed 76","76", t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
+
         String dirb = (String) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_DIRECTION_COLUMN);
         Assert.assertEquals("dir rev",Bundle.getMessage("REV"),dirb );
         
@@ -423,7 +421,7 @@ public class CbusSlotMonitorDataModelTest {
     
         Assert.assertEquals("loco 777",777,(int) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_ID_COLUMN) );
         Assert.assertEquals("Long",true, (boolean) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_ID_LONG_COLUMN) );
-        Assert.assertEquals("speed 0","0", (String) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
+        Assert.assertEquals("speed 0","0", t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
         Assert.assertEquals("speed step 128","128",t.getValueAt(0,CbusSlotMonitorDataModel.SPEED_STEP_COLUMN) );
         
         r = new CanReply();

--- a/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModelTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModelTest.java
@@ -112,8 +112,8 @@ public class CbusSlotMonitorDataModelTest {
         Assert.assertEquals("reply ploc 4 cell val speedstep","128",spdStepb );
         String funcb = (String) t.getValueAt(2,CbusSlotMonitorDataModel.FUNCTION_LIST);
         Assert.assertEquals("reply ploc 4 cell val funcs","2 5 6 8 ",funcb );
-        int locoSpd = (Integer) t.getValueAt(2,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN);
-        Assert.assertEquals("reply ploc 4 cell val speed",39,locoSpd );
+        String locoSpd = (String) t.getValueAt(2,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN);
+        Assert.assertEquals("reply ploc 4 cell val speed","38",locoSpd );
         String dirb = (String) t.getValueAt(2,CbusSlotMonitorDataModel.LOCO_DIRECTION_COLUMN);
         Assert.assertEquals("reply ploc 4 cell val direction",Bundle.getMessage("FWD"),dirb );
         
@@ -226,8 +226,8 @@ public class CbusSlotMonitorDataModelTest {
         Assert.assertFalse("Not Long", (boolean) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_ID_LONG_COLUMN) );
         Assert.assertEquals("No consist",0, (int) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_CONSIST_COLUMN) );
         Assert.assertEquals("Flags","", t.getValueAt(0,CbusSlotMonitorDataModel.FLAGS_COLUMN) );
-        Assert.assertEquals("speed 39",39,
-            (int) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
+        Assert.assertEquals("speed 38","38",
+            (String) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
         
         t.setValueAt("do button Click",0,CbusSlotMonitorDataModel.ESTOP_COLUMN);
         Assert.assertEquals("table sends estop session 1", "[5f8] 47 01 81",
@@ -241,8 +241,8 @@ public class CbusSlotMonitorDataModelTest {
         r.setElement(2, 77); // integer speed 77
         t.reply(r);
         
-        Assert.assertEquals("speed 77",77,
-            (int) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
+        Assert.assertEquals("speed 76","76",
+            (String) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
         
         String dirb = (String) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_DIRECTION_COLUMN);
         Assert.assertEquals("dir rev",Bundle.getMessage("REV"),dirb );
@@ -423,7 +423,7 @@ public class CbusSlotMonitorDataModelTest {
     
         Assert.assertEquals("loco 777",777,(int) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_ID_COLUMN) );
         Assert.assertEquals("Long",true, (boolean) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_ID_LONG_COLUMN) );
-        Assert.assertEquals("speed 0",0, (int) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
+        Assert.assertEquals("speed 0","0", (String) t.getValueAt(0,CbusSlotMonitorDataModel.LOCO_COMMANDED_SPEED_COLUMN) );
         Assert.assertEquals("speed step 128","128",t.getValueAt(0,CbusSlotMonitorDataModel.SPEED_STEP_COLUMN) );
         
         r = new CanReply();

--- a/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorPaneTest.java
@@ -72,7 +72,7 @@ public class CbusSlotMonitorPaneTest extends jmri.util.swing.JmriPanelTest {
         ra.setElement(1, 0x01); // session
         ra.setElement(2, 0x00); // addr hi
         ra.setElement(3, 0x03); // addr lo
-        ra.setElement(4, 0xa7);
+        ra.setElement(4, 0xa7); // spd 38 fwds
         ra.setElement(5, 0xa2);
         ra.setElement(6, 0x7b);
         ra.setElement(7, 0x00);
@@ -80,9 +80,9 @@ public class CbusSlotMonitorPaneTest extends jmri.util.swing.JmriPanelTest {
         
         tbl.waitCell("1",0,0); // session 1 in column 1
         tbl.waitCell("3",0,1); // loco id in col 2
-        tbl.waitCell("39",0,3); // speed in col 4
+        tbl.waitCell("38",0,3); // speed in col 4
         tbl.waitCell(Bundle.getMessage("FWD"),0,4); // direction in col 5
-        tbl.waitCell("2 5 6 8",0,5); // speed in col 6
+        tbl.waitCell("2 5 6 8",0,5); // functions in col 6
         
         JMenuBarOperator mainbar = new JMenuBarOperator(jfo);
         mainbar.pushMenu(Bundle.getMessage("SessCol")); // stops at top level
@@ -92,7 +92,7 @@ public class CbusSlotMonitorPaneTest extends jmri.util.swing.JmriPanelTest {
             new JPopupMenuOperator(jpm),Bundle.getMessage("Long")); // Long DCC Address
         jmio.push();
         
-        tbl.waitCell("39",0,4); // Now speed in col 5
+        tbl.waitCell("38",0,4); // Now speed in col 5
         
         // jmri.util.swing.JemmyUtil.pressButton(new JFrameOperator(f),("Pause Test"));
         

--- a/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorSessionTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorSessionTest.java
@@ -18,14 +18,12 @@ public class CbusSlotMonitorSessionTest {
     public void testCtor() {
         CbusSlotMonitorSession t = new CbusSlotMonitorSession( new DccLocoAddress (179,true) );
         Assert.assertNotNull("exists", t);
-        t = null;
     }
     
     @Test
     public void testReturnLocoAddress() {
         CbusSlotMonitorSession t = new CbusSlotMonitorSession( new DccLocoAddress (1234,true) );
         Assert.assertEquals("loco address returned",new DccLocoAddress (1234,true),t.getLocoAddr() );
-        t = null;
     }
 
     @Test
@@ -33,30 +31,26 @@ public class CbusSlotMonitorSessionTest {
         CbusSlotMonitorSession t = new CbusSlotMonitorSession( new DccLocoAddress (4,false) );
         t.setSessionId(7);
         Assert.assertEquals("session id",7,t.getSessionId() );
-        t = null;
     }
 
     @Test
     public void testSpeedSteps() {
         CbusSlotMonitorSession t = new CbusSlotMonitorSession( new DccLocoAddress (4,false) );
         Assert.assertEquals("default speed steps 128","128",t.getSpeedSteps() );
-        t = null;
     }
     
     @Test
     public void testSpeeds() {
         CbusSlotMonitorSession t = new CbusSlotMonitorSession( new DccLocoAddress (4,false) );
         t.setDccSpeed(77);
-        Assert.assertEquals("speed 77",77,t.getCommandedSpeed() );
+        Assert.assertEquals("speed 77","76",t.getCommandedSpeed() );
         t.setDccSpeed(211);
-        Assert.assertEquals("speed 211",83,t.getCommandedSpeed() );
+        Assert.assertEquals("speed 211","82",t.getCommandedSpeed() );
         t.setDccSpeed(129);
-        Assert.assertEquals("speed 0 fwd estop",0,t.getCommandedSpeed() );
+        Assert.assertEquals("speed 0 fwd estop","0 E Stop ",t.getCommandedSpeed() );
         
         t.setSpeedSteps("28");
         Assert.assertEquals("28 speed steps","28",t.getSpeedSteps() );
-        t = null;
-        
     }
     
     @Test
@@ -80,22 +74,21 @@ public class CbusSlotMonitorSessionTest {
         t.setSpeedSteps("28");
         t.setDccSpeed(1);
         Assert.assertTrue("28 1 rev",t.getDirection().contains("Rev"));
-        t.setDccSpeed(28);
-        Assert.assertTrue("28 28 fwd",t.getDirection().contains("For"));
+        t.setDccSpeed(131);
+        Assert.assertTrue("28 131 fwd",t.getDirection().contains("For"));
 
         t.setSpeedSteps("28I");
         t.setDccSpeed(1);
         Assert.assertTrue("28i 1 rev",t.getDirection().contains("Rev"));
-        t.setDccSpeed(28);
+        t.setDccSpeed(131);
         Assert.assertTrue("28i 28 fwd",t.getDirection().contains("For"));
 
         t.setSpeedSteps("14");
         t.setDccSpeed(1);
         Assert.assertTrue("14 1 rev",t.getDirection().contains("Rev"));
-        t.setDccSpeed(14);
+        t.setDccSpeed(131);
         Assert.assertTrue("14 14 fwd",t.getDirection().contains("For"));
         
-        t = null;
     }
     
     @Test
@@ -124,8 +117,7 @@ public class CbusSlotMonitorSessionTest {
             t.setFunction(i,false);
         }
         Assert.assertTrue( t.getFunctionString().isEmpty() );
-        
-        t = null;
+
     }
     
     @Test
@@ -136,17 +128,19 @@ public class CbusSlotMonitorSessionTest {
         Assert.assertTrue( t.getFlagString().isEmpty() );
 
         t.setFlags(0b0000_0001);
-        Assert.assertEquals("speed steps by flag 28 I","28I",t.getSpeedSteps() );
-        
-        t.setFlags(0b0000_0010);
         Assert.assertEquals("speed steps by flag 14","14",t.getSpeedSteps() );
         
+        t.setFlags(0b0000_0010);
+        Assert.assertEquals("speed steps by flag 28i","28I",t.getSpeedSteps() );
+        
         t.setFlags(0b0000_0011);
-        Assert.assertEquals("speed steps by flag 14","28",t.getSpeedSteps() );
+        Assert.assertEquals("speed steps by flag 28","28",t.getSpeedSteps() );
         
         t.setFlags(0b0000_0000);
         Assert.assertEquals("speed steps by flag 128","128",t.getSpeedSteps() );
-        t = null;
+        
+        t.setFlags(0xFF);
+        Assert.assertEquals("speed steps by 0xff flag 28","28",t.getSpeedSteps() );
         
     }
     
@@ -157,7 +151,6 @@ public class CbusSlotMonitorSessionTest {
         Assert.assertTrue( t.getConsistId() == 0 );
         t.setConsistId(77);
         Assert.assertTrue( t.getConsistId() == 77 );
-        t = null;
         
     }
     
@@ -186,8 +179,6 @@ public class CbusSlotMonitorSessionTest {
         
         t.setFlags(0b0000_1000);
         Assert.assertTrue("flags 3",t.getFlagString().contains("Direction:1"));
-        
-        t = null;
         
     }
     

--- a/xml/cbus/CbusOpcData.xml
+++ b/xml/cbus/CbusOpcData.xml
@@ -10,6 +10,7 @@ decode = The decode parse string used in CbusOpCodes.java, used for Console Log.
     Values starting "OPC_" must have a corresponding CbusBundle value
     ~OPC_SN~
     %1 - Translate next 1 Byte ( 0-255 )
+    ^S - Translate next 1 byte as loco speed / direction
     %2 - Translate next 2 bytes as hi lo pair ( 0-65535 )
     ^2 - Translate next 2 bytes to Loco ID
     $2 - Translate next 2 bytes with node name ( if possible )
@@ -45,7 +46,7 @@ filter = Enum of which categories apply in CbusFilter.java
   <CbusOpc hex="44" minPri="2" name="STMOD" decode="~OPC_SN~: ,%1, ~OPC_DA~: ,%1" filter="CFCS,CFCSAQRL"/>
   <CbusOpc hex="45" minPri="2" name="PCON" decode="~OPC_SN~: ,%1, ~OPC_CA~: ,%1" filter="CFCS,CFCSAQRL"/>
   <CbusOpc hex="46" minPri="2" name="KCON" decode="~OPC_SN~: ,%1, ~OPC_CA~: ,%1" filter="CFCS,CFCSAQRL"/>
-  <CbusOpc hex="47" minPri="2" name="DSPD" decode="~OPC_SN~: ,%1, ~OPC_SD~: ,%1" filter="CFCS,CFCSDSPD"/>
+  <CbusOpc hex="47" minPri="2" name="DSPD" decode="~OPC_SN~: ,%1,^S" filter="CFCS,CFCSDSPD"/>
   <CbusOpc hex="48" minPri="2" name="DFLG" decode="~OPC_SN~: ,%1, ~OPC_FL~: ,%1" filter="CFCS,CFCSAQRL"/>
   <CbusOpc hex="49" minPri="2" name="DFNON" decode="~OPC_SN~: ,%1, ~OPC_FN~: ,%1" filter="CFCS,CFCSFUNC"/>
   <CbusOpc hex="4A" minPri="2" name="DFNOF" decode="~OPC_SN~: ,%1, ~OPC_FN~: ,%1" filter="CFCS,CFCSFUNC"/>
@@ -130,7 +131,7 @@ filter = Enum of which categories apply in CbusFilter.java
   <CbusOpc hex="DE" minPri="3" name="ARSOF2" decode="$4, ~OPC_DA~: ,%1, ,%1" filter="CFEVENT,CFNODE,CFOF,CFSHORT,CFRESPONSE,CFED2"/>
   <CbusOpc hex="DF" minPri="3" name="EXTC5" decode=": ,%1, ~OPC_DA~: ,%1, ,%1, ,%1, ,%1, ,%1" filter="CFMISC,CFOTHER"/>
   <CbusOpc hex="E0" minPri="2" name="RDCC6" decode="~OPC_RP~: ,%1, ~OPC_DA~: ,%1, ,%1, ,%1, ,%1, ,%1, ,%1" filter="CFCS,CFCSLC"/>
-  <CbusOpc hex="E1" minPri="2" name="PLOC" decode="~OPC_SN~: ,%1, ~OPC_AD~: ,^2, ~OPC_SD~: ,%1, F1: ,%1, F2: ,%1, F3: ,%1" filter="CFCS,CFCSAQRL"/>
+  <CbusOpc hex="E1" minPri="2" name="PLOC" decode="~OPC_SN~: ,%1, ~OPC_AD~: ,^2,^S, F1: ,%1, F2: ,%1, F3: ,%1" filter="CFCS,CFCSAQRL"/>
   <CbusOpc hex="E2" minPri="3" name="NAME" decode="~OPC_CH~: ,%1, ,%1, ,%1, ,%1, ,%1, ,%1, ,%1" filter="CFNDCONFIG,CFNDSETUP"/>
   <CbusOpc hex="E3" minPri="2" name="STAT" decode="$2, ~OPC_CS~: ,%1, ~OPC_FL~: ,%1, ~OPC_VN~: ,%1, ,%1, ,%1" filter="CFNODE,CFCS,CFCSC"/>
   <CbusOpc hex="EF" minPri="3" name="PARAMS" decode="~OPC_PA~ :,%1, ,%1, ,%1, ,%1, ,%1, ,%1, ,%1" filter="CFNDCONFIG,CFNDSETUP"/>


### PR DESCRIPTION
Adds speed / direction translation to console log.
Fixes incorrect speed translation  within CbusSlotMonitor.