### PR TITLE
Build warnings - Logging scripts tests

### DIFF
--- a/java/test/jmri/jmrit/jython/SampleScriptTest.java
+++ b/java/test/jmri/jmrit/jython/SampleScriptTest.java
@@ -8,6 +8,7 @@ import javax.annotation.Nonnull;
 
 import jmri.util.JUnitUtil;
 import jmri.script.JmriScriptEngineManager;
+import jmri.util.JUnitAppender;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
@@ -65,6 +66,14 @@ public class SampleScriptTest {
             log.error("IOException during test of {}", file, ex2);
             Assert.fail("IOException during test of " + file);
         }
+
+        if (file.toPath().endsWith("LoggingTest.py")) {
+            JUnitAppender.assertWarnMessage("This WARN is OK, it's emitted from LoggingTest.py on purpose");
+        }
+        if (file.toPath().endsWith("JavaScriptTest.js")) {
+            JUnitAppender.assertWarnMessage("JavaScriptTest: Turnout.THROWN is 4 (WARN OK here)");
+        }
+
     }
 
     @BeforeAll

--- a/java/test/jmri/jmrit/jython/SampleScriptTest.java
+++ b/java/test/jmri/jmrit/jython/SampleScriptTest.java
@@ -70,7 +70,7 @@ public class SampleScriptTest {
         if (file.toPath().endsWith("LoggingTest.py")) {
             JUnitAppender.assertWarnMessage("This WARN is OK, it's emitted from LoggingTest.py on purpose");
         }
-        if (file.toPath().endsWith("JavaScriptTest.js")) {
+        else if (file.toPath().endsWith("JavaScriptTest.js")) {
             JUnitAppender.assertWarnMessage("JavaScriptTest: Turnout.THROWN is 4 (WARN OK here)");
         }
 


### PR DESCRIPTION
Remove 2 Test Runtime Warnings relating to slf4j test scripts, eg
https://builds.jmri.org/jenkins/job/development/job/builds/1191/jmri-test-runtime-warnings/