### PR TITLE
CAN / misc. javadoc update

### DIFF
--- a/java/src/jmri/SpeedStepMode.java
+++ b/java/src/jmri/SpeedStepMode.java
@@ -48,6 +48,11 @@ public enum SpeedStepMode {
     public final float increment;
     public final String description;
 
+    /**
+     * Get a locale friendly Step Mode Description.
+     * For just "128" use name()
+     * @return e.g. "128 SS"
+     */
     @Override
     public String toString() {
         return description;

--- a/java/src/jmri/jmrix/CaptiveSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/CaptiveSystemConnectionMemo.java
@@ -16,10 +16,11 @@ import jmri.util.NamedBeanPreferNumericComparator;
  * by providing connection memo services without being connected to a particular system
  * instantiation.
  * <p>
- * An object of this classe does not get registered
+ * An object of this class does not get registered
  * with the {@link jmri.InstanceManager} and is likely to have a system prefix
  * and user name that conflict with the default values of another, user
- * controllable, manager. This SystemConnectionMemo is not intended to be
+ * controllable, manager.
+ * This SystemConnectionMemo is not intended to be
  * invoked on any system connection that is configurable by the user.
  * Note that this is handled as a special case in
  * {@link DefaultSystemConnectionMemo}.

--- a/java/src/jmri/jmrix/DefaultSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/DefaultSystemConnectionMemo.java
@@ -204,6 +204,13 @@ public abstract class DefaultSystemConnectionMemo extends Bean implements System
         }
     }
 
+    /**
+     * Dispose of System Connection.
+     * <p>
+     * Removes objects from classObjectMap after
+     * calling dispose if Disposable.
+     * Removes these objects from InstanceManager.
+     */
     @Override
     public void dispose() {
         Set<Class<?>> keySet = new HashSet<>(classObjectMap.keySet());
@@ -211,6 +218,14 @@ public abstract class DefaultSystemConnectionMemo extends Bean implements System
         SystemConnectionMemoManager.getDefault().deregister(this);
     }
 
+    /**
+     * Remove single class object.
+     * Removes from InstanceManager
+     * Removes from Memo class list
+     * Call object dispose if class implements Disposable
+     * @param <T> class Type
+     * @param c actual class
+     */
     private <T> void removeRegisteredObject(Class<T> c) {
         T object = get(c);
         if (object != null) {
@@ -330,10 +345,30 @@ public abstract class DefaultSystemConnectionMemo extends Bean implements System
         jmri.InstanceManager.store(c, ConsistManager.class);
     }
 
+    /**
+     * Store a class object to the system connection memo.
+     * <p>
+     * Does NOT register the class with InstanceManager.
+     * <p>
+     * On memo dispose, each class will be removed from InstanceManager,
+     * and if the class implements disposable, the dispose method is called.
+     * @param <T> Class type obtained from item object.
+     * @param item the class object to store, eg. mySensorManager
+     * @param type Class type, eg. SensorManager.class
+     */
     public <T> void store(@Nonnull T item, @Nonnull Class<T> type){
         classObjectMap.put(type,item);
     }
 
+    /**
+     * Remove a class object from the system connection memo classObjectMap.
+     * <p>
+     * Does NOT remove the class from InstanceManager.
+     * <p>
+     * @param <T> Class type obtained from item object.
+     * @param item the class object to store, eg. mySensorManager
+     * @param type Class type, eg. SensorManager.class
+     */
     public <T> void deregister(@Nonnull T item, @Nonnull Class<T> type){
         classObjectMap.remove(type,item);
     }

--- a/java/src/jmri/jmrix/can/CanConfigurationManager.java
+++ b/java/src/jmri/jmrix/can/CanConfigurationManager.java
@@ -40,9 +40,6 @@ public class CanConfigurationManager extends ConfigurationManager {
      */
     @Override
     public boolean provides(Class<?> type) {
-        if (adapterMemo.getDisabled()) {
-            return false;
-        }
         return false; // nothing, by default
     }
 
@@ -52,9 +49,6 @@ public class CanConfigurationManager extends ConfigurationManager {
      */
     @Override
     public <T> T get(Class<?> T) {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
         return null;
     }
 

--- a/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
@@ -7,9 +7,8 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
+import jmri.*;
 import jmri.jmrix.ConfiguringSystemConnectionMemo;
-import jmri.InstanceManager;
-import jmri.NamedBean;
 import jmri.jmrix.DefaultSystemConnectionMemo;
 import jmri.jmrix.can.ConfigurationManager.SubProtocol;
 import jmri.jmrix.can.ConfigurationManager.ProgModeSwitch;
@@ -37,11 +36,21 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
 
     private boolean protocolOptionsChanged = false;
 
+    /**
+     * Create a new CanSystemConnectionMemo.
+     * Default prefix: M
+     * Default Username: CAN
+     */
     public CanSystemConnectionMemo() {
         super("M", DEFAULT_USERNAME);
     }
-    
-    // Allow for default systemPrefix other than "M"
+
+    /**
+     * Create a new CanSystemConnectionMemo.
+     * Allows for default systemPrefix other than "M"
+     * Default Username: CAN
+     * @param prefix System prefix to use, e.g. M.
+     */
     public CanSystemConnectionMemo(String prefix) {
         super(prefix, DEFAULT_USERNAME);
     }
@@ -63,7 +72,7 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
     protected TrafficController tm;
 
     /**
-     * Set Connection Traffic Controller
+     * Set Connection Traffic Controller.
      * @param tm System Connection Traffic Controller
      */
     public void setTrafficController(TrafficController tm) {
@@ -71,7 +80,7 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
     }
     
     /**
-     * Get Connection Traffic Controller
+     * Get Connection Traffic Controller.
      * @return System Connection Traffic Controller
      */
     public TrafficController getTrafficController() {
@@ -84,6 +93,7 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
 
     /**
      * {@inheritDoc }
+     * Searches ConfigurationManager for class before super.
      */
     @Override
     public boolean provides(Class<?> type) {
@@ -114,20 +124,44 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
 
     /**
      * {@inheritDoc }
+     * Searches ConfigurationManager for class before super.
      */
     @SuppressWarnings("unchecked")
     @Override
     public <T> T get(Class<?> T) {
         if (manager != null && !getDisabled()) {
-            return (T) manager.get(T);
+            T existing = manager.get(T);
+            if ( existing !=null ) {
+                return existing;
+            }
         }
         return super.get(T);
     }
 
+    /**
+     * Get a class directly from the memo Class Object Map.
+     * @param <T> Class type
+     * @param T Class type
+     * @return object in class object map, or null if not present.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getFromMap(Class<?> T) {
+        return (T) classObjectMap.get(T);
+    }
+
+    /**
+     * Get the Protocol in use by the CAN Connection.
+     * e.g. ConfigurationManager.SPROGCBUS
+     * @return ConfigurationManager constant of protocol.
+     */
     public String getProtocol() {
         return _protocol;
     }
-    
+
+    /**
+     * Set the protocol in use by the connection.
+     * @param protocol e.g. ConfigurationManager.SPROGCBUS
+     */
     public void setProtocol(String protocol) {
         StartupActionFactory old = getActionFactory();
         if (null != protocol) {
@@ -153,10 +187,18 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
         firePropertyChange("actionFactory", old, getActionFactory());
     }
 
+    /**
+     * Get ENUM of the sub protocol.
+     * @return the sub protocol in use, e.g. SubProtocol.CBUS
+     */
     public SubProtocol getSubProtocol() {
         return _subProtocol;
     }
-    
+
+    /**
+     * Set the sub protocol ENUM.
+     * @param sp e.g. SubProtocol.CBUS
+     */
     public void setSubProtocol(SubProtocol sp) {
         if (null != sp) {
             _subProtocol = sp;
@@ -164,8 +206,8 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
     }
 
     /**
-     * Get the stare of the programming mode switch which indicates what combination
-     * o service and/or ops mode programming is supported by the connection.
+     * Get the state of the programming mode switch which indicates what combination
+     * of service and/or ops mode programming is supported by the connection.
      * 
      * @return the supported modes
      */
@@ -220,8 +262,11 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
     }
     
     /**
-     * Configure the common managers for Can connections. This puts the common
-     * manager config in one place.
+     * Configure the common managers for Can connections.
+     * {@inheritDoc }
+     * Calls ConfigurationManager.configureManagers
+     * Stores Can Memo to Instance to indicate available.
+     * 
      */
     @Override
     public void configureManagers() {
@@ -324,11 +369,11 @@ public class CanSystemConnectionMemo extends DefaultSystemConnectionMemo impleme
      */
     @Override
     public void dispose() {
+        super.dispose(); // remove class map object items before manager config
         if (manager != null) {
             manager.dispose();
         }
         tm = null;
-        super.dispose();
     }
 
     private static final Logger log = LoggerFactory.getLogger(CanSystemConnectionMemo.class);

--- a/java/src/jmri/jmrix/can/cbus/CbusClockControl.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusClockControl.java
@@ -5,6 +5,8 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+
+import jmri.Disposable;
 import jmri.TimebaseRateException;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.CanListener;
@@ -19,7 +21,7 @@ import org.slf4j.LoggerFactory;
  * @since 4.19.6
  * @author Steve Young (C) 2020
  */
-public class CbusClockControl extends jmri.implementation.DefaultClockControl implements CanListener {
+public class CbusClockControl extends jmri.implementation.DefaultClockControl implements CanListener, Disposable {
 
     private boolean isRunning;
     private int _cbusTemp = 0;
@@ -317,6 +319,7 @@ public class CbusClockControl extends jmri.implementation.DefaultClockControl im
      * Stops listening for updates from network and main time base.
      *
      */
+    @Override
     public void dispose() {
         clock.removeMinuteChangeListener(this::newMinute);
         this.removeTc(_memo);

--- a/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.can.cbus;
 
+import jmri.Disposable;
 import jmri.JmriException;
 import jmri.jmrix.can.CanListener;
 import jmri.jmrix.can.CanMessage;
@@ -14,7 +15,7 @@ import jmri.managers.AbstractPowerManager;
  * @author Bob Jacobsen Copyright (C) 2001
  * @author Andrew Crosland Copyright (C) 2009, 2021
  */
-public class CbusPowerManager extends AbstractPowerManager<CanSystemConnectionMemo> implements CanListener {
+public class CbusPowerManager extends AbstractPowerManager<CanSystemConnectionMemo> implements CanListener, Disposable {
 
     private TrafficController tc;
 
@@ -60,7 +61,7 @@ public class CbusPowerManager extends AbstractPowerManager<CanSystemConnectionMe
      * {@inheritDoc}
      */
     @Override
-    public void dispose() throws JmriException {
+    public void dispose() {
         removeTc(tc);
         tc = null;
     }

--- a/java/src/jmri/jmrix/can/cbus/CbusPredefinedMeters.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusPredefinedMeters.java
@@ -24,7 +24,7 @@ import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
  * @author Andrew Crosland 2021
  * Added extra current meter for systems with two track outputs
 */
-public class CbusPredefinedMeters implements CanListener {
+public class CbusPredefinedMeters implements CanListener, Disposable {
 
     private final TrafficController tc;
     private int _nodeToListen;
@@ -105,6 +105,7 @@ public class CbusPredefinedMeters implements CanListener {
     public void message(CanMessage m) {
     }
     
+    @Override
     public void dispose() {
         updateTask.disable(currentMeter);
         updateTask.disable(currentMeterExtra);

--- a/java/src/jmri/jmrix/can/cbus/eventtable/CbusBasicEventTableModel.java
+++ b/java/src/jmri/jmrix/can/cbus/eventtable/CbusBasicEventTableModel.java
@@ -65,8 +65,13 @@ public class CbusBasicEventTableModel extends javax.swing.table.AbstractTableMod
         EVENT_DAT_1, EVENT_DAT_2, EVENT_DAT_3 };
 
     public CbusBasicEventTableModel(CanSystemConnectionMemo memo) {
+        this(memo, 1);
+    }
+
+    public CbusBasicEventTableModel(CanSystemConnectionMemo memo, int initialArray) {
+        super();
         _memo = memo;
-        _mainArray = new ArrayList<>();
+        _mainArray = new ArrayList<>(initialArray);
         ta = new CbusEventTableAction( this);
     }
 

--- a/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableAction.java
+++ b/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableAction.java
@@ -68,7 +68,7 @@ public class CbusEventTableAction implements PropertyChangeListener {
         _model._mainArray.forEach((n) -> n.resetBeans() );
         fireAllJmriCellsChanged();
         for (Class<?> classType : classTypes) {
-            jmri.Manager<?> sm = (jmri.Manager<?>) InstanceManager.getDefault(classType);
+            jmri.Manager<?> sm = (jmri.Manager<?>) InstanceManager.getDefault(classType); // proxy manager
             sm.getNamedBeanSet().forEach((nb) -> {
                 if (nb instanceof CbusEventInterface) {
                     linkHwaddtoEvent( nb, true, ((CbusEventInterface)nb).getBeanOnMessage());

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeTrickleFetch.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeTrickleFetch.java
@@ -90,7 +90,7 @@ public class CbusNodeTrickleFetch implements CanListener {
     
     public void dispose(){
         stopTrickleTimer();
-        tc.removeCanListener(this);
+        removeTc(tc);
     }
 
     // private final static Logger log = LoggerFactory.getLogger(CbusNodeTrickleFetch.class);

--- a/java/src/jmri/jmrix/can/nmranet/NmraConfigurationManager.java
+++ b/java/src/jmri/jmrix/can/nmranet/NmraConfigurationManager.java
@@ -15,7 +15,7 @@ public class NmraConfigurationManager extends jmri.jmrix.can.ConfigurationManage
         super(memo);
         InstanceManager.store(cf = new jmri.jmrix.can.nmranet.swing.NmraNetComponentFactory(adapterMemo),
                 jmri.jmrix.swing.ComponentFactory.class);
-        InstanceManager.store(this, NmraConfigurationManager.class);
+        InstanceManager.store(NmraConfigurationManager.this, NmraConfigurationManager.class);
     }
 
     jmri.jmrix.swing.ComponentFactory cf = null;
@@ -29,17 +29,11 @@ public class NmraConfigurationManager extends jmri.jmrix.can.ConfigurationManage
      */
     @Override
     public boolean provides(Class<?> type) {
-        if (adapterMemo.getDisabled()) {
-            return false;
-        }
         return false; // nothing, by default
     }
 
     @Override
     public <T> T get(Class<?> T) {
-        if (adapterMemo.getDisabled()) {
-            return null;
-        }
         return null; // nothing, by default
     }
 

--- a/java/test/jmri/jmrix/can/CanSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/can/CanSystemConnectionMemoTest.java
@@ -18,6 +18,8 @@ public class CanSystemConnectionMemoTest extends SystemConnectionMemoTestBase<Ca
         // without knowing which system is connected via can, there is no
         // way to provide a consist manager.
         Assert.assertFalse("Provides ConsistManager", scm.provides(jmri.ConsistManager.class));
+        scm.setProtocol(ConfigurationManager.SPROGCBUS);
+        Assert.assertTrue("Provides ConsistManager", scm.provides(jmri.ConsistManager.class));
     }
 
     @Override

--- a/java/test/jmri/jmrix/can/TrafficControllerScaffold.java
+++ b/java/test/jmri/jmrix/can/TrafficControllerScaffold.java
@@ -1,9 +1,12 @@
 package jmri.jmrix.can;
 
+import java.util.List;
 import java.util.Vector;
+
 import jmri.jmrix.AbstractMRListener;
 import jmri.jmrix.AbstractMRMessage;
 import jmri.jmrix.AbstractMRReply;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,9 +24,7 @@ public class TrafficControllerScaffold extends TrafficController {
 
     static public TrafficControllerScaffold instance() {
         if (self == null) {
-            if (log.isDebugEnabled()) {
-                log.debug("creating a new TrafficControllerScaffold object");
-            }
+            log.debug("creating a new TrafficControllerScaffold object");
             self = new TrafficControllerScaffold();
         }
         return self;
@@ -80,9 +81,7 @@ public class TrafficControllerScaffold extends TrafficController {
 
     @Override
     public void sendCanMessage(CanMessage m, CanListener l) {
-        if (log.isDebugEnabled()) {
-            log.debug("sendCanMessage [{}]", m);
-        }
+        log.debug("sendCanMessage [{}]", m);
         // save a copy
         outbound.addElement(m);
         mLastSender = l;
@@ -90,9 +89,7 @@ public class TrafficControllerScaffold extends TrafficController {
 
     @Override
     public void sendCanReply(CanReply r, CanListener l) {
-        if (log.isDebugEnabled()) {
-            log.debug("sendCanReply [{}]", r);
-        }
+        log.debug("sendCanReply [{}]", r);
         // save a copy
         inbound.addElement(r);
     }
@@ -102,6 +99,14 @@ public class TrafficControllerScaffold extends TrafficController {
      */
     public int numListeners() {
         return cmdListeners.size();
+    }
+
+    /**
+     * Get List of Listeners.
+     * @return List of CAN Listeners.
+     */
+    public List<AbstractMRListener> getListeners() {
+        return cmdListeners;
     }
 
     private final static Logger log = LoggerFactory.getLogger(TrafficControllerScaffold.class);

--- a/java/test/jmri/jmrix/can/cbus/CbusPowerManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusPowerManagerTest.java
@@ -163,9 +163,7 @@ public class CbusPowerManagerTest extends AbstractPowerManagerTestBase {
     @AfterEach
     public void tearDown() {
         
-        try {
-            pwr.dispose();
-        } catch (jmri.JmriException ex) {}
+        pwr.dispose();
         
         memo.dispose();
         controller.terminateThreads();


### PR DESCRIPTION
DefaultSystemConnectionMemo - javadoc
CanSystemConnectionMemo - add direct access to memo classObjectMap storage ( further update to follow once this is merged )
CanSystemConnectionMemo  - dispose calls super before can manager configuration class

can - remove some unused if statements
cbus - implement some disposables

test can TrafficControllerScaffold - add access to can listener list to identify listeners on dispose.