### PR TITLE
Issue-8503: User names compare before system names always

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -463,7 +463,11 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li></li>
+            <li>The order of presenting these elements in combo boxes
+                has been changed to make it more consistent.  They now
+                list all user names first, followed by ones with just system
+                names.  This also fixes a problem where some items are
+                not listed in the combo box.</li>
         </ul>
 
     <h3>Scripting</h3>
@@ -558,9 +562,9 @@
                     <li>Occupied by an unknown train.</li>
                     <li>Signal protects it from entry.</li>
                 </ul>
-            </li> 
+            </li>
             <li>
-                When entering a block, the warrant will allocate as many blocks as it can up to the 
+                When entering a block, the warrant will allocate as many blocks as it can up to the
                 next restricted block or its limit.
                  <ul>
                     <li>Shared warrants only allocate up to a maximum of 2 blocks. (limit is 2)</li>
@@ -568,14 +572,14 @@
                 </ul>
             </li>
             <li>
-                Crossovers typically use one turnout to control both switches. Often, each switch is 
-                track in different blocks. For such shared turnouts, throwing the switch in one block 
+                Crossovers typically use one turnout to control both switches. Often, each switch is
+                track in different blocks. For such shared turnouts, throwing the switch in one block
                 may change the path in another block and could cause a derailment.
                  <ul>
-                    <li>Warrants now detect shared turnouts. Should the paths in the respective 
+                    <li>Warrants now detect shared turnouts. Should the paths in the respective
                     blocks have different settings for the turnout, the warrant will allocate the block
                     sharing the turnout but <b>not</b> set its path.</li>
-                    <li>The warrant will stop the train before 
+                    <li>The warrant will stop the train before
                      entering the block. The train will continue when the conflict is resolved.</li>
                  </ul>
             </li>

--- a/java/src/jmri/util/NamedBeanUserNameComparator.java
+++ b/java/src/jmri/util/NamedBeanUserNameComparator.java
@@ -7,7 +7,7 @@ import jmri.NamedBean;
  * <p>
  * If the User Names are both non-null and are not equal, uses the {@link AlphanumComparator},
  * otherwise uses the {@link NamedBeanComparator}.
- * 
+ *
  * @param <B> supported type of NamedBean
  */
 public class NamedBeanUserNameComparator<B extends NamedBean> implements java.util.Comparator<B> {
@@ -15,22 +15,28 @@ public class NamedBeanUserNameComparator<B extends NamedBean> implements java.ut
     public NamedBeanUserNameComparator() {
     }
 
+    static final AlphanumComparator comparator = new AlphanumComparator();
+
     @Override
     public int compare(B n1, B n2) {
         String s1 = n1.getUserName();
         String s2 = n2.getUserName();
-        int comparison = 0;
-        AlphanumComparator comparator = new AlphanumComparator();
+
         // handle both usernames being null or empty
         if ((s1 == null || s1.isEmpty()) && (s2 == null || s2.isEmpty())) {
             return n1.compareTo(n2);
         }
+
+        // if both have user names, compare those
+        if (! (s1 == null || s1.isEmpty()) && ! (s2 == null || s2.isEmpty())) {
+            return comparator.compare(s1, s2);
+        }
+
+        // now must have one with and one without
         if (s1 == null || s1.isEmpty()) {
-            s1 = n1.getSystemName();
+            return +1; // system name always after n2 with user name
+        } else {
+             return -1; // user name always before n2 with only system name
         }
-        if (s2 == null || s2.isEmpty()) {
-            s2 = n1.getSystemName();
-        }
-        return comparison != 0 ? comparison : comparator.compare(s1, s2);
     }
 }

--- a/java/test/jmri/swing/NamedBeanComboBoxTest.java
+++ b/java/test/jmri/swing/NamedBeanComboBoxTest.java
@@ -59,7 +59,7 @@ public class NamedBeanComboBoxTest {
         assertThat(t.getSelectedItemSystemName()).isEqualTo("IS2");
         // Display name is user name if present
         assertThat(t.getSelectedItemDisplayName()).isEqualTo("Sensor 2");
-        
+
         GuiActionRunner.execute(() -> t.setSelectedItem(null));
         assertThat(t.getSelectedItemUserName()).isNull();
         assertThat(t.getSelectedItemSystemName()).isNull();
@@ -90,6 +90,64 @@ public class NamedBeanComboBoxTest {
         assertThat(t.getSelectedItemSystemName()).isEqualTo("IS3");
         // Display name is user name if present
         assertThat(t.getSelectedItemDisplayName()).isEqualTo("Sensor 3");
+    }
+
+    @Test
+    public void testSensorUserNameMixThatCausedProblems() {
+        assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
+        // add an LS manager
+        ((jmri.managers.ProxySensorManager) InstanceManager.getDefault(SensorManager.class)).getDefaultManager();
+        var lsm = new jmri.jmrix.internal.InternalSensorManager(
+                    new jmri.jmrix.internal.InternalSystemConnectionMemo("L", "LocoNet"));
+        ((jmri.managers.ProxySensorManager) InstanceManager.getDefault(SensorManager.class)).addManager(lsm);
+        SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
+
+        Sensor is101 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS101");
+        is101.setUserName("IS 101");
+        Sensor is102 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS102");
+        is102.setUserName("IS102");
+
+        Sensor clock = InstanceManager.getDefault(SensorManager.class).provideSensor ("ISCLOCKRUNNING");
+
+        Sensor ls101 = InstanceManager.getDefault(SensorManager.class).provideSensor("LS101");
+        ls101.setUserName("LS 101");
+        Sensor ls102 = InstanceManager.getDefault(SensorManager.class).provideSensor("LS102");
+        ls102.setUserName("LS102");
+
+        NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> {
+            NamedBeanComboBox<Sensor> b = new NamedBeanComboBox<>(m, is101, DisplayOptions.DISPLAYNAME);
+            assertThat(b.getSelectedItem()).isEqualTo(is101);
+            b.setSelectedItem(is102);
+            return b;
+        });
+        assertThat(t).as("exists").isNotNull();
+
+        assertThat(t.getSelectedItem()).isEqualTo(is102);
+        assertThat(t.getSelectedItemUserName()).isEqualTo("IS102");
+        assertThat(t.getSelectedItemSystemName()).isEqualTo("IS102");
+        // Display name is user name if present
+        assertThat(t.getSelectedItemDisplayName()).isEqualTo("IS102");
+
+        // check that they're all there
+        assertThat(t.getItemCount()).isEqualTo(5);
+
+        GuiActionRunner.execute(() -> {
+            t.setSelectedIndex(0);
+
+        });
+        assertThat(t.getSelectedItem()).isEqualTo(is102);
+
+        GuiActionRunner.execute(() -> {
+            t.setSelectedIndex(1);
+
+        });
+        assertThat(t.getSelectedItem()).isEqualTo(is101);
+
+        GuiActionRunner.execute(() -> {
+            t.setSelectedIndex(4);
+
+        });
+        assertThat(t.getSelectedItem()).isEqualTo(clock);
     }
 
     @Test
@@ -154,7 +212,7 @@ public class NamedBeanComboBoxTest {
         Manager<Sensor> m = InstanceManager.getDefault(jmri.SensorManager.class);
         NamedBeanComboBox<Sensor> t = GuiActionRunner.execute(() -> new NamedBeanComboBox<>(m));
         assertThat(t).isNotNull();
-        
+
         assertThat(t.isValidatingInput()).isTrue();
 
         t.setValidatingInput(false);
@@ -169,12 +227,12 @@ public class NamedBeanComboBoxTest {
     static int countAdded;
     static int countRemoved;
     static Manager.ManagerDataEvent<Sensor> lastEvent;
-    
+
     @Test
     public void testDataUpdatesForNewDataModel() {
         assumeThat(GraphicsEnvironment.isHeadless()).isFalse();
         SensorManager m = InstanceManager.getDefault(jmri.SensorManager.class);
-        
+
         Manager.ManagerDataListener<Sensor> listener = new Manager.ManagerDataListener<Sensor>() {
             @Override
             public void contentsChanged(Manager.ManagerDataEvent<Sensor> e) {
@@ -199,11 +257,11 @@ public class NamedBeanComboBoxTest {
         lastEvent = null;
 
         GuiActionRunner.execute(() -> m.provideSensor("IS2"));
-        
+
         assertThat(countContents).isEqualTo(0);
         assertThat(countAdded).isEqualTo(1);
         assertThat(countRemoved).isEqualTo(0);
-        
+
         assertThat(lastEvent.getIndex0()).isEqualTo(0);  // new element 0
         assertThat(lastEvent.getIndex1()).isEqualTo(0);
 
@@ -211,7 +269,7 @@ public class NamedBeanComboBoxTest {
         lastEvent = null;
 
         GuiActionRunner.execute(() -> m.provideSensor("IS3"));
-        
+
         assertThat(countContents).isEqualTo(0);
         assertThat(countAdded).isEqualTo(1);
         assertThat(countRemoved).isEqualTo(0);
@@ -223,7 +281,7 @@ public class NamedBeanComboBoxTest {
         lastEvent = null;
 
         GuiActionRunner.execute(() -> m.provideSensor("IS1"));
-        
+
         assertThat(countContents).isEqualTo(0);
         assertThat(countAdded).isEqualTo(1);
         assertThat(countRemoved).isEqualTo(0);
@@ -231,7 +289,7 @@ public class NamedBeanComboBoxTest {
         assertThat(lastEvent.getIndex0()).isEqualTo(0);  // new element 0
         assertThat(lastEvent.getIndex1()).isEqualTo(0);
     }
-        
+
     @Test
     public void testSensorAllowEdit() {
         assumeThat(GraphicsEnvironment.isHeadless()).isFalse();

--- a/java/test/jmri/util/NamedBeanUserNameComparatorTest.java
+++ b/java/test/jmri/util/NamedBeanUserNameComparatorTest.java
@@ -12,95 +12,188 @@ import jmri.*;
  * @author Paul Bender Copyright (C) 2017
  */
 public class NamedBeanUserNameComparatorTest {
-    
+
     @Test
     public void testNonNullUserNameCases() {
         NamedBeanUserNameComparator<Turnout> t = new NamedBeanUserNameComparator<>();
-        
+
         Turnout it1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
         Turnout it10 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT10");
         Turnout it2 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT2");
         it1.setUserName(it1.getSystemName());
         it10.setUserName(it10.getSystemName());
         it2.setUserName(it2.getSystemName());
-        
+
         Assert.assertEquals("IT1 == IT1", 0, t.compare(it1, it1));
-        
+
         Assert.assertEquals("IT1 < IT2", -1, t.compare(it1, it2));
         Assert.assertEquals("IT2 > IT1", +1, t.compare(it2, it1));
-        
+
         Assert.assertEquals("IT10 > IT2", +1, t.compare(it10, it2));
         Assert.assertEquals("IT2 < IT10", -1, t.compare(it2, it10));
-        
+
+        TreeSet<Turnout> set = new TreeSet<>(t);
+        set.addAll(InstanceManager.getDefault(TurnoutManager.class).getNamedBeanSet());
+        Assert.assertArrayEquals(
+                new Turnout[]{it1, it2, it10},
+                set.toArray(new Turnout[set.size()]));
+
         it1.setUserName("A");
         it10.setUserName("B");
         it2.setUserName("C");
-        
+
         Assert.assertEquals("A == A", 0, t.compare(it1, it1));
-        
+
         Assert.assertEquals("A < C", -1, t.compare(it1, it2));
         Assert.assertEquals("C > A", +1, t.compare(it2, it1));
-        
+
         Assert.assertEquals("B < C", -1, t.compare(it10, it2));
         Assert.assertEquals("C > B", +1, t.compare(it2, it10));
-        
+
+        set = new TreeSet<>(t);
+        set.addAll(InstanceManager.getDefault(TurnoutManager.class).getNamedBeanSet());
+        Assert.assertArrayEquals(
+                new Turnout[]{it1, it10, it2},
+                set.toArray(new Turnout[set.size()]));
     }
-    
+
     @Test
     public void testOneLetterCases() {
         NamedBeanUserNameComparator<Turnout> t = new NamedBeanUserNameComparator<>();
-        
+
         Turnout it1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
         Turnout it10 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT10");
         Turnout it2 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT2");
-        
+
         Assert.assertEquals("IT1 == IT1", 0, t.compare(it1, it1));
-        
+
         Assert.assertEquals("IT1 < IT2", -1, t.compare(it1, it2));
         Assert.assertEquals("IT2 > IT1", +1, t.compare(it2, it1));
-        
+
         Assert.assertEquals("IT10 > IT2", +1, t.compare(it10, it2));
         Assert.assertEquals("IT2 < IT10", -1, t.compare(it2, it10));
+
+        TreeSet<Turnout> set = new TreeSet<>(t);
+        set.addAll(InstanceManager.getDefault(TurnoutManager.class).getNamedBeanSet());
+        Assert.assertArrayEquals(
+                new Turnout[]{it1, it2, it10},
+                set.toArray(new Turnout[set.size()]));
     }
-    
+
     @Test
     public void testTwoLetterCases() {
         NamedBeanUserNameComparator<Turnout> t = new NamedBeanUserNameComparator<>();
-        
+
         Turnout i2t1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I2T1");
         Turnout i2t10 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I2T10");
         Turnout i2t2 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I2T2");
-        
+
         Assert.assertEquals("I2T1 == I2T1", 0, t.compare(i2t1, i2t1));
-        
+
         Assert.assertEquals("I2T1 < I2T2", -1, t.compare(i2t1, i2t2));
         Assert.assertEquals("I2T2 > I2T1", +1, t.compare(i2t2, i2t1));
-        
+
         Assert.assertEquals("I2T10 > I2T2", +1, t.compare(i2t10, i2t2));
         Assert.assertEquals("I2T2 < I2T10", -1, t.compare(i2t2, i2t10));
     }
-    
+
     @Test
     public void testThreeLetterCases() {
         NamedBeanUserNameComparator<Turnout> t = new NamedBeanUserNameComparator<>();
-        
+
         Turnout i23t1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T1");
         Turnout i23t10 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T10");
         Turnout i23t2 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T2");
-        
+
         Assert.assertEquals("I23T1 == I23T1", 0, t.compare(i23t1, i23t1));
-        
+
         Assert.assertEquals("I23T1 < I23T2", -1, t.compare(i23t1, i23t2));
         Assert.assertEquals("I23T2 > I23T1", +1, t.compare(i23t2, i23t1));
-        
+
         Assert.assertEquals("I23T10 > I23T2", +1, t.compare(i23t10, i23t2));
         Assert.assertEquals("I23T2 < I23T10", -1, t.compare(i23t2, i23t10));
     }
-    
+
+    @Test
+    public void testForUniqueOrdering() {
+
+        // check the ordering of mix of beans with and without user names
+        //    IT3 FOO
+        //    IT1 XYZ
+        //    IT2
+        //    IT4
+
+        NamedBeanUserNameComparator<Turnout> t = new NamedBeanUserNameComparator<>();
+
+        Turnout it1xyz = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
+        it1xyz.setUserName("XYZ");
+        Turnout it2 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT2");
+        Turnout it3foo = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT3");
+        it3foo.setUserName("FOO");
+        Turnout it4 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT4");
+
+        Assert.assertEquals("IT3 < IT1", -1, t.compare(it3foo, it1xyz));
+        Assert.assertEquals("IT3 < IT2", -1, t.compare(it3foo, it2));
+        Assert.assertEquals("IT3 < IT4", -1, t.compare(it3foo, it4));
+        Assert.assertEquals("IT1 < IT2", -1, t.compare(it1xyz, it2));
+        Assert.assertEquals("IT1 < IT4", -1, t.compare(it1xyz, it4));
+        Assert.assertEquals("IT2 < IT4", -1, t.compare(it2, it4));
+
+        TreeSet<Turnout> set = new TreeSet<>(t);
+        set.addAll(InstanceManager.getDefault(TurnoutManager.class).getNamedBeanSet());
+        Assert.assertArrayEquals(
+                new Turnout[]{it3foo, it1xyz, it2, it4},
+                set.toArray(new Turnout[set.size()]));
+    }
+
+    @Test
+    public void testForUniqueOrderingWithLS() {
+        ((jmri.managers.ProxySensorManager) InstanceManager.getDefault(SensorManager.class)).getDefaultManager();
+        // add an LS manager
+        var lsm = new jmri.jmrix.internal.InternalSensorManager(
+                    new jmri.jmrix.internal.InternalSystemConnectionMemo("L", "LocoNet"));
+        ((jmri.managers.ProxySensorManager) InstanceManager.getDefault(SensorManager.class)).addManager(lsm);
+
+        // Check the ordering of mix of beans with and without user names
+        // Expect:
+        //  IS102    // due to prefer number comparator
+        //  IS 101
+        //  LS102
+        //  LS 101
+        //  ISCLOCKRUNNING
+
+
+        NamedBeanUserNameComparator<Sensor> t = new NamedBeanUserNameComparator<>();
+
+        Sensor is101 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS101");
+        is101.setUserName("IS 101");
+        Sensor is102 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS102");
+        is102.setUserName("IS102");
+
+        Sensor clock = InstanceManager.getDefault(SensorManager.class).provideSensor ("ISCLOCKRUNNING");
+
+        Sensor ls101 = InstanceManager.getDefault(SensorManager.class).provideSensor("LS101");
+        ls101.setUserName("LS 101");
+        Sensor ls102 = InstanceManager.getDefault(SensorManager.class).provideSensor("LS102");
+        ls102.setUserName("LS102");
+
+        Assert.assertEquals("LS101", ls101.getSystemName());
+        Assert.assertEquals("IS101", is101.getSystemName()); // checking that no prefixes were added
+
+        Assert.assertEquals("IS102 < IS101", -1, t.compare(is102, is101));
+        Assert.assertEquals("IS101 < ISCLOCKRUNNING", -1, t.compare(is101, clock));
+
+        TreeSet<Sensor> set = new TreeSet<>(t);
+        set.addAll(InstanceManager.getDefault(SensorManager.class).getNamedBeanSet());
+        Assert.assertArrayEquals(
+                new Sensor[]{is102, is101, ls102, ls101, clock},  // wrong order - fail
+                set.toArray(new Sensor[set.size()]));
+    }
+
     @Test
     public void testMixedUserNamesSystemNamesCase() {
         NamedBeanUserNameComparator<Turnout> c = new NamedBeanUserNameComparator<>();
-        
+
         Turnout i23t1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T1");
         Turnout i23t10 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T10");
         Turnout i23t2 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T2");
@@ -111,13 +204,15 @@ public class NamedBeanUserNameComparatorTest {
         Turnout i23t7 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T7");
         Turnout i23t8 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T8");
         Turnout i23t9 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T9");
-        
+
         i23t3.setUserName("Name 4");
         i23t4.setUserName("Name 3");
         i23t5.setUserName("A name");
 
         // expected sort order:
-        // i23t5
+        // i23t5 (A Name)
+        // i23t4 (Name 3)
+        // i23t3 (Name 4)
         // i23t1
         // i23t2
         // i23t6
@@ -125,8 +220,6 @@ public class NamedBeanUserNameComparatorTest {
         // i23t8
         // i23t9
         // i23t10
-        // i23t4
-        // i23t3
         Assert.assertEquals("I23T1 == I23T1", 0, c.compare(i23t1, i23t1));
         Assert.assertEquals("I23T2 == I23T2", 0, c.compare(i23t2, i23t2));
         Assert.assertEquals("I23T3 == I23T3", 0, c.compare(i23t3, i23t3));
@@ -137,28 +230,28 @@ public class NamedBeanUserNameComparatorTest {
         Assert.assertEquals("I23T8 == I23T8", 0, c.compare(i23t8, i23t8));
         Assert.assertEquals("I23T9 == I23T9", 0, c.compare(i23t9, i23t9));
         Assert.assertEquals("I23T10 == I23T10", 0, c.compare(i23t10, i23t10));
-        
+
         Assert.assertEquals("I23T1 < I23T2", -1, c.compare(i23t1, i23t2));
         Assert.assertEquals("I23T2 > I23T1", +1, c.compare(i23t2, i23t1));
-        
+
         Assert.assertEquals("I23T10 > I23T2", +1, c.compare(i23t10, i23t2));
         Assert.assertEquals("I23T2 < I23T10", -1, c.compare(i23t2, i23t10));
-        
+
         Assert.assertEquals("I23T4 < I23T3", -1, c.compare(i23t4, i23t3));
         Assert.assertEquals("I23T3 > I23T4", +1, c.compare(i23t3, i23t4));
-        
+
         Assert.assertEquals("I23T5 < I23T1", -1, c.compare(i23t5, i23t1));
         Assert.assertEquals("I23T1 > I23T5", +1, c.compare(i23t1, i23t5));
-        
+
         TreeSet<Turnout> set = new TreeSet<>(c);
         set.addAll(InstanceManager.getDefault(TurnoutManager.class).getNamedBeanSet());
         Assert.assertArrayEquals(
-                new Turnout[]{i23t5, i23t1, i23t2, i23t6, i23t7, i23t8, i23t9, i23t10, i23t4, i23t3},
+                new Turnout[]{i23t5, i23t4, i23t3, i23t1, i23t2, i23t6, i23t7, i23t8, i23t9, i23t10},
                 set.toArray(new Turnout[set.size()]));
     }
-    
+
     boolean hit = false;
-    
+
     @Test
     public void testSystemSpecificCase() {
         NamedBeanUserNameComparator<Turnout> t = new NamedBeanUserNameComparator<>();
@@ -166,37 +259,37 @@ public class NamedBeanUserNameComparatorTest {
         // this just checks that the local sort is called
         Turnout it1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
         Turnout it2 = new jmri.implementation.AbstractTurnout("IT2") {
-            
+
             @Override
             protected void forwardCommandChangeToLayout(int s) {
             }
-            
+
             @Override
             protected void turnoutPushbuttonLockout(boolean b) {
             }
-            
+
             @Override
             public int compareSystemNameSuffix(String suffix1, String suffix2, jmri.NamedBean n) {
                 hit = true;
                 return super.compareSystemNameSuffix(suffix1, suffix2, n);
             }
         };
-        
+
         hit = false;
         Assert.assertEquals("IT1 < IT2", -1, t.compare(it1, it2));
         Assert.assertFalse(hit);
-        
+
         hit = false;
         Assert.assertEquals("IT2 < IT1", +1, t.compare(it2, it1));
         Assert.assertTrue(hit);
     }
-    
+
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.initInternalTurnoutManager();
     }
-    
+
     @AfterEach
     public void tearDown() {
         JUnitUtil.tearDown();


### PR DESCRIPTION
This updates NamedBeanUserNameComparator to always place beans with user names ahead of beans without.  This moves system-name-only beans to the bottom of comboboxes, and (should) resolve Issue #8503 where some beans were not listed. 