### PR TITLE
Update LogixNG DefaultGlobalVariable Test

### DIFF
--- a/java/test/jmri/jmrit/logixng/implementation/DefaultGlobalVariableTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultGlobalVariableTest.java
@@ -49,7 +49,7 @@ public class DefaultGlobalVariableTest {
 
         // Assign a copy of a table to a global variable
         NamedTable csvTable = InstanceManager.getDefault(NamedTableManager.class)
-                        .loadTableFromCSV("IQT1", null, "scripts:LogixNG/LogixNG_ExampleTable.csv");
+                        .loadTableFromCSV("IQT1", null, jmri.util.FileUtil.getProgramPath()+ "jython/LogixNG/LogixNG_ExampleTable.csv");
         Assert.assertNotNull(csvTable);
         Object value = getVariableValue(InitialValueType.LogixNG_Table, csvTable.getSystemName());
         Assert.assertNotNull(value);


### PR DESCRIPTION
Use absolute, not portable file path due to potential issue with jmri.Util.FileUtil
see #10942 

Candidate for early merge to ensure build process runs ok before test release build.