### PR TITLE
allow extensions to add  LocoNet menu items

### DIFF
--- a/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
+++ b/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
@@ -1,25 +1,106 @@
 package jmri.jmrix.loconet.swing;
 
+import javax.swing.Action;
 import javax.swing.JMenu;
+import javax.swing.JComponent;
+import javax.swing.JSeparator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+
+import jmri.jmrix.loconet.locomon.LocoMonPane;
+import jmri.jmrix.loconet.slotmon.SlotMonPane;
+import jmri.jmrix.loconet.clockmon.ClockMonPane;
+import jmri.jmrix.loconet.locostats.swing.LocoStatsPanel;
+import jmri.jmrix.loconet.bdl16.BDL16Panel;
+import jmri.jmrix.loconet.pm4.PM4Panel;
+import jmri.jmrix.loconet.se8.SE8Panel;
+import jmri.jmrix.loconet.ds64.Ds64TabbedPanel;
+import jmri.jmrix.loconet.cmdstnconfig.CmdStnConfigPane;
+import jmri.jmrix.loconet.locoid.LocoIdPanel;
+import jmri.jmrix.loconet.duplexgroup.swing.DuplexGroupTabbedPanel;
+import jmri.jmrix.loconet.swing.throttlemsg.MessagePanel;
+import jmri.jmrix.loconet.locogen.LocoGenPanel;
+import jmri.jmrix.loconet.swing.lncvprog.LncvProgPane;
+import jmri.jmrix.loconet.pr3.swing.Pr3SelectPane;
+import jmri.jmrix.loconet.soundloader.LoaderPane;
+import jmri.jmrix.loconet.soundloader.EditorPane;
+import jmri.jmrix.loconet.locormi.LnMessageServerAction;
+import jmri.jmrix.loconet.loconetovertcp.LnTcpServerAction;
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import jmri.jmrix.loconet.LnCommandStationType;
+import jmri.jmrix.loconet.swing.menuitemspi.MenuItemsService;
+
+import jmri.util.swing.WindowInterface;
+import jmri.util.swing.sdi.JmriJFrameInterface;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Create a "Systems" menu containing the Jmri LocoNet-specific tools.
  *
  * @author Bob Jacobsen Copyright 2003, 2010
+ * @author B. Milhaupt Copyright 2021, 2022
  */
 public class LocoNetMenu extends JMenu {
+    private boolean lastWasSeparator;
+    
+
 
     /**
-     * Create a LocoNet menu. Preloads the TrafficController to certain actions.
+     * Create a LocoNet menu.
+     * <br>
+     * Adds menu items for JMRI code's LocoNet menu items, as defined in
+     * the initialization of <code>panelItems</code> here, and appends those
+     * menu items from SPI extensions which implement 
+     * {@link jmri.jmrix.loconet.swing.menuitemspi.spi.MenuItemsInterface} 
+     * to report additional menu items for inclusion on the LocoNet menu.
+     * <br>
+     * This method pre-loads the TrafficController to certain actions.
+     * <br>
      * Actions will open new windows.
-     *
+     *<br>
      * @param memo      {@link jmri.jmrix.loconet.LocoNetSystemConnectionMemo} to
      *                  be used by this object
+     * @see jmri.jmrix.loconet.swing.menuitemspi.spi.MenuItemsInterface
+     * @see jmri.jmrix.loconet.swing.menuitemspi.MenuItemsService
      */
     public LocoNetMenu(LocoNetSystemConnectionMemo memo) {
         super();
+        ArrayList<LocoNetMenuItem> panelItems;
+        panelItems = new ArrayList<>();
+        
+        // Define the common allExtensionItems in the LocoNet menu.  Note that
+        // LnMessageServer and LnTcpServer are special-cased because they have no
+        // GUI interface and are handled slightly differently by processItems().
+
+        panelItems.add(new LocoNetMenuItem("MenuItemLocoNetMonitor", LocoMonPane.class, false, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemSlotMonitor", SlotMonPane.class, false, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemClockMon", ClockMonPane.class, true, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemLocoStats", LocoStatsPanel.class, false, true)); // NOI18N
+        panelItems.add(null);
+        panelItems.add(new LocoNetMenuItem("MenuItemBDL16Programmer", BDL16Panel.class, true, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemPM4Programmer", PM4Panel.class, true, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemSE8cProgrammer", SE8Panel.class, true, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemDS64Programmer", Ds64TabbedPanel.class, true, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemCmdStnConfig", CmdStnConfigPane.class,true, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemSetID", LocoIdPanel.class, true, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemDuplex", DuplexGroupTabbedPanel.class, true, true)); // NOI18N
+        panelItems.add(null);
+        panelItems.add(new LocoNetMenuItem("MenuItemThrottleMessages", MessagePanel.class, true, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemSendPacket", LocoGenPanel.class, false, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemLncvProg", LncvProgPane.class, true, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemPr3ModeSelect", Pr3SelectPane.class, false, true)); // NOI18N
+        panelItems.add(null);
+        panelItems.add(new LocoNetMenuItem("MenuItemDownload", jmri.jmrix.loconet.downloader.LoaderPane.class, false, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemSoundload", LoaderPane.class, false, true)); // NOI18N
+        panelItems.add(new LocoNetMenuItem("MenuItemSoundEditor", EditorPane.class, false, true)); // NOI18N
+        panelItems.add(null);
+        panelItems.add(new LocoNetMenuItem("MenuItemStartLocoNetServer", LnMessageServerAction.class, false, false));
+        panelItems.add(new LocoNetMenuItem("MenuItemLocoNetOverTCPServer", LnTcpServerAction.class, false, false));
 
         LnCommandStationType cmdStation = null;
         if (memo != null) {
@@ -29,83 +110,227 @@ public class LocoNetMenu extends JMenu {
             setText(Bundle.getMessage("MenuLocoNet"));
         }
 
-        jmri.util.swing.WindowInterface wi = new jmri.util.swing.sdi.JmriJFrameInterface();
+        WindowInterface wi = new JmriJFrameInterface();
 
         boolean isLocoNetInterface;
-        if ((cmdStation == null) ||
+        isLocoNetInterface = (cmdStation == null) ||
                 (!cmdStation.equals(LnCommandStationType.COMMAND_STATION_PR2_ALONE) &&
                 !cmdStation.equals(LnCommandStationType.COMMAND_STATION_PR3_ALONE) &&
                 !cmdStation.equals(LnCommandStationType.COMMAND_STATION_PR4_ALONE) &&
                 !cmdStation.equals(LnCommandStationType.COMMAND_STATION_USB_DCS240_ALONE) &&
-                !cmdStation.equals(LnCommandStationType.COMMAND_STATION_USB_DCS52_ALONE))
-                ) {
-            isLocoNetInterface = true;
-        } else {
-            isLocoNetInterface = false;
+                !cmdStation.equals(LnCommandStationType.COMMAND_STATION_USB_DCS52_ALONE));
+
+        JMenu hostMenu = this;
+        lastWasSeparator = true;  // to prevent an initial separator in menu
+        processItems(hostMenu, panelItems, isLocoNetInterface, wi, memo);
+
+        lastWasSeparator = false;
+        add(hostMenu);
+        panelItems.clear();
+        // Deal with menu item tasks from SPI extensions
+        ArrayList<JMenu> extensionMenus  = getExtensionMenuItems(isLocoNetInterface,
+             wi,  memo);
+        log.trace("number of extension items is {}.", panelItems.size());
+        while ((!extensionMenus.isEmpty()) && (extensionMenus.get(extensionMenus.size()-1) == null)) {
+            // remove any dangling separators at end of list of menu allExtensionItems
+            extensionMenus.remove(panelItems.size()-1);
         }
-
-        /*
-         * A local variable to help prevent a leading JSeparator and sequential
-         * JSeparators.
-         */
-        boolean lastWasSeparator = true;
-
-        for (Item item : panelItems) {
-            if (item == null) {
-                if (!lastWasSeparator) {
-                    add(new javax.swing.JSeparator());
-                    lastWasSeparator = true;
-                }
-            } else {
-                if ((!item.interfaceOnly) ||
-                        isLocoNetInterface) {
-                    add(new LnNamedPaneAction(Bundle.getMessage(item.name), wi, item.load, memo));
-                    lastWasSeparator = false;
-                }
+        if (!extensionMenus.isEmpty()) {
+            add(new JSeparator());  // ensure placement of a horizontal bar above 
+                                    // extension menu
+            log.debug("number of items {}", panelItems.size());
+            while (!extensionMenus.isEmpty()) {
+                JMenu menu = extensionMenus.get(0);
+                add(menu);
+                log.trace("Added extension menu {}", menu.getName());
+                extensionMenus.remove(0);
             }
         }
-
-        if (isLocoNetInterface) {
-            add(new javax.swing.JSeparator());
-            add(new jmri.jmrix.loconet.locormi.LnMessageServerAction(Bundle.getMessage("MenuItemStartLocoNetServer")));
-            add(new jmri.jmrix.loconet.loconetovertcp.LnTcpServerAction(Bundle.getMessage("MenuItemLocoNetOverTCPServer")));
+    }
+    
+    /**
+     * Create an Action suitable for inclusion as a menu item on a LocoNet menu.
+     * 
+     * @param item a LocoetMenuItem object which defines the menu item's 
+     *      characteristics, and which will be the basis for the returned Action 
+     *      object.
+     * @param isLocoNetInterface is true if the LocoNet connection has a physical 
+     *      interface to LocoNet, else false.
+     * @param wi the WindowInterface associated with the JMRI instance and LocoNetMenu.
+     * @param memo the LocoNetSystemConnectionMemo associated with the LocoNet 
+     *          connection.
+     * @return an Action which may be added to a local JMenu for inclusion in a
+     * LocoNet connection's menu; the action's object may make use of the LocoNet 
+     * memo and associate its GUI objects with the JMRI WindowInterface.  If the 
+     * item requires a physical LocoNet interface but the connection does not have
+     * such an interface, then null is returned.
+     */
+    public Action processExternalItem(LocoNetMenuItem item, boolean isLocoNetInterface,
+            WindowInterface wi, LocoNetSystemConnectionMemo memo) {
+        if (item == null) {
+            return null;
+        }
+        if (item.hasGui()  ) {
+            if (isLocoNetInterface || (!item.isInterfaceOnly())) {
+                log.trace("created GUI menu item {}.", item.getName());
+                return createGuiAction(item, wi, memo);
+            } else {
+                log.trace("not displaying item {} ({}) account requires "
+                        + "interface which is not present in current "
+                        + "configuration.",
+                        item.getName(), item.getClassToLoad().getCanonicalName()
+                        );
+                return null;
+            }
+        } else {
+            log.trace("created non-GUI menu item {}.", item.getName());
+            return createNonGuiAction(item);
         }
     }
 
-    Item[] panelItems = new Item[]{
-        new Item("MenuItemLocoNetMonitor", "jmri.jmrix.loconet.locomon.LocoMonPane", false), // NOI18N
-        new Item("MenuItemSlotMonitor", "jmri.jmrix.loconet.slotmon.SlotMonPane", false), // NOI18N
-        new Item("MenuItemClockMon", "jmri.jmrix.loconet.clockmon.ClockMonPane", true), // NOI18N
-        new Item("MenuItemLocoStats", "jmri.jmrix.loconet.locostats.swing.LocoStatsPanel", false), // NOI18N
-        null,
-        new Item("MenuItemBDL16Programmer", "jmri.jmrix.loconet.bdl16.BDL16Panel", true), // NOI18N
-        new Item("MenuItemPM4Programmer", "jmri.jmrix.loconet.pm4.PM4Panel", true), // NOI18N
-        new Item("MenuItemSE8cProgrammer", "jmri.jmrix.loconet.se8.SE8Panel", true), // NOI18N
-        new Item("MenuItemDS64Programmer", "jmri.jmrix.loconet.ds64.Ds64TabbedPanel", true), // NOI18N
-        new Item("MenuItemCmdStnConfig", "jmri.jmrix.loconet.cmdstnconfig.CmdStnConfigPane",true), // NOI18N
-        new Item("MenuItemSetID", "jmri.jmrix.loconet.locoid.LocoIdPanel", true), // NOI18N
-        new Item("MenuItemDuplex", "jmri.jmrix.loconet.duplexgroup.swing.DuplexGroupTabbedPanel", true), // NOI18N
-        null,
-        new Item("MenuItemThrottleMessages", "jmri.jmrix.loconet.swing.throttlemsg.MessagePanel", true), // NOI18N
-        new Item("MenuItemSendPacket", "jmri.jmrix.loconet.locogen.LocoGenPanel", false), // NOI18N
-        new Item("MenuItemLncvProg", "jmri.jmrix.loconet.swing.lncvprog.LncvProgPane", true), // NOI18N
-        new Item("MenuItemPr3ModeSelect", "jmri.jmrix.loconet.pr3.swing.Pr3SelectPane", false), // NOI18N
-        null,
-        new Item("MenuItemDownload", "jmri.jmrix.loconet.downloader.LoaderPane", false), // NOI18N
-        new Item("MenuItemSoundload", "jmri.jmrix.loconet.soundloader.LoaderPane", false), // NOI18N
-        new Item("MenuItemSoundEditor", "jmri.jmrix.loconet.soundloader.EditorPane", false) // NOI18N
-    };
-
-    static class Item {
-
-        Item(String name, String load, boolean interfaceOnly) {
-            this.name = name;
-            this.load = load;
-            this.interfaceOnly = interfaceOnly;
+    /**
+     * Create an Action object from a LocoNetMenuItem, linked to the appropriate
+     * WindowInterface, for use as a menu item on a LocoNet menu.
+     * 
+     * Depending on whether the item needs a gui and/or a physical LocoNet 
+     * interface, this method returns null or an Action which is suitable for 
+     * use as a menu item on a LocoNet menu.
+     *<br>
+     * If the item's name is found as a key the Bundle associated with this object,
+     * then the I18N'd string will be used as the Action's text.
+     * 
+     * @param item LocoNetMenuItem which defines the menu item's requirements.
+     * @param wi WindowInterface to which the item's GUI object will be linked.
+     * @param memo LocoNetSystemConnectionMemo with which the item will be linked.
+     * @return null if the item's requirements are not met by the current 
+     *      connection, or an Action which may be used as a JMenuItem.
+     */
+    public Action createGuiAction(LocoNetMenuItem item, WindowInterface wi,
+            LocoNetSystemConnectionMemo memo) {
+        String translatedMenuItemName;
+        try {
+            translatedMenuItemName = Bundle.getMessage(item.getName());
+        } catch (java.util.MissingResourceException e) {
+            // skip internationalization if name is not present as a "key"
+            translatedMenuItemName = item.getName();
         }
-        String name;
-        String load;
-        boolean interfaceOnly;
+
+        return new LnNamedPaneAction(translatedMenuItemName, wi, 
+                item.getClassToLoad().getCanonicalName(), memo);
     }
+
+    /**
+     * Create an Action object from a LocoNetMenuItem, for use as a menu item on 
+     * a LocoNet menu, without linkage to the WindowInterface associated with the 
+     * LocoNet menu.
+     * 
+     * This method returns an Action which is suitable for use as a menu item on 
+     * a LocoNet menu.
+     *<br>
+     * If the item's name is found as a key the Bundle associated with this object,
+     * then the I18N'd string will be used as the Action's text.
+     * 
+     * @param item LocoNetMenuItem which defines the menu item's requirements.
+     * @return an Action which may be used as a JMenuItem.
+     */
+    public Action createNonGuiAction(LocoNetMenuItem item) {
+        Action menuItem = null;
+        try {
+            menuItem = (Action) item.getClassToLoad()
+                            .getDeclaredConstructor().newInstance();
+            menuItem.putValue("NAME", item.getName()); // set the menu item name // NOI18N
+        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | java.lang.reflect.InvocationTargetException ex ) {
+            log.warn("could not load menu item {} ({})", 
+                    item.getName(), item.getClassToLoad().getCanonicalName(), ex);
+        }
+        return menuItem;
+    }
+     
+    /**
+     * Get an ArrayList of JMenu objects as provided via the SPI "extension" 
+     * mechanisms.
+     * @param isConnectionWithHardwareInterface informs whether the connection 
+     *      has actual hardware
+     * @param wi allows the extension menu items to be associated with the 
+     *      JAVA WindowInterface which relates to the connection's menu
+     * @param memo the LocoNetSystemConnectionMemo associated with the menu to 
+     *      which the extension's MenuItem(s) are to be attached.
+     * @return an ArrayList of JMenu objects, as populated from the menu items 
+     *      reported by any available SPI extensions.  May be an empty ArrayList
+     *      if none of the SPI extensions provide menu items for this menu.
+     * <br>
+     * @see jmri.jmrix.loconet.swing.menuitemspi.spi.MenuItemsInterface
+     * @see jmri.jmrix.loconet.swing.menuitemspi.MenuItemsService
+     */
+    public final java.util.ArrayList<JMenu> getExtensionMenuItems(
+            boolean isConnectionWithHardwareInterface, WindowInterface wi, 
+            LocoNetSystemConnectionMemo memo) {
+        ArrayList<JMenu> locoNetMenuItems = new ArrayList<>();
+        log.trace("searching for extensions for the canonical name {}", 
+                this.getClass().getCanonicalName());
+        MenuItemsService lnMenuItemServiceInstance;
+        lnMenuItemServiceInstance = MenuItemsService.getInstance();
+        locoNetMenuItems.addAll(
+                lnMenuItemServiceInstance.getMenuExtensionsItems(
+                        isConnectionWithHardwareInterface, wi, memo));
+        log.trace("LocoNetItems size is {}", locoNetMenuItems.size());
+        return locoNetMenuItems;
+    }
+
+    private void processItems(JMenu menu, ArrayList<LocoNetMenuItem> items, boolean isLocoNetInterface,
+            WindowInterface wi, LocoNetSystemConnectionMemo memo) {
+        items.forEach(item -> {
+            processAnItem(menu, item, isLocoNetInterface, wi, memo);
+        });
+    }
+        
+    private void processAnItem(JMenu menu, LocoNetMenuItem item, boolean isLocoNetInterface,
+            WindowInterface wi, LocoNetSystemConnectionMemo memo) {
+        if (item == null) {
+            if (!lastWasSeparator) {
+                menu.add(new JSeparator());
+                log.trace("Added new JSeparator");
+
+                lastWasSeparator = true;
+            }
+        } else if (item.hasGui()  ) {
+            if (isLocoNetInterface || (!item.isInterfaceOnly())) {
+                addGuiItem(menu, item, wi, memo);
+                log.trace("added GUI item {}", item.getName());
+            } else {
+                log.trace("not displaying item {} ({}) account requires "
+                        + "interface which is not present in current "
+                        + "configuration.",
+                        item.getName(), item.getClassToLoad().getCanonicalName());
+            }
+        } else {
+            addNonGuiItem(menu, item);
+                log.trace("added non-GUI item {}", item.getName());
+        }
+    }
+
+    private void addNonGuiItem(JMenu menu, LocoNetMenuItem item) {
+        if (item != null) {
+            Action menuItem = createNonGuiAction(item);
+            menu.add(menuItem);
+            log.debug("Adding (non-gui) item {} ({})",
+                    item.getName(), item.getClassToLoad());
+            lastWasSeparator = false;
+        } else {
+            menu.add(new JSeparator());
+            lastWasSeparator = true;
+            log.trace("adding a JSeparator account null item");
+        }
+    }
+    private void addGuiItem(JMenu menu, LocoNetMenuItem item, WindowInterface wi,
+            LocoNetSystemConnectionMemo memo) {
+        Action a = createGuiAction(item, wi, memo);
+        menu.add(a);
+        lastWasSeparator = false;
+        log.debug("Added new GUI-based item for {} ({}).", 
+                item.getName(), item.getClassToLoad().getCanonicalName());
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(LocoNetMenu.class);
 
 }

--- a/java/src/jmri/jmrix/loconet/swing/LocoNetMenuItem.java
+++ b/java/src/jmri/jmrix/loconet/swing/LocoNetMenuItem.java
@@ -1,0 +1,49 @@
+package jmri.jmrix.loconet.swing;
+
+/**
+ * A LocoNet Menu item.
+ * 
+ * @author Bob Milhaupt  Copyright (C) 2021
+ */
+public class LocoNetMenuItem {
+    /**
+     * Construct a Menu Item for all LocoNet-specific connection menu(s).
+     * 
+     * @param <T> Type of class to be executed upon activation of the menu item
+     * @param name Text to be shown in the menu item
+     * @param load class to be constructed upon selection of the menu item
+     * @param interfaceOnly true if menu item is to be shown only for JMRI 
+     *          connections having a physical interface, else false
+     * @param hasGui true if the menu item has a GUI object which must be 
+     *          associated with the main JMRI Window Interface, else false
+     */
+    public <T> LocoNetMenuItem(String name, Class<T> load, boolean interfaceOnly, boolean hasGui) {
+        
+        this.name = name;
+        this.classToLoad = load;
+        this.hasGui = hasGui;
+        this.interfaceOnly = interfaceOnly;
+        }
+    
+    private final boolean interfaceOnly;
+    private final String name;
+    private final Class<?> classToLoad;
+    private final boolean hasGui;
+
+
+    public boolean isInterfaceOnly() {
+        return interfaceOnly;
+    }
+    public String getName() {
+        return name;
+    }
+
+    public Class<?> getClassToLoad() {
+        return classToLoad;
+    }
+
+    public boolean hasGui() {
+        return hasGui;
+    }
+
+}

--- a/java/src/jmri/jmrix/loconet/swing/menuitemspi/MenuItemsService.java
+++ b/java/src/jmri/jmrix/loconet/swing/menuitemspi/MenuItemsService.java
@@ -64,7 +64,7 @@ public final class MenuItemsService {
             java.util.Iterator<MenuItemsInterface> miIterator = loader.iterator();
             while (miIterator.hasNext()) {
                 MenuItemsInterface mii = miIterator.next();
-                log.warn("adding menu items for extension {}", mii.getClass());
+                log.debug("adding menu items for extension {}", mii.getClass());
                 ArrayList <JMenu> me = mii.getMenuItems(isLocoNetInterface, wi, memo);
                 menus.addAll(me);
             }

--- a/java/src/jmri/jmrix/loconet/swing/menuitemspi/MenuItemsService.java
+++ b/java/src/jmri/jmrix/loconet/swing/menuitemspi/MenuItemsService.java
@@ -1,0 +1,77 @@
+package jmri.jmrix.loconet.swing.menuitemspi;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceConfigurationError;
+
+import jmri.util.swing.WindowInterface;
+
+import javax.swing.JMenu;
+
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
+import jmri.jmrix.loconet.swing.LocoNetMenuItem;
+import jmri.jmrix.loconet.swing.menuitemspi.spi.MenuItemsInterface;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A JAVA SPI Service to retrieve, from providers of the {@link 
+ * jmri.jmrix.loconet.swing.menuitemspi.spi.MenuItemsInterface} service, lists 
+ * of items to be added to the JMRI menu(s) associated with LocoNet connections.
+ * <br>
+ * @author Bob M.  Copyright (C) 2021
+ */
+public final class MenuItemsService {
+    private static MenuItemsService service; // (singleton pattern)
+    private final ServiceLoader <MenuItemsInterface> loader;
+
+    private MenuItemsService () {
+        loader = ServiceLoader.load(MenuItemsInterface.class);
+    }
+
+    /**
+     * Method for getting the SPI service "singleton"
+     * <p>
+     * @return the singleton instance of this class
+     */
+    public static synchronized MenuItemsService getInstance() {
+        if (service == null) {
+            service = new MenuItemsService();
+        }
+        return service;
+    }
+
+    /**
+     * Return menu items from all LocoNet Menu Extension SPI providers.
+     * <br>
+     * @param isLocoNetInterface informs whether the connection
+     *      has actual hardware
+     * @param wi allows the extension menu items to be associated with the
+     *      JAVA WindowInterface which relates to the connection's menu
+     * @param memo the LocoNetSystemConnectionMemo associated with the menu to
+     *      which the extension's MenuItem(s) are to be attached.
+     * @return an ArrayList of JMenu objects, as populated from the menu items
+     *      reported by any available SPI extensions.  May be an empty ArrayList
+     *      if none of the SPI extensions provide menu items for this menu.
+     */
+    public List<JMenu> getMenuExtensionsItems(boolean isLocoNetInterface,
+            WindowInterface wi, LocoNetSystemConnectionMemo memo) {
+        ArrayList <JMenu> menus = new java.util.ArrayList<>();
+
+        try {
+            java.util.Iterator<MenuItemsInterface> miIterator = loader.iterator();
+            while (miIterator.hasNext()) {
+                MenuItemsInterface mii = miIterator.next();
+                log.warn("adding menu items for extension {}", mii.getClass());
+                ArrayList <JMenu> me = mii.getMenuItems(isLocoNetInterface, wi, memo);
+                menus.addAll(me);
+            }
+        } catch (ServiceConfigurationError serviceError) {
+            // ignore the exception
+        }
+        return menus;
+    }
+    private final static Logger log = LoggerFactory.getLogger(MenuItemsService.class);
+}

--- a/java/src/jmri/jmrix/loconet/swing/menuitemspi/spi/MenuItemsInterface.java
+++ b/java/src/jmri/jmrix/loconet/swing/menuitemspi/spi/MenuItemsInterface.java
@@ -1,0 +1,44 @@
+package jmri.jmrix.loconet.swing.menuitemspi.spi;
+
+import java.util.ArrayList;
+import javax.swing.JMenu;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
+import jmri.util.swing.WindowInterface;
+
+/**
+ * An interface which allows for extension of LocoNet menu items via an
+ * implementation of the {@link java.util.spi} mechanism.
+ * <br>
+ * The {@link jmri.jmrix.loconet.swing.menuitemspi.MenuItemsService} invokes the 
+ * {@link jmri.jmrix.loconet.swing.menuitemspi.spi.MenuItemsInterface#getMenuItems(boolean, jmri.util.swing.WindowInterface, jmri.jmrix.loconet.LocoNetSystemConnectionMemo)} 
+ * method to retrieve the service provider's menu items.
+ * <br>
+ * @author Bob Milhaupt  Copyright (C) 2021
+ */
+
+public interface MenuItemsInterface {
+    /**
+     * An interface for extension of the menu(s) associated with JMRI LocoNet-based
+     * connections, the JAVA SPI mechanism.
+     * 
+     * Implementers of this JAVA SPI interface provide an ArrayList of zero or 
+     * more items to be added to JMRI menu(s) for connection(s) of the "LocoNet" type.
+     * <br>
+     * The returned {@link java.util.ArrayList} may contain zero, one or more of any of the 
+     * objects allowed by a {@link javax.swing.JMenu} object.  This includes 
+     * objects of the class {@link jmri.jmrix.loconet.swing.LocoNetMenuItem}.
+     * <br>
+     * @param isLocoNetInterface informs whether the connection
+     *      has actual hardware.
+     * @param wi allows the extension menu items to be associated with the
+     *      {@link jmri.util.swing.WindowInterface} which relates to the connection's menu.
+     * @param memo the {@link jmri.jmrix.loconet.LocoNetSystemConnectionMemo} associated with the menu to
+     *      which the extension's MenuItem(s) are to be attached.
+     * @return an {@link java.util.ArrayList} of JMenu-compatible objects, as populated from the 
+     *      menu items reported by any available SPI extensions.  Implementer may
+     *      return an empty ArrayList if it does not implement any menu items.
+     */
+    public ArrayList<JMenu> getMenuItems(boolean isLocoNetInterface,
+            WindowInterface wi, LocoNetSystemConnectionMemo memo);
+
+}

--- a/java/test/jmri/jmrix/loconet/swing/LocoNetMenuItemTest.java
+++ b/java/test/jmri/jmrix/loconet/swing/LocoNetMenuItemTest.java
@@ -1,0 +1,61 @@
+package jmri.jmrix.loconet.swing;
+
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
+import jmri.jmrix.loconet.locomon.LocoMonPane;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for LocoNetMenuItem.
+ * <br>
+ * @author Bob Milhaupt  Copyright (C) 2022
+ */
+public class LocoNetMenuItemTest {
+
+    @Test
+    public void testIsInterfaceOnly() {
+        LocoNetMenuItem instance = new LocoNetMenuItem("a.b.c.d",
+                LocoMonPane.class, false, true);
+        boolean expResult = false;
+        boolean result = instance.isInterfaceOnly();
+        assertEquals("isInterfaceOnly expect false", expResult, result);
+        instance = new LocoNetMenuItem("a.b.c.d",
+                LocoMonPane.class, true, false);
+        expResult = true;
+        result = instance.isInterfaceOnly();
+        assertEquals("isInterfaceOnly expect true", expResult, result);
+    }
+
+    @Test
+    public void testGetName() {
+        LocoNetMenuItem instance = new LocoNetMenuItem("a.b.c.d",
+                LocoMonPane.class, false, true);
+        String expResult = "a.b.c.d";
+        String result = instance.getName();
+        assertEquals("getName expect 'a.b.c.d'", expResult, result);
+    }
+
+    @Test
+    public void testGetClassToLoad() {
+        LocoNetMenuItem instance = new LocoNetMenuItem("a.b.c.d",
+                LocoMonPane.class, false, true);
+        Class expResult = LocoMonPane.class;
+        Class result = instance.getClassToLoad();
+        assertEquals("getClassToLoad test", expResult, result);
+    }
+
+    @Test
+    public void testHasGui() {
+        LocoNetMenuItem instance = new LocoNetMenuItem("a.b.c.d",
+                LocoMonPane.class, false, true);
+        boolean expResult = true;
+        boolean result = instance.hasGui();
+        assertEquals("hasGui expect true", expResult, result);
+        instance = new LocoNetMenuItem("a.b.c.d",
+                LocoMonPane.class, true, false);
+        expResult = false;
+        result = instance.hasGui();
+        assertEquals("hasGui expect false", expResult, result);    }
+
+}

--- a/java/test/jmri/jmrix/loconet/swing/menuitemspi/MenuItemsServiceTest.java
+++ b/java/test/jmri/jmrix/loconet/swing/menuitemspi/MenuItemsServiceTest.java
@@ -1,0 +1,65 @@
+package jmri.jmrix.loconet.swing.menuitemspi;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JMenu;
+
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
+import jmri.util.swing.WindowInterface;
+import jmri.jmrix.loconet.swing.menuitemspi.spi.MenuItemsInterface;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Tests for MenuItemsService.
+ * <br>
+ * @author Bob Milhaupt  Copyright (C) 2022
+ */
+
+@ServiceProvider(service = jmri.jmrix.loconet.swing.menuitemspi.spi.MenuItemsInterface.class)
+public class MenuItemsServiceTest implements MenuItemsInterface {
+
+    @Test
+    public void testGetInstance() {
+        MenuItemsService result = MenuItemsService.getInstance();
+        assertNotNull( result);
+        assertEquals("check class returned", MenuItemsService.class, result.getClass());
+    }
+
+    @Test
+    public void testGetMenuExtensionsItems() {
+        boolean isLocoNetInterface = false;
+        WindowInterface wi = null;
+        LocoNetSystemConnectionMemo memo = null;
+        MenuItemsService instance = MenuItemsService.getInstance();
+        List<JMenu> result = instance.getMenuExtensionsItems(isLocoNetInterface, wi, memo);
+        assertEquals("result number of menus", 2, result.size());
+        JMenu j1 = result.get(0);
+        assertEquals("result's  first item is a JMenu", JMenu.class,
+                j1.getClass());
+        assertEquals("result element 0's name", "A menu", j1.getName());
+        assertEquals("result menu 1's number of items",
+                0, j1.getItemCount());
+        JMenu j2 = result.get(1);
+        assertEquals("result's  second item is a JMenu", JMenu.class,
+                j2.getClass());
+        assertEquals("result second item's name", "B menu", j2.getName());
+        assertEquals("result second item's number of items",
+                0, j2.getItemCount());
+    }
+
+    @Override
+    public ArrayList<JMenu> getMenuItems(boolean isLocoNetInterface,
+            WindowInterface wi, LocoNetSystemConnectionMemo memo) {
+        ArrayList<JMenu> j = new ArrayList<>();
+        JMenu jm = new JMenu();
+        jm.setName("A menu");
+        j.add(jm);
+        jm = new JMenu();
+        jm.setName("B menu");
+        j.add(jm); // add another menu so there's something more to check on.
+        return j;
+    }
+}


### PR DESCRIPTION
A separate JAR file can add items to all of the connection-specific menus for connections of the LocoNet type, via SPI mechanism.
