### PR TITLE
Update AbstractThrottle Warnings / DCCppThrottleTest

### DIFF
--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.util.StdDateFormat;
 import java.beans.PropertyChangeListener;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
+
 import jmri.BasicRosterEntry;
 import jmri.CommandStation;
 import jmri.LocoAddress;
@@ -201,7 +201,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
     @Override
     public boolean getFunction(int fN) {
         if (fN<0 || fN > FUNCTION_BOOLEAN_ARRAY.length-1){
-            log.warn("Unhandled get function: {}",fN);
+            log.warn("Unhandled get function: {} {}", fN, this.getClass().getName());
             return false;
         }
         return FUNCTION_BOOLEAN_ARRAY[fN];
@@ -213,7 +213,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
     @Override
     public boolean getFunctionMomentary(int fN) {
         if (fN<0 || fN > FUNCTION_MOMENTARY_BOOLEAN_ARRAY.length-1){
-            log.warn("Unhandled get momentary function: {}",fN);
+            log.warn("Unhandled get momentary function: {} {}", fN, this.getClass().getName());
             return false;
         }
         return FUNCTION_MOMENTARY_BOOLEAN_ARRAY[fN];
@@ -276,7 +276,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
     @Override
     public void addPropertyChangeListener(PropertyChangeListener l) {
         if ( Arrays.asList(getPropertyChangeListeners()).contains(l) ){
-            log.warn("Preventing {} adding duplicate PCL", l);
+            log.warn("Preventing {} adding duplicate PCL to {}", l, this.getClass().getName());
             return;
         }
         super.addPropertyChangeListener(l);
@@ -317,7 +317,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
     @Override
     public void dispose(ThrottleListener l) {
         if (!active) {
-            log.error("Dispose called when not active");
+            log.error("Dispose called when not active {}", this.getClass().getName());
         }
         InstanceManager.throttleManagerInstance().disposeThrottle(this, l);
     }
@@ -328,7 +328,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
     @Override
     public void dispatch(ThrottleListener l) {
         if (!active) {
-            log.warn("dispatch called when not active");
+            log.warn("dispatch called when not active {}", this.getClass().getName());
         }
         InstanceManager.throttleManagerInstance().dispatchThrottle(this, l);
     }
@@ -339,7 +339,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
     @Override
     public void release(ThrottleListener l) {
         if (!active) {
-            log.warn("release called when not active");
+            log.warn("release called when not active {}",this.getClass().getName());
         }
         InstanceManager.throttleManagerInstance().releaseThrottle(this, l);
     }
@@ -435,7 +435,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
      */
     public void updateFunctionMomentary(int fn, boolean state) {
         if (fn < 0 || fn > FUNCTION_MOMENTARY_BOOLEAN_ARRAY.length-1) {
-            log.warn("Unhandled update momentary function number: {}", fn);
+            log.warn("Unhandled update momentary function number: {} {}", fn, this.getClass().getName());
             return;
         }
         boolean old = FUNCTION_MOMENTARY_BOOLEAN_ARRAY[fn];
@@ -545,7 +545,7 @@ abstract public class AbstractThrottle extends PropertyChangeSupport implements 
     @Override
     public void setFunctionMomentary(int momFuncNum, boolean state){
         if (momFuncNum < 0 || momFuncNum > FUNCTION_MOMENTARY_BOOLEAN_ARRAY.length-1) {
-            log.warn("Unhandled set momentary function number: {}", momFuncNum);
+            log.warn("Unhandled set momentary function number: {} {}", momFuncNum, this.getClass().getName());
             return;
         }
         boolean old = FUNCTION_MOMENTARY_BOOLEAN_ARRAY[momFuncNum];

--- a/java/test/jmri/jmrix/dccpp/DCCppThrottleTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppThrottleTest.java
@@ -74,21 +74,21 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         Assert.assertEquals(instance.getSpeedSetting(), 0.5f, 0.0001);
         Assert.assertTrue(instance.getIsForward());
         DCCppMessage lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "t 3 63 1");
+        Assert.assertEquals( "t 3 63 1", lm.toString());
 
         instance.setSpeedSetting(0.0f);
         instance.setIsForward(false);
         Assert.assertEquals(instance.getSpeedSetting(), 0.0f, 0.0001);
         Assert.assertFalse(instance.getIsForward());
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "t 3 0 0");
+        Assert.assertEquals( "t 3 0 0", lm.toString());
 
         instance.setSpeedSetting(1.0f);
         instance.setIsForward(false);
         Assert.assertEquals(instance.getSpeedSetting(), 1.0f, 0.0001);
         Assert.assertFalse(instance.getIsForward());
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "t 3 126 0");
+        Assert.assertEquals( "t 3 126 0", lm.toString());
 
         r = DCCppReply.parseDCCppReply(
                 "iDCC++ BASE STATION FOR ARDUINO MEGA / ARDUINO MOTOR SHIELD: BUILD 23 Feb 2015 09:23:57");
@@ -99,21 +99,21 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         Assert.assertEquals(instance.getSpeedSetting(), 0.5f, 0.0001);
         Assert.assertTrue(instance.getIsForward());
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "t -1 3 63 1");
+        Assert.assertEquals( "t -1 3 63 1", lm.toString());
 
         instance.setSpeedSetting(0.0f);
         instance.setIsForward(false);
         Assert.assertEquals(instance.getSpeedSetting(), 0.0f, 0.0001);
         Assert.assertFalse(instance.getIsForward());
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "t -1 3 0 0");
+        Assert.assertEquals( "t -1 3 0 0", lm.toString());
 
         instance.setSpeedSetting(1.0f);
         instance.setIsForward(false);
         Assert.assertEquals(instance.getSpeedSetting(), 1.0f, 0.0001);
         Assert.assertFalse(instance.getIsForward());
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "t -1 3 126 0");
+        Assert.assertEquals( "t -1 3 126 0", lm.toString());
 
     }
 
@@ -134,25 +134,26 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         instance.setFunction(0, true);
         Assert.assertTrue(instance.getFunction(0));
         DCCppMessage lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "F 3 0 1");
+        Assert.assertEquals( "F 3 0 1", lm.toString());
         instance.setFunction(0, false);
 
         instance.setFunction(22, false);
         Assert.assertFalse(instance.getFunction(22));
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "F 3 22 0");
+        Assert.assertEquals( "F 3 22 0", lm.toString());
 
         instance.setFunction(28, true);
         Assert.assertTrue(instance.getFunction(28));
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "F 3 28 1");
+        Assert.assertEquals( "F 3 28 1", lm.toString());
         instance.setFunction(28, false);
 
         instance.setFunction(16, true);
-        Assert.assertFalse(instance.getFunction(61));
+        Assert.assertTrue(instance.getFunction(16));
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "F 3 16 1");
+        Assert.assertEquals( "F 3 16 1", lm.toString());
         instance.setFunction(16, false);
+        Assert.assertFalse(instance.getFunction(16));
 
         r = DCCppReply.parseDCCppReply(
                 "iDCC++ BASE STATION FOR ARDUINO MEGA / ARDUINO MOTOR SHIELD: BUILD 23 Feb 2015 09:23:57");
@@ -161,24 +162,24 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         instance.setFunction(0, true);
         Assert.assertTrue(instance.getFunction(0));
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "f 3 144");
+        Assert.assertEquals( "f 3 144", lm.toString());
         instance.setFunction(0, false);
 
         instance.setFunction(21, false);
         Assert.assertFalse(instance.getFunction(21));
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "f 3 223 0");
+        Assert.assertEquals( "f 3 223 0", lm.toString());
 
         instance.setFunction(4, true);
         Assert.assertTrue(instance.getFunction(4));
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "f 3 136");
+        Assert.assertEquals( "f 3 136", lm.toString());
         instance.setFunction(4, false);
 
         instance.setFunction(28, true);
         Assert.assertTrue(instance.getFunction(28));
         lm = tc.outbound.get(tc.outbound.size()-1);
-        Assert.assertEquals(lm.toString(), "f 3 223 128");
+        Assert.assertEquals( "f 3 223 128", lm.toString());
         instance.setFunction(28, false);
 
     }


### PR DESCRIPTION
AbstractThrottle  - Improve warnings to include jmrix class

DCCppThrottleTest - Fixes the Build Test Runtime Warning

`jmri.jmrix.AbstractThrottle.getFunction():0 - Unhandled get function: 61`
https://builds.jmri.org/jenkins/job/development/job/builds/1201/jmri-test-runtime-warnings/NORMAL

DCCppThrottleTest - Tweak order of AssertEquals