### PR TITLE
New decoder definitions for SUSI Mapping

### DIFF
--- a/xml/decoders/0NMRA_SUSI_Output_Mapping_Range1.xml
+++ b/xml/decoders/0NMRA_SUSI_Output_Mapping_Range1.xml
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI All rights reserved -->
+<!-- $Id: 0NMRA_SUSI_Output_Mapping_Range1.xml ,v 1.0 2022/04/24 Alain CARASSO $       -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Alain CARASSO" version="1.0" lastUpdated="20220424"/>
+  <!--  Based on MASSOTH_eMotion SUSI Settings, who was published by Jeff Schmaltz -->
+  <decoder>
+    <family name="SUSI Output Mapping definitions" mfg="NMRA">
+      <model model="SUSI Output Mapping definition Range 1"/>
+    </family>
+    <programming direct="yes" paged="no" register="yes" ops="yes"/>
+    <variables>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
+      <variable item="SUSI-range" CV="897" readOnly="yes" default="1" tooltip="Will not read/write properly if multiple SUSI modules attached">
+        <enumVal>
+          <enumChoice choice="Not used"/>
+          <enumChoice choice="Range I (CVs 900-939)"/>
+          <enumChoice choice="Range II (CVs 940-979)"/>
+          <enumChoice choice="Range III (CVs 980-1019)"/>
+        </enumVal>
+        <label>SUSI-range</label>
+      </variable>
+      <variable CV="900" readOnly="yes" default="238" item="Manufacturer" tooltip="The manufacturer's ID number (read only)">
+        <decVal/>
+       <label>Manufacturer ID</label>
+      </variable>
+      <variable CV="901" readOnly="yes" item="Decoder Version" tooltip="The decoder version number (read only)">
+        <decVal/>
+        <label>Software Version Number</label>
+      </variable>
+      <variable item="Output A" CV="902" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output A</label>
+      </variable>
+      <variable item="Output B" CV="903" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output B</label>
+      </variable>
+      <variable item="Output C" CV="904" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output C</label>
+      </variable>
+      <variable item="Output D" CV="905" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output D</label>
+      </variable>
+      <variable item="Output E" CV="906" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output E</label>
+      </variable>
+      <variable item="Output F" CV="907" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output F</label>
+      </variable>
+      <variable item="Output G" CV="908" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output G</label>
+      </variable>
+      <variable item="Output H" CV="909" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output H</label>
+      </variable>
+      <variable item="Output I" CV="910" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output I</label>
+      </variable>
+      <variable item="Output J" CV="911" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output J</label>
+      </variable>
+      <variable item="Output K" CV="912" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output K</label>
+      </variable>
+     <variable item="Output L" CV="913" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output L</label>
+      </variable>
+     <variable item="Output M" CV="914" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output M</label>
+      </variable>
+     <variable item="Output N" CV="915" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output N</label>
+      </variable>
+     <variable item="Output O" CV="916" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output O</label>
+      </variable>
+     <variable item="Output P" CV="917" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output P</label>
+      </variable>
+
+     <variable item="Settings for Output A" CV="918" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output A</label>
+     </variable>
+     <variable item="Settings for Output B" CV="919" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output B</label>
+     </variable>
+     <variable item="Settings for Output C" CV="920" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output C</label>
+     </variable>
+     <variable item="Settings for Output D" CV="921" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output D</label>
+     </variable>
+     <variable item="Settings for Output E" CV="922" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output E</label>
+     </variable>
+     <variable item="Settings for Output F" CV="923" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output F</label>
+     </variable>
+     <variable item="Settings for Output G" CV="924" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output G</label>
+     </variable>
+     <variable item="Settings for Output H" CV="925" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output H</label>
+     </variable>
+     <variable item="Settings for Output I" CV="926" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output I</label>
+     </variable>
+     <variable item="Settings for Output J" CV="927" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output J</label>
+     </variable>
+     <variable item="Settings for Output K" CV="928" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output K</label>
+     </variable>
+     <variable item="Settings for Output L" CV="929" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output L</label>
+     </variable>
+     <variable item="Settings for Output M" CV="930" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output M</label>
+     </variable>
+     <variable item="Settings for Output N" CV="931" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output N</label>
+     </variable>
+     <variable item="Settings for Output O" CV="932" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output O</label>
+     </variable>
+     <variable item="Settings for Output P" CV="933" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output P</label>
+     </variable>
+     <variable item="Settings for DCC and SUSI Detection" CV="937" default="0" tooltip="0=Autodetect, 1=DCC SUSI On, 2=Analog Modef">
+        <decVal min="0" max="2"/>
+        <label>Detection setting for range 1</label>
+     </variable>
+   </variables>
+  </decoder>
+
+  <pane>
+    <name>Selected SUSI info</name>
+    <column>
+       <label>
+        <text> ================================================================================================ </text>
+      </label>      <label>
+         <text> SUSI Range 1 definitions, if different range found, then use correct range of SUSI definition</text>
+      </label>
+      <label>
+        <text> As SUSI is an addition to an existing decoder, without knowledge of the decoder Brand, Reset is not defined nor provided</text>
+      </label>
+        <label>
+        <text> ================================================================================================ </text>
+      </label>
+     <label>
+        <text> </text>
+      </label>
+        <display item="SUSI-range"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Manufacturer"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Decoder Version"/>
+    </column>
+  </pane>
+
+  <pane>
+    <name>CVs</name>
+    <column>
+      <cvtable/>
+    </column>
+  </pane>
+  <pane>
+    <name>SUSI Defined Outputs to Fkey mapping</name>
+    <column>
+      <label>
+        <text> select the F key you want to use for each available SUSI Output</text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text> 0 for F0, 1 for F1, 2 for F2, 3 for F3, 4 for F4, 5 for F5, 6 for F6, 7 for F7                           </text>
+      </label>
+      <label>
+        <text> 8 for F8, 9 for F9, 10 for F10, 11 for F11, 12 for F12, 14 for F14, 15 for F15, 16 for F16</text>
+      </label>
+      <label>
+        <text> if you want an Fkey to perform multiple Outputs, simply add the F# in each of the output row    </text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Output A"/>
+      <display item="Output B"/>
+      <display item="Output C"/>
+      <display item="Output D"/>
+      <display item="Output E"/>
+      <display item="Output F"/>
+      <display item="Output G"/>
+      <display item="Output H"/>
+      <display item="Output I"/>
+      <display item="Output J"/>
+      <display item="Output K"/>
+      <display item="Output L"/>
+      <display item="Output M"/>
+      <display item="Output N"/>
+      <display item="Output O"/>
+      <display item="Output P"/>
+    </column>
+  </pane>
+
+
+  <pane>
+    <name>SUSI customized features for each defined Outputs</name>
+    <column>
+      <label>
+        <text>Define the customized features (dimming, timer, Light effects) for each available SUSI Output</text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Settings for Output A"/>
+      <display item="Settings for Output B"/>
+      <display item="Settings for Output C"/>
+      <display item="Settings for Output D"/>
+      <display item="Settings for Output E"/>
+      <display item="Settings for Output F"/>
+      <display item="Settings for Output G"/>
+      <display item="Settings for Output H"/>
+      <display item="Settings for Output I"/>
+      <display item="Settings for Output J"/>
+      <display item="Settings for Output K"/>
+      <display item="Settings for Output L"/>
+      <display item="Settings for Output M"/>
+      <display item="Settings for Output N"/>
+      <display item="Settings for Output O"/>
+      <display item="Settings for Output P"/>
+      <display item="Settings for DCC and SUSI Detection"/>
+    </column>
+  </pane>
+</decoder-config>

--- a/xml/decoders/0NMRA_SUSI_Output_Mapping_Range2.xml
+++ b/xml/decoders/0NMRA_SUSI_Output_Mapping_Range2.xml
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI All rights reserved -->
+<!-- $Id: 0NMRA_SUSI_Output_Mapping_Range2.xml ,v 1.0 2022/04/24 Alain CARASSO $       -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Alain CARASSO" version="1.0" lastUpdated="20220424"/>
+  <!--  Based on MASSOTH_eMotion SUSI Settings, who was published by Jeff Schmaltz -->
+  <decoder>
+    <family name="SUSI Output Mapping definitions" mfg="NMRA">
+      <model model="SUSI Output Mapping definition Range 2"/>
+    </family>
+    <programming direct="yes" paged="no" register="yes" ops="yes"/>
+    <variables>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
+       <variable item="SUSI-range" CV="897" readOnly="yes" default="2" tooltip="Will not read/write properly if multiple SUSI modules attached">
+        <enumVal>
+          <enumChoice choice="Not used"/>
+          <enumChoice choice="Range I (CVs 900-939)"/>
+          <enumChoice choice="Range II (CVs 940-979)"/>
+          <enumChoice choice="Range III (CVs 980-1019)"/>
+        </enumVal>
+        <label>SUSI-range</label>
+      </variable>
+      <variable CV="940" readOnly="yes" default="238" item="Manufacturer" tooltip="The manufacturer's ID number (read only)">
+        <decVal/>
+       <label>Manufacturer ID</label>
+      </variable>
+      <variable CV="941" readOnly="yes" item="Decoder Version" tooltip="The decoder version number (read only)">
+        <decVal/>
+        <label>Software Version Number</label>
+      </variable>
+      <variable item="Output A" CV="942" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output A</label>
+      </variable>
+      <variable item="Output B" CV="943" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output B</label>
+      </variable>
+      <variable item="Output C" CV="944" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output C</label>
+      </variable>
+      <variable item="Output D" CV="945" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output D</label>
+      </variable>
+      <variable item="Output E" CV="946" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output E</label>
+      </variable>
+      <variable item="Output F" CV="947" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output F</label>
+      </variable>
+      <variable item="Output G" CV="948" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output G</label>
+      </variable>
+      <variable item="Output H" CV="949" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output H</label>
+      </variable>
+      <variable item="Output I" CV="950" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output I</label>
+      </variable>
+      <variable item="Output J" CV="951" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output J</label>
+      </variable>
+      <variable item="Output K" CV="952" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output K</label>
+      </variable>
+     <variable item="Output L" CV="953" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output L</label>
+      </variable>
+     <variable item="Output M" CV="954" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output M</label>
+      </variable>
+     <variable item="Output N" CV="955" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output N</label>
+      </variable>
+     <variable item="Output O" CV="956" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output O</label>
+      </variable>
+     <variable item="Output P" CV="957" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output P</label>
+      </variable>
+
+     <variable item="Settings for Output A" CV="958" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output A</label>
+     </variable>
+     <variable item="Settings for Output B" CV="959" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output B</label>
+     </variable>
+     <variable item="Settings for Output C" CV="960" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output C</label>
+     </variable>
+     <variable item="Settings for Output D" CV="961" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output D</label>
+     </variable>
+     <variable item="Settings for Output E" CV="962" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output E</label>
+     </variable>
+     <variable item="Settings for Output F" CV="963" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output F</label>
+     </variable>
+     <variable item="Settings for Output G" CV="964" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output G</label>
+     </variable>
+     <variable item="Settings for Output H" CV="965" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output H</label>
+     </variable>
+     <variable item="Settings for Output I" CV="966" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output I</label>
+     </variable>
+     <variable item="Settings for Output J" CV="967" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output J</label>
+     </variable>
+     <variable item="Settings for Output K" CV="968" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output K</label>
+     </variable>
+     <variable item="Settings for Output L" CV="969" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output L</label>
+     </variable>
+     <variable item="Settings for Output M" CV="970" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output M</label>
+     </variable>
+     <variable item="Settings for Output N" CV="971" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output N</label>
+     </variable>
+     <variable item="Settings for Output O" CV="972" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output O</label>
+     </variable>
+     <variable item="Settings for Output P" CV="973" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output P</label>
+     </variable>
+     <variable item="Settings for DCC and SUSI Detection" CV="977" default="0" tooltip="0=Autodetect, 1=DCC SUSI On, 2=Analog Modef">
+        <decVal min="0" max="2"/>
+        <label>Detection setting for range 2</label>
+     </variable>
+   </variables>
+  </decoder>
+
+  <pane>
+    <name>Selected SUSI info</name>
+    <column>
+       <label>
+        <text> ================================================================================================ </text>
+      </label>
+      <label>
+        <text> SUSI Range 2 definitions, if different range found, then use correct range of SUSI definition</text>
+      </label>
+      <label>
+        <text> As SUSI is an addition to an existing decoder, without knowledge of the decoder Brand, Reset is not defined nor provided</text>
+      </label>
+       <label>
+        <text> ================================================================================================ </text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+        <display item="SUSI-range"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Manufacturer"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Decoder Version"/>
+    </column>
+  </pane>
+
+  <pane>
+    <name>CVs</name>
+    <column>
+      <cvtable/>
+    </column>
+  </pane>
+  <pane>
+    <name>SUSI Defined Outputs to Fkey mapping</name>
+    <column>
+      <label>
+        <text> select the F key you want to use for each available SUSI Output</text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text> 0 for F0, 1 for F1, 2 for F2, 3 for F3, 4 for F4, 5 for F5, 6 for F6, 7 for F7                           </text>
+      </label>
+      <label>
+        <text> 8 for F8, 9 for F9, 10 for F10, 11 for F11, 12 for F12, 14 for F14, 15 for F15, 16 for F16</text>
+      </label>
+      <label>
+        <text> if you want an Fkey to perform multiple Outputs, simply add the F# in each of the output row    </text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Output A"/>
+      <display item="Output B"/>
+      <display item="Output C"/>
+      <display item="Output D"/>
+      <display item="Output E"/>
+      <display item="Output F"/>
+      <display item="Output G"/>
+      <display item="Output H"/>
+      <display item="Output I"/>
+      <display item="Output J"/>
+      <display item="Output K"/>
+      <display item="Output L"/>
+      <display item="Output M"/>
+      <display item="Output N"/>
+      <display item="Output O"/>
+      <display item="Output P"/>
+    </column>
+  </pane>
+
+  <pane>
+     <name>SUSI customized features for each defined Outputs</name>
+    <column>
+      <label>
+        <text>Define the customized features (dimming, timer, Light effects) for each available SUSI Output</text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Settings for Output A"/>
+      <display item="Settings for Output B"/>
+      <display item="Settings for Output C"/>
+      <display item="Settings for Output D"/>
+      <display item="Settings for Output E"/>
+      <display item="Settings for Output F"/>
+      <display item="Settings for Output G"/>
+      <display item="Settings for Output H"/>
+      <display item="Settings for Output I"/>
+      <display item="Settings for Output J"/>
+      <display item="Settings for Output K"/>
+      <display item="Settings for Output L"/>
+      <display item="Settings for Output M"/>
+      <display item="Settings for Output N"/>
+      <display item="Settings for Output O"/>
+      <display item="Settings for Output P"/>
+      <display item="Settings for DCC and SUSI Detection"/>
+    </column>
+  </pane>
+</decoder-config>

--- a/xml/decoders/0NMRA_SUSI_Output_Mapping_Range3.xml
+++ b/xml/decoders/0NMRA_SUSI_Output_Mapping_Range3.xml
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI All rights reserved -->
+<!-- $Id: 0NMRA_SUSI_Output_Mapping_Range3.xml ,v 1.0 2022/04/24 Alain CARASSO $       -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Alain CARASSO" version="1.0" lastUpdated="20220424"/>
+  <!--  Based on MASSOTH_eMotion SUSI Settings, who was published by Jeff Schmaltz -->
+  <decoder>
+    <family name="SUSI Output Mapping definitions" mfg="NMRA">
+      <model model="SUSI Output Mapping definition Range 3"/>
+    </family>
+    <programming direct="yes" paged="no" register="yes" ops="yes"/>
+    <variables>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
+      <variable item="SUSI-range" CV="897" readOnly="yes" default="3" tooltip="Will not read/write properly if multiple SUSI modules attached">
+        <enumVal>
+          <enumChoice choice="Not used"/>
+          <enumChoice choice="Range I (CVs 900-939)"/>
+          <enumChoice choice="Range II (CVs 940-979)"/>
+          <enumChoice choice="Range III (CVs 980-1019)"/>
+        </enumVal>
+        <label>SUSI-range</label>
+      </variable>
+      <variable CV="980" readOnly="yes" default="238" item="Manufacturer" tooltip="The manufacturer's ID number (read only)">
+        <decVal/>
+       <label>Manufacturer ID</label>
+      </variable>
+      <variable CV="981" readOnly="yes" item="Decoder Version" tooltip="The decoder version number (read only)">
+        <decVal/>
+        <label>Software Version Number</label>
+      </variable>
+      <variable item="Output A" CV="982" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output A</label>
+      </variable>
+      <variable item="Output B" CV="983" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output B</label>
+      </variable>
+      <variable item="Output C" CV="984" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output C</label>
+      </variable>
+      <variable item="Output D" CV="985" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output D</label>
+      </variable>
+      <variable item="Output E" CV="986" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output E</label>
+      </variable>
+      <variable item="Output F" CV="987" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output F</label>
+      </variable>
+      <variable item="Output G" CV="988" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output G</label>
+      </variable>
+      <variable item="Output H" CV="989" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output H</label>
+      </variable>
+      <variable item="Output I" CV="990" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output I</label>
+      </variable>
+      <variable item="Output J" CV="991" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output J</label>
+      </variable>
+      <variable item="Output K" CV="992" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output K</label>
+      </variable>
+     <variable item="Output L" CV="993" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output L</label>
+      </variable>
+     <variable item="Output M" CV="994" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output M</label>
+      </variable>
+     <variable item="Output N" CV="995" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output N</label>
+      </variable>
+     <variable item="Output O" CV="996" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output O</label>
+      </variable>
+     <variable item="Output P" CV="997" tooltip="1=F0, 128=F16">
+        <decVal min="1" max="255"/>
+        <label> Output P</label>
+      </variable>
+
+      <variable item="Settings for Output A" CV="998" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output A</label>
+     </variable>
+     <variable item="Settings for Output B" CV="999" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output B</label>
+     </variable>
+     <variable item="Settings for Output C" CV="1000" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output C</label>
+     </variable>
+     <variable item="Settings for Output D" CV="1001" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output D</label>
+     </variable>
+     <variable item="Settings for Output E" CV="1002" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output E</label>
+     </variable>
+     <variable item="Settings for Output F" CV="1003" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output F</label>
+     </variable>
+     <variable item="Settings for Output G" CV="1004" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output G</label>
+     </variable>
+     <variable item="Settings for Output H" CV="1005" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output H</label>
+     </variable>
+     <variable item="Settings for Output I" CV="1006" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output I</label>
+     </variable>
+     <variable item="Settings for Output J" CV="1007" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output J</label>
+     </variable>
+     <variable item="Settings for Output K" CV="1008" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output K</label>
+     </variable>
+     <variable item="Settings for Output L" CV="1009" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output L</label>
+     </variable>
+     <variable item="Settings for Output M" CV="1010" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output M</label>
+     </variable>
+     <variable item="Settings for Output N" CV="1011" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output N</label>
+     </variable>
+     <variable item="Settings for Output O" CV="1012" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output O</label>
+     </variable>
+     <variable item="Settings for Output P" CV="1013" >
+        <decVal min="1" max="255"/>
+        <label>Setting of Output P</label>
+     </variable>
+     <variable item="Settings for DCC and SUSI Detection" CV="1017" default="0" tooltip="0=Autodetect, 1=DCC SUSI On, 2=Analog Modef">
+        <decVal min="0" max="2"/>
+        <label>Detection setting for range 3</label>
+     </variable>
+   </variables>
+  </decoder>
+
+  <pane>
+    <name>Selected SUSI info</name>
+    <column>
+       <label>
+        <text> ================================================================================================ </text>
+      </label>
+      <label>
+        <text> SUSI Range 3 definitions, if different range found, then use correct range of SUSI definition</text>
+      </label>
+      <label>
+        <text> As SUSI is an addition to an existing decoder, without knowledge of the decoder Brand, Reset is not defined nor provided</text>
+      </label>
+       <label>
+        <text> ================================================================================================ </text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+        <display item="SUSI-range"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Manufacturer"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Decoder Version"/>
+    </column>
+  </pane>
+
+  <pane>
+    <name>CVs</name>
+    <column>
+      <cvtable/>
+    </column>
+  </pane>
+  <pane>
+    <name>SUSI Defined Outputs to Fkey mapping</name>
+    <column>
+      <label>
+        <text> select the F key you want to use for each available SUSI Output</text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text> 0 for F0, 1 for F1, 2 for F2, 3 for F3, 4 for F4, 5 for F5, 6 for F6, 7 for F7                           </text>
+      </label>
+      <label>
+        <text> 8 for F8, 9 for F9, 10 for F10, 11 for F11, 12 for F12, 14 for F14, 15 for F15, 16 for F16</text>
+      </label>
+      <label>
+        <text> if you want an Fkey to perform multiple Outputs, simply add the F# in each of the output row    </text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Output A"/>
+      <display item="Output B"/>
+      <display item="Output C"/>
+      <display item="Output D"/>
+      <display item="Output E"/>
+      <display item="Output F"/>
+      <display item="Output G"/>
+      <display item="Output H"/>
+      <display item="Output I"/>
+      <display item="Output J"/>
+      <display item="Output K"/>
+      <display item="Output L"/>
+      <display item="Output M"/>
+      <display item="Output N"/>
+      <display item="Output O"/>
+      <display item="Output P"/>
+    </column>
+  </pane>
+
+
+  <pane>
+    <name>SUSI customized features for each defined Outputs</name>
+    <column>
+      <label>
+        <text>Define the customized features (dimming, timer, Light effects) for each available SUSI Output</text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Settings for Output A"/>
+      <display item="Settings for Output B"/>
+      <display item="Settings for Output C"/>
+      <display item="Settings for Output D"/>
+      <display item="Settings for Output E"/>
+      <display item="Settings for Output F"/>
+      <display item="Settings for Output G"/>
+      <display item="Settings for Output H"/>
+      <display item="Settings for Output I"/>
+      <display item="Settings for Output J"/>
+      <display item="Settings for Output K"/>
+      <display item="Settings for Output L"/>
+      <display item="Settings for Output M"/>
+      <display item="Settings for Output N"/>
+      <display item="Settings for Output O"/>
+      <display item="Settings for Output P"/>
+      <display item="Settings for DCC and SUSI Detection"/>
+    </column>
+  </pane>
+</decoder-config>

--- a/xml/decoders/0NMRA_SUSI_Sound_Mapping_Range1.xml
+++ b/xml/decoders/0NMRA_SUSI_Sound_Mapping_Range1.xml
@@ -1,0 +1,595 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI All rights reserved -->
+<!-- $Id: 0NMRA_SUSI_Sound_Mapping_Range1.xml ,v 1.0 2022/04/24 Alain CARASSO $       -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Alain CARASSO" version="1.0" lastUpdated="20220424"/>
+  <!--  Based on MASSOTH_eMotion SUSI Settings, who was published by Jeff Schmaltz -->
+  <decoder>
+    <family name="SUSI Sound Mapping definitions" mfg="NMRA">
+      <model model="SUSI Sound Mapping definitions Range 1"/>
+    </family>
+    <programming direct="yes" paged="no" register="yes" ops="yes"/>
+    <variables>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
+      <variable item="SUSI-range" CV="897" readOnly="yes" default="1" tooltip="Will not read/write properly if multiple SUSI modules attached">
+        <enumVal>
+          <enumChoice choice="Not used"/>
+          <enumChoice choice="Range I (CVs 900-939)"/>
+          <enumChoice choice="Range II (CVs 940-979)"/>
+          <enumChoice choice="Range III (CVs 980-1019)"/>
+        </enumVal>
+        <label>SUSI-range</label>
+      </variable>
+      <variable CV="900" readOnly="yes" default="238" item="Manufacturer" tooltip="The manufacturer's ID number (read only)">
+        <decVal/>
+       <label>Manufacturer ID</label>
+      </variable>
+      <variable CV="901" item="Decoder Version" tooltip="The decoder version number (read only)">
+        <decVal/>
+        <label>Software Version Number</label>
+      </variable>
+      <variable item="Master Volume Level" CV="902" default="128" tooltip="1=Low, 63=Loud, 255=external Potentiometer">
+        <decVal min="1" max="255"/>
+        <label>Master Volume Level</label>
+      </variable>
+      <variable item="Sound_01 : Individual Volume Level" CV="903"  default="128" tooltip="Controls volume of Sound_01">
+        <decVal max="255"/>
+        <label>Sound_01 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_02 : Individual Volume Level" CV="904"  default="128" tooltip="Controls volume of Sound_02">
+        <decVal max="255"/>
+        <label>Sound_02 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_03 : Individual Volume Level" CV="905"  default="128" tooltip="Controls volume of Sound_03">
+         <decVal max="255"/>
+         <label>Sound_03 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_04 : Individual Volume Level" CV="906"  default="128" tooltip="Controls volume of Sound_04">
+         <decVal max="255"/>
+         <label>Sound_04 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_05 : Individual Volume Level" CV="907" default="128" tooltip="Controls volume of Sound_05">
+          <decVal max="255" />
+          <label>Sound_05 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_06 : Individual Volume Level" CV="908" default="128" tooltip="Controls volume of Sound_06">
+          <decVal max="255" />
+          <label>Sound_06 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_07 : Individual Volume Level" CV="909" default="128" tooltip="Controls volume of Sound_07">
+         <decVal max="255"/>
+         <label>Sound_07 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_08 : Individual Volume Level" CV="910" default="128" tooltip="Controls volume of Sound_08">
+          <decVal max="255"/>
+          <label>Sound_08 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_09 : Individual Volume Level" CV="911" default="128" tooltip="Controls volume of Sound_09">
+          <decVal max="255"/>
+          <label>Sound_09 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_10 : Individual Volume Level" CV="912" default="128" tooltip="Controls volume of Sound_10">
+          <decVal max="255"/>
+          <label>Sound_10 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_11 : Individual Volume Level" CV="913" default="128" tooltip="Controls volume of Sound_11">
+          <decVal max="255"/>
+          <label>Sound_11 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_12 : Individual Volume Level" CV="914" default="128" tooltip="Controls volume of Sound_12">
+          <decVal max="255"/>
+          <label>Sound_12 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_01: Command Allocation - Function Keys" CV="921" default="1" tooltip="Function key which switches Sound_01">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_01: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_02: Command Allocation - Function Keys" CV="922" tooltip="Function key which switches Sound_02">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_02: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_03: Command Allocation - Function Keys" CV="923" tooltip="Function key which switches Sound_03">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_03: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_04: Command Allocation - Function Keys" CV="924" tooltip="Function key which switches Sound_04">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_04: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_05: Command Allocation - Function Keys" CV="925" tooltip="Function key which switches Sound_05">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_05: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_06: Command Allocation - Function Keys" CV="926" tooltip="Function key which switches Sound_06">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_06: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_07: Command Allocation - Function Keys" CV="927" tooltip="Function key which switches Sound_07">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_07: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_08: Command Allocation - Function Keys" CV="928" tooltip="Function key which switches Sound_08">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_08: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_09: Command Allocation - Function Keys" CV="929" tooltip="Function key which switches Sound_09">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_09: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_10: Command Allocation - Function Keys" CV="930" tooltip="Function key which switches Sound_10">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_10: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_11: Command Allocation - Function Keys" CV="931" tooltip="Function key which switches Sound_11">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_11: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_12: Command Allocation - Function Keys" CV="932" tooltip="Function key which switches Sound_12">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_12: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound On/Off: Command Allocation - Function Keys" CV="937" default="1" tooltip="Function key which switches sound (amplifier) on/off">
+        <enumVal>
+          <enumChoice choice="Sound steady (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound On/Off: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Loco Start Up/Shut Down: Command Allocation - Function Keys" CV="938" default="16" tooltip="Function key which switches Loco Start Up/Shut Down">
+        <enumVal>
+          <enumChoice choice="Loco always on (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Loco Start Up/Shut Down: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Random Sounds Generator" CV="939" mask="XXXXXXXV" default="0" tooltip="Random generator active or not">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Random Sounds Generator</label>
+      </variable>
+      <variable item="Standing Phase Noise" CV="939" mask="XXXXXXVX" default="1" tooltip="Standing Phase Noise active or not">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Standing Phase Noise</label>
+      </variable>
+      <variable item="Load dependent sound" CV="939" mask="XXXXXVXX" tooltip="Rolling noise during coasting active or not">
+        <enumVal>
+          <enumChoice choice="Off (Standard Driving Sound)"/>
+          <enumChoice choice="On (Load-Dependent Sound)"/>
+        </enumVal>
+        <label>Load dependent sound</label>
+      </variable>
+      <variable item="Cylinder Valves Open/Closed (Steam only)" CV="939" mask="XXXXVXXX" tooltip="Only steam locos during start of movement">
+        <enumVal>
+          <enumChoice choice="Cylinder valves closed during start"/>
+          <enumChoice choice="Cylinder valves open during start"/>
+        </enumVal>
+        <label>Cylinder Valves Open/Closed (Steam only)</label>
+      </variable>
+      <variable item="Directional triggering of reed contacts" CV="939" mask="XXXVXXXX" tooltip="Sound triggered by reed contacts direction-dependent or not">
+        <enumVal>
+          <enumChoice choice="Reed contact sounds both directions"/>
+          <enumChoice choice="Reed contact sounds forward only"/>
+        </enumVal>
+        <label>Directional triggering of reed contacts</label>
+      </variable>
+      <variable item="Automatic Background Noises" CV="939" mask="XXVXXXXX" tooltip="Automatic background noises active or not">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Automatic Background Noises</label>
+      </variable>
+      <variable item="Start Signal Delay" CV="939" mask="XVXXXXXX" tooltip="Starting sound reduced during frequent direction changes">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Start Signal Delay</label>
+      </variable>
+    </variables>
+  </decoder>
+  <pane>
+    <name>INFO: Selected SUSI range, MFG ID, SW version</name>
+    <column>
+       <label>
+        <text> ================================================================================================ </text>
+      </label>
+      <label>
+        <text> SUSI Range 1 definitions, if different range found, then use correct range of SUSI definition</text>
+      </label>
+      <label>
+        <text> As SUSI is an addition to an existing decoder, without knowledge of the decoder Brand, Reset is not defined nor provided</text>
+      </label>
+       <label>
+        <text> ================================================================================================ </text>
+      </label>
+       <label>
+        <text> </text>
+      </label>
+       <label>
+        <text> </text>
+      </label>
+       <label>
+        <text>  </text>
+      </label>
+      <display item="SUSI-range"/>
+      <display item="Manufacturer"/>
+      <display item="Decoder Version"/>
+    </column>
+  </pane>
+  <pane>
+    <name>Sound - Main</name>
+    <column>
+      <display item="Sound On/Off: Command Allocation - Function Keys"/>
+      <display item="Loco Start Up/Shut Down: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text>Sound configuration</text>
+      </label>
+      <display item="Random Sounds Generator"/>
+      <display item="Standing Phase Noise"/>
+      <display item="Load dependent sound"/>
+      <display item="Cylinder Valves Open/Closed (Steam only)"/>
+      <display item="Directional triggering of reed contacts"/>
+      <display item="Automatic Background Noises"/>
+      <display item="Start Signal Delay"/>
+      <label>
+        <text> </text>
+      </label>
+    </column>
+  </pane>
+  <pane>
+    <name>Sound to F-Keys</name>
+    <column>
+      <display item="Sound_01: Command Allocation - Function Keys"/>
+       <label>
+        <text> </text>
+      </label>
+      <display item="Sound_02: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_03: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_04: Command Allocation - Function Keys"/>
+     <label>
+        <text> </text>
+      </label>
+      <display item="Sound_05: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_06: Command Allocation - Function Keys"/>
+     <label>
+        <text> </text>
+      </label>
+      <display item="Sound_07: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_08: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_09: Command Allocation - Function Keys"/>
+     <label>
+        <text> </text>
+      </label>
+      <display item="Sound_10: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_11: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_12: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+    </column>
+  </pane>
+  <pane>
+    <name>Sound - Volume</name>
+    <column>
+      <display item="Master Volume Level"/>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+    <column>
+      <display item="Sound_01 : Individual Volume Level"/>
+      <display item="Sound_02 : Individual Volume Level"/>
+      <display item="Sound_03 : Individual Volume Level"/>
+      <display item="Sound_04 : Individual Volume Level"/>
+  <separator/>
+     <display item="Sound_05 : Individual Volume Level"/>
+      <display item="Sound_06 : Individual Volume Level"/>
+      <display item="Sound_07 : Individual Volume Level"/>
+      <display item="Sound_08 : Individual Volume Level"/>
+ <separator/>
+      <display item="Sound_09 : Individual Volume Level"/>
+      <display item="Sound_10 : Individual Volume Level"/>
+      <display item="Sound_11 : Individual Volume Level"/>
+      <display item="Sound_12 : Individual Volume Level"/>
+    </column>
+      <label>
+        <text> </text>
+      </label>
+    </column>
+  </pane>
+  <pane>
+    <name>CVs</name>
+    <column>
+      <cvtable/>
+    </column>
+  </pane>
+</decoder-config>

--- a/xml/decoders/0NMRA_SUSI_Sound_Mapping_Range2.xml
+++ b/xml/decoders/0NMRA_SUSI_Sound_Mapping_Range2.xml
@@ -1,0 +1,595 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI All rights reserved -->
+<!-- $Id: 0NMRA_SUSI_Sound_Mapping_Range2.xml ,v 1.0 2022/04/24 Alain CARASSO $       -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Alain CARASSO" version="1.0" lastUpdated="20220424"/>
+  <!--  Based on MASSOTH_eMotion SUSI Settings, who was published by Jeff Schmaltz -->
+  <decoder>
+    <family name="SUSI Sound Mapping definitions" mfg="NMRA">
+      <model model="SUSI Sound Mapping definitions Range 2"/>
+    </family>
+    <programming direct="yes" paged="no" register="yes" ops="yes"/>
+    <variables>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
+      <variable item="SUSI-range" CV="897" readOnly="yes" default="2" tooltip="Will not read/write properly if multiple SUSI modules attached">
+        <enumVal>
+          <enumChoice choice="Not used"/>
+          <enumChoice choice="Range I (CVs 900-939)"/>
+          <enumChoice choice="Range II (CVs 940-979)"/>
+          <enumChoice choice="Range III (CVs 980-1019)"/>
+        </enumVal>
+        <label>SUSI-range</label>
+      </variable>
+      <variable CV="940" readOnly="yes" default="238" item="Manufacturer" tooltip="The manufacturer's ID number (read only)">
+        <decVal/>
+       <label>Manufacturer ID</label>
+      </variable>
+      <variable CV="941" item="Decoder Version" tooltip="The decoder version number (read only)">
+        <decVal/>
+        <label>Software Version Number</label>
+      </variable>
+      <variable item="Master Volume Level" CV="942" default="128" tooltip="1=Low, 63=Loud, 255=external Potentiometer">
+        <decVal min="1" max="255"/>
+        <label>Master Volume Level</label>
+      </variable>
+      <variable item="Sound_01 : Individual Volume Level" CV="943"  default="128" tooltip="Controls volume of Sound_01">
+        <decVal max="255"/>
+        <label>Sound_01 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_02 : Individual Volume Level" CV="944"  default="128" tooltip="Controls volume of Sound_02">
+        <decVal max="255"/>
+        <label>Sound_02 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_03 : Individual Volume Level" CV="945"  default="128" tooltip="Controls volume of Sound_03">
+         <decVal max="255"/>
+         <label>Sound_03 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_04 : Individual Volume Level" CV="946"  default="128" tooltip="Controls volume of Sound_04">
+         <decVal max="255"/>
+         <label>Sound_04 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_05 : Individual Volume Level" CV="947" default="128" tooltip="Controls volume of Sound_05">
+          <decVal max="255" />
+          <label>Sound_05 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_06 : Individual Volume Level" CV="948" default="128" tooltip="Controls volume of Sound_06">
+          <decVal max="255" />
+          <label>Sound_06 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_07 : Individual Volume Level" CV="949" default="128" tooltip="Controls volume of Sound_07">
+         <decVal max="255"/>
+         <label>Sound_07 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_08 : Individual Volume Level" CV="950" default="128" tooltip="Controls volume of Sound_08">
+          <decVal max="255"/>
+          <label>Sound_08 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_09 : Individual Volume Level" CV="951" default="128" tooltip="Controls volume of Sound_09">
+          <decVal max="255"/>
+          <label>Sound_09 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_10 : Individual Volume Level" CV="952" default="128" tooltip="Controls volume of Sound_10">
+          <decVal max="255"/>
+          <label>Sound_10 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_11 : Individual Volume Level" CV="953" default="128" tooltip="Controls volume of Sound_11">
+          <decVal max="255"/>
+          <label>Sound_11 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_12 : Individual Volume Level" CV="954" default="128" tooltip="Controls volume of Sound_12">
+          <decVal max="255"/>
+          <label>Sound_12 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_01: Command Allocation - Function Keys" CV="961" default="1" tooltip="Function key which switches Sound_01">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_01: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_02: Command Allocation - Function Keys" CV="962" tooltip="Function key which switches Sound_02">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_02: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_03: Command Allocation - Function Keys" CV="963" tooltip="Function key which switches Sound_03">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_03: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_04: Command Allocation - Function Keys" CV="964" tooltip="Function key which switches Sound_04">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_04: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_05: Command Allocation - Function Keys" CV="965" tooltip="Function key which switches Sound_05">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_05: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_06: Command Allocation - Function Keys" CV="966" tooltip="Function key which switches Sound_06">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_06: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_07: Command Allocation - Function Keys" CV="967" tooltip="Function key which switches Sound_07">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_07: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_08: Command Allocation - Function Keys" CV="968" tooltip="Function key which switches Sound_08">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_08: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_09: Command Allocation - Function Keys" CV="969" tooltip="Function key which switches Sound_09">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_09: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_10: Command Allocation - Function Keys" CV="970" tooltip="Function key which switches Sound_10">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_10: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_11: Command Allocation - Function Keys" CV="971" tooltip="Function key which switches Sound_11">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_11: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_12: Command Allocation - Function Keys" CV="972" tooltip="Function key which switches Sound_12">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_12: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound On/Off: Command Allocation - Function Keys" CV="977" default="1" tooltip="Function key which switches sound (amplifier) on/off">
+        <enumVal>
+          <enumChoice choice="Sound steady (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound On/Off: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Loco Start Up/Shut Down: Command Allocation - Function Keys" CV="978" default="16" tooltip="Function key which switches Loco Start Up/Shut Down">
+        <enumVal>
+          <enumChoice choice="Loco always on (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Loco Start Up/Shut Down: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Random Sounds Generator" CV="979" mask="XXXXXXXV" default="0" tooltip="Random generator active or not">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Random Sounds Generator</label>
+      </variable>
+      <variable item="Standing Phase Noise" CV="979" mask="XXXXXXVX" default="1" tooltip="Standing Phase Noise active or not">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Standing Phase Noise</label>
+      </variable>
+      <variable item="Load dependent sound" CV="979" mask="XXXXXVXX" tooltip="Rolling noise during coasting active or not">
+        <enumVal>
+          <enumChoice choice="Off (Standard Driving Sound)"/>
+          <enumChoice choice="On (Load-Dependent Sound)"/>
+        </enumVal>
+        <label>Load dependent sound</label>
+      </variable>
+      <variable item="Cylinder Valves Open/Closed (Steam only)" CV="979" mask="XXXXVXXX" tooltip="Only steam locos during start of movement">
+        <enumVal>
+          <enumChoice choice="Cylinder valves closed during start"/>
+          <enumChoice choice="Cylinder valves open during start"/>
+        </enumVal>
+        <label>Cylinder Valves Open/Closed (Steam only)</label>
+      </variable>
+      <variable item="Directional triggering of reed contacts" CV="979" mask="XXXVXXXX" tooltip="Sound triggered by reed contacts direction-dependent or not">
+        <enumVal>
+          <enumChoice choice="Reed contact sounds both directions"/>
+          <enumChoice choice="Reed contact sounds forward only"/>
+        </enumVal>
+        <label>Directional triggering of reed contacts</label>
+      </variable>
+      <variable item="Automatic Background Noises" CV="979" mask="XXVXXXXX" tooltip="Automatic background noises active or not">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Automatic Background Noises</label>
+      </variable>
+      <variable item="Start Signal Delay" CV="979" mask="XVXXXXXX" tooltip="Starting sound reduced during frequent direction changes">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Start Signal Delay</label>
+      </variable>
+    </variables>
+  </decoder>
+  <pane>
+    <name>INFO: Selected SUSI range, MFG ID, SW version</name>
+    <column>
+       <label>
+        <text> ================================================================================================ </text>
+      </label>
+      <label>
+        <text> SUSI Range 2 definitions, if different range found, then use correct range of SUSI definition</text>
+      </label>
+      <label>
+        <text> As SUSI is an addition to an existing decoder, without knowledge of the decoder Brand, Reset is not defined nor provided</text>
+      </label>
+       <label>
+        <text> ================================================================================================ </text>
+      </label>
+       <label>
+        <text> </text>
+      </label>
+       <label>
+        <text> </text>
+      </label>
+       <label>
+        <text>  </text>
+      </label>
+      <display item="SUSI-range"/>
+      <display item="Manufacturer"/>
+      <display item="Decoder Version"/>
+    </column>
+  </pane>
+  <pane>
+    <name>Sound - Main</name>
+    <column>
+      <display item="Sound On/Off: Command Allocation - Function Keys"/>
+      <display item="Loco Start Up/Shut Down: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text>Sound configuration</text>
+      </label>
+      <display item="Random Sounds Generator"/>
+      <display item="Standing Phase Noise"/>
+      <display item="Load dependent sound"/>
+      <display item="Cylinder Valves Open/Closed (Steam only)"/>
+      <display item="Directional triggering of reed contacts"/>
+      <display item="Automatic Background Noises"/>
+      <display item="Start Signal Delay"/>
+      <label>
+        <text> </text>
+      </label>
+    </column>
+  </pane>
+  <pane>
+    <name>Sound to F-Keys</name>
+    <column>
+      <display item="Sound_01: Command Allocation - Function Keys"/>
+       <label>
+        <text> </text>
+      </label>
+      <display item="Sound_02: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_03: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_04: Command Allocation - Function Keys"/>
+     <label>
+        <text> </text>
+      </label>
+      <display item="Sound_05: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_06: Command Allocation - Function Keys"/>
+     <label>
+        <text> </text>
+      </label>
+      <display item="Sound_07: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_08: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_09: Command Allocation - Function Keys"/>
+     <label>
+        <text> </text>
+      </label>
+      <display item="Sound_10: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_11: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_12: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+    </column>
+  </pane>
+  <pane>
+    <name>Sound - Volume</name>
+    <column>
+      <display item="Master Volume Level"/>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+    <column>
+      <display item="Sound_01 : Individual Volume Level"/>
+      <display item="Sound_02 : Individual Volume Level"/>
+      <display item="Sound_03 : Individual Volume Level"/>
+      <display item="Sound_04 : Individual Volume Level"/>
+  <separator/>
+     <display item="Sound_05 : Individual Volume Level"/>
+      <display item="Sound_06 : Individual Volume Level"/>
+      <display item="Sound_07 : Individual Volume Level"/>
+      <display item="Sound_08 : Individual Volume Level"/>
+ <separator/>
+      <display item="Sound_09 : Individual Volume Level"/>
+      <display item="Sound_10 : Individual Volume Level"/>
+      <display item="Sound_11 : Individual Volume Level"/>
+      <display item="Sound_12 : Individual Volume Level"/>
+    </column>
+      <label>
+        <text> </text>
+      </label>
+    </column>
+  </pane>
+  <pane>
+    <name>CVs</name>
+    <column>
+      <cvtable/>
+    </column>
+  </pane>
+</decoder-config>

--- a/xml/decoders/0NMRA_SUSI_Sound_Mapping_Range3.xml
+++ b/xml/decoders/0NMRA_SUSI_Sound_Mapping_Range3.xml
@@ -1,0 +1,595 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI All rights reserved -->
+<!-- $Id: 0NMRA_SUSI_Sound_Mapping_Range3.xml ,v 1.0 2022/04/24 Alain CARASSO $       -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Alain CARASSO" version="1.0" lastUpdated="20220424"/>
+  <!--  Based on MASSOTH_eMotion SUSI Settings, who was published by Jeff Schmaltz -->
+  <decoder>
+    <family name="SUSI Sound Mapping definitions" mfg="NMRA">
+      <model model="SUSI Sound Mapping definitions Range 3"/>
+    </family>
+    <programming direct="yes" paged="no" register="yes" ops="yes"/>
+    <variables>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
+      <variable item="SUSI-range" CV="897" readOnly="yes" default="3" tooltip="Will not read/write properly if multiple SUSI modules attached">
+        <enumVal>
+          <enumChoice choice="Not used"/>
+          <enumChoice choice="Range I (CVs 900-939)"/>
+          <enumChoice choice="Range II (CVs 940-979)"/>
+          <enumChoice choice="Range III (CVs 980-1019)"/>
+        </enumVal>
+        <label>SUSI-range</label>
+      </variable>
+      <variable CV="980" readOnly="yes" default="238" item="Manufacturer" tooltip="The manufacturer's ID number (read only)">
+        <decVal/>
+       <label>Manufacturer ID</label>
+      </variable>
+      <variable CV="981" item="Decoder Version" tooltip="The decoder version number (read only)">
+        <decVal/>
+        <label>Software Version Number</label>
+      </variable>
+      <variable item="Master Volume Level" CV="982" default="128" tooltip="1=Low, 63=Loud, 255=external Potentiometer">
+        <decVal min="1" max="255"/>
+        <label>Master Volume Level</label>
+      </variable>
+      <variable item="Sound_01 : Individual Volume Level" CV="983"  default="128" tooltip="Controls volume of Sound_01">
+        <decVal max="255"/>
+        <label>Sound_01 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_02 : Individual Volume Level" CV="984"  default="128" tooltip="Controls volume of Sound_02">
+        <decVal max="255"/>
+        <label>Sound_02 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_03 : Individual Volume Level" CV="985"  default="128" tooltip="Controls volume of Sound_03">
+         <decVal max="255"/>
+         <label>Sound_03 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_04 : Individual Volume Level" CV="986"  default="128" tooltip="Controls volume of Sound_04">
+         <decVal max="255"/>
+         <label>Sound_04 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_05 : Individual Volume Level" CV="987" default="128" tooltip="Controls volume of Sound_05">
+          <decVal max="255" />
+          <label>Sound_05 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_06 : Individual Volume Level" CV="988" default="128" tooltip="Controls volume of Sound_06">
+          <decVal max="255" />
+          <label>Sound_06 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_07 : Individual Volume Level" CV="989" default="128" tooltip="Controls volume of Sound_07">
+         <decVal max="255"/>
+         <label>Sound_07 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_08 : Individual Volume Level" CV="990" default="128" tooltip="Controls volume of Sound_08">
+          <decVal max="255"/>
+          <label>Sound_08 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_09 : Individual Volume Level" CV="991" default="128" tooltip="Controls volume of Sound_09">
+          <decVal max="255"/>
+          <label>Sound_09 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_10 : Individual Volume Level" CV="992" default="128" tooltip="Controls volume of Sound_10">
+          <decVal max="255"/>
+          <label>Sound_10 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_11 : Individual Volume Level" CV="993" default="128" tooltip="Controls volume of Sound_11">
+          <decVal max="255"/>
+          <label>Sound_11 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_12 : Individual Volume Level" CV="994" default="128" tooltip="Controls volume of Sound_12">
+          <decVal max="255"/>
+          <label>Sound_12 : Individual Volume Level</label>
+      </variable>
+      <variable item="Sound_01: Command Allocation - Function Keys" CV="1001" default="1" tooltip="Function key which switches Sound_01">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_01: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_02: Command Allocation - Function Keys" CV="1002" tooltip="Function key which switches Sound_02">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_02: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_03: Command Allocation - Function Keys" CV="1003" tooltip="Function key which switches Sound_03">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_03: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_04: Command Allocation - Function Keys" CV="1004" tooltip="Function key which switches Sound_04">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_04: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_05: Command Allocation - Function Keys" CV="1005" tooltip="Function key which switches Sound_05">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_05: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_06: Command Allocation - Function Keys" CV="1006" tooltip="Function key which switches Sound_06">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_06: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_07: Command Allocation - Function Keys" CV="1007" tooltip="Function key which switches Sound_07">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_07: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_08: Command Allocation - Function Keys" CV="1008" tooltip="Function key which switches Sound_08">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_08: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_09: Command Allocation - Function Keys" CV="1009" tooltip="Function key which switches Sound_09">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_09: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_10: Command Allocation - Function Keys" CV="1010" tooltip="Function key which switches Sound_10">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_10: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_11: Command Allocation - Function Keys" CV="1011" tooltip="Function key which switches Sound_11">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_11: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound_12: Command Allocation - Function Keys" CV="1012" tooltip="Function key which switches Sound_12">
+        <enumVal>
+          <enumChoice choice="Deactivated (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound_12: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Sound On/Off: Command Allocation - Function Keys" CV="1017" default="1" tooltip="Function key which switches sound (amplifier) on/off">
+        <enumVal>
+          <enumChoice choice="Sound steady (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Sound On/Off: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Loco Start Up/Shut Down: Command Allocation - Function Keys" CV="1018" default="16" tooltip="Function key which switches Loco Start Up/Shut Down">
+        <enumVal>
+          <enumChoice choice="Loco always on (not switched with F-Key)" value="0"/>
+          <enumChoice choice="F1" value="1"/>
+          <enumChoice choice="F2" value="2"/>
+          <enumChoice choice="F3" value="3"/>
+          <enumChoice choice="F4" value="4"/>
+          <enumChoice choice="F5" value="5"/>
+          <enumChoice choice="F6" value="6"/>
+          <enumChoice choice="F7" value="7"/>
+          <enumChoice choice="F8" value="8"/>
+          <enumChoice choice="F9" value="9"/>
+          <enumChoice choice="F10" value="10"/>
+          <enumChoice choice="F11" value="11"/>
+          <enumChoice choice="F12" value="12"/>
+          <enumChoice choice="F13" value="13"/>
+          <enumChoice choice="F14" value="14"/>
+          <enumChoice choice="F15" value="15"/>
+          <enumChoice choice="F16" value="16"/>
+        </enumVal>
+        <label>Loco Start Up/Shut Down: Command Allocation - Function Keys</label>
+      </variable>
+      <variable item="Random Sounds Generator" CV="1019" mask="XXXXXXXV" default="0" tooltip="Random generator active or not">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Random Sounds Generator</label>
+      </variable>
+      <variable item="Standing Phase Noise" CV="1019" mask="XXXXXXVX" default="1" tooltip="Standing Phase Noise active or not">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Standing Phase Noise</label>
+      </variable>
+      <variable item="Load dependent sound" CV="1019" mask="XXXXXVXX" tooltip="Rolling noise during coasting active or not">
+        <enumVal>
+          <enumChoice choice="Off (Standard Driving Sound)"/>
+          <enumChoice choice="On (Load-Dependent Sound)"/>
+        </enumVal>
+        <label>Load dependent sound</label>
+      </variable>
+      <variable item="Cylinder Valves Open/Closed (Steam only)" CV="1019" mask="XXXXVXXX" tooltip="Only steam locos during start of movement">
+        <enumVal>
+          <enumChoice choice="Cylinder valves closed during start"/>
+          <enumChoice choice="Cylinder valves open during start"/>
+        </enumVal>
+        <label>Cylinder Valves Open/Closed (Steam only)</label>
+      </variable>
+      <variable item="Directional triggering of reed contacts" CV="1019" mask="XXXVXXXX" tooltip="Sound triggered by reed contacts direction-dependent or not">
+        <enumVal>
+          <enumChoice choice="Reed contact sounds both directions"/>
+          <enumChoice choice="Reed contact sounds forward only"/>
+        </enumVal>
+        <label>Directional triggering of reed contacts</label>
+      </variable>
+      <variable item="Automatic Background Noises" CV="1019" mask="XXVXXXXX" tooltip="Automatic background noises active or not">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Automatic Background Noises</label>
+      </variable>
+      <variable item="Start Signal Delay" CV="1019" mask="XVXXXXXX" tooltip="Starting sound reduced during frequent direction changes">
+        <enumVal>
+          <enumChoice choice="Off"/>
+          <enumChoice choice="On"/>
+        </enumVal>
+        <label>Start Signal Delay</label>
+      </variable>
+    </variables>
+  </decoder>
+  <pane>
+    <name>INFO: Selected SUSI range, MFG ID, SW version</name>
+    <column>
+       <label>
+        <text> ================================================================================================ </text>
+      </label>
+      <label>
+        <text> SUSI Range 3 definitions, if different range found, then use correct range of SUSI definition</text>
+      </label>
+      <label>
+        <text> As SUSI is an addition to an existing decoder, without knowledge of the decoder Brand, Reset is not defined nor provided</text>
+      </label>
+       <label>
+        <text> ================================================================================================ </text>
+      </label>
+       <label>
+        <text> </text>
+      </label>
+       <label>
+        <text> </text>
+      </label>
+       <label>
+        <text>  </text>
+      </label>
+      <display item="SUSI-range"/>
+      <display item="Manufacturer"/>
+      <display item="Decoder Version"/>
+    </column>
+  </pane>
+  <pane>
+    <name>Sound - Main</name>
+    <column>
+      <display item="Sound On/Off: Command Allocation - Function Keys"/>
+      <display item="Loco Start Up/Shut Down: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text>Sound configuration</text>
+      </label>
+      <display item="Random Sounds Generator"/>
+      <display item="Standing Phase Noise"/>
+      <display item="Load dependent sound"/>
+      <display item="Cylinder Valves Open/Closed (Steam only)"/>
+      <display item="Directional triggering of reed contacts"/>
+      <display item="Automatic Background Noises"/>
+      <display item="Start Signal Delay"/>
+      <label>
+        <text> </text>
+      </label>
+    </column>
+  </pane>
+  <pane>
+    <name>Sound to F-Keys</name>
+    <column>
+      <display item="Sound_01: Command Allocation - Function Keys"/>
+       <label>
+        <text> </text>
+      </label>
+      <display item="Sound_02: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_03: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_04: Command Allocation - Function Keys"/>
+     <label>
+        <text> </text>
+      </label>
+      <display item="Sound_05: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_06: Command Allocation - Function Keys"/>
+     <label>
+        <text> </text>
+      </label>
+      <display item="Sound_07: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_08: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_09: Command Allocation - Function Keys"/>
+     <label>
+        <text> </text>
+      </label>
+      <display item="Sound_10: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_11: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Sound_12: Command Allocation - Function Keys"/>
+      <label>
+        <text> </text>
+      </label>
+    </column>
+  </pane>
+  <pane>
+    <name>Sound - Volume</name>
+    <column>
+      <display item="Master Volume Level"/>
+      <label>
+        <text> </text>
+      </label>
+      <label>
+        <text> </text>
+      </label>
+    <column>
+      <display item="Sound_01 : Individual Volume Level"/>
+      <display item="Sound_02 : Individual Volume Level"/>
+      <display item="Sound_03 : Individual Volume Level"/>
+      <display item="Sound_04 : Individual Volume Level"/>
+  <separator/>
+     <display item="Sound_05 : Individual Volume Level"/>
+      <display item="Sound_06 : Individual Volume Level"/>
+      <display item="Sound_07 : Individual Volume Level"/>
+      <display item="Sound_08 : Individual Volume Level"/>
+ <separator/>
+      <display item="Sound_09 : Individual Volume Level"/>
+      <display item="Sound_10 : Individual Volume Level"/>
+      <display item="Sound_11 : Individual Volume Level"/>
+      <display item="Sound_12 : Individual Volume Level"/>
+    </column>
+      <label>
+        <text> </text>
+      </label>
+    </column>
+  </pane>
+  <pane>
+    <name>CVs</name>
+    <column>
+      <cvtable/>
+    </column>
+  </pane>
+</decoder-config>

--- a/xml/decoders/LSM_SUSI_Function_Mapping.xml
+++ b/xml/decoders/LSM_SUSI_Function_Mapping.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI All rights reserved -->
+<!-- $Id: LSM_SUSI_Function_Mapping.xml ,v 1.0 2022/04/24 Alain CARASSO $       -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Alain CARASSO" version="1.0" lastUpdated="20220424"/>
+  <!--  LSM SUSI CVs output mapping to Fkeys definition (SUSI Range2) -->
+  <decoder>
+    <family name="LS Models Function Mapping definitions" mfg="LS Models Sprl">
+      <model model="LS Models SUSI Outputs Function Mapping"/>
+    </family>
+    <programming direct="yes" paged="no" register="yes" ops="yes"/>
+    <variables>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
+       <variable item="SUSI-range" CV="897" readOnly="yes" default="2" tooltip="Will not read/write properly if multiple SUSI modules attached">
+        <enumVal>
+          <enumChoice choice="Not used"/>
+          <enumChoice choice="Range I (CVs 900-939)"/>
+          <enumChoice choice="Range II (CVs 940-979)"/>
+          <enumChoice choice="Range III (CVs 980-1019)"/>
+        </enumVal>
+        <label>SUSI-range</label>
+      </variable>
+      <variable CV="940" readOnly="yes" default="77" item="Manufacturer" tooltip="The manufacturer's ID number (read only)">
+        <decVal/>
+       <label>Manufacturer ID</label>
+      </variable>
+      <variable CV="941" readOnly="yes" item="Decoder Version" tooltip="The decoder version number (read only)">
+        <decVal/>
+        <label>Software Version Number</label>
+      </variable>
+<!-- only the CVs shown in manual are available, unused Cvs removed-->
+      <variable item="Fkey for headlights" CV="943" default="0" tooltip="0=F0, 1=F1 up to 28=F28">
+        <decVal min="0" max="28"/>
+        <label>Fkey for headlights</label>
+      </variable>
+      <variable item="Fkey for Driver cab" CV="945" default="5" tooltip="0=F0, 1=F1 up to 28=F28">
+        <decVal min="0" max="28"/>
+        <label>Fkey for Driver cab</label>
+      </variable>
+      <variable item="Fkey for Yard Lights" CV="946" default="6" tooltip="0=F0, 1=F1 up to 28=F28">
+        <decVal min="0" max="28"/>
+        <label>Fkey for Yard Lights</label>
+      </variable>
+      <variable item="Fkey for Safety Light" CV="947" default="10" tooltip="0=F0, 1=F1 up to 28=F28">
+        <decVal min="0" max="28"/>
+        <label>Fkey for Safety Light</label>
+      </variable>
+      <variable item="Fkey for Side1 Light" CV="948" default="7" tooltip="0=F0, 1=F1 up to 28=F28">
+        <decVal min="0" max="28"/>
+        <label>Fkey for Side1 Light</label>
+      </variable>
+      <variable item="Fkey for Side2 Light" CV="949" default="8" tooltip="0=F0, 1=F1 up to 28=F28">
+        <decVal min="0" max="28"/>
+        <label>Fkey for Side2 Light</label>
+      </variable>
+      <variable item="Fkey for Interior Light" CV="950" default="3" tooltip="0=F0, 1=F1 up to 28=F28">
+        <decVal min="0" max="28"/>
+        <label>Fkey for Interior Light</label>
+      </variable>
+      <variable item="Fkey for Warnings" CV="951" default="9" tooltip="0=F0, 1=F1 up to 28=F28">
+        <decVal min="0" max="28"/>
+        <label>Fkey for Warnings</label>
+      </variable>
+     <variable item="Driver Cab Dimming" CV="968" default="20" tooltip="Driver Cab intensity 0 to 63" >
+        <decVal min="1" max="63"/>
+        <label>Driver Cab Dimming</label>
+     </variable>
+     <variable item="Safety Light Dimming" CV="969" default="5" tooltip="Safety Light intensity 0 to 63" >
+        <decVal min="1" max="63"/>
+        <label>Safety Light Dimming</label>
+     </variable>
+     <variable item="Analog Light settings" CV="970" default="0" tooltip="0=auto, 1= Side1 Off, 2=Side2 Off, 3=All Off" >
+        <decVal min="0" max="63"/>
+        <label>Analog Light settings</label>
+     </variable>
+      <variable item="SUSI Detection setting" CV="977" default="0" tooltip="0=Autodetect, 1=DCC SUSI On, 2=Analog Modef">
+        <decVal min="0" max="2"/>
+        <label>SUSI Detection setting</label>
+     </variable>
+   </variables>
+  </decoder>
+
+  <pane>
+    <name>CVs</name>
+    <column>
+      <cvtable/>
+    </column>
+  </pane>
+  <pane>
+    <name>SUSI Defined Outputs to Fkey mapping</name>
+    <column>
+       <label>
+        <text> ================================================================================================= </text>
+      </label>
+      <label>
+        <text> ========================= LS Models specific SUSI Range 2 CV definitions ========================= </text>
+      </label>
+      <label>
+        <text> ===  As SUSI is an addition to an existing decoder used to drive SUSI, the real decoder reset is not available === </text>
+      </label>
+      <label>
+        <text> ============= if available, the CV to reset the SUSI module can be found in the SUSI module manual ============ </text>
+      </label>
+       <label>
+        <text> ================================================================================================= </text>
+      </label>
+      <label>
+        <text> select the F key you want to use for each available SUSI output by entering </text>
+      </label>
+      <label>
+        <text> its number: 0 for F0, 1 for F1, 2 for F2...../...... up to 28 for F28                             </text>
+      </label>
+       <label>
+        <text> ================================================================================================= </text>
+      </label>
+      <display item="SUSI-range"/>
+      <display item="Manufacturer"/>
+      <display item="Decoder Version"/>
+      <label>
+        <text> </text>
+      </label>
+      <display item="Fkey for headlights"/>
+      <display item="Fkey for Driver cab" />
+      <display item="Fkey for Yard Lights"/>
+      <display item="Fkey for Safety Light"/>
+      <display item="Fkey for Side1 Light"/>
+      <display item="Fkey for Side2 Light"/>
+      <display item="Fkey for Interior Light"/>
+      <display item="Fkey for Warnings"/>
+      <display item="Driver Cab Dimming"/>
+      <display item="Safety Light Dimming"/>
+      <display item="Analog Light settings"/>
+      <display item="SUSI Detection setting"/>
+    </column>
+  </pane>
+</decoder-config>


### PR DESCRIPTION
I created new decoders definitions for SUSI mapping:
6 files under NMRA mfg name 3 for Function mapping (one per range 1, 2 or 3) and 3 for Sound mapping;
1 file for LS Models Sprl mfg name, as LS Models doesn't follow proposed SUSI mapping.