### PR TITLE
Clean up warn logging messages

### DIFF
--- a/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
@@ -3,6 +3,8 @@ package jmri.jmrit.logixng.tools;
 import java.awt.GraphicsEnvironment;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
 import jmri.*;
 import jmri.jmrit.entryexit.DestinationPoints;
@@ -13,6 +15,8 @@ import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import jmri.util.junit.rules.*;
 
+import org.apache.log4j.Level;
+import org.apache.log4j.spi.LoggingEvent;
 import org.junit.*;
 
 /**
@@ -218,11 +222,15 @@ public class ImportEntryExitTest {
 
     @After
     public void tearDown() {
-        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0001C1' to LogixNG 'IQ:AUTO:0001'");
-        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0002C1' to LogixNG 'IQ:AUTO:0002'");
-        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0003C1' to LogixNG 'IQ:AUTO:0003'");
-        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0004C1' to LogixNG 'IQ:AUTO:0004'");
-        JUnitAppender.assertWarnMessage("Import Conditional 'IX:RTXINITIALIZER1T' to LogixNG 'IQ:AUTO:0005'");
+        List<LoggingEvent> list = new ArrayList<>(JUnitAppender.getBacklog());
+        for (LoggingEvent event : list) {
+            if ((event.getLevel() == Level.WARN)
+                    && (event.getMessage().toString().startsWith("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:000'")
+                        || event.getMessage().toString().equals("Import Conditional 'IX:RTXINITIALIZER1T' to LogixNG 'IQ:AUTO:0005'"))
+                    ) {
+                JUnitAppender.suppressErrorMessage(event.getMessage().toString());
+            }
+        }
 
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.clearTurnoutThreads();

--- a/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
@@ -9,6 +9,7 @@ import jmri.jmrit.entryexit.DestinationPoints;
 import jmri.jmrit.logix.*;
 import jmri.jmrit.logixng.ConditionalNG_Manager;
 import jmri.jmrit.logixng.LogixNG_Manager;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import jmri.util.junit.rules.*;
 
@@ -217,6 +218,12 @@ public class ImportEntryExitTest {
 
     @After
     public void tearDown() {
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0001C1' to LogixNG 'IQ:AUTO:0001'");
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0002C1' to LogixNG 'IQ:AUTO:0002'");
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0003C1' to LogixNG 'IQ:AUTO:0003'");
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0004C1' to LogixNG 'IQ:AUTO:0004'");
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX:RTXINITIALIZER1T' to LogixNG 'IQ:AUTO:0005'");
+
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.clearTurnoutThreads();
         JUnitUtil.clearRouteThreads();

--- a/java/test/jmri/jmrit/logixng/tools/ImportExpressionComplexTestBase.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportExpressionComplexTestBase.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.logixng.tools;
 
-import java.util.ArrayList;
-import java.util.SortedSet;
+import java.util.*;
 
 import jmri.*;
 import jmri.implementation.DefaultConditionalAction;
@@ -10,6 +9,8 @@ import jmri.jmrit.logixng.LogixNG_Manager;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
+import org.apache.log4j.Level;
+import org.apache.log4j.spi.LoggingEvent;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -23,11 +24,11 @@ import org.junit.Test;
  * deletes the original Logix and then test that the new LogixNG works.
  * <P>
  * This class is base class for the expression tests
- * 
+ *
  * @author Daniel Bergqvist (C) 2020
  */
 public abstract class ImportExpressionComplexTestBase {
-    
+
     public enum Setup {
         Init,
         Fail1,
@@ -38,14 +39,14 @@ public abstract class ImportExpressionComplexTestBase {
         Succeed3,
         Succeed4,
     }
-    
+
     private LogixManager logixManager;
     protected Logix logix;
     protected Conditional conditional;
     private ArrayList<ConditionalVariable> variables;
     private ArrayList<ConditionalAction> actions;
     private Turnout t1;
-    
+
     /**
      * Some NamedBeans, for example Light, does not support other states than ON and OFF
      * @return true if other states than ON and OFF is allowed
@@ -53,27 +54,27 @@ public abstract class ImportExpressionComplexTestBase {
     public boolean isStateOtherAllowed() {
         return true;
     }
-    
+
     /**
      * Set the sensor, turnout, or other bean to the desired state.
      * <P>
      * If the parameter expectSuccess is true, this method should setup the
      * bean so that the Logix/LogixNG will be successfull if the Logix/LogixNG
      * is executed.
-     * 
+     *
      * @param e the enum
      * @param setup the setup
      * @throws jmri.JmriException in case of an exception
      */
     abstract public void setNamedBeanState(Enum e, Setup setup) throws JmriException;
-    
+
     /**
      * Create a new conditional variable of the desired type
      * @return the conditional variable
      */
     abstract public ConditionalVariable newConditionalVariable();
-    
-    
+
+
     public void assertBoolean(String message, boolean expectSuccess, boolean result) {
         if (expectSuccess) {
             Assert.assertTrue(message, result);
@@ -81,44 +82,44 @@ public abstract class ImportExpressionComplexTestBase {
             Assert.assertFalse(message, result);
         }
     }
-    
+
     abstract public Enum[] getEnums();
-    
+
     public Enum getOtherEnum(Enum e) {
         Enum[] enums = getEnums();
         int value = e.ordinal() + 1;
         if (value >= enums.length) value -= enums.length;
         return enums[value];
     }
-    
+
     public Enum getThirdEnum(Enum e) {
         Enum[] enums = getEnums();
         int value = e.ordinal() + 2;
         if (value >= enums.length) value -= enums.length;
         return enums[value];
     }
-    
+
     public void testEnum(Enum e) throws JmriException {
 //        Enum otherE = getOtherEnum(e);
 //        Enum thirdE = getThirdEnum(e);
-        
+
         RunTestScaffold check = (message, expectSuccess) -> {
             setNamedBeanState(e, Setup.Init);
 //            setConditionalVariableState(e);
             t1.setState(Turnout.CLOSED);
-            
+
             // This should not throw the turnout
             setNamedBeanState(e, Setup.Fail1);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             // This should not throw the turnout
             setNamedBeanState(e, Setup.Fail2);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             // This should not throw the turnout
             setNamedBeanState(e, Setup.Fail3);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
 //            setNamedBeanState(e, Setup.Init);
 //            setConditionalVariableState(e);
             setNamedBeanState(e, Setup.Fail1);
@@ -133,14 +134,14 @@ public abstract class ImportExpressionComplexTestBase {
             setNamedBeanState(e, Setup.Succeed2);
             if (expectSuccess) JUnitUtil.waitFor(() -> t1.getState() == Turnout.THROWN);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
-            
+
             setNamedBeanState(e, Setup.Fail1);
             t1.setState(Turnout.CLOSED);
             // This should throw the turnout if Logix/LogixNG is activated
             setNamedBeanState(e, Setup.Succeed3);
             if (expectSuccess) JUnitUtil.waitFor(() -> t1.getState() == Turnout.THROWN);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
-            
+
             setNamedBeanState(e, Setup.Fail1);
             t1.setState(Turnout.CLOSED);
             // This should throw the turnout if Logix/LogixNG is activated
@@ -148,45 +149,45 @@ public abstract class ImportExpressionComplexTestBase {
             if (expectSuccess) JUnitUtil.waitFor(() -> t1.getState() == Turnout.THROWN);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
         };
-        
-        
+
+
         check.runTest("Logix is not activated. Enum: "+e.name(), false);
-        
+
         logixManager.activateAllLogixs();
-        
+
         check.runTest("Logix is activated. Enum: "+e.name(), true);
-        
+
         logix.deActivateLogix();
         conditional = null;
-        
+
         // Import the logix to LogixNG
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
-        
+
 //        logix.setEnabled(false);
 //        logixManager.deleteLogix(logix);
 //        ConditionalManager conditionalManager = InstanceManager.getDefault(ConditionalManager.class);
 //        SortedSet<Conditional> set = conditionalManager.getNamedBeanSet();
 //        for (Conditional c : set) conditionalManager.deleteConditional(c);
-        
+
         check.runTest("Logix is deactivated and LogixNG is not activated. Enum: "+e.name(), false);
 //        check.runTest("Logix is removed and LogixNG is not activated. Enum: "+e.name(), false);
-        
+
         // We want the conditionalNGs run immediately during this test
         InstanceManager.getDefault(ConditionalNG_Manager.class).setRunOnGUIDelayed(false);
-        
+
         importLogix.getLogixNG().setEnabled(true);
         InstanceManager.getDefault(LogixNG_Manager.class)
                 .activateAllLogixNGs(false, false);
-        
+
         check.runTest("LogixNG is activated. Enum: "+e.name(), true);
-        
+
         importLogix.getLogixNG().setEnabled(false);
         InstanceManager.getDefault(LogixNG_Manager.class).deleteLogixNG(importLogix.getLogixNG());
-        
+
         check.runTest("LogixNG is removed. Enum: "+e.name(), false);
     }
-    
+
     @Test
     public void testAll() throws JmriException {
         for (Enum e : getEnums()) {
@@ -201,7 +202,7 @@ public abstract class ImportExpressionComplexTestBase {
             teardownTest();
         }
     }
-    
+
 //    // The minimal setup for log4J
 //    @Before
 //    public void setUp() {
@@ -214,21 +215,21 @@ public abstract class ImportExpressionComplexTestBase {
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixManager();
         JUnitUtil.initLogixNGManager();
-        
+
         t1 = InstanceManager.getDefault(TurnoutManager.class).provide("IT1");
-        
+
         logixManager = InstanceManager.getDefault(LogixManager.class);
         ConditionalManager conditionalManager = InstanceManager.getDefault(ConditionalManager.class);
-        
+
         logix = logixManager.createNewLogix("IX1", null);
         logix.setEnabled(true);
-        
+
         conditional = conditionalManager.createNewConditional("IX1C1", "First conditional");
         logix.addConditional(conditional.getSystemName(), 0);
-        
+
         conditional.setTriggerOnChange(true);
         conditional.setLogicType(Conditional.AntecedentOperator.ALL_AND, "");
-        
+
         variables = new ArrayList<>();
         ConditionalVariable cv = newConditionalVariable();
         cv.setTriggerActions(true);
@@ -239,7 +240,7 @@ public abstract class ImportExpressionComplexTestBase {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         variables.add(cv);
         conditional.setStateVariables(variables);
-        
+
         actions = new ArrayList<>();
         ConditionalAction ca = new DefaultConditionalAction();
         ca.setType(Conditional.Action.SET_TURNOUT);
@@ -247,7 +248,7 @@ public abstract class ImportExpressionComplexTestBase {
         ca.setDeviceName("IT1");
         actions.add(ca);
         conditional.setAction(actions);
-        
+
         InstanceManager.getDefault(LogixNG_Manager.class)
                 .activateAllLogixNGs(false, false);
     }
@@ -256,10 +257,19 @@ public abstract class ImportExpressionComplexTestBase {
 //    public void tearDown() {
     public void teardownTest() {
         // JUnitAppender.clearBacklog();    REMOVE THIS!!!
-        
+
+        List<LoggingEvent> list = new ArrayList<>(JUnitAppender.getBacklog());
+        for (LoggingEvent event : list) {
+            if ((event.getLevel() == Level.WARN)
+                    && event.getMessage().toString().equals(
+                            "Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'")) {
+                JUnitAppender.suppressErrorMessage(event.getMessage().toString());
+            }
+        }
+
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/tools/ImportExpressionTestBase.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportExpressionTestBase.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.logixng.tools;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import jmri.*;
 import jmri.implementation.DefaultConditionalAction;
@@ -9,6 +10,8 @@ import jmri.jmrit.logixng.LogixNG_Manager;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
+import org.apache.log4j.Level;
+import org.apache.log4j.spi.LoggingEvent;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -22,24 +25,24 @@ import org.junit.Test;
  * deletes the original Logix and then test that the new LogixNG works.
  * <P>
  * This class is base class for the expression tests
- * 
+ *
  * @author Daniel Bergqvist (C) 2020
  */
 public abstract class ImportExpressionTestBase {
-    
+
     public enum State {
         ON,     // Sensor.ACTIVE, Turnout.CLOSED, and so on
         OFF,    // Sensor.INACTIVE, Turnout.THROWN, and so on
         OTHER,  // Sensor.UNKNOWN, Turnout.UNKNOWN, and so on
     }
-    
+
     private LogixManager logixManager;
     private Logix logix;
     private Conditional conditional;
     private ArrayList<ConditionalVariable> variables;
     private ArrayList<ConditionalAction> actions;
     private Turnout t1;
-    
+
     /**
      * Some NamedBeans, for example Light, does not support other states than ON and OFF
      * @return true if other states than ON and OFF is allowed
@@ -47,27 +50,27 @@ public abstract class ImportExpressionTestBase {
     public boolean isStateOtherAllowed() {
         return true;
     }
-    
+
     /**
      * Set the sensor, turnout, or other bean to the desired state
      * @param state the state
      * @throws jmri.JmriException in case of an exception
      */
     abstract public void setNamedBeanState(State state) throws JmriException;
-    
+
     /**
      * Set the conditional variable to check for the desired state
      * @param state the state
      */
     abstract public void setConditionalVariableState(State state);
-    
+
     /**
      * Create a new conditional variable of the desired type
      * @return the new conditional variable
      */
     abstract public ConditionalVariable newConditionalVariable();
-    
-    
+
+
     public void assertBoolean(String message, boolean expectSuccess, boolean result) {
         if (expectSuccess) {
             Assert.assertTrue(message, result);
@@ -75,7 +78,7 @@ public abstract class ImportExpressionTestBase {
             Assert.assertFalse(message, result);
         }
     }
-    
+
     // Test that state ON is imported correctly
     @Test
     public void testOn() throws JmriException {
@@ -86,7 +89,7 @@ public abstract class ImportExpressionTestBase {
             // This should not throw the turnout
             if (isStateOtherAllowed()) setNamedBeanState(State.OTHER);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             setNamedBeanState(State.OFF);
             setConditionalVariableState(State.ON);
             t1.setState(Turnout.CLOSED);
@@ -94,39 +97,39 @@ public abstract class ImportExpressionTestBase {
             setNamedBeanState(State.ON);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
         };
-        
+
         check.runTest("Logix is not activated", false);
-        
+
         logixManager.activateAllLogixs();
-        
+
         check.runTest("Logix is activated", true);
-        
+
         logix.deActivateLogix();
-        
+
         // Import the logix to LogixNG
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
-        
+
         logix.setEnabled(false);
         logixManager.deleteLogix(logix);
-        
+
         check.runTest("Logix is removed and LogixNG is not activated", false);
-        
+
         // We want the conditionalNGs run immediately during this test
         InstanceManager.getDefault(ConditionalNG_Manager.class).setRunOnGUIDelayed(false);
-        
+
         importLogix.getLogixNG().setEnabled(true);
         InstanceManager.getDefault(LogixNG_Manager.class)
                 .activateAllLogixNGs(false, false);
-        
+
         check.runTest("LogixNG is activated", true);
-        
+
         importLogix.getLogixNG().setEnabled(false);
         InstanceManager.getDefault(LogixNG_Manager.class).deleteLogixNG(importLogix.getLogixNG());
-        
+
         check.runTest("LogixNG is removed", false);
     }
-    
+
     // Test that state OFF is imported correctly
     @Test
     public void testOff() throws JmriException {
@@ -137,7 +140,7 @@ public abstract class ImportExpressionTestBase {
             // This should not throw the turnout
             if (isStateOtherAllowed()) setNamedBeanState(State.OTHER);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             setNamedBeanState(State.ON);
             setConditionalVariableState(State.OFF);
             t1.setState(Turnout.CLOSED);
@@ -145,39 +148,39 @@ public abstract class ImportExpressionTestBase {
             setNamedBeanState(State.OFF);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
         };
-        
+
         check.runTest("Logix is not activated", false);
-        
+
         logixManager.activateAllLogixs();
-        
+
         check.runTest("Logix is activated", true);
-        
+
         logix.deActivateLogix();
-        
+
         // Import the logix to LogixNG
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
-        
+
         logix.setEnabled(false);
         logixManager.deleteLogix(logix);
-        
+
         check.runTest("Logix is removed and LogixNG is not activated", false);
-        
+
         // We want the conditionalNGs run immediately during this test
         InstanceManager.getDefault(ConditionalNG_Manager.class).setRunOnGUIDelayed(false);
-        
+
         importLogix.getLogixNG().setEnabled(true);
         InstanceManager.getDefault(LogixNG_Manager.class)
                 .activateAllLogixNGs(false, false);
-        
+
         check.runTest("LogixNG is activated", true);
-        
+
         importLogix.getLogixNG().setEnabled(false);
         InstanceManager.getDefault(LogixNG_Manager.class).deleteLogixNG(importLogix.getLogixNG());
-        
+
         check.runTest("LogixNG is removed", false);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -189,20 +192,20 @@ public abstract class ImportExpressionTestBase {
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixManager();
         JUnitUtil.initLogixNGManager();
-        
+
         t1 = InstanceManager.getDefault(TurnoutManager.class).provide("IT1");
-        
+
         logixManager = InstanceManager.getDefault(LogixManager.class);
         ConditionalManager conditionalManager = InstanceManager.getDefault(ConditionalManager.class);
-        
+
         logix = logixManager.createNewLogix("IX1", null);
-        
+
         conditional = conditionalManager.createNewConditional("IX1C1", "First conditional");
         logix.addConditional(conditional.getSystemName(), 0);
-        
+
         conditional.setTriggerOnChange(true);
         conditional.setLogicType(Conditional.AntecedentOperator.ALL_AND, "");
-        
+
         variables = new ArrayList<>();
         ConditionalVariable cv = newConditionalVariable();
         cv.setTriggerActions(true);
@@ -213,7 +216,7 @@ public abstract class ImportExpressionTestBase {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         variables.add(cv);
         conditional.setStateVariables(variables);
-        
+
         actions = new ArrayList<>();
         ConditionalAction ca = new DefaultConditionalAction();
         ca.setType(Conditional.Action.SET_TURNOUT);
@@ -226,10 +229,19 @@ public abstract class ImportExpressionTestBase {
     @After
     public void tearDown() {
         // JUnitAppender.clearBacklog();    REMOVE THIS!!!
-        
+
+        List<LoggingEvent> list = new ArrayList<>(JUnitAppender.getBacklog());
+        for (LoggingEvent event : list) {
+            if ((event.getLevel() == Level.WARN)
+                    && event.getMessage().toString().equals(
+                            "Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'")) {
+                JUnitAppender.suppressErrorMessage(event.getMessage().toString());
+            }
+        }
+
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/tools/ImportExpressionWarrantTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportExpressionWarrantTest.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import jmri.*;
 import jmri.jmrit.logix.*;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
@@ -18,7 +19,7 @@ import org.junit.Test;
  * deletes the original Logix and then test that the new LogixNG works.
  * <P>
  This test tests expression warrant
- * 
+ *
  * @author Daniel Bergqvist (C) 2020
  */
 public class ImportExpressionWarrantTest {
@@ -29,48 +30,53 @@ public class ImportExpressionWarrantTest {
     private ArrayList<ConditionalVariable> variables;
     private ArrayList<ConditionalAction> actions;
     ConditionalVariable cv;
-    
-    
+
+
     @Test
     public void testRouteFree() throws JmriException {
         cv.setType(Conditional.Type.ROUTE_FREE);
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
         Assert.assertNotNull(importLogix.getLogixNG().getConditionalNG(0));
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
     }
-    
+
     @Test
     public void testRouteOccupied() throws JmriException {
         cv.setType(Conditional.Type.ROUTE_OCCUPIED);
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
         Assert.assertNotNull(importLogix.getLogixNG().getConditionalNG(0));
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
     }
-    
+
     @Test
     public void testRouteAllocated() throws JmriException {
         cv.setType(Conditional.Type.ROUTE_ALLOCATED);
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
         Assert.assertNotNull(importLogix.getLogixNG().getConditionalNG(0));
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
     }
-    
+
     @Test
     public void testRouteSet() throws JmriException {
         cv.setType(Conditional.Type.ROUTE_SET);
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
         Assert.assertNotNull(importLogix.getLogixNG().getConditionalNG(0));
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
     }
-    
+
     @Test
     public void testTrainRunning() throws JmriException {
         cv.setType(Conditional.Type.TRAIN_RUNNING);
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
         Assert.assertNotNull(importLogix.getLogixNG().getConditionalNG(0));
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -82,24 +88,24 @@ public class ImportExpressionWarrantTest {
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixManager();
         JUnitUtil.initLogixNGManager();
-        
-        
+
+
         WarrantPreferences.getDefault().setShutdown(WarrantPreferences.Shutdown.NO_MERGE);
         InstanceManager.getDefault(WarrantManager.class).register(new Warrant("IW1", null));
-        
+
         logixManager = InstanceManager.getDefault(LogixManager.class);
         ConditionalManager conditionalManager = InstanceManager.getDefault(ConditionalManager.class);
-        
+
         logix = logixManager.createNewLogix("IX1", null);
-        
+
         conditional = conditionalManager.createNewConditional("IX1C1", "First conditional");
         logix.addConditional(conditional.getSystemName(), 0);
-        
+
         conditional.setTriggerOnChange(true);
         conditional.setLogicType(Conditional.AntecedentOperator.ALL_AND, "");
-        
+
         variables = new ArrayList<>();
-        
+
         cv = new ConditionalVariable();
         cv.setTriggerActions(true);
         cv.setNegation(false);
@@ -110,7 +116,7 @@ public class ImportExpressionWarrantTest {
         cv.setName("IW1");
         variables.add(cv);
         conditional.setStateVariables(variables);
-        
+
         actions = new ArrayList<>();
         conditional.setAction(actions);
     }
@@ -121,5 +127,5 @@ public class ImportExpressionWarrantTest {
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/tools/ImportTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportTest.java
@@ -11,6 +11,7 @@ import jmri.jmrit.entryexit.DestinationPoints;
 import jmri.jmrit.logix.WarrantPreferences;
 import jmri.jmrit.logixng.ConditionalNG_Manager;
 import jmri.jmrit.logixng.LogixNG_Manager;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import jmri.util.junit.rules.RetryRule;
 
@@ -160,6 +161,12 @@ public class ImportTest {
 
         // Test route
         runTestSetRoute(turnout101, turnout102, sensor210);
+
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0001C1' to LogixNG 'IQ:AUTO:0001'");
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0002C1' to LogixNG 'IQ:AUTO:0002'");
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0003C1' to LogixNG 'IQ:AUTO:0003'");
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX:AUTO:0004C1' to LogixNG 'IQ:AUTO:0004'");
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX:RTXINITIALIZER1T' to LogixNG 'IQ:AUTO:0005'");
     }
 
 

--- a/java/test/jmri/jmrit/logixng/tools/Import_AndOrMixed_Test.java
+++ b/java/test/jmri/jmrit/logixng/tools/Import_AndOrMixed_Test.java
@@ -21,11 +21,11 @@ import org.junit.Test;
  * deletes the original Logix and then test that the new LogixNG works.
  * <P>
  * This test tests And, Or, Mixed
- * 
+ *
  * @author Daniel Bergqvist (C) 2020
  */
 public class Import_AndOrMixed_Test {
-    
+
     Sensor s1;
     Sensor s2;
     Sensor s3;
@@ -35,8 +35,8 @@ public class Import_AndOrMixed_Test {
     private Conditional conditional;
     private ArrayList<ConditionalVariable> variables;
     private ArrayList<ConditionalAction> actions;
-    
-    
+
+
     public void assertBoolean(String message, boolean expectSuccess, boolean result) {
         if (expectSuccess) {
             Assert.assertTrue(message, result);
@@ -44,7 +44,7 @@ public class Import_AndOrMixed_Test {
             Assert.assertFalse(message, result);
         }
     }
-    
+
     // Test that the operator AND is imported correctly
     @Test
     public void testAnd() throws JmriException {
@@ -56,7 +56,7 @@ public class Import_AndOrMixed_Test {
             // This should not throw the turnout
             s2.setState(Sensor.ACTIVE);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             s1.setState(Sensor.INACTIVE);
             s2.setState(Sensor.ACTIVE);
             s3.setState(Sensor.INACTIVE);
@@ -64,7 +64,7 @@ public class Import_AndOrMixed_Test {
             // This should not throw the turnout
             s1.setState(Sensor.ACTIVE);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             s1.setState(Sensor.ACTIVE);
             s2.setState(Sensor.INACTIVE);
             s3.setState(Sensor.ACTIVE);
@@ -72,7 +72,7 @@ public class Import_AndOrMixed_Test {
             // This should throw the turnout if the logix/logixng is active
             s2.setState(Sensor.ACTIVE);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
-            
+
             s1.setState(Sensor.INACTIVE);
             s2.setState(Sensor.ACTIVE);
             s3.setState(Sensor.ACTIVE);
@@ -81,9 +81,9 @@ public class Import_AndOrMixed_Test {
             s1.setState(Sensor.ACTIVE);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
         };
-        
+
         check.runTest("Logix is not activated", false);
-        
+
         conditional.setLogicType(Conditional.AntecedentOperator.ALL_AND, "");
         ConditionalVariable cv = new ConditionalVariable();
         cv.setTriggerActions(true);
@@ -94,7 +94,7 @@ public class Import_AndOrMixed_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS1");
         variables.add(cv);
-        
+
         cv = new ConditionalVariable();
         cv.setTriggerActions(true);
         cv.setNegation(false);
@@ -104,7 +104,7 @@ public class Import_AndOrMixed_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS2");
         variables.add(cv);
-        
+
         cv = new ConditionalVariable();
         cv.setTriggerActions(true);
         cv.setNegation(false);
@@ -114,37 +114,37 @@ public class Import_AndOrMixed_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS3");
         variables.add(cv);
-        
+
         ConditionalAction ca = new DefaultConditionalAction();
         ca.setType(Conditional.Action.SET_TURNOUT);
         ca.setActionData(Turnout.THROWN);
         ca.setDeviceName("IT1");
         actions.add(ca);
-        
+
         check.runTest("Logix is not activated", false);
-        
+
         logixManager.activateAllLogixs();
-        
+
         check.runTest("Logix is activated", true);
-        
+
         logix.deActivateLogix();
-        
+
         // Import the logix to LogixNG
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
-        
+
         logix.setEnabled(false);
         logixManager.deleteLogix(logix);
-        
+
         check.runTest("Logix is removed and LogixNG is not activated", false);
-        
+
         // We want the conditionalNGs run immediately during this test
         InstanceManager.getDefault(ConditionalNG_Manager.class).setRunOnGUIDelayed(false);
-        
+
         importLogix.getLogixNG().setEnabled(true);
         InstanceManager.getDefault(LogixNG_Manager.class)
                 .activateAllLogixNGs(false, false);
-/*        
+/*
         System.err.println("-------------------------------------------");
         java.io.PrintWriter p = new java.io.PrintWriter(System.err);
         for (jmri.jmrit.logixng.LogixNG l : InstanceManager.getDefault(LogixNG_Manager.class).getNamedBeanSet()) {
@@ -154,15 +154,17 @@ public class Import_AndOrMixed_Test {
             p.flush();
         }
         System.err.println("-------------------------------------------");
-*/        
+*/
         check.runTest("LogixNG is activated", true);
-        
+
         importLogix.getLogixNG().setEnabled(false);
         InstanceManager.getDefault(LogixNG_Manager.class).deleteLogixNG(importLogix.getLogixNG());
-        
+
         check.runTest("LogixNG is removed", false);
+
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
     }
-    
+
     // Test that the operator OR is imported correctly
     @Test
     public void testOr() throws JmriException {
@@ -174,7 +176,7 @@ public class Import_AndOrMixed_Test {
             // This should throw the turnout if the logix/logixng is active
             s2.setState(Sensor.ACTIVE);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
-            
+
             s1.setState(Sensor.INACTIVE);
             s2.setState(Sensor.ACTIVE);
             s3.setState(Sensor.INACTIVE);
@@ -182,7 +184,7 @@ public class Import_AndOrMixed_Test {
             // This should not throw the turnout
             s1.setState(Sensor.ACTIVE);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             s1.setState(Sensor.ACTIVE);
             s2.setState(Sensor.INACTIVE);
             s3.setState(Sensor.ACTIVE);
@@ -190,7 +192,7 @@ public class Import_AndOrMixed_Test {
             // This should not throw the turnout
             s2.setState(Sensor.ACTIVE);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             s1.setState(Sensor.INACTIVE);
             s2.setState(Sensor.ACTIVE);
             s3.setState(Sensor.ACTIVE);
@@ -199,9 +201,9 @@ public class Import_AndOrMixed_Test {
             s1.setState(Sensor.ACTIVE);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
         };
-        
+
         check.runTest("Logix is not activated", false);
-        
+
         conditional.setLogicType(Conditional.AntecedentOperator.ALL_OR, "");
         ConditionalVariable cv = new ConditionalVariable();
         cv.setTriggerActions(true);
@@ -212,7 +214,7 @@ public class Import_AndOrMixed_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS1");
         variables.add(cv);
-        
+
         cv = new ConditionalVariable();
         cv.setTriggerActions(true);
         cv.setNegation(false);
@@ -222,7 +224,7 @@ public class Import_AndOrMixed_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS2");
         variables.add(cv);
-        
+
         cv = new ConditionalVariable();
         cv.setTriggerActions(true);
         cv.setNegation(false);
@@ -232,43 +234,45 @@ public class Import_AndOrMixed_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS3");
         variables.add(cv);
-        
+
         ConditionalAction ca = new DefaultConditionalAction();
         ca.setType(Conditional.Action.SET_TURNOUT);
         ca.setActionData(Turnout.THROWN);
         ca.setDeviceName("IT1");
         actions.add(ca);
-        
+
         logixManager.activateAllLogixs();
-        
+
         check.runTest("Logix is activated", true);
-        
+
         logix.deActivateLogix();
-        
+
         // Import the logix to LogixNG
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
-        
+
         logix.setEnabled(false);
         logixManager.deleteLogix(logix);
-        
+
         check.runTest("Logix is removed and LogixNG is not activated", false);
-        
+
         // We want the conditionalNGs run immediately during this test
         InstanceManager.getDefault(ConditionalNG_Manager.class).setRunOnGUIDelayed(false);
-        
+
         importLogix.getLogixNG().setEnabled(true);
         InstanceManager.getDefault(LogixNG_Manager.class)
                 .activateAllLogixNGs(false, false);
-        
+
         check.runTest("LogixNG is activated", true);
-        
+
         importLogix.getLogixNG().setEnabled(false);
         InstanceManager.getDefault(LogixNG_Manager.class).deleteLogixNG(importLogix.getLogixNG());
-        
+
         check.runTest("LogixNG is removed", false);
+
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
     }
-    
+
     // Test that the operator MIXED is imported correctly
     @Test
     public void testMixed() throws JmriException {
@@ -280,7 +284,7 @@ public class Import_AndOrMixed_Test {
             // This should not throw the turnout
             s2.setState(Sensor.ACTIVE);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             s1.setState(Sensor.INACTIVE);
             s2.setState(Sensor.INACTIVE);
             s3.setState(Sensor.INACTIVE);
@@ -288,7 +292,7 @@ public class Import_AndOrMixed_Test {
             // This should not throw the turnout
             s1.setState(Sensor.ACTIVE);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             s1.setState(Sensor.INACTIVE);
             s2.setState(Sensor.ACTIVE);
             s3.setState(Sensor.INACTIVE);
@@ -296,7 +300,7 @@ public class Import_AndOrMixed_Test {
             // This should not throw the turnout
             s3.setState(Sensor.ACTIVE);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             s1.setState(Sensor.ACTIVE);
             s2.setState(Sensor.INACTIVE);
             s3.setState(Sensor.INACTIVE);
@@ -304,7 +308,7 @@ public class Import_AndOrMixed_Test {
             // This should throw the turnout if the logix/logixng is active
             s2.setState(Sensor.ACTIVE);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
-            
+
             s1.setState(Sensor.INACTIVE);
             s2.setState(Sensor.INACTIVE);
             s3.setState(Sensor.ACTIVE);
@@ -312,11 +316,11 @@ public class Import_AndOrMixed_Test {
             // This should throw the turnout if the logix/logixng is active
             s1.setState(Sensor.ACTIVE);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
-            
+
         };
-        
+
         check.runTest("Logix is not activated", false);
-        
+
         conditional.setLogicType(Conditional.AntecedentOperator.MIXED, "R1 AND (R2 OR R3)");
         ConditionalVariable cv = new ConditionalVariable();
         cv.setTriggerActions(true);
@@ -327,7 +331,7 @@ public class Import_AndOrMixed_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS1");
         variables.add(cv);
-        
+
         cv = new ConditionalVariable();
         cv.setTriggerActions(true);
         cv.setNegation(false);
@@ -337,7 +341,7 @@ public class Import_AndOrMixed_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS2");
         variables.add(cv);
-        
+
         cv = new ConditionalVariable();
         cv.setTriggerActions(true);
         cv.setNegation(false);
@@ -347,43 +351,45 @@ public class Import_AndOrMixed_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS3");
         variables.add(cv);
-        
+
         ConditionalAction ca = new DefaultConditionalAction();
         ca.setType(Conditional.Action.SET_TURNOUT);
         ca.setActionData(Turnout.THROWN);
         ca.setDeviceName("IT1");
         actions.add(ca);
-        
+
         logixManager.activateAllLogixs();
-        
+
         check.runTest("Logix is activated", true);
-        
+
         logix.deActivateLogix();
-        
+
         // Import the logix to LogixNG
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
-        
+
         logix.setEnabled(false);
         logixManager.deleteLogix(logix);
-        
+
         check.runTest("Logix is removed and LogixNG is not activated", false);
-        
+
         // We want the conditionalNGs run immediately during this test
         InstanceManager.getDefault(ConditionalNG_Manager.class).setRunOnGUIDelayed(false);
-        
+
         importLogix.getLogixNG().setEnabled(true);
         InstanceManager.getDefault(LogixNG_Manager.class)
                 .activateAllLogixNGs(false, false);
-        
+
         check.runTest("LogixNG is activated", true);
-        
+
         importLogix.getLogixNG().setEnabled(false);
         InstanceManager.getDefault(LogixNG_Manager.class).deleteLogixNG(importLogix.getLogixNG());
-        
+
         check.runTest("LogixNG is removed", false);
+
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -395,26 +401,26 @@ public class Import_AndOrMixed_Test {
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixManager();
         JUnitUtil.initLogixNGManager();
-        
+
         s1 = InstanceManager.getDefault(SensorManager.class).provide("IS1");
         s2 = InstanceManager.getDefault(SensorManager.class).provide("IS2");
         s3 = InstanceManager.getDefault(SensorManager.class).provide("IS3");
         t1 = InstanceManager.getDefault(TurnoutManager.class).provide("IT1");
-        
+
         logixManager = InstanceManager.getDefault(LogixManager.class);
         ConditionalManager conditionalManager = InstanceManager.getDefault(ConditionalManager.class);
-        
+
         logix = logixManager.createNewLogix("IX1", null);
-        
+
         conditional = conditionalManager.createNewConditional("IX1C1", "First conditional");
         logix.addConditional(conditional.getSystemName(), 0);
-        
+
         conditional.setTriggerOnChange(true);
         conditional.setLogicType(Conditional.AntecedentOperator.ALL_AND, "");
-        
+
         variables = new ArrayList<>();
         conditional.setStateVariables(variables);
-        
+
         actions = new ArrayList<>();
         conditional.setAction(actions);
     }
@@ -425,5 +431,5 @@ public class Import_AndOrMixed_Test {
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/tools/Import_TriggerOnChange_Test.java
+++ b/java/test/jmri/jmrit/logixng/tools/Import_TriggerOnChange_Test.java
@@ -21,11 +21,11 @@ import org.junit.Test;
  * <P>
  * This class creates a Logix, test that it works, imports it to LogixNG,
  * deletes the original Logix and then test that the new LogixNG works.
- * 
+ *
  * @author Daniel Bergqvist (C) 2020
  */
 public class Import_TriggerOnChange_Test {
-    
+
     Sensor s1;
     Sensor s2;
     Sensor s3;
@@ -35,8 +35,8 @@ public class Import_TriggerOnChange_Test {
     private Conditional conditional;
     private ArrayList<ConditionalVariable> variables;
     private ArrayList<ConditionalAction> actions;
-    
-    
+
+
     public void assertBoolean(String message, boolean expectSuccess, boolean result) {
         if (expectSuccess) {
             Assert.assertTrue(message, result);
@@ -44,7 +44,7 @@ public class Import_TriggerOnChange_Test {
             Assert.assertFalse(message, result);
         }
     }
-    
+
     // Test that TriggerOnChange == true is imported correctly
     @Test
     public void testTriggerOnChange_True() throws JmriException {
@@ -58,7 +58,7 @@ public class Import_TriggerOnChange_Test {
             // This should not throw the turnout
             s2.setState(Sensor.ACTIVE);
             assertBoolean(message, true, t1.getState() == Turnout.CLOSED);
-            
+
             // Trigger on change is true. The result of evaluation has changed
             // so actions should be executed.
             s1.setState(Sensor.ACTIVE);
@@ -69,9 +69,9 @@ public class Import_TriggerOnChange_Test {
             s2.setState(Sensor.ACTIVE);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
         };
-        
+
         check.runTest("Logix is not activated", false);
-        
+
         conditional.setTriggerOnChange(true);
         conditional.setLogicType(Conditional.AntecedentOperator.ALL_AND, "");
         ConditionalVariable cv = new ConditionalVariable();
@@ -83,7 +83,7 @@ public class Import_TriggerOnChange_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS1");
         variables.add(cv);
-        
+
         cv = new ConditionalVariable();
         cv.setTriggerActions(true);
         cv.setNegation(false);
@@ -93,7 +93,7 @@ public class Import_TriggerOnChange_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS2");
         variables.add(cv);
-        
+
         cv = new ConditionalVariable();
         cv.setTriggerActions(true);
         cv.setNegation(false);
@@ -103,46 +103,48 @@ public class Import_TriggerOnChange_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS3");
         variables.add(cv);
-        
+
         ConditionalAction ca = new DefaultConditionalAction();
         ca.setOption(Conditional.ACTION_OPTION_ON_CHANGE);
         ca.setType(Conditional.Action.SET_TURNOUT);
         ca.setActionData(Turnout.THROWN);
         ca.setDeviceName("IT1");
         actions.add(ca);
-        
+
         check.runTest("Logix is not activated", false);
-        
+
         logixManager.activateAllLogixs();
-        
+
         check.runTest("Logix is activated", true);
-        
+
         logix.deActivateLogix();
-        
+
         // Import the logix to LogixNG
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
-        
+
         logix.setEnabled(false);
         logixManager.deleteLogix(logix);
-        
+
         check.runTest("Logix is removed and LogixNG is not activated", false);
-        
+
         // We want the conditionalNGs run immediately during this test
         InstanceManager.getDefault(ConditionalNG_Manager.class).setRunOnGUIDelayed(false);
-        
+
         importLogix.getLogixNG().setEnabled(true);
         InstanceManager.getDefault(LogixNG_Manager.class)
                 .activateAllLogixNGs(false, false);
-        
+
         check.runTest("LogixNG is activated", true);
-        
+
         importLogix.getLogixNG().setEnabled(false);
         InstanceManager.getDefault(LogixNG_Manager.class).deleteLogixNG(importLogix.getLogixNG());
-        
+
         check.runTest("LogixNG is removed", false);
+
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
     }
-    
+
     // Test that TriggerOnChange == false is imported correctly
     @Test
     public void testTriggerOnChange_False() throws JmriException {
@@ -156,7 +158,7 @@ public class Import_TriggerOnChange_Test {
             // This should throw the turnout
             s2.setState(Sensor.ACTIVE);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
-            
+
             // Trigger on change is false. The result of evaluation has changed
             // and actions should be executed in any case.
             s1.setState(Sensor.ACTIVE);
@@ -167,9 +169,9 @@ public class Import_TriggerOnChange_Test {
             s2.setState(Sensor.ACTIVE);
             assertBoolean(message, expectSuccess, t1.getState() == Turnout.THROWN);
         };
-        
+
         check.runTest("Logix is not activated", false);
-        
+
         conditional.setTriggerOnChange(false);
         conditional.setLogicType(Conditional.AntecedentOperator.ALL_AND, "");
         ConditionalVariable cv = new ConditionalVariable();
@@ -181,7 +183,7 @@ public class Import_TriggerOnChange_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS1");
         variables.add(cv);
-        
+
         cv = new ConditionalVariable();
         cv.setTriggerActions(true);
         cv.setNegation(false);
@@ -191,7 +193,7 @@ public class Import_TriggerOnChange_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS2");
         variables.add(cv);
-        
+
         cv = new ConditionalVariable();
         cv.setTriggerActions(true);
         cv.setNegation(false);
@@ -201,30 +203,30 @@ public class Import_TriggerOnChange_Test {
         cv.setType(Conditional.Type.SENSOR_ACTIVE);
         cv.setName("IS3");
         variables.add(cv);
-        
+
         ConditionalAction ca = new DefaultConditionalAction();
         ca.setOption(Conditional.ACTION_OPTION_ON_CHANGE);
         ca.setType(Conditional.Action.SET_TURNOUT);
         ca.setActionData(Turnout.THROWN);
         ca.setDeviceName("IT1");
         actions.add(ca);
-        
+
         check.runTest("Logix is not activated", false);
-        
+
         logixManager.activateAllLogixs();
-        
+
         check.runTest("Logix is activated", true);
-        
+
         logix.deActivateLogix();
-        
+
         // Import the logix to LogixNG
         ImportLogix importLogix = new ImportLogix(logix);
         importLogix.doImport();
-        
+
         logixManager.deleteLogix(logix);
-        
+
         check.runTest("Logix is removed and LogixNG is not activated", false);
-/*        
+/*
         System.err.println("-------------------------------------------");
         java.io.PrintWriter p = new java.io.PrintWriter(System.err);
         for (jmri.jmrit.logixng.LogixNG l : InstanceManager.getDefault(LogixNG_Manager.class).getNamedBeanSet()) {
@@ -234,22 +236,24 @@ public class Import_TriggerOnChange_Test {
             p.flush();
         }
         System.err.println("-------------------------------------------");
-*/        
+*/
         // We want the conditionalNGs run immediately during this test
         InstanceManager.getDefault(ConditionalNG_Manager.class).setRunOnGUIDelayed(false);
-        
+
         importLogix.getLogixNG().setEnabled(true);
         InstanceManager.getDefault(LogixNG_Manager.class)
                 .activateAllLogixNGs(false, false);
-        
+
         check.runTest("LogixNG is activated", true);
-        
+
         importLogix.getLogixNG().setEnabled(false);
         InstanceManager.getDefault(LogixNG_Manager.class).deleteLogixNG(importLogix.getLogixNG());
-        
+
         check.runTest("LogixNG is removed", false);
+
+        JUnitAppender.assertWarnMessage("Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'");
     }
-/*    
+/*
     @Test
     public void testConditionalVariableTurnout() {
         ConditionalVariable cv = new ConditionalVariable();
@@ -260,7 +264,7 @@ public class Import_TriggerOnChange_Test {
         cv.setOpern(Conditional.Operator.OR);
         cv.setType(Conditional.Type.BLOCK_STATUS_EQUALS);
     }
-    
+
     @Test
     public void testConditionalActionTurnout() {
         Assume.assumeFalse(true);
@@ -275,7 +279,7 @@ public class Import_TriggerOnChange_Test {
         ca.setType(Conditional.Action.NONE);
         ca.setType("aaa");
     }
-*/    
+*/
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -287,47 +291,47 @@ public class Import_TriggerOnChange_Test {
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixManager();
         JUnitUtil.initLogixNGManager();
-        
+
         s1 = InstanceManager.getDefault(SensorManager.class).provide("IS1");
         s2 = InstanceManager.getDefault(SensorManager.class).provide("IS2");
         s3 = InstanceManager.getDefault(SensorManager.class).provide("IS3");
         t1 = InstanceManager.getDefault(TurnoutManager.class).provide("IT1");
-        
+
         logixManager = InstanceManager.getDefault(LogixManager.class);
         ConditionalManager conditionalManager = InstanceManager.getDefault(ConditionalManager.class);
-        
+
         logix = logixManager.createNewLogix("IX1", null);
-        
+
         conditional = conditionalManager.createNewConditional("IX1C1", "First conditional");
         logix.addConditional(conditional.getSystemName(), 0);
-        
+
         conditional.setTriggerOnChange(true);
         conditional.setLogicType(Conditional.AntecedentOperator.ALL_AND, "");
-        
+
         variables = new ArrayList<>();
         conditional.setStateVariables(variables);
-        
+
         actions = new ArrayList<>();
         conditional.setAction(actions);
-        
+
 //        logixManager.activateAllLogixs();
     }
 
     @After
     public void tearDown() {
         // JUnitAppender.clearBacklog();    REMOVE THIS!!!
-        
+
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
-    
-    
+
+
+
     public interface RunTest {
         public void runTest(String message, boolean expectSuccess) throws JmriException;
     }
-    
-    
+
+
 //    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Import_TriggerOnChange_Test.class);
 }


### PR DESCRIPTION
@bobjacobsen 
During import of Logixs to LogixNGs, warning messages are printed to the log. This PR suppresses those warning messages. There was 91 warning messages like `Import Conditional 'IX1C1' to LogixNG 'IQ:AUTO:0001'` which are now removed.