### PR TITLE
Prevent LE NPE; change default DCS240 command station type

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorChecks.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorChecks.java
@@ -486,10 +486,10 @@ final public class LayoutEditorChecks {
             if (pp.getType() == PositionablePoint.PointType.ANCHOR) {
                 // adjacent track segments must be defined...
                 TrackSegment ts1 = pp.getConnect1();
-                TrackSegmentView ts1v = layoutEditor.getTrackSegmentView(ts1);
                 TrackSegment ts2 = pp.getConnect2();
-                TrackSegmentView ts2v = layoutEditor.getTrackSegmentView(ts2);
                 if ((ts1 != null) && (ts2 != null)) {
+                    TrackSegmentView ts1v = layoutEditor.getTrackSegmentView(ts1);
+                    TrackSegmentView ts2v = layoutEditor.getTrackSegmentView(ts2);
                     // can't be an arc, circle or bezier...
                     if (!ts1v.isArc() && !ts1v.isCircle() && !ts1v.isBezier()
                             && !ts2v.isArc() && !ts2v.isCircle() && !ts2v.isBezier()) {
@@ -659,7 +659,7 @@ final public class LayoutEditorChecks {
         log.debug("doCheckLinearBezierTrackSegmentsMenuItem({})", trackSegmentName);
 
         LayoutTrack layoutTrack = layoutEditor.getFinder().findObjectByName(trackSegmentName);
-        
+
         if (layoutTrack != null) {
             LayoutTrackView layoutTrackView = layoutEditor.getLayoutTrackView(layoutTrack);
             layoutEditor.setSelectionRect(layoutTrackView.getBounds());
@@ -783,7 +783,7 @@ final public class LayoutEditorChecks {
         log.debug("doCheckFixedRadiusBezierTrackSegmentsMenuItem({})", trackSegmentName);
 
         LayoutTrack layoutTrack = layoutEditor.getFinder().findObjectByName(trackSegmentName);
-        
+
         if (layoutTrack != null) {
             LayoutTrackView layoutTrackView = layoutEditor.getLayoutTrackView(layoutTrack);
             layoutEditor.setSelectionRect(layoutTrackView.getBounds());

--- a/java/src/jmri/jmrix/loconet/usb_dcs210Plus/UsbDcs210PlusAdapter.java
+++ b/java/src/jmri/jmrix/loconet/usb_dcs210Plus/UsbDcs210PlusAdapter.java
@@ -68,10 +68,10 @@ public class UsbDcs210PlusAdapter extends LocoBufferAdapter {
             // connect to a packetizing traffic controller
             // that does echoing
             //
-            // Note - already created a LocoNetSystemConnectionMemo, so re-use 
+            // Note - already created a LocoNetSystemConnectionMemo, so re-use
             // it when creating a PR2 Packetizer.  (If create a new one, will
             // end up with two "LocoNet" menus...)
-            jmri.jmrix.loconet.pr2.LnPr2Packetizer packets = 
+            jmri.jmrix.loconet.pr2.LnPr2Packetizer packets =
                     new jmri.jmrix.loconet.pr2.LnPr2Packetizer(this.getSystemConnectionMemo());
             packets.connectPort(this);
 
@@ -162,12 +162,12 @@ public class UsbDcs210PlusAdapter extends LocoBufferAdapter {
      */
     public String[] commandStationOptions() {
         String[] retval = new String[commandStationNames.length + 1];
-        retval[0] = LnCommandStationType.COMMAND_STATION_USB_DCS210Plus_ALONE.getName();
-        retval[1] = LnCommandStationType.COMMAND_STATION_DCS210PLUS.getName();
+        retval[0] = LnCommandStationType.COMMAND_STATION_DCS210PLUS.getName();
+        retval[1] = LnCommandStationType.COMMAND_STATION_USB_DCS210Plus_ALONE.getName();
         int count = 2;
         for (String commandStationName : commandStationNames) {
             if (!commandStationName.equals(LnCommandStationType.COMMAND_STATION_DCS210PLUS.getName())) {
-            // include all but COMMAND_STATION_DCS210Plus, which was forced  to 
+            // include all but COMMAND_STATION_DCS210Plus, which was forced  to
             // the front of the list (above)
                 retval[count++] = commandStationName;
         }

--- a/java/src/jmri/jmrix/loconet/usb_dcs240/UsbDcs240Adapter.java
+++ b/java/src/jmri/jmrix/loconet/usb_dcs240/UsbDcs240Adapter.java
@@ -68,10 +68,10 @@ public class UsbDcs240Adapter extends LocoBufferAdapter {
             // connect to a packetizing traffic controller
             // that does echoing
             //
-            // Note - already created a LocoNetSystemConnectionMemo, so re-use 
+            // Note - already created a LocoNetSystemConnectionMemo, so re-use
             // it when creating a PR2 Packetizer.  (If create a new one, will
             // end up with two "LocoNet" menus...)
-            jmri.jmrix.loconet.pr2.LnPr2Packetizer packets = 
+            jmri.jmrix.loconet.pr2.LnPr2Packetizer packets =
                     new jmri.jmrix.loconet.pr2.LnPr2Packetizer(this.getSystemConnectionMemo());
             packets.connectPort(this);
 
@@ -162,12 +162,12 @@ public class UsbDcs240Adapter extends LocoBufferAdapter {
      */
     public String[] commandStationOptions() {
         String[] retval = new String[commandStationNames.length + 1];
-        retval[0] = LnCommandStationType.COMMAND_STATION_USB_DCS240_ALONE.getName();
-        retval[1] = LnCommandStationType.COMMAND_STATION_DCS240.getName();
+        retval[0] = LnCommandStationType.COMMAND_STATION_DCS240.getName();
+        retval[1] = LnCommandStationType.COMMAND_STATION_USB_DCS240_ALONE.getName();
         int count = 2;
         for (String commandStationName : commandStationNames) {
             if (!commandStationName.equals(LnCommandStationType.COMMAND_STATION_DCS240.getName())) {
-                // include all but COMMAND_STATION_DCS240, which was forced  to 
+                // include all but COMMAND_STATION_DCS240, which was forced  to
                 // the front of the list (above)
                 retval[count++] = commandStationName;
             }

--- a/java/src/jmri/jmrix/loconet/usb_dcs52/UsbDcs52Adapter.java
+++ b/java/src/jmri/jmrix/loconet/usb_dcs52/UsbDcs52Adapter.java
@@ -68,10 +68,10 @@ public class UsbDcs52Adapter extends LocoBufferAdapter {
             // connect to a packetizing traffic controller
             // that does echoing
             //
-            // Note - already created a LocoNetSystemConnectionMemo, so re-use 
+            // Note - already created a LocoNetSystemConnectionMemo, so re-use
             // it when creating a PR2 Packetizer.  (If create a new one, will
             // end up with two "LocoNet" menus...)
-            jmri.jmrix.loconet.pr2.LnPr2Packetizer packets = 
+            jmri.jmrix.loconet.pr2.LnPr2Packetizer packets =
                     new jmri.jmrix.loconet.pr2.LnPr2Packetizer(this.getSystemConnectionMemo());
             packets.connectPort(this);
 
@@ -162,12 +162,12 @@ public class UsbDcs52Adapter extends LocoBufferAdapter {
      */
     public String[] commandStationOptions() {
         String[] retval = new String[commandStationNames.length + 1];
-        retval[0] = LnCommandStationType.COMMAND_STATION_USB_DCS52_ALONE.getName();
-        retval[1] = LnCommandStationType.COMMAND_STATION_DCS052.getName();
+        retval[0] = LnCommandStationType.COMMAND_STATION_DCS052.getName();
+        retval[1] = LnCommandStationType.COMMAND_STATION_USB_DCS52_ALONE.getName();
         int count = 2;
         for (String commandStationName : commandStationNames) {
             if (!commandStationName.equals(LnCommandStationType.COMMAND_STATION_DCS052.getName())) {
-                // include all but COMMAND_STATION_DCS052, which was forced  to 
+                // include all but COMMAND_STATION_DCS052, which was forced  to
                 // the front of the list (above)
                 retval[count++] = commandStationName;
             }


### PR DESCRIPTION
- The LE anchor check would create a NPE when an anchor point only had one track segment assigned.
- The DCS240 command station type was defaulting to the standalone programmer mode.  If a user was not paying attention, they would have issues trying to use all of the command station capability.

