### PR TITLE
Use scripts to initialize LogixNG variables

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -407,6 +407,8 @@
           <li><i>Global Variables</i> has been added. A Global Variable
           is similar to a Local Variable, except that it is shared among
           the ConditionalNGs.</li>
+          <li>Global variables and Local variables can now be initialized
+          with a script expression or a script file.</li>
           <li>The action <i>Listen on beans</i> now protects against
           removal of the beans it's listening to.</li>
         </ul>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -411,6 +411,8 @@
           with a script expression or a script file.</li>
           <li>The action <i>Listen on beans</i> now protects against
           removal of the beans it's listening to.</li>
+          <li>The <i>Edit local variables</i> dialog can now be resized
+          so that the table grows and shrinks when it's resized.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/jmri/jmrit/beantable/LogixNGTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixNGTableAction.java
@@ -90,6 +90,7 @@ public class LogixNGTableAction extends AbstractLogixNGTableAction<LogixNG> {
         LogixNG logixNG =
                 InstanceManager.getDefault(LogixNG_Manager.class)
                         .createLogixNG(userName);
+        logixNG.activate();
         logixNG.setEnabled(true);
         return logixNG;
     }
@@ -99,6 +100,7 @@ public class LogixNGTableAction extends AbstractLogixNGTableAction<LogixNG> {
         LogixNG logixNG =
                 InstanceManager.getDefault(LogixNG_Manager.class)
                         .createLogixNG(systemName, userName);
+        logixNG.activate();
         logixNG.setEnabled(true);
         return logixNG;
     }

--- a/java/src/jmri/jmrit/logixng/LogixNG.java
+++ b/java/src/jmri/jmrit/logixng/LogixNG.java
@@ -29,6 +29,14 @@ public interface LogixNG extends Base, NamedBean {
     public boolean isEnabled();
 
     /**
+     * Activates this LogixNG.
+     * <P>
+     * This method is only called by the LogixNG manager and it is called
+     * during initialization of the LogixNGs.
+     */
+    public void activate();
+
+    /**
      * Set the system name for the conditionalNG at the specified position in this list
      * @param index index of the element to set the system name
      * @return the system name

--- a/java/src/jmri/jmrit/logixng/LogixNGBundle.properties
+++ b/java/src/jmri/jmrit/logixng/LogixNGBundle.properties
@@ -72,6 +72,7 @@ InitialValueType_Reference      = Reference
 InitialValueType_Formula        = Formula
 InitialValueType_ScriptExpression   = Script expression
 InitialValueType_ScriptFile         = Script file
+InitialValueType_LogixNGTable       = LogixNG Table
 
 ReturnValueType_None            = None
 ReturnValueType_LocalVariable   = Local variable

--- a/java/src/jmri/jmrit/logixng/LogixNGBundle.properties
+++ b/java/src/jmri/jmrit/logixng/LogixNGBundle.properties
@@ -70,6 +70,8 @@ InitialValueType_LocalVariable  = Local variable
 InitialValueType_Memory         = Memory
 InitialValueType_Reference      = Reference
 InitialValueType_Formula        = Formula
+InitialValueType_ScriptExpression   = Script expression
+InitialValueType_ScriptFile         = Script file
 
 ReturnValueType_None            = None
 ReturnValueType_LocalVariable   = Local variable

--- a/java/src/jmri/jmrit/logixng/LogixNG_ScriptBindings.java
+++ b/java/src/jmri/jmrit/logixng/LogixNG_ScriptBindings.java
@@ -1,0 +1,33 @@
+package jmri.jmrit.logixng;
+
+import javax.script.Bindings;
+
+import jmri.InstanceManager;
+
+/**
+ * Script bindings for LogixNG.
+ *
+ * @author Daniel Bergqvist 2022
+ */
+public class LogixNG_ScriptBindings {
+
+    // This class should never be instanciated.
+    private LogixNG_ScriptBindings() {}
+
+    public static void addScriptBindings(Bindings bindings) {
+        // this should agree with help/en/html/tools/scripting/Start.shtml - this link is wrong and should point to LogixNG documentation
+        bindings.put("logixngs", InstanceManager.getNullableDefault(LogixNG_Manager.class));
+        bindings.put("conditionalngs", InstanceManager.getNullableDefault(ConditionalNG_Manager.class));
+        bindings.put("globalVariables", InstanceManager.getNullableDefault(GlobalVariableManager.class));
+        bindings.put("logixngModules", InstanceManager.getNullableDefault(ModuleManager.class));
+        bindings.put("logixngTables", InstanceManager.getNullableDefault(NamedTableManager.class));
+        bindings.put("analogActions", InstanceManager.getNullableDefault(AnalogActionManager.class));
+        bindings.put("analogExpressions", InstanceManager.getNullableDefault(AnalogExpressionManager.class));
+        bindings.put("digitalActions", InstanceManager.getNullableDefault(DigitalActionManager.class));
+        bindings.put("digitalBooleanActions", InstanceManager.getNullableDefault(DigitalBooleanActionManager.class));
+        bindings.put("digitalExpressions", InstanceManager.getNullableDefault(DigitalExpressionManager.class));
+        bindings.put("stringActions", InstanceManager.getNullableDefault(StringActionManager.class));
+        bindings.put("stringExpressions", InstanceManager.getNullableDefault(StringExpressionManager.class));
+    }
+
+}

--- a/java/src/jmri/jmrit/logixng/SymbolTable.java
+++ b/java/src/jmri/jmrit/logixng/SymbolTable.java
@@ -317,11 +317,11 @@ public interface SymbolTable {
         NamedTable myTable = InstanceManager.getDefault(NamedTableManager.class)
                 .getNamedTable(initialData);
 
-        var myMap = new java.util.concurrent.ConcurrentHashMap();
+        var myMap = new java.util.concurrent.ConcurrentHashMap<Object, Map<Object, Object>>();
 
         for (int row=1; row <= myTable.numRows(); row++) {
             Object rowKey = myTable.getCell(row, 0);
-            var rowMap = new java.util.concurrent.ConcurrentHashMap();
+            var rowMap = new java.util.concurrent.ConcurrentHashMap<Object, Object>();
 
             for (int col=1; col <= myTable.numColumns(); col++) {
                 var columnKey = myTable.getCell(0, col);

--- a/java/src/jmri/jmrit/logixng/SymbolTable.java
+++ b/java/src/jmri/jmrit/logixng/SymbolTable.java
@@ -271,9 +271,13 @@ public interface SymbolTable {
                 "variable.set(" + initialData + ")";
 
         JmriScriptEngineManager scriptEngineManager = jmri.script.JmriScriptEngineManager.getDefault();
+
         Bindings bindings = new SimpleBindings();
+        LogixNG_ScriptBindings.addScriptBindings(bindings);
+
         var variable = new Reference<Object>();
         bindings.put("variable", variable);
+
         try {
             String theScript = String.format("import jmri%n") + script;
             scriptEngineManager.getEngineByName(JmriScriptEngineManager.JYTHON)
@@ -286,8 +290,12 @@ public interface SymbolTable {
     }
 
     private static Object runScriptFile(String initialData) {
+
         JmriScriptEngineManager scriptEngineManager = jmri.script.JmriScriptEngineManager.getDefault();
+
         Bindings bindings = new SimpleBindings();
+        LogixNG_ScriptBindings.addScriptBindings(bindings);
+
         var variable = new Reference<Object>();
         bindings.put("variable", variable);
 
@@ -424,6 +432,7 @@ public interface SymbolTable {
     }
 
 
+    @SuppressFBWarnings(value="SLF4J_LOGGER_SHOULD_BE_PRIVATE", justification="Interfaces cannot have private fields")
     final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SymbolTable.class);
 
 }

--- a/java/src/jmri/jmrit/logixng/SymbolTable.java
+++ b/java/src/jmri/jmrit/logixng/SymbolTable.java
@@ -141,7 +141,8 @@ public interface SymbolTable {
         Reference(Bundle.getMessage("InitialValueType_Reference"), true),
         Formula(Bundle.getMessage("InitialValueType_Formula"), true),
         ScriptExpression(Bundle.getMessage("InitialValueType_ScriptExpression"), true),
-        ScriptFile(Bundle.getMessage("InitialValueType_ScriptFile"), true);
+        ScriptFile(Bundle.getMessage("InitialValueType_ScriptFile"), true),
+        LogixNG_Table(Bundle.getMessage("InitialValueType_LogixNGTable"), true);
 
         private final String _descr;
         private final boolean _isValidAsParameter;
@@ -311,6 +312,29 @@ public interface SymbolTable {
         return variable.get();
     }
 
+    private static Object copyLogixNG_Table(String initialData) {
+
+        NamedTable myTable = InstanceManager.getDefault(NamedTableManager.class)
+                .getNamedTable(initialData);
+
+        var myMap = new java.util.concurrent.ConcurrentHashMap();
+
+        for (int row=1; row <= myTable.numRows(); row++) {
+            Object rowKey = myTable.getCell(row, 0);
+            var rowMap = new java.util.concurrent.ConcurrentHashMap();
+
+            for (int col=1; col <= myTable.numColumns(); col++) {
+                var columnKey = myTable.getCell(0, col);
+                var cellValue = myTable.getCell(row, col);
+                rowMap.put(columnKey, cellValue);
+            }
+
+            myMap.put(rowKey, rowMap);
+        }
+
+        return myMap;
+    }
+
     public static Object getInitialValue(
             InitialValueType initialType,
             String initialData,
@@ -403,6 +427,9 @@ public interface SymbolTable {
 
             case ScriptFile:
                 return runScriptFile(initialData);
+
+            case LogixNG_Table:
+                return copyLogixNG_Table(initialData);
 
             default:
                 log.error("definition._initialValueType has invalid value: {}", initialType.name());

--- a/java/src/jmri/jmrit/logixng/actions/ActionScript.java
+++ b/java/src/jmri/jmrit/logixng/actions/ActionScript.java
@@ -256,16 +256,8 @@ public class ActionScript extends AbstractDigitalAction {
         JmriScriptEngineManager scriptEngineManager = jmri.script.JmriScriptEngineManager.getDefault();
 
         Bindings bindings = new SimpleBindings();
-//        ScriptParams params = new ScriptParams(this);
 
-        // this should agree with help/en/html/tools/scripting/Start.shtml - this link is wrong and should point to LogixNG documentation
-        bindings.put("analogActions", InstanceManager.getNullableDefault(AnalogActionManager.class));
-        bindings.put("analogExpressions", InstanceManager.getNullableDefault(AnalogExpressionManager.class));
-        bindings.put("digitalActions", InstanceManager.getNullableDefault(DigitalActionManager.class));
-        bindings.put("digitalBooleanActions", InstanceManager.getNullableDefault(DigitalBooleanActionManager.class));
-        bindings.put("digitalExpressions", InstanceManager.getNullableDefault(DigitalExpressionManager.class));
-        bindings.put("stringActions", InstanceManager.getNullableDefault(StringActionManager.class));
-        bindings.put("stringExpressions", InstanceManager.getNullableDefault(StringExpressionManager.class));
+        LogixNG_ScriptBindings.addScriptBindings(bindings);
 
         SymbolTable symbolTable = getConditionalNG().getSymbolTable();
         bindings.put("symbolTable", symbolTable);    // Give the script access to the local variable 'symbolTable'

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionListenOnBeansSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionListenOnBeansSwing.java
@@ -20,7 +20,7 @@ import jmri.util.table.ButtonRenderer;
 
 /**
  * Configures an ActionListenOnBeans object with a Swing JPanel.
- * 
+ *
  * @author Daniel Bergqvist Copyright 2021
  */
 public class ActionListenOnBeansSwing extends AbstractDigitalActionSwing {
@@ -30,21 +30,20 @@ public class ActionListenOnBeansSwing extends AbstractDigitalActionSwing {
     private JTextField _localVariableNamedBean;
     private JTextField _localVariableEvent;
     private JTextField _localVariableNewValue;
-    
+
     @Override
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
         if ((object != null) && (! (object instanceof ActionListenOnBeans))) {
             throw new IllegalArgumentException("object is not a ActionListenOnBeans: " + object.getClass().getName());
         }
         ActionListenOnBeans listenOnBeans = (ActionListenOnBeans)object;
-        
+
         panel = new JPanel();
-        
+
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        
-        JPanel tablePanel = new JPanel();
+
         _listenOnBeansTable = new JTable();
-        
+
         if (listenOnBeans != null) {
             List<NamedBeanReference> namedBeanReference
                     = new ArrayList<>(listenOnBeans.getReferences());
@@ -58,7 +57,7 @@ public class ActionListenOnBeansSwing extends AbstractDigitalActionSwing {
         } else {
             _listenOnBeansTableModel = new ListenOnBeansTableModel(null);
         }
-        
+
         _listenOnBeansTable.setModel(_listenOnBeansTableModel);
         _listenOnBeansTable.setDefaultRenderer(NamedBeanType.class,
                 new ListenOnBeansTableModel.CellRenderer());
@@ -69,7 +68,7 @@ public class ActionListenOnBeansSwing extends AbstractDigitalActionSwing {
         _listenOnBeansTableModel.setColumnsForComboBoxes(_listenOnBeansTable);
         _listenOnBeansTable.setDefaultRenderer(JButton.class, new ButtonRenderer());
         _listenOnBeansTable.setDefaultEditor(JButton.class, new ButtonEditor(new JButton()));
-        
+
         JButton testButton = new JButton("XXXXXX");  // NOI18N
         _listenOnBeansTable.setRowHeight(testButton.getPreferredSize().height);
         TableColumn deleteColumn = _listenOnBeansTable.getColumnModel()
@@ -77,7 +76,7 @@ public class ActionListenOnBeansSwing extends AbstractDigitalActionSwing {
         deleteColumn.setMinWidth(testButton.getPreferredSize().width);
         deleteColumn.setMaxWidth(testButton.getPreferredSize().width);
         deleteColumn.setResizable(false);
-        
+
         // The dummy column is used to be able to force update of the
         // other columns when the panel is closed.
         TableColumn dummyColumn = _listenOnBeansTable.getColumnModel()
@@ -85,36 +84,35 @@ public class ActionListenOnBeansSwing extends AbstractDigitalActionSwing {
         dummyColumn.setMinWidth(0);
         dummyColumn.setPreferredWidth(0);
         dummyColumn.setMaxWidth(0);
-        
+
         JScrollPane scrollpane = new JScrollPane(_listenOnBeansTable);
         scrollpane.setPreferredSize(new Dimension(400, 200));
-        tablePanel.add(scrollpane, BorderLayout.CENTER);
-        panel.add(tablePanel);
-        
+        panel.add(scrollpane);
+
         JPanel localVariableNamedBeanPanel = new JPanel();
         localVariableNamedBeanPanel.add(new JLabel(Bundle.getMessage("ActionListenOnBeansSwing_LocalVariableNamedBean")));
         _localVariableNamedBean = new JTextField(20);
         localVariableNamedBeanPanel.add(_localVariableNamedBean);
         panel.add(localVariableNamedBeanPanel);
-        
+
         JPanel localVariableNamedEventPanel = new JPanel();
         localVariableNamedEventPanel.add(new JLabel(Bundle.getMessage("ActionListenOnBeansSwing_LocalVariableEvent")));
         _localVariableEvent = new JTextField(20);
         localVariableNamedEventPanel.add(_localVariableEvent);
         panel.add(localVariableNamedEventPanel);
-        
+
         JPanel localVariableNewValuePanel = new JPanel();
         localVariableNewValuePanel.add(new JLabel(Bundle.getMessage("ActionListenOnBeansSwing_LocalVariableNewValue")));
         _localVariableNewValue = new JTextField(20);
         localVariableNewValuePanel.add(_localVariableNewValue);
         panel.add(localVariableNewValuePanel);
-        
+
         if (listenOnBeans != null) {
             _localVariableNamedBean.setText(listenOnBeans.getLocalVariableNamedBean());
             _localVariableEvent.setText(listenOnBeans.getLocalVariableEvent());
             _localVariableNewValue.setText(listenOnBeans.getLocalVariableNewValue());
         }
-        
+
         // Add parameter
         JButton add = new JButton(Bundle.getMessage("ActionListenOnBeans_TableAddReference"));
         buttonPanel.add(add);
@@ -122,13 +120,13 @@ public class ActionListenOnBeansSwing extends AbstractDigitalActionSwing {
             _listenOnBeansTableModel.add();
         });
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public boolean validate(@Nonnull List<String> errorMessages) {
         return true;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
@@ -136,7 +134,7 @@ public class ActionListenOnBeansSwing extends AbstractDigitalActionSwing {
         updateObject(action);
         return InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void updateObject(@Nonnull Base object) {
@@ -144,29 +142,29 @@ public class ActionListenOnBeansSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object is not a ActionListenOnBeans: " + object.getClass().getName());
         }
         ActionListenOnBeans listenOnBeans = (ActionListenOnBeans)object;
-        
+
         // Do this to force update of the table
         _listenOnBeansTable.editCellAt(0, 2);
-        
+
         listenOnBeans.clearReferences();
-        
+
         for (NamedBeanReference reference : _listenOnBeansTableModel.getReferences()) {
             listenOnBeans.addReference(reference);
         }
-        
+
         listenOnBeans.setLocalVariableNamedBean(_localVariableNamedBean.getText());
         listenOnBeans.setLocalVariableEvent(_localVariableEvent.getText());
         listenOnBeans.setLocalVariableNewValue(_localVariableNewValue.getText());
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public String toString() {
         return Bundle.getMessage("ActionListenOnBeans_Short");
     }
-    
+
     @Override
     public void dispose() {
     }
-    
+
 }

--- a/java/src/jmri/jmrit/logixng/actions/swing/DigitalCallModuleSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/DigitalCallModuleSwing.java
@@ -21,25 +21,25 @@ import jmri.util.swing.JComboBoxUtil;
 
 /**
  * Configures an ModuleDigitalAction object with a Swing JPanel.
- * 
+ *
  * @author Daniel Bergqvist Copyright 2021
  */
 public class DigitalCallModuleSwing extends AbstractDigitalActionSwing {
 
     private JComboBox<ModuleItem> _moduleComboBox;
     private CallModuleParameterTableModel _moduleParametersTableModel;
-    
+
     @Override
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
         if ((object != null) && (! (object instanceof DigitalCallModule))) {
             throw new IllegalArgumentException("object is not a Module: " + object.getClass().getName());
         }
         DigitalCallModule callModule = (DigitalCallModule)object;
-        
+
         panel = new JPanel();
-        
+
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        
+
         JPanel beanPanel = new JPanel();
         beanPanel.add(new JLabel("Module:"));
         _moduleComboBox = new JComboBox<>();
@@ -59,7 +59,7 @@ public class DigitalCallModuleSwing extends AbstractDigitalActionSwing {
         JComboBoxUtil.setupComboBoxMaxRows(_moduleComboBox);
         beanPanel.add(_moduleComboBox);
         panel.add(beanPanel);
-        
+
         Module module = null;
         List<ParameterData> parameterData;
         if (callModule != null) {
@@ -70,7 +70,6 @@ public class DigitalCallModuleSwing extends AbstractDigitalActionSwing {
         } else {
             parameterData = new ArrayList<>();
         }
-        JPanel tablePanel = new JPanel();
         JTable table = new JTable();
         _moduleParametersTableModel = new CallModuleParameterTableModel(module, parameterData);
         table.setModel(_moduleParametersTableModel);
@@ -85,16 +84,15 @@ public class DigitalCallModuleSwing extends AbstractDigitalActionSwing {
         _moduleParametersTableModel.setColumnsForComboBoxes(table);
         JScrollPane scrollpane = new JScrollPane(table);
         scrollpane.setPreferredSize(new Dimension(400, 200));
-        tablePanel.add(scrollpane, BorderLayout.CENTER);
-        panel.add(tablePanel);
+        panel.add(scrollpane);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public boolean validate(@Nonnull List<String> errorMessages) {
         return true;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
@@ -102,7 +100,7 @@ public class DigitalCallModuleSwing extends AbstractDigitalActionSwing {
         updateObject(action);
         return InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void updateObject(@Nonnull Base object) {
@@ -110,7 +108,7 @@ public class DigitalCallModuleSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object is not a Module: " + object.getClass().getName());
         }
         DigitalCallModule callModule = (DigitalCallModule)object;
-        
+
         ModuleItem mi = _moduleComboBox.getItemAt(_moduleComboBox.getSelectedIndex());
         if (mi._module != null) {
             callModule.setModule(mi._module);
@@ -124,31 +122,31 @@ public class DigitalCallModuleSwing extends AbstractDigitalActionSwing {
             callModule.removeModule();
         }
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public String toString() {
         return Bundle.getMessage("DigitalCallModule_Short");
     }
-    
+
     @Override
     public void dispose() {
     }
-    
-    
+
+
     private static class ModuleItem {
-        
+
         private final Module _module;
-        
+
         public ModuleItem(Module m) {
             _module = m;
         }
-        
+
         @Override
         public String toString() {
             if (_module == null) return "";
             else return _module.getDisplayName();
         }
     }
-    
+
 }

--- a/java/src/jmri/jmrit/logixng/actions/swing/LogDataSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/LogDataSwing.java
@@ -19,7 +19,7 @@ import jmri.util.table.ButtonRenderer;
 
 /**
  * Configures an LogData object with a Swing JPanel.
- * 
+ *
  * @author Daniel Bergqvist Copyright 2021
  */
 public class LogDataSwing extends AbstractDigitalActionSwing {
@@ -30,26 +30,26 @@ public class LogDataSwing extends AbstractDigitalActionSwing {
     private JTextField _format;
     private JTable _logDataTable;
     private LogDataTableModel _logDataTableModel;
-    
+
     @Override
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
         if ((object != null) && (! (object instanceof LogData))) {
             throw new IllegalArgumentException("object is not a LogData: " + object.getClass().getName());
         }
         LogData logData = (LogData)object;
-        
+
         panel = new JPanel();
-        
+
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        
-        
+
+
         _logToLogCheckBox = new JCheckBox(Bundle.getMessage("LogData_LogToLog"));
         panel.add(_logToLogCheckBox);
-        
+
         _logToScriptOutputCheckBox = new JCheckBox(Bundle.getMessage("LogData_LogToScriptOutput"));
         panel.add(_logToScriptOutputCheckBox);
-        
-        
+
+
         JPanel formatTypePanel = new JPanel();
         _formatType = new JComboBox<>();
         for (LogData.FormatType formatType : LogData.FormatType.values()) {
@@ -58,25 +58,24 @@ public class LogDataSwing extends AbstractDigitalActionSwing {
         formatTypePanel.add(new JLabel(Bundle.getMessage("LogData_FormatType")));
         formatTypePanel.add(_formatType);
         panel.add(formatTypePanel);
-        
+
         JPanel formatPanel = new JPanel();
         _format = new JTextField(20);
         formatPanel.add(new JLabel(Bundle.getMessage("LogData_Format")));
         formatPanel.add(_format);
         panel.add(formatPanel);
-        
-        
+
+
         if (logData != null) {
             _logToLogCheckBox.setSelected(logData.getLogToLog());
             _logToScriptOutputCheckBox.setSelected(logData.getLogToScriptOutput());
             _formatType.setSelectedItem(logData.getFormatType());
             _format.setText(logData.getFormat());
         }
-        
-        
-        JPanel tablePanel = new JPanel();
+
+
         _logDataTable = new JTable();
-        
+
         if (logData != null) {
             List<LogData.Data> dataList
                     = new ArrayList<>(logData.getDataList());
@@ -85,7 +84,7 @@ public class LogDataSwing extends AbstractDigitalActionSwing {
         } else {
             _logDataTableModel = new LogDataTableModel(null);
         }
-        
+
         _logDataTable.setModel(_logDataTableModel);
         _logDataTable.setDefaultRenderer(LogData.DataType.class,
                 new LogDataTableModel.CellRenderer());
@@ -94,7 +93,7 @@ public class LogDataSwing extends AbstractDigitalActionSwing {
         _logDataTableModel.setColumnsForComboBoxes(_logDataTable);
         _logDataTable.setDefaultRenderer(JButton.class, new ButtonRenderer());
         _logDataTable.setDefaultEditor(JButton.class, new ButtonEditor(new JButton()));
-        
+
         JButton testButton = new JButton("XXXXXX");  // NOI18N
         _logDataTable.setRowHeight(testButton.getPreferredSize().height);
         TableColumn deleteColumn = _logDataTable.getColumnModel()
@@ -102,7 +101,7 @@ public class LogDataSwing extends AbstractDigitalActionSwing {
         deleteColumn.setMinWidth(testButton.getPreferredSize().width);
         deleteColumn.setMaxWidth(testButton.getPreferredSize().width);
         deleteColumn.setResizable(false);
-        
+
         // The dummy column is used to be able to force update of the
         // other columns when the panel is closed.
         TableColumn dummyColumn = _logDataTable.getColumnModel()
@@ -110,12 +109,11 @@ public class LogDataSwing extends AbstractDigitalActionSwing {
         dummyColumn.setMinWidth(0);
         dummyColumn.setPreferredWidth(0);
         dummyColumn.setMaxWidth(0);
-        
+
         JScrollPane scrollpane = new JScrollPane(_logDataTable);
         scrollpane.setPreferredSize(new Dimension(400, 200));
-        tablePanel.add(scrollpane, BorderLayout.CENTER);
-        panel.add(tablePanel);
-        
+        panel.add(scrollpane);
+
         // Add parameter
         JButton add = new JButton(Bundle.getMessage("LogData_TableAdd"));
         buttonPanel.add(add);
@@ -123,7 +121,7 @@ public class LogDataSwing extends AbstractDigitalActionSwing {
             _logDataTableModel.add();
         });
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public boolean validate(@Nonnull List<String> errorMessages) {
@@ -142,7 +140,7 @@ public class LogDataSwing extends AbstractDigitalActionSwing {
         }
         return result;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
@@ -150,7 +148,7 @@ public class LogDataSwing extends AbstractDigitalActionSwing {
         updateObject(action);
         return InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void updateObject(@Nonnull Base object) {
@@ -158,33 +156,33 @@ public class LogDataSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object is not a LogData: " + object.getClass().getName());
         }
         LogData logData = (LogData)object;
-        
-        
+
+
         logData.setLogToLog(_logToLogCheckBox.isSelected());
         logData.setLogToScriptOutput(_logToScriptOutputCheckBox.isSelected());
-        
+
         logData.setFormatType(_formatType.getItemAt(_formatType.getSelectedIndex()));
         logData.setFormat(_format.getText());
-        
-        
+
+
         // Do this to force update of the table
         _logDataTable.editCellAt(0, 2);
-        
+
         logData.getDataList().clear();
-        
+
         for (LogData.Data data : _logDataTableModel.getDataList()) {
             logData.getDataList().add(data);
         }
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public String toString() {
         return Bundle.getMessage("LogData_Short");
     }
-    
+
     @Override
     public void dispose() {
     }
-    
+
 }

--- a/java/src/jmri/jmrit/logixng/actions/swing/ShowDialogSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ShowDialogSwing.java
@@ -20,7 +20,7 @@ import jmri.util.table.ButtonRenderer;
 
 /**
  * Configures an ShowDialog object with a Swing JPanel.
- * 
+ *
  * @author Daniel Bergqvist Copyright 2021
  */
 public class ShowDialogSwing extends AbstractDigitalActionSwing {
@@ -34,19 +34,19 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
     private JCheckBox _multiLineCheckBox;
     private JTextField _localVariableForSelectedButton;
     private JTextField _localVariableForInputString;
-    
+
     @Override
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
         if ((object != null) && (! (object instanceof ShowDialog))) {
             throw new IllegalArgumentException("object is not a ShowDialog: " + object.getClass().getName());
         }
         ShowDialog showDialog = (ShowDialog)object;
-        
+
         panel = new JPanel();
-        
+
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        
-        
+
+
         JPanel buttonCheckBoxPanel = new JPanel();
         buttonCheckBoxPanel.setBorder(BorderFactory.createTitledBorder(
                 Bundle.getMessage("ShowDialog_Buttons")));
@@ -63,8 +63,8 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
             }
         }
         panel.add(buttonCheckBoxPanel);
-        
-        
+
+
         JPanel formatTypePanel = new JPanel();
         _formatType = new JComboBox<>();
         for (ShowDialog.FormatType formatType : ShowDialog.FormatType.values()) {
@@ -73,17 +73,16 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
         formatTypePanel.add(new JLabel(Bundle.getMessage("ShowDialog_FormatType")));
         formatTypePanel.add(_formatType);
         panel.add(formatTypePanel);
-        
+
         JPanel formatPanel = new JPanel();
         _format = new JTextField(40);
         formatPanel.add(new JLabel(Bundle.getMessage("ShowDialog_Format")));
         formatPanel.add(_format);
         panel.add(formatPanel);
-        
-        
-        JPanel tablePanel = new JPanel();
+
+
         _showDialogTable = new JTable();
-        
+
         if (showDialog != null) {
             List<ShowDialog.Data> dataList
                     = new ArrayList<>(showDialog.getDataList());
@@ -92,7 +91,7 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
         } else {
             _showDialogTableModel = new ShowDialogTableModel(null);
         }
-        
+
         _showDialogTable.setModel(_showDialogTableModel);
         _showDialogTable.setDefaultRenderer(ShowDialog.DataType.class,
                 new ShowDialogTableModel.CellRenderer());
@@ -101,7 +100,7 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
         _showDialogTableModel.setColumnsForComboBoxes(_showDialogTable);
         _showDialogTable.setDefaultRenderer(JButton.class, new ButtonRenderer());
         _showDialogTable.setDefaultEditor(JButton.class, new ButtonEditor(new JButton()));
-        
+
         JButton testButton = new JButton("XXXXXX");  // NOI18N
         _showDialogTable.setRowHeight(testButton.getPreferredSize().height);
         TableColumn deleteColumn = _showDialogTable.getColumnModel()
@@ -109,7 +108,7 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
         deleteColumn.setMinWidth(testButton.getPreferredSize().width);
         deleteColumn.setMaxWidth(testButton.getPreferredSize().width);
         deleteColumn.setResizable(false);
-        
+
         // The dummy column is used to be able to force update of the
         // other columns when the panel is closed.
         TableColumn dummyColumn = _showDialogTable.getColumnModel()
@@ -117,42 +116,41 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
         dummyColumn.setMinWidth(0);
         dummyColumn.setPreferredWidth(0);
         dummyColumn.setMaxWidth(0);
-        
+
         JScrollPane scrollpane = new JScrollPane(_showDialogTable);
         scrollpane.setPreferredSize(new Dimension(400, 200));
-        tablePanel.add(scrollpane, BorderLayout.CENTER);
-        panel.add(tablePanel);
-        
+        panel.add(scrollpane);
+
         // Add parameter
         JButton add = new JButton(Bundle.getMessage("ShowDialog_TableAdd"));
         buttonPanel.add(add);
         add.addActionListener((ActionEvent e) -> {
             _showDialogTableModel.add();
         });
-        
-        
+
+
         _modalCheckBox = new JCheckBox(Bundle.getMessage("ShowDialog_Modal"));
         panel.add(_modalCheckBox);
-        
+
         _multiLineCheckBox = new JCheckBox(Bundle.getMessage("ShowDialog_Multiline"));
         panel.add(_multiLineCheckBox);
-        
+
         panel.add(new JLabel(Bundle.getMessage("ShowDialog_MultilineHelp")));
-        
-        
+
+
         JPanel localVariableForSelectedButtonPanel = new JPanel();
         _localVariableForSelectedButton = new JTextField(20);
         localVariableForSelectedButtonPanel.add(new JLabel(Bundle.getMessage("ShowDialog_LocalVariableForSelectedButton")));
         localVariableForSelectedButtonPanel.add(_localVariableForSelectedButton);
         panel.add(localVariableForSelectedButtonPanel);
-        
+
         JPanel localVariableForInputStringPanel = new JPanel();
         _localVariableForInputString = new JTextField(20);
         localVariableForInputStringPanel.add(new JLabel(Bundle.getMessage("ShowDialog_LocalVariableForInputString")));
         localVariableForInputStringPanel.add(_localVariableForInputString);
         panel.add(localVariableForInputStringPanel);
-        
-        
+
+
         if (showDialog != null) {
             _modalCheckBox.setSelected(showDialog.getModal());
             _multiLineCheckBox.setSelected(showDialog.getMultiLine());
@@ -162,7 +160,7 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
             _format.setText(showDialog.getFormat());
         }
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public boolean validate(@Nonnull List<String> errorMessages) {
@@ -175,7 +173,7 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
             errorMessages.add(Bundle.getMessage("ShowDialog_ErrorNoEnabledButton"));
             result = false;
         }
-        
+
         for (ShowDialog.Data data : _showDialogTableModel.getDataList()) {
             if (data.getDataType() == ShowDialog.DataType.Formula) {
                 try {
@@ -190,7 +188,7 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
         }
         return result;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
@@ -198,7 +196,7 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
         updateObject(action);
         return InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void updateObject(@Nonnull Base object) {
@@ -206,63 +204,63 @@ public class ShowDialogSwing extends AbstractDigitalActionSwing {
             throw new IllegalArgumentException("object is not a ShowDialog: " + object.getClass().getName());
         }
         ShowDialog showDialog = (ShowDialog)object;
-        
-        
+
+
         Set<Button> enabledButtons = showDialog.getEnabledButtons();
         enabledButtons.clear();
-        
+
         for (ButtonCheckBox buttonCheckBox : _buttonCheckBoxes) {
             if (buttonCheckBox._checkBox.isSelected()) {
                 enabledButtons.add(buttonCheckBox._button);
             }
         }
-        
-        
+
+
         showDialog.setLocalVariableForSelectedButton(_localVariableForSelectedButton.getText());
         showDialog.setLocalVariableForInputString(_localVariableForInputString.getText());
-        
+
         showDialog.setFormatType(_formatType.getItemAt(_formatType.getSelectedIndex()));
         showDialog.setFormat(_format.getText());
-        
-        
+
+
         showDialog.setModal(_modalCheckBox.isSelected());
         showDialog.setMultiLine(_multiLineCheckBox.isSelected());
-        
+
         showDialog.setFormatType(_formatType.getItemAt(_formatType.getSelectedIndex()));
         showDialog.setFormat(_format.getText());
-        
-        
+
+
         // Do this to force update of the table
         _showDialogTable.editCellAt(0, 2);
-        
+
         showDialog.getDataList().clear();
-        
+
         for (ShowDialog.Data data : _showDialogTableModel.getDataList()) {
             showDialog.getDataList().add(data);
         }
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public String toString() {
         return Bundle.getMessage("ShowDialog_Short");
     }
-    
+
     @Override
     public void dispose() {
     }
-    
-    
+
+
     private static class ButtonCheckBox {
-        
+
         private final Button _button;
         private final JCheckBox _checkBox;
-        
+
         private ButtonCheckBox(Button button, JCheckBox checkBox) {
             this._button = button;
             this._checkBox = checkBox;
         }
-        
+
     }
-    
+
 }

--- a/java/src/jmri/jmrit/logixng/expressions/ExpressionScript.java
+++ b/java/src/jmri/jmrit/logixng/expressions/ExpressionScript.java
@@ -289,14 +289,7 @@ public class ExpressionScript extends AbstractDigitalExpression
         Bindings bindings = new SimpleBindings();
         MutableBoolean result = new MutableBoolean(false);
 
-        // this should agree with help/en/html/tools/scripting/Start.shtml - this link is wrong and should point to LogixNG documentation
-        bindings.put("analogActions", InstanceManager.getNullableDefault(AnalogActionManager.class));
-        bindings.put("analogExpressions", InstanceManager.getNullableDefault(AnalogExpressionManager.class));
-        bindings.put("digitalActions", InstanceManager.getNullableDefault(DigitalActionManager.class));
-        bindings.put("digitalBooleanActions", InstanceManager.getNullableDefault(DigitalBooleanActionManager.class));
-        bindings.put("digitalExpressions", InstanceManager.getNullableDefault(DigitalExpressionManager.class));
-        bindings.put("stringActions", InstanceManager.getNullableDefault(StringActionManager.class));
-        bindings.put("stringExpressions", InstanceManager.getNullableDefault(StringExpressionManager.class));
+        LogixNG_ScriptBindings.addScriptBindings(bindings);
 
         SymbolTable symbolTable = getConditionalNG().getSymbolTable();
         bindings.put("symbolTable", symbolTable);    // Give the script access to the local variable 'symbolTable'
@@ -421,14 +414,7 @@ public class ExpressionScript extends AbstractDigitalExpression
                 Bindings bindings = new SimpleBindings();
                 MutableBoolean result = new MutableBoolean(false);
 
-                // this should agree with help/en/html/tools/scripting/Start.shtml - this link is wrong and should point to LogixNG documentation
-                bindings.put("analogActions", InstanceManager.getNullableDefault(AnalogActionManager.class));
-                bindings.put("analogExpressions", InstanceManager.getNullableDefault(AnalogExpressionManager.class));
-                bindings.put("digitalActions", InstanceManager.getNullableDefault(DigitalActionManager.class));
-                bindings.put("digitalBooleanActions", InstanceManager.getNullableDefault(DigitalBooleanActionManager.class));
-                bindings.put("digitalExpressions", InstanceManager.getNullableDefault(DigitalExpressionManager.class));
-                bindings.put("stringActions", InstanceManager.getNullableDefault(StringActionManager.class));
-                bindings.put("stringExpressions", InstanceManager.getNullableDefault(StringExpressionManager.class));
+                LogixNG_ScriptBindings.addScriptBindings(bindings);
 
                 bindings.put("result", result);     // Give the script access to the local variable 'result'
 
@@ -459,14 +445,7 @@ public class ExpressionScript extends AbstractDigitalExpression
                 Bindings bindings = new SimpleBindings();
                 MutableBoolean result = new MutableBoolean(false);
 
-                // this should agree with help/en/html/tools/scripting/Start.shtml - this link is wrong and should point to LogixNG documentation
-                bindings.put("analogActions", InstanceManager.getNullableDefault(AnalogActionManager.class));
-                bindings.put("analogExpressions", InstanceManager.getNullableDefault(AnalogExpressionManager.class));
-                bindings.put("digitalActions", InstanceManager.getNullableDefault(DigitalActionManager.class));
-                bindings.put("digitalBooleanActions", InstanceManager.getNullableDefault(DigitalBooleanActionManager.class));
-                bindings.put("digitalExpressions", InstanceManager.getNullableDefault(DigitalExpressionManager.class));
-                bindings.put("stringActions", InstanceManager.getNullableDefault(StringActionManager.class));
-                bindings.put("stringExpressions", InstanceManager.getNullableDefault(StringExpressionManager.class));
+                LogixNG_ScriptBindings.addScriptBindings(bindings);
 
                 bindings.put("result", result);     // Give the script access to the local variable 'result'
 

--- a/java/src/jmri/jmrit/logixng/expressions/swing/DigitalCallModuleSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/DigitalCallModuleSwing.java
@@ -20,25 +20,25 @@ import jmri.util.swing.JComboBoxUtil;
 
 /**
  * Configures an ModuleDigitalExpression object with a Swing JPanel.
- * 
+ *
  * @author Daniel Bergqvist Copyright 2021
  */
 public class DigitalCallModuleSwing extends AbstractDigitalExpressionSwing {
 
     private JComboBox<ModuleItem> _moduleComboBox;
     private CallModuleParameterTableModel _moduleParametersTableModel;
-    
+
     @Override
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
         if ((object != null) && (! (object instanceof DigitalCallModule))) {
             throw new IllegalArgumentException("object is not a Module: " + object.getClass().getName());
         }
         DigitalCallModule callModule = (DigitalCallModule)object;
-        
+
         panel = new JPanel();
-        
+
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        
+
         JPanel beanPanel = new JPanel();
         beanPanel.add(new JLabel("Module:"));
         _moduleComboBox = new JComboBox<>();
@@ -58,7 +58,7 @@ public class DigitalCallModuleSwing extends AbstractDigitalExpressionSwing {
         JComboBoxUtil.setupComboBoxMaxRows(_moduleComboBox);
         beanPanel.add(_moduleComboBox);
         panel.add(beanPanel);
-        
+
         Module module = null;
         List<ParameterData> parameterData;
         if (callModule != null) {
@@ -69,7 +69,6 @@ public class DigitalCallModuleSwing extends AbstractDigitalExpressionSwing {
         } else {
             parameterData = new ArrayList<>();
         }
-        JPanel tablePanel = new JPanel();
         JTable table = new JTable();
         _moduleParametersTableModel = new CallModuleParameterTableModel(module, parameterData);
         table.setModel(_moduleParametersTableModel);
@@ -84,16 +83,15 @@ public class DigitalCallModuleSwing extends AbstractDigitalExpressionSwing {
         _moduleParametersTableModel.setColumnsForComboBoxes(table);
         JScrollPane scrollpane = new JScrollPane(table);
         scrollpane.setPreferredSize(new Dimension(400, 200));
-        tablePanel.add(scrollpane, BorderLayout.CENTER);
-        panel.add(tablePanel);
+        panel.add(scrollpane);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public boolean validate(@Nonnull List<String> errorMessages) {
         return true;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
@@ -101,7 +99,7 @@ public class DigitalCallModuleSwing extends AbstractDigitalExpressionSwing {
         updateObject(action);
         return InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(action);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void updateObject(@Nonnull Base object) {
@@ -109,7 +107,7 @@ public class DigitalCallModuleSwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object is not a Module: " + object.getClass().getName());
         }
         DigitalCallModule callModule = (DigitalCallModule)object;
-        
+
         ModuleItem mi = _moduleComboBox.getItemAt(_moduleComboBox.getSelectedIndex());
         if (mi._module != null) {
             callModule.setModule(mi._module);
@@ -123,31 +121,31 @@ public class DigitalCallModuleSwing extends AbstractDigitalExpressionSwing {
             callModule.removeModule();
         }
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public String toString() {
         return Bundle.getMessage("DigitalCallModule_Short");
     }
-    
+
     @Override
     public void dispose() {
     }
-    
-    
+
+
     private static class ModuleItem {
-        
+
         private final Module _module;
-        
+
         public ModuleItem(Module m) {
             _module = m;
         }
-        
+
         @Override
         public String toString() {
             if (_module == null) return "";
             else return _module.getDisplayName();
         }
     }
-    
+
 }

--- a/java/src/jmri/jmrit/logixng/expressions/swing/LogDataSwing.java
+++ b/java/src/jmri/jmrit/logixng/expressions/swing/LogDataSwing.java
@@ -19,7 +19,7 @@ import jmri.util.table.ButtonRenderer;
 
 /**
  * Configures an LogData object with a Swing JPanel.
- * 
+ *
  * @author Daniel Bergqvist Copyright 2021
  */
 public class LogDataSwing extends AbstractDigitalExpressionSwing {
@@ -31,19 +31,19 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
     private JTextField _format;
     private JTable _logDataTable;
     private LogDataTableModel _logDataTableModel;
-    
+
     @Override
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
         if ((object != null) && (! (object instanceof LogData))) {
             throw new IllegalArgumentException("object is not a LogData: " + object.getClass().getName());
         }
         LogData logData = (LogData)object;
-        
+
         panel = new JPanel();
-        
+
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        
-        
+
+
         JPanel resultTypePanel = new JPanel();
         _resultType = new JComboBox<>();
         for (ResultType formatType : ResultType.values()) {
@@ -52,16 +52,16 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
         resultTypePanel.add(new JLabel(Bundle.getMessage("LogData_ResultType")));
         resultTypePanel.add(_resultType);
         panel.add(resultTypePanel);
-        
-        
+
+
         _logToLogCheckBox = new JCheckBox(Bundle.getMessage("LogData_LogToLog"));
         _logToLogCheckBox.setSelected(true);    // Selected as default
         panel.add(_logToLogCheckBox);
-        
+
         _logToScriptOutputCheckBox = new JCheckBox(Bundle.getMessage("LogData_LogToScriptOutput"));
         panel.add(_logToScriptOutputCheckBox);
-        
-        
+
+
         JPanel formatTypePanel = new JPanel();
         _formatType = new JComboBox<>();
         for (LogData.FormatType formatType : LogData.FormatType.values()) {
@@ -70,14 +70,14 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
         formatTypePanel.add(new JLabel(Bundle.getMessage("LogData_FormatType")));
         formatTypePanel.add(_formatType);
         panel.add(formatTypePanel);
-        
+
         JPanel formatPanel = new JPanel();
         _format = new JTextField(20);
         formatPanel.add(new JLabel(Bundle.getMessage("LogData_Format")));
         formatPanel.add(_format);
         panel.add(formatPanel);
-        
-        
+
+
         if (logData != null) {
             _resultType.setSelectedItem(ResultType.parseResult(logData.getResult()));
             _logToLogCheckBox.setSelected(logData.getLogToLog());
@@ -85,11 +85,10 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
             _formatType.setSelectedItem(logData.getFormatType());
             _format.setText(logData.getFormat());
         }
-        
-        
-        JPanel tablePanel = new JPanel();
+
+
         _logDataTable = new JTable();
-        
+
         if (logData != null) {
             List<LogData.Data> dataList
                     = new ArrayList<>(logData.getDataList());
@@ -98,7 +97,7 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
         } else {
             _logDataTableModel = new LogDataTableModel(null);
         }
-        
+
         _logDataTable.setModel(_logDataTableModel);
         _logDataTable.setDefaultRenderer(LogData.DataType.class,
                 new LogDataTableModel.CellRenderer());
@@ -107,7 +106,7 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
         _logDataTableModel.setColumnsForComboBoxes(_logDataTable);
         _logDataTable.setDefaultRenderer(JButton.class, new ButtonRenderer());
         _logDataTable.setDefaultEditor(JButton.class, new ButtonEditor(new JButton()));
-        
+
         JButton testButton = new JButton("XXXXXX");  // NOI18N
         _logDataTable.setRowHeight(testButton.getPreferredSize().height);
         TableColumn deleteColumn = _logDataTable.getColumnModel()
@@ -115,7 +114,7 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
         deleteColumn.setMinWidth(testButton.getPreferredSize().width);
         deleteColumn.setMaxWidth(testButton.getPreferredSize().width);
         deleteColumn.setResizable(false);
-        
+
         // The dummy column is used to be able to force update of the
         // other columns when the panel is closed.
         TableColumn dummyColumn = _logDataTable.getColumnModel()
@@ -123,12 +122,11 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
         dummyColumn.setMinWidth(0);
         dummyColumn.setPreferredWidth(0);
         dummyColumn.setMaxWidth(0);
-        
+
         JScrollPane scrollpane = new JScrollPane(_logDataTable);
         scrollpane.setPreferredSize(new Dimension(400, 200));
-        tablePanel.add(scrollpane, BorderLayout.CENTER);
-        panel.add(tablePanel);
-        
+        panel.add(scrollpane);
+
         // Add parameter
         JButton add = new JButton(Bundle.getMessage("LogData_TableAdd"));
         buttonPanel.add(add);
@@ -136,7 +134,7 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
             _logDataTableModel.add();
         });
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public boolean validate(@Nonnull List<String> errorMessages) {
@@ -153,7 +151,7 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
         }
         return true;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
@@ -161,7 +159,7 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
         updateObject(expression);
         return InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expression);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void updateObject(@Nonnull Base object) {
@@ -169,33 +167,33 @@ public class LogDataSwing extends AbstractDigitalExpressionSwing {
             throw new IllegalArgumentException("object is not a LogData: " + object.getClass().getName());
         }
         LogData logData = (LogData)object;
-        
-        
+
+
         logData.setResult(_resultType.getItemAt(_resultType.getSelectedIndex()).getResult());
-        
+
         logData.setLogToLog(_logToLogCheckBox.isSelected());
         logData.setLogToScriptOutput(_logToScriptOutputCheckBox.isSelected());
-        
+
         logData.setFormatType(_formatType.getItemAt(_formatType.getSelectedIndex()));
         logData.setFormat(_format.getText());
-        
-        
+
+
         // Do this to force update of the table
         _logDataTable.editCellAt(0, 2);
-        
+
         logData.getDataList().clear();
-        
+
         for (LogData.Data data : _logDataTableModel.getDataList()) {
             logData.getDataList().add(data);
         }
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public String toString() {
         return Bundle.getMessage("LogData_Short");
     }
-    
+
     @Override
     public void dispose() {
     }

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultGlobalVariable.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultGlobalVariable.java
@@ -55,7 +55,7 @@ public class DefaultGlobalVariable extends AbstractNamedBean
 
     /** {@inheritDoc} */
     @Override
-    @SuppressWarnings("unchecked")  // Checked cast is not possible due to type erasure
+    @SuppressWarnings({"unchecked", "rawtypes"})    // Checked cast is not possible due to type erasure
     public void initialize() throws JmriException {
         SymbolTable symbolTable = new DefaultSymbolTable();
 

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNG.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNG.java
@@ -33,6 +33,7 @@ public class DefaultLogixNG extends AbstractNamedBean
 
     private final LogixNG_Manager _manager = InstanceManager.getDefault(LogixNG_Manager.class);
     private boolean _enabled = false;
+    private boolean _isActive = false;
     private final List<ConditionalNG_Entry> _conditionalNG_Entries = new ArrayList<>();
 
 
@@ -134,6 +135,12 @@ public class DefaultLogixNG extends AbstractNamedBean
         } else {
             unregisterListeners();
         }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void activate() {
+        _isActive = true;
     }
 
     /** {@inheritDoc} */
@@ -259,7 +266,7 @@ public class DefaultLogixNG extends AbstractNamedBean
     /** {@inheritDoc} */
     @Override
     public boolean isActive() {
-        return _enabled && _manager.isActive();
+        return _enabled && _isActive && _manager.isActive();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
@@ -247,12 +247,11 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
         // Therefore we create a new thread for this task.
         Runnable runnable = () -> {
 
-            // Activate and execute the initialization LogixNGs first.
+            // Initialize the values of the global variables
             Set<GlobalVariable> globalVariables =
                     InstanceManager.getDefault(GlobalVariableManager.class)
                             .getNamedBeanSet();
 
-            // Initialize the value of the global variable
             for (GlobalVariable gv : globalVariables) {
                 try {
                     gv.initialize();

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
@@ -269,6 +269,7 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
                             .getList();
 
             for (LogixNG logixNG : initLogixNGs) {
+                logixNG.activate();
                 if (logixNG.isActive()) {
                     logixNG.registerListeners();
                     logixNG.execute(false);
@@ -283,6 +284,8 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
                     .sorted()
                     .filter((logixNG) -> !(activeLogixNGs.contains(logixNG)))
                     .forEachOrdered((logixNG) -> {
+
+                logixNG.activate();
 
                 if (logixNG.isActive()) {
                     logixNG.registerListeners();

--- a/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
+++ b/java/src/jmri/jmrit/logixng/implementation/DefaultLogixNGManager.java
@@ -246,6 +246,21 @@ public class DefaultLogixNGManager extends AbstractManager<LogixNG>
         // This may take a long time so it must not be done on the GUI thread.
         // Therefore we create a new thread for this task.
         Runnable runnable = () -> {
+
+            // Activate and execute the initialization LogixNGs first.
+            Set<GlobalVariable> globalVariables =
+                    InstanceManager.getDefault(GlobalVariableManager.class)
+                            .getNamedBeanSet();
+
+            // Initialize the value of the global variable
+            for (GlobalVariable gv : globalVariables) {
+                try {
+                    gv.initialize();
+                } catch (JmriException e) {
+                    log.warn("Variable {} could not be initialized", gv.getUserName(), e);
+                }
+            }
+
             Set<LogixNG> activeLogixNGs = new HashSet<>();
 
             // Activate and execute the initialization LogixNGs first.

--- a/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultGlobalVariableXml.java
+++ b/java/src/jmri/jmrit/logixng/implementation/configurexml/DefaultGlobalVariableXml.java
@@ -64,13 +64,6 @@ public class DefaultGlobalVariableXml extends jmri.managers.configurexml.Abstrac
             h.setInitialValueData(elementInitialValueData.getTextTrim());
         }
 
-        try {
-            // Initialize the value of the global variable
-            h.initialize();
-        } catch (JmriException e) {
-            throw new JmriConfigureXmlException(e);
-        }
-
         return true;
     }
 

--- a/java/src/jmri/jmrit/logixng/implementation/swing/DefaultModuleSwing.java
+++ b/java/src/jmri/jmrit/logixng/implementation/swing/DefaultModuleSwing.java
@@ -25,20 +25,20 @@ public class DefaultModuleSwing extends AbstractSwingConfigurator {
 
     static final java.util.ResourceBundle rbx =
             java.util.ResourceBundle.getBundle("jmri.jmrit.logixng.tools.swing.LogixNGSwingBundle");  // NOI18N
-    
+
     protected JPanel panel;
     ModuleParametersTableModel _moduleParametersTableModel;
-    
+
     /** {@inheritDoc} */
     @Override
     public String getExecuteEvaluateMenuText() {
         return Bundle.getMessage("MenuText_ExecuteEvaluate");
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void executeEvaluate(@Nonnull Base object) {
-        
+
         if (! (object instanceof MaleSocket)) {
             throw new IllegalArgumentException("object is not a MaleSocket");
         }
@@ -46,7 +46,7 @@ public class DefaultModuleSwing extends AbstractSwingConfigurator {
             throw new IllegalArgumentException("((MaleSocket)object).getObject() is not a Module");
         }
         Module module = (Module)((MaleSocket)object).getObject();
-        
+
         FemaleSocket femaleSocket = module.getRootSocket();
         if (!femaleSocket.isConnected()) {
             // Nothing to do since nothing is connected to the female socket
@@ -58,7 +58,7 @@ public class DefaultModuleSwing extends AbstractSwingConfigurator {
             });
             return;
         }
-        
+
         Base obj = femaleSocket.getConnectedSocket();
         if (obj == null) throw new NullPointerException("object is null");
         while (obj instanceof MaleSocket) {
@@ -66,54 +66,53 @@ public class DefaultModuleSwing extends AbstractSwingConfigurator {
         }
         SwingConfiguratorInterface swi =
                 SwingTools.getSwingConfiguratorForClass(obj.getClass());
-        
+
         swi.executeEvaluate(femaleSocket.getConnectedSocket());
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public BaseManager<? extends NamedBean> getManager() {
         return null;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public JPanel getConfigPanel(@Nonnull JPanel buttonPanel) throws IllegalArgumentException {
         // This method is used to create a new item.
         throw new UnsupportedOperationException("Not supported");
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public JPanel getConfigPanel(@Nonnull Base object, @Nonnull JPanel buttonPanel) throws IllegalArgumentException {
         createPanel(object, buttonPanel);
         return panel;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public String getExampleSystemName() {
         throw new UnsupportedOperationException("Not supported");
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public String getAutoSystemName() {
         throw new UnsupportedOperationException("Not supported");
     }
-    
+
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
         // This method is never used to create a module so we expect to have a module
         if (! (object instanceof Module)) {
             throw new IllegalArgumentException("object is not a Module: " + object.getClass().getName());
         }
         Module module = (Module)object;
-        
+
         panel = new JPanel();
-        
+
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        
-        JPanel tablePanel = new JPanel();
+
         JTable table = new JTable();
         _moduleParametersTableModel = new ModuleParametersTableModel(module);
         table.setModel(_moduleParametersTableModel);
@@ -128,9 +127,8 @@ public class DefaultModuleSwing extends AbstractSwingConfigurator {
         _moduleParametersTableModel.setColumnForMenu(table);
         JScrollPane scrollpane = new JScrollPane(table);
         scrollpane.setPreferredSize(new Dimension(400, 200));
-        tablePanel.add(scrollpane, BorderLayout.CENTER);
-        panel.add(tablePanel);
-        
+        panel.add(scrollpane);
+
         // Add parameter
         JButton add = new JButton(Bundle.getMessage("TableAddParameter"));
         buttonPanel.add(add);
@@ -138,7 +136,7 @@ public class DefaultModuleSwing extends AbstractSwingConfigurator {
             _moduleParametersTableModel.add();
         });
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public boolean validate(@Nonnull List<String> errorMessages) {
@@ -156,16 +154,16 @@ public class DefaultModuleSwing extends AbstractSwingConfigurator {
                 hasErrors = true;
             }
         }
-        
+
         return !hasErrors;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
         throw new UnsupportedOperationException("Not supported");
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void updateObject(@Nonnull Base object) {
@@ -174,21 +172,21 @@ public class DefaultModuleSwing extends AbstractSwingConfigurator {
             throw new IllegalArgumentException("object is not a Module: " + object.getClass().getName());
         }
         Module module = (Module)object;
-        
+
         module.getParameters().clear();
         for (Parameter p : _moduleParametersTableModel.getParameters()) {
             module.addParameter(p);
         }
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public String toString() {
         return Bundle.getMessage("DefaultModule_Short");
     }
-    
+
     @Override
     public void dispose() {
     }
-    
+
 }

--- a/java/src/jmri/jmrit/logixng/tools/ImportLogix.java
+++ b/java/src/jmri/jmrit/logixng/tools/ImportLogix.java
@@ -48,6 +48,8 @@ public class ImportLogix {
 
             if (logixNG == null) throw new RuntimeException("Cannot create new LogixNG with name: \"Logix: " + logix.getDisplayName()+"\"");
 
+            logixNG.activate();
+
             log.debug("Import Logix {} to LogixNG {}", logix.getSystemName(), logixNG.getSystemName());
         }
 

--- a/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
+++ b/java/src/jmri/jmrit/logixng/tools/swing/TreeEditor.java
@@ -942,7 +942,6 @@ public class TreeEditor extends TreeViewer {
             Container contentPanel = _editLocalVariablesDialog.getContentPane();
             contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
 
-            JPanel tablePanel = new JPanel();
             JTable table = new JTable();
             _localVariableTableModel = new LocalVariableTableModel(maleSocket);
             table.setModel(_localVariableTableModel);
@@ -957,8 +956,7 @@ public class TreeEditor extends TreeViewer {
             _localVariableTableModel.setColumnForMenu(table);
             JScrollPane scrollpane = new JScrollPane(table);
             scrollpane.setPreferredSize(new Dimension(400, 200));
-            tablePanel.add(scrollpane, BorderLayout.CENTER);
-            contentPanel.add(tablePanel);
+            contentPanel.add(scrollpane);
 
             // set up create and cancel buttons
             JPanel buttonPanel = new JPanel();

--- a/java/src/jmri/jmrit/logixng/util/parser/RecursiveDescentParser.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/RecursiveDescentParser.java
@@ -6,25 +6,25 @@ import java.util.Map;
 
 /**
  * A recursive descent parser
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class RecursiveDescentParser {
 
     private List<Token> _tokens;
     private final Map<String, Variable> _variables;
-    
-    
+
+
     public RecursiveDescentParser(Map<String, Variable> variables) {
         _variables = variables;
     }
-    
+
     private State next(State state) {
         int newTokenIndex = state._tokenIndex+1;
         return new State(newTokenIndex, _tokens.get(newTokenIndex), state._tokenIndex, state._token);
     }
-    
-    
+
+
     private State accept(TokenType tokenType, State state) throws ParserException {
         if (state._token == null) {
             return null;
@@ -44,8 +44,8 @@ public class RecursiveDescentParser {
             return null;
         }
     }
-    
-    
+
+
     private State expect(TokenType tokenType, State state) throws ParserException {
         State newState = accept(tokenType, state);
         if (newState == null) {
@@ -53,39 +53,39 @@ public class RecursiveDescentParser {
         }
         return newState;
     }
-    
-    
+
+
     public ExpressionNode parseExpression(String expression) throws ParserException {
         _tokens = Tokenizer.getTokens(expression);
-        
+
         if (_tokens.isEmpty()) {
             return null;
         }
-        
+
         ExpressionNodeAndState exprNodeAndState = firstRule.parse(new State(0, _tokens.get(0), 0, new Token()));
-        
+
         if (exprNodeAndState == null) {
             return null;
         }
-        
+
         if ((exprNodeAndState._state != null)
                 && (exprNodeAndState._state._tokenIndex < _tokens.size())) {
-            
+
             throw new InvalidSyntaxException(Bundle.getMessage("InvalidSyntaxNotFullyParsed", exprNodeAndState._state._tokenIndex));
         }
         return exprNodeAndState._exprNode;
     }
-    
-    
-    
-    
+
+
+
+
     private static class State {
-        
+
         private final int _tokenIndex;
         private final Token _token;
         private final int _lastTokenPos;
         private final Token _lastToken;
-        
+
         public State(int tokenIndex, Token token, int lastTokenPos, Token lastToken) {
             _tokenIndex = tokenIndex;
             _token = token;
@@ -93,28 +93,28 @@ public class RecursiveDescentParser {
             _lastToken = lastToken;
         }
     }
-    
-    
+
+
     private static class ExpressionNodeAndState {
         private final ExpressionNode _exprNode;
         private final State _state;
-        
+
         private ExpressionNodeAndState(ExpressionNode exprNode, State state) {
             _exprNode = exprNode;
             _state = state;
         }
     }
-    
+
     private interface Rule {
-        
+
         public ExpressionNodeAndState parse(State state) throws ParserException;
-        
+
     }
-    
-    
+
+
     // The rules below are numbered from the list on this page:
     // https://introcs.cs.princeton.edu/java/11precedence/
-    
+
     private final Rule rule1 = new Rule1();
     private final Rule rule2 = new Rule2();
     private final Rule rule3 = new Rule3();
@@ -133,10 +133,10 @@ public class RecursiveDescentParser {
     private final Rule rule20 = new Rule20();
     private final Rule21_Function rule21_Function = new Rule21_Function();
     private final Rule21_Method rule21_Method = new Rule21_Method();
-    
+
     private final Rule firstRule = rule1;
-    
-    
+
+
     // Assignment
     // <rule1> ::= <rule2> ||
     //             <rule2> = <rule1> ||
@@ -175,20 +175,20 @@ public class RecursiveDescentParser {
                         || (newState._token._tokenType == TokenType.ASSIGN_SHIFT_RIGHT)
                         || (newState._token._tokenType == TokenType.ASSIGN_UNSIGNED_SHIFT_RIGHT)
                     )) {
-                
+
                 TokenType operatorTokenType = newState._token._tokenType;
                 newState = next(newState);
                 ExpressionNodeAndState rightSide = rule2.parse(newState);
-                
+
                 ExpressionNode exprNode = new ExpressionNodeAssignmentOperator(operatorTokenType, leftSide._exprNode, rightSide._exprNode);
                 leftSide = new ExpressionNodeAndState(exprNode, rightSide._state);
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Rule2 is ternary. <rule3> | <rule3> ? <rule2> : <rule2>
     private class Rule2 implements Rule {
 
@@ -201,18 +201,18 @@ public class RecursiveDescentParser {
             State newState = leftSide._state;
             if ((newState._token != null)
                     && ((newState._token._tokenType == TokenType.TERNARY_QUESTION_MARK))) {
-                
+
                 newState = next(newState);
                 ExpressionNodeAndState middleSide = rule3.parse(newState);
-                
+
                 newState = middleSide._state;
-                
+
                 if ((newState._token != null)
                         && ((newState._token._tokenType == TokenType.TERNARY_COLON))) {
-                    
+
                     newState = next(newState);
                     ExpressionNodeAndState rightRightSide = rule3.parse(newState);
-                    
+
                     ExpressionNode exprNode = new ExpressionNodeTernaryOperator(
                             leftSide._exprNode, middleSide._exprNode, rightRightSide._exprNode);
                     leftSide = new ExpressionNodeAndState(exprNode, rightRightSide._state);
@@ -222,10 +222,10 @@ public class RecursiveDescentParser {
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Logical OR
     // <rule3> ::= <rule4> | <rule4> || <rule4>
     private class Rule3 implements Rule {
@@ -239,21 +239,21 @@ public class RecursiveDescentParser {
             State newState = leftSide._state;
             while ((newState._token != null)
                     && ((newState._token._tokenType == TokenType.BOOLEAN_OR))) {
-                
+
                 TokenType operatorTokenType = newState._token._tokenType;
                 newState = next(newState);
                 ExpressionNodeAndState rightSide = rule4.parse(newState);
-                
+
                 ExpressionNode exprNode = new ExpressionNodeBooleanOperator(operatorTokenType, leftSide._exprNode, rightSide._exprNode);
                 leftSide = new ExpressionNodeAndState(exprNode, rightSide._state);
                 newState = rightSide._state;
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Logical AND
     // <rule4> ::= <rule5> | <rule5> && <rule5>
     private class Rule4 implements Rule {
@@ -267,21 +267,21 @@ public class RecursiveDescentParser {
             State newState = leftSide._state;
             while ((newState._token != null)
                     && ((newState._token._tokenType == TokenType.BOOLEAN_AND))) {
-                
+
                 TokenType operatorTokenType = newState._token._tokenType;
                 newState = next(newState);
                 ExpressionNodeAndState rightSide = rule5.parse(newState);
-                
+
                 ExpressionNode exprNode = new ExpressionNodeBooleanOperator(operatorTokenType, leftSide._exprNode, rightSide._exprNode);
                 leftSide = new ExpressionNodeAndState(exprNode, rightSide._state);
                 newState = rightSide._state;
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Bitwise OR
     // <rule5> ::= <rule6> | <rule6> | <rule6>
     private class Rule5 implements Rule {
@@ -295,21 +295,21 @@ public class RecursiveDescentParser {
             State newState = leftSide._state;
             while ((newState._token != null)
                     && ((newState._token._tokenType == TokenType.BINARY_OR))) {
-                
+
                 TokenType operatorTokenType = newState._token._tokenType;
                 newState = next(newState);
                 ExpressionNodeAndState rightSide = rule6.parse(newState);
-                
+
                 ExpressionNode exprNode = new ExpressionNodeBinaryOperator(operatorTokenType, leftSide._exprNode, rightSide._exprNode);
                 leftSide = new ExpressionNodeAndState(exprNode, rightSide._state);
                 newState = rightSide._state;
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Bitwise XOR
     // <rule6> ::= <rule7> | <rule7> ^ <rule7>
     private class Rule6 implements Rule {
@@ -323,21 +323,21 @@ public class RecursiveDescentParser {
             State newState = leftSide._state;
             while ((newState._token != null)
                     && ((newState._token._tokenType == TokenType.BINARY_XOR))) {
-                
+
                 TokenType operatorTokenType = newState._token._tokenType;
                 newState = next(newState);
                 ExpressionNodeAndState rightSide = rule7.parse(newState);
-                
+
                 ExpressionNode exprNode = new ExpressionNodeBinaryOperator(operatorTokenType, leftSide._exprNode, rightSide._exprNode);
                 leftSide = new ExpressionNodeAndState(exprNode, rightSide._state);
                 newState = rightSide._state;
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Bitwise AND
     // <rule7> ::= <rule8> | <rule8> & <rule8>
     private class Rule7 implements Rule {
@@ -351,21 +351,21 @@ public class RecursiveDescentParser {
             State newState = leftSide._state;
             while ((newState._token != null)
                     && ((newState._token._tokenType == TokenType.BINARY_AND))) {
-                
+
                 TokenType operatorTokenType = newState._token._tokenType;
                 newState = next(newState);
                 ExpressionNodeAndState rightSide = rule8.parse(newState);
-                
+
                 ExpressionNode exprNode = new ExpressionNodeBinaryOperator(operatorTokenType, leftSide._exprNode, rightSide._exprNode);
                 leftSide = new ExpressionNodeAndState(exprNode, rightSide._state);
                 newState = rightSide._state;
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Equality
     // <rule8> ::= <rule9> | <rule9> == <rule9> | <rule9> != <rule9>
     private class Rule8 implements Rule {
@@ -391,10 +391,10 @@ public class RecursiveDescentParser {
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Relational
     // <rule9> ::= <rule10> | <rule10> < <rule10> | <rule10> <= <rule10> | <rule10> > <rule10> | <rule10> >= <rule10>
     private class Rule9 implements Rule {
@@ -422,10 +422,10 @@ public class RecursiveDescentParser {
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Shift
     // <rule10> ::= <rule11> | <rule11> << <rule11> | <rule11> >> <rule11> | <rule11> >>> <rule11>
     private class Rule10 implements Rule {
@@ -452,10 +452,10 @@ public class RecursiveDescentParser {
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Additive
     // <rule11> ::= <rule12> | <rule12> + <rule12> | <rule12> - <rule12>
     private class Rule11 implements Rule {
@@ -481,10 +481,10 @@ public class RecursiveDescentParser {
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Multiplicative
     // <rule12> ::= <rule13> | <rule13> * <rule13> | <rule13> / <rule13> | <rule13> % <rule13>
     private class Rule12 implements Rule {
@@ -511,13 +511,13 @@ public class RecursiveDescentParser {
             }
             return leftSide;
         }
-        
+
     }
-    
-    
+
+
     // Rule13 in Java is cast object and object creation. Not relevant here.
-    
-    
+
+
     // Unary pre-increment, unary pre-decrement, unary plus, unary minus, unary logical NOT, unary bitwise NOT
     // <rule14> ::= <rule16> | ++ <rule16> | -- <rule16> | + <rule16> | - <rule16> | ! <rule16> | ~ <rule16>
     private class Rule14 implements Rule {
@@ -525,25 +525,25 @@ public class RecursiveDescentParser {
         @Override
         public ExpressionNodeAndState parse(State state) throws ParserException {
             State newState = accept(TokenType.BOOLEAN_NOT, state);
-            
+
             if (newState != null) {
                 ExpressionNodeAndState exprNodeAndState = rule14.parse(newState);
                 if (exprNodeAndState._exprNode == null) {
                     throw new InvalidSyntaxException(Bundle.getMessage("InvalidSyntax"));
                 }
-                
+
                 ExpressionNode exprNode = new ExpressionNodeBooleanOperator(newState._lastToken._tokenType, null, exprNodeAndState._exprNode);
                 return new ExpressionNodeAndState(exprNode, exprNodeAndState._state);
-                
+
             } else {
                 newState = accept(TokenType.BINARY_NOT, state);
 
                 if (newState != null) {
                     ExpressionNodeAndState exprNodeAndState = rule14.parse(newState);
-                    
+
                     ExpressionNode exprNode = new ExpressionNodeArithmeticOperator(newState._lastToken._tokenType, null, exprNodeAndState._exprNode);
                     return new ExpressionNodeAndState(exprNode, exprNodeAndState._state);
-                    
+
                 } else {
                     newState = accept(TokenType.ADD, state);
 
@@ -595,27 +595,27 @@ public class RecursiveDescentParser {
                 }
             }
         }
-        
+
     }
-    
-    
+
+
     // Rule15 in Java is unary post-increment, unary post-decrement, ++ and --.
     private class Rule15 implements Rule {
 
         @Override
         public ExpressionNodeAndState parse(State state) throws ParserException {
-            
+
             ExpressionNodeAndState exprNodeAndState = rule16.parse(state);
             if (exprNodeAndState == null) return null;
-            
+
             State newState = accept(TokenType.INCREMENT, exprNodeAndState._state);
-            
+
             if (newState != null) {
                 ExpressionNode exprNode = new ExpressionNodeIncreaseDecreaseOperator(newState._lastToken._tokenType, exprNodeAndState._exprNode, false);
                 return new ExpressionNodeAndState(exprNode, newState);
             } else {
                 newState = accept(TokenType.DECREMENT, exprNodeAndState._state);
-                
+
                 if (newState != null) {
                     ExpressionNode exprNode = new ExpressionNodeIncreaseDecreaseOperator(newState._lastToken._tokenType, exprNodeAndState._exprNode, false);
                     return new ExpressionNodeAndState(exprNode, newState);
@@ -624,19 +624,19 @@ public class RecursiveDescentParser {
                 }
             }
         }
-        
+
     }
-    
-    
+
+
     // Parentheses
     // <rule16> ::= <rule20> | ( <firstRule> )
     private class Rule16 implements Rule {
 
         @Override
         public ExpressionNodeAndState parse(State state) throws ParserException {
-            
+
             State newState = accept(TokenType.LEFT_PARENTHESIS, state);
-            
+
             if (newState != null) {
                 ExpressionNodeAndState exprNodeAndState = firstRule.parse(newState);
                 if (exprNodeAndState._state._token == null) {
@@ -648,10 +648,10 @@ public class RecursiveDescentParser {
                 return rule20.parse(state);
             }
         }
-        
+
     }
-    
-    
+
+
     // Identifiers and constants
     // <rule20> ::= <identifier>
     //              | <identifier> ( <rule21> )
@@ -659,7 +659,7 @@ public class RecursiveDescentParser {
     //              | <rule20> { <rule21> }
     //              | <rule20> . <rule20>
     //              | <rule20> . <identifier> ( <rule21> )
-    
+
     // <rule20> ::= <identifier>
     //              | <identifier> ( <rule21> )
     //              | <identifier> [ <rule21> ]
@@ -684,16 +684,20 @@ public class RecursiveDescentParser {
         public ExpressionNodeAndState parse(State state) throws ParserException {
             ExpressionNode exprNode;
             State newState;
-            
+
+            // Do we have an integer?
             if ((newState = accept(TokenType.INTEGER_NUMBER, state)) != null) {
                 exprNode = new ExpressionNodeIntegerNumber(newState._lastToken);
                 return new ExpressionNodeAndState(exprNode, newState);
+
+            // Or do we have a floating point number?
             } else if ((newState = accept(TokenType.FLOATING_NUMBER, state)) != null) {
                 exprNode = new ExpressionNodeFloatingNumber(newState._lastToken);
                 return new ExpressionNodeAndState(exprNode, newState);
             }
-            
-            
+
+
+            // Do we have an identifier or a function?
             ExpressionNodeAndState expressionNodeAndState;
             if ((newState = accept(TokenType.IDENTIFIER, state)) != null) {
                 State newState2;
@@ -716,8 +720,10 @@ public class RecursiveDescentParser {
             } else {
                 return null;
             }
-            
-            
+
+
+            // If here, we have an identifier or a function.
+            // Do we have a dot followed by a method call?
             boolean completed = false;
             do {
                 State newState2;
@@ -774,65 +780,65 @@ public class RecursiveDescentParser {
                     completed = true;
                 }
             } while (!completed);
-            
+
             return expressionNodeAndState;
         }
-        
+
     }
-    
-    
-    // <rule21> ::= <empty> | <rule21> | <rule21> , <rule3>
+
+
+    // <rule21> ::= <empty> | <rule21> | <rule21> , <firstRule>
     private class Rule21_Function {
 
         public ExpressionNodeAndState parse(State state, String identifier) throws ParserException {
-            
+
             List<ExpressionNode> parameterList = new ArrayList<>();
-            
+
             State newState = state;
             State newState2;
             if ((accept(TokenType.RIGHT_PARENTHESIS, newState)) == null) {
-                ExpressionNodeAndState exprNodeAndState = rule3.parse(state);
+                ExpressionNodeAndState exprNodeAndState = firstRule.parse(state);
                 parameterList.add(exprNodeAndState._exprNode);
-                
+
                 while ((newState2 = accept(TokenType.COMMA, exprNodeAndState._state)) != null) {
-                    exprNodeAndState = rule3.parse(newState2);
+                    exprNodeAndState = firstRule.parse(newState2);
                     parameterList.add(exprNodeAndState._exprNode);
                 }
-                
+
                 newState = exprNodeAndState._state;
             }
             ExpressionNode exprNode = new ExpressionNodeFunction(identifier, parameterList);
             return new ExpressionNodeAndState(exprNode, newState);
         }
-        
+
     }
-    
-    
-    // <rule21> ::= <empty> | <rule21> | <rule21> , <rule3>
+
+
+    // <rule21> ::= <empty> | <rule21> | <rule21> , <firstRule>
     private class Rule21_Method {
 
         public ExpressionNodeAndState parse(State state, String variable, String method) throws ParserException {
-            
+
             List<ExpressionNode> parameterList = new ArrayList<>();
-            
+
             State newState = state;
             State newState2;
             if ((accept(TokenType.RIGHT_PARENTHESIS, newState)) == null) {
-                ExpressionNodeAndState exprNodeAndState = rule3.parse(state);
+                ExpressionNodeAndState exprNodeAndState = firstRule.parse(state);
                 parameterList.add(exprNodeAndState._exprNode);
-                
+
                 while ((newState2 = accept(TokenType.COMMA, exprNodeAndState._state)) != null) {
-                    exprNodeAndState = rule3.parse(newState2);
+                    exprNodeAndState = firstRule.parse(newState2);
                     parameterList.add(exprNodeAndState._exprNode);
                 }
-                
+
                 newState = exprNodeAndState._state;
             }
             ExpressionNode exprNode = new ExpressionNodeMethod(method, _variables, parameterList);
             return new ExpressionNodeAndState(exprNode, newState);
         }
-        
+
     }
-    
-    
+
+
 }

--- a/java/test/jmri/jmrit/display/logixng/ActionPositionableTest.java
+++ b/java/test/jmri/jmrit/display/logixng/ActionPositionableTest.java
@@ -19,7 +19,7 @@ import org.junit.*;
 
 /**
  * Test ActionPositionable
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class ActionPositionableTest extends AbstractDigitalActionTestBase {
@@ -32,28 +32,28 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
     private Positionable positionable1;
     private Positionable positionable2;
     private Positionable positionable3;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Set icon/label \"Some other id\" on panel \"A panel editor\" to \"Disable\" ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -62,42 +62,42 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
                 "      ! A%n" +
                 "         Set icon/label \"Some other id\" on panel \"A panel editor\" to \"Disable\" ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ActionPositionable(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() throws JmriException {
         Assert.assertTrue("object exists", _base != null);
-        
+
         ActionPositionable action2;
         Assert.assertNotNull("turnout is not null", turnout);
         turnout.setState(Turnout.ON);
-        
+
         action2 = new ActionPositionable("IQDA321", null);
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Set icon/label \"''\" on panel \"''\" to \"Enable\"", action2.getLongDescription());
-        
+
         action2 = new ActionPositionable("IQDA321", "My turnout");
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My turnout", action2.getUserName());
         Assert.assertEquals("String matches", "Set icon/label \"''\" on panel \"''\" to \"Enable\"", action2.getLongDescription());
-/*        
+/*
         action2 = new ActionPositionable("IQDA321", null);
         action2.setTurnout(turnout);
         Assert.assertTrue("turnout is correct", turnout == action2.getTurnout().getBean());
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Set turnout IT1 to state Thrown", action2.getLongDescription());
-        
+
         Turnout l = InstanceManager.getDefault(TurnoutManager.class).provide("IT1");
         action2 = new ActionPositionable("IQDA321", "My turnout");
         action2.setTurnout(l);
@@ -105,7 +105,7 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My turnout", action2.getUserName());
         Assert.assertEquals("String matches", "Set turnout IT1 to state Thrown", action2.getLongDescription());
-*/        
+*/
         boolean thrown = false;
         try {
             // Illegal system name
@@ -114,7 +114,7 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -123,15 +123,15 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         // Test setup(). This method doesn't do anything, but execute it for coverage.
         _base.setup();
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == actionPositionable.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             actionPositionable.getChild(0);
@@ -141,13 +141,13 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testTurnoutState() {
         Assert.assertEquals("String matches", "Disable", ActionPositionable.Operation.Disable.toString());
         Assert.assertEquals("String matches", "Enable", ActionPositionable.Operation.Enable.toString());
     }
-/*    
+/*
     @Test
     public void testSetTurnout() {
         Turnout turnout11 = InstanceManager.getDefault(TurnoutManager.class).provide("IL11");
@@ -156,30 +156,30 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         Turnout turnout13 = InstanceManager.getDefault(TurnoutManager.class).provide("IL13");
         Turnout turnout14 = InstanceManager.getDefault(TurnoutManager.class).provide("IL14");
         turnout14.setUserName("Some user name");
-        
+
         actionEnableDisable.removeTurnout();
         Assert.assertNull("turnout handle is null", actionEnableDisable.getTurnout());
-        
+
         actionEnableDisable.setTurnout(turnout11);
         Assert.assertTrue("turnout is correct", turnout11 == actionEnableDisable.getTurnout().getBean());
-        
+
         actionEnableDisable.removeTurnout();
         Assert.assertNull("turnout handle is null", actionEnableDisable.getTurnout());
-        
+
         actionEnableDisable.setTurnout(turnoutHandle12);
         Assert.assertTrue("turnout handle is correct", turnoutHandle12 == actionEnableDisable.getTurnout());
-        
+
         actionEnableDisable.setTurnout("A non existent turnout");
         Assert.assertNull("turnout handle is null", actionEnableDisable.getTurnout());
         JUnitAppender.assertErrorMessage("turnout \"A non existent turnout\" is not found");
-        
+
         actionEnableDisable.setTurnout(turnout13.getSystemName());
         Assert.assertTrue("turnout is correct", turnout13 == actionEnableDisable.getTurnout().getBean());
-        
+
         actionEnableDisable.setTurnout(turnout14.getUserName());
         Assert.assertTrue("turnout is correct", turnout14 == actionEnableDisable.getTurnout().getBean());
     }
-    
+
     @Test
     public void testAction() throws SocketAlreadyConnectedException, JmriException {
         // Set the light
@@ -190,21 +190,21 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the turnout should be thrown
         Assert.assertTrue("turnout is thrown",turnout.getCommandedState() == Turnout.THROWN);
-        
+
         // Test to set turnout to closed
         actionEnableDisable.setBeanState(ActionPositionable.TurnoutState.Closed);
         // Execute the conditional
         conditionalNG.execute();
         // The action should now be executed so the turnout should be thrown
         Assert.assertTrue("turnout is thrown",turnout.getCommandedState() == Turnout.CLOSED);
-        
+
         // Test to set turnout to toggle
         actionEnableDisable.setBeanState(ActionPositionable.TurnoutState.Toggle);
         // Execute the conditional
         conditionalNG.execute();
         // The action should now be executed so the turnout should be thrown
         Assert.assertTrue("turnout is thrown",turnout.getCommandedState() == Turnout.THROWN);
-        
+
         // Test to set turnout to toggle
         actionEnableDisable.setBeanState(ActionPositionable.TurnoutState.Toggle);
         // Execute the conditional
@@ -212,20 +212,20 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         // The action should now be executed so the turnout should be thrown
         Assert.assertTrue("turnout is thrown",turnout.getCommandedState() == Turnout.CLOSED);
     }
-    
+
     @Test
     public void testIndirectAddressing() throws JmriException {
-        
+
         Memory m1 = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
         m1.setValue("IT102");
-        
+
         Assert.assertTrue(conditionalNG.isActive());
         Turnout t1 = InstanceManager.getDefault(TurnoutManager.class).provide("IT101");
         Turnout t2 = InstanceManager.getDefault(TurnoutManager.class).provide("IT102");
         Turnout t3 = InstanceManager.getDefault(TurnoutManager.class).provide("IT103");
         Turnout t4 = InstanceManager.getDefault(TurnoutManager.class).provide("IT104");
         Turnout t5 = InstanceManager.getDefault(TurnoutManager.class).provide("IT105");
-        
+
         actionEnableDisable.setBeanState(ActionPositionable.TurnoutState.Thrown);
         actionEnableDisable.setTurnout(t1.getSystemName());
         actionEnableDisable.setReference("{IM1}");    // Points to "IT102"
@@ -234,7 +234,7 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket.addLocalVariable("refTurnout", SymbolTable.InitialValueType.String, "IT103");
         _baseMaleSocket.addLocalVariable("myTurnout", SymbolTable.InitialValueType.String, "IT104");
         _baseMaleSocket.addLocalVariable("index", SymbolTable.InitialValueType.Integer, "5");
-        
+
         // Test direct addressing
         actionEnableDisable.setAddressing(NamedBeanAddressing.Direct);
         t1.setState(Turnout.CLOSED);
@@ -250,7 +250,7 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Turnout.CLOSED, t3.getCommandedState());
         Assert.assertEquals(Turnout.CLOSED, t4.getCommandedState());
         Assert.assertEquals(Turnout.CLOSED, t5.getCommandedState());
-        
+
         // Test reference by memory addressing
         actionEnableDisable.setAddressing(NamedBeanAddressing.Reference);
         t1.setState(Turnout.CLOSED);
@@ -266,7 +266,7 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Turnout.CLOSED, t3.getCommandedState());
         Assert.assertEquals(Turnout.CLOSED, t4.getCommandedState());
         Assert.assertEquals(Turnout.CLOSED, t5.getCommandedState());
-        
+
         // Test reference by local variable addressing
         actionEnableDisable.setReference("{refTurnout}");    // Points to "IT103"
         actionEnableDisable.setAddressing(NamedBeanAddressing.Reference);
@@ -283,7 +283,7 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Turnout.THROWN, t3.getCommandedState());
         Assert.assertEquals(Turnout.CLOSED, t4.getCommandedState());
         Assert.assertEquals(Turnout.CLOSED, t5.getCommandedState());
-        
+
         // Test local variable addressing
         actionEnableDisable.setAddressing(NamedBeanAddressing.LocalVariable);
         t1.setState(Turnout.CLOSED);
@@ -299,7 +299,7 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Turnout.CLOSED, t3.getCommandedState());
         Assert.assertEquals(Turnout.THROWN, t4.getCommandedState());
         Assert.assertEquals(Turnout.CLOSED, t5.getCommandedState());
-        
+
         // Test formula addressing
         actionEnableDisable.setAddressing(NamedBeanAddressing.Formula);
         t1.setState(Turnout.CLOSED);
@@ -316,16 +316,16 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Turnout.CLOSED, t4.getCommandedState());
         Assert.assertEquals(Turnout.THROWN, t5.getCommandedState());
     }
-    
+
     @Test
     public void testIndirectStateAddressing() throws JmriException {
-        
+
         Memory m1 = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
         m1.setValue("IT102");
-        
+
         Assert.assertTrue(conditionalNG.isActive());
-        
-        
+
+
         // Test direct addressing
         actionEnableDisable.setStateAddressing(NamedBeanAddressing.Direct);
         // Test Closed
@@ -342,8 +342,8 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct turnout should be thrown
         Assert.assertEquals(Turnout.THROWN, turnout.getCommandedState());
-        
-        
+
+
         // Test reference by memory addressing
         actionEnableDisable.setStateAddressing(NamedBeanAddressing.Reference);
         actionEnableDisable.setStateReference("{IM1}");
@@ -361,8 +361,8 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct turnout should be thrown
         Assert.assertEquals(Turnout.THROWN, turnout.getCommandedState());
-        
-        
+
+
         // Test reference by local variable addressing
         actionEnableDisable.setStateAddressing(NamedBeanAddressing.Reference);
         actionEnableDisable.setStateReference("{refVariable}");
@@ -382,8 +382,8 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct turnout should be thrown
         Assert.assertEquals(Turnout.THROWN, turnout.getCommandedState());
-        
-        
+
+
         // Test local variable addressing
         actionEnableDisable.setStateAddressing(NamedBeanAddressing.Reference);
         actionEnableDisable.setStateLocalVariable("myVariable");
@@ -403,8 +403,8 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct turnout should be thrown
         Assert.assertEquals(Turnout.THROWN, turnout.getCommandedState());
-        
-        
+
+
         // Test formula addressing
         actionEnableDisable.setStateAddressing(NamedBeanAddressing.Formula);
         actionEnableDisable.setStateFormula("refVariable + myVariable");
@@ -427,7 +427,7 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         // The action should now be executed so the correct turnout should be thrown
         Assert.assertEquals(Turnout.THROWN, turnout.getCommandedState());
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Get the action and set the turnout
@@ -435,28 +435,28 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         Assert.assertNotNull("Turnout is not null", turnout);
         ActionPositionable action = new ActionPositionable(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
         action.setTurnout(turnout);
-        
+
         // Get some other turnout for later use
         Turnout otherTurnout = InstanceManager.getDefault(TurnoutManager.class).provide("IM99");
         Assert.assertNotNull("Turnout is not null", otherTurnout);
         Assert.assertNotEquals("Turnout is not equal", turnout, otherTurnout);
-        
+
         // Test vetoableChange() for some other propery
         action.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
-        
+
         // Test vetoableChange() for a string
         action.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
-        
+
         // Test vetoableChange() for another turnout
         action.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherTurnout, null));
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherTurnout, null));
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
-        
+
         // Test vetoableChange() for its own turnout
         boolean thrown = false;
         try {
@@ -465,27 +465,27 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", turnout, null));
         Assert.assertNull("Turnout is null", action.getTurnout());
     }
-*/    
+*/
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", CategoryDisplay.DISPLAY == _base.getCategory());
     }
-    
+
     @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Icon/Label on panel", _base.getShortDescription());
     }
-    
+
     @Test
     public void testLongDescription() {
         Assert.assertEquals("String matches", "Set icon/label \"Some other id\" on panel \"A panel editor\" to \"Disable\"", _base.getLongDescription());
     }
-    
+
     @Test
     public void testChild() {
         Assert.assertTrue("Num children is zero", 0 == _base.getChildCount());
@@ -498,12 +498,12 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException, Positionable.DuplicateIdException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
+
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager();
@@ -511,26 +511,26 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         EditorManager editorManager = InstanceManager.getDefault(EditorManager.class);
         editor = new jmri.jmrit.display.panelEditor.PanelEditor("Some panel");
         editor.setName("A panel editor");
         editorManager.add(editor);
-        
+
         positionable1 = new jmri.jmrit.display.MemoryIcon("Memory", editor);
         editor.putItem(positionable1);
         positionable1.setId("Some id");
-        
+
         positionable2 = new jmri.jmrit.display.MemoryIcon("Memory", editor);
         editor.putItem(positionable2);
         positionable2.setId("Some other id");
-        
+
         positionable3 = new jmri.jmrit.display.MemoryIcon("Memory", editor);
         editor.putItem(positionable3);
-        
+
         turnout = InstanceManager.getDefault(TurnoutManager.class).provide("IT1");
         turnout.setCommandedState(Turnout.CLOSED);
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A logixNG");
@@ -545,11 +545,12 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         actionPositionable.setOperation(ActionPositionable.Operation.Disable);
         MaleSocket socket = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionPositionable);
         conditionalNG.getChild(0).connect(socket);
-        
+
         _base = actionPositionable;
         _baseMaleSocket = socket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -564,5 +565,5 @@ public class ActionPositionableTest extends AbstractDigitalActionTestBase {
         JUnitUtil.deregisterEditorManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -4089,6 +4089,7 @@ public class CreateLogixNGTreeScaffold {
         "index * 2",    // Formula
         "sensors.provide(\"mySensor)\"",    // Script expression
         "scripts:InitLogixNGVariable",      // Script file
+        "MyTable",      // LogixNG Table
     };
 
 

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -4087,6 +4087,8 @@ public class CreateLogixNGTreeScaffold {
         "IM2",          // Memory
         "{IM3}",        // Reference
         "index * 2",    // Formula
+        "sensors.provide(\"mySensor)\"",    // Script expression
+        "scripts:InitLogixNGVariable",      // Script file
     };
 
 

--- a/java/test/jmri/jmrit/logixng/LogixNGTest.java
+++ b/java/test/jmri/jmrit/logixng/LogixNGTest.java
@@ -269,6 +269,7 @@ public class LogixNGTest {
         logixNG.addConditionalNG(conditionalNG_3);
         conditionalNG_3.setEnabled(false);
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
 
         Assert.assertFalse("listeners for conditionalNG_1 are not registered", conditionalNG_1.listenersAreRegistered);
         Assert.assertFalse("listeners for conditionalNG_2 are not registered", conditionalNG_2.listenersAreRegistered);

--- a/java/test/jmri/jmrit/logixng/RecursiveModuleTest.java
+++ b/java/test/jmri/jmrit/logixng/RecursiveModuleTest.java
@@ -21,53 +21,53 @@ import org.junit.jupiter.api.*;
 
 /**
  * Test that a module can be used recursive by calculating the Fibonacci numbers.
- * 
+ *
  * @author Daniel Bergqvist 2020
  */
 public class RecursiveModuleTest {
-    
+
     private LogixNG logixNG;
     private ConditionalNG conditionalNG;
     private Memory n;
     private Memory result;
-    
-    
+
+
     @Test
     public void testFibonacci() {
         n.setValue(0);
         Assert.assertEquals(Long.valueOf(1), result.getValue());
-        
+
         n.setValue(1);
         Assert.assertEquals(Long.valueOf(1), result.getValue());
-        
+
         n.setValue(2);
         Assert.assertEquals(Long.valueOf(2), result.getValue());
-        
+
         n.setValue(3);
         Assert.assertEquals(Long.valueOf(3), result.getValue());
-        
+
         n.setValue(4);
         Assert.assertEquals(Long.valueOf(5), result.getValue());
-        
+
         n.setValue(5);
         Assert.assertEquals(Long.valueOf(8), result.getValue());
-        
+
         n.setValue(6);
         Assert.assertEquals(Long.valueOf(13), result.getValue());
-        
+
         n.setValue(7);
         Assert.assertEquals(Long.valueOf(21), result.getValue());
-        
+
         n.setValue(8);
         Assert.assertEquals(Long.valueOf(34), result.getValue());
-        
+
         n.setValue(9);
         Assert.assertEquals(Long.valueOf(55), result.getValue());
-        
+
         n.setValue(10);
         Assert.assertEquals(Long.valueOf(89), result.getValue());
     }
-    
+
     // The minimal setup for log4J
     @BeforeEach
     public void setUp() throws SocketAlreadyConnectedException, JmriException {
@@ -79,34 +79,34 @@ public class RecursiveModuleTest {
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
         NamedBeanType.reset();
-        
+
         n = InstanceManager.getDefault(MemoryManager.class).provide("IMN");
         n.setValue(1);
-        
+
         result = InstanceManager.getDefault(MemoryManager.class).provide("IMRESULT");
         result.setValue("Hello");
-        
+
         Module module = InstanceManager.getDefault(ModuleManager.class).createModule("IQM1", null,
                 InstanceManager.getDefault(FemaleSocketManager.class)
                         .getSocketTypeByType("DefaultFemaleDigitalActionSocket"));
-        
+
         module.addParameter("n", true, false);
         module.addParameter("result", false, true);
         module.addLocalVariable("temp1", InitialValueType.None, null);
         module.addLocalVariable("temp2", InitialValueType.None, null);
-        
+
         DigitalMany many901 = new DigitalMany("IQDA901", null);
         MaleSocket manySocket901 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(many901);
         module.getRootSocket().connect(manySocket901);
-        
+
         IfThenElse ifThenElse912 = new IfThenElse("IQDA912", null);
         ifThenElse912.setType(IfThenElse.Type.AlwaysExecute);
         MaleSocket ifThenElseSocket912 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse912);
         manySocket901.getChild(0).connect(ifThenElseSocket912);
-        
-        
+
+
         ExpressionLocalVariable expressionLocalVariable913 = new ExpressionLocalVariable("IQDE913", null);
         expressionLocalVariable913.setLocalVariable("n");
         expressionLocalVariable913.setConstantValue("0");
@@ -115,7 +115,7 @@ public class RecursiveModuleTest {
         MaleSocket maleSocket913 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionLocalVariable913);
         ifThenElseSocket912.getChild(0).connect(maleSocket913);
-        
+
         ActionLocalVariable actionLocalVariable914 = new ActionLocalVariable("IQDA914", null);
         actionLocalVariable914.setLocalVariable("result");
         actionLocalVariable914.setFormula("1");   // Since this is a formula, it's the number 1, not the string "1"
@@ -123,14 +123,14 @@ public class RecursiveModuleTest {
         MaleSocket maleSocket914 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionLocalVariable914);
         ifThenElseSocket912.getChild(1).connect(maleSocket914);
-        
-        
+
+
         IfThenElse ifThenElse915 = new IfThenElse("IQDA915", null);
         ifThenElse915.setType(IfThenElse.Type.AlwaysExecute);
         MaleSocket ifThenElseSocket915 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse915);
         ifThenElseSocket912.getChild(2).connect(ifThenElseSocket915);
-        
+
         ExpressionLocalVariable expressionLocalVariable916 = new ExpressionLocalVariable("IQDE916", null);
         expressionLocalVariable916.setLocalVariable("n");
         expressionLocalVariable916.setConstantValue("1");
@@ -139,7 +139,7 @@ public class RecursiveModuleTest {
         MaleSocket maleSocket916 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionLocalVariable916);
         ifThenElse915.getChild(0).connect(maleSocket916);
-        
+
         ActionLocalVariable actionLocalVariable917 = new ActionLocalVariable("IQDA917", null);
         actionLocalVariable917.setLocalVariable("result");
         actionLocalVariable917.setFormula("1");   // Since this is a formula, it's the number 1, not the string "1"
@@ -147,14 +147,14 @@ public class RecursiveModuleTest {
         MaleSocket maleSocket917 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionLocalVariable917);
         ifThenElse915.getChild(1).connect(maleSocket917);
-        
-        
-        
+
+
+
         DigitalMany many921 = new DigitalMany("IQDA921", null);
         MaleSocket manySocket921 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(many921);
         ifThenElse915.getChild(2).connect(manySocket921);
-        
+
         // Call the module for n-1
         DigitalCallModule moduleDigitalAction925 = new DigitalCallModule("IQDA925", null);
         moduleDigitalAction925.setModule("IQM1");
@@ -163,7 +163,7 @@ public class RecursiveModuleTest {
         MaleSocket maleSocket925 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(moduleDigitalAction925);
         manySocket921.getChild(0).connect(maleSocket925);
-        
+
         // Call the module
         DigitalCallModule moduleDigitalAction932 = new DigitalCallModule("IQDA932", null);
         moduleDigitalAction932.setModule("IQM1");
@@ -172,7 +172,7 @@ public class RecursiveModuleTest {
         MaleSocket maleSocket932 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(moduleDigitalAction932);
         manySocket921.getChild(1).connect(maleSocket932);
-        
+
         ActionLocalVariable actionLocalVariable933 = new ActionLocalVariable("IQDA933", null);
         actionLocalVariable933.setLocalVariable("result");
         actionLocalVariable933.setFormula("temp1 + temp2");
@@ -180,21 +180,21 @@ public class RecursiveModuleTest {
         MaleSocket maleSocket933 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionLocalVariable933);
         manySocket921.getChild(2).connect(maleSocket933);
-        
-        
-        
+
+
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
         logixNG.addConditionalNG(conditionalNG);
-        
+
         DigitalMany many = new DigitalMany("IQDA1", null);
         MaleSocket manySocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(many);
         conditionalNG.getChild(0).connect(manySocket);
-        
+
         ActionListenOnBeans listenOnBeans = new ActionListenOnBeans("IQDA2", null);
         listenOnBeans.addReference(new NamedBeanReference("IMN", NamedBeanType.Memory, false));
 //        listenOnBeans.addReference("Turnoaut:IT1");
@@ -203,7 +203,7 @@ public class RecursiveModuleTest {
         MaleSocket listenSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(listenOnBeans);
         manySocket.getChild(0).connect(listenSocket);
-        
+
         DigitalCallModule moduleDigitalAction = new DigitalCallModule("IQDA4", null);
         moduleDigitalAction.setModule("IQM1");
 //        moduleDigitalAction.addParameter("n", InitialValueType.LocalVariable, "n");
@@ -212,27 +212,27 @@ public class RecursiveModuleTest {
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(moduleDigitalAction);
         manySocket.getChild(1).connect(maleSocket2);
-/*        
+/*
         final String treeIndent = "   ";
-        
+
         System.out.println();
         System.out.println("===========================================");
         System.out.println();
-        
+
         java.io.StringWriter stringWriter = new java.io.StringWriter();
         java.io.PrintWriter printWriter = new java.io.PrintWriter(stringWriter);
         logixNG.printTree(java.util.Locale.ENGLISH, printWriter, treeIndent);
         System.out.println(stringWriter.toString());
-        
+
         System.out.println();
         System.out.println("===========================================");
         System.out.println();
-        
+
         stringWriter = new java.io.StringWriter();
         printWriter = new java.io.PrintWriter(stringWriter);
         module.printTree(java.util.Locale.ENGLISH, printWriter, treeIndent);
         System.out.println(stringWriter.toString());
-        
+
         System.out.println();
         System.out.println("===========================================");
         System.out.println();
@@ -240,17 +240,18 @@ public class RecursiveModuleTest {
         System.out.println();
         System.out.println();
         System.out.println();
-*/        
-        
+*/
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
-    
+
     @AfterEach
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/ActionAtomicBooleanTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionAtomicBooleanTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 
 /**
  * Test ActionAtomicBoolean
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
@@ -26,28 +26,28 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
     private ConditionalNG conditionalNG;
     private AtomicBoolean atomicBoolean;
     private ActionAtomicBoolean actionAtomicBoolean;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Set the atomic boolean to true ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -56,42 +56,42 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
                 "      ! A%n" +
                 "         Set the atomic boolean to true ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ActionAtomicBoolean(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Assert.assertTrue("object exists", _base != null);
-        
+
         ActionAtomicBoolean action2;
         Assert.assertNotNull("atomicBoolean is not null", atomicBoolean);
         atomicBoolean.set(true);
-        
+
         action2 = new ActionAtomicBoolean("IQDA321", null);
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Set the atomic boolean to false", action2.getLongDescription());
-        
+
         action2 = new ActionAtomicBoolean("IQDA321", "My atomicBoolean");
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My atomicBoolean", action2.getUserName());
         Assert.assertEquals("String matches", "Set the atomic boolean to false", action2.getLongDescription());
-        
+
         action2 = new ActionAtomicBoolean("IQDA321", null);
         action2.setAtomicBoolean(atomicBoolean);
         Assert.assertTrue("atomic boolean is correct", atomicBoolean == action2.getAtomicBoolean());
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Set the atomic boolean to false", action2.getLongDescription());
-        
+
         AtomicBoolean ab = new AtomicBoolean();
         action2 = new ActionAtomicBoolean("IQDA321", "My atomicBoolean");
         action2.setAtomicBoolean(ab);
@@ -99,7 +99,7 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My atomicBoolean", action2.getUserName());
         Assert.assertEquals("String matches", "Set the atomic boolean to false", action2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -108,7 +108,7 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -117,15 +117,15 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         // Test setup(). This method doesn't do anything, but execute it for coverage.
         _base.setup();
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == actionAtomicBoolean.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             actionAtomicBoolean.getChild(0);
@@ -135,7 +135,7 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testAction() throws SocketAlreadyConnectedException {
         // Set new value to true
@@ -149,7 +149,7 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the atomic boolean should be true
         Assert.assertTrue("atomicBoolean is true",atomicBoolean.get());
-        
+
         // Set new value to false
         actionAtomicBoolean.setNewValue(false);
         Assert.assertFalse("new value is false", actionAtomicBoolean.getNewValue());
@@ -158,22 +158,22 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
         // The action should now be executed so the atomic boolean should be true
         Assert.assertFalse("atomicBoolean is false",atomicBoolean.get());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.OTHER == _base.getCategory());
     }
-    
+
     @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Atomic boolean", _base.getShortDescription());
     }
-    
+
     @Test
     public void testLongDescription() {
         Assert.assertEquals("String matches", "Set the atomic boolean to true", _base.getLongDescription());
     }
-    
+
     @Test
     public void testChild() {
         Assert.assertTrue("Num children is zero", 0 == _base.getChildCount());
@@ -186,7 +186,7 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -197,10 +197,10 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A logixNG");
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
@@ -212,11 +212,12 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
         MaleSocket socket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         conditionalNG.getChild(0).connect(socket);
-        
+
         _base = actionAtomicBoolean;
         _baseMaleSocket = socket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -225,5 +226,5 @@ public class ActionAtomicBooleanTest extends AbstractDigitalActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionLightTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 /**
  * Test ActionLight
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class ActionLightTest extends AbstractDigitalActionTestBase {
@@ -27,18 +27,18 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
     private ConditionalNG conditionalNG;
     private ActionLight actionLight;
     private Light light;
-    
-    
+
+
     @Test
     public void testLightState() {
         Assert.assertEquals("String matches", "Off", ActionLight.LightState.Off.toString());
         Assert.assertEquals("String matches", "On", ActionLight.LightState.On.toString());
         Assert.assertEquals("String matches", "Toggle", ActionLight.LightState.Toggle.toString());
-        
+
         Assert.assertTrue("objects are equal", ActionLight.LightState.Off == ActionLight.LightState.get(Light.OFF));
         Assert.assertTrue("objects are equal", ActionLight.LightState.On == ActionLight.LightState.get(Light.ON));
         Assert.assertTrue("objects are equal", ActionLight.LightState.Toggle == ActionLight.LightState.get(-1));
-        
+
         boolean hasThrown = false;
         try {
             ActionLight.LightState.get(100);    // The number 100 is a state that ActionLight.LightState isn't aware of
@@ -48,27 +48,27 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Set light IL1 to state On ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -77,42 +77,42 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
                 "      ! A%n" +
                 "         Set light IL1 to state On ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ActionLight(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Assert.assertTrue("object exists", _base != null);
-        
+
         ActionLight action2;
         Assert.assertNotNull("light is not null", light);
         light.setState(Light.ON);
-        
+
         action2 = new ActionLight("IQDA321", null);
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Set light '' to state On", action2.getLongDescription());
-        
+
         action2 = new ActionLight("IQDA321", "My light");
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My light", action2.getUserName());
         Assert.assertEquals("String matches", "Set light '' to state On", action2.getLongDescription());
-        
+
         action2 = new ActionLight("IQDA321", null);
         action2.setLight(light);
         Assert.assertTrue("light is correct", light == action2.getLight().getBean());
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Set light IL1 to state On", action2.getLongDescription());
-        
+
         Light l = InstanceManager.getDefault(LightManager.class).provide("IL1");
         action2 = new ActionLight("IQDA321", "My light");
         action2.setLight(l);
@@ -120,7 +120,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My light", action2.getUserName());
         Assert.assertEquals("String matches", "Set light IL1 to state On", action2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -129,7 +129,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -138,15 +138,15 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         // Test setup(). This method doesn't do anything, but execute it for coverage.
         _base.setup();
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == actionLight.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             actionLight.getChild(0);
@@ -156,7 +156,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testSetLight() {
         Light light11 = InstanceManager.getDefault(LightManager.class).provide("IL11");
@@ -165,33 +165,33 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         Light light13 = InstanceManager.getDefault(LightManager.class).provide("IL13");
         Light light14 = InstanceManager.getDefault(LightManager.class).provide("IL14");
         light14.setUserName("Some user name");
-        
+
         actionLight.removeLight();
         Assert.assertNull("light handle is null", actionLight.getLight());
-        
+
         actionLight.setLight(light11);
         Assert.assertTrue("light is correct", light11 == actionLight.getLight().getBean());
-        
+
         actionLight.removeLight();
         Assert.assertNull("light handle is null", actionLight.getLight());
-        
+
         actionLight.setLight(lightHandle12);
         Assert.assertTrue("light handle is correct", lightHandle12 == actionLight.getLight());
-        
+
         actionLight.setLight("A non existent light");
         Assert.assertNull("light handle is null", actionLight.getLight());
         JUnitAppender.assertWarnMessage("light \"A non existent light\" is not found");
-        
+
         actionLight.setLight(light13.getSystemName());
         Assert.assertTrue("light is correct", light13 == actionLight.getLight().getBean());
-        
+
         actionLight.setLight(light14.getUserName());
         Assert.assertTrue("light is correct", light14 == actionLight.getLight().getBean());
     }
-    
+
     @Test
     public void testAction() throws SocketAlreadyConnectedException, JmriException {
-        
+
         // Set the light
         light.setCommandedState(Light.OFF);
         // The light should be off
@@ -200,21 +200,21 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the light should be on
         Assert.assertTrue("light is on",light.getCommandedState() == Light.ON);
-        
+
         // Test to set light to off
         actionLight.setBeanState(ActionLight.LightState.Off);
         // Execute the conditional
         conditionalNG.execute();
         // The action should now be executed so the light should be on
         Assert.assertTrue("light is on",light.getCommandedState() == Light.OFF);
-        
+
         // Test to set light to toggle
         actionLight.setBeanState(ActionLight.LightState.Toggle);
         // Execute the conditional
         conditionalNG.execute();
         // The action should now be executed so the light should be on
         Assert.assertTrue("light is on",light.getCommandedState() == Light.ON);
-        
+
         // Test to set light to toggle
         actionLight.setBeanState(ActionLight.LightState.Toggle);
         // Execute the conditional
@@ -222,20 +222,20 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         // The action should now be executed so the light should be on
         Assert.assertTrue("light is on",light.getCommandedState() == Light.OFF);
     }
-    
+
     @Test
     public void testIndirectAddressing() throws JmriException {
-        
+
         Memory m1 = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
         m1.setValue("IL102");
-        
+
         Assert.assertTrue(conditionalNG.isActive());
         Light t1 = InstanceManager.getDefault(LightManager.class).provide("IL101");
         Light t2 = InstanceManager.getDefault(LightManager.class).provide("IL102");
         Light t3 = InstanceManager.getDefault(LightManager.class).provide("IL103");
         Light t4 = InstanceManager.getDefault(LightManager.class).provide("IL104");
         Light t5 = InstanceManager.getDefault(LightManager.class).provide("IL105");
-        
+
         actionLight.setBeanState(ActionLight.LightState.On);
         actionLight.setLight(t1.getSystemName());
         actionLight.setReference("{IM1}");    // Points to "IL102"
@@ -244,7 +244,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket.addLocalVariable("refLight", SymbolTable.InitialValueType.String, "IL103");
         _baseMaleSocket.addLocalVariable("myLight", SymbolTable.InitialValueType.String, "IL104");
         _baseMaleSocket.addLocalVariable("index", SymbolTable.InitialValueType.Integer, "5");
-        
+
         // Test direct addressing
         actionLight.setAddressing(NamedBeanAddressing.Direct);
         t1.setState(Light.OFF);
@@ -260,7 +260,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Light.OFF, t3.getCommandedState());
         Assert.assertEquals(Light.OFF, t4.getCommandedState());
         Assert.assertEquals(Light.OFF, t5.getCommandedState());
-        
+
         // Test reference by memory addressing
         actionLight.setAddressing(NamedBeanAddressing.Reference);
         t1.setState(Light.OFF);
@@ -276,7 +276,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Light.OFF, t3.getCommandedState());
         Assert.assertEquals(Light.OFF, t4.getCommandedState());
         Assert.assertEquals(Light.OFF, t5.getCommandedState());
-        
+
         // Test reference by local variable addressing
         actionLight.setReference("{refLight}");    // Points to "IL103"
         actionLight.setAddressing(NamedBeanAddressing.Reference);
@@ -293,7 +293,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Light.ON, t3.getCommandedState());
         Assert.assertEquals(Light.OFF, t4.getCommandedState());
         Assert.assertEquals(Light.OFF, t5.getCommandedState());
-        
+
         // Test local variable addressing
         actionLight.setAddressing(NamedBeanAddressing.LocalVariable);
         t1.setState(Light.OFF);
@@ -309,7 +309,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Light.OFF, t3.getCommandedState());
         Assert.assertEquals(Light.ON, t4.getCommandedState());
         Assert.assertEquals(Light.OFF, t5.getCommandedState());
-        
+
         // Test formula addressing
         actionLight.setAddressing(NamedBeanAddressing.Formula);
         t1.setState(Light.OFF);
@@ -326,16 +326,16 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Light.OFF, t4.getCommandedState());
         Assert.assertEquals(Light.ON, t5.getCommandedState());
     }
-    
+
     @Test
     public void testIndirectStateAddressing() throws JmriException {
-        
+
         Memory m1 = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
         m1.setValue("IL102");
-        
+
         Assert.assertTrue(conditionalNG.isActive());
-        
-        
+
+
         // Test direct addressing
         actionLight.setStateAddressing(NamedBeanAddressing.Direct);
         // Test Off
@@ -352,8 +352,8 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct light should be thrown
         Assert.assertEquals(Light.ON, light.getCommandedState());
-        
-        
+
+
         // Test reference by memory addressing
         actionLight.setStateAddressing(NamedBeanAddressing.Reference);
         actionLight.setStateReference("{IM1}");
@@ -371,8 +371,8 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct light should be thrown
         Assert.assertEquals(Light.ON, light.getCommandedState());
-        
-        
+
+
         // Test reference by local variable addressing
         actionLight.setStateAddressing(NamedBeanAddressing.Reference);
         actionLight.setStateReference("{refVariable}");
@@ -392,8 +392,8 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct light should be thrown
         Assert.assertEquals(Light.ON, light.getCommandedState());
-        
-        
+
+
         // Test local variable addressing
         actionLight.setStateAddressing(NamedBeanAddressing.Reference);
         actionLight.setStateLocalVariable("myVariable");
@@ -413,8 +413,8 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct light should be thrown
         Assert.assertEquals(Light.ON, light.getCommandedState());
-        
-        
+
+
         // Test formula addressing
         actionLight.setStateAddressing(NamedBeanAddressing.Formula);
         actionLight.setStateFormula("refVariable + myVariable");
@@ -437,7 +437,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         // The action should now be executed so the correct light should be thrown
         Assert.assertEquals(Light.ON, light.getCommandedState());
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Get the action and set the light
@@ -445,28 +445,28 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         Assert.assertNotNull("Light is not null", light);
 //        ActionLight action = new ActionLight();
 //        action.setLight(light);
-        
+
         // Get some other light for later use
         Light otherLight = InstanceManager.getDefault(LightManager.class).provide("IM99");
         Assert.assertNotNull("Light is not null", otherLight);
         Assert.assertNotEquals("Light is not equal", light, otherLight);
-        
+
         // Test vetoableChange() for some other propery
         actionLight.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Light matches", light, actionLight.getLight().getBean());
-        
+
         // Test vetoableChange() for a string
         actionLight.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Light matches", light, actionLight.getLight().getBean());
         actionLight.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Light matches", light, actionLight.getLight().getBean());
-        
+
         // Test vetoableChange() for another light
         actionLight.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherLight, null));
         Assert.assertEquals("Light matches", light, actionLight.getLight().getBean());
         actionLight.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherLight, null));
         Assert.assertEquals("Light matches", light, actionLight.getLight().getBean());
-        
+
         // Test vetoableChange() for its own light
         boolean thrown = false;
         try {
@@ -475,27 +475,27 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Light matches", light, actionLight.getLight().getBean());
         actionLight.vetoableChange(new PropertyChangeEvent(this, "DoDelete", light, null));
         Assert.assertNull("Light is null", actionLight.getLight());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Light", _base.getShortDescription());
     }
-    
+
     @Test
     public void testLongDescription() {
         Assert.assertEquals("String matches", "Set light IL1 to state On", _base.getLongDescription());
     }
-    
+
     @Test
     public void testChild() {
         Assert.assertTrue("Num children is zero", 0 == _base.getChildCount());
@@ -508,7 +508,7 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -519,10 +519,10 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         light = InstanceManager.getDefault(LightManager.class).provide("IL1");
         light.setCommandedState(Light.OFF);
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A logixNG");
@@ -536,11 +536,12 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         actionLight.setBeanState(ActionLight.LightState.On);
         MaleSocket socket = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionLight);
         conditionalNG.getChild(0).connect(socket);
-        
+
         _base = actionLight;
         _baseMaleSocket = socket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -549,5 +550,5 @@ public class ActionLightTest extends AbstractDigitalActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionListenOnBeansTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 
 /**
  * Test ActionListenOnBeans
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
@@ -23,27 +23,27 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
     private LogixNG logixNG;
     private ConditionalNG conditionalNG;
     private ActionListenOnBeans actionListenOnBeans;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Listen on beans ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -52,27 +52,27 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
                 "      ! A%n" +
                 "         Listen on beans ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ActionListenOnBeans(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         ActionListenOnBeans t = new ActionListenOnBeans("IQDA1", null);
         Assert.assertNotNull("not null", t);
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == actionListenOnBeans.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             actionListenOnBeans.getChild(0);
@@ -82,17 +82,17 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.OTHER == _base.getCategory());
     }
-    
+
     @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Listen on beans", _base.getShortDescription());
     }
-    
+
     @Test
     public void testLongDescription() {
         ActionListenOnBeans a1 = new ActionListenOnBeans("IQDA321", null);
@@ -100,7 +100,7 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
         ActionListenOnBeans a2 = new ActionListenOnBeans("IQDA321", null);
         Assert.assertEquals("strings are equal", "Listen on beans", a2.getLongDescription());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -111,10 +111,10 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A logixNG");
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -124,11 +124,12 @@ public class ActionListenOnBeansTest extends AbstractDigitalActionTestBase {
         actionListenOnBeans = new ActionListenOnBeans(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
         MaleSocket socket = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionListenOnBeans);
         conditionalNG.getChild(0).connect(socket);
-        
+
         _base = actionListenOnBeans;
         _baseMaleSocket = socket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionMemoryTest.java
@@ -330,6 +330,7 @@ public class ActionMemoryTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket = socket;
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
@@ -342,6 +342,7 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket = socketActionSimpleScript;
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionSensorTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 /**
  * Test ActionSensor
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class ActionSensorTest extends AbstractDigitalActionTestBase {
@@ -27,18 +27,18 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
     private ConditionalNG conditionalNG;
     private ActionSensor actionSensor;
     private Sensor sensor;
-    
-    
+
+
     @Test
     public void testSensorState() {
         Assert.assertEquals("String matches", "Inactive", ActionSensor.SensorState.Inactive.toString());
         Assert.assertEquals("String matches", "Active", ActionSensor.SensorState.Active.toString());
         Assert.assertEquals("String matches", "Toggle", ActionSensor.SensorState.Toggle.toString());
-        
+
         Assert.assertTrue("objects are equal", ActionSensor.SensorState.Inactive == ActionSensor.SensorState.get(Sensor.INACTIVE));
         Assert.assertTrue("objects are equal", ActionSensor.SensorState.Active == ActionSensor.SensorState.get(Sensor.ACTIVE));
         Assert.assertTrue("objects are equal", ActionSensor.SensorState.Toggle == ActionSensor.SensorState.get(-1));
-        
+
         boolean hasThrown = false;
         try {
             ActionSensor.SensorState.get(100);      // The number 100 is a state that ActionSensor.SensorState isn't aware of
@@ -48,27 +48,27 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Set sensor IS1 to state Active ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -77,42 +77,42 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
                 "      ! A%n" +
                 "         Set sensor IS1 to state Active ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ActionSensor(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() throws JmriException {
         Assert.assertTrue("object exists", _base != null);
-        
+
         ActionSensor action2;
         Assert.assertNotNull("sensor is not null", sensor);
         sensor.setState(Sensor.ON);
-        
+
         action2 = new ActionSensor("IQDA321", null);
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Set sensor '' to state Active", action2.getLongDescription());
-        
+
         action2 = new ActionSensor("IQDA321", "My sensor");
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My sensor", action2.getUserName());
         Assert.assertEquals("String matches", "Set sensor '' to state Active", action2.getLongDescription());
-        
+
         action2 = new ActionSensor("IQDA321", null);
         action2.setSensor(sensor);
         Assert.assertTrue("sensor is correct", sensor == action2.getSensor().getBean());
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Set sensor IS1 to state Active", action2.getLongDescription());
-        
+
         Sensor l = InstanceManager.getDefault(SensorManager.class).provide("IS1");
         action2 = new ActionSensor("IQDA321", "My sensor");
         action2.setSensor(l);
@@ -120,7 +120,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My sensor", action2.getUserName());
         Assert.assertEquals("String matches", "Set sensor IS1 to state Active", action2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -129,7 +129,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -138,15 +138,15 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         // Test setup(). This method doesn't do anything, but execute it for coverage.
         _base.setup();
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == actionSensor.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             actionSensor.getChild(0);
@@ -156,7 +156,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testSetSensor() {
         Sensor sensor11 = InstanceManager.getDefault(SensorManager.class).provide("IS11");
@@ -165,30 +165,30 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         Sensor sensor13 = InstanceManager.getDefault(SensorManager.class).provide("IS13");
         Sensor sensor14 = InstanceManager.getDefault(SensorManager.class).provide("IS14");
         sensor14.setUserName("Some user name");
-        
+
         actionSensor.removeSensor();
         Assert.assertNull("sensor handle is null", actionSensor.getSensor());
-        
+
         actionSensor.setSensor(sensor11);
         Assert.assertTrue("sensor is correct", sensor11 == actionSensor.getSensor().getBean());
-        
+
         actionSensor.removeSensor();
         Assert.assertNull("sensor handle is null", actionSensor.getSensor());
-        
+
         actionSensor.setSensor(sensorHandle12);
         Assert.assertTrue("sensor handle is correct", sensorHandle12 == actionSensor.getSensor());
-        
+
         actionSensor.setSensor("A non existent sensor");
         Assert.assertNull("sensor handle is null", actionSensor.getSensor());
         JUnitAppender.assertWarnMessage("sensor \"A non existent sensor\" is not found");
-        
+
         actionSensor.setSensor(sensor13.getSystemName());
         Assert.assertTrue("sensor is correct", sensor13 == actionSensor.getSensor().getBean());
-        
+
         actionSensor.setSensor(sensor14.getUserName());
         Assert.assertTrue("sensor is correct", sensor14 == actionSensor.getSensor().getBean());
     }
-    
+
     @Test
     public void testAction() throws SocketAlreadyConnectedException, JmriException {
         // Set the light
@@ -199,21 +199,21 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the sensor should be active
         Assert.assertTrue("sensor is active",sensor.getCommandedState() == Sensor.ACTIVE);
-        
+
         // Test to set sensor to inactive
         actionSensor.setBeanState(ActionSensor.SensorState.Inactive);
         // Execute the conditional
         conditionalNG.execute();
         // The action should now be executed so the sensor should be active
         Assert.assertTrue("sensor is active",sensor.getCommandedState() == Sensor.INACTIVE);
-        
+
         // Test to set sensor to toggle
         actionSensor.setBeanState(ActionSensor.SensorState.Toggle);
         // Execute the conditional
         conditionalNG.execute();
         // The action should now be executed so the sensor should be active
         Assert.assertTrue("sensor is active",sensor.getCommandedState() == Sensor.ACTIVE);
-        
+
         // Test to set sensor to toggle
         actionSensor.setBeanState(ActionSensor.SensorState.Toggle);
         // Execute the conditional
@@ -221,20 +221,20 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         // The action should now be executed so the sensor should be active
         Assert.assertTrue("sensor is active",sensor.getCommandedState() == Sensor.INACTIVE);
     }
-    
+
     @Test
     public void testIndirectAddressing() throws JmriException {
-        
+
         Memory m1 = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
         m1.setValue("IS102");
-        
+
         Assert.assertTrue(conditionalNG.isActive());
         Sensor t1 = InstanceManager.getDefault(SensorManager.class).provide("IS101");
         Sensor t2 = InstanceManager.getDefault(SensorManager.class).provide("IS102");
         Sensor t3 = InstanceManager.getDefault(SensorManager.class).provide("IS103");
         Sensor t4 = InstanceManager.getDefault(SensorManager.class).provide("IS104");
         Sensor t5 = InstanceManager.getDefault(SensorManager.class).provide("IS105");
-        
+
         actionSensor.setBeanState(ActionSensor.SensorState.Active);
         actionSensor.setSensor(t1.getSystemName());
         actionSensor.setReference("{IM1}");    // Points to "IS102"
@@ -243,7 +243,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket.addLocalVariable("refSensor", SymbolTable.InitialValueType.String, "IS103");
         _baseMaleSocket.addLocalVariable("mySensor", SymbolTable.InitialValueType.String, "IS104");
         _baseMaleSocket.addLocalVariable("index", SymbolTable.InitialValueType.Integer, "5");
-        
+
         // Test direct addressing
         actionSensor.setAddressing(NamedBeanAddressing.Direct);
         t1.setState(Sensor.INACTIVE);
@@ -259,7 +259,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Sensor.INACTIVE, t3.getCommandedState());
         Assert.assertEquals(Sensor.INACTIVE, t4.getCommandedState());
         Assert.assertEquals(Sensor.INACTIVE, t5.getCommandedState());
-        
+
         // Test reference by memory addressing
         actionSensor.setAddressing(NamedBeanAddressing.Reference);
         t1.setState(Sensor.INACTIVE);
@@ -275,7 +275,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Sensor.INACTIVE, t3.getCommandedState());
         Assert.assertEquals(Sensor.INACTIVE, t4.getCommandedState());
         Assert.assertEquals(Sensor.INACTIVE, t5.getCommandedState());
-        
+
         // Test reference by local variable addressing
         actionSensor.setReference("{refSensor}");    // Points to "IS103"
         actionSensor.setAddressing(NamedBeanAddressing.Reference);
@@ -292,7 +292,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Sensor.ACTIVE, t3.getCommandedState());
         Assert.assertEquals(Sensor.INACTIVE, t4.getCommandedState());
         Assert.assertEquals(Sensor.INACTIVE, t5.getCommandedState());
-        
+
         // Test local variable addressing
         actionSensor.setAddressing(NamedBeanAddressing.LocalVariable);
         t1.setState(Sensor.INACTIVE);
@@ -308,7 +308,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Sensor.INACTIVE, t3.getCommandedState());
         Assert.assertEquals(Sensor.ACTIVE, t4.getCommandedState());
         Assert.assertEquals(Sensor.INACTIVE, t5.getCommandedState());
-        
+
         // Test formula addressing
         actionSensor.setAddressing(NamedBeanAddressing.Formula);
         t1.setState(Sensor.INACTIVE);
@@ -325,16 +325,16 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals(Sensor.INACTIVE, t4.getCommandedState());
         Assert.assertEquals(Sensor.ACTIVE, t5.getCommandedState());
     }
-    
+
     @Test
     public void testIndirectStateAddressing() throws JmriException {
-        
+
         Memory m1 = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
         m1.setValue("IS102");
-        
+
         Assert.assertTrue(conditionalNG.isActive());
-        
-        
+
+
         // Test direct addressing
         actionSensor.setStateAddressing(NamedBeanAddressing.Direct);
         // Test Inactive
@@ -351,8 +351,8 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct sensor should be thrown
         Assert.assertEquals(Sensor.ACTIVE, sensor.getCommandedState());
-        
-        
+
+
         // Test reference by memory addressing
         actionSensor.setStateAddressing(NamedBeanAddressing.Reference);
         actionSensor.setStateReference("{IM1}");
@@ -370,8 +370,8 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct sensor should be thrown
         Assert.assertEquals(Sensor.ACTIVE, sensor.getCommandedState());
-        
-        
+
+
         // Test reference by local variable addressing
         actionSensor.setStateAddressing(NamedBeanAddressing.Reference);
         actionSensor.setStateReference("{refVariable}");
@@ -391,8 +391,8 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct sensor should be thrown
         Assert.assertEquals(Sensor.ACTIVE, sensor.getCommandedState());
-        
-        
+
+
         // Test local variable addressing
         actionSensor.setStateAddressing(NamedBeanAddressing.Reference);
         actionSensor.setStateLocalVariable("myVariable");
@@ -412,8 +412,8 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct sensor should be thrown
         Assert.assertEquals(Sensor.ACTIVE, sensor.getCommandedState());
-        
-        
+
+
         // Test formula addressing
         actionSensor.setStateAddressing(NamedBeanAddressing.Formula);
         actionSensor.setStateFormula("refVariable + myVariable");
@@ -436,7 +436,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         // The action should now be executed so the correct sensor should be thrown
         Assert.assertEquals(Sensor.ACTIVE, sensor.getCommandedState());
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Get the action and set the sensor
@@ -444,28 +444,28 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         Assert.assertNotNull("Sensor is not null", sensor);
         ActionSensor action = new ActionSensor(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
         action.setSensor(sensor);
-        
+
         // Get some other sensor for later use
         Sensor otherSensor = InstanceManager.getDefault(SensorManager.class).provide("IM99");
         Assert.assertNotNull("Sensor is not null", otherSensor);
         Assert.assertNotEquals("Sensor is not equal", sensor, otherSensor);
-        
+
         // Test vetoableChange() for some other propery
         action.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Sensor matches", sensor, action.getSensor().getBean());
-        
+
         // Test vetoableChange() for a string
         action.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Sensor matches", sensor, action.getSensor().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Sensor matches", sensor, action.getSensor().getBean());
-        
+
         // Test vetoableChange() for another sensor
         action.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherSensor, null));
         Assert.assertEquals("Sensor matches", sensor, action.getSensor().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherSensor, null));
         Assert.assertEquals("Sensor matches", sensor, action.getSensor().getBean());
-        
+
         // Test vetoableChange() for its own sensor
         boolean thrown = false;
         try {
@@ -474,27 +474,27 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Sensor matches", sensor, action.getSensor().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", sensor, null));
         Assert.assertNull("Sensor is null", action.getSensor());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Sensor", _base.getShortDescription());
     }
-    
+
     @Test
     public void testLongDescription() {
         Assert.assertEquals("String matches", "Set sensor IS1 to state Active", _base.getLongDescription());
     }
-    
+
     @Test
     public void testChild() {
         Assert.assertTrue("Num children is zero", 0 == _base.getChildCount());
@@ -507,7 +507,7 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -518,10 +518,10 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         sensor = InstanceManager.getDefault(SensorManager.class).provide("IS1");
         sensor.setCommandedState(Sensor.INACTIVE);
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A logixNG");
@@ -535,11 +535,12 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         actionSensor.setBeanState(ActionSensor.SensorState.Active);
         MaleSocket socket = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionSensor);
         conditionalNG.getChild(0).connect(socket);
-        
+
         _base = actionSensor;
         _baseMaleSocket = socket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -549,5 +550,5 @@ public class ActionSensorTest extends AbstractDigitalActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/ActionThrottleTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionThrottleTest.java
@@ -747,6 +747,7 @@ public class ActionThrottleTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket = maleSocket;
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionTimerTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTimerTest.java
@@ -314,6 +314,7 @@ public class ActionTimerTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket = maleSocket;
 
         if (! _logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        _logixNG.activate();
         _logixNG.setEnabled(false);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ActionTurnoutLockTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTurnoutLockTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 /**
  * Test ActionTurnoutLock
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
@@ -29,28 +29,28 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
     private ConditionalNG conditionalNG;
     private ActionTurnoutLock actionTurnoutLock;
     private Turnout turnout;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Set lock for turnout IT1 to Lock ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -59,42 +59,42 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
                 "      ! A%n" +
                 "         Set lock for turnout IT1 to Lock ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ActionTurnoutLock(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() throws JmriException {
         Assert.assertTrue("object exists", _base != null);
-        
+
         ActionTurnoutLock action2;
         Assert.assertNotNull("turnout is not null", turnout);
         turnout.setState(Turnout.ON);
-        
+
         action2 = new ActionTurnoutLock("IQDA321", null);
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Set lock for turnout '' to Unlock", action2.getLongDescription());
-        
+
         action2 = new ActionTurnoutLock("IQDA321", "My turnout");
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My turnout", action2.getUserName());
         Assert.assertEquals("String matches", "Set lock for turnout '' to Unlock", action2.getLongDescription());
-        
+
         action2 = new ActionTurnoutLock("IQDA321", null);
         action2.setTurnout(turnout);
         Assert.assertTrue("turnout is correct", turnout == action2.getTurnout().getBean());
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Set lock for turnout IT1 to Unlock", action2.getLongDescription());
-        
+
         Turnout l = InstanceManager.getDefault(TurnoutManager.class).provide("IT1");
         action2 = new ActionTurnoutLock("IQDA321", "My turnout");
         action2.setTurnout(l);
@@ -102,7 +102,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My turnout", action2.getUserName());
         Assert.assertEquals("String matches", "Set lock for turnout IT1 to Unlock", action2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -111,7 +111,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -120,15 +120,15 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         // Test setup(). This method doesn't do anything, but execute it for coverage.
         _base.setup();
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == actionTurnoutLock.getChildCount());
-        
+
         boolean hasLock = false;
         try {
             actionTurnoutLock.getChild(0);
@@ -138,14 +138,14 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasLock);
     }
-    
+
     @Test
     public void testTurnoutLock() {
         Assert.assertEquals("String matches", "Unlock", ActionTurnoutLock.TurnoutLock.Unlock.toString());
         Assert.assertEquals("String matches", "Lock", ActionTurnoutLock.TurnoutLock.Lock.toString());
         Assert.assertEquals("String matches", "Toggle", ActionTurnoutLock.TurnoutLock.Toggle.toString());
     }
-    
+
     @Test
     public void testSetTurnout() {
         Turnout turnout11 = InstanceManager.getDefault(TurnoutManager.class).provide("IL11");
@@ -154,30 +154,30 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         Turnout turnout13 = InstanceManager.getDefault(TurnoutManager.class).provide("IL13");
         Turnout turnout14 = InstanceManager.getDefault(TurnoutManager.class).provide("IL14");
         turnout14.setUserName("Some user name");
-        
+
         actionTurnoutLock.removeTurnout();
         Assert.assertNull("turnout handle is null", actionTurnoutLock.getTurnout());
-        
+
         actionTurnoutLock.setTurnout(turnout11);
         Assert.assertTrue("turnout is correct", turnout11 == actionTurnoutLock.getTurnout().getBean());
-        
+
         actionTurnoutLock.removeTurnout();
         Assert.assertNull("turnout handle is null", actionTurnoutLock.getTurnout());
-        
+
         actionTurnoutLock.setTurnout(turnoutHandle12);
         Assert.assertTrue("turnout handle is correct", turnoutHandle12 == actionTurnoutLock.getTurnout());
-        
+
         actionTurnoutLock.setTurnout("A non existent turnout");
         Assert.assertNull("turnout handle is null", actionTurnoutLock.getTurnout());
         JUnitAppender.assertErrorMessage("turnout \"A non existent turnout\" is not found");
-        
+
         actionTurnoutLock.setTurnout(turnout13.getSystemName());
         Assert.assertTrue("turnout is correct", turnout13 == actionTurnoutLock.getTurnout().getBean());
-        
+
         actionTurnoutLock.setTurnout(turnout14.getUserName());
         Assert.assertTrue("turnout is correct", turnout14 == actionTurnoutLock.getTurnout().getBean());
     }
-    
+
     @Test
     public void testAction() throws SocketAlreadyConnectedException, JmriException {
         // Set the light
@@ -188,21 +188,21 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the turnout should be thrown
         Assert.assertTrue(turnout.getLocked(Turnout.CABLOCKOUT));
-        
+
         // Test to set turnout to closed
         actionTurnoutLock.setTurnoutLock(ActionTurnoutLock.TurnoutLock.Unlock);
         // Execute the conditional
         conditionalNG.execute();
         // The action should now be executed so the turnout should be thrown
         Assert.assertTrue(!turnout.getLocked(Turnout.CABLOCKOUT));
-        
+
         // Test to set turnout to toggle
         actionTurnoutLock.setTurnoutLock(ActionTurnoutLock.TurnoutLock.Toggle);
         // Execute the conditional
         conditionalNG.execute();
         // The action should now be executed so the turnout should be thrown
         Assert.assertTrue(turnout.getLocked(Turnout.CABLOCKOUT));
-        
+
         // Test to set turnout to toggle
         actionTurnoutLock.setTurnoutLock(ActionTurnoutLock.TurnoutLock.Toggle);
         // Execute the conditional
@@ -210,20 +210,20 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         // The action should now be executed so the turnout should be thrown
         Assert.assertTrue(!turnout.getLocked(Turnout.CABLOCKOUT));
     }
-    
+
     @Test
     public void testIndirectAddressing() throws JmriException {
-        
+
         Memory m1 = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
         m1.setValue("IT102");
-        
+
         Assert.assertTrue(conditionalNG.isActive());
         Turnout t1 = new MyTurnout("IT101"); InstanceManager.getDefault(TurnoutManager.class).register(t1);
         Turnout t2 = new MyTurnout("IT102"); InstanceManager.getDefault(TurnoutManager.class).register(t2);
         Turnout t3 = new MyTurnout("IT103"); InstanceManager.getDefault(TurnoutManager.class).register(t3);
         Turnout t4 = new MyTurnout("IT104"); InstanceManager.getDefault(TurnoutManager.class).register(t4);
         Turnout t5 = new MyTurnout("IT105"); InstanceManager.getDefault(TurnoutManager.class).register(t5);
-        
+
         actionTurnoutLock.setTurnoutLock(ActionTurnoutLock.TurnoutLock.Lock);
         actionTurnoutLock.setTurnout(t1.getSystemName());
         actionTurnoutLock.setReference("{IM1}");    // Points to "IT102"
@@ -232,7 +232,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket.addLocalVariable("refTurnout", SymbolTable.InitialValueType.String, "IT103");
         _baseMaleSocket.addLocalVariable("myTurnout", SymbolTable.InitialValueType.String, "IT104");
         _baseMaleSocket.addLocalVariable("index", SymbolTable.InitialValueType.Integer, "5");
-        
+
         // Test direct addressing
         actionTurnoutLock.setAddressing(NamedBeanAddressing.Direct);
         t1.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, false);
@@ -248,7 +248,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         Assert.assertTrue(!t3.getLocked(Turnout.CABLOCKOUT));
         Assert.assertTrue(!t4.getLocked(Turnout.CABLOCKOUT));
         Assert.assertTrue(!t5.getLocked(Turnout.CABLOCKOUT));
-        
+
         // Test reference by memory addressing
         actionTurnoutLock.setAddressing(NamedBeanAddressing.Reference);
         t1.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, false);
@@ -264,7 +264,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         Assert.assertTrue(!t3.getLocked(Turnout.CABLOCKOUT));
         Assert.assertTrue(!t4.getLocked(Turnout.CABLOCKOUT));
         Assert.assertTrue(!t5.getLocked(Turnout.CABLOCKOUT));
-        
+
         // Test reference by local variable addressing
         actionTurnoutLock.setReference("{refTurnout}");    // Points to "IT103"
         actionTurnoutLock.setAddressing(NamedBeanAddressing.Reference);
@@ -281,7 +281,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         Assert.assertTrue(t3.getLocked(Turnout.CABLOCKOUT));
         Assert.assertTrue(!t4.getLocked(Turnout.CABLOCKOUT));
         Assert.assertTrue(!t5.getLocked(Turnout.CABLOCKOUT));
-        
+
         // Test local variable addressing
         actionTurnoutLock.setAddressing(NamedBeanAddressing.LocalVariable);
         t1.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, false);
@@ -297,7 +297,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         Assert.assertTrue(!t3.getLocked(Turnout.CABLOCKOUT));
         Assert.assertTrue(t4.getLocked(Turnout.CABLOCKOUT));
         Assert.assertTrue(!t5.getLocked(Turnout.CABLOCKOUT));
-        
+
         // Test formula addressing
         actionTurnoutLock.setAddressing(NamedBeanAddressing.Formula);
         t1.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, false);
@@ -314,16 +314,16 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         Assert.assertTrue(!t4.getLocked(Turnout.CABLOCKOUT));
         Assert.assertTrue(t5.getLocked(Turnout.CABLOCKOUT));
     }
-    
+
     @Test
     public void testIndirectStateAddressing() throws JmriException {
-        
+
         Memory m1 = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
         m1.setValue("IT102");
-        
+
         Assert.assertTrue(conditionalNG.isActive());
-        
-        
+
+
         // Test direct addressing
         actionTurnoutLock.setLockAddressing(NamedBeanAddressing.Direct);
         // Test Unlock
@@ -340,7 +340,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct turnout should be thrown
         Assert.assertTrue(turnout.getLocked(Turnout.CABLOCKOUT));
-        
+
         // Test reference by memory addressing
         actionTurnoutLock.setLockAddressing(NamedBeanAddressing.Reference);
         actionTurnoutLock.setLockReference("{IM1}");
@@ -358,8 +358,8 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct turnout should be thrown
         Assert.assertTrue(turnout.getLocked(Turnout.CABLOCKOUT));
-        
-        
+
+
         // Test reference by local variable addressing
         actionTurnoutLock.setLockAddressing(NamedBeanAddressing.Reference);
         actionTurnoutLock.setLockReference("{refVariable}");
@@ -379,8 +379,8 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct turnout should be thrown
         Assert.assertTrue(turnout.getLocked(Turnout.CABLOCKOUT));
-        
-        
+
+
         // Test local variable addressing
         actionTurnoutLock.setLockAddressing(NamedBeanAddressing.Reference);
         actionTurnoutLock.setLockLocalVariable("myVariable");
@@ -400,8 +400,8 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         conditionalNG.execute();
         // The action should now be executed so the correct turnout should be thrown
         Assert.assertTrue(turnout.getLocked(Turnout.CABLOCKOUT));
-        
-        
+
+
         // Test formula addressing
         actionTurnoutLock.setLockAddressing(NamedBeanAddressing.Formula);
         actionTurnoutLock.setLockFormula("refVariable + myVariable");
@@ -424,7 +424,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         // The action should now be executed so the correct turnout should be thrown
         Assert.assertTrue(turnout.getLocked(Turnout.CABLOCKOUT));
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Get the action and set the turnout
@@ -432,28 +432,28 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         Assert.assertNotNull("Turnout is not null", turnout);
         ActionTurnoutLock action = new ActionTurnoutLock(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
         action.setTurnout(turnout);
-        
+
         // Get some other turnout for later use
         Turnout otherTurnout = InstanceManager.getDefault(TurnoutManager.class).provide("IM99");
         Assert.assertNotNull("Turnout is not null", otherTurnout);
         Assert.assertNotEquals("Turnout is not equal", turnout, otherTurnout);
-        
+
         // Test vetoableChange() for some other propery
         action.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
-        
+
         // Test vetoableChange() for a string
         action.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
-        
+
         // Test vetoableChange() for another turnout
         action.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherTurnout, null));
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherTurnout, null));
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
-        
+
         // Test vetoableChange() for its own turnout
         boolean thrown = false;
         try {
@@ -462,27 +462,27 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Turnout matches", turnout, action.getTurnout().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", turnout, null));
         Assert.assertNull("Turnout is null", action.getTurnout());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Turnout, lock", _base.getShortDescription());
     }
-    
+
     @Test
     public void testLongDescription() {
         Assert.assertEquals("String matches", "Set lock for turnout IT1 to Lock", _base.getLongDescription());
     }
-    
+
     @Test
     public void testChild() {
         Assert.assertTrue("Num children is zero", 0 == _base.getChildCount());
@@ -495,7 +495,7 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasLock);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -506,10 +506,10 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
 //        turnout = InstanceManager.getDefault(TurnoutManager.class).provide("IT1");
         turnout = new MyTurnout("IT1");
         InstanceManager.getDefault(TurnoutManager.class).register(turnout);
@@ -525,11 +525,12 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         actionTurnoutLock.setTurnoutLock(ActionTurnoutLock.TurnoutLock.Lock);
         MaleSocket socket = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionTurnoutLock);
         conditionalNG.getChild(0).connect(socket);
-        
+
         _base = actionTurnoutLock;
         _baseMaleSocket = socket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -538,14 +539,14 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     private static class MyTurnout extends AbstractTurnout {
-        
+
         MyTurnout(@Nonnull String systemName) {
             super(systemName);
         }
-        
+
         @Override
         protected void forwardCommandChangeToLayout(int s) {
             // Do nothing
@@ -555,12 +556,12 @@ public class ActionTurnoutLockTest extends AbstractDigitalActionTestBase {
         protected void turnoutPushbuttonLockout(boolean locked) {
             // Do nothing
         }
-        
+
         @Override
         public boolean canLock(int turnoutLockout) {
             return true;
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/ActionTurnoutTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionTurnoutTest.java
@@ -539,6 +539,7 @@ public class ActionTurnoutTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket = socket;
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/AnalogManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/AnalogManyTest.java
@@ -19,24 +19,24 @@ import org.junit.Test;
 
 /**
  * Test Many
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class AnalogManyTest extends AbstractAnalogActionTestBase {
 
     LogixNG logixNG;
     ConditionalNG conditionalNG;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         AnalogMany action = new AnalogMany("IQAA999", null);
@@ -44,7 +44,7 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
                 InstanceManager.getDefault(AnalogActionManager.class).registerAction(action);
         return maleSocket;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -52,7 +52,7 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
                 "   !~ A1%n" +
                 "      Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -67,12 +67,12 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
                 "                  !~ A1%n" +
                 "                     Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new AnalogMany(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() throws SocketAlreadyConnectedException {
         int count = _base.getChildCount();
@@ -83,7 +83,7 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
         }
         return true;
     }
-    
+
     @Test
     public void testCtor() {
         AnalogMany action = new AnalogMany("IQAA321", null);
@@ -94,19 +94,19 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
                 "jmri.jmrit.logixng.implementation.DefaultFemaleAnalogActionSocket",
                 action.getChild(0).getClass().getName());
     }
-    
+
     // Test action when at least one child socket is not connected
     @Test
     public void testCtorAndSetup1() {
         AnalogActionManager m = InstanceManager.getDefault(AnalogActionManager.class);
-        
+
         List<MaleSocket> maleSockets = new ArrayList<>();
         maleSockets.add(m.registerAction(new AnalogActionMemory("IQAA52", null)));
         maleSockets.add(null);  // This is null by purpose
         maleSockets.add(m.registerAction(new AnalogActionMemory("IQAA554", null)));
         maleSockets.add(null);  // This is null by purpose
         maleSockets.add(m.registerAction(new AnalogActionMemory("IQAA3", null)));
-        
+
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQAA52"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("ZH12", null));   // This is null by purpose
@@ -114,11 +114,11 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
         // IQAA61232 doesn't exist by purpose
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("SomethingElse", "IQAA61232"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Yes123", "IQAA3"));
-        
+
         AnalogMany action = new AnalogMany("IQAA321", null, actionSystemNames);
         Assert.assertNotNull("exists", action);
         Assert.assertEquals("action has 5 female sockets", 5, action.getChildCount());
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
@@ -129,17 +129,17 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
             Assert.assertFalse("action female socket is not connected",
                     action.getChild(i).isConnected());
         }
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load analog action IQAA61232");
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
                     entry.getKey(), action.getChild(i).getName());
-            
+
             if (maleSockets.get(i) != null) {
                 Assert.assertTrue("action female socket is connected",
                         action.getChild(i).isConnected());
@@ -151,34 +151,34 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
                         action.getChild(i).isConnected());
             }
         }
-        
+
         Assert.assertEquals("action has 5 female sockets", 5, action.getChildCount());
     }
-    
+
     // Test action when at least one child socket is not connected.
     // This should never happen, but test it anyway.
     @Test
     public void testCtorAndSetup2() {
         AnalogActionManager m = InstanceManager.getDefault(AnalogActionManager.class);
-        
+
         List<MaleSocket> maleSockets = new ArrayList<>();
         maleSockets.add(m.registerAction(new AnalogActionMemory("IQAA52", null)));
         maleSockets.add(m.registerAction(new AnalogActionMemory("IQAA99", null)));
         maleSockets.add(m.registerAction(new AnalogActionMemory("IQAA554", null)));
         maleSockets.add(m.registerAction(new AnalogActionMemory("IQAA61232", null)));
         maleSockets.add(m.registerAction(new AnalogActionMemory("IQAA3", null)));
-        
+
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQAA52"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("ZH12", "IQAA99"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Hello", "IQAA554"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("SomethingElse", "IQAA61232"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Yes123", "IQAA3"));
-        
+
         AnalogMany action = new AnalogMany("IQAA321", null, actionSystemNames);
         Assert.assertNotNull("exists", action);
         Assert.assertEquals("action has 5 female sockets", 5, action.getChildCount());
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
@@ -189,15 +189,15 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
             Assert.assertFalse("action female socket is not connected",
                     action.getChild(i).isConnected());
         }
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
                     entry.getKey(), action.getChild(i).getName());
-            
+
             if (maleSockets.get(i) != null) {
                 Assert.assertTrue("action female socket is connected",
                         action.getChild(i).isConnected());
@@ -209,28 +209,28 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
                         action.getChild(i).isConnected());
             }
         }
-        
+
         // Since all the sockets are connected, a new socket must have been created.
         Assert.assertEquals("action has 6 female sockets", 6, action.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         action.setup();
-        
+
         Assert.assertEquals("action has 6 female sockets", 6, action.getChildCount());
     }
-    
+
     // Test calling setActionSystemNames() twice
     @Test
     public void testCtorAndSetup3() throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException {
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQAA52"));
-        
+
         AnalogMany action = new AnalogMany("IQAA321", null, actionSystemNames);
-        
+
         java.lang.reflect.Method method =
                 action.getClass().getDeclaredMethod("setActionSystemNames", new Class<?>[]{List.class});
         method.setAccessible(true);
-        
+
         boolean hasThrown = false;
         try {
             method.invoke(action, new Object[]{null});
@@ -244,19 +244,19 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testGetChild() throws SocketAlreadyConnectedException {
         AnalogMany action2 = new AnalogMany("IQAA321", null);
-        
+
         for (int i=0; i < 3; i++) {
             Assert.assertTrue("getChildCount() returns "+i, i+1 == action2.getChildCount());
-            
+
             Assert.assertNotNull("getChild(0) returns a non null value",
                     action2.getChild(0));
-            
+
             assertIndexOutOfBoundsException(action2::getChild, i+1, i+1);
-            
+
             // Connect a new child expression
             AnalogActionMemory expr = new AnalogActionMemory("IQAA"+i, null);
             MaleSocket maleSocket =
@@ -264,23 +264,23 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
             action2.getChild(i).connect(maleSocket);
         }
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
-    
+
     // Test the methods connected(FemaleSocket) and getActionSystemName(int)
     @Test
     public void testConnected_getActionSystemName() throws SocketAlreadyConnectedException {
         AnalogMany action = new AnalogMany("IQAA121", null);
-        
+
         AnalogActionMemory analogActionMemory = new AnalogActionMemory("IQAA122", null);
         MaleSocket maleSAMSocket =
                 InstanceManager.getDefault(AnalogActionManager.class).registerAction(analogActionMemory);
-        
+
         Assert.assertEquals("Num children is correct", 1, action.getChildCount());
-        
+
         // Test connect and disconnect
         action.getChild(0).connect(maleSAMSocket);
         Assert.assertEquals("Num children is correct", 2, action.getChildCount());
@@ -290,7 +290,7 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
         Assert.assertEquals("Num children is correct", 2, action.getChildCount());
         Assert.assertNull("getActionSystemName(0) is null", action.getActionSystemName(0));
         Assert.assertNull("getActionSystemName(1) is null", action.getActionSystemName(1));
-        
+
         action.getChild(1).connect(maleSAMSocket);
         Assert.assertEquals("Num children is correct", 2, action.getChildCount());
         Assert.assertNull("getActionSystemName(0) is null", action.getActionSystemName(0));
@@ -304,14 +304,14 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
         Assert.assertNull("getActionSystemName(0) is null", action.getActionSystemName(0));
         Assert.assertNull("getActionSystemName(1) is null", action.getActionSystemName(1));
     }
-    
+
     @Test
     public void testDescription() {
         AnalogMany action = new AnalogMany("IQAA121", null);
         Assert.assertEquals("Short description", "Many", action.getShortDescription());
         Assert.assertEquals("Long description", "Many", action.getLongDescription());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -322,31 +322,32 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.COMMON;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setEnabled(true);
         conditionalNG.setRunDelayed(false);
         logixNG.addConditionalNG(conditionalNG);
-        
+
         DoAnalogAction doAnalogAction = new DoAnalogAction("IQDA321", null);
         MaleSocket maleSocketDoAnalogAction =
                 InstanceManager.getDefault(DigitalActionManager.class)
                         .registerAction(doAnalogAction);
         conditionalNG.getChild(0).connect(maleSocketDoAnalogAction);
-        
+
         AnalogMany action = new AnalogMany("IQAA321", null);
         MaleSocket maleSocket =
                 InstanceManager.getDefault(AnalogActionManager.class).registerAction(action);
         doAnalogAction.getChild(1).connect(maleSocket);
         _base = action;
         _baseMaleSocket = maleSocket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -355,5 +356,5 @@ public class AnalogManyTest extends AbstractAnalogActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/DigitalBooleanOnChangeTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DigitalBooleanOnChangeTest.java
@@ -337,6 +337,7 @@ public class DigitalBooleanOnChangeTest extends AbstractDigitalBooleanActionTest
         _baseMaleSocket = maleSocketActionOnChange;
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/DigitalManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DigitalManyTest.java
@@ -19,24 +19,24 @@ import org.junit.Test;
 
 /**
  * Test Many
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DigitalManyTest extends AbstractDigitalActionTestBase {
 
     LogixNG logixNG;
     ConditionalNG conditionalNG;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         DigitalMany action = new DigitalMany("IQDA999", null);
@@ -44,7 +44,7 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
         return maleSocket;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -52,7 +52,7 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
                 "   ! A1%n" +
                 "      Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -63,12 +63,12 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
                 "            ! A1%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new DigitalMany(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() throws SocketAlreadyConnectedException {
         int count = _base.getChildCount();
@@ -79,7 +79,7 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
         }
         return true;
     }
-    
+
     @Test
     public void testCtor() {
         DigitalMany action = new DigitalMany("IQDA321", null);
@@ -90,19 +90,19 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
                 "jmri.jmrit.logixng.implementation.DefaultFemaleDigitalActionSocket",
                 action.getChild(0).getClass().getName());
     }
-    
+
     // Test action when at least one child socket is not connected
     @Test
     public void testCtorAndSetup1() {
         DigitalActionManager m = InstanceManager.getDefault(DigitalActionManager.class);
-        
+
         List<MaleSocket> maleSockets = new ArrayList<>();
         maleSockets.add(m.registerAction(new ActionMemory("IQDA52", null)));
         maleSockets.add(null);  // This is null by purpose
         maleSockets.add(m.registerAction(new ActionMemory("IQDA554", null)));
         maleSockets.add(null);  // This is null by purpose
         maleSockets.add(m.registerAction(new ActionMemory("IQDA3", null)));
-        
+
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQDA52"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("ZH12", null));   // This is null by purpose
@@ -110,11 +110,11 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
         // IQDA61232 doesn't exist by purpose
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("SomethingElse", "IQDA61232"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Yes123", "IQDA3"));
-        
+
         DigitalMany action = new DigitalMany("IQDA321", null, actionSystemNames);
         Assert.assertNotNull("exists", action);
         Assert.assertEquals("action has 5 female sockets", 5, action.getChildCount());
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
@@ -125,17 +125,17 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
             Assert.assertFalse("action female socket is not connected",
                     action.getChild(i).isConnected());
         }
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load digital action IQDA61232");
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
                     entry.getKey(), action.getChild(i).getName());
-            
+
             if (maleSockets.get(i) != null) {
                 Assert.assertTrue("action female socket is connected",
                         action.getChild(i).isConnected());
@@ -147,32 +147,32 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
                         action.getChild(i).isConnected());
             }
         }
-        
+
         Assert.assertEquals("action has 5 female sockets", 5, action.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup2() {
         DigitalActionManager m = InstanceManager.getDefault(DigitalActionManager.class);
-        
+
         List<MaleSocket> maleSockets = new ArrayList<>();
         maleSockets.add(m.registerAction(new ActionMemory("IQDA52", null)));
         maleSockets.add(m.registerAction(new ActionMemory("IQDA99", null)));
         maleSockets.add(m.registerAction(new ActionMemory("IQDA554", null)));
         maleSockets.add(m.registerAction(new ActionMemory("IQDA61232", null)));
         maleSockets.add(m.registerAction(new ActionMemory("IQDA3", null)));
-        
+
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQDA52"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("ZH12", "IQDA99"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Hello", "IQDA554"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("SomethingElse", "IQDA61232"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Yes123", "IQDA3"));
-        
+
         DigitalMany action = new DigitalMany("IQDA321", null, actionSystemNames);
         Assert.assertNotNull("exists", action);
         Assert.assertEquals("action has 5 female sockets", 5, action.getChildCount());
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
@@ -183,15 +183,15 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
             Assert.assertFalse("action female socket is not connected",
                     action.getChild(i).isConnected());
         }
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
                     entry.getKey(), action.getChild(i).getName());
-            
+
             if (maleSockets.get(i) != null) {
                 Assert.assertTrue("action female socket is connected",
                         action.getChild(i).isConnected());
@@ -203,27 +203,27 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
                         action.getChild(i).isConnected());
             }
         }
-        
+
         Assert.assertEquals("action has 5 female sockets", 5, action.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         action.setup();
-        
+
         Assert.assertEquals("action has 5 female sockets", 5, action.getChildCount());
     }
-    
+
     // Test calling setActionSystemNames() twice
     @Test
     public void testCtorAndSetup3() throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException {
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQDA52"));
-        
+
         DigitalMany action = new DigitalMany("IQDA321", null, actionSystemNames);
-        
+
         java.lang.reflect.Method method =
                 action.getClass().getDeclaredMethod("setActionSystemNames", new Class<?>[]{List.class});
         method.setAccessible(true);
-        
+
         boolean hasThrown = false;
         try {
             method.invoke(action, new Object[]{null});
@@ -237,19 +237,19 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testGetChild() throws SocketAlreadyConnectedException {
         DigitalMany action2 = new DigitalMany("IQDA321", null);
-        
+
         for (int i=0; i < 3; i++) {
             Assert.assertTrue("getChildCount() returns "+i, i+1 == action2.getChildCount());
-            
+
             Assert.assertNotNull("getChild(0) returns a non null value",
                     action2.getChild(0));
-            
+
             assertIndexOutOfBoundsException(action2::getChild, i+1, i+1);
-            
+
             // Connect a new child expression
             ActionLight expr = new ActionLight("IQDA"+i, null);
             MaleSocket maleSocket =
@@ -257,23 +257,23 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
             action2.getChild(i).connect(maleSocket);
         }
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
-    
+
     // Test the methods connected(FemaleSocket) and getActionSystemName(int)
     @Test
     public void testConnected_getActionSystemName() throws SocketAlreadyConnectedException {
         DigitalMany action = new DigitalMany("IQDA121", null);
-        
+
         ActionMemory actionMemory = new ActionMemory("IQDA122", null);
         MaleSocket maleSAMSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionMemory);
-        
+
         Assert.assertEquals("Num children is correct", 1, action.getChildCount());
-        
+
         // Test connect and disconnect
         action.getChild(0).connect(maleSAMSocket);
         Assert.assertEquals("Num children is correct", 2, action.getChildCount());
@@ -283,7 +283,7 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals("Num children is correct", 2, action.getChildCount());
         Assert.assertNull("getActionSystemName(0) is null", action.getActionSystemName(0));
         Assert.assertNull("getActionSystemName(1) is null", action.getActionSystemName(1));
-        
+
         action.getChild(1).connect(maleSAMSocket);
         Assert.assertEquals("Num children is correct", 2, action.getChildCount());
         Assert.assertNull("getActionSystemName(0) is null", action.getActionSystemName(0));
@@ -297,14 +297,14 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
         Assert.assertNull("getActionSystemName(0) is null", action.getActionSystemName(0));
         Assert.assertNull("getActionSystemName(1) is null", action.getActionSystemName(1));
     }
-    
+
     @Test
     public void testDescription() {
         DigitalMany action = new DigitalMany("IQDA121", null);
         Assert.assertEquals("Short description", "Many", action.getShortDescription());
         Assert.assertEquals("Long description", "Many", action.getLongDescription());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -314,13 +314,13 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initConfigureManager();
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
-        
+
         InstanceManager.getDefault(LogixNGPreferences.class).setInstallDebugger(false);
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.COMMON;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -333,8 +333,9 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
         conditionalNG.getChild(0).connect(maleSocket);
         _base = action;
         _baseMaleSocket = maleSocket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -343,5 +344,5 @@ public class DigitalManyTest extends AbstractDigitalActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/DoAnalogActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DoAnalogActionTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 /**
  * Test DoAnalogAction
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
@@ -26,17 +26,17 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
     LogixNG logixNG;
     ConditionalNG conditionalNG;
     DoAnalogAction actionDoAnalogAction;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         AnalogExpressionBean childExpression = new AnalogExpressionConstant("IQAE999", null);
@@ -44,7 +44,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 InstanceManager.getDefault(AnalogExpressionManager.class).registerExpression(childExpression);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -54,7 +54,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 "   !~ A%n" +
                 "      Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -67,22 +67,22 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 "            !~ A%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new DoAnalogAction(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Assert.assertNotNull("exists", new DoAnalogAction("IQDA321", null));
     }
-    
+
     @Test
     public void testCtorAndSetup1() {
         DoAnalogAction expression = new DoAnalogAction("IQDA321", null);
@@ -92,7 +92,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
         expression.setAnalogExpressionSocketSystemName("IQAE52");
         expression.getChild(1).setName("ZH12");
         expression.setAnalogActionSocketSystemName("IQAA554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -101,7 +101,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -109,13 +109,13 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load analog expression IQAE52");
         jmri.util.JUnitAppender.assertMessage("cannot load analog action IQAA554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -124,7 +124,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -132,10 +132,10 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup2() {
         DoAnalogAction expression = new DoAnalogAction("IQDA321", null);
@@ -145,7 +145,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
         expression.setAnalogExpressionSocketSystemName(null);
         expression.getChild(1).setName("ZH12");
         expression.setAnalogActionSocketSystemName(null);
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -154,7 +154,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -162,10 +162,10 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -174,7 +174,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -182,18 +182,18 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup3() {
         AnalogExpressionManager m0 = InstanceManager.getDefault(AnalogExpressionManager.class);
         AnalogActionManager m1 = InstanceManager.getDefault(AnalogActionManager.class);
-        
+
         m0.registerExpression(new AnalogExpressionMemory("IQAE52", null));
         m1.registerAction(new AnalogActionMemory("IQAA554", null));
-        
+
         DoAnalogAction expression = new DoAnalogAction("IQDA321", null);
         Assert.assertNotNull("exists", expression);
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
@@ -201,7 +201,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
         expression.setAnalogExpressionSocketSystemName("IQAE52");
         expression.getChild(1).setName("ZH12");
         expression.setAnalogActionSocketSystemName("IQAA554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -210,7 +210,7 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -218,39 +218,39 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(0).isConnected());
 //        Assert.assertEquals("child is correct bean",
 //                childSocket0,
 //                expression.getChild(0).getConnectedSocket());
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(1).isConnected());
 //        Assert.assertEquals("child is correct bean",
 //                childSocket1,
 //                expression.getChild(1).getConnectedSocket());
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         expression.setup();
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 2", 2 == actionDoAnalogAction.getChildCount());
-        
+
         Assert.assertNotNull("getChild(0) returns a non null value",
                 actionDoAnalogAction.getChild(0));
         Assert.assertNotNull("getChild(1) returns a non null value",
                 actionDoAnalogAction.getChild(1));
-        
+
         boolean hasThrown = false;
         try {
             actionDoAnalogAction.getChild(2);
@@ -260,12 +260,12 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertEquals("Category matches", Category.COMMON, _base.getCategory());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -276,10 +276,10 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.OTHER;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -292,8 +292,9 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
         conditionalNG.getChild(0).connect(maleSocket);
         _base = actionDoAnalogAction;
         _baseMaleSocket = maleSocket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -302,5 +303,5 @@ public class DoAnalogActionTest extends AbstractDigitalActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/DoStringActionTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/DoStringActionTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 /**
  * Test DoStringAction
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class DoStringActionTest extends AbstractDigitalActionTestBase {
@@ -26,17 +26,17 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
     LogixNG logixNG;
     ConditionalNG conditionalNG;
     DoStringAction actionDoStringAction;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         StringExpressionBean childExpression = new StringExpressionConstant("IQSE999", null);
@@ -44,7 +44,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 InstanceManager.getDefault(StringExpressionManager.class).registerExpression(childExpression);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -54,7 +54,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 "   !s A%n" +
                 "      Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -67,22 +67,22 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 "            !s A%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new DoStringAction(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Assert.assertNotNull("exists", new DoStringAction("IQDA321", null));
     }
-    
+
     @Test
     public void testCtorAndSetup1() {
         DoStringAction expression = new DoStringAction("IQDA321", null);
@@ -92,7 +92,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
         expression.setStringExpressionSocketSystemName("IQSE52");
         expression.getChild(1).setName("ZH12");
         expression.setStringActionSocketSystemName("IQSA554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -101,7 +101,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -109,13 +109,13 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load string expression IQSE52");
         jmri.util.JUnitAppender.assertMessage("cannot load string action IQSA554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -124,7 +124,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -132,10 +132,10 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup2() {
         DoStringAction expression = new DoStringAction("IQDA321", null);
@@ -145,7 +145,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
         expression.setStringExpressionSocketSystemName(null);
         expression.getChild(1).setName("ZH12");
         expression.setStringActionSocketSystemName(null);
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -154,7 +154,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -162,10 +162,10 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -174,7 +174,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -182,18 +182,18 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup3() {
         StringExpressionManager m0 = InstanceManager.getDefault(StringExpressionManager.class);
         StringActionManager m1 = InstanceManager.getDefault(StringActionManager.class);
-        
+
         m0.registerExpression(new StringExpressionMemory("IQSE52", null));
         m1.registerAction(new StringActionMemory("IQSA554", null));
-        
+
         DoStringAction expression = new DoStringAction("IQDA321", null);
         Assert.assertNotNull("exists", expression);
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
@@ -201,7 +201,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
         expression.setStringExpressionSocketSystemName("IQSE52");
         expression.getChild(1).setName("ZH12");
         expression.setStringActionSocketSystemName("IQSA554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -210,7 +210,7 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -218,39 +218,39 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(0).isConnected());
 //        Assert.assertEquals("child is correct bean",
 //                childSocket0,
 //                expression.getChild(0).getConnectedSocket());
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(1).isConnected());
 //        Assert.assertEquals("child is correct bean",
 //                childSocket1,
 //                expression.getChild(1).getConnectedSocket());
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         expression.setup();
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 2", 2 == actionDoStringAction.getChildCount());
-        
+
         Assert.assertNotNull("getChild(0) returns a non null value",
                 actionDoStringAction.getChild(0));
         Assert.assertNotNull("getChild(1) returns a non null value",
                 actionDoStringAction.getChild(1));
-        
+
         boolean hasThrown = false;
         try {
             actionDoStringAction.getChild(2);
@@ -260,12 +260,12 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertEquals("Category matches", Category.COMMON, _base.getCategory());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -276,10 +276,10 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.OTHER;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -292,8 +292,9 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
         conditionalNG.getChild(0).connect(maleSocket);
         _base = actionDoStringAction;
         _baseMaleSocket = maleSocket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -302,5 +303,5 @@ public class DoStringActionTest extends AbstractDigitalActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ExecuteDelayedTest.java
@@ -235,6 +235,7 @@ public class ExecuteDelayedTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket = maleSocket;
 
         if (! _logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        _logixNG.activate();
         _logixNG.setEnabled(false);
     }
 

--- a/java/test/jmri/jmrit/logixng/actions/ForTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ForTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 /**
  * Test TableForEach
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class ForTest extends AbstractDigitalActionTestBase {
@@ -33,17 +33,17 @@ public class ForTest extends AbstractDigitalActionTestBase {
     ConditionalNG _conditionalNG;
     For _for;
     MaleSocket _maleSocket;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return _conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return _logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         DigitalMany action = new DigitalMany("IQDA999", null);
@@ -51,7 +51,7 @@ public class ForTest extends AbstractDigitalActionTestBase {
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
         return maleSocket;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -67,7 +67,7 @@ public class ForTest extends AbstractDigitalActionTestBase {
                 "   ! Do%n" +
                 "      Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -86,17 +86,17 @@ public class ForTest extends AbstractDigitalActionTestBase {
                 "            ! Do%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new TableForEach(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         TableForEach t = new TableForEach("IQDA321", null);
@@ -104,7 +104,7 @@ public class ForTest extends AbstractDigitalActionTestBase {
         t = new TableForEach("IQDA321", null);
         Assert.assertNotNull("exists",t);
     }
-/* DISABLE FOR NOW    
+/* DISABLE FOR NOW
     @Test
     public void testCtorAndSetup1() {
         TableForEach action = new TableForEach("IQDA321", null);
@@ -112,7 +112,7 @@ public class ForTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals("action has 1 female socket", 1, action.getChildCount());
         action.getChild(0).setName("ZH12");
         action.setTimerActionSocketSystemName("IQDA554");
-        
+
         Assert.assertEquals("action female socket name is ZH12",
                 "ZH12", action.getChild(0).getName());
         Assert.assertEquals("action female socket is of correct class",
@@ -120,12 +120,12 @@ public class ForTest extends AbstractDigitalActionTestBase {
                 action.getChild(0).getClass().getName());
         Assert.assertFalse("action female socket is not connected",
                 action.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load digital action IQDA554");
-        
+
         Assert.assertEquals("action female socket name is ZH12",
                 "ZH12", action.getChild(0).getName());
         Assert.assertEquals("action female socket is of correct class",
@@ -133,10 +133,10 @@ public class ForTest extends AbstractDigitalActionTestBase {
                 action.getChild(0).getClass().getName());
         Assert.assertFalse("action female socket is not connected",
                 action.getChild(0).isConnected());
-        
+
         Assert.assertEquals("action has 1 female socket", 1, action.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup2() {
         TableForEach action = new TableForEach("IQDA321", null);
@@ -144,7 +144,7 @@ public class ForTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals("action has 1 female socket", 1, action.getChildCount());
         action.getChild(0).setName("ZH12");
         action.setTimerActionSocketSystemName(null);
-        
+
         Assert.assertEquals("action female socket name is ZH12",
                 "ZH12", action.getChild(0).getName());
         Assert.assertEquals("action female socket is of correct class",
@@ -152,10 +152,10 @@ public class ForTest extends AbstractDigitalActionTestBase {
                 action.getChild(0).getClass().getName());
         Assert.assertFalse("action female socket is not connected",
                 action.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         Assert.assertEquals("action female socket name is ZH12",
                 "ZH12", action.getChild(0).getName());
         Assert.assertEquals("action female socket is of correct class",
@@ -163,22 +163,22 @@ public class ForTest extends AbstractDigitalActionTestBase {
                 action.getChild(0).getClass().getName());
         Assert.assertFalse("action female socket is not connected",
                 action.getChild(0).isConnected());
-        
+
         Assert.assertEquals("action has 1 female socket", 1, action.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup3() {
         DigitalActionManager m1 = InstanceManager.getDefault(DigitalActionManager.class);
-        
+
         MaleSocket childSocket0 = m1.registerAction(new ActionMemory("IQDA554", null));
-        
+
         TableForEach action = new TableForEach("IQDA321", null);
         Assert.assertNotNull("exists", action);
         Assert.assertEquals("action has 1 female socket", 1, action.getChildCount());
         action.getChild(0).setName("ZH12");
         action.setTimerActionSocketSystemName("IQDA554");
-        
+
         Assert.assertEquals("action female socket name is ZH12",
                 "ZH12", action.getChild(0).getName());
         Assert.assertEquals("action female socket is of correct class",
@@ -186,31 +186,31 @@ public class ForTest extends AbstractDigitalActionTestBase {
                 action.getChild(0).getClass().getName());
         Assert.assertFalse("action female socket is not connected",
                 action.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         Assert.assertTrue("action female socket is connected",
                 action.getChild(0).isConnected());
         Assert.assertEquals("child is correct bean",
                 childSocket0,
                 action.getChild(0).getConnectedSocket());
-        
+
         Assert.assertEquals("action has 1 female sockets", 1, action.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         action.setup();
-        
+
         Assert.assertEquals("action has 1 female sockets", 1, action.getChildCount());
     }
-*/    
+*/
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 4", 4 == _for.getChildCount());
-        
+
         Assert.assertNotNull("getChild(0) returns a non null value",
                 _for.getChild(0));
-        
+
         boolean hasThrown = false;
         try {
             _for.getChild(4);
@@ -220,12 +220,12 @@ public class ForTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         TableForEach a1 = new TableForEach("IQDA321", null);
@@ -233,22 +233,22 @@ public class ForTest extends AbstractDigitalActionTestBase {
         TableForEach a2 = new TableForEach("IQDA321", null);
         Assert.assertEquals("strings are equal", "Table: For each column of row \"\" in table \"''\" set variable \"\" and execute action A1", a2.getLongDescription());
     }
-    
+
     @Test
     public void testExecute()
             throws IOException, SocketAlreadyConnectedException, ParserException {
-        
+
         Memory result = InstanceManager.getDefault(MemoryManager.class).provide("IM_RESULT");
 //        Memory debug = InstanceManager.getDefault(MemoryManager.class).provide("IM_DEBUG");
         DigitalActionManager digitalActionManager = InstanceManager.getDefault(DigitalActionManager.class);
         DigitalExpressionManager digitalExpressionManager = InstanceManager.getDefault(DigitalExpressionManager.class);
-        
+
         _maleSocket.addLocalVariable("MyVariable", SymbolTable.InitialValueType.None, null);
-        
+
         _logixNG.setEnabled(false);
-        
+
         _for.getChild(0).disconnect();
-        
+
         // Calculate the first 10 fibonacci numbers
         _maleSocket.addLocalVariable("n", SymbolTable.InitialValueType.None, null);         // n
         _maleSocket.addLocalVariable("fn_2", SymbolTable.InitialValueType.None, null);      // f(n-2)
@@ -256,138 +256,138 @@ public class ForTest extends AbstractDigitalActionTestBase {
         _maleSocket.addLocalVariable("fn", SymbolTable.InitialValueType.None, null);        // f(n)
         _maleSocket.addLocalVariable("N", SymbolTable.InitialValueType.Formula, "10");      // N
         _maleSocket.addLocalVariable("result", SymbolTable.InitialValueType.None, null);    // result
-        
+
 //        _maleSocket.addLocalVariable("debug", SymbolTable.InitialValueType.None, null);
-        
+
         MaleSocket m1 = digitalActionManager.registerAction(
                 new DigitalMany(digitalActionManager.getAutoSystemName(), null));
-        
+
         ActionLocalVariable lv = new ActionLocalVariable(digitalActionManager.getAutoSystemName(), null);
         lv.setLocalVariable("n");
         lv.setVariableOperation(ActionLocalVariable.VariableOperation.CalculateFormula);
         lv.setFormula("2");
         m1.getChild(0).connect(digitalActionManager.registerAction(lv));
-        
+
         lv = new ActionLocalVariable(digitalActionManager.getAutoSystemName(), null);
         lv.setLocalVariable("fn_2");
         lv.setVariableOperation(ActionLocalVariable.VariableOperation.CalculateFormula);
         lv.setFormula("0");
         m1.getChild(1).connect(digitalActionManager.registerAction(lv));
-        
+
         lv = new ActionLocalVariable(digitalActionManager.getAutoSystemName(), null);
         lv.setLocalVariable("fn_1");
         lv.setVariableOperation(ActionLocalVariable.VariableOperation.CalculateFormula);
         lv.setFormula("1");
         m1.getChild(2).connect(digitalActionManager.registerAction(lv));
-        
+
         lv = new ActionLocalVariable(digitalActionManager.getAutoSystemName(), null);
         lv.setLocalVariable("result");
         lv.setVariableOperation(ActionLocalVariable.VariableOperation.SetToString);
         lv.setConstantValue("0, 1");
         m1.getChild(3).connect(digitalActionManager.registerAction(lv));
-/*        
+/*
         lv = new ActionLocalVariable(digitalActionManager.getAutoSystemName(), null);
         lv.setVariable("debug");
         lv.setVariableOperation(ActionLocalVariable.VariableOperation.SetToString);
         lv.setData("");
         m1.getChild(4).connect(digitalActionManager.registerAction(lv));
-*/        
+*/
         _for.getChild(0).connect(m1);
-        
-        
+
+
         DigitalFormula formula = new DigitalFormula(digitalExpressionManager.getAutoSystemName(), null);
         formula.setFormula("n < N");
         _for.getChild(1).connect(digitalExpressionManager.registerExpression(formula));
-        
-        
+
+
         lv = new ActionLocalVariable(digitalActionManager.getAutoSystemName(), null);
         lv.setLocalVariable("n");
         lv.setVariableOperation(ActionLocalVariable.VariableOperation.CalculateFormula);
         lv.setFormula("n + 1");
         _for.getChild(2).connect(digitalActionManager.registerAction(lv));
-        
-        
+
+
         m1 = digitalActionManager.registerAction(
                 new DigitalMany(digitalActionManager.getAutoSystemName(), null));
-        
+
         lv = new ActionLocalVariable(digitalActionManager.getAutoSystemName(), null);
         lv.setLocalVariable("fn");
         lv.setVariableOperation(ActionLocalVariable.VariableOperation.CalculateFormula);
         lv.setFormula("fn_1 + fn_2");
         m1.getChild(0).connect(digitalActionManager.registerAction(lv));
-        
+
         lv = new ActionLocalVariable(digitalActionManager.getAutoSystemName(), null);
         lv.setLocalVariable("fn_2");
         lv.setVariableOperation(ActionLocalVariable.VariableOperation.CalculateFormula);
         lv.setFormula("fn_1");
         m1.getChild(1).connect(digitalActionManager.registerAction(lv));
-        
+
         lv = new ActionLocalVariable(digitalActionManager.getAutoSystemName(), null);
         lv.setLocalVariable("fn_1");
         lv.setVariableOperation(ActionLocalVariable.VariableOperation.CalculateFormula);
         lv.setFormula("fn");
         m1.getChild(2).connect(digitalActionManager.registerAction(lv));
-        
+
         lv = new ActionLocalVariable(digitalActionManager.getAutoSystemName(), null);
         lv.setLocalVariable("result");
         lv.setVariableOperation(ActionLocalVariable.VariableOperation.CalculateFormula);
         lv.setFormula("result + \", \" + str(fn)");
         m1.getChild(3).connect(digitalActionManager.registerAction(lv));
-        
+
         ActionMemory lm = new ActionMemory(digitalActionManager.getAutoSystemName(), null);
         lm.setMemory("IM_RESULT");
         lm.setMemoryOperation(ActionMemory.MemoryOperation.CopyVariableToMemory);
         lm.setOtherLocalVariable("result");
         m1.getChild(4).connect(digitalActionManager.registerAction(lm));
-/*        
+/*
         lv = new ActionLocalVariable(digitalActionManager.getAutoSystemName(), null);
         lv.setVariable("debug");
         lv.setVariableOperation(ActionLocalVariable.VariableOperation.CalculateFormula);
         lv.setFormula("debug + format(\"N: %d, n: %d, fn_2: %d, fn_1: %d, fn: %d, result: %s%n\", N, n, fn_2, fn_1, fn, result)");
         m1.getChild(5).connect(digitalActionManager.registerAction(lv));
-        
+
         lm = new ActionMemory(digitalActionManager.getAutoSystemName(), null);
         lm.setMemory("IM_DEBUG");
         lm.setMemoryOperation(ActionMemory.MemoryOperation.CopyVariableToMemory);
         lm.setData("debug");
         m1.getChild(6).connect(digitalActionManager.registerAction(lm));
-*/        
+*/
         _for.getChild(3).connect(m1);
-        
-        
+
+
         _logixNG.setEnabled(true);
-        
+
 //        SymbolTable symbolTable =
 //                InstanceManager.getDefault(LogixNG_Manager.class).getSymbolTable();
-        
+
 //        System.out.format("N: %s%n", symbolTable.getValue("N"));
 //        System.out.format("n: %s%n", symbolTable.getValue("n"));
 //        System.out.format("fn_1: %s%n", symbolTable.getValue("fn_1"));
 //        System.out.format("fn: %s%n", symbolTable.getValue("fn"));
 //        System.out.format("result: %s%n", symbolTable.getValue("result"));
 //        System.out.format("result: %s%n", result.getValue());
-        
+
 //        System.out.format("%n%n%ndebug: %s%n", debug.getValue());
-        
+
         // The memory "result" should have a list of the first 10 fibonacci numbers
         Assert.assertEquals("0, 1, 1, 2, 3, 5, 8, 13, 21, 34",
                 result.getValue());
     }
-    
+
     @Test
     @Override
     public void testIsActive() {
         _logixNG.setEnabled(true);
         super.testIsActive();
     }
-    
+
     @Test
     @Override
     public void testMaleSocketIsActive() {
         _logixNG.setEnabled(true);
         super.testMaleSocketIsActive();
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -398,10 +398,10 @@ public class ForTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.OTHER;
         _isExternal = false;
-        
+
         _logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         _conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(_conditionalNG);
@@ -414,12 +414,13 @@ public class ForTest extends AbstractDigitalActionTestBase {
         _conditionalNG.getChild(0).connect(_maleSocket);
         _base = _for;
         _baseMaleSocket = _maleSocket;
-        
+
         _for.getChild(0).connect(InstanceManager.getDefault(DigitalActionManager.class)
                 .registerAction(new DigitalMany(
                         InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null)));
-        
+
         if (! _logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        _logixNG.activate();
         _logixNG.setEnabled(false);
     }
 
@@ -436,5 +437,5 @@ public class ForTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket = null;
         _maleSocket = null;
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/IfThenElseTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/IfThenElseTest.java
@@ -15,7 +15,7 @@ import org.junit.*;
 
 /**
  * Test IfThenElse
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class IfThenElseTest extends AbstractDigitalActionTestBase {
@@ -23,17 +23,17 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
     LogixNG logixNG;
     ConditionalNG conditionalNG;
     IfThenElse actionIfThenElse;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         DigitalExpressionBean childExpression = new True("IQDE999", null);
@@ -41,7 +41,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(childExpression);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -53,7 +53,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 "   ! Else%n" +
                 "      Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -68,17 +68,17 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new IfThenElse(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         IfThenElse t = new IfThenElse("IQDA321", null);
@@ -88,7 +88,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
         t.setType(IfThenElse.Type.AlwaysExecute);
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testCtorAndSetup1() {
         IfThenElse expression = new IfThenElse("IQDA321", null);
@@ -101,7 +101,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
         expression.setThenActionSocketSystemName("IQDA554");
         expression.getChild(2).setName("Bj23");
         expression.setElseActionSocketSystemName("IQDA594");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -110,7 +110,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -118,7 +118,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is Bj23",
                 "Bj23", expression.getChild(2).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -126,14 +126,14 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(2).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(2).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load digital expression IQDE52");
         jmri.util.JUnitAppender.assertMessage("cannot load digital action IQDA554");
         jmri.util.JUnitAppender.assertMessage("cannot load digital action IQDA594");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -142,7 +142,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -150,7 +150,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is Bj23",
                 "Bj23", expression.getChild(2).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -158,10 +158,10 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(2).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(2).isConnected());
-        
+
         Assert.assertEquals("expression has 3 female sockets", 3, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup2() {
         IfThenElse expression = new IfThenElse("IQDA321", null);
@@ -174,7 +174,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
         expression.setThenActionSocketSystemName(null);
         expression.getChild(2).setName("Bj23");
         expression.setElseActionSocketSystemName(null);
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -183,7 +183,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -191,7 +191,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is Bj23",
                 "Bj23", expression.getChild(2).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -199,10 +199,10 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(2).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(2).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -211,7 +211,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -219,7 +219,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is Bj23",
                 "Bj23", expression.getChild(2).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -227,19 +227,19 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(2).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(2).isConnected());
-        
+
         Assert.assertEquals("expression has 3 female sockets", 3, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup3() {
         DigitalExpressionManager m0 = InstanceManager.getDefault(DigitalExpressionManager.class);
         DigitalActionManager m1 = InstanceManager.getDefault(DigitalActionManager.class);
-        
+
         MaleSocket childSocket0 = m0.registerExpression(new ExpressionMemory("IQDE52", null));
         MaleSocket childSocket1 = m1.registerAction(new ActionMemory("IQDA554", null));
         MaleSocket childSocket2 = m1.registerAction(new ActionMemory("IQDA594", null));
-        
+
         IfThenElse expression = new IfThenElse("IQDA321", null);
         expression.setType(IfThenElse.Type.ExecuteOnChange);
         Assert.assertNotNull("exists", expression);
@@ -250,7 +250,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
         expression.setThenActionSocketSystemName("IQDA554");
         expression.getChild(2).setName("Bj23");
         expression.setElseActionSocketSystemName("IQDA594");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -259,7 +259,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -267,7 +267,7 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is Bj23",
                 "Bj23", expression.getChild(2).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -275,49 +275,49 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
                 expression.getChild(2).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(2).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(0).isConnected());
         Assert.assertEquals("child is correct bean",
                 childSocket0,
                 expression.getChild(0).getConnectedSocket());
         Assert.assertEquals("expression has 3 female sockets", 3, expression.getChildCount());
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(1).isConnected());
         Assert.assertEquals("child is correct bean",
                 childSocket1,
                 expression.getChild(1).getConnectedSocket());
         Assert.assertEquals("expression has 3 female sockets", 3, expression.getChildCount());
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(2).isConnected());
         Assert.assertEquals("child is correct bean",
                 childSocket2,
                 expression.getChild(2).getConnectedSocket());
-        
+
         Assert.assertEquals("expression has 3 female sockets", 3, expression.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         expression.setup();
-        
+
         Assert.assertEquals("expression has 3 female sockets", 3, expression.getChildCount());
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 3", 3 == actionIfThenElse.getChildCount());
-        
+
         Assert.assertNotNull("getChild(0) returns a non null value",
                 actionIfThenElse.getChild(0));
         Assert.assertNotNull("getChild(1) returns a non null value",
                 actionIfThenElse.getChild(1));
         Assert.assertNotNull("getChild(2) returns a non null value",
                 actionIfThenElse.getChild(2));
-        
+
         boolean hasThrown = false;
         try {
             actionIfThenElse.getChild(3);
@@ -327,25 +327,25 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testToString() {
         IfThenElse action = new IfThenElse("IQDA321", null);
         action.setType(IfThenElse.Type.ExecuteOnChange);
         Assert.assertEquals("strings are equal", "If Then Else", action.getShortDescription());
         Assert.assertEquals("strings are equal", "If Then Else. Execute on change", action.getLongDescription());
-        
+
         action = new IfThenElse("IQDA321", null);
         action.setType(IfThenElse.Type.AlwaysExecute);
         Assert.assertEquals("strings are equal", "If Then Else", action.getShortDescription());
         Assert.assertEquals("strings are equal", "If Then Else. Always execute", action.getLongDescription());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -355,13 +355,13 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initConfigureManager();
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
-        
+
         InstanceManager.getDefault(LogixNGPreferences.class).setInstallDebugger(false);
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.COMMON;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -373,21 +373,22 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionIfThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         ExpressionSensor expressionSensor = new ExpressionSensor("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionSensor);
         actionIfThenElse.getChild(0).connect(maleSocket2);
-        
+
         ActionTurnout actionTurnout = new ActionTurnout("IQDA322", null);
         maleSocket2 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionTurnout);
         actionIfThenElse.getChild(1).connect(maleSocket2);
-        
+
         _base = actionIfThenElse;
         _baseMaleSocket = maleSocket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -396,5 +397,5 @@ public class IfThenElseTest extends AbstractDigitalActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/LogixTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/LogixTest.java
@@ -16,7 +16,7 @@ import org.junit.*;
 
 /**
  * Test Logix
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class LogixTest extends AbstractDigitalActionTestBase {
@@ -24,17 +24,17 @@ public class LogixTest extends AbstractDigitalActionTestBase {
     LogixNG logixNG;
     ConditionalNG conditionalNG;
     Logix actionLogix;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         DigitalExpressionBean childExpression = new True("IQDE999", null);
@@ -42,7 +42,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(childExpression);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -54,7 +54,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 "         ! A%n" +
                 "            Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -69,17 +69,17 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 "                  ! A%n" +
                 "                     Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new Logix(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         DigitalActionBean t = new Logix("IQDA321", null);
@@ -87,7 +87,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         t = new Logix("IQDA321", null);
         Assert.assertNotNull("exists",t);
     }
-    
+
     @Test
     public void testCtorAndSetup1() {
         Logix expression = new Logix("IQDA321", null);
@@ -97,7 +97,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         expression.setExpressionSocketSystemName("IQDE52");
         expression.getChild(1).setName("ZH12");
         expression.setActionSocketSystemName("IQDB554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -106,7 +106,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -114,13 +114,13 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load digital expression IQDE52");
         jmri.util.JUnitAppender.assertMessage("cannot load digital boolean action IQDB554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -129,7 +129,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -137,10 +137,10 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup2() {
         Logix expression = new Logix("IQDA321", null);
@@ -150,7 +150,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         expression.setExpressionSocketSystemName(null);
         expression.getChild(1).setName("ZH12");
         expression.setActionSocketSystemName(null);
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -159,7 +159,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -167,10 +167,10 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -179,7 +179,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -187,18 +187,18 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup3() {
         DigitalExpressionManager m0 = InstanceManager.getDefault(DigitalExpressionManager.class);
         DigitalBooleanActionManager m1 = InstanceManager.getDefault(DigitalBooleanActionManager.class);
-        
+
         m0.registerExpression(new ExpressionMemory("IQDE52", null));
         m1.registerAction(new DigitalBooleanOnChange("IQDB554", null, DigitalBooleanOnChange.Trigger.CHANGE));
-        
+
         Logix expression = new Logix("IQDA321", null);
         Assert.assertNotNull("exists", expression);
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
@@ -206,7 +206,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         expression.setExpressionSocketSystemName("IQDE52");
         expression.getChild(1).setName("ZH12");
         expression.setActionSocketSystemName("IQDB554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -215,7 +215,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -223,41 +223,41 @@ public class LogixTest extends AbstractDigitalActionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(0).isConnected());
 //        Assert.assertEquals("child is correct bean",
 //                childSocket0,
 //                expression.getChild(0).getConnectedSocket());
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(1).isConnected());
 //        Assert.assertEquals("child is correct bean",
 //                childSocket1,
 //                expression.getChild(1).getConnectedSocket());
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         expression.setup();
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 2", 2 == actionLogix.getChildCount());
-        
+
         Assert.assertNotNull("getChild(0) returns a non null value",
                 actionLogix.getChild(0));
         Assert.assertNotNull("getChild(1) returns a non null value",
                 actionLogix.getChild(1));
-        
+
         boolean hasThrown = false;
         try {
             actionLogix.getChild(2);
@@ -267,7 +267,7 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testToString() {
         DigitalActionBean a1 = new Logix("IQDA321", null);
@@ -275,12 +275,12 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         DigitalActionBean a2 = new Logix("IQDA321", null);
         Assert.assertEquals("strings are equal", "Logix", a2.getLongDescription());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.OTHER == _base.getCategory());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -291,10 +291,10 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.COMMON;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -305,21 +305,22 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionLogix);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         ExpressionSensor expressionSensor = new ExpressionSensor("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionSensor);
         actionLogix.getChild(0).connect(maleSocket2);
-        
+
         DigitalBooleanOnChange actionOnChange = new DigitalBooleanOnChange("IQDB4", null, DigitalBooleanOnChange.Trigger.CHANGE);
         maleSocket2 =
                 InstanceManager.getDefault(DigitalBooleanActionManager.class).registerAction(actionOnChange);
         actionLogix.getChild(1).connect(maleSocket2);
-        
+
         _base = actionLogix;
         _baseMaleSocket = maleSocket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -328,5 +329,5 @@ public class LogixTest extends AbstractDigitalActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/ShutdownComputerTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ShutdownComputerTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 
 /**
  * Test ShutdownComputer
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
@@ -26,27 +26,27 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
     private ConditionalNG conditionalNG;
     private ShutdownComputer actionShutdownComputer;
     private MockShutDownManager mockShutDownManager;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Shutdown JMRI/computer: Shut down JMRI ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -55,26 +55,26 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
                 "      ! A%n" +
                 "         Shutdown JMRI/computer: Shut down JMRI ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ShutdownComputer(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Assert.assertNotNull("exists", new ShutdownComputer("IQDA321", null));
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == actionShutdownComputer.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             actionShutdownComputer.getChild(0);
@@ -84,12 +84,12 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.OTHER == _base.getCategory());
     }
-    
+
     @Test
     @Override
     public void testMaleSocketIsActive() {
@@ -97,7 +97,7 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
         JUnitAppender.assertErrorMessage("Shutdown failed");
         JUnitAppender.assertErrorMessage("Shutdown failed");
     }
-    
+
     @Test
     @Override
     public void testIsActive() {
@@ -105,32 +105,32 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
         JUnitAppender.assertErrorMessage("Shutdown failed");
         JUnitAppender.assertErrorMessage("Shutdown failed");
     }
-    
+
     @Test
     public void testExecute() throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
         ShutdownComputer action = new ShutdownComputer("IQDA321", null);
-        
+
         action.setOperation(ShutdownComputer.Operation.ShutdownComputer);
         action.execute();
         Assert.assertEquals(MockShutDownManager.Result.SHUTDOWN_OS, mockShutDownManager.result);
         JUnitAppender.assertErrorMessage("Shutdown failed");
-        
+
         action.setOperation(ShutdownComputer.Operation.RebootComputer);
         action.execute();
         Assert.assertEquals(MockShutDownManager.Result.RESTART_OS, mockShutDownManager.result);
         JUnitAppender.assertErrorMessage("Shutdown failed");
-        
+
         action.setOperation(ShutdownComputer.Operation.ShutdownJMRI);
         action.execute();
         Assert.assertEquals(MockShutDownManager.Result.SHUTDOWN_JMRI, mockShutDownManager.result);
         JUnitAppender.assertErrorMessage("Shutdown failed");
-        
+
         action.setOperation(ShutdownComputer.Operation.RebootJMRI);
         action.execute();
         Assert.assertEquals(MockShutDownManager.Result.RESTART_JMRI, mockShutDownManager.result);
         JUnitAppender.assertErrorMessage("Shutdown failed");
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -141,13 +141,13 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager(true);
-        
+
         mockShutDownManager = new MockShutDownManager();
         InstanceManager.setDefault(ShutDownManager.class, mockShutDownManager);
-        
+
         _category = Category.OTHER;
         _isExternal = true;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -160,31 +160,32 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
         conditionalNG.getChild(0).connect(maleSocket);
         _base = actionShutdownComputer;
         _baseMaleSocket = maleSocket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
-    
+
     @After
     public void tearDown() {
         JUnitAppender.assertErrorMessage("Shutdown failed");
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
-    
-    
+
+
+
     private static class MockShutDownManager extends DefaultShutDownManager {
-        
+
         public enum Result {
             SHUTDOWN_JMRI,
             SHUTDOWN_OS,
             RESTART_JMRI,
             RESTART_OS,
         }
-        
+
         public Result result = null;
-        
+
         @Override
         public boolean shutdown() {
             result = Result.SHUTDOWN_JMRI;
@@ -209,8 +210,8 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
             return true;
         }
     }
-    
-    
+
+
     /**
      * Exception thrown by restartOS() when simulating shutdown.
      */
@@ -234,5 +235,5 @@ public class ShutdownComputerTest extends AbstractDigitalActionTestBase {
      */
     public static class ShutdownException extends RuntimeException {
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/StringActionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/StringActionMemoryTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 /**
  * Test StringActionMemory
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class StringActionMemoryTest extends AbstractStringActionTestBase {
@@ -31,27 +31,27 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
     LogixNG logixNG;
     ConditionalNG conditionalNG;
     protected Memory _memory;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Set memory IM1 ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -64,47 +64,47 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
                 "            !s A%n" +
                 "               Set memory IM1 ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new StringMany(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Assert.assertTrue("object exists", _base != null);
-        
+
         StringActionMemory action2;
         Assert.assertNotNull("memory is not null", _memory);
         _memory.setValue(10.2);
-        
+
         action2 = new StringActionMemory("IQSA11", null);
         Assert.assertNotNull("object exists", action2);
         Assert.assertTrue("Username matches", null == action2.getUserName());
         Assert.assertEquals("String matches", "Set memory none", action2.getLongDescription());
-        
+
         action2 = new StringActionMemory("IQSA11", "My memory");
         Assert.assertNotNull("object exists", action2);
         Assert.assertTrue("Username matches", "My memory".equals(action2.getUserName()));
         Assert.assertEquals("String matches", "Set memory none", action2.getLongDescription());
-        
+
         action2 = new StringActionMemory("IQSA11", null);
         action2.setMemory(_memory);
         Assert.assertNotNull("object exists", action2);
         Assert.assertTrue("Username matches", null == action2.getUserName());
         Assert.assertEquals("String matches", "Set memory IM1", action2.getLongDescription());
-        
+
         action2 = new StringActionMemory("IQSA11", "My memory");
         action2.setMemory(_memory);
         Assert.assertNotNull("object exists", action2);
         Assert.assertTrue("Username matches", "My memory".equals(action2.getUserName()));
         Assert.assertEquals("String matches", "Set memory IM1", action2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -113,7 +113,7 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -123,7 +123,7 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testAction() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
         StringActionMemory action = (StringActionMemory)_base;
@@ -135,7 +135,7 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
         action.setValue("Other test");
         Assert.assertEquals("Memory has correct value", "Test", _memory.getValue());
     }
-    
+
     @Test
     public void testMemory() {
         StringActionMemory action = (StringActionMemory)_base;
@@ -143,7 +143,7 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
         Assert.assertNull("Memory is null", action.getMemory());
         ((StringActionMemory)_base).setMemory(_memory);
         Assert.assertTrue("Memory matches", _memory == action.getMemory().getBean());
-        
+
         action.removeMemory();
         Assert.assertNull("Memory is null", action.getMemory());
         Memory otherMemory = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
@@ -153,46 +153,46 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
         ((StringActionMemory)_base).setMemory(memoryHandle);
         Assert.assertTrue("Memory matches", memoryHandle == action.getMemory());
         Assert.assertTrue("Memory matches", otherMemory == action.getMemory().getBean());
-        
+
         action.removeMemory();
         Assert.assertNull("Memory is null", action.getMemory());
         action.setMemory(memoryHandle.getName());
         Assert.assertTrue("Memory matches", memoryHandle == action.getMemory());
-        
+
         // Test setMemory with a memory name that doesn't exists
         action.setMemory("Non existent memory");
         Assert.assertNull("Memory is null", action.getMemory());
         JUnitAppender.assertErrorMessage("memory \"Non existent memory\" is not found");
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Get some other memory for later use
         Memory otherMemory = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
         Assert.assertNotNull("Memory is not null", otherMemory);
         Assert.assertNotEquals("Memory is not equal", _memory, otherMemory);
-        
+
         // Get the expression and set the memory
         StringActionMemory action = (StringActionMemory)_base;
         action.setMemory(_memory);
         Assert.assertEquals("Memory matches", _memory, action.getMemory().getBean());
-        
+
         // Test vetoableChange() for some other propery
         action.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Memory matches", _memory, action.getMemory().getBean());
-        
+
         // Test vetoableChange() for a string
         action.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Memory matches", _memory, action.getMemory().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Memory matches", _memory, action.getMemory().getBean());
-        
+
         // Test vetoableChange() for another memory
         action.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherMemory, null));
         Assert.assertEquals("Memory matches", _memory, action.getMemory().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherMemory, null));
         Assert.assertEquals("Memory matches", _memory, action.getMemory().getBean());
-        
+
         // Test vetoableChange() for its own memory
         boolean thrown = false;
         try {
@@ -201,27 +201,27 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Memory matches", _memory, action.getMemory().getBean());
         action.vetoableChange(new PropertyChangeEvent(this, "DoDelete", _memory, null));
         Assert.assertNull("Memory is null", action.getMemory());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Memory", _base.getShortDescription());
     }
-    
+
     @Test
     public void testLongDescription() {
         Assert.assertTrue("String matches", "Set memory IM1".equals(_base.getLongDescription()));
     }
-    
+
     @Test
     public void testChild() {
         Assert.assertTrue("Num children is zero", 0 == _base.getChildCount());
@@ -234,7 +234,7 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -246,7 +246,7 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initLogixNGManager();
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -265,8 +265,9 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
         stringActionMemory.setMemory(_memory);
         _base = stringActionMemory;
         _baseMaleSocket = maleSocketStringActionMemory;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -276,5 +277,5 @@ public class StringActionMemoryTest extends AbstractStringActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/StringManyTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/StringManyTest.java
@@ -19,24 +19,24 @@ import org.junit.Test;
 
 /**
  * Test Many
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class StringManyTest extends AbstractStringActionTestBase {
 
     LogixNG logixNG;
     ConditionalNG conditionalNG;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         StringMany action = new StringMany("IQSA999", null);
@@ -44,7 +44,7 @@ public class StringManyTest extends AbstractStringActionTestBase {
                 InstanceManager.getDefault(StringActionManager.class).registerAction(action);
         return maleSocket;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -52,7 +52,7 @@ public class StringManyTest extends AbstractStringActionTestBase {
                 "   !s A1%n" +
                 "      Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -67,12 +67,12 @@ public class StringManyTest extends AbstractStringActionTestBase {
                 "                  !s A1%n" +
                 "                     Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new StringMany(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() throws SocketAlreadyConnectedException {
         int count = _base.getChildCount();
@@ -83,7 +83,7 @@ public class StringManyTest extends AbstractStringActionTestBase {
         }
         return true;
     }
-    
+
     @Test
     public void testCtor() {
         StringMany action = new StringMany("IQSA321", null);
@@ -94,19 +94,19 @@ public class StringManyTest extends AbstractStringActionTestBase {
                 "jmri.jmrit.logixng.implementation.DefaultFemaleStringActionSocket",
                 action.getChild(0).getClass().getName());
     }
-    
+
     // Test action when at least one child socket is not connected
     @Test
     public void testCtorAndSetup1() {
         StringActionManager m = InstanceManager.getDefault(StringActionManager.class);
-        
+
         List<MaleSocket> maleSockets = new ArrayList<>();
         maleSockets.add(m.registerAction(new StringActionMemory("IQSA52", null)));
         maleSockets.add(null);  // This is null by purpose
         maleSockets.add(m.registerAction(new StringActionMemory("IQSA554", null)));
         maleSockets.add(null);  // This is null by purpose
         maleSockets.add(m.registerAction(new StringActionMemory("IQSA3", null)));
-        
+
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQSA52"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("ZH12", null));   // This is null by purpose
@@ -114,11 +114,11 @@ public class StringManyTest extends AbstractStringActionTestBase {
         // IQSA61232 doesn't exist by purpose
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("SomethingElse", "IQSA61232"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Yes123", "IQSA3"));
-        
+
         StringMany action = new StringMany("IQSA321", null, actionSystemNames);
         Assert.assertNotNull("exists", action);
         Assert.assertEquals("action has 5 female sockets", 5, action.getChildCount());
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
@@ -129,17 +129,17 @@ public class StringManyTest extends AbstractStringActionTestBase {
             Assert.assertFalse("action female socket is not connected",
                     action.getChild(i).isConnected());
         }
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load string action IQSA61232");
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
                     entry.getKey(), action.getChild(i).getName());
-            
+
             if (maleSockets.get(i) != null) {
                 Assert.assertTrue("action female socket is connected",
                         action.getChild(i).isConnected());
@@ -151,32 +151,32 @@ public class StringManyTest extends AbstractStringActionTestBase {
                         action.getChild(i).isConnected());
             }
         }
-        
+
         Assert.assertEquals("action has 5 female sockets", 5, action.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup2() {
         StringActionManager m = InstanceManager.getDefault(StringActionManager.class);
-        
+
         List<MaleSocket> maleSockets = new ArrayList<>();
         maleSockets.add(m.registerAction(new StringActionMemory("IQSA52", null)));
         maleSockets.add(m.registerAction(new StringActionMemory("IQSA99", null)));
         maleSockets.add(m.registerAction(new StringActionMemory("IQSA554", null)));
         maleSockets.add(m.registerAction(new StringActionMemory("IQSA61232", null)));
         maleSockets.add(m.registerAction(new StringActionMemory("IQSA3", null)));
-        
+
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQSA52"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("ZH12", "IQSA99"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Hello", "IQSA554"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("SomethingElse", "IQSA61232"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Yes123", "IQSA3"));
-        
+
         StringMany action = new StringMany("IQSA321", null, actionSystemNames);
         Assert.assertNotNull("exists", action);
         Assert.assertEquals("action has 5 female sockets", 5, action.getChildCount());
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
@@ -187,15 +187,15 @@ public class StringManyTest extends AbstractStringActionTestBase {
             Assert.assertFalse("action female socket is not connected",
                     action.getChild(i).isConnected());
         }
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("action female socket name is "+entry.getKey(),
                     entry.getKey(), action.getChild(i).getName());
-            
+
             if (maleSockets.get(i) != null) {
                 Assert.assertTrue("action female socket is connected",
                         action.getChild(i).isConnected());
@@ -207,27 +207,27 @@ public class StringManyTest extends AbstractStringActionTestBase {
                         action.getChild(i).isConnected());
             }
         }
-        
+
         Assert.assertEquals("action has 6 female sockets", 6, action.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         action.setup();
-        
+
         Assert.assertEquals("action has 6 female sockets", 6, action.getChildCount());
     }
-    
+
     // Test calling setActionSystemNames() twice
     @Test
     public void testCtorAndSetup3() throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException {
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQSA52"));
-        
+
         StringMany action = new StringMany("IQSA321", null, actionSystemNames);
-        
+
         java.lang.reflect.Method method =
                 action.getClass().getDeclaredMethod("setActionSystemNames", new Class<?>[]{List.class});
         method.setAccessible(true);
-        
+
         boolean hasThrown = false;
         try {
             method.invoke(action, new Object[]{null});
@@ -241,19 +241,19 @@ public class StringManyTest extends AbstractStringActionTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testGetChild() throws SocketAlreadyConnectedException {
         StringMany action2 = new StringMany("IQSA321", null);
-        
+
         for (int i=0; i < 3; i++) {
             Assert.assertTrue("getChildCount() returns "+i, i+1 == action2.getChildCount());
-            
+
             Assert.assertNotNull("getChild(0) returns a non null value",
                     action2.getChild(0));
-            
+
             assertIndexOutOfBoundsException(action2::getChild, i+1, i+1);
-            
+
             // Connect a new child expression
             StringActionMemory expr = new StringActionMemory("IQSA"+i, null);
             MaleSocket maleSocket =
@@ -261,23 +261,23 @@ public class StringManyTest extends AbstractStringActionTestBase {
             action2.getChild(i).connect(maleSocket);
         }
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
-    
+
     // Test the methods connected(FemaleSocket) and getActionSystemName(int)
     @Test
     public void testConnected_getActionSystemName() throws SocketAlreadyConnectedException {
         StringMany action = new StringMany("IQSA121", null);
-        
+
         StringActionMemory stringActionMemory = new StringActionMemory("IQSA122", null);
         MaleSocket maleSAMSocket =
                 InstanceManager.getDefault(StringActionManager.class).registerAction(stringActionMemory);
-        
+
         Assert.assertEquals("Num children is correct", 1, action.getChildCount());
-        
+
         // Test connect and disconnect
         action.getChild(0).connect(maleSAMSocket);
         Assert.assertEquals("Num children is correct", 2, action.getChildCount());
@@ -287,7 +287,7 @@ public class StringManyTest extends AbstractStringActionTestBase {
         Assert.assertEquals("Num children is correct", 2, action.getChildCount());
         Assert.assertNull("getActionSystemName(0) is null", action.getActionSystemName(0));
         Assert.assertNull("getActionSystemName(1) is null", action.getActionSystemName(1));
-        
+
         action.getChild(1).connect(maleSAMSocket);
         Assert.assertEquals("Num children is correct", 2, action.getChildCount());
         Assert.assertNull("getActionSystemName(0) is null", action.getActionSystemName(0));
@@ -301,14 +301,14 @@ public class StringManyTest extends AbstractStringActionTestBase {
         Assert.assertNull("getActionSystemName(0) is null", action.getActionSystemName(0));
         Assert.assertNull("getActionSystemName(1) is null", action.getActionSystemName(1));
     }
-    
+
     @Test
     public void testDescription() {
         StringMany action = new StringMany("IQSA121", null);
         Assert.assertEquals("Short description", "Many", action.getShortDescription());
         Assert.assertEquals("Long description", "Many", action.getLongDescription());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -319,31 +319,32 @@ public class StringManyTest extends AbstractStringActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.COMMON;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setEnabled(true);
         conditionalNG.setRunDelayed(false);
         logixNG.addConditionalNG(conditionalNG);
-        
+
         DoStringAction doStringAction = new DoStringAction("IQDA321", null);
         MaleSocket maleSocketDoStringAction =
                 InstanceManager.getDefault(DigitalActionManager.class)
                         .registerAction(doStringAction);
         conditionalNG.getChild(0).connect(maleSocketDoStringAction);
-        
+
         StringMany action = new StringMany("IQSA321", null);
         MaleSocket maleSocket =
                 InstanceManager.getDefault(StringActionManager.class).registerAction(action);
         doStringAction.getChild(1).connect(maleSocket);
         _base = action;
         _baseMaleSocket = maleSocket;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -352,5 +353,5 @@ public class StringManyTest extends AbstractStringActionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/TableForEachTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 /**
  * Test TableForEach
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class TableForEachTest extends AbstractDigitalActionTestBase {
@@ -32,17 +32,17 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
     TableForEach _tableForEach;
     MaleSocket _maleSocket;
     private final List<String> _cells = new ArrayList<>();
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return _conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return _logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         DigitalMany action = new DigitalMany("IQDA999", null);
@@ -50,7 +50,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
         return maleSocket;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -58,7 +58,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
                 "   ! A1%n" +
                 "      MyAction ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -69,17 +69,17 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
                 "            ! A1%n" +
                 "               MyAction ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new TableForEach(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         TableForEach t = new TableForEach("IQDA321", null);
@@ -87,7 +87,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         t = new TableForEach("IQDA321", null);
         Assert.assertNotNull("exists",t);
     }
-/* DISABLE FOR NOW    
+/* DISABLE FOR NOW
     @Test
     public void testCtorAndSetup1() {
         TableForEach action = new TableForEach("IQDA321", null);
@@ -95,7 +95,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals("action has 1 female socket", 1, action.getChildCount());
         action.getChild(0).setName("ZH12");
         action.setTimerActionSocketSystemName("IQDA554");
-        
+
         Assert.assertEquals("action female socket name is ZH12",
                 "ZH12", action.getChild(0).getName());
         Assert.assertEquals("action female socket is of correct class",
@@ -103,12 +103,12 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
                 action.getChild(0).getClass().getName());
         Assert.assertFalse("action female socket is not connected",
                 action.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load digital action IQDA554");
-        
+
         Assert.assertEquals("action female socket name is ZH12",
                 "ZH12", action.getChild(0).getName());
         Assert.assertEquals("action female socket is of correct class",
@@ -116,10 +116,10 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
                 action.getChild(0).getClass().getName());
         Assert.assertFalse("action female socket is not connected",
                 action.getChild(0).isConnected());
-        
+
         Assert.assertEquals("action has 1 female socket", 1, action.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup2() {
         TableForEach action = new TableForEach("IQDA321", null);
@@ -127,7 +127,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         Assert.assertEquals("action has 1 female socket", 1, action.getChildCount());
         action.getChild(0).setName("ZH12");
         action.setTimerActionSocketSystemName(null);
-        
+
         Assert.assertEquals("action female socket name is ZH12",
                 "ZH12", action.getChild(0).getName());
         Assert.assertEquals("action female socket is of correct class",
@@ -135,10 +135,10 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
                 action.getChild(0).getClass().getName());
         Assert.assertFalse("action female socket is not connected",
                 action.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         Assert.assertEquals("action female socket name is ZH12",
                 "ZH12", action.getChild(0).getName());
         Assert.assertEquals("action female socket is of correct class",
@@ -146,22 +146,22 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
                 action.getChild(0).getClass().getName());
         Assert.assertFalse("action female socket is not connected",
                 action.getChild(0).isConnected());
-        
+
         Assert.assertEquals("action has 1 female socket", 1, action.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup3() {
         DigitalActionManager m1 = InstanceManager.getDefault(DigitalActionManager.class);
-        
+
         MaleSocket childSocket0 = m1.registerAction(new ActionMemory("IQDA554", null));
-        
+
         TableForEach action = new TableForEach("IQDA321", null);
         Assert.assertNotNull("exists", action);
         Assert.assertEquals("action has 1 female socket", 1, action.getChildCount());
         action.getChild(0).setName("ZH12");
         action.setTimerActionSocketSystemName("IQDA554");
-        
+
         Assert.assertEquals("action female socket name is ZH12",
                 "ZH12", action.getChild(0).getName());
         Assert.assertEquals("action female socket is of correct class",
@@ -169,31 +169,31 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
                 action.getChild(0).getClass().getName());
         Assert.assertFalse("action female socket is not connected",
                 action.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         action.setup();
-        
+
         Assert.assertTrue("action female socket is connected",
                 action.getChild(0).isConnected());
         Assert.assertEquals("child is correct bean",
                 childSocket0,
                 action.getChild(0).getConnectedSocket());
-        
+
         Assert.assertEquals("action has 1 female sockets", 1, action.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         action.setup();
-        
+
         Assert.assertEquals("action has 1 female sockets", 1, action.getChildCount());
     }
-*/    
+*/
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 1", 1 == _tableForEach.getChildCount());
-        
+
         Assert.assertNotNull("getChild(0) returns a non null value",
                 _tableForEach.getChild(0));
-        
+
         boolean hasThrown = false;
         try {
             _tableForEach.getChild(1);
@@ -203,12 +203,12 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         TableForEach a1 = new TableForEach("IQDA321", null);
@@ -216,46 +216,46 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         TableForEach a2 = new TableForEach("IQDA321", null);
         Assert.assertEquals("strings are equal", "Table: For each column of row \"\" in table \"''\" set variable \"\" and execute action A1", a2.getLongDescription());
     }
-    
+
     @Test
     public void testExecute()
             throws IOException {
-        
+
         _maleSocket.addLocalVariable("MyVariable", SymbolTable.InitialValueType.None, null);
-        
+
         _logixNG.setEnabled(false);
-        
+
         // Load table turnout_and_signals.csv
         NamedTable csvTable =
                 InstanceManager.getDefault(NamedTableManager.class)
                         .loadTableFromCSV("IQT1", null, "program:java/test/jmri/jmrit/logixng/panel_and_data_files/turnout_and_signals.csv");
-        
+
         _tableForEach.setTable(csvTable);
         _tableForEach.setRowOrColumn(TableRowOrColumn.Column);
         _tableForEach.setRowOrColumnName("1");
         _tableForEach.setLocalVariableName("MyVariable");
         _logixNG.setEnabled(true);
-        
+
         Assert.assertEquals("IT1 :::  ::: IH1 :::  :::  ::: IT1 ::: IT3 ::: IH1" +
                 " ::: IH6 :::  ::: IH4 ::: IH6 ::: IT1 ::: IH1 ::: IH3 ::: IH4" +
                 " ::: IH6 ::: IT1 ::: IT3 :::  :::  ::: ",
                 String.join(" ::: ", _cells));
     }
-    
+
     @Test
     @Override
     public void testIsActive() {
         _logixNG.setEnabled(true);
         super.testIsActive();
     }
-    
+
     @Test
     @Override
     public void testMaleSocketIsActive() {
         _logixNG.setEnabled(true);
         super.testMaleSocketIsActive();
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -266,10 +266,10 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.OTHER;
         _isExternal = false;
-        
+
         _logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         _conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(_conditionalNG);
@@ -282,11 +282,12 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         _conditionalNG.getChild(0).connect(_maleSocket);
         _base = _tableForEach;
         _baseMaleSocket = _maleSocket;
-        
+
         _tableForEach.getChild(0).connect(InstanceManager.getDefault(DigitalActionManager.class)
                 .registerAction(new MyAction("IQDA999", null)));
-        
+
         if (! _logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        _logixNG.activate();
         _logixNG.setEnabled(false);
     }
 
@@ -304,8 +305,8 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
         _baseMaleSocket = null;
         _maleSocket = null;
     }
-    
-    
+
+
     private class MyAction extends AbstractDigitalAction {
 
         public MyAction(String sys, String user) throws BadUserNameException, BadSystemNameException {
@@ -373,7 +374,7 @@ public class TableForEachTest extends AbstractDigitalActionTestBase {
             SymbolTable symbolTable = this.getConditionalNG().getSymbolTable();
             _cells.add(symbolTable.getValue("MyVariable").toString());
         }
-        
+
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
@@ -10,7 +10,6 @@ import java.util.*;
 import jmri.*;
 import jmri.jmrit.logixng.*;
 import jmri.jmrit.logixng.Base.PrintTreeSettings;
-import jmri.jmrit.logixng.Module;
 import jmri.jmrit.logixng.util.LogixNG_Thread;
 import jmri.util.*;
 

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionConstantTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionConstantTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 /**
  * Test AnalogExpressionConstant
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBase {
@@ -32,28 +32,28 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
     private AnalogExpressionConstant expressionConstant;
     private Memory _memoryOut;
     private AnalogActionMemory actionMemory;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Get analog constant 10.2 ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -66,48 +66,48 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
                 "            !~ A%n" +
                 "               Set memory IM2 ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new AnalogExpressionConstant(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Assert.assertTrue("object exists", _base != null);
-        
+
         AnalogExpressionConstant expression2;
-        
+
         expression2 = new AnalogExpressionConstant("IQAE11", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", null, expression2.getUserName());
         Assert.assertEquals("String matches", "Get analog constant 0", expression2.getLongDescription(Locale.ENGLISH));
-        
+
         expression2 = new AnalogExpressionConstant("IQAE11", "My constant value");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My constant value", expression2.getUserName());
         Assert.assertEquals("String matches", "Get analog constant 0", expression2.getLongDescription(Locale.ENGLISH));
-        
+
         expression2 = new AnalogExpressionConstant("IQAE11", null);
         expression2.setValue(12.34);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", null, expression2.getUserName());
         Assert.assertEquals("String matches", "Get analog constant 12.34", expression2.getLongDescription(Locale.ENGLISH));
-        
+
         expression2 = new AnalogExpressionConstant("IQAE11", "My constant");
         expression2.setValue(98.76);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My constant", expression2.getUserName());
         Assert.assertEquals("String matches", "Get analog constant 98.76", expression2.getLongDescription(Locale.ENGLISH));
-        
+
         // Call setup(). It doesn't do anything, but we call it for coverage
         expression2.setup();
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -116,7 +116,7 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -126,7 +126,7 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testSetValueWithListenersRegistered() {
         boolean exceptionThrown = false;
@@ -140,7 +140,7 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
         Assert.assertTrue("Exception thrown", exceptionThrown);
         JUnitAppender.assertErrorMessage("setValue must not be called when listeners are registered");
     }
-    
+
     @Test
     public void testEvaluate() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
         // Disable the conditionalNG. This will unregister the listeners
@@ -151,10 +151,10 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
         expression.setValue(10.0d);
         Assert.assertTrue("Evaluate matches", 10.0d == expression.evaluate());
     }
-    
+
     @Test
     public void testEvaluateAndAction() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
-        
+
         // Set the memory
         _memoryOut.setValue(0.0);
         // The double should be 0.0
@@ -163,7 +163,7 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
         logixNG.execute();
         // The action is executed so the double should be 10.2
         Assert.assertTrue("memory is 10.2", 10.2 == (Double)_memoryOut.getValue());
-        
+
         // Disable the conditionalNG
         conditionalNG.setEnabled(false);
         // Set the value of the constant.
@@ -176,22 +176,22 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
         // The action is executed so the double should be 1.0
         Assert.assertTrue("memory is 1.0", 1.0 == (Double)_memoryOut.getValue());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Analog constant", _base.getShortDescription());
     }
-    
+
     @Test
     public void testLongDescription() {
         Assert.assertEquals("String matches", "Get analog constant 10.2", _base.getLongDescription(Locale.ENGLISH));
     }
-    
+
     @Test
     public void testChild() {
         Assert.assertTrue("Num children is zero", 0 == _base.getChildCount());
@@ -204,7 +204,7 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -216,28 +216,28 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initLogixNGManager();
-        
+
         expressionConstant = new AnalogExpressionConstant("IQAE321", null);
         expressionConstant.setValue(10.2);
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A logixNG");
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         logixNG.addConditionalNG(conditionalNG);
-        
+
         DigitalActionBean actionDoAnalog =
                 new DoAnalogAction(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
         MaleSocket socketDoAnalog =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionDoAnalog);
         conditionalNG.getChild(0).connect(socketDoAnalog);
-        
+
         MaleSocket socketExpression =
                 InstanceManager.getDefault(AnalogExpressionManager.class).registerExpression(expressionConstant);
         socketDoAnalog.getChild(0).connect(socketExpression);
-        
+
         _memoryOut = InstanceManager.getDefault(MemoryManager.class).provide("IM2");
         _memoryOut.setValue(0.0);
         actionMemory = new AnalogActionMemory("IQAA1", null);
@@ -245,11 +245,12 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
         MaleSocket socketAction =
                 InstanceManager.getDefault(AnalogActionManager.class).registerAction(actionMemory);
         socketDoAnalog.getChild(1).connect(socketAction);
-        
+
         _base = expressionConstant;
         _baseMaleSocket = socketExpression;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -260,5 +261,5 @@ public class AnalogExpressionConstantTest extends AbstractAnalogExpressionTestBa
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogExpressionMemoryTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 /**
  * Test AnalogExpressionMemory
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase {
@@ -36,28 +36,28 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
     private AnalogExpressionMemory expressionMemory;
     private Memory _memoryOut;
     private AnalogActionMemory actionMemory;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Get memory IM1 as analog value ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -70,47 +70,47 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
                 "            !~ A%n" +
                 "               Set memory IM2 ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new AnalogExpressionMemory(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Assert.assertTrue("object exists", _base != null);
-        
+
         AnalogExpressionMemory expression2;
         Assert.assertNotNull("memory is not null", _memory);
         _memory.setValue(10.2);
-        
+
         expression2 = new AnalogExpressionMemory("IQAE11", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertTrue("Username matches", null == expression2.getUserName());
         Assert.assertEquals("String matches", "Get memory none as analog value", expression2.getLongDescription());
-        
+
         expression2 = new AnalogExpressionMemory("IQAE11", "My memory");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertTrue("Username matches", "My memory".equals(expression2.getUserName()));
         Assert.assertEquals("String matches", "Get memory none as analog value", expression2.getLongDescription());
-        
+
         expression2 = new AnalogExpressionMemory("IQAE11", null);
         expression2.setMemory(_memory);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertTrue("Username matches", null == expression2.getUserName());
         Assert.assertEquals("String matches", "Get memory IM1 as analog value", expression2.getLongDescription());
-        
+
         expression2 = new AnalogExpressionMemory("IQAE11", "My memory");
         expression2.setMemory(_memory);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertTrue("Username matches", "My memory".equals(expression2.getUserName()));
         Assert.assertEquals("String matches", "Get memory IM1 as analog value", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -119,7 +119,7 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -129,7 +129,7 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testEvaluate() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
         // Disable the conditionalNG. This will unregister the listeners
@@ -142,7 +142,7 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         expression.removeMemory();
         Assert.assertTrue("Evaluate matches", 0.0d == expression.evaluate());
     }
-    
+
     @Test
     public void testEvaluateAndAction() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
         // Disable the conditionalNG. This will unregister the listeners
@@ -183,23 +183,23 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         _memory.setValue(5.0);
         // The action should not be executed so the memory should still be 3.0
         Assert.assertTrue("memory is 3.0", 3.0 == (Double)_memoryOut.getValue());
-        
+
         // Test register listeners when there is no memory.
         expressionMemory.removeMemory();
         expressionMemory.registerListeners();
     }
-    
+
     @Test
     public void testMemory() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         AnalogExpressionMemory expressionMemory = (AnalogExpressionMemory)_base;
         expressionMemory.removeMemory();
         Assert.assertNull("Memory is null", expressionMemory.getMemory());
         expressionMemory.setMemory(_memory);
         Assert.assertTrue("Memory matches", _memory == expressionMemory.getMemory().getBean());
-        
+
         expressionMemory.removeMemory();
         Assert.assertNull("Memory is null", expressionMemory.getMemory());
         Memory otherMemory = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
@@ -209,17 +209,17 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         expressionMemory.setMemory(memoryHandle);
         Assert.assertTrue("Memory matches", memoryHandle == expressionMemory.getMemory());
         Assert.assertTrue("Memory matches", otherMemory == expressionMemory.getMemory().getBean());
-        
+
         expressionMemory.removeMemory();
         Assert.assertNull("Memory is null", expressionMemory.getMemory());
         expressionMemory.setMemory(memoryHandle.getName());
         Assert.assertTrue("Memory matches", memoryHandle == expressionMemory.getMemory());
-        
+
         // Test setMemory with a memory name that doesn't exists
         expressionMemory.setMemory("Non existent memory");
         Assert.assertNull("Memory is null", expressionMemory.getMemory());
         JUnitAppender.assertErrorMessage("memory \"Non existent memory\" is not found");
-        
+
         // Test setMemory() when listeners are registered
         expressionMemory.setMemory(_memory);
         Assert.assertNotNull("Memory is null", expressionMemory.getMemory());
@@ -233,7 +233,7 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             expressionMemory.removeMemory();
@@ -242,7 +242,7 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             expressionMemory.removeMemory();
@@ -252,7 +252,7 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
     }
-    
+
     @Test
     public void testRegisterListeners() {
         // Test registerListeners() when the ExpressionMemory has no memory
@@ -260,38 +260,38 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         expressionMemory.removeMemory();
         conditionalNG.setEnabled(true);
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Get some other memory for later use
         Memory otherMemory = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
         Assert.assertNotNull("Memory is not null", otherMemory);
         Assert.assertNotEquals("Memory is not equal", _memory, otherMemory);
-        
+
         // Get the expression and set the memory
         AnalogExpressionMemory expression = (AnalogExpressionMemory)_base;
         expression.setMemory(_memory);
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
-        
+
         // Test vetoableChange() for some other propery
         expression.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
-        
+
         // Test vetoableChange() for a string
         expression.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
         expression.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
-        
+
         // Test vetoableChange() for another memory
         expression.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherMemory, null));
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
         expression.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherMemory, null));
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
-        
+
         // Test vetoableChange() for its own memory
         boolean thrown = false;
         try {
@@ -300,27 +300,27 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
         expression.vetoableChange(new PropertyChangeEvent(this, "DoDelete", _memory, null));
         Assert.assertNull("Memory is null", expression.getMemory());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "Memory as analog value", _base.getShortDescription());
     }
-    
+
     @Test
     public void testLongDescription() {
         Assert.assertEquals("Get memory IM1 as analog value", _base.getLongDescription());
     }
-    
+
     @Test
     public void testChild() {
         Assert.assertTrue("Num children is zero", 0 == _base.getChildCount());
@@ -333,7 +333,7 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -345,31 +345,31 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _memory = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
         Assert.assertNotNull("memory is not null", _memory);
         _memory.setValue(10.2);
         expressionMemory = new AnalogExpressionMemory("IQAE321", null);
         expressionMemory.setMemory(_memory);
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A logixNG");
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         logixNG.addConditionalNG(conditionalNG);
-        
+
         DigitalActionBean actionDoAnalog =
                 new DoAnalogAction(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
         MaleSocket socketDoAnalog =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionDoAnalog);
         conditionalNG.getChild(0).connect(socketDoAnalog);
-        
+
         MaleSocket socketExpression =
                 InstanceManager.getDefault(AnalogExpressionManager.class).registerExpression(expressionMemory);
         socketDoAnalog.getChild(0).connect(socketExpression);
-        
+
         _memoryOut = InstanceManager.getDefault(MemoryManager.class).provide("IM2");
         _memoryOut.setValue(0.0);
         actionMemory = new AnalogActionMemory("IQAA1", null);
@@ -377,11 +377,12 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         MaleSocket socketAction =
                 InstanceManager.getDefault(AnalogActionManager.class).registerAction(actionMemory);
         socketDoAnalog.getChild(1).connect(socketAction);
-        
+
         _base = expressionMemory;
         _baseMaleSocket = socketExpression;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -391,5 +392,5 @@ public class AnalogExpressionMemoryTest extends AbstractAnalogExpressionTestBase
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/AnalogFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AnalogFormulaTest.java
@@ -727,6 +727,7 @@ public class AnalogFormulaTest extends AbstractAnalogExpressionTestBase {
         doAnalogAction.getChild(1).connect(socketAnalogActionMemory);
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/AndTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AndTest.java
@@ -28,25 +28,25 @@ import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
 
 /**
  * Test And
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class AndTest extends AbstractDigitalExpressionTestBase {
 
     private LogixNG logixNG;
     private ConditionalNG conditionalNG;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         DigitalExpressionBean childExpression = new True("IQDE999", null);
@@ -54,7 +54,7 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(childExpression);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -62,7 +62,7 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
                 "   ? E1%n" +
                 "      Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -79,12 +79,12 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new And(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() throws SocketAlreadyConnectedException {
         int count = _base.getChildCount();
@@ -95,21 +95,21 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         }
         return true;
     }
-    
+
     @Test
     public void testCtor() {
         And expression2;
-        
+
         expression2 = new And("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "And", expression2.getLongDescription());
-        
+
         expression2 = new And("IQDE321", "My expression");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My expression", expression2.getUserName());
         Assert.assertEquals("String matches", "And", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -118,7 +118,7 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -128,19 +128,19 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     // Test action when at least one child socket is not connected
     @Test
     public void testCtorAndSetup1() {
         DigitalExpressionManager m = InstanceManager.getDefault(DigitalExpressionManager.class);
-        
+
         List<MaleSocket> maleSockets = new ArrayList<>();
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE52", null)));
         maleSockets.add(null);  // This is null by purpose
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE554", null)));
         maleSockets.add(null);  // This is null by purpose
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE3", null)));
-        
+
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQDE52"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("ZH12", null));   // This is null by purpose
@@ -148,11 +148,11 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         // IQDE61232 doesn't exist by purpose
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("SomethingElse", "IQDE61232"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Yes123", "IQDE3"));
-        
+
         And expression = new And("IQDE321", null, actionSystemNames);
         Assert.assertNotNull("exists", expression);
         Assert.assertEquals("expression has 5 female sockets", 5, expression.getChildCount());
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("expression female socket name is "+entry.getKey(),
@@ -164,17 +164,17 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
             Assert.assertFalse("expression female socket is not connected",
                     expression.getChild(i).isConnected());
         }
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load digital expression IQDE61232");
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("expression female socket name is "+entry.getKey(),
                     entry.getKey(), expression.getChild(i).getName());
-            
+
             if (maleSockets.get(i) != null) {
                 Assert.assertTrue("expression female socket is connected",
                         expression.getChild(i).isConnected());
@@ -186,34 +186,34 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
                         expression.getChild(i).isConnected());
             }
         }
-        
+
         Assert.assertEquals("expression has 5 female sockets", 5, expression.getChildCount());
     }
-    
+
     // Test action when at least one child socket is not connected.
     // This should never happen, but test it anyway.
     @Test
     public void testCtorAndSetup2() {
         DigitalExpressionManager m = InstanceManager.getDefault(DigitalExpressionManager.class);
-        
+
         List<MaleSocket> maleSockets = new ArrayList<>();
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE52", null)));
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE99", null)));
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE554", null)));
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE61232", null)));
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE3", null)));
-        
+
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQDE52"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("ZH12", "IQDE99"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Hello", "IQDE554"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("SomethingElse", "IQDE61232"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Yes123", "IQDE3"));
-        
+
         And expression = new And("IQDE321", null, actionSystemNames);
         Assert.assertNotNull("exists", expression);
         Assert.assertEquals("expression has 5 female sockets", 5, expression.getChildCount());
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("expression female socket name is "+entry.getKey(),
@@ -225,15 +225,15 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
             Assert.assertFalse("expression female socket is not connected",
                     expression.getChild(i).isConnected());
         }
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("expression female socket name is "+entry.getKey(),
                     entry.getKey(), expression.getChild(i).getName());
-            
+
             if (maleSockets.get(i) != null) {
                 Assert.assertTrue("expression female socket is connected",
                         expression.getChild(i).isConnected());
@@ -245,28 +245,28 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
                         expression.getChild(i).isConnected());
             }
         }
-        
+
         // Since all the sockets are connected, a new socket must have been created.
         Assert.assertEquals("expression has 6 female sockets", 6, expression.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         expression.setup();
-        
+
         Assert.assertEquals("expression has 6 female sockets", 6, expression.getChildCount());
     }
-    
+
     // Test calling setActionSystemNames() twice
     @Test
     public void testCtorAndSetup3() throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException {
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQDE52"));
-        
+
         And expression = new And("IQDE321", null, actionSystemNames);
-        
+
         java.lang.reflect.Method method =
                 expression.getClass().getDeclaredMethod("setExpressionSystemNames", new Class<?>[]{List.class});
         method.setAccessible(true);
-        
+
         boolean hasThrown = false;
         try {
             method.invoke(expression, new Object[]{null});
@@ -280,19 +280,19 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testGetChild() throws SocketAlreadyConnectedException {
         And expression2 = new And("IQDE321", null);
-        
+
         for (int i=0; i < 3; i++) {
             Assert.assertTrue("getChildCount() returns "+i, i+1 == expression2.getChildCount());
-            
+
             Assert.assertNotNull("getChild(0) returns a non null value",
                     expression2.getChild(0));
-            
+
             assertIndexOutOfBoundsException(expression2::getChild, i+1, i+1);
-            
+
             // Connect a new child expression
             True expr = new True("IQDE"+i, null);
             MaleSocket maleSocket =
@@ -300,23 +300,23 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
             expression2.getChild(i).connect(maleSocket);
         }
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
-    
+
     // Test the methods connected(FemaleSocket) and getExpressionSystemName(int)
     @Test
     public void testConnected_getExpressionSystemName() throws SocketAlreadyConnectedException {
         And expression = new And("IQDE121", null);
-        
+
         ExpressionMemory stringExpressionMemory = new ExpressionMemory("IQDE122", null);
         MaleSocket maleSAMSocket =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(stringExpressionMemory);
-        
+
         Assert.assertEquals("Num children is correct", 1, expression.getChildCount());
-        
+
         // Test connect and disconnect
         expression.getChild(0).connect(maleSAMSocket);
         Assert.assertEquals("Num children is correct", 2, expression.getChildCount());
@@ -326,7 +326,7 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("Num children is correct", 2, expression.getChildCount());
         Assert.assertNull("getExpressionSystemName(0) is null", expression.getExpressionSystemName(0));
         Assert.assertNull("getExpressionSystemName(1) is null", expression.getExpressionSystemName(1));
-        
+
         expression.getChild(1).connect(maleSAMSocket);
         Assert.assertEquals("Num children is correct", 2, expression.getChildCount());
         Assert.assertNull("getExpressionSystemName(0) is null", expression.getExpressionSystemName(0));
@@ -340,14 +340,14 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         Assert.assertNull("getExpressionSystemName(0) is null", expression.getExpressionSystemName(0));
         Assert.assertNull("getExpressionSystemName(1) is null", expression.getExpressionSystemName(1));
     }
-    
+
     @Test
     public void testDescription() {
         And e1 = new And("IQDE321", null);
         Assert.assertTrue("And".equals(e1.getShortDescription()));
         Assert.assertTrue("And".equals(e1.getLongDescription()));
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -358,10 +358,10 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.COMMON;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -372,16 +372,17 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         DigitalExpressionBean expression = new And("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expression);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expression;
         _baseMaleSocket = maleSocket2;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -390,5 +391,5 @@ public class AndTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/AntecedentTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/AntecedentTest.java
@@ -703,6 +703,7 @@ public class AntecedentTest extends AbstractDigitalExpressionTestBase implements
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/DigitalFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/DigitalFormulaTest.java
@@ -727,6 +727,7 @@ public class DigitalFormulaTest extends AbstractDigitalExpressionTestBase {
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionLightTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionLightTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 /**
  * Test ExpressionLight
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
@@ -46,28 +46,28 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
     private ActionAtomicBoolean actionAtomicBoolean;
     private AtomicBoolean atomicBoolean;
     private Light light;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Light IL1 is On ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -82,40 +82,40 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ExpressionLight(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         ExpressionLight expression2;
         Assert.assertNotNull("light is not null", light);
         light.setState(Light.ON);
-        
+
         expression2 = new ExpressionLight("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Light '' is On", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionLight("IQDE321", "My light");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My light", expression2.getUserName());
         Assert.assertEquals("String matches", "Light '' is On", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionLight("IQDE321", null);
         expression2.setLight(light);
         Assert.assertTrue("light is correct", light == expression2.getLight().getBean());
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Light IL1 is On", expression2.getLongDescription());
-        
+
         Light l = InstanceManager.getDefault(LightManager.class).provide("IL2");
         expression2 = new ExpressionLight("IQDE321", "My light");
         expression2.setLight(l);
@@ -123,7 +123,7 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My light", expression2.getUserName());
         Assert.assertEquals("String matches", "Light IL2 is On", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -132,7 +132,7 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -142,11 +142,11 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionLight.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             expressionLight.getChild(0);
@@ -156,34 +156,34 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testLightState() {
         Assert.assertEquals("String matches", "Off", ExpressionLight.LightState.Off.toString());
         Assert.assertEquals("String matches", "On", ExpressionLight.LightState.On.toString());
         Assert.assertEquals("String matches", "Other", ExpressionLight.LightState.Other.toString());
-        
+
         Assert.assertTrue("objects are equal", ExpressionLight.LightState.Off == ExpressionLight.LightState.get(Light.OFF));
         Assert.assertTrue("objects are equal", ExpressionLight.LightState.On == ExpressionLight.LightState.get(Light.ON));
         Assert.assertTrue("objects are equal", ExpressionLight.LightState.Other == ExpressionLight.LightState.get(Light.UNKNOWN));
         Assert.assertTrue("objects are equal", ExpressionLight.LightState.Other == ExpressionLight.LightState.get(Light.INCONSISTENT));
         Assert.assertTrue("objects are equal", ExpressionLight.LightState.Other == ExpressionLight.LightState.get(-1));
-        
+
         Assert.assertEquals("ID matches", Light.ON, ExpressionLight.LightState.On.getID());
         Assert.assertEquals("ID matches", Light.OFF, ExpressionLight.LightState.Off.getID());
         Assert.assertEquals("ID matches", -1, ExpressionLight.LightState.Other.getID());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         expressionLight.removeLight();
         Assert.assertTrue("Light".equals(expressionLight.getShortDescription()));
         Assert.assertTrue("Light '' is On".equals(expressionLight.getLongDescription()));
@@ -196,7 +196,7 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         expressionLight.setBeanState(ExpressionLight.LightState.Other);
         Assert.assertTrue("Light IL1 is not Other".equals(expressionLight.getLongDescription()));
     }
-    
+
     @Test
     public void testExpression() throws SocketAlreadyConnectedException, JmriException {
         // Clear flag
@@ -228,7 +228,7 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         light.setCommandedState(Light.OFF);
         // The action should now be executed so the atomic boolean should be true
         Assert.assertFalse("atomicBoolean is false",atomicBoolean.get());
-        
+
         // Test IS_NOT
         expressionLight.set_Is_IsNot(Is_IsNot_Enum.IsNot);
         // Turn the light on. This should not execute the conditional.
@@ -240,16 +240,16 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         // The action should now be executed so the atomic boolean should be true
         Assert.assertTrue("atomicBoolean is true",atomicBoolean.get());
     }
-    
+
     @Test
     public void testSetLight() {
         expressionLight.unregisterListeners();
-        
+
         Light otherLight = InstanceManager.getDefault(LightManager.class).provide("IL99");
         Assert.assertNotEquals("Lights are different", otherLight, expressionLight.getLight().getBean());
         expressionLight.setLight(otherLight);
         Assert.assertEquals("Lights are equal", otherLight, expressionLight.getLight().getBean());
-        
+
         NamedBeanHandle<Light> otherLightHandle =
                 InstanceManager.getDefault(NamedBeanHandleManager.class)
                         .getNamedBeanHandle(otherLight.getDisplayName(), otherLight);
@@ -259,44 +259,44 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("Lights are equal", otherLight, expressionLight.getLight().getBean());
         Assert.assertEquals("LightHandles are equal", otherLightHandle, expressionLight.getLight());
     }
-    
+
     @Test
     public void testSetLight2() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         Light light11 = InstanceManager.getDefault(LightManager.class).provide("IL11");
         Light light12 = InstanceManager.getDefault(LightManager.class).provide("IL12");
         NamedBeanHandle<Light> lightHandle12 = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(light12.getDisplayName(), light12);
         Light light13 = InstanceManager.getDefault(LightManager.class).provide("IL13");
         Light light14 = InstanceManager.getDefault(LightManager.class).provide("IL14");
         light14.setUserName("Some user name");
-        
+
         expressionLight.removeLight();
         Assert.assertNull("light handle is null", expressionLight.getLight());
-        
+
         expressionLight.setLight(light11);
         Assert.assertTrue("light is correct", light11 == expressionLight.getLight().getBean());
-        
+
         expressionLight.removeLight();
         Assert.assertNull("light handle is null", expressionLight.getLight());
-        
+
         expressionLight.setLight(lightHandle12);
         Assert.assertTrue("light handle is correct", lightHandle12 == expressionLight.getLight());
-        
+
         expressionLight.setLight("A non existent light");
         Assert.assertNull("light handle is null", expressionLight.getLight());
         JUnitAppender.assertErrorMessage("light \"A non existent light\" is not found");
-        
+
         expressionLight.setLight(light13.getSystemName());
         Assert.assertTrue("light is correct", light13 == expressionLight.getLight().getBean());
-        
+
         String userName = light14.getUserName();
         Assert.assertNotNull("light is not null", userName);
         expressionLight.setLight(userName);
         Assert.assertTrue("light is correct", light14 == expressionLight.getLight().getBean());
     }
-    
+
     @Test
     public void testSetLightException() {
         // Test setLight() when listeners are registered
@@ -311,7 +311,7 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setLight must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             Light light99 = InstanceManager.getDefault(LightManager.class).provide("IL99");
@@ -323,7 +323,7 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setLight must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             expressionLight.setLight((Light)null);
@@ -333,7 +333,7 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setLight must not be called when listeners are registered");
     }
-    
+
     @Test
     public void testRegisterListeners() {
         // Test registerListeners() when the ExpressionLight has no light
@@ -341,36 +341,36 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         expressionLight.removeLight();
         conditionalNG.setEnabled(true);
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Get the expression and set the light
         Assert.assertNotNull("Light is not null", light);
-        
+
         // Get some other light for later use
         Light otherLight = InstanceManager.getDefault(LightManager.class).provide("IM99");
         Assert.assertNotNull("Light is not null", otherLight);
         Assert.assertNotEquals("Light is not equal", light, otherLight);
-        
+
         // Test vetoableChange() for some other propery
         expressionLight.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Light matches", light, expressionLight.getLight().getBean());
-        
+
         // Test vetoableChange() for a string
         expressionLight.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Light matches", light, expressionLight.getLight().getBean());
         expressionLight.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Light matches", light, expressionLight.getLight().getBean());
-        
+
         // Test vetoableChange() for another light
         expressionLight.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherLight, null));
         Assert.assertEquals("Light matches", light, expressionLight.getLight().getBean());
         expressionLight.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherLight, null));
         Assert.assertEquals("Light matches", light, expressionLight.getLight().getBean());
-        
+
         // Test vetoableChange() for its own light
         boolean thrown = false;
         try {
@@ -379,12 +379,12 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Light matches", light, expressionLight.getLight().getBean());
         expressionLight.vetoableChange(new PropertyChangeEvent(this, "DoDelete", light, null));
         Assert.assertNull("Light is null", expressionLight.getLight());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -394,41 +394,42 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initConfigureManager();
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         logixNG.addConditionalNG(conditionalNG);
-        
+
         IfThenElse ifThenElse = new IfThenElse("IQDA321", null);
         MaleSocket socketIfThenElse =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(socketIfThenElse);
-        
+
         expressionLight = new ExpressionLight("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionLight);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expressionLight;
         _baseMaleSocket = maleSocket2;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
         light = InstanceManager.getDefault(LightManager.class).provide("IL1");
         expressionLight.setLight(light);
         light.setCommandedState(Light.ON);
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -437,5 +438,5 @@ public class ExpressionLightTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionLocalVariableTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionLocalVariableTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 /**
  * Test ExpressionLocalVariable
- * 
+ *
  * @author Daniel Bergqvist 2021
  */
 public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBase {
@@ -30,28 +30,28 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
     private MaleSocket localVariableMaleSocket;
     private ActionAtomicBoolean actionAtomicBoolean;
     private AtomicBoolean atomicBoolean;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Local variable myVar is equal to \"\" ::: Use default%n   ::: Local variable \"myVar\", init to String \"\"%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -67,40 +67,40 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ExpressionLocalVariable(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         ExpressionLocalVariable expression2;
-        
+
         expression2 = new ExpressionLocalVariable("IQDE321", null);
         expression2.setLocalVariable("");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Local variable '' is equal to \"\"", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionLocalVariable("IQDE321", "My memory");
         expression2.setLocalVariable("");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My memory", expression2.getUserName());
         Assert.assertEquals("String matches", "Local variable '' is equal to \"\"", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionLocalVariable("IQDE321", null);
         expression2.setLocalVariable("myVar");
         Assert.assertEquals("variable is correct", "myVar", expression2.getLocalVariable());
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Local variable myVar is equal to \"\"", expression2.getLongDescription());
-        
+
         Memory l = InstanceManager.getDefault(MemoryManager.class).provide("IM2");
         expression2 = new ExpressionLocalVariable("IQDE321", "My memory");
         expression2.setLocalVariable("someVar");
@@ -109,7 +109,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My memory", expression2.getUserName());
         Assert.assertEquals("String matches", "Local variable someVar is equal to \"\"", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -118,7 +118,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -128,11 +128,11 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionLocalVariable.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             expressionLocalVariable.getChild(0);
@@ -142,7 +142,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testVariableOperation() {
         Assert.assertEquals("String matches", "is less than", ExpressionLocalVariable.VariableOperation.LessThan.toString());
@@ -155,7 +155,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertEquals("String matches", "is not null", ExpressionLocalVariable.VariableOperation.IsNotNull.toString());
         Assert.assertEquals("String matches", "does match regular expression", ExpressionLocalVariable.VariableOperation.MatchRegex.toString());
         Assert.assertEquals("String matches", "does not match regular expression", ExpressionLocalVariable.VariableOperation.NotMatchRegex.toString());
-        
+
         Assert.assertTrue("operation has extra value", ExpressionLocalVariable.VariableOperation.LessThan.hasExtraValue());
         Assert.assertTrue("operation has extra value", ExpressionLocalVariable.VariableOperation.LessThanOrEqual.hasExtraValue());
         Assert.assertTrue("operation has extra value", ExpressionLocalVariable.VariableOperation.Equal.hasExtraValue());
@@ -167,17 +167,17 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertTrue("operation has extra value", ExpressionLocalVariable.VariableOperation.MatchRegex.hasExtraValue());
         Assert.assertTrue("operation has extra value", ExpressionLocalVariable.VariableOperation.NotMatchRegex.hasExtraValue());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         expressionLocalVariable.setLocalVariable("someVar");
         Assert.assertEquals("Local variable", expressionLocalVariable.getShortDescription());
         Assert.assertEquals("Local variable someVar is equal to \"\"", expressionLocalVariable.getLongDescription());
@@ -188,7 +188,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertEquals("Local variable myVar is equal to \"Another value\"", expressionLocalVariable.getLongDescription());
         Assert.assertEquals("Local variable myVar is equal to \"Another value\"", expressionLocalVariable.getLongDescription());
     }
-    
+
     @Test
     public void testExpression() throws SocketAlreadyConnectedException, JmriException {
         // Clear flag
@@ -196,14 +196,14 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         // Set the local variable
         localVariableMaleSocket.clearLocalVariables();
         localVariableMaleSocket.addLocalVariable("myVar", SymbolTable.InitialValueType.String, "New value");
-        
+
         // Disable the conditionalNG
         conditionalNG.setEnabled(false);
-        
+
         expressionLocalVariable.setCompareTo(ExpressionLocalVariable.CompareTo.Value);
         expressionLocalVariable.setVariableOperation(ExpressionLocalVariable.VariableOperation.Equal);
         expressionLocalVariable.setConstantValue("New value");
-        
+
         // The action is not yet executed so the atomic boolean should be false
         Assert.assertFalse("atomicBoolean is false",atomicBoolean.get());
         // The conditionalNG is not yet enabled so it shouldn't be executed.
@@ -216,8 +216,8 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         // Set the memory. This should execute the conditional.
         // The action should now be executed so the atomic boolean should be true
         Assert.assertTrue("atomicBoolean is true",atomicBoolean.get());
-        
-        
+
+
         // Test regular expression match
         conditionalNG.setEnabled(false);
         expressionLocalVariable.setVariableOperation(ExpressionLocalVariable.VariableOperation.MatchRegex);
@@ -230,7 +230,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertTrue("The expression returns true",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         // Set the local variable
         localVariableMaleSocket.clearLocalVariables();
@@ -239,7 +239,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
+
         // Test regular expressions
         conditionalNG.setEnabled(false);
         expressionLocalVariable.setRegEx("\\w\\w\\d+\\s\\d+");
@@ -250,7 +250,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertTrue("The expression returns true",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         // Set the local variable
         localVariableMaleSocket.clearLocalVariables();
@@ -259,8 +259,8 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
-        
+
+
         // Test regular expression not match
         conditionalNG.setEnabled(false);
         expressionLocalVariable.setVariableOperation(ExpressionLocalVariable.VariableOperation.NotMatchRegex);
@@ -273,7 +273,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         // Set the local variable
         localVariableMaleSocket.clearLocalVariables();
@@ -282,7 +282,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertTrue("The expression returns true",atomicBoolean.get());
-        
+
         // Test regular expressions
         conditionalNG.setEnabled(false);
         expressionLocalVariable.setRegEx("\\w\\w\\d+\\s\\d+");
@@ -293,7 +293,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         // Set the local variable
         localVariableMaleSocket.clearLocalVariables();
@@ -303,16 +303,16 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         conditionalNG.setEnabled(true);
         Assert.assertTrue("The expression returns true",atomicBoolean.get());
     }
-/*    
+/*
     @Test
     public void testSetMemory() {
         expressionLocalVariable.unregisterListeners();
-        
+
         Memory otherMemory = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
         Assert.assertNotEquals("Memorys are different", otherMemory, expressionLocalVariable.getMemory().getBean());
         expressionLocalVariable.setMemory(otherMemory);
         Assert.assertEquals("Memorys are equal", otherMemory, expressionLocalVariable.getMemory().getBean());
-        
+
         NamedBeanHandle<Memory> otherMemoryHandle =
                 InstanceManager.getDefault(NamedBeanHandleManager.class)
                         .getNamedBeanHandle(otherMemory.getDisplayName(), otherMemory);
@@ -322,44 +322,44 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertEquals("Memorys are equal", otherMemory, expressionLocalVariable.getMemory().getBean());
         Assert.assertEquals("MemoryHandles are equal", otherMemoryHandle, expressionLocalVariable.getMemory());
     }
-    
+
     @Test
     public void testSetMemory2() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         Memory memory11 = InstanceManager.getDefault(MemoryManager.class).provide("IM11");
         Memory memory12 = InstanceManager.getDefault(MemoryManager.class).provide("IM12");
         NamedBeanHandle<Memory> memoryHandle12 = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(memory12.getDisplayName(), memory12);
         Memory memory13 = InstanceManager.getDefault(MemoryManager.class).provide("IM13");
         Memory memory14 = InstanceManager.getDefault(MemoryManager.class).provide("IM14");
         memory14.setUserName("Some user name");
-        
+
         expressionLocalVariable.removeMemory();
         Assert.assertNull("memory handle is null", expressionLocalVariable.getMemory());
-        
+
         expressionLocalVariable.setMemory(memory11);
         Assert.assertTrue("memory is correct", memory11 == expressionLocalVariable.getMemory().getBean());
-        
+
         expressionLocalVariable.removeMemory();
         Assert.assertNull("memory handle is null", expressionLocalVariable.getMemory());
-        
+
         expressionLocalVariable.setMemory(memoryHandle12);
         Assert.assertTrue("memory handle is correct", memoryHandle12 == expressionLocalVariable.getMemory());
-        
+
         expressionLocalVariable.setMemory("A non existent memory");
         Assert.assertNull("memory handle is null", expressionLocalVariable.getMemory());
         JUnitAppender.assertWarnMessage("memory \"A non existent memory\" is not found");
-        
+
         expressionLocalVariable.setMemory(memory13.getSystemName());
         Assert.assertTrue("memory is correct", memory13 == expressionLocalVariable.getMemory().getBean());
-        
+
         String userName = memory14.getUserName();
         Assert.assertNotNull("memory is not null", userName);
         expressionLocalVariable.setMemory(userName);
         Assert.assertTrue("memory is correct", memory14 == expressionLocalVariable.getMemory().getBean());
     }
-    
+
     @Test
     public void testSetMemoryException() {
         // Test setMemory() when listeners are registered
@@ -374,7 +374,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             Memory memory99 = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
@@ -386,7 +386,7 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             expressionLocalVariable.setMemory((Memory)null);
@@ -396,36 +396,36 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Get the expression and set the memory
         Assert.assertNotNull("Memory is not null", memory);
-        
+
         // Get some other memory for later use
         Memory otherMemory = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
         Assert.assertNotNull("Memory is not null", otherMemory);
         Assert.assertNotEquals("Memory is not equal", memory, otherMemory);
-        
+
         // Test vetoableChange() for some other propery
         expressionLocalVariable.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Memory matches", memory, expressionLocalVariable.getMemory().getBean());
-        
+
         // Test vetoableChange() for a string
         expressionLocalVariable.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Memory matches", memory, expressionLocalVariable.getMemory().getBean());
         expressionLocalVariable.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Memory matches", memory, expressionLocalVariable.getMemory().getBean());
-        
+
         // Test vetoableChange() for another memory
         expressionLocalVariable.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherMemory, null));
         Assert.assertEquals("Memory matches", memory, expressionLocalVariable.getMemory().getBean());
         expressionLocalVariable.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherMemory, null));
         Assert.assertEquals("Memory matches", memory, expressionLocalVariable.getMemory().getBean());
-        
+
         // Test vetoableChange() for its own memory
         boolean thrown = false;
         try {
@@ -434,12 +434,12 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Memory matches", memory, expressionLocalVariable.getMemory().getBean());
         expressionLocalVariable.vetoableChange(new PropertyChangeEvent(this, "DoDelete", memory, null));
         Assert.assertNull("Memory is null", expressionLocalVariable.getMemory());
     }
-*/    
+*/
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
@@ -449,42 +449,43 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         JUnitUtil.initConfigureManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         conditionalNG.setSymbolTable(new DefaultSymbolTable(conditionalNG));
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         logixNG.addConditionalNG(conditionalNG);
-        
+
         IfThenElse ifThenElse = new IfThenElse("IQDA321", null);
         ifThenElse.setType(IfThenElse.Type.AlwaysExecute);
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionLocalVariable = new ExpressionLocalVariable("IQDE321", null);
         localVariableMaleSocket =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionLocalVariable);
         localVariableMaleSocket.addLocalVariable("myVar", SymbolTable.InitialValueType.String, "");
         ifThenElse.getChild(0).connect(localVariableMaleSocket);
-        
+
         _base = expressionLocalVariable;
         _baseMaleSocket = localVariableMaleSocket;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
         expressionLocalVariable.setLocalVariable("myVar");
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -493,5 +494,5 @@ public class ExpressionLocalVariableTest extends AbstractDigitalExpressionTestBa
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionMemoryTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 
 /**
  * Test ExpressionMemory
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
@@ -45,28 +45,28 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
     private ActionAtomicBoolean actionAtomicBoolean;
     private AtomicBoolean atomicBoolean;
     private Memory memory;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Memory IM1 is equal to \"\" ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -81,39 +81,39 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ExpressionMemory(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         ExpressionMemory expression2;
         Assert.assertNotNull("memory is not null", memory);
-        
+
         expression2 = new ExpressionMemory("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Memory '' is equal to \"\"", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionMemory("IQDE321", "My memory");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My memory", expression2.getUserName());
         Assert.assertEquals("String matches", "Memory '' is equal to \"\"", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionMemory("IQDE321", null);
         expression2.setMemory(memory);
         Assert.assertTrue("memory is correct", memory == expression2.getMemory().getBean());
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Memory IM1 is equal to \"\"", expression2.getLongDescription());
-        
+
         Memory l = InstanceManager.getDefault(MemoryManager.class).provide("IM2");
         expression2 = new ExpressionMemory("IQDE321", "My memory");
         expression2.setMemory(l);
@@ -121,7 +121,7 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My memory", expression2.getUserName());
         Assert.assertEquals("String matches", "Memory IM2 is equal to \"\"", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -130,7 +130,7 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -140,11 +140,11 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionMemory.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             expressionMemory.getChild(0);
@@ -154,7 +154,7 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testMemoryOperation() {
         Assert.assertEquals("String matches", "is less than", ExpressionMemory.MemoryOperation.LessThan.toString());
@@ -167,7 +167,7 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("String matches", "is not null", ExpressionMemory.MemoryOperation.IsNotNull.toString());
         Assert.assertEquals("String matches", "does match regular expression", ExpressionMemory.MemoryOperation.MatchRegex.toString());
         Assert.assertEquals("String matches", "does not match regular expression", ExpressionMemory.MemoryOperation.NotMatchRegex.toString());
-        
+
         Assert.assertTrue("operation has extra value", ExpressionMemory.MemoryOperation.LessThan.hasExtraValue());
         Assert.assertTrue("operation has extra value", ExpressionMemory.MemoryOperation.LessThanOrEqual.hasExtraValue());
         Assert.assertTrue("operation has extra value", ExpressionMemory.MemoryOperation.Equal.hasExtraValue());
@@ -179,17 +179,17 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("operation has extra value", ExpressionMemory.MemoryOperation.MatchRegex.hasExtraValue());
         Assert.assertTrue("operation has extra value", ExpressionMemory.MemoryOperation.NotMatchRegex.hasExtraValue());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         expressionMemory.removeMemory();
         Assert.assertEquals("Memory", expressionMemory.getShortDescription());
         Assert.assertEquals("Memory '' is equal to \"\"", expressionMemory.getLongDescription());
@@ -200,21 +200,21 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("Memory IM1 is equal to \"Another value\"", expressionMemory.getLongDescription());
         Assert.assertEquals("Memory IM1 is equal to \"Another value\"", expressionMemory.getLongDescription());
     }
-    
+
     @Test
     public void testExpression() throws SocketAlreadyConnectedException, JmriException {
         // Clear flag
         atomicBoolean.set(false);
         // Set the memory
         memory.setValue("New value");
-        
+
         // Disable the conditionalNG
         conditionalNG.setEnabled(false);
-        
+
         expressionMemory.setCompareTo(ExpressionMemory.CompareTo.Value);
         expressionMemory.setMemoryOperation(ExpressionMemory.MemoryOperation.Equal);
         expressionMemory.setConstantValue("New value");
-        
+
         // The action is not yet executed so the atomic boolean should be false
         Assert.assertFalse("atomicBoolean is false",atomicBoolean.get());
         // Set the memory. This should not execute the conditional.
@@ -235,8 +235,8 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         memory.setValue("New value");
         // The action should now be executed so the atomic boolean should be true
         Assert.assertTrue("atomicBoolean is true",atomicBoolean.get());
-        
-        
+
+
         // Test regular expression match
         conditionalNG.setEnabled(false);
         expressionMemory.setMemoryOperation(ExpressionMemory.MemoryOperation.MatchRegex);
@@ -247,14 +247,14 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertTrue("The expression returns true",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         memory.setValue("Some world");
         atomicBoolean.set(false);
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
+
         // Test regular expressions
         conditionalNG.setEnabled(false);
         expressionMemory.setRegEx("\\w\\w\\d+\\s\\d+");
@@ -263,15 +263,15 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertTrue("The expression returns true",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         memory.setValue("Ab213_31");    // Underscore instead of space
         atomicBoolean.set(false);
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
-        
+
+
         // Test regular expression not match
         conditionalNG.setEnabled(false);
         expressionMemory.setMemoryOperation(ExpressionMemory.MemoryOperation.NotMatchRegex);
@@ -282,14 +282,14 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         memory.setValue("Some world");
         atomicBoolean.set(false);
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertTrue("The expression returns true",atomicBoolean.get());
-        
+
         // Test regular expressions
         conditionalNG.setEnabled(false);
         expressionMemory.setRegEx("\\w\\w\\d+\\s\\d+");
@@ -298,7 +298,7 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         memory.setValue("Ab213_31");    // Underscore instead of space
         atomicBoolean.set(false);
@@ -306,16 +306,16 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         conditionalNG.setEnabled(true);
         Assert.assertTrue("The expression returns true",atomicBoolean.get());
     }
-    
+
     @Test
     public void testSetMemory() {
         expressionMemory.unregisterListeners();
-        
+
         Memory otherMemory = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
         Assert.assertNotEquals("Memorys are different", otherMemory, expressionMemory.getMemory().getBean());
         expressionMemory.setMemory(otherMemory);
         Assert.assertEquals("Memorys are equal", otherMemory, expressionMemory.getMemory().getBean());
-        
+
         NamedBeanHandle<Memory> otherMemoryHandle =
                 InstanceManager.getDefault(NamedBeanHandleManager.class)
                         .getNamedBeanHandle(otherMemory.getDisplayName(), otherMemory);
@@ -325,44 +325,44 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("Memorys are equal", otherMemory, expressionMemory.getMemory().getBean());
         Assert.assertEquals("MemoryHandles are equal", otherMemoryHandle, expressionMemory.getMemory());
     }
-    
+
     @Test
     public void testSetMemory2() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         Memory memory11 = InstanceManager.getDefault(MemoryManager.class).provide("IM11");
         Memory memory12 = InstanceManager.getDefault(MemoryManager.class).provide("IM12");
         NamedBeanHandle<Memory> memoryHandle12 = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(memory12.getDisplayName(), memory12);
         Memory memory13 = InstanceManager.getDefault(MemoryManager.class).provide("IM13");
         Memory memory14 = InstanceManager.getDefault(MemoryManager.class).provide("IM14");
         memory14.setUserName("Some user name");
-        
+
         expressionMemory.removeMemory();
         Assert.assertNull("memory handle is null", expressionMemory.getMemory());
-        
+
         expressionMemory.setMemory(memory11);
         Assert.assertTrue("memory is correct", memory11 == expressionMemory.getMemory().getBean());
-        
+
         expressionMemory.removeMemory();
         Assert.assertNull("memory handle is null", expressionMemory.getMemory());
-        
+
         expressionMemory.setMemory(memoryHandle12);
         Assert.assertTrue("memory handle is correct", memoryHandle12 == expressionMemory.getMemory());
-        
+
         expressionMemory.setMemory("A non existent memory");
         Assert.assertNull("memory handle is null", expressionMemory.getMemory());
         JUnitAppender.assertWarnMessage("memory \"A non existent memory\" is not found");
-        
+
         expressionMemory.setMemory(memory13.getSystemName());
         Assert.assertTrue("memory is correct", memory13 == expressionMemory.getMemory().getBean());
-        
+
         String userName = memory14.getUserName();
         Assert.assertNotNull("memory is not null", userName);
         expressionMemory.setMemory(userName);
         Assert.assertTrue("memory is correct", memory14 == expressionMemory.getMemory().getBean());
     }
-    
+
     @Test
     public void testSetMemoryException() {
         // Test setMemory() when listeners are registered
@@ -377,7 +377,7 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             Memory memory99 = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
@@ -389,7 +389,7 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             expressionMemory.setMemory((Memory)null);
@@ -399,36 +399,36 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Get the expression and set the memory
         Assert.assertNotNull("Memory is not null", memory);
-        
+
         // Get some other memory for later use
         Memory otherMemory = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
         Assert.assertNotNull("Memory is not null", otherMemory);
         Assert.assertNotEquals("Memory is not equal", memory, otherMemory);
-        
+
         // Test vetoableChange() for some other propery
         expressionMemory.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Memory matches", memory, expressionMemory.getMemory().getBean());
-        
+
         // Test vetoableChange() for a string
         expressionMemory.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Memory matches", memory, expressionMemory.getMemory().getBean());
         expressionMemory.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Memory matches", memory, expressionMemory.getMemory().getBean());
-        
+
         // Test vetoableChange() for another memory
         expressionMemory.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherMemory, null));
         Assert.assertEquals("Memory matches", memory, expressionMemory.getMemory().getBean());
         expressionMemory.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherMemory, null));
         Assert.assertEquals("Memory matches", memory, expressionMemory.getMemory().getBean());
-        
+
         // Test vetoableChange() for its own memory
         boolean thrown = false;
         try {
@@ -437,12 +437,12 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Memory matches", memory, expressionMemory.getMemory().getBean());
         expressionMemory.vetoableChange(new PropertyChangeEvent(this, "DoDelete", memory, null));
         Assert.assertNull("Memory is null", expressionMemory.getMemory());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
@@ -452,42 +452,43 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initConfigureManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         logixNG.addConditionalNG(conditionalNG);
-        
+
         IfThenElse ifThenElse = new IfThenElse("IQDA321", null);
         ifThenElse.setType(IfThenElse.Type.AlwaysExecute);
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionMemory = new ExpressionMemory("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionMemory);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expressionMemory;
         _baseMaleSocket = maleSocket2;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
         memory = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
         expressionMemory.setMemory(memory);
         memory.setValue("");
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -496,5 +497,5 @@ public class ExpressionMemoryTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionReferenceTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionReferenceTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 /**
  * Test ExpressionReference
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
@@ -39,18 +39,18 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
     private ExpressionReference expressionReference;
     private ActionAtomicBoolean actionAtomicBoolean;
     private AtomicBoolean atomicBoolean;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         DigitalExpressionBean childExpression = new True("IQDE999", null);
@@ -58,12 +58,12 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(childExpression);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Reference '' is Nothing ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -78,31 +78,31 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ExpressionReference(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         ExpressionReference expression2;
-        
+
         expression2 = new ExpressionReference("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Reference '' is Nothing", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionReference("IQDE321", "My expression");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My expression", expression2.getUserName());
         Assert.assertEquals("String matches", "Reference '' is Nothing", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -111,7 +111,7 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -121,11 +121,11 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionReference.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             expressionReference.getChild(0);
@@ -135,70 +135,70 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         Assert.assertEquals("Reference", expressionReference.getShortDescription());
         Assert.assertEquals("Reference '' is Nothing", expressionReference.getLongDescription());
     }
-    
+
     @Test
     public void testExpression() throws SocketAlreadyConnectedException, JmriException {
-        
+
         Memory m = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
-        
+
         expressionReference.setReference("{IM1}");
-        
+
         // Test IS
         expressionReference.set_Is_IsNot(Is_IsNot_Enum.Is);
-        
+
         m.setValue("Turnout 1");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Nothing);
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         m.setValue("");
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is Nothing", expressionReference.getLongDescription());
-        
+
         m.setValue("Table 1");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.LogixNGTable);
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         InstanceManager.getDefault(NamedTableManager.class).newInternalTable("IQT1", "Table 1", 2, 3);
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is LogixNG Table", expressionReference.getLongDescription());
-        
+
         m.setValue("Audio 1");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Audio);
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         InstanceManager.getDefault(AudioManager.class).newAudio("IAB1", "Audio 1");
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is Audio", expressionReference.getLongDescription());
-        
+
         m.setValue("Light 1");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Light);
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         InstanceManager.getDefault(LightManager.class).newLight("IL1", "Light 1");
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is Light", expressionReference.getLongDescription());
-        
+
         m.setValue("Memory 1");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Memory);
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         InstanceManager.getDefault(MemoryManager.class).newMemory("IM5", "Memory 1");
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is Memory", expressionReference.getLongDescription());
-        
+
         m.setValue("Sensor 1");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Sensor);
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         InstanceManager.getDefault(SensorManager.class).newSensor("IS1", "Sensor 1");
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is Sensor", expressionReference.getLongDescription());
-        
+
         m.setValue("Signal Head 1");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.SignalHead);
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
@@ -206,67 +206,67 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         InstanceManager.getDefault(SignalHeadManager.class).register(signalHeadIH1);
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is SignalHead", expressionReference.getLongDescription());
-        
+
         m.setValue("IF$shsm:AAR-1946:CPL(IH1)");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.SignalMast);
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         InstanceManager.getDefault(SignalMastManager.class).provideSignalMast("IF$shsm:AAR-1946:CPL(IH1)");
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is SignalMast", expressionReference.getLongDescription());
-        
+
         m.setValue("Turnout 1");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Turnout);
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         InstanceManager.getDefault(TurnoutManager.class).newTurnout("IT1", "Turnout 1");
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is Turnout", expressionReference.getLongDescription());
-        
-        
+
+
         // Test IS_NOT
         expressionReference.set_Is_IsNot(Is_IsNot_Enum.IsNot);
-        
+
         m.setValue("Turnout 2");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Nothing);
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         m.setValue("");
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is not Nothing", expressionReference.getLongDescription());
-        
+
         m.setValue("Table 2");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.LogixNGTable);
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         InstanceManager.getDefault(NamedTableManager.class).newInternalTable("IQT2", "Table 2", 2, 3);
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is not LogixNG Table", expressionReference.getLongDescription());
-        
+
         m.setValue("Audio 2");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Audio);
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         InstanceManager.getDefault(AudioManager.class).newAudio("IAB2", "Audio 2");
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is not Audio", expressionReference.getLongDescription());
-        
+
         m.setValue("Light 2");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Light);
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         InstanceManager.getDefault(LightManager.class).newLight("IL2", "Light 2");
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is not Light", expressionReference.getLongDescription());
-        
+
         m.setValue("Memory 2");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Memory);
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         InstanceManager.getDefault(MemoryManager.class).newMemory("IM6", "Memory 2");
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is not Memory", expressionReference.getLongDescription());
-        
+
         m.setValue("Sensor 2");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Sensor);
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         InstanceManager.getDefault(SensorManager.class).newSensor("IS2", "Sensor 2");
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is not Sensor", expressionReference.getLongDescription());
-        
+
         m.setValue("Signal Head 2");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.SignalHead);
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
@@ -274,14 +274,14 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         InstanceManager.getDefault(SignalHeadManager.class).register(signalHeadIH2);
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is not SignalHead", expressionReference.getLongDescription());
-        
+
         m.setValue("IF$shsm:AAR-1946:CPL(IH2)");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.SignalMast);
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
         InstanceManager.getDefault(SignalMastManager.class).provideSignalMast("IF$shsm:AAR-1946:CPL(IH2)");
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is not SignalMast", expressionReference.getLongDescription());
-        
+
         m.setValue("Turnout 2");
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Turnout);
         Assert.assertTrue("evaluate returns true",expressionReference.evaluate());
@@ -289,7 +289,7 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         Assert.assertFalse("evaluate returns false",expressionReference.evaluate());
         Assert.assertEquals("Reference {IM1} is not Turnout", expressionReference.getLongDescription());
     }
-    
+
     @Test
     public void testSetReferenceException() {
         String reference = "{IM1}";
@@ -307,7 +307,7 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setReference must not be called when listeners are registered");
     }
-    
+
     @Test
     public void testRegisterListeners() {
         // Test registerListeners() when the ExpressionReference has no reference
@@ -315,7 +315,7 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         expressionReference.setReference(null);
         conditionalNG.setEnabled(true);
     }
-    
+
     @Test
     @Override
     public void testEnableAndEvaluate() {
@@ -324,7 +324,7 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         // to add support here. It doesn't need to be tested for every digital
         // expression.
     }
-    
+
     @Test
     @Override
     public void testDebugConfig() {
@@ -333,7 +333,7 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         // to add support here. It doesn't need to be tested for every digital
         // expression.
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -351,47 +351,48 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initInternalSignalHeadManager();
         JUnitUtil.initDefaultSignalMastManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         logixNG.addConditionalNG(conditionalNG);
         IfThenElse ifThenElse = new IfThenElse("IQDA321", null);
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionReference = new ExpressionReference("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionReference);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expressionReference;
         _baseMaleSocket = maleSocket2;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
     @After
     public void tearDown() {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
-        
+
         // this created an audio manager, clean that up
         InstanceManager.getDefault(jmri.AudioManager.class).cleanup();
-        
+
         JUnitUtil.deregisterBlockManagerShutdownTask();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionReporterTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionReporterTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 /**
  * Test ExpressionReport
- * 
+ *
  * @author Daniel Bergqvist 2021
  */
 public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
@@ -47,28 +47,28 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
     private AtomicBoolean atomicBoolean;
     private AtomicLong atomicCounter;
     private Reporter reporter;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Reporter IR1 Current Report is equal to \"\" ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -83,39 +83,39 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ExpressionReporter(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         ExpressionReporter expression2;
         Assert.assertNotNull("reporter is not null", reporter);
-        
+
         expression2 = new ExpressionReporter("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Reporter '' Current Report is equal to \"\"", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionReporter("IQDE321", "My reporter");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My reporter", expression2.getUserName());
         Assert.assertEquals("String matches", "Reporter '' Current Report is equal to \"\"", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionReporter("IQDE321", null);
         expression2.setReporter(reporter);
         Assert.assertTrue("reporter is correct", reporter == expression2.getReporter().getBean());
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Reporter IR1 Current Report is equal to \"\"", expression2.getLongDescription());
-        
+
         Reporter l = InstanceManager.getDefault(ReporterManager.class).provide("IR2");
         expression2 = new ExpressionReporter("IQDE321", "My reporter");
         expression2.setReporter(l);
@@ -123,7 +123,7 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My reporter", expression2.getUserName());
         Assert.assertEquals("String matches", "Reporter IR2 Current Report is equal to \"\"", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -132,7 +132,7 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -142,11 +142,11 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionReporter.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             expressionReporter.getChild(0);
@@ -156,7 +156,7 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testReporterOperation() {
         Assert.assertEquals("String matches", "is less than", ExpressionReporter.ReporterOperation.LessThan.toString());
@@ -169,7 +169,7 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("String matches", "is not null", ExpressionReporter.ReporterOperation.IsNotNull.toString());
         Assert.assertEquals("String matches", "does match regular expression", ExpressionReporter.ReporterOperation.MatchRegex.toString());
         Assert.assertEquals("String matches", "does not match regular expression", ExpressionReporter.ReporterOperation.NotMatchRegex.toString());
-        
+
         Assert.assertTrue("operation has extra value", ExpressionReporter.ReporterOperation.LessThan.hasExtraValue());
         Assert.assertTrue("operation has extra value", ExpressionReporter.ReporterOperation.LessThanOrEqual.hasExtraValue());
         Assert.assertTrue("operation has extra value", ExpressionReporter.ReporterOperation.Equal.hasExtraValue());
@@ -181,17 +181,17 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("operation has extra value", ExpressionReporter.ReporterOperation.MatchRegex.hasExtraValue());
         Assert.assertTrue("operation has extra value", ExpressionReporter.ReporterOperation.NotMatchRegex.hasExtraValue());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         expressionReporter.removeReporter();
         Assert.assertEquals("Reporter", expressionReporter.getShortDescription());
         Assert.assertEquals("Reporter '' Current Report is equal to \"\"", expressionReporter.getLongDescription());
@@ -202,21 +202,21 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("Reporter IR1 Current Report is equal to \"Another value\"", expressionReporter.getLongDescription());
         Assert.assertEquals("Reporter IR1 Current Report is equal to \"Another value\"", expressionReporter.getLongDescription());
     }
-    
+
     @Test
     public void testExpression() throws SocketAlreadyConnectedException, JmriException {
         // Clear flag
         atomicBoolean.set(false);
         // Set the report
         reporter.setReport("New value");
-        
+
         // Disable the conditionalNG
         conditionalNG.setEnabled(false);
-        
+
         expressionReporter.setCompareTo(ExpressionReporter.CompareTo.Value);
         expressionReporter.setReporterOperation(ExpressionReporter.ReporterOperation.Equal);
         expressionReporter.setConstantValue("New value");
-        
+
         // The action is not yet executed so the atomic boolean should be false
         Assert.assertFalse("atomicBoolean is false",atomicBoolean.get());
         // Set the report. This should not execute the conditional.
@@ -237,8 +237,8 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         reporter.setReport("New value");
         // The action should now be executed so the atomic boolean should be true
         Assert.assertTrue("atomicBoolean is true",atomicBoolean.get());
-        
-        
+
+
         // Test regular expression match
         conditionalNG.setEnabled(false);
         expressionReporter.setReporterOperation(ExpressionReporter.ReporterOperation.MatchRegex);
@@ -249,14 +249,14 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertTrue("The expression returns true",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         reporter.setReport("Some world");
         atomicBoolean.set(false);
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
+
         // Test regular expressions
         conditionalNG.setEnabled(false);
         expressionReporter.setRegEx("\\w\\w\\d+\\s\\d+");
@@ -265,15 +265,15 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertTrue("The expression returns true",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         reporter.setReport("Ab213_31");    // Underscore instead of space
         atomicBoolean.set(false);
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
-        
+
+
         // Test regular expression not match
         conditionalNG.setEnabled(false);
         expressionReporter.setReporterOperation(ExpressionReporter.ReporterOperation.NotMatchRegex);
@@ -284,14 +284,14 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         reporter.setReport("Some world");
         atomicBoolean.set(false);
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertTrue("The expression returns true",atomicBoolean.get());
-        
+
         // Test regular expressions
         conditionalNG.setEnabled(false);
         expressionReporter.setRegEx("\\w\\w\\d+\\s\\d+");
@@ -300,7 +300,7 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         Assert.assertFalse("The expression has not executed or returns false",atomicBoolean.get());
         conditionalNG.setEnabled(true);
         Assert.assertFalse("The expression returns false",atomicBoolean.get());
-        
+
         conditionalNG.setEnabled(false);
         reporter.setReport("Ab213_31");    // Underscore instead of space
         atomicBoolean.set(false);
@@ -518,16 +518,16 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         Assert.assertFalse("atomicBoolean is false",atomicBoolean.get());
         Assert.assertEquals("counter is correct",counter,atomicCounter.get());
     }
-    
+
     @Test
     public void testSetReporter() {
         expressionReporter.unregisterListeners();
-        
+
         Reporter otherReporter = InstanceManager.getDefault(ReporterManager.class).provide("IR99");
         Assert.assertNotEquals("Reporters are different", otherReporter, expressionReporter.getReporter().getBean());
         expressionReporter.setReporter(otherReporter);
         Assert.assertEquals("Reporters are equal", otherReporter, expressionReporter.getReporter().getBean());
-        
+
         NamedBeanHandle<Reporter> otherReporterHandle =
                 InstanceManager.getDefault(NamedBeanHandleManager.class)
                         .getNamedBeanHandle(otherReporter.getDisplayName(), otherReporter);
@@ -537,44 +537,44 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("Reporters are equal", otherReporter, expressionReporter.getReporter().getBean());
         Assert.assertEquals("ReporterHandles are equal", otherReporterHandle, expressionReporter.getReporter());
     }
-    
+
     @Test
     public void testSetReporter2() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         Reporter reporter11 = InstanceManager.getDefault(ReporterManager.class).provide("IR11");
         Reporter reporter12 = InstanceManager.getDefault(ReporterManager.class).provide("IR12");
         NamedBeanHandle<Reporter> memoryHandle12 = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(reporter12.getDisplayName(), reporter12);
         Reporter reporter13 = InstanceManager.getDefault(ReporterManager.class).provide("IR13");
         Reporter reporter14 = InstanceManager.getDefault(ReporterManager.class).provide("IR14");
         reporter14.setUserName("Some user name");
-        
+
         expressionReporter.removeReporter();
         Assert.assertNull("reporter handle is null", expressionReporter.getReporter());
-        
+
         expressionReporter.setReporter(reporter11);
         Assert.assertTrue("reporter is correct", reporter11 == expressionReporter.getReporter().getBean());
-        
+
         expressionReporter.removeReporter();
         Assert.assertNull("reporter handle is null", expressionReporter.getReporter());
-        
+
         expressionReporter.setReporter(memoryHandle12);
         Assert.assertTrue("reporter handle is correct", memoryHandle12 == expressionReporter.getReporter());
-        
+
         expressionReporter.setReporter("A non existent reporter");
         Assert.assertNull("reporter handle is null", expressionReporter.getReporter());
         JUnitAppender.assertWarnMessage("reporter \"A non existent reporter\" is not found");
-        
+
         expressionReporter.setReporter(reporter13.getSystemName());
         Assert.assertTrue("reporter is correct", reporter13 == expressionReporter.getReporter().getBean());
-        
+
         String userName = reporter14.getUserName();
         Assert.assertNotNull("reporter is not null", userName);
         expressionReporter.setReporter(userName);
         Assert.assertTrue("reporter is correct", reporter14 == expressionReporter.getReporter().getBean());
     }
-    
+
     @Test
     public void testSetReporterException() {
         // Test setReporter() when listeners are registered
@@ -589,7 +589,7 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setReporter must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             Reporter reporter99 = InstanceManager.getDefault(ReporterManager.class).provide("IR99");
@@ -601,7 +601,7 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setReporter must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             expressionReporter.setReporter((Reporter)null);
@@ -611,36 +611,36 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setReporter must not be called when listeners are registered");
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Get the expression and set the memory
         Assert.assertNotNull("Reporter is not null", reporter);
-        
+
         // Get some other memory for later use
         Reporter otherReporter = InstanceManager.getDefault(ReporterManager.class).provide("IR99");
         Assert.assertNotNull("Reporter is not null", otherReporter);
         Assert.assertNotEquals("Reporter is not equal", reporter, otherReporter);
-        
+
         // Test vetoableChange() for some other propery
         expressionReporter.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Reporter matches", reporter, expressionReporter.getReporter().getBean());
-        
+
         // Test vetoableChange() for a string
         expressionReporter.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Reporter matches", reporter, expressionReporter.getReporter().getBean());
         expressionReporter.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Reporter matches", reporter, expressionReporter.getReporter().getBean());
-        
+
         // Test vetoableChange() for another memory
         expressionReporter.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherReporter, null));
         Assert.assertEquals("Reporter matches", reporter, expressionReporter.getReporter().getBean());
         expressionReporter.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherReporter, null));
         Assert.assertEquals("Reporter matches", reporter, expressionReporter.getReporter().getBean());
-        
+
         // Test vetoableChange() for its own memory
         boolean thrown = false;
         try {
@@ -649,12 +649,12 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Reporter matches", reporter, expressionReporter.getReporter().getBean());
         expressionReporter.vetoableChange(new PropertyChangeEvent(this, "DoDelete", reporter, null));
         Assert.assertNull("Reporter is null", expressionReporter.getReporter());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
@@ -664,44 +664,45 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initConfigureManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         logixNG.addConditionalNG(conditionalNG);
-        
+
         IfThenElse ifThenElse = new IfThenElse("IQDA321", null);
         ifThenElse.setType(IfThenElse.Type.AlwaysExecute);
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionReporter = new ExpressionReporter("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionReporter);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expressionReporter;
         _baseMaleSocket = maleSocket2;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         atomicCounter = new AtomicLong(0);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true, atomicCounter);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
         expressionReporter.setReporterValue(ExpressionReporter.ReporterValue.CurrentReport);
         reporter = InstanceManager.getDefault(ReporterManager.class).provide("IR1");
         expressionReporter.setReporter(reporter);
         reporter.setReport("");
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -710,5 +711,5 @@ public class ExpressionReporterTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionScriptTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionScriptTest.java
@@ -16,31 +16,31 @@ import org.junit.Test;
 
 /**
  * Test ActionSimpleScript
- * 
+ *
  * @author Daniel Bergqvist 2021
  */
 public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
 
     private final String _scriptText = "result.setValue( sensors.provideSensor(\"IS1\").getState() == ACTIVE )";
-    
-    
+
+
     private LogixNG logixNG;
     private ConditionalNG conditionalNG;
     private IfThenElse ifThenElse;
     private ExpressionScript expressionScript;
     private Sensor sensor;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         AnalogActionBean childAction = new AnalogActionMemory("IQAA999", null);
@@ -48,13 +48,13 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
                 InstanceManager.getDefault(AnalogActionManager.class).registerAction(childAction);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
                 "Evaluate script: Jython command. Script result.setValue( sensors.provideSensor(\"IS1\").getState() == ACTIVE ) ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -69,33 +69,33 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ExpressionScript(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         ExpressionScript expression2;
-        
+
         expression2 = new ExpressionScript("IQDE321", null);
         expression2.setScript(_scriptText);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Evaluate script: Jython command. Script result.setValue( sensors.provideSensor(\"IS1\").getState() == ACTIVE )", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionScript("IQDE321", "My expression");
         expression2.setScript(_scriptText);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My expression", expression2.getUserName());
         Assert.assertEquals("String matches", "Evaluate script: Jython command. Script result.setValue( sensors.provideSensor(\"IS1\").getState() == ACTIVE )", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -104,7 +104,7 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -114,16 +114,16 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testGetChild() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Test without script
         expressionScript.setScript(null);
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionScript.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             expressionScript.getChild(0);
@@ -132,24 +132,24 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
             Assert.assertEquals("Error message is correct", "Not supported.", ex.getMessage());
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
-        
+
         // Test with script
         expressionScript.setScript(_scriptText);
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionScript.getChildCount());
     }
-    
+
     @Test
     public void testDescription() {
         Assert.assertEquals("Script", expressionScript.getShortDescription());
         Assert.assertEquals("Evaluate script: Jython command. Script result.setValue( sensors.provideSensor(\"IS1\").getState() == ACTIVE )", expressionScript.getLongDescription());
     }
-    
+
     @Test
     public void testExpression_JythonCommand() throws Exception {
         // Test expression
         Light light = InstanceManager.getDefault(LightManager.class).provide("IL1");
         light.setCommandedState(Light.OFF);
-        
+
         // The action is not yet executed so the light should be off
         Assert.assertTrue("light is off", light.getState() == Light.OFF);
         // Set the sensor to inactive so we get a property change when we activate the sensor later
@@ -162,15 +162,15 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         sensor.setState(Sensor.ACTIVE);
         // The action should now be executed so the light should be on
         Assert.assertTrue("light is on", light.getState() == Light.ON);
-        
-        
+
+
         // Test action when triggered because the script is listening on the sensor IS2
         Sensor sensor2 = InstanceManager.getDefault(SensorManager.class).provide("IS2");
         sensor2.setCommandedState(Sensor.INACTIVE);
         light.setCommandedState(Light.OFF);
-        
+
         logixNG.unregisterListeners();
-        
+
         // The action is not yet executed so the atomic boolean should be false
         Assert.assertEquals("light is off",Light.OFF,light.getState());
         // Activate the sensor. This should not execute the conditional.
@@ -188,7 +188,7 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         sensor2.setCommandedState(Sensor.ACTIVE);
         // The action should now be executed so the atomic boolean should be true
         Assert.assertEquals("light is on",Light.ON,light.getState());
-        
+
         // Unregister listeners
         expressionScript.unregisterListeners();
         light.setState(Light.OFF);
@@ -198,21 +198,21 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         sensor2.setCommandedState(Sensor.ACTIVE);
         // Listerners are not registered so the atomic boolean should be false
         Assert.assertEquals("light is off",Light.OFF,light.getState());
-        
+
         // Test evaluate() without script.
         expressionScript.setScript("");
         Assert.assertFalse(expressionScript.evaluate());
     }
-    
+
     @Test
     public void testExpression_RunScript() throws Exception {
         expressionScript.setOperationType(ExpressionScript.OperationType.RunScript);
         expressionScript.setScript("java/test/jmri/jmrit/logixng/expressions/ExpressionScriptTest.py");
-        
+
         // Test action
         Light light = InstanceManager.getDefault(LightManager.class).provide("IL1");
         light.setCommandedState(Light.OFF);
-        
+
         // Set the sensor to inactive so we get a property change when we activate the sensor later
         sensor.setState(Sensor.INACTIVE);
         // The action is not yet executed so the light should be off
@@ -224,22 +224,22 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         // The action should now be executed so the light should be on
         Assert.assertTrue("light is on", light.getState() == Light.ON);
     }
-    
+
     @Test
     public void testSetScript() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Test setScript() when listeners are registered
         Assert.assertNotNull("Script is not null", _scriptText);
         expressionScript.setScript(_scriptText);
         Assert.assertNotNull("Script is not null", expressionScript.getScript());
-        
+
         // Test bad script
         expressionScript.setScript("This is a bad script");
         Assert.assertEquals("This is a bad script", expressionScript.getScript());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException, JmriException {
@@ -250,49 +250,50 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A logixNG");
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         logixNG.addConditionalNG(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         ifThenElse = new IfThenElse("IQDA321", null);
         ifThenElse.setType(IfThenElse.Type.AlwaysExecute);
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         sensor = InstanceManager.getDefault(SensorManager.class).provide("IS1");
-        
+
         expressionScript = new ExpressionScript(InstanceManager.getDefault(DigitalExpressionManager.class).getAutoSystemName(), null);
         expressionScript.setScript(_scriptText);
         expressionScript.setRegisterListenerScript("sensors.provideSensor(\"IS1\").addPropertyChangeListener(self)");
         expressionScript.setUnregisterListenerScript("sensors.provideSensor(\"IS1\").removePropertyChangeListener(self)");
         MaleSocket socketExpressionScript = InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionScript);
         ifThenElse.getChild(0).connect(socketExpressionScript);
-        
+
         ActionLight actionLight = new ActionLight("IQDA322", null);
         actionLight.setLight(InstanceManager.getDefault(LightManager.class).provide("IL1"));
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionLight);
         ifThenElse.getChild(1).connect(maleSocket2);
-        
+
         // Set sensor to active to ensure the script returns true
         sensor.setState(Sensor.ACTIVE);
         // Ensure the sensor is active
         Assert.assertTrue( InstanceManager.getDefault(SensorManager.class).provideSensor("IS1").getState() == Sensor.ACTIVE );
         // Ensure the script returns true
         Assert.assertTrue(expressionScript.evaluate());
-        
+
         _base = expressionScript;
         _baseMaleSocket = socketExpressionScript;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -307,5 +308,5 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         expressionScript = null;
         sensor = null;
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionSensorTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionSensorTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 /**
  * Test ExpressionSensor
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
@@ -46,28 +46,28 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
     private ActionAtomicBoolean actionAtomicBoolean;
     private AtomicBoolean atomicBoolean;
     private Sensor sensor;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Sensor IS1 is Active ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -82,40 +82,40 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ExpressionSensor(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() throws JmriException {
         ExpressionSensor expression2;
         Assert.assertNotNull("sensor is not null", sensor);
         sensor.setState(Sensor.ON);
-        
+
         expression2 = new ExpressionSensor("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Sensor '' is Active", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionSensor("IQDE321", "My sensor");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My sensor", expression2.getUserName());
         Assert.assertEquals("String matches", "Sensor '' is Active", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionSensor("IQDE321", null);
         expression2.setSensor(sensor);
         Assert.assertTrue("sensor is correct", sensor == expression2.getSensor().getBean());
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Sensor IS1 is Active", expression2.getLongDescription());
-        
+
         Sensor s = InstanceManager.getDefault(SensorManager.class).provide("IS2");
         expression2 = new ExpressionSensor("IQDE321", "My sensor");
         expression2.setSensor(s);
@@ -123,7 +123,7 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My sensor", expression2.getUserName());
         Assert.assertEquals("String matches", "Sensor IS2 is Active", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -132,7 +132,7 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -142,11 +142,11 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionSensor.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             expressionSensor.getChild(0);
@@ -156,34 +156,34 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testSensorState() {
         Assert.assertEquals("String matches", "Inactive", ExpressionSensor.SensorState.Inactive.toString());
         Assert.assertEquals("String matches", "Active", ExpressionSensor.SensorState.Active.toString());
         Assert.assertEquals("String matches", "Other", ExpressionSensor.SensorState.Other.toString());
-        
+
         Assert.assertTrue("objects are equal", ExpressionSensor.SensorState.Inactive == ExpressionSensor.SensorState.get(Sensor.INACTIVE));
         Assert.assertTrue("objects are equal", ExpressionSensor.SensorState.Active == ExpressionSensor.SensorState.get(Sensor.ACTIVE));
         Assert.assertTrue("objects are equal", ExpressionSensor.SensorState.Other == ExpressionSensor.SensorState.get(Sensor.UNKNOWN));
         Assert.assertTrue("objects are equal", ExpressionSensor.SensorState.Other == ExpressionSensor.SensorState.get(Sensor.INCONSISTENT));
         Assert.assertTrue("objects are equal", ExpressionSensor.SensorState.Other == ExpressionSensor.SensorState.get(-1));
-        
+
         Assert.assertEquals("ID matches", Sensor.INACTIVE, ExpressionSensor.SensorState.Inactive.getID());
         Assert.assertEquals("ID matches", Sensor.ACTIVE, ExpressionSensor.SensorState.Active.getID());
         Assert.assertEquals("ID matches", -1, ExpressionSensor.SensorState.Other.getID());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         expressionSensor.removeSensor();
         Assert.assertEquals("Sensor", expressionSensor.getShortDescription());
         Assert.assertEquals("Sensor '' is Active", expressionSensor.getLongDescription());
@@ -196,7 +196,7 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         expressionSensor.setBeanState(ExpressionSensor.SensorState.Other);
         Assert.assertTrue("Sensor IS1 is not Other".equals(expressionSensor.getLongDescription()));
     }
-    
+
     @Test
     public void testExpression() throws SocketAlreadyConnectedException, JmriException {
         // Clear flag
@@ -205,11 +205,11 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         sensor.setCommandedState(Sensor.INACTIVE);
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         expressionSensor.setSensor(sensor);
         expressionSensor.set_Is_IsNot(Is_IsNot_Enum.Is);
         expressionSensor.setBeanState(ExpressionSensor.SensorState.Active);
-        
+
         // The action is not yet executed so the atomic boolean should be false
         Assert.assertFalse("atomicBoolean is false",atomicBoolean.get());
         // Activate the sensor. This should not execute the conditional.
@@ -233,7 +233,7 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         sensor.setCommandedState(Sensor.INACTIVE);
         // The action should now be executed so the atomic boolean should be true
         Assert.assertFalse("atomicBoolean is false",atomicBoolean.get());
-        
+
         // Test IS_NOT
         expressionSensor.set_Is_IsNot(Is_IsNot_Enum.IsNot);
         // Activate the sensor. This should not execute the conditional.
@@ -245,16 +245,16 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         // The action should now be executed so the atomic boolean should be true
         Assert.assertTrue("atomicBoolean is true",atomicBoolean.get());
     }
-    
+
     @Test
     public void testSetSensor() {
         expressionSensor.unregisterListeners();
-        
+
         Sensor otherSensor = InstanceManager.getDefault(SensorManager.class).provide("IM99");
         Assert.assertNotEquals("Sensors are different", otherSensor, expressionSensor.getSensor().getBean());
         expressionSensor.setSensor(otherSensor);
         Assert.assertEquals("Sensors are equal", otherSensor, expressionSensor.getSensor().getBean());
-        
+
         NamedBeanHandle<Sensor> otherSensorHandle =
                 InstanceManager.getDefault(NamedBeanHandleManager.class)
                         .getNamedBeanHandle(otherSensor.getDisplayName(), otherSensor);
@@ -264,44 +264,44 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("Sensors are equal", otherSensor, expressionSensor.getSensor().getBean());
         Assert.assertEquals("SensorHandles are equal", otherSensorHandle, expressionSensor.getSensor());
     }
-    
+
     @Test
     public void testSetSensor2() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         Sensor sensor11 = InstanceManager.getDefault(SensorManager.class).provide("IL11");
         Sensor sensor12 = InstanceManager.getDefault(SensorManager.class).provide("IL12");
         NamedBeanHandle<Sensor> sensorHandle12 = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(sensor12.getDisplayName(), sensor12);
         Sensor sensor13 = InstanceManager.getDefault(SensorManager.class).provide("IL13");
         Sensor sensor14 = InstanceManager.getDefault(SensorManager.class).provide("IL14");
         sensor14.setUserName("Some user name");
-        
+
         expressionSensor.removeSensor();
         Assert.assertNull("sensor handle is null", expressionSensor.getSensor());
-        
+
         expressionSensor.setSensor(sensor11);
         Assert.assertTrue("sensor is correct", sensor11 == expressionSensor.getSensor().getBean());
-        
+
         expressionSensor.removeSensor();
         Assert.assertNull("sensor handle is null", expressionSensor.getSensor());
-        
+
         expressionSensor.setSensor(sensorHandle12);
         Assert.assertTrue("sensor handle is correct", sensorHandle12 == expressionSensor.getSensor());
-        
+
         expressionSensor.setSensor("A non existent sensor");
         Assert.assertNull("sensor handle is null", expressionSensor.getSensor());
         JUnitAppender.assertErrorMessage("sensor \"A non existent sensor\" is not found");
-        
+
         expressionSensor.setSensor(sensor13.getSystemName());
         Assert.assertTrue("sensor is correct", sensor13 == expressionSensor.getSensor().getBean());
-        
+
         String userName = sensor14.getUserName();
         Assert.assertNotNull("sensor is not null", userName);
         expressionSensor.setSensor(userName);
         Assert.assertTrue("sensor is correct", sensor14 == expressionSensor.getSensor().getBean());
     }
-    
+
     @Test
     public void testSetSensorException() {
         Assert.assertNotNull("Sensor is not null", sensor);
@@ -315,7 +315,7 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setSensor must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             Sensor sensor99 = InstanceManager.getDefault(SensorManager.class).provide("IS99");
@@ -327,7 +327,7 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setSensor must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             expressionSensor.removeSensor();
@@ -337,7 +337,7 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setSensor must not be called when listeners are registered");
     }
-    
+
     @Test
     public void testRegisterListeners() {
         // Test registerListeners() when the ExpressionSensor has no sensor
@@ -345,37 +345,37 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         expressionSensor.removeSensor();
         conditionalNG.setEnabled(true);
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Get the expressionSensor and set the sensor
         Assert.assertNotNull("Sensor is not null", sensor);
         expressionSensor.setSensor(sensor);
-        
+
         // Get some other sensor for later use
         Sensor otherSensor = InstanceManager.getDefault(SensorManager.class).provide("IM99");
         Assert.assertNotNull("Sensor is not null", otherSensor);
         Assert.assertNotEquals("Sensor is not equal", sensor, otherSensor);
-        
+
         // Test vetoableChange() for some other propery
         expressionSensor.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Sensor matches", sensor, expressionSensor.getSensor().getBean());
-        
+
         // Test vetoableChange() for a string
         expressionSensor.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Sensor matches", sensor, expressionSensor.getSensor().getBean());
         expressionSensor.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Sensor matches", sensor, expressionSensor.getSensor().getBean());
-        
+
         // Test vetoableChange() for another sensor
         expressionSensor.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherSensor, null));
         Assert.assertEquals("Sensor matches", sensor, expressionSensor.getSensor().getBean());
         expressionSensor.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherSensor, null));
         Assert.assertEquals("Sensor matches", sensor, expressionSensor.getSensor().getBean());
-        
+
         // Test vetoableChange() for its own sensor
         boolean thrown = false;
         try {
@@ -384,12 +384,12 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Sensor matches", sensor, expressionSensor.getSensor().getBean());
         expressionSensor.vetoableChange(new PropertyChangeEvent(this, "DoDelete", sensor, null));
         Assert.assertNull("Sensor is null", expressionSensor.getSensor());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -399,41 +399,42 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initConfigureManager();
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         logixNG.addConditionalNG(conditionalNG);
-        
+
         IfThenElse ifThenElse = new IfThenElse("IQDA321", null);
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionSensor = new ExpressionSensor("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionSensor);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expressionSensor;
         _baseMaleSocket = maleSocket2;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
         sensor = InstanceManager.getDefault(SensorManager.class).provide("IS1");
         expressionSensor.setSensor(sensor);
         sensor.setCommandedState(Sensor.ACTIVE);
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -442,5 +443,5 @@ public class ExpressionSensorTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionTurnoutTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionTurnoutTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 /**
  * Test ExpressionTurnout
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
@@ -46,28 +46,28 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
     private ActionAtomicBoolean actionAtomicBoolean;
     private AtomicBoolean atomicBoolean;
     private Turnout turnout;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Turnout IT1 is Thrown ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -82,40 +82,40 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new ExpressionTurnout(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() throws JmriException {
         ExpressionTurnout expression2;
         Assert.assertNotNull("turnout is not null", turnout);
         turnout.setState(Turnout.THROWN);
-        
+
         expression2 = new ExpressionTurnout("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Turnout '' is Thrown", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionTurnout("IQDE321", "My turnout");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My turnout", expression2.getUserName());
         Assert.assertEquals("String matches", "Turnout '' is Thrown", expression2.getLongDescription());
-        
+
         expression2 = new ExpressionTurnout("IQDE321", null);
         expression2.setTurnout(turnout);
         Assert.assertTrue("turnout is correct", turnout == expression2.getTurnout().getBean());
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Turnout IT1 is Thrown", expression2.getLongDescription());
-        
+
         Turnout t = InstanceManager.getDefault(TurnoutManager.class).provide("IT2");
         expression2 = new ExpressionTurnout("IQDE321", "My turnout");
         expression2.setTurnout(t);
@@ -123,7 +123,7 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My turnout", expression2.getUserName());
         Assert.assertEquals("String matches", "Turnout IT2 is Thrown", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -132,7 +132,7 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -142,11 +142,11 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionTurnout.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             expressionTurnout.getChild(0);
@@ -156,34 +156,34 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testTurnoutState() {
         Assert.assertEquals("String matches", "Closed", ExpressionTurnout.TurnoutState.Closed.toString());
         Assert.assertEquals("String matches", "Thrown", ExpressionTurnout.TurnoutState.Thrown.toString());
         Assert.assertEquals("String matches", "Other", ExpressionTurnout.TurnoutState.Other.toString());
-        
+
         Assert.assertTrue("objects are equal", ExpressionTurnout.TurnoutState.Closed == ExpressionTurnout.TurnoutState.get(Turnout.CLOSED));
         Assert.assertTrue("objects are equal", ExpressionTurnout.TurnoutState.Thrown == ExpressionTurnout.TurnoutState.get(Turnout.THROWN));
         Assert.assertTrue("objects are equal", ExpressionTurnout.TurnoutState.Other == ExpressionTurnout.TurnoutState.get(Turnout.UNKNOWN));
         Assert.assertTrue("objects are equal", ExpressionTurnout.TurnoutState.Other == ExpressionTurnout.TurnoutState.get(Turnout.INCONSISTENT));
         Assert.assertTrue("objects are equal", ExpressionTurnout.TurnoutState.Other == ExpressionTurnout.TurnoutState.get(-1));
-        
+
         Assert.assertEquals("ID matches", Turnout.CLOSED, ExpressionTurnout.TurnoutState.Closed.getID());
         Assert.assertEquals("ID matches", Turnout.THROWN, ExpressionTurnout.TurnoutState.Thrown.getID());
         Assert.assertEquals("ID matches", -1, ExpressionTurnout.TurnoutState.Other.getID());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         expressionTurnout.removeTurnout();
         Assert.assertTrue("Turnout".equals(expressionTurnout.getShortDescription()));
         Assert.assertTrue("Turnout '' is Thrown".equals(expressionTurnout.getLongDescription()));
@@ -196,7 +196,7 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         expressionTurnout.setBeanState(ExpressionTurnout.TurnoutState.Other);
         Assert.assertTrue("Turnout IT1 is not Other".equals(expressionTurnout.getLongDescription()));
     }
-    
+
     @Test
     public void testExpression() throws SocketAlreadyConnectedException, JmriException {
         // Clear flag
@@ -205,11 +205,11 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         turnout.setCommandedState(Turnout.CLOSED);
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         expressionTurnout.setTurnout(turnout);
         expressionTurnout.set_Is_IsNot(Is_IsNot_Enum.Is);
         expressionTurnout.setBeanState(ExpressionTurnout.TurnoutState.Thrown);
-        
+
         // The action is not yet executed so the atomic boolean should be false
         Assert.assertFalse("atomicBoolean is false",atomicBoolean.get());
         // Throw the switch. This should not execute the conditional.
@@ -233,7 +233,7 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         turnout.setCommandedState(Turnout.CLOSED);
         // The action should now be executed so the atomic boolean should be true
         Assert.assertFalse("atomicBoolean is false",atomicBoolean.get());
-        
+
         // Test IS_NOT
         expressionTurnout.set_Is_IsNot(Is_IsNot_Enum.IsNot);
         // Throw the switch. This should not execute the conditional.
@@ -245,16 +245,16 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         // The action should now be executed so the atomic boolean should be true
         Assert.assertTrue("atomicBoolean is true",atomicBoolean.get());
     }
-    
+
     @Test
     public void testSetTurnout() {
         expressionTurnout.unregisterListeners();
-        
+
         Turnout otherTurnout = InstanceManager.getDefault(TurnoutManager.class).provide("IM99");
         Assert.assertNotEquals("Turnouts are different", otherTurnout, expressionTurnout.getTurnout().getBean());
         expressionTurnout.setTurnout(otherTurnout);
         Assert.assertEquals("Turnouts are equal", otherTurnout, expressionTurnout.getTurnout().getBean());
-        
+
         NamedBeanHandle<Turnout> otherTurnoutHandle =
                 InstanceManager.getDefault(NamedBeanHandleManager.class)
                         .getNamedBeanHandle(otherTurnout.getDisplayName(), otherTurnout);
@@ -264,44 +264,44 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("Turnouts are equal", otherTurnout, expressionTurnout.getTurnout().getBean());
         Assert.assertEquals("TurnoutHandles are equal", otherTurnoutHandle, expressionTurnout.getTurnout());
     }
-    
+
     @Test
     public void testSetTurnout2() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         Turnout turnout11 = InstanceManager.getDefault(TurnoutManager.class).provide("IT11");
         Turnout turnout12 = InstanceManager.getDefault(TurnoutManager.class).provide("IT12");
         NamedBeanHandle<Turnout> turnoutHandle12 = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle(turnout12.getDisplayName(), turnout12);
         Turnout turnout13 = InstanceManager.getDefault(TurnoutManager.class).provide("IT13");
         Turnout turnout14 = InstanceManager.getDefault(TurnoutManager.class).provide("IT14");
         turnout14.setUserName("Some user name");
-        
+
         expressionTurnout.removeTurnout();
         Assert.assertNull("turnout handle is null", expressionTurnout.getTurnout());
-        
+
         expressionTurnout.setTurnout(turnout11);
         Assert.assertTrue("turnout is correct", turnout11 == expressionTurnout.getTurnout().getBean());
-        
+
         expressionTurnout.removeTurnout();
         Assert.assertNull("turnout handle is null", expressionTurnout.getTurnout());
-        
+
         expressionTurnout.setTurnout(turnoutHandle12);
         Assert.assertTrue("turnout handle is correct", turnoutHandle12 == expressionTurnout.getTurnout());
-        
+
         expressionTurnout.setTurnout("A non existent turnout");
         Assert.assertNull("turnout handle is null", expressionTurnout.getTurnout());
         JUnitAppender.assertErrorMessage("turnout \"A non existent turnout\" is not found");
-        
+
         expressionTurnout.setTurnout(turnout13.getSystemName());
         Assert.assertTrue("turnout is correct", turnout13 == expressionTurnout.getTurnout().getBean());
-        
+
         String userName = turnout14.getUserName();
         Assert.assertNotNull("turnout is not null", userName);
         expressionTurnout.setTurnout(userName);
         Assert.assertTrue("turnout is correct", turnout14 == expressionTurnout.getTurnout().getBean());
     }
-    
+
     @Test
     public void testSetTurnoutException() {
         Assert.assertNotNull("Turnout is not null", turnout);
@@ -315,7 +315,7 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setTurnout must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             Turnout turnout99 = InstanceManager.getDefault(TurnoutManager.class).provide("IT99");
@@ -327,7 +327,7 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setTurnout must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             expressionTurnout.removeTurnout();
@@ -337,7 +337,7 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setTurnout must not be called when listeners are registered");
     }
-    
+
     @Test
     public void testRegisterListeners() {
         // Test registerListeners() when the ExpressionTurnout has no turnout
@@ -345,37 +345,37 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         expressionTurnout.removeTurnout();
         conditionalNG.setEnabled(true);
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Get the expressionTurnout and set the turnout
         Assert.assertNotNull("Turnout is not null", turnout);
         expressionTurnout.setTurnout(turnout);
-        
+
         // Get some other turnout for later use
         Turnout otherTurnout = InstanceManager.getDefault(TurnoutManager.class).provide("IM99");
         Assert.assertNotNull("Turnout is not null", otherTurnout);
         Assert.assertNotEquals("Turnout is not equal", turnout, otherTurnout);
-        
+
         // Test vetoableChange() for some other propery
         expressionTurnout.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Turnout matches", turnout, expressionTurnout.getTurnout().getBean());
-        
+
         // Test vetoableChange() for a string
         expressionTurnout.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Turnout matches", turnout, expressionTurnout.getTurnout().getBean());
         expressionTurnout.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Turnout matches", turnout, expressionTurnout.getTurnout().getBean());
-        
+
         // Test vetoableChange() for another turnout
         expressionTurnout.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherTurnout, null));
         Assert.assertEquals("Turnout matches", turnout, expressionTurnout.getTurnout().getBean());
         expressionTurnout.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherTurnout, null));
         Assert.assertEquals("Turnout matches", turnout, expressionTurnout.getTurnout().getBean());
-        
+
         // Test vetoableChange() for its own turnout
         boolean thrown = false;
         try {
@@ -384,12 +384,12 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Turnout matches", turnout, expressionTurnout.getTurnout().getBean());
         expressionTurnout.vetoableChange(new PropertyChangeEvent(this, "DoDelete", turnout, null));
         Assert.assertNull("Turnout is null", expressionTurnout.getTurnout());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -399,41 +399,42 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initConfigureManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.ITEM;
         _isExternal = true;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         logixNG.addConditionalNG(conditionalNG);
-        
+
         IfThenElse ifThenElse = new IfThenElse("IQDA321", null);
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionTurnout = new ExpressionTurnout("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionTurnout);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expressionTurnout;
         _baseMaleSocket = maleSocket2;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
         turnout = InstanceManager.getDefault(TurnoutManager.class).provide("IT1");
         expressionTurnout.setTurnout(turnout);
         turnout.setCommandedState(Turnout.THROWN);
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -442,5 +443,5 @@ public class ExpressionTurnoutTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/FalseTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/FalseTest.java
@@ -28,7 +28,7 @@ import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
 
 /**
  * Test False
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class FalseTest extends AbstractDigitalExpressionTestBase {
@@ -38,28 +38,28 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
     private False expressionFalse;
     private ActionAtomicBoolean actionAtomicBoolean;
     private AtomicBoolean atomicBoolean;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Always false ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -74,31 +74,31 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new False(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         False expression2;
-        
+
         expression2 = new False("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Always false", expression2.getLongDescription());
-        
+
         expression2 = new False("IQDE321", "My expression");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My expression", expression2.getUserName());
         Assert.assertEquals("String matches", "Always false", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -107,7 +107,7 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -117,11 +117,11 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionFalse.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             expressionFalse.getChild(0);
@@ -131,25 +131,25 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.OTHER == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         False e1 = new False("IQDE321", null);
         Assert.assertTrue("Always false".equals(e1.getShortDescription()));
         Assert.assertTrue("Always false".equals(e1.getLongDescription()));
     }
-    
+
     @Test
     public void testExpression() throws Exception {
         DigitalExpressionBean t = new False("IQDE321", null);
         Assert.assertFalse("Expression is false",t.evaluate());
     }
-    
+
     @Test
     @Override
     public void testEnableAndEvaluate() {
@@ -158,7 +158,7 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
         // to add support here. It doesn't need to be tested for every digital
         // expression.
     }
-    
+
     @Test
     @Override
     public void testDebugConfig() {
@@ -167,7 +167,7 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
         // to add support here. It doesn't need to be tested for every digital
         // expression.
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -178,10 +178,10 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.COMMON;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -192,21 +192,22 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionFalse = new False("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionFalse);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expressionFalse;
         _baseMaleSocket = maleSocket2;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -215,5 +216,5 @@ public class FalseTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/HoldTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/HoldTest.java
@@ -19,7 +19,7 @@ import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
 
 /**
  * Test Hold
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class HoldTest extends AbstractDigitalExpressionTestBase {
@@ -29,20 +29,20 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
     private Hold expressionHold;
     private ActionAtomicBoolean actionAtomicBoolean;
     private AtomicBoolean atomicBoolean;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     private static int beanID = 901;
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         DigitalExpressionBean childExpression = new True("IQDE"+Integer.toString(beanID++), null);
@@ -50,7 +50,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(childExpression);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -60,7 +60,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 "   ? Hold%n" +
                 "      Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -79,31 +79,31 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new Hold(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Hold expression2;
-        
+
         expression2 = new Hold("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Trigger on expression Trigger. Hold while expression Hold", expression2.getLongDescription());
-        
+
         expression2 = new Hold("IQDE321", "My expression");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My expression", expression2.getUserName());
         Assert.assertEquals("String matches", "Trigger on expression Trigger. Hold while expression Hold", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -112,7 +112,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -122,7 +122,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testCtorAndSetup1() {
         Hold expression = new Hold("IQDE321", null);
@@ -132,7 +132,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         expression.setTriggerExpressionSocketSystemName("IQDE52");
         expression.getChild(1).setName("ZH12");
         expression.setHoldActionSocketSystemName("IQDE554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -141,7 +141,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -150,13 +150,13 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load digital expression IQDE52");
         jmri.util.JUnitAppender.assertMessage("cannot load digital expression IQDE554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -165,7 +165,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -174,10 +174,10 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup2() {
         Hold expression = new Hold("IQDE321", null);
@@ -187,7 +187,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         expression.setHoldActionSocketSystemName(null);
         expression.getChild(1).setName("ZH12");
         expression.setTriggerExpressionSocketSystemName(null);
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -196,7 +196,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -205,10 +205,10 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -217,7 +217,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -226,17 +226,17 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup3() {
         DigitalExpressionManager m = InstanceManager.getDefault(DigitalExpressionManager.class);
-        
+
         m.registerExpression(new ExpressionMemory("IQDE52", null));
         m.registerExpression(new ExpressionMemory("IQDE554", null));
-        
+
         Hold expression = new Hold("IQDE321", null);
         Assert.assertNotNull("exists", expression);
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
@@ -244,7 +244,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         expression.setHoldActionSocketSystemName("IQDE52");
         expression.getChild(1).setName("ZH12");
         expression.setTriggerExpressionSocketSystemName("IQDE554");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -253,7 +253,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression female socket name is ZH12",
                 "ZH12", expression.getChild(1).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -262,39 +262,39 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(1).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(1).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(0).isConnected());
 //        Assert.assertEquals("child is correct bean",
 //                childSocket0,
 //                expression.getChild(0).getConnectedSocket());
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(1).isConnected());
 //        Assert.assertEquals("child is correct bean",
 //                childSocket1,
 //                expression.getChild(1).getConnectedSocket());
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         expression.setup();
-        
+
         Assert.assertEquals("expression has 2 female sockets", 2, expression.getChildCount());
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 2", 2 == expressionHold.getChildCount());
-        
+
         Assert.assertNotNull("getChild(0) returns a non null value",
                 expressionHold.getChild(0));
         Assert.assertNotNull("getChild(1) returns a non null value",
                 expressionHold.getChild(1));
-        
+
         boolean hasThrown = false;
         try {
             expressionHold.getChild(2);
@@ -304,19 +304,19 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.OTHER == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         Hold e1 = new Hold("IQDE321", null);
         Assert.assertTrue("Hold".equals(e1.getShortDescription()));
         Assert.assertTrue("Trigger on expression Trigger. Hold while expression Hold".equals(e1.getLongDescription()));
     }
-    
+
     @Test
     @Override
     public void testEnableAndEvaluate() {
@@ -325,7 +325,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         // to add support here. It doesn't need to be tested for every digital
         // expression.
     }
-    
+
     @Test
     @Override
     public void testDebugConfig() {
@@ -334,7 +334,7 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         // to add support here. It doesn't need to be tested for every digital
         // expression.
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -345,10 +345,10 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.OTHER;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -359,21 +359,22 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionHold = new Hold("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionHold);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expressionHold;
         _baseMaleSocket = maleSocket2;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -382,5 +383,5 @@ public class HoldTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/NotTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/NotTest.java
@@ -19,7 +19,7 @@ import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
 
 /**
  * Test Not
- * 
+ *
  * @author Daniel Bergqvist 2021
  */
 public class NotTest extends AbstractDigitalExpressionTestBase {
@@ -29,20 +29,20 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
     private Not expressionNot;
     private ActionAtomicBoolean actionAtomicBoolean;
     private AtomicBoolean atomicBoolean;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     private static int beanID = 901;
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         DigitalExpressionBean childExpression = new True("IQDE"+Integer.toString(beanID++), null);
@@ -50,7 +50,7 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(childExpression);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -58,7 +58,7 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
                 "   ? E%n" +
                 "      Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -75,31 +75,31 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new Not(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Not expression2;
-        
+
         expression2 = new Not("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Not", expression2.getLongDescription());
-        
+
         expression2 = new Not("IQDE321", "My expression");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My expression", expression2.getUserName());
         Assert.assertEquals("String matches", "Not", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -108,7 +108,7 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -118,7 +118,7 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testCtorAndSetup1() {
         Not expression = new Not("IQDE321", null);
@@ -126,7 +126,7 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
         expression.getChild(0).setName("XYZ123");
         expression.setSocketSystemName("IQDE52");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -135,12 +135,12 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load digital expression IQDE52");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -149,10 +149,10 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup2() {
         Not expression = new Not("IQDE321", null);
@@ -160,7 +160,7 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
         expression.getChild(0).setName("XYZ123");
         expression.setSocketSystemName(null);
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -169,10 +169,10 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -181,23 +181,23 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup3() {
         DigitalExpressionManager m = InstanceManager.getDefault(DigitalExpressionManager.class);
-        
+
         m.registerExpression(new ExpressionMemory("IQDE52", null));
         m.registerExpression(new ExpressionMemory("IQDE554", null));
-        
+
         Not expression = new Not("IQDE321", null);
         Assert.assertNotNull("exists", expression);
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
         expression.getChild(0).setName("XYZ123");
         expression.setSocketSystemName("IQDE52");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -206,30 +206,30 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertTrue("expression female socket is connected",
                 expression.getChild(0).isConnected());
 //        Assert.assertEquals("child is correct bean",
 //                childSocket0,
 //                expression.getChild(0).getConnectedSocket());
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         expression.setup();
-        
+
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 1", 1 == expressionNot.getChildCount());
-        
+
         Assert.assertNotNull("getChild(0) returns a non null value",
                 expressionNot.getChild(0));
-        
+
         boolean hasThrown = false;
         try {
             expressionNot.getChild(1);
@@ -239,19 +239,19 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         Not e1 = new Not("IQDE321", null);
         Assert.assertTrue("Not".equals(e1.getShortDescription()));
         Assert.assertTrue("Not".equals(e1.getLongDescription()));
     }
-    
+
     @Test
     @Override
     public void testEnableAndEvaluate() {
@@ -260,7 +260,7 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
         // to add support here. It doesn't need to be tested for every digital
         // expression.
     }
-    
+
     @Test
     @Override
     public void testDebugConfig() {
@@ -269,7 +269,7 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
         // to add support here. It doesn't need to be tested for every digital
         // expression.
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -280,10 +280,10 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.OTHER;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -294,21 +294,22 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionNot = new Not("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionNot);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expressionNot;
         _baseMaleSocket = maleSocket2;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -317,5 +318,5 @@ public class NotTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/OrTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/OrTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 
 /**
  * Test Or
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class OrTest extends AbstractDigitalExpressionTestBase {
@@ -27,18 +27,18 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
     private LogixNG logixNG;
     private ConditionalNG conditionalNG;
     private Or expressionOr;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         DigitalExpressionBean childExpression = new True("IQDE999", null);
@@ -46,7 +46,7 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(childExpression);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -75,12 +75,12 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new Or(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() throws SocketAlreadyConnectedException {
         int count = _base.getChildCount();
@@ -91,21 +91,21 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         }
         return true;
     }
-    
+
     @Test
     public void testCtor() {
         Or expression2;
-        
+
         expression2 = new Or("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Or", expression2.getLongDescription());
-        
+
         expression2 = new Or("IQDE321", "My expression");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My expression", expression2.getUserName());
         Assert.assertEquals("String matches", "Or", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -114,7 +114,7 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -124,19 +124,19 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     // Test action when at least one child socket is not connected
     @Test
     public void testCtorAndSetup1() {
         DigitalExpressionManager m = InstanceManager.getDefault(DigitalExpressionManager.class);
-        
+
         List<MaleSocket> maleSockets = new ArrayList<>();
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE52", null)));
         maleSockets.add(null);  // This is null by purpose
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE554", null)));
         maleSockets.add(null);  // This is null by purpose
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE3", null)));
-        
+
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQDE52"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("ZH12", null));   // This is null by purpose
@@ -144,11 +144,11 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         // IQDE61232 doesn't exist by purpose
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("SomethingElse", "IQDE61232"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Yes123", "IQDE3"));
-        
+
         Or expression = new Or("IQDE321", null, actionSystemNames);
         Assert.assertNotNull("exists", expression);
         Assert.assertEquals("expression has 5 female sockets", 5, expression.getChildCount());
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("expression female socket name is "+entry.getKey(),
@@ -160,17 +160,17 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
             Assert.assertFalse("expression female socket is not connected",
                     expression.getChild(i).isConnected());
         }
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load digital expression IQDE61232");
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("expression female socket name is "+entry.getKey(),
                     entry.getKey(), expression.getChild(i).getName());
-            
+
             if (maleSockets.get(i) != null) {
                 Assert.assertTrue("expression female socket is connected",
                         expression.getChild(i).isConnected());
@@ -182,34 +182,34 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
                         expression.getChild(i).isConnected());
             }
         }
-        
+
         Assert.assertEquals("expression has 5 female sockets", 5, expression.getChildCount());
     }
-    
+
     // Test action when at least one child socket is not connected.
     // This should never happen, but test it anyway.
     @Test
     public void testCtorAndSetup2() {
         DigitalExpressionManager m = InstanceManager.getDefault(DigitalExpressionManager.class);
-        
+
         List<MaleSocket> maleSockets = new ArrayList<>();
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE52", null)));
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE99", null)));
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE554", null)));
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE61232", null)));
         maleSockets.add(m.registerExpression(new ExpressionMemory("IQDE3", null)));
-        
+
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQDE52"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("ZH12", "IQDE99"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Hello", "IQDE554"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("SomethingElse", "IQDE61232"));
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("Yes123", "IQDE3"));
-        
+
         Or expression = new Or("IQDE321", null, actionSystemNames);
         Assert.assertNotNull("exists", expression);
         Assert.assertEquals("expression has 5 female sockets", 5, expression.getChildCount());
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("expression female socket name is "+entry.getKey(),
@@ -221,15 +221,15 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
             Assert.assertFalse("expression female socket is not connected",
                     expression.getChild(i).isConnected());
         }
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         for (int i=0; i < 5; i++) {
             Map.Entry<String,String> entry = actionSystemNames.get(i);
             Assert.assertEquals("expression female socket name is "+entry.getKey(),
                     entry.getKey(), expression.getChild(i).getName());
-            
+
             if (maleSockets.get(i) != null) {
                 Assert.assertTrue("expression female socket is connected",
                         expression.getChild(i).isConnected());
@@ -241,28 +241,28 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
                         expression.getChild(i).isConnected());
             }
         }
-        
+
         // Since all the sockets are connected, a new socket must have been created.
         Assert.assertEquals("expression has 6 female sockets", 6, expression.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         expression.setup();
-        
+
         Assert.assertEquals("expression has 6 female sockets", 6, expression.getChildCount());
     }
-    
+
     // Test calling setActionSystemNames() twice
     @Test
     public void testCtorAndSetup3() throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException {
         List<Map.Entry<String, String>> actionSystemNames = new ArrayList<>();
         actionSystemNames.add(new java.util.HashMap.SimpleEntry<>("XYZ123", "IQDE52"));
-        
+
         Or expression = new Or("IQDE321", null, actionSystemNames);
-        
+
         java.lang.reflect.Method method =
                 expression.getClass().getDeclaredMethod("setExpressionSystemNames", new Class<?>[]{List.class});
         method.setAccessible(true);
-        
+
         boolean hasThrown = false;
         try {
             method.invoke(expression, new Object[]{null});
@@ -276,19 +276,19 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception thrown", hasThrown);
     }
-    
+
     @Test
     public void testGetChild() throws SocketAlreadyConnectedException {
         Or expression2 = new Or("IQDE321", null);
-        
+
         for (int i=0; i < 3; i++) {
             Assert.assertTrue("getChildCount() returns "+i, i+1 == expression2.getChildCount());
-            
+
             Assert.assertNotNull("getChild(0) returns a non null value",
                     expression2.getChild(0));
-            
+
             assertIndexOutOfBoundsException(expression2::getChild, i+1, i+1);
-            
+
             // Connect a new child expression
             True expr = new True("IQDE"+i, null);
             MaleSocket maleSocket =
@@ -296,23 +296,23 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
             expression2.getChild(i).connect(maleSocket);
         }
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.COMMON == _base.getCategory());
     }
-    
+
     // Test the methods connected(FemaleSocket) and getExpressionSystemName(int)
     @Test
     public void testConnected_getExpressionSystemName() throws SocketAlreadyConnectedException {
         Or expression = new Or("IQDE121", null);
-        
+
         ExpressionMemory stringExpressionMemory = new ExpressionMemory("IQDE122", null);
         MaleSocket maleSAMSocket =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(stringExpressionMemory);
-        
+
         Assert.assertEquals("Num children is correct", 1, expression.getChildCount());
-        
+
         // Test connect and disconnect
         expression.getChild(0).connect(maleSAMSocket);
         Assert.assertEquals("Num children is correct", 2, expression.getChildCount());
@@ -322,7 +322,7 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("Num children is correct", 2, expression.getChildCount());
         Assert.assertNull("getExpressionSystemName(0) is null", expression.getExpressionSystemName(0));
         Assert.assertNull("getExpressionSystemName(1) is null", expression.getExpressionSystemName(1));
-        
+
         expression.getChild(1).connect(maleSAMSocket);
         Assert.assertEquals("Num children is correct", 2, expression.getChildCount());
         Assert.assertNull("getExpressionSystemName(0) is null", expression.getExpressionSystemName(0));
@@ -336,7 +336,7 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         Assert.assertNull("getExpressionSystemName(0) is null", expression.getExpressionSystemName(0));
         Assert.assertNull("getExpressionSystemName(1) is null", expression.getExpressionSystemName(1));
     }
-    
+
     @Test
     public void testDescription() {
         Or e1 = new Or("IQDE321", null);
@@ -354,10 +354,10 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.COMMON;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -368,21 +368,22 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionOr = new Or("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionOr);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         DigitalExpressionBean childExpression = new True("IQDE322", null);
         MaleSocket maleSocketChild =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(childExpression);
         maleSocket2.getChild(0).connect(maleSocketChild);
-        
+
         _base = expressionOr;
         _baseMaleSocket = maleSocket2;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -391,5 +392,5 @@ public class OrTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/StringExpressionConstantTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringExpressionConstantTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 /**
  * Test StringExpressionConstant
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class StringExpressionConstantTest extends AbstractStringExpressionTestBase {
@@ -33,28 +33,28 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
     private StringExpressionConstant expressionConstant;
     private Memory _memoryOut;
     private StringActionMemory actionMemory;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Get string constant \"Something\" ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -67,48 +67,48 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
                 "            !s A%n" +
                 "               Set memory IM2 ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new StringExpressionConstant(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Assert.assertTrue("object exists", _base != null);
-        
+
         StringExpressionConstant expression2;
-        
+
         expression2 = new StringExpressionConstant("IQSE11", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", null, expression2.getUserName());
         Assert.assertEquals("String matches", "Get string constant \"\"", expression2.getLongDescription(Locale.ENGLISH));
-        
+
         expression2 = new StringExpressionConstant("IQSE11", "My constant value");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My constant value", expression2.getUserName());
         Assert.assertEquals("String matches", "Get string constant \"\"", expression2.getLongDescription(Locale.ENGLISH));
-        
+
         expression2 = new StringExpressionConstant("IQSE11", null);
         expression2.setValue("A value");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", null, expression2.getUserName());
         Assert.assertEquals("String matches", "Get string constant \"A value\"", expression2.getLongDescription(Locale.ENGLISH));
-        
+
         expression2 = new StringExpressionConstant("IQSE11", "My constant");
         expression2.setValue("Some other value");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My constant", expression2.getUserName());
         Assert.assertEquals("String matches", "Get string constant \"Some other value\"", expression2.getLongDescription(Locale.ENGLISH));
-        
+
         // Call setup(). It doesn't do anything, but we call it for coverage
         expression2.setup();
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -117,7 +117,7 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -126,11 +126,11 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         // Call setup() for coverage. setup() doesn't do anything
         expression2.setup();
     }
-    
+
     @Test
     public void testSetValue() {
         conditionalNG.setEnabled(false);
@@ -142,7 +142,7 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
         expression.setValue("Some other value");
         Assert.assertEquals("getValue() returns correct value", "Some other value", expression.getValue());
     }
-    
+
     @Test
     public void testSetValueWithListenersRegistered() {
         boolean exceptionThrown = false;
@@ -156,7 +156,7 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
         Assert.assertTrue("Exception thrown", exceptionThrown);
         JUnitAppender.assertErrorMessage("setValue must not be called when listeners are registered");
     }
-    
+
     @Test
     public void testEvaluate() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
         // Disable the conditionalNG. This will unregister the listeners
@@ -167,10 +167,10 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
         expression.setValue("");
         Assert.assertEquals("Evaluate matches", "", expression.evaluate());
     }
-    
+
     @Test
     public void testEvaluateAndAction() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
-        
+
         // Set the memory
         _memoryOut.setValue("");
         // The string should be ""
@@ -179,7 +179,7 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
         logixNG.execute();
         // The action is executed so the string should be "Something"
         Assert.assertEquals("memory is \"Something\"", "Something", _memoryOut.getValue());
-        
+
         // Disable the conditionalNG
         conditionalNG.setEnabled(false);
         // Set the value of the constant.
@@ -191,22 +191,22 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
         // The action is executed so the string should be "A value"
         Assert.assertEquals("memory is \"A value\"", "A value", _memoryOut.getValue());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testShortDescription() {
         Assert.assertEquals("String matches", "String constant", _base.getShortDescription(Locale.ENGLISH));
     }
-    
+
     @Test
     public void testLongDescription() {
         Assert.assertEquals("String matches", "Get string constant \"Something\"", _base.getLongDescription(Locale.ENGLISH));
     }
-    
+
     @Test
     public void testChild() {
         Assert.assertTrue("Num children is zero", 0 == _base.getChildCount());
@@ -219,7 +219,7 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -231,28 +231,28 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initLogixNGManager();
-        
+
         expressionConstant = new StringExpressionConstant("IQSE321", null);
         expressionConstant.setValue("Something");
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A logixNG");
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         logixNG.addConditionalNG(conditionalNG);
-        
+
         DigitalActionBean actionDoString =
                 new DoStringAction(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
         MaleSocket socketDoString =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionDoString);
         conditionalNG.getChild(0).connect(socketDoString);
-        
+
         MaleSocket socketExpression =
                 InstanceManager.getDefault(StringExpressionManager.class).registerExpression(expressionConstant);
         socketDoString.getChild(0).connect(socketExpression);
-        
+
         _memoryOut = InstanceManager.getDefault(MemoryManager.class).provide("IM2");
         _memoryOut.setValue(0.0);
         actionMemory = new StringActionMemory("IQSA1", null);
@@ -260,11 +260,12 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
         MaleSocket socketAction =
                 InstanceManager.getDefault(StringActionManager.class).registerAction(actionMemory);
         socketDoString.getChild(1).connect(socketAction);
-        
+
         _base = expressionConstant;
         _baseMaleSocket = socketExpression;
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -274,5 +275,5 @@ public class StringExpressionConstantTest extends AbstractStringExpressionTestBa
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/StringExpressionMemoryTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringExpressionMemoryTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 /**
  * Test StringExpressionMemory
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase {
@@ -35,27 +35,27 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
     StringExpressionMemory stringExpressionMemory;
     protected Memory _memory;
     protected Memory _memoryOut;
-    
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Get memory IM1 as string value ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -68,47 +68,47 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
                 "            !s A%n" +
                 "               Set memory IM2 ::: Use default%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new StringExpressionMemory(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         Assert.assertTrue("object exists", _base != null);
-        
+
         StringExpressionMemory expression2;
         Assert.assertNotNull("memory is not null", _memory);
         _memory.setValue(10.2);
-        
+
         expression2 = new StringExpressionMemory("IQSE11", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertTrue("Username matches", null == expression2.getUserName());
         Assert.assertEquals("String matches", "Get memory none as string value", expression2.getLongDescription());
-        
+
         expression2 = new StringExpressionMemory("IQSE11", "My memory");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertTrue("Username matches", "My memory".equals(expression2.getUserName()));
         Assert.assertEquals("String matches", "Get memory none as string value", expression2.getLongDescription());
-        
+
         expression2 = new StringExpressionMemory("IQSE11", null);
         expression2.setMemory(_memory);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertTrue("Username matches", null == expression2.getUserName());
         Assert.assertEquals("String matches", "Get memory IM1 as string value", expression2.getLongDescription());
-        
+
         expression2 = new StringExpressionMemory("IQSE11", "My memory");
         expression2.setMemory(_memory);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertTrue("Username matches", "My memory".equals(expression2.getUserName()));
         Assert.assertEquals("String matches", "Get memory IM1 as string value", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -117,7 +117,7 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -127,12 +127,12 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testEvaluate() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         StringExpressionMemory expression = (StringExpressionMemory)_base;
         _memory.setValue("");
         Assert.assertEquals("Evaluate matches", "", expression.evaluate());
@@ -141,12 +141,12 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         expression.removeMemory();
         Assert.assertEquals("Evaluate matches", "", expression.evaluate());
     }
-    
+
     @Test
     public void testEvaluateAndAction() throws SocketAlreadyConnectedException, SocketAlreadyConnectedException {
         // Disable the conditionalNG
         conditionalNG.setEnabled(false);
-        
+
         // Set the memory
         _memoryOut.setValue("");
         // The memory should have the value ""
@@ -185,23 +185,23 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         _memory.setValue("Something different");
         // The action should not be executed so the memory should still be 3.0
         Assert.assertEquals("memory is \"something else\"", "Something else", _memoryOut.getValue());
-        
+
         // Test register listeners when there is no memory.
         stringExpressionMemory.removeMemory();
         stringExpressionMemory.registerListeners();
     }
-    
+
     @Test
     public void testMemory() {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         StringExpressionMemory expressionMemory = (StringExpressionMemory)_base;
         expressionMemory.removeMemory();
         Assert.assertNull("Memory is null", expressionMemory.getMemory());
         expressionMemory.setMemory(_memory);
         Assert.assertTrue("Memory matches", _memory == expressionMemory.getMemory().getBean());
-        
+
         expressionMemory.removeMemory();
         Assert.assertNull("Memory is null", expressionMemory.getMemory());
         Memory otherMemory = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
@@ -211,17 +211,17 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         expressionMemory.setMemory(memoryHandle);
         Assert.assertTrue("Memory matches", memoryHandle == expressionMemory.getMemory());
         Assert.assertTrue("Memory matches", otherMemory == expressionMemory.getMemory().getBean());
-        
+
         expressionMemory.removeMemory();
         Assert.assertNull("Memory is null", expressionMemory.getMemory());
         expressionMemory.setMemory(memoryHandle.getName());
         Assert.assertTrue("Memory matches", memoryHandle == expressionMemory.getMemory());
-        
+
         // Test setMemory with a memory name that doesn't exists
         expressionMemory.setMemory("Non existent memory");
         Assert.assertNull("Memory is null", expressionMemory.getMemory());
         JUnitAppender.assertErrorMessage("memory \"Non existent memory\" is not found");
-        
+
         // Test setMemory() when listeners are registered
         expressionMemory.setMemory(_memory);
         Assert.assertNotNull("Memory is null", expressionMemory.getMemory());
@@ -235,7 +235,7 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             expressionMemory.removeMemory();
@@ -244,7 +244,7 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         }
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
-        
+
         thrown = false;
         try {
             expressionMemory.removeMemory();
@@ -254,7 +254,7 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         Assert.assertTrue("Expected exception thrown", thrown);
         JUnitAppender.assertErrorMessage("setMemory must not be called when listeners are registered");
     }
-    
+
     @Test
     public void testRegisterListeners() {
         StringExpressionMemory expressionString = (StringExpressionMemory)_base;
@@ -263,38 +263,38 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         expressionString.removeMemory();
         conditionalNG.setEnabled(true);
     }
-    
+
     @Test
     public void testVetoableChange() throws PropertyVetoException {
         // Disable the conditionalNG. This will unregister the listeners
         conditionalNG.setEnabled(false);
-        
+
         // Get some other memory for later use
         Memory otherMemory = InstanceManager.getDefault(MemoryManager.class).provide("IM99");
         Assert.assertNotNull("Memory is not null", otherMemory);
         Assert.assertNotEquals("Memory is not equal", _memory, otherMemory);
-        
+
         // Get the stringExpressionMemory and set the memory
         StringExpressionMemory expression = (StringExpressionMemory)_base;
         expression.setMemory(_memory);
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
-        
+
         // Test vetoableChange() for some other propery
         expression.vetoableChange(new PropertyChangeEvent(this, "CanSomething", "test", null));
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
-        
+
         // Test vetoableChange() for a string
         expression.vetoableChange(new PropertyChangeEvent(this, "CanDelete", "test", null));
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
         expression.vetoableChange(new PropertyChangeEvent(this, "DoDelete", "test", null));
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
-        
+
         // Test vetoableChange() for another memory
         expression.vetoableChange(new PropertyChangeEvent(this, "CanDelete", otherMemory, null));
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
         expression.vetoableChange(new PropertyChangeEvent(this, "DoDelete", otherMemory, null));
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
-        
+
         // Test vetoableChange() for its own memory
         boolean thrown = false;
         try {
@@ -303,27 +303,27 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         Assert.assertEquals("Memory matches", _memory, expression.getMemory().getBean());
         expression.vetoableChange(new PropertyChangeEvent(this, "DoDelete", _memory, null));
         Assert.assertNull("Memory is null", expression.getMemory());
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.ITEM == _base.getCategory());
     }
-    
+
     @Test
     public void testShortDescription() {
         Assert.assertEquals("Memory as string value", _base.getShortDescription());
     }
-    
+
     @Test
     public void testLongDescription() {
         Assert.assertEquals("Get memory IM1 as string value", _base.getLongDescription());
     }
-    
+
     @Test
     public void testChild() {
         Assert.assertTrue("Num children is zero", 0 == _base.getChildCount());
@@ -336,7 +336,7 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -348,15 +348,15 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initLogixNGManager();
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
         conditionalNG.setRunDelayed(false);
         conditionalNG.setEnabled(true);
-        
+
         logixNG.addConditionalNG(conditionalNG);
-        
+
         DoStringAction doStringAction = new DoStringAction("IQDA321", null);
         MaleSocket maleSocketDoStringAction =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(doStringAction);
@@ -369,19 +369,20 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         stringExpressionMemory.setMemory(_memory);
         _base = stringExpressionMemory;
         _baseMaleSocket = maleSocketStringExpressionMemory;
-        
+
         _memory = InstanceManager.getDefault(MemoryManager.class).provide("IM1");
         Assert.assertNotNull("memory is not null", _memory);
         _memory.setValue(10.2);
-        
+
         _memoryOut = InstanceManager.getDefault(MemoryManager.class).provide("IM2");
         _memoryOut.setValue("");
         StringActionMemory actionMemory = new StringActionMemory("IQSA1", null);
         actionMemory.setMemory(_memoryOut);
         MaleSocket socketAction = InstanceManager.getDefault(StringActionManager.class).registerAction(actionMemory);
         maleSocketDoStringAction.getChild(1).connect(socketAction);
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -391,5 +392,5 @@ public class StringExpressionMemoryTest extends AbstractStringExpressionTestBase
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/StringFormulaTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/StringFormulaTest.java
@@ -732,6 +732,7 @@ public class StringFormulaTest extends AbstractStringExpressionTestBase {
         doStringAction.getChild(1).connect(socketAtomicBoolean);
 
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 

--- a/java/test/jmri/jmrit/logixng/expressions/TriggerOnceTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/TriggerOnceTest.java
@@ -18,7 +18,7 @@ import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
 
 /**
  * Test TriggerOnce
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
@@ -28,18 +28,18 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
     private TriggerOnce expressionTriggerOnce;
     private ActionAtomicBoolean actionAtomicBoolean;
     private AtomicBoolean atomicBoolean;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         DigitalExpressionBean childExpression = new True("IQDE"+Integer.toString(beanID++), null);
@@ -47,7 +47,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(childExpression);
         return maleSocketChild;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format(
@@ -55,7 +55,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
                 "   ? E%n" +
                 "      Socket not connected%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -72,35 +72,35 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new TriggerOnce(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor()
             throws NamedBean.BadUserNameException,
                     NamedBean.BadSystemNameException,
                     SocketAlreadyConnectedException {
-        
+
         TriggerOnce expression2;
-        
+
         expression2 = new TriggerOnce("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Trigger once", expression2.getLongDescription());
-        
+
         expression2 = new TriggerOnce("IQDE321", "My sensor");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My sensor", expression2.getUserName());
         Assert.assertEquals("String matches", "Trigger once", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -109,7 +109,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -119,7 +119,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     // Test action when at least one child socket is not connected
     @Test
     public void testCtorAndSetup1() {
@@ -128,7 +128,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
         expression.getChild(0).setName("XYZ123");
         expression.setChildSocketSystemName("IQDE52");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -137,12 +137,12 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         jmri.util.JUnitAppender.assertMessage("cannot load digital expression IQDE52");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -151,10 +151,10 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup2() {
         TriggerOnce expression = new TriggerOnce("IQDE321", null);
@@ -162,7 +162,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
         expression.getChild(0).setName("XYZ123");
         expression.setChildSocketSystemName(null);
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -171,10 +171,10 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -183,22 +183,22 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
     }
-    
+
     @Test
     public void testCtorAndSetup3() {
         DigitalExpressionManager m = InstanceManager.getDefault(DigitalExpressionManager.class);
-        
+
         m.registerExpression(new ExpressionMemory("IQDE52", null));
-        
+
         TriggerOnce expression = new TriggerOnce("IQDE321", null);
         Assert.assertNotNull("exists", expression);
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
         expression.getChild(0).setName("XYZ123");
         expression.setChildSocketSystemName("IQDE52");
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertEquals("expression female socket is of correct class",
@@ -207,10 +207,10 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
                 expression.getChild(0).getClass().getName());
         Assert.assertFalse("expression female socket is not connected",
                 expression.getChild(0).isConnected());
-        
+
         // Setup action. This connects the child actions to this action
         expression.setup();
-        
+
         Assert.assertEquals("expression female socket name is XYZ123",
                 "XYZ123", expression.getChild(0).getName());
         Assert.assertTrue("expression female socket is connected",
@@ -218,24 +218,24 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
 //        Assert.assertEquals("child is correct bean",
 //                childSocket,
 //                expression.getChild(0).getConnectedSocket());
-        
+
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
-        
+
         // Try run setup() again. That should not cause any problems.
         expression.setup();
-        
+
         Assert.assertEquals("expression has 1 female socket", 1, expression.getChildCount());
     }
-    
+
     private static int beanID = 901;
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 1", 1 == expressionTriggerOnce.getChildCount());
-        
+
         Assert.assertNotNull("getChild(0) returns a non null value",
                 expressionTriggerOnce.getChild(0));
-        
+
         boolean hasThrown = false;
         try {
             expressionTriggerOnce.getChild(1);
@@ -245,12 +245,12 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.OTHER == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription()
             throws NamedBean.BadUserNameException,
@@ -260,7 +260,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("Trigger once".equals(e1.getShortDescription()));
         Assert.assertTrue("Trigger once".equals(e1.getLongDescription()));
     }
-    
+
     @Test
     @Override
     public void testEnableAndEvaluate() {
@@ -269,7 +269,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         // to add support here. It doesn't need to be tested for every digital
         // expression.
     }
-    
+
     @Test
     @Override
     public void testDebugConfig() {
@@ -278,7 +278,7 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         // to add support here. It doesn't need to be tested for every digital
         // expression.
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -289,10 +289,10 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.OTHER;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -303,21 +303,22 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionTriggerOnce = new TriggerOnce("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionTriggerOnce);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expressionTriggerOnce;
         _baseMaleSocket = maleSocket2;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -326,5 +327,5 @@ public class TriggerOnceTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/expressions/TrueTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/TrueTest.java
@@ -28,7 +28,7 @@ import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
 
 /**
  * Test True
- * 
+ *
  * @author Daniel Bergqvist 2018
  */
 public class TrueTest extends AbstractDigitalExpressionTestBase {
@@ -38,28 +38,28 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
     private True expressionTrue;
     private ActionAtomicBoolean actionAtomicBoolean;
     private AtomicBoolean atomicBoolean;
-    
-    
+
+
     @Override
     public ConditionalNG getConditionalNG() {
         return conditionalNG;
     }
-    
+
     @Override
     public LogixNG getLogixNG() {
         return logixNG;
     }
-    
+
     @Override
     public MaleSocket getConnectableChild() {
         return null;
     }
-    
+
     @Override
     public String getExpectedPrintedTree() {
         return String.format("Always true ::: Use default%n");
     }
-    
+
     @Override
     public String getExpectedPrintedTreeFromRoot() {
         return String.format(
@@ -74,31 +74,31 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
                 "            ! Else%n" +
                 "               Socket not connected%n");
     }
-    
+
     @Override
     public NamedBean createNewBean(String systemName) {
         return new True(systemName, null);
     }
-    
+
     @Override
     public boolean addNewSocket() {
         return false;
     }
-    
+
     @Test
     public void testCtor() {
         True expression2;
-        
+
         expression2 = new True("IQDE321", null);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Always true", expression2.getLongDescription());
-        
+
         expression2 = new True("IQDE321", "My expression");
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My expression", expression2.getUserName());
         Assert.assertEquals("String matches", "Always true", expression2.getLongDescription());
-        
+
         boolean thrown = false;
         try {
             // Illegal system name
@@ -107,7 +107,7 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
             thrown = true;
         }
         Assert.assertTrue("Expected exception thrown", thrown);
-        
+
         thrown = false;
         try {
             // Illegal system name
@@ -117,11 +117,11 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Expected exception thrown", thrown);
     }
-    
+
     @Test
     public void testGetChild() {
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionTrue.getChildCount());
-        
+
         boolean hasThrown = false;
         try {
             expressionTrue.getChild(0);
@@ -131,25 +131,25 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
         }
         Assert.assertTrue("Exception is thrown", hasThrown);
     }
-    
+
     @Test
     public void testCategory() {
         Assert.assertTrue("Category matches", Category.OTHER == _base.getCategory());
     }
-    
+
     @Test
     public void testDescription() {
         DigitalExpressionBean e1 = new True("IQDE321", null);
         Assert.assertTrue("Always true".equals(e1.getShortDescription()));
         Assert.assertTrue("Always true".equals(e1.getLongDescription()));
     }
-    
+
     @Test
     public void testExpression() throws Exception {
         DigitalExpressionBean t = new True("IQDE321", null);
         Assert.assertTrue("Expression is true",t.evaluate());
     }
-    
+
     // The minimal setup for log4J
     @Before
     public void setUp() throws SocketAlreadyConnectedException {
@@ -160,10 +160,10 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initLogixNGManager();
-        
+
         _category = Category.COMMON;
         _isExternal = false;
-        
+
         logixNG = InstanceManager.getDefault(LogixNG_Manager.class).createLogixNG("A new logix for test");  // NOI18N
         conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
         InstanceManager.getDefault(ConditionalNG_Manager.class).register(conditionalNG);
@@ -174,21 +174,22 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
         MaleSocket maleSocket =
                 InstanceManager.getDefault(DigitalActionManager.class).registerAction(ifThenElse);
         conditionalNG.getChild(0).connect(maleSocket);
-        
+
         expressionTrue = new True("IQDE321", null);
         MaleSocket maleSocket2 =
                 InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionTrue);
         ifThenElse.getChild(0).connect(maleSocket2);
-        
+
         _base = expressionTrue;
         _baseMaleSocket = maleSocket2;
-        
+
         atomicBoolean = new AtomicBoolean(false);
         actionAtomicBoolean = new ActionAtomicBoolean(atomicBoolean, true);
         MaleSocket socketAtomicBoolean = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionAtomicBoolean);
         ifThenElse.getChild(1).connect(socketAtomicBoolean);
-        
+
         if (! logixNG.setParentForAllChildren(new ArrayList<>())) throw new RuntimeException();
+        logixNG.activate();
         logixNG.setEnabled(true);
     }
 
@@ -197,5 +198,5 @@ public class TrueTest extends AbstractDigitalExpressionTestBase {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
+
 }

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultGlobalVariableTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultGlobalVariableTest.java
@@ -36,6 +36,7 @@ public class DefaultGlobalVariableTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testInitialValue() throws JmriException, NamedBean.BadUserNameException, NamedBean.BadSystemNameException, IOException {
         Assert.assertEquals("java.util.concurrent.CopyOnWriteArrayList",
                 getVariableValue(InitialValueType.Array, "").getClass().getName());

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultGlobalVariableTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultGlobalVariableTest.java
@@ -1,0 +1,63 @@
+package jmri.jmrit.logixng.implementation;
+
+import jmri.JmriException;
+import jmri.jmrit.logixng.SymbolTable.InitialValueType;
+import jmri.util.JUnitUtil;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test DefaultGlobalVariable
+ *
+ * @author Daniel Bergqvist 2022
+ */
+public class DefaultGlobalVariableTest {
+
+    @Test
+    public void testCtor() {
+        Assert.assertNotNull("exists", new DefaultGlobalVariable("IQGV10", "MyGlobal"));
+    }
+
+    private Object getVariableValue(InitialValueType type, String data)
+            throws JmriException {
+        var v = new DefaultGlobalVariable("IQGV10", "MyGlobal");
+        v.setInitialValueType(type);
+        v.setInitialValueData(data);
+        v.initialize();
+        return v.getValue();
+    }
+
+    @Test
+    public void testInitialValue() throws JmriException {
+        Assert.assertEquals("java.util.concurrent.CopyOnWriteArrayList",
+                getVariableValue(InitialValueType.Array, "").getClass().getName());
+        Assert.assertEquals("java.util.concurrent.ConcurrentHashMap",
+                getVariableValue(InitialValueType.Map, "").getClass().getName());
+        Assert.assertEquals(25, (long)getVariableValue(InitialValueType.Formula, "12*2+1"));
+        Assert.assertEquals(352, (long)getVariableValue(InitialValueType.Integer, "352"));
+        Assert.assertNull(getVariableValue(InitialValueType.None, ""));
+        Assert.assertEquals("Hello", getVariableValue(InitialValueType.String, "Hello"));
+    }
+
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initLogixNGManager();
+    }
+
+    @After
+    public void tearDown() {
+        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+        JUnitUtil.tearDown();
+    }
+
+}

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultGlobalVariableTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultGlobalVariableTest.java
@@ -1,6 +1,11 @@
 package jmri.jmrit.logixng.implementation;
 
-import jmri.JmriException;
+import java.io.IOException;
+import java.util.Map;
+
+import jmri.*;
+import jmri.jmrit.logixng.NamedTable;
+import jmri.jmrit.logixng.NamedTableManager;
 import jmri.jmrit.logixng.SymbolTable.InitialValueType;
 import jmri.util.JUnitUtil;
 
@@ -31,7 +36,7 @@ public class DefaultGlobalVariableTest {
     }
 
     @Test
-    public void testInitialValue() throws JmriException {
+    public void testInitialValue() throws JmriException, NamedBean.BadUserNameException, NamedBean.BadSystemNameException, IOException {
         Assert.assertEquals("java.util.concurrent.CopyOnWriteArrayList",
                 getVariableValue(InitialValueType.Array, "").getClass().getName());
         Assert.assertEquals("java.util.concurrent.ConcurrentHashMap",
@@ -40,6 +45,23 @@ public class DefaultGlobalVariableTest {
         Assert.assertEquals(352, (long)getVariableValue(InitialValueType.Integer, "352"));
         Assert.assertNull(getVariableValue(InitialValueType.None, ""));
         Assert.assertEquals("Hello", getVariableValue(InitialValueType.String, "Hello"));
+
+        // Assign a copy of a table to a global variable
+        NamedTable csvTable = InstanceManager.getDefault(NamedTableManager.class)
+                        .loadTableFromCSV("IQT1", null, "scripts:LogixNG/LogixNG_ExampleTable.csv");
+        Assert.assertNotNull(csvTable);
+        Object value = getVariableValue(InitialValueType.LogixNG_Table, csvTable.getSystemName());
+        Assert.assertNotNull(value);
+        Assert.assertEquals("java.util.concurrent.ConcurrentHashMap", value.getClass().getName());
+        Map<String,Map<String,String>> map = (Map)value;
+        Assert.assertEquals("Left turnout", map.get("Left").get("Turnouts"));
+        Assert.assertEquals("Right turnout", map.get("Right").get("Turnouts"));
+        Assert.assertEquals("IT15", map.get("First siding").get("Turnouts"));
+        Assert.assertEquals("IT22", map.get("Second siding").get("Turnouts"));
+        Assert.assertEquals("Left sensor", map.get("Left").get("Sensors"));
+        Assert.assertEquals("Right sensor", map.get("Right").get("Sensors"));
+        Assert.assertEquals("IS15", map.get("First siding").get("Sensors"));
+        Assert.assertEquals("IS22", map.get("Second siding").get("Sensors"));
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrit/logixng/util/parser/RecursiveDescentParserTest.java
+++ b/java/test/jmri/jmrit/logixng/util/parser/RecursiveDescentParserTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 /**
  * Test ExpressionParser
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 public class RecursiveDescentParserTest {
@@ -28,24 +28,24 @@ public class RecursiveDescentParserTest {
         RecursiveDescentParser t = new RecursiveDescentParser(null);
         Assert.assertNotNull("not null", t);
     }
-    
+
     @Test
     public void testParseAndCalculate() throws Exception {
-        
+
         AtomicBoolean exceptionIsThrown = new AtomicBoolean();
         Map<String, Variable> variables = new HashMap<>();
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
-        
+
         variables.put("abc", new MyVariable("abc", "ABC"));
         variables.put("x", new MyVariable("x", 12));
-        
+
         Variable myVar = new MyVariable("myVar", "");
         variables.put(myVar.getName(), myVar);
-        
+
         MyVariable mySecondVar = new MyVariable("mySecondVar", "");
         variables.put(mySecondVar.getName(), mySecondVar);
-        
+
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
         ExpressionNode exprNode = t.parseExpression("");
         Assert.assertTrue("expression node is null", null == exprNode);
@@ -79,7 +79,7 @@ public class RecursiveDescentParserTest {
         exprNode = t.parseExpression("12/23.2-43");
         Assert.assertTrue("expression matches", "((IntNumber:12)/(FloatNumber:23.2))-(IntNumber:43)".equals(exprNode.getDefinitionString()));
         Assert.assertTrue("calculate is correct", ((Double)(-42.482758620689655172413793103448)).equals(exprNode.calculate(symbolTable)));
-        
+
         exprNode = t.parseExpression("12 < 2");
         Assert.assertTrue("expression matches", "(IntNumber:12)<(IntNumber:2)".equals(exprNode.getDefinitionString()));
 //        System.err.format("calculate: '%s', %s%n", exprNode.calculate(symbolTable), exprNode.calculate(symbolTable).getClass().getName());
@@ -104,7 +104,7 @@ public class RecursiveDescentParserTest {
         Assert.assertTrue("expression matches", "(IntNumber:12)!=(IntNumber:2)".equals(exprNode.getDefinitionString()));
 //        System.err.format("calculate: '%s', %s%n", exprNode.calculate(symbolTable), exprNode.calculate(symbolTable).getClass().getName());
         Assert.assertTrue("calculate is correct", ((Boolean)true).equals(exprNode.calculate(symbolTable)));
-/*        
+/*
         exprNode = t.parseExpression("not 12 < 2");
         System.err.format("getDefinitionString: '%s'%n", exprNode.getDefinitionString());
         System.err.format("calculate: '%s', %s%n", exprNode.calculate(symbolTable), exprNode.calculate(symbolTable).getClass().getName());
@@ -115,7 +115,7 @@ public class RecursiveDescentParserTest {
         System.err.format("calculate: '%s', %s%n", exprNode.calculate(symbolTable), exprNode.calculate(symbolTable).getClass().getName());
         Assert.assertTrue("expression matches", "not ((IntNumber:12)<(IntNumber:2))".equals(exprNode.getDefinitionString()));
         Assert.assertTrue("calculate is correct", ((Boolean)true).equals(exprNode.calculate(symbolTable)));
-*/        
+*/
         exprNode = t.parseExpression("2 <= 3");
         Assert.assertTrue("expression matches", "(IntNumber:2)<=(IntNumber:3)".equals(exprNode.getDefinitionString()));
 //        exprNode = t.parseExpression("2 <= 3 and 3");
@@ -140,7 +140,7 @@ public class RecursiveDescentParserTest {
 //        Assert.assertTrue("expression matches", "IntNumber:134".equals(exprNode.getDefinitionString()));
 //        exprNode = t.parseExpression("(2 <= 3) and (3 > 4) or 2 < 3");
 //        Assert.assertTrue("expression matches", "IntNumber:134".equals(exprNode.getDefinitionString()));
-        
+
         exceptionIsThrown.set(false);
         try {
             t.parseExpression("12+31*(23-1)+((((9*2+3)-2)/23");
@@ -156,8 +156,8 @@ public class RecursiveDescentParserTest {
                 "expression matches",
                 "((IntNumber:12)+((IntNumber:31)*((IntNumber:23)-(IntNumber:1))))+((IntNumber:21)*((((((((IntNumber:9)*(IntNumber:2))+(IntNumber:3))-(IntNumber:2))/(IntNumber:23))+(IntNumber:3))/(IntNumber:3))+(IntNumber:4)))"
                         .equals(exprNode.getDefinitionString()));
-        
-/*        
+
+/*
         exceptionIsThrown.set(false);
         try {
             t.parseExpression("abcde");
@@ -167,7 +167,7 @@ public class RecursiveDescentParserTest {
             exceptionIsThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", exceptionIsThrown.get());
-*/        
+*/
         exceptionIsThrown.set(false);
         try {
             exprNode = t.parseExpression("123+\"abc\"");
@@ -178,50 +178,50 @@ public class RecursiveDescentParserTest {
             exceptionIsThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", exceptionIsThrown.get());
-        
-        
-        
+
+
+
         exprNode = t.parseExpression("myVar = 12");
         Assert.assertEquals("expression matches", "(Identifier:myVar)=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 12, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 12, (long)(Long)myVar.getValue(symbolTable));
-        
+
         myVar.setValue(symbolTable, 10);
         exprNode = t.parseExpression("myVar += 12");
         Assert.assertEquals("expression matches", "(Identifier:myVar)+=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar is correct", 10, (long)(Integer)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", 22, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 22, (long)(Long)myVar.getValue(symbolTable));
-        
+
         myVar.setValue(symbolTable, (long)10);
         exprNode = t.parseExpression("myVar -= 12");
         Assert.assertEquals("expression matches", "(Identifier:myVar)-=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar is correct", 10, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", -2, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", -2, (long)(Long)myVar.getValue(symbolTable));
-        
+
         myVar.setValue(symbolTable, (long)10);
         exprNode = t.parseExpression("myVar *= 12");
         Assert.assertEquals("expression matches", "(Identifier:myVar)*=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar is correct", 10, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", 120, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 120, (long)(Long)myVar.getValue(symbolTable));
-        
+
         myVar.setValue(symbolTable, (long)10);
         exprNode = t.parseExpression("myVar /= 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)/=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar is correct", 10, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", 5, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 5, (long)(Long)myVar.getValue(symbolTable));
-        
+
         myVar.setValue(symbolTable, (long)10);
         exprNode = t.parseExpression("myVar %= 3");
         Assert.assertEquals("expression matches", "(Identifier:myVar)%=(IntNumber:3)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar is correct", 10, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", 1, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 1, (long)(Long)myVar.getValue(symbolTable));
-        
-        
+
+
         myVar.setValue(symbolTable, (long)10);
         exprNode = t.parseExpression("++myVar");
         Assert.assertNotNull(exprNode);
@@ -229,57 +229,57 @@ public class RecursiveDescentParserTest {
         Assert.assertEquals("myVar is correct", 10, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", 11, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 11, (long)(Long)myVar.getValue(symbolTable));
-        
+
         int i = 10; // The purpuse of these tests is to ensure LogixNG formula ++ follows Java ++
         myVar.setValue(symbolTable, (long)10);
         Assert.assertEquals("myVar is correct", i, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", ++i, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", i, (long)(Long)myVar.getValue(symbolTable));
-        
-        
+
+
         myVar.setValue(symbolTable, (long)10);
         exprNode = t.parseExpression("myVar++");
         Assert.assertEquals("expression matches", "(Identifier:myVar)++", exprNode.getDefinitionString());
         Assert.assertEquals("myVar is correct", 10, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", 10, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 11, (long)(Long)myVar.getValue(symbolTable));
-        
+
         i = 10;     // The purpuse of these tests is to ensure LogixNG formula ++ follows Java ++
         myVar.setValue(symbolTable, (long)10);
         Assert.assertEquals("myVar is correct", i, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", i++, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", i, (long)(Long)myVar.getValue(symbolTable));
-        
-        
+
+
         myVar.setValue(symbolTable, (long)10);
         exprNode = t.parseExpression("--myVar");
         Assert.assertEquals("expression matches", "--(Identifier:myVar)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar is correct", 10, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", 9, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 9, (long)(Long)myVar.getValue(symbolTable));
-        
+
         i = 10;     // The purpuse of these tests is to ensure LogixNG formula -- follows Java --
         myVar.setValue(symbolTable, (long)10);
         Assert.assertEquals("myVar is correct", i, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", --i, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", i, (long)(Long)myVar.getValue(symbolTable));
-        
-        
+
+
         myVar.setValue(symbolTable, (long)10);
         exprNode = t.parseExpression("myVar--");
         Assert.assertEquals("expression matches", "(Identifier:myVar)--", exprNode.getDefinitionString());
         Assert.assertEquals("myVar is correct", 10, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", 10, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 9, (long)(Long)myVar.getValue(symbolTable));
-        
+
         i = 10;     // The purpuse of these tests is to ensure LogixNG formula -- follows Java --
         myVar.setValue(symbolTable, (long)10);
         Assert.assertEquals("myVar is correct", i, (long)(Long)myVar.getValue(symbolTable));
         Assert.assertEquals("calculate is correct", i--, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", i, (long)(Long)myVar.getValue(symbolTable));
     }
-    
-    
+
+
     //             <rule2> = <rule1> ||
     //             <rule2> += <rule1> ||
     //             <rule2> -= <rule1> ||
@@ -297,120 +297,135 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         MyVariable myVar = new MyVariable("myVar", "");
         variables.put(myVar.getName(), myVar);
-        
+
         myVar._value = 10;
         ExpressionNode exprNode = t.parseExpression("myVar = 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("myVar += 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)+=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 12, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("myVar -= 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)-=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 8, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("myVar *= 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)*=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 20, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("myVar /= 3");
         Assert.assertEquals("expression matches", "(Identifier:myVar)/=(IntNumber:3)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 3, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("myVar %= 3");
         Assert.assertEquals("expression matches", "(Identifier:myVar)%=(IntNumber:3)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 1, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("myVar &= 3");
         Assert.assertEquals("expression matches", "(Identifier:myVar)&=(IntNumber:3)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("myVar ^= 3");
         Assert.assertEquals("expression matches", "(Identifier:myVar)^=(IntNumber:3)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 9, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("myVar |= 3");
         Assert.assertEquals("expression matches", "(Identifier:myVar)|=(IntNumber:3)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 11, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 1000;
         exprNode = t.parseExpression("myVar <<= 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)<<=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 1000 << 2, (long)(Long)exprNode.calculate(symbolTable));
         myVar._value = 1000;
         Assert.assertEquals("calculate is correct", 4000, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = -1000;
         exprNode = t.parseExpression("myVar <<= 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)<<=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", -1000 << 2, (long)(Long)exprNode.calculate(symbolTable));
         myVar._value = 1000;
         Assert.assertEquals("calculate is correct", 4000, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 1000;
         exprNode = t.parseExpression("myVar >>= 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)>>=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 1000 >> 2, (long)(Long)exprNode.calculate(symbolTable));
         myVar._value = 1000;
         Assert.assertEquals("calculate is correct", 250, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = -1000;
         exprNode = t.parseExpression("myVar >>= 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)>>=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", -1000 >> 2, (long)(Long)exprNode.calculate(symbolTable));
         myVar._value = -1000;
         Assert.assertEquals("calculate is correct", -250, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 1000;
         exprNode = t.parseExpression("myVar >>>= 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)>>>=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 1000 >>> 2, (long)(Long)exprNode.calculate(symbolTable));
         myVar._value = 1000;
         Assert.assertEquals("calculate is correct", 250, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = -1000;
         exprNode = t.parseExpression("myVar >>>= 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)>>>=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", -1000L >>> 2, (long)(Long)exprNode.calculate(symbolTable));
         myVar._value = -1000;
         Assert.assertEquals("calculate is correct", 4611686018427387654L, (long)(Long)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Rule2 is ternary. <rule3> | <rule3> ? <rule2> : <rule2>
     @Test
     public void testRule2() throws JmriException {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         MyVariable myVar = new MyVariable("myVar", "");
         variables.put(myVar.getName(), myVar);
-        
+
         myVar._value = 2;
         ExpressionNode exprNode = t.parseExpression("myVar < 4 ? \"Hello\" : \"World\"");
         Assert.assertEquals("expression matches", "((Identifier:myVar)<(IntNumber:4))?(String:\"Hello\"):(String:\"World\")", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", "Hello", exprNode.calculate(symbolTable));
         myVar._value = 10;
         Assert.assertEquals("calculate is correct", "World", exprNode.calculate(symbolTable));
-        
+
+        myVar._value = 2;
+        exprNode = t.parseExpression("str(myVar == 2 ? 4 : 2)");
+        Assert.assertEquals("expression matches", "Function:str(((Identifier:myVar)==(IntNumber:2))?(IntNumber:4):(IntNumber:2))", exprNode.getDefinitionString());
+        Assert.assertEquals("calculate is correct", "4", exprNode.calculate(symbolTable));
+        myVar._value = 10;
+        Assert.assertEquals("calculate is correct", "2", exprNode.calculate(symbolTable));
+
+        exprNode = t.parseExpression("str(sensorBlink.getState() == 2 ? 4 : 2)");
+        Assert.assertEquals("expression matches", "Function:str(((Identifier:sensorBlink->Method:getState())==(IntNumber:2))?(IntNumber:4):(IntNumber:2))", exprNode.getDefinitionString());
+
+        exprNode = t.parseExpression("sensorBlink.setState(myVar == 2 ? 4 : 2)");
+        Assert.assertEquals("expression matches", "Identifier:sensorBlink->Method:setState(((Identifier:myVar)==(IntNumber:2))?(IntNumber:4):(IntNumber:2))", exprNode.getDefinitionString());
+
+        exprNode = t.parseExpression("sensorBlink.setState(sensorBlink.getState() == 2 ? 4 : 2)");
+        Assert.assertEquals("expression matches", "Identifier:sensorBlink->Method:setState(((Identifier:sensorBlink->Method:getState())==(IntNumber:2))?(IntNumber:4):(IntNumber:2))", exprNode.getDefinitionString());
     }
-    
-    
+
+
     // Logical OR
     // <rule3> ::= <rule4> | <rule4> || <rule4>
     @Test
@@ -418,22 +433,22 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         ExpressionNode exprNode = t.parseExpression("(1 < 2) || (5 > 2)");
         Assert.assertEquals("expression matches", "((IntNumber:1)<(IntNumber:2))||((IntNumber:5)>(IntNumber:2))", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("(1 < 2) || (1 > 2)");
         Assert.assertEquals("expression matches", "((IntNumber:1)<(IntNumber:2))||((IntNumber:1)>(IntNumber:2))", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("(2 < 2) || (1 > 2)");
         Assert.assertEquals("expression matches", "((IntNumber:2)<(IntNumber:2))||((IntNumber:1)>(IntNumber:2))", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Logical AND
     // <rule4> ::= <rule5> | <rule5> && <rule5>
     @Test
@@ -441,22 +456,22 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         ExpressionNode exprNode = t.parseExpression("(1 < 2) && (5 > 2)");
         Assert.assertEquals("expression matches", "((IntNumber:1)<(IntNumber:2))&&((IntNumber:5)>(IntNumber:2))", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("(1 < 2) && (1 > 2)");
         Assert.assertEquals("expression matches", "((IntNumber:1)<(IntNumber:2))&&((IntNumber:1)>(IntNumber:2))", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("(2 < 2) && (1 > 2)");
         Assert.assertEquals("expression matches", "((IntNumber:2)<(IntNumber:2))&&((IntNumber:1)>(IntNumber:2))", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Bitwise OR
     // <rule5> ::= <rule6> | <rule6> | <rule6>
     @Test
@@ -464,18 +479,18 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         ExpressionNode exprNode = t.parseExpression("2 | 10");
         Assert.assertEquals("expression matches", "(IntNumber:2)|(IntNumber:10)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 10, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("2 | 5");
         Assert.assertEquals("expression matches", "(IntNumber:2)|(IntNumber:5)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 7, (long)(Long)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Bitwise XOR
     // <rule6> ::= <rule7> | <rule7> ^ <rule7>
     @Test
@@ -483,18 +498,18 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         ExpressionNode exprNode = t.parseExpression("2 ^ 10");
         Assert.assertEquals("expression matches", "(IntNumber:2)^(IntNumber:10)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 8, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("2 ^ 5");
         Assert.assertEquals("expression matches", "(IntNumber:2)^(IntNumber:5)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 7, (long)(Long)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Bitwise AND
     // <rule7> ::= <rule8> | <rule8> & <rule8>
     @Test
@@ -502,18 +517,18 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         ExpressionNode exprNode = t.parseExpression("2 & 10");
         Assert.assertEquals("expression matches", "(IntNumber:2)&(IntNumber:10)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("2 & 5");
         Assert.assertEquals("expression matches", "(IntNumber:2)&(IntNumber:5)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 0, (long)(Long)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Equality
     // <rule8> ::= <rule9> | <rule9> == <rule9> | <rule9> != <rule9>
     @Test
@@ -521,26 +536,26 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         ExpressionNode exprNode = t.parseExpression("1 == 2");
         Assert.assertEquals("expression matches", "(IntNumber:1)==(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("2 == 2");
         Assert.assertEquals("expression matches", "(IntNumber:2)==(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("1 != 2");
         Assert.assertEquals("expression matches", "(IntNumber:1)!=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("2 != 2");
         Assert.assertEquals("expression matches", "(IntNumber:2)!=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Relational
     // <rule9> ::= <rule10> | <rule10> < <rule10> | <rule10> <= <rule10> | <rule10> > <rule10> | <rule10> >= <rule10>
     @Test
@@ -548,58 +563,58 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         ExpressionNode exprNode = t.parseExpression("1 < 2");
         Assert.assertEquals("expression matches", "(IntNumber:1)<(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("2 < 2");
         Assert.assertEquals("expression matches", "(IntNumber:2)<(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("3 < 2");
         Assert.assertEquals("expression matches", "(IntNumber:3)<(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("1 <= 2");
         Assert.assertEquals("expression matches", "(IntNumber:1)<=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("2 <= 2");
         Assert.assertEquals("expression matches", "(IntNumber:2)<=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("3 <= 2");
         Assert.assertEquals("expression matches", "(IntNumber:3)<=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("1 > 2");
         Assert.assertEquals("expression matches", "(IntNumber:1)>(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("2 > 2");
         Assert.assertEquals("expression matches", "(IntNumber:2)>(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("3 > 2");
         Assert.assertEquals("expression matches", "(IntNumber:3)>(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("1 >= 2");
         Assert.assertEquals("expression matches", "(IntNumber:1)>=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("2 >= 2");
         Assert.assertEquals("expression matches", "(IntNumber:2)>=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("3 >= 2");
         Assert.assertEquals("expression matches", "(IntNumber:3)>=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Shift
     // <rule10> ::= <rule11> | <rule11> << <rule11> | <rule11> >> <rule11> | <rule11> >>> <rule11>
     @Test
@@ -607,40 +622,40 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         ExpressionNode exprNode = t.parseExpression("10 << 2");
         Assert.assertEquals("expression matches", "(IntNumber:10)<<(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 40, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("calculate is correct", 10 << 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("-10 << 2");
         Assert.assertEquals("expression matches", "(-(IntNumber:10))<<(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", -40, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("calculate is correct", -10 << 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("1000 >> 2");
         Assert.assertEquals("expression matches", "(IntNumber:1000)>>(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 250, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("calculate is correct", 1000 >> 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("-1000 >> 2");
         Assert.assertEquals("expression matches", "(-(IntNumber:1000))>>(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", -250, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("calculate is correct", -1000 >> 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("1000 >>> 2");
         Assert.assertEquals("expression matches", "(IntNumber:1000)>>>(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 250, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("calculate is correct", 1000 >>> 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("-1000 >>> 2");
         Assert.assertEquals("expression matches", "(-(IntNumber:1000))>>>(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 4611686018427387654L, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("calculate is correct", -1000L >>> 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Additive
     // <rule11> ::= <rule12> | <rule12> + <rule12> | <rule12> - <rule12>
     @Test
@@ -648,18 +663,18 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         ExpressionNode exprNode = t.parseExpression("10 + 2");
         Assert.assertEquals("expression matches", "(IntNumber:10)+(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 12, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("10 - 2");
         Assert.assertEquals("expression matches", "(IntNumber:10)-(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 8, (long)(Long)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Multiplicative
     // <rule12> ::= <rule13> | <rule13> * <rule13> | <rule13> / <rule13> | <rule13> % <rule13>
     @Test
@@ -667,25 +682,25 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         ExpressionNode exprNode = t.parseExpression("10 * 2");
         Assert.assertEquals("expression matches", "(IntNumber:10)*(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 20, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("10 / 3");
         Assert.assertEquals("expression matches", "(IntNumber:10)/(IntNumber:3)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 3, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("10 % 3");
         Assert.assertEquals("expression matches", "(IntNumber:10)%(IntNumber:3)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct",1 , (long)(Long)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Rule13 in Java is cast object and object creation. Not relevant here.
-    
-    
+
+
     // Unary pre-increment, unary pre-decrement, unary plus, unary minus, unary logical NOT, unary bitwise NOT
     // <rule14> ::= <rule16> | ++ <rule16> | -- <rule16> | + <rule16> | - <rule16> | ! <rule16> | ~ <rule16>
     @Test
@@ -693,107 +708,107 @@ public class RecursiveDescentParserTest {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         MyVariable myVar = new MyVariable("myVar", "");
         variables.put(myVar.getName(), myVar);
-        
+
         myVar._value = 10;
         ExpressionNode exprNode = t.parseExpression("++myVar");
         Assert.assertEquals("expression matches", "++(Identifier:myVar)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 11, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 11, (long)myVar._value);
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("--myVar");
         Assert.assertEquals("expression matches", "--(Identifier:myVar)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 9, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 9, (long)myVar._value);
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("+myVar");
         Assert.assertEquals("expression matches", "+(Identifier:myVar)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 10, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("-myVar");
         Assert.assertEquals("expression matches", "-(Identifier:myVar)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", -10, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("!1");
         Assert.assertEquals("expression matches", "!(IntNumber:1)", exprNode.getDefinitionString());
         Assert.assertFalse("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("!0");
         Assert.assertEquals("expression matches", "!(IntNumber:0)", exprNode.getDefinitionString());
         Assert.assertTrue("calculate is correct", (Boolean)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("~myVar");
         Assert.assertEquals("expression matches", "~(Identifier:myVar)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", -11, (long)(Long)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Rule15 in Java is unary post-increment, unary post-decrement, ++ and --.
     @Test
     public void testRule15() throws JmriException {
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         MyVariable myVar = new MyVariable("myVar", "");
         variables.put(myVar.getName(), myVar);
-        
+
         myVar._value = 10;
         ExpressionNode exprNode = t.parseExpression("myVar++");
         Assert.assertEquals("expression matches", "(Identifier:myVar)++", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 10, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 11, (long)myVar._value);
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("myVar--");
         Assert.assertEquals("expression matches", "(Identifier:myVar)--", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 10, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 9, (long)myVar._value);
-        
+
     }
-    
-    
+
+
     // Parentheses
     // <rule16> ::= <rule20> | ( <firstRule> )
     @Test
     public void testRule16() throws JmriException {
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         MyVariable myVar = new MyVariable("myVar", "");
         variables.put(myVar.getName(), myVar);
-        
+
         myVar._value = (long)10;
         ExpressionNode exprNode = t.parseExpression("(myVar)");
         Assert.assertEquals("expression matches", "Identifier:myVar", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 10, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("(2)");
         Assert.assertEquals("expression matches", "IntNumber:2", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("(myVar = 2)");
         Assert.assertEquals("expression matches", "(Identifier:myVar)=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         myVar._value = 10;
         exprNode = t.parseExpression("(((myVar = 2)))");
         Assert.assertEquals("expression matches", "(Identifier:myVar)=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
     }
-    
-    
+
+
     // Identifiers and constants
     // <rule20> ::= <identifier>
     //              | <identifier> ( <rule21> )
@@ -801,7 +816,7 @@ public class RecursiveDescentParserTest {
     //              | <rule20> { <rule21> }
     //              | <rule20> . <rule20>
     //              | <rule20> . <identifier> ( <rule21> )
-    
+
     // <rule20> ::= <identifier>
     //              | <identifier> ( <rule21> )
     //              | <identifier> [ <rule21> ]
@@ -823,27 +838,27 @@ public class RecursiveDescentParserTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testRule20() throws JmriException {
-        
+
         AtomicBoolean exceptionIsThrown = new AtomicBoolean();
-        
+
         SymbolTable symbolTable = new DefaultSymbolTable(new DefaultConditionalNG("IQC1", null));
         Map<String, Variable> variables = new HashMap<>();
         variables.put("someString", new MyVariable("someString", "A simple string"));
         variables.put("myTestField", new MyVariable("myTestField", new TestField()));
-        
+
         RecursiveDescentParser t = new RecursiveDescentParser(variables);
-        
+
         MyVariable myVar = new MyVariable("myVar", "");
         variables.put(myVar.getName(), myVar);
-        
+
         MyVariable mySecondVar = new MyVariable("mySecondVar", "");
         variables.put(mySecondVar.getName(), mySecondVar);
-        
+
         myVar._value = 10;
         ExpressionNode exprNode = t.parseExpression("myVar = 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar)=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 2, (long)(Long)exprNode.calculate(symbolTable));
-        
+
         exprNode = t.parseExpression("random()");
         Assert.assertTrue("expression matches", "Function:random()".equals(exprNode.getDefinitionString()));
         Object result = exprNode.calculate(symbolTable);
@@ -858,7 +873,7 @@ public class RecursiveDescentParserTest {
         Assert.assertTrue("expression matches", "Function:int(((Identifier:x)*(IntNumber:2))+(IntNumber:5))".equals(exprNode.getDefinitionString()));
         exprNode = t.parseExpression("int((x))");
         Assert.assertTrue("expression matches", "Function:int(Identifier:x)".equals(exprNode.getDefinitionString()));
-        
+
         exceptionIsThrown.set(false);
         try {
             t.parseExpression("abc(123)");
@@ -879,7 +894,7 @@ public class RecursiveDescentParserTest {
             exceptionIsThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", exceptionIsThrown.get());
-        
+
         exceptionIsThrown.set(false);
         try {
             exprNode = t.parseExpression("sin(1,2,3)");
@@ -890,21 +905,21 @@ public class RecursiveDescentParserTest {
             exceptionIsThrown.set(true);
         }
         Assert.assertTrue("exception is thrown", exceptionIsThrown.get());
-        
-        
-        
+
+
+
         jmri.Timebase fastClock = InstanceManager.getDefault(jmri.Timebase.class);
         fastClock.setRun(false);
         fastClock.setTime(new Date(0,0,0,11,05));   // 11:05
-        
+
         int minSinceMidnight = (11 * 60) + 5;
         exprNode = t.parseExpression("fastClock()");
         Assert.assertEquals("expression matches", "Function:fastClock()", exprNode.getDefinitionString());
 //        System.err.format("Result: %s, %s%n", result, result.getClass().getName());
         Assert.assertEquals("calculate is correct", minSinceMidnight, (int)exprNode.calculate(symbolTable));
-        
-        
-        
+
+
+
         ExpressionNode expressionNode = t.parseExpression("\"A simple string\".toString()");
         Assert.assertEquals("expression matches", "String:\"A simple string\"->Method:toString()", expressionNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", "A simple string", expressionNode.calculate(symbolTable));
@@ -917,7 +932,7 @@ public class RecursiveDescentParserTest {
         expressionNode = t.parseExpression("\"A simple string\".indexOf(\"i\",8)");
         Assert.assertEquals("expression matches", "String:\"A simple string\"->Method:indexOf(String:\"i\",IntNumber:8)", expressionNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 12, (int)expressionNode.calculate(symbolTable));
-        
+
         expressionNode = t.parseExpression("someString.toString()");
         Assert.assertEquals("expression matches", "Identifier:someString->Method:toString()", expressionNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", "A simple string", expressionNode.calculate(symbolTable));
@@ -930,11 +945,11 @@ public class RecursiveDescentParserTest {
         expressionNode = t.parseExpression("someString.indexOf(\"i\",8)");
         Assert.assertEquals("expression matches", "Identifier:someString->Method:indexOf(String:\"i\",IntNumber:8)", expressionNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 12, (int)expressionNode.calculate(symbolTable));
-        
-        
-        
+
+
+
         TestField testField = (TestField) variables.get("myTestField").getValue(symbolTable);
-        
+
         expressionNode = t.parseExpression("myTestField.myString");
         Assert.assertEquals("expression matches", "Identifier:myTestField->InstanceVariable:myString", expressionNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", "Hello", expressionNode.calculate(symbolTable));
@@ -944,26 +959,26 @@ public class RecursiveDescentParserTest {
         expressionNode = t.parseExpression("myTestField.myFloat");
         Assert.assertEquals("expression matches", "Identifier:myTestField->InstanceVariable:myFloat", expressionNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 31.32, (float)expressionNode.calculate(symbolTable), 0.000001);
-        
-        
-        
+
+
+
         ExpressionNodeInstanceVariable instanceVariable = new ExpressionNodeInstanceVariable("myString", variables);
         Assert.assertEquals("Hello", testField.myString);
         instanceVariable.assignValue(testField, symbolTable, "Something else");
         Assert.assertEquals("Something else", testField.myString);
-        
+
         instanceVariable = new ExpressionNodeInstanceVariable("myInt", variables);
         Assert.assertEquals(32, testField.myInt);
         instanceVariable.assignValue(testField, symbolTable, (long)23103);
         Assert.assertEquals(23103, testField.myInt);
-        
+
         instanceVariable = new ExpressionNodeInstanceVariable("myFloat", variables);
         Assert.assertEquals(31.32, testField.myFloat, 0.000001);
         instanceVariable.assignValue(testField, symbolTable, 112.12);
         Assert.assertEquals((float)112.12, testField.myFloat, 0.000001);
-        
-        
-        
+
+
+
         List<Object> myList = new ArrayList<>();
         myList.add(0, "Test");
         myList.add(1, "Something");
@@ -974,42 +989,42 @@ public class RecursiveDescentParserTest {
         Assert.assertEquals("expression matches", "(Identifier:myVar->[IntNumber:1])=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 12, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar[1] is correct", 12, (long)((List<Long>)myVar.getValue(symbolTable)).get(1));
-        
+
         myList.set(1, (long)10);
         exprNode = t.parseExpression("myVar[1] += 12");
         Assert.assertEquals("expression matches", "(Identifier:myVar->[IntNumber:1])+=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar[1] is correct", 10, (long)((List<Long>)myVar.getValue(symbolTable)).get(1));
         Assert.assertEquals("calculate is correct", 22, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar[1] is correct", 22, (long)((List<Long>)myVar.getValue(symbolTable)).get(1));
-        
+
         myList.set(1, (long)10);
         exprNode = t.parseExpression("myVar[1] -= 12");
         Assert.assertEquals("expression matches", "(Identifier:myVar->[IntNumber:1])-=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar[1] is correct", 10, (long)((List<Long>)myVar.getValue(symbolTable)).get(1));
         Assert.assertEquals("calculate is correct", -2, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar[1] is correct", -2, (long)((List<Long>)myVar.getValue(symbolTable)).get(1));
-        
+
         myList.set(1, (long)10);
         exprNode = t.parseExpression("myVar[1] *= 12");
         Assert.assertEquals("expression matches", "(Identifier:myVar->[IntNumber:1])*=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar[1] is correct", 10, (long)((List<Long>)myVar.getValue(symbolTable)).get(1));
         Assert.assertEquals("calculate is correct", 120, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar[1] is correct", 120, (long)((List<Long>)myVar.getValue(symbolTable)).get(1));
-        
+
         myList.set(1, (long)10);
         exprNode = t.parseExpression("myVar[1] /= 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar->[IntNumber:1])/=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar[1] is correct", 10, (long)((List<Long>)myVar.getValue(symbolTable)).get(1));
         Assert.assertEquals("calculate is correct", 5, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar[1] is correct", 5, (long)((List<Long>)myVar.getValue(symbolTable)).get(1));
-        
+
         myList.set(1, (long)10);
         exprNode = t.parseExpression("myVar[1] %= 3");
         Assert.assertEquals("expression matches", "(Identifier:myVar->[IntNumber:1])%=(IntNumber:3)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar[1] is correct", 10, (long)((List<Long>)myVar.getValue(symbolTable)).get(1));
         Assert.assertEquals("calculate is correct", 1, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar[1] is correct", 1, (long)((List<Long>)myVar.getValue(symbolTable)).get(1));
-        
+
         mySecondVar._myValue = "Something";
         myList.set(1, mySecondVar);
         exprNode = t.parseExpression("myVar[1]._myValue = \"Something else\"");
@@ -1017,14 +1032,14 @@ public class RecursiveDescentParserTest {
         Assert.assertEquals("myVar[1]._myValue is correct", "Something", mySecondVar._myValue);
         Assert.assertEquals("calculate is correct", "Something else", exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar[1]._myValue is correct", "Something else", mySecondVar._myValue);
-        
+
         exprNode = t.parseExpression("myVar[1].myFunc(\"Hello\")");
         Assert.assertEquals("expression matches", "Identifier:myVar->[IntNumber:1]->Method:myFunc(String:\"Hello\")", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", "++Hello++", exprNode.calculate(symbolTable));
-        
-        
-        
-        
+
+
+
+
         Map<Object, Object> myMap = new HashMap<>();
         myMap.put("Red", "Test");
         myMap.put("Green", "Something");
@@ -1035,42 +1050,42 @@ public class RecursiveDescentParserTest {
         Assert.assertEquals("expression matches", "(Identifier:myVar->{String:\"Green\"})=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", 12, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar{\"Green\"} is correct", 12, (long)((Map<Object, Object>)myVar.getValue(symbolTable)).get("Green"));
-        
+
         myMap.put("Green", (long)10);
         exprNode = t.parseExpression("myVar{\"Green\"} += 12");
         Assert.assertEquals("expression matches", "(Identifier:myVar->{String:\"Green\"})+=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar{\"Green\"} is correct", 10, (long)((Map<Object, Object>)myVar.getValue(symbolTable)).get("Green"));
         Assert.assertEquals("calculate is correct", 22, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar{\"Green\"} is correct", 22, (long)((Map<Object, Object>)myVar.getValue(symbolTable)).get("Green"));
-        
+
         myMap.put("Green", (long)10);
         exprNode = t.parseExpression("myVar{\"Green\"} -= 12");
         Assert.assertEquals("expression matches", "(Identifier:myVar->{String:\"Green\"})-=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar{\"Green\"} is correct", 10, (long)((Map<Object, Object>)myVar.getValue(symbolTable)).get("Green"));
         Assert.assertEquals("calculate is correct", -2, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar{\"Green\"} is correct", -2, (long)((Map<Object, Object>)myVar.getValue(symbolTable)).get("Green"));
-        
+
         myMap.put("Green", (long)10);
         exprNode = t.parseExpression("myVar{\"Green\"} *= 12");
         Assert.assertEquals("expression matches", "(Identifier:myVar->{String:\"Green\"})*=(IntNumber:12)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar{\"Green\"} is correct", 10, (long)((Map<Object, Object>)myVar.getValue(symbolTable)).get("Green"));
         Assert.assertEquals("calculate is correct", 120, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar{\"Green\"} is correct", 120, (long)((Map<Object, Object>)myVar.getValue(symbolTable)).get("Green"));
-        
+
         myMap.put("Green", (long)10);
         exprNode = t.parseExpression("myVar{\"Green\"} /= 2");
         Assert.assertEquals("expression matches", "(Identifier:myVar->{String:\"Green\"})/=(IntNumber:2)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar{\"Green\"} is correct", 10, (long)((Map<Object, Object>)myVar.getValue(symbolTable)).get("Green"));
         Assert.assertEquals("calculate is correct", 5, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar{\"Green\"} is correct", 5, (long)((Map<Object, Object>)myVar.getValue(symbolTable)).get("Green"));
-        
+
         myMap.put("Green", (long)10);
         exprNode = t.parseExpression("myVar{\"Green\"} %= 3");
         Assert.assertEquals("expression matches", "(Identifier:myVar->{String:\"Green\"})%=(IntNumber:3)", exprNode.getDefinitionString());
         Assert.assertEquals("myVar{\"Green\"} is correct", 10, (long)((Map<Object, Object>)myVar.getValue(symbolTable)).get("Green"));
         Assert.assertEquals("calculate is correct", 1, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar{\"Green\"} is correct", 1, (long)((Map<Object, Object>)myVar.getValue(symbolTable)).get("Green"));
-        
+
         mySecondVar._myValue = "Something";
         myMap.put("Hello", mySecondVar);
         exprNode = t.parseExpression("myVar{\"Hello\"}._myValue = \"Something else\"");
@@ -1078,33 +1093,33 @@ public class RecursiveDescentParserTest {
         Assert.assertEquals("myVar{\"Hello\"}._myValue is correct", "Something", mySecondVar._myValue);
         Assert.assertEquals("calculate is correct", "Something else", exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar{\"Hello\"}._myValue is correct", "Something else", mySecondVar._myValue);
-        
+
         exprNode = t.parseExpression("myVar{\"Hello\"}.myFunc(\"Hello\")");
         Assert.assertEquals("expression matches", "Identifier:myVar->{String:\"Hello\"}->Method:myFunc(String:\"Hello\")", exprNode.getDefinitionString());
         Assert.assertEquals("calculate is correct", "++Hello++", exprNode.calculate(symbolTable));
-        
-        
-        
+
+
+
         Map<String, Object> myMap1 = new HashMap<>();
         Map<String, Object> myMap2 = new HashMap<>();
         Map<String, Object> myMap3 = new HashMap<>();
         Map<String, Object> myMap4 = new HashMap<>();
         Map<String, Object> myMap5 = new HashMap<>();
-        
+
         List<Object> myOtherList = new ArrayList<>();
         myOtherList.add(0, "Test!!");
         myOtherList.add(1, "Something!!");
         myOtherList.add(2, "Else!!");
-        
+
         List<Object> myThirdList = new ArrayList<>();
         myThirdList.add(0, "Test!!");
         myThirdList.add(1, "Something!!");
         myThirdList.add(2, "Else!!");
-        
+
         variables.put("myIndex1", new MyVariable("myIndex1", 1));
         variables.put("myIndex2", new MyVariable("myIndex2", 2));
         variables.put("theThirdKey", new MyVariable("theThirdKey", "A third key"));
-        
+
         myMap1.put("A key", myMap2);
         myMap2.put("A second key", myList);
         myList.set(1, myOtherList);
@@ -1133,8 +1148,8 @@ public class RecursiveDescentParserTest {
         Assert.assertEquals("calculate is correct", 12, (long)(Long)exprNode.calculate(symbolTable));
         Assert.assertEquals("myVar is correct", 12, (long)(Long)myMap5.get("A fifth key"));
     }
-    
-    
+
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -1152,19 +1167,19 @@ public class RecursiveDescentParserTest {
         jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
         JUnitUtil.tearDown();
     }
-    
-    
+
+
     public static class MyVariable implements Variable {
         // If this class is private instead of public, we will get the error:
         // The method myFunc(String) from the type RecursiveDescentParserTest.MyVariable is never used locally
         // But the myFunc(String) is used by formula.
-        
+
         private final String _name;
         private Object _value;
-        
+
         public Object _myValue;     // Must be public for the test
-        
-        
+
+
         private MyVariable(String name, Object value) {
             _name = name;
             _value = value;
@@ -1189,12 +1204,12 @@ public class RecursiveDescentParserTest {
             return "++" + param + "++";
         }
     }
-    
-    
+
+
     private static class TestField {
         public String myString = "Hello";
         public int myInt = 32;
         public float myFloat = (float) 31.32;
     }
-    
+
 }

--- a/jython/LogixNG/InitVariableToSensor.py
+++ b/jython/LogixNG/InitVariableToSensor.py
@@ -1,0 +1,6 @@
+# Sample script that is used to initialize a local variable
+# or a global variable in LogixNG.
+
+import jmri
+mySensor = sensors.provide("MySensor")
+variable.set(mySensor)

--- a/jython/LogixNG/InitVariableToTableContents.py
+++ b/jython/LogixNG/InitVariableToTableContents.py
@@ -1,0 +1,38 @@
+# Sample script that is used to initialize a local variable
+# or a global variable in LogixNG.
+#
+# The variable is initialized to a map that has the values
+# from a LogixNG Table.
+
+import jmri
+import java
+
+# Configure this script
+# tableName is the name of the table
+# columnName is the name of the column you want to use for the values
+tableName = "MyTable"
+columnName = "Turnouts"
+
+
+
+myTable = logixngTables.getNamedTable(tableName)
+
+print "Table: "
+print myTable
+
+# ConcurrentHashMap is thread safe
+myMap = java.util.concurrent.ConcurrentHashMap()
+
+print "Table: " + myTable.getSystemName()
+
+column = myTable.getColumnNumber(columnName)
+
+for row in range(1, myTable.numRows()):
+    key = myTable.getCell(row, 0)
+    print "key: " + key
+    value = myTable.getCell(row, column)
+    print "value: " + value
+    myMap.put(key, value)
+
+
+variable.set(myMap)

--- a/jython/LogixNG/InitVariableToTableContents.py
+++ b/jython/LogixNG/InitVariableToTableContents.py
@@ -3,24 +3,25 @@
 #
 # The variable is initialized to a map that has the values
 # from a LogixNG Table.
+#
+# In this example, we use ConcurrentHashMap since it's thread safe
 
-import jmri
-import java
 
 # Configure this script
+#
 # tableName is the name of the table
 # columnName is the name of the column you want to use for the values
+
 tableName = "MyTable"
 columnName = "Turnouts"
 
 
 
+import jmri
+import java
+
 myTable = logixngTables.getNamedTable(tableName)
 
-print "Table: "
-print myTable
-
-# ConcurrentHashMap is thread safe
 myMap = java.util.concurrent.ConcurrentHashMap()
 
 print "Table: " + myTable.getSystemName()
@@ -29,9 +30,7 @@ column = myTable.getColumnNumber(columnName)
 
 for row in range(1, myTable.numRows()):
     key = myTable.getCell(row, 0)
-    print "key: " + key
     value = myTable.getCell(row, column)
-    print "value: " + value
     myMap.put(key, value)
 
 

--- a/jython/LogixNG/InitVariableToTableContents.py
+++ b/jython/LogixNG/InitVariableToTableContents.py
@@ -28,7 +28,7 @@ print "Table: " + myTable.getSystemName()
 
 column = myTable.getColumnNumber(columnName)
 
-for row in range(1, myTable.numRows()):
+for row in range(1, myTable.numRows()+1):
     key = myTable.getCell(row, 0)
     value = myTable.getCell(row, column)
     myMap.put(key, value)

--- a/jython/LogixNG/InitVariableToTableContents2.py
+++ b/jython/LogixNG/InitVariableToTableContents2.py
@@ -13,10 +13,8 @@
 # Configure this script
 #
 # tableName is the name of the table
-# columnName is the name of the column you want to use for the values
 
 tableName = "MyTable"
-columnName = "Turnouts"
 
 
 
@@ -28,8 +26,6 @@ myTable = logixngTables.getNamedTable(tableName)
 myMap = java.util.concurrent.ConcurrentHashMap()
 
 print "Table: " + myTable.getSystemName()
-
-column = myTable.getColumnNumber(columnName)
 
 for row in range(1, myTable.numRows()+1):
     rowKey = myTable.getCell(row, 0)

--- a/jython/LogixNG/InitVariableToTableContents2.py
+++ b/jython/LogixNG/InitVariableToTableContents2.py
@@ -1,0 +1,46 @@
+# Sample script that is used to initialize a local variable or
+# a global variable in LogixNG.
+#
+# The variable is initialized to a multi dimensional map that
+# has the values from a LogixNG Table.
+#
+# The first map has the rows. Each row has a map with the column
+# header as the key and the cell value as the value.
+#
+# In this example, we use ConcurrentHashMap since it's thread safe
+
+
+# Configure this script
+#
+# tableName is the name of the table
+# columnName is the name of the column you want to use for the values
+
+tableName = "MyTable"
+columnName = "Turnouts"
+
+
+
+import jmri
+import java
+
+myTable = logixngTables.getNamedTable(tableName)
+
+myMap = java.util.concurrent.ConcurrentHashMap()
+
+print "Table: " + myTable.getSystemName()
+
+column = myTable.getColumnNumber(columnName)
+
+for row in range(1, myTable.numRows()+1):
+    rowKey = myTable.getCell(row, 0)
+    rowMap = java.util.concurrent.ConcurrentHashMap()
+
+    for col in range(1, myTable.numColumns()+1):
+        columnKey = myTable.getCell(0, col)
+        cellValue = myTable.getCell(row, col)
+        rowMap.put(columnKey, cellValue)
+
+    myMap.put(rowKey, rowMap)
+
+
+variable.set(myMap)

--- a/jython/LogixNG/LogixNG_ExampleTable.csv
+++ b/jython/LogixNG/LogixNG_ExampleTable.csv
@@ -1,0 +1,5 @@
+	Turnouts	Sensors
+Left	Left turnout	Left sensor
+Right	Right turnout	Left turnout
+First siding	IT15	IS15
+Second siding	IT22	IS22

--- a/jython/LogixNG/LogixNG_ExampleTable.csv
+++ b/jython/LogixNG/LogixNG_ExampleTable.csv
@@ -1,5 +1,5 @@
 	Turnouts	Sensors
 Left	Left turnout	Left sensor
-Right	Right turnout	Left turnout
+Right	Right turnout	Right sensor
 First siding	IT15	IS15
 Second siding	IT22	IS22

--- a/xml/schema/logixng/common-types-4.23.1.xsd
+++ b/xml/schema/logixng/common-types-4.23.1.xsd
@@ -46,6 +46,7 @@
         <xs:enumeration value="Formula"/>
         <xs:enumeration value="ScriptExpression"/>
         <xs:enumeration value="ScriptFile"/>
+        <xs:enumeration value="LogixNG_Table"/>
       </xs:restriction>
     </xs:simpleType>
 

--- a/xml/schema/logixng/common-types-4.23.1.xsd
+++ b/xml/schema/logixng/common-types-4.23.1.xsd
@@ -44,6 +44,8 @@
         <xs:enumeration value="Memory"/>
         <xs:enumeration value="Reference"/>
         <xs:enumeration value="Formula"/>
+        <xs:enumeration value="ScriptExpression"/>
+        <xs:enumeration value="ScriptFile"/>
       </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
This PR adds the possibility to use scripts to initialize local and global variables in LogixNG.

Scripts have three main advantages:
* They let you create an instance of an arbitrary Java object, for example if you need a variable which is a HashSet.
* They let you assign a named bean to a variable, for example sensors.provide("MySensor")
* Using a script file, you can do a more complex initialization, for example assign a map with a predefined set of values.

The PR also changes the initialization of global variables. It now first loads all the logixngs, modules and tables and then initializes the global variables. It allows a global variable to access a table during initialization.