### PR TITLE
MQTT support for LogixNG

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -100,7 +100,9 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li></li>
+                <li>LogixNG has now support for MQTT. If a MQTT connection is
+                defined, the category MQTT is visible with the LogixNG actions
+                <i>Publish</i> and <i>Subscribe</i>.</li>
             </ul>
 
         <h4>MRC</h4>
@@ -417,6 +419,9 @@
           so that the table grows and shrinks when it's resized.</li>
           <li>Update the Sequence action to reset itself when done if the continuous option is not
           selected.</li>
+          <li>Support for MQTT has been added. If a MQTT connection is
+          defined, the category MQTT is visible with the actions <i>Publish</i>
+          and <i>Subscribe</i>.</li>
         </ul>
 
     <h3>Meters and MeterFrames</h3>

--- a/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectStringXml.java
+++ b/java/src/jmri/jmrit/logixng/util/configurexml/LogixNG_SelectStringXml.java
@@ -29,7 +29,9 @@ public class LogixNG_SelectStringXml {
         Element enumElement = new Element(tagName);
 
         enumElement.addContent(new Element("addressing").addContent(selectStr.getAddressing().name()));
-        enumElement.addContent(new Element("value").addContent(selectStr.getValue()));
+        if (selectStr.getValue() != null) {
+            enumElement.addContent(new Element("value").addContent(selectStr.getValue()));
+        }
         if (selectStr.getReference() != null && !selectStr.getReference().isEmpty()) {
             enumElement.addContent(new Element("reference").addContent(selectStr.getReference()));
         }

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle.properties
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/FunctionsBundle.properties
@@ -123,6 +123,14 @@ Math.ConstantDescriptions                 = <html>                          \
 </html>
 
 
+Math.abs_Descr                  = <html>                                                    \
+<h1>abs()</h1>                                                                              \
+<h2>abs(value)</h2>                                                                         \
+Returns the absolute value. If the parameter is an integer, it returns an integer.          \
+Otherwise it returns a double.                                                              \
+</html>
+
+
 Math.random_Descr               = <html>                                                    \
 <h1>random()</h1>                                                                           \
 <h2>random()</h2>                                                                           \

--- a/java/src/jmri/jmrit/logixng/util/parser/functions/MathFunctions.java
+++ b/java/src/jmri/jmrit/logixng/util/parser/functions/MathFunctions.java
@@ -13,7 +13,7 @@ import org.openide.util.lookup.ServiceProvider;
 
 /**
  * Implementation of mathematical functions.
- * 
+ *
  * @author Daniel Bergqvist 2019
  */
 @ServiceProvider(service = FunctionFactory.class)
@@ -23,10 +23,11 @@ public class MathFunctions implements FunctionFactory {
     public String getModule() {
         return "Math";
     }
-    
+
     @Override
     public Set<Function> getFunctions() {
         Set<Function> functionClasses = new HashSet<>();
+        functionClasses.add(new AbsFunction());
         functionClasses.add(new RandomFunction());
         functionClasses.add(new SinFunction());
         return functionClasses;
@@ -44,30 +45,30 @@ public class MathFunctions implements FunctionFactory {
     public String getConstantDescription() {
         return Bundle.getMessage("Math.ConstantDescriptions");
     }
-    
-    
-    
+
+
+
     public static class RandomFunction implements Function {
-        
+
         @Override
         public String getModule() {
             return new MathFunctions().getModule();
         }
-        
+
         @Override
         public String getConstantDescriptions() {
             return new MathFunctions().getConstantDescription();
         }
-        
+
         @Override
         public String getName() {
             return "random";
         }
-        
+
         @Override
         public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
                 throws CalculateException, JmriException {
-            
+
             double min;
             double max;
             switch (parameterList.size()) {
@@ -87,35 +88,90 @@ public class MathFunctions implements FunctionFactory {
                     throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName()));
             }
         }
-        
+
         @Override
         public String getDescription() {
             return Bundle.getMessage("Math.random_Descr");
         }
-        
+
     }
-    
-    public static class SinFunction implements Function {
-        
+
+    public static class AbsFunction implements Function {
+
         @Override
         public String getModule() {
             return new MathFunctions().getModule();
         }
-        
+
         @Override
         public String getConstantDescriptions() {
             return new MathFunctions().getConstantDescription();
         }
-        
+
+        @Override
+        public String getName() {
+            return "abs";
+        }
+
+        @Override
+        public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
+                throws CalculateException, JmriException {
+
+            switch (parameterList.size()) {
+                case 1:
+                    Object value = parameterList.get(0).calculate(symbolTable);
+                    if ((value instanceof java.util.concurrent.atomic.AtomicInteger)
+                            || (value instanceof java.util.concurrent.atomic.AtomicLong)
+                            || (value instanceof java.math.BigInteger)
+                            || (value instanceof Byte)
+                            || (value instanceof Short)
+                            || (value instanceof Integer)
+                            || (value instanceof Long)
+                            || (value instanceof java.util.concurrent.atomic.LongAccumulator)
+                            || (value instanceof java.util.concurrent.atomic.LongAdder)) {
+                        return Math.abs(((Number)value).longValue());
+                    }
+                    if ((value instanceof java.math.BigDecimal)
+                            || (value instanceof Float)
+                            || (value instanceof Double)
+                            || (value instanceof java.util.concurrent.atomic.DoubleAccumulator)
+                            || (value instanceof java.util.concurrent.atomic.DoubleAdder)) {
+                        return Math.abs(((Number)value).doubleValue());
+                    }
+                    return Math.abs(TypeConversionUtil.convertToDouble(value, false));
+                default:
+                    throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName()));
+            }
+        }
+
+        @Override
+        public String getDescription() {
+            return Bundle.getMessage("Math.abs_Descr");
+        }
+
+    }
+
+    public static class SinFunction implements Function {
+
+        @Override
+        public String getModule() {
+            return new MathFunctions().getModule();
+        }
+
+        @Override
+        public String getConstantDescriptions() {
+            return new MathFunctions().getConstantDescription();
+        }
+
         @Override
         public String getName() {
             return "sin";
         }
-        
+
         @Override
         public Object calculate(SymbolTable symbolTable, List<ExpressionNode> parameterList)
                 throws JmriException {
-            
+
             if (parameterList.size() == 1) {
                 double param = TypeConversionUtil.convertToDouble(
                         parameterList.get(0).calculate(symbolTable), false);
@@ -143,7 +199,7 @@ public class MathFunctions implements FunctionFactory {
                 } else {
                     throw new CalculateException(Bundle.getMessage("IllegalParameter", 2, param1, getName()));
                 }
-                
+
                 switch (parameterList.size()) {
                     case 2:
                         return result;
@@ -159,12 +215,12 @@ public class MathFunctions implements FunctionFactory {
             }
             throw new WrongNumberOfParametersException(Bundle.getMessage("WrongNumberOfParameters1", getName()));
         }
-        
+
         @Override
         public String getDescription() {
             return Bundle.getMessage("Math.sin_Descr");
         }
-        
+
     }
-    
+
 }

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectStringSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectStringSwing.java
@@ -105,6 +105,7 @@ public class LogixNG_SelectStringSwing {
                 _valueTextField.setText(selectStr.getValue());
             }
             _referenceTextField.setText(selectStr.getReference());
+            _memoryPanel.setDefaultNamedBean(selectStr.getMemory());
             _listenToMemoryCheckBox.setSelected(selectStr.getListenToMemory());
             _localVariableTextField.setText(selectStr.getLocalVariable());
             _formulaTextField.setText(selectStr.getFormula());

--- a/java/src/jmri/jmrix/mqtt/logixng/ActionFactory.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/ActionFactory.java
@@ -29,6 +29,7 @@ public class ActionFactory implements DigitalActionFactory {
         // We don't want to add these classes if we don't have a MQTT connection
         if (CategoryMqtt.hasMQTT()) {
             actionClasses.add(new AbstractMap.SimpleEntry<>(CategoryMqtt.MQTT, Publish.class));
+            actionClasses.add(new AbstractMap.SimpleEntry<>(CategoryMqtt.MQTT, Subscribe.class));
         }
 
         return actionClasses;

--- a/java/src/jmri/jmrix/mqtt/logixng/ActionFactory.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/ActionFactory.java
@@ -1,0 +1,37 @@
+package jmri.jmrix.mqtt.logixng;
+
+import java.util.AbstractMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import jmri.jmrit.logixng.Category;
+import jmri.jmrit.logixng.DigitalActionFactory;
+import jmri.jmrit.logixng.DigitalActionBean;
+
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * The factory for LogixNG MQTT classes.
+ */
+@ServiceProvider(service = DigitalActionFactory.class)
+public class ActionFactory implements DigitalActionFactory {
+
+    @Override
+    public void init() {
+        CategoryMqtt.registerCategory();
+    }
+
+    @Override
+    public Set<Map.Entry<Category, Class<? extends DigitalActionBean>>> getActionClasses() {
+        Set<Map.Entry<Category, Class<? extends DigitalActionBean>>> actionClasses = new HashSet<>();
+
+        // We don't want to add these classes if we don't have a MQTT connection
+        if (CategoryMqtt.hasMQTT()) {
+            actionClasses.add(new AbstractMap.SimpleEntry<>(CategoryMqtt.MQTT, Publish.class));
+        }
+
+        return actionClasses;
+    }
+
+}

--- a/java/src/jmri/jmrix/mqtt/logixng/Bundle.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/Bundle.java
@@ -1,0 +1,96 @@
+package jmri.jmrix.mqtt.logixng;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Locale;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.jmrix.mqtt.Bundle {
+
+    @CheckForNull
+    private static final String name =  "jmri.jmrix.mqtt.logixng.Bundle"; // NOI18N
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/src/jmri/jmrix/mqtt/logixng/Bundle.properties
+++ b/java/src/jmri/jmrix/mqtt/logixng/Bundle.properties
@@ -6,3 +6,6 @@ MenuMQTT        = MQTT
 
 Publish_Short   = Publish
 Publish_Long    = Publish {1} to topic {0}
+
+Subscribe_Short = Subscribe
+Subscribe_Long  = Subscribe to topic {0}

--- a/java/src/jmri/jmrix/mqtt/logixng/Bundle.properties
+++ b/java/src/jmri/jmrix/mqtt/logixng/Bundle.properties
@@ -1,0 +1,8 @@
+# jmri.jmrix.mqtt.logixng.Bundle.properties
+#
+# Default properties for Mqtt connections.
+
+MenuMQTT        = MQTT
+
+Publish_Short   = Publish
+Publish_Long    = Publish {1} to topic {0}

--- a/java/src/jmri/jmrix/mqtt/logixng/CategoryMqtt.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/CategoryMqtt.java
@@ -1,0 +1,44 @@
+package jmri.jmrix.mqtt.logixng;
+
+import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
+
+import java.util.List;
+
+import jmri.jmrit.logixng.Category;
+
+/**
+ * Defines the category MQTT
+ *
+ * @author Daniel Bergqvist Copyright 2022
+ */
+public final class CategoryMqtt extends Category {
+
+    /**
+     * A item on the layout, for example turnout, sensor and signal mast.
+     */
+    public static final CategoryMqtt MQTT = new CategoryMqtt();
+
+
+    public CategoryMqtt() {
+        super("MQTT", Bundle.getMessage("MenuMQTT"), 300);
+    }
+
+    public static void registerCategory() {
+        // We don't want to add these classes if we don't have a MQTT connection
+        if (hasMQTT() && !Category.values().contains(MQTT)) {
+            Category.registerCategory(MQTT);
+        }
+    }
+
+    /**
+     * Do we have a MQTT connection?
+     * @return true if we have MQTT, false otherwise
+     */
+    public static boolean hasMQTT() {
+        List<MqttSystemConnectionMemo> list = jmri.InstanceManager.getList(MqttSystemConnectionMemo.class);
+
+        // We have at least one LocoNet connection if the list is not empty
+        return !list.isEmpty();
+    }
+
+}

--- a/java/src/jmri/jmrix/mqtt/logixng/Publish.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/Publish.java
@@ -1,0 +1,141 @@
+package jmri.jmrix.mqtt.logixng;
+
+import jmri.jmrit.logixng.actions.*;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.*;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.util.LogixNG_SelectString;
+import jmri.jmrit.logixng.util.parser.ParserException;
+import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
+import jmri.util.ThreadingUtil;
+
+/**
+ * This action publishes a message to MQTT.
+ *
+ * @author Daniel Bergqvist Copyright 2022
+ */
+public class Publish extends AbstractDigitalAction
+        implements PropertyChangeListener {
+
+    private final LogixNG_SelectString _selectTopic =
+            new LogixNG_SelectString(this, this);
+    private final LogixNG_SelectString _selectData =
+            new LogixNG_SelectString(this, this);
+
+    private MqttSystemConnectionMemo _memo;
+
+
+    public Publish(String sys, String user, MqttSystemConnectionMemo memo)
+            throws BadUserNameException, BadSystemNameException {
+        super(sys, user);
+        _memo = memo;
+    }
+
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws ParserException {
+        DigitalActionManager manager = InstanceManager.getDefault(DigitalActionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        Publish copy = new Publish(sysName, userName, _memo);
+        copy.setComment(getComment());
+        _selectTopic.copy(copy._selectTopic);
+        _selectData.copy(copy._selectData);
+        return manager.registerAction(copy);
+    }
+
+    public void setMemo(MqttSystemConnectionMemo memo) {
+        assertListenersAreNotRegistered(log, "setMemo");
+        _memo = memo;
+    }
+
+    public MqttSystemConnectionMemo getMemo() {
+        return _memo;
+    }
+
+    public LogixNG_SelectString getSelectTopic() {
+        return _selectTopic;
+    }
+
+    public LogixNG_SelectString getSelectData() {
+        return _selectData;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category getCategory() {
+        return Category.ITEM;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void execute() throws JmriException {
+
+        String topic = _selectTopic.evaluateValue(getConditionalNG());
+        String data = _selectData.evaluateValue(getConditionalNG());
+
+        ThreadingUtil.runOnLayoutWithJmriException(() -> {
+            _memo.getMqttAdapter().publish(topic, data);
+        });
+    }
+
+    @Override
+    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public int getChildCount() {
+        return 0;
+    }
+
+    @Override
+    public String getShortDescription(Locale locale) {
+        return Bundle.getMessage(locale, "Publish_Short");
+    }
+
+    @Override
+    public String getLongDescription(Locale locale) {
+        return Bundle.getMessage(locale, "Publish_Long",
+                _selectTopic.getDescription(locale),
+                _selectData.getDescription(locale));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setup() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+        _selectTopic.registerListeners();
+        _selectData.registerListeners();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+        _selectTopic.unregisterListeners();
+        _selectData.unregisterListeners();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        getConditionalNG().execute();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Publish.class);
+
+}

--- a/java/src/jmri/jmrix/mqtt/logixng/Publish.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/Publish.java
@@ -23,7 +23,7 @@ public class Publish extends AbstractDigitalAction
 
     private final LogixNG_SelectString _selectTopic =
             new LogixNG_SelectString(this, this);
-    private final LogixNG_SelectString _selectData =
+    private final LogixNG_SelectString _selectMessage =
             new LogixNG_SelectString(this, this);
 
     private MqttSystemConnectionMemo _memo;
@@ -44,7 +44,7 @@ public class Publish extends AbstractDigitalAction
         Publish copy = new Publish(sysName, userName, _memo);
         copy.setComment(getComment());
         _selectTopic.copy(copy._selectTopic);
-        _selectData.copy(copy._selectData);
+        _selectMessage.copy(copy._selectMessage);
         return manager.registerAction(copy);
     }
 
@@ -61,8 +61,8 @@ public class Publish extends AbstractDigitalAction
         return _selectTopic;
     }
 
-    public LogixNG_SelectString getSelectData() {
-        return _selectData;
+    public LogixNG_SelectString getSelectMessage() {
+        return _selectMessage;
     }
 
     /** {@inheritDoc} */
@@ -76,7 +76,7 @@ public class Publish extends AbstractDigitalAction
     public void execute() throws JmriException {
 
         String topic = _selectTopic.evaluateValue(getConditionalNG());
-        String data = _selectData.evaluateValue(getConditionalNG());
+        String data = _selectMessage.evaluateValue(getConditionalNG());
 
         ThreadingUtil.runOnLayoutWithJmriException(() -> {
             _memo.getMqttAdapter().publish(topic, data);
@@ -102,7 +102,7 @@ public class Publish extends AbstractDigitalAction
     public String getLongDescription(Locale locale) {
         return Bundle.getMessage(locale, "Publish_Long",
                 _selectTopic.getDescription(locale),
-                _selectData.getDescription(locale));
+                _selectMessage.getDescription(locale));
     }
 
     /** {@inheritDoc} */
@@ -115,14 +115,14 @@ public class Publish extends AbstractDigitalAction
     @Override
     public void registerListenersForThisClass() {
         _selectTopic.registerListeners();
-        _selectData.registerListeners();
+        _selectMessage.registerListeners();
     }
 
     /** {@inheritDoc} */
     @Override
     public void unregisterListenersForThisClass() {
         _selectTopic.unregisterListeners();
-        _selectData.unregisterListeners();
+        _selectMessage.unregisterListeners();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/jmrix/mqtt/logixng/Subscribe.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/Subscribe.java
@@ -1,0 +1,165 @@
+package jmri.jmrix.mqtt.logixng;
+
+import jmri.jmrit.logixng.actions.*;
+
+import java.util.*;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.util.parser.ParserException;
+import jmri.jmrix.mqtt.MqttEventListener;
+import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
+import jmri.util.ThreadingUtil;
+
+/**
+ * This action subscribes to a topic to MQTT.
+ *
+ * @author Daniel Bergqvist Copyright 2022
+ */
+public class Subscribe extends AbstractDigitalAction
+        implements MqttEventListener {
+
+    private MqttSystemConnectionMemo _memo;
+    private String _subscribeToTopic;
+    private String _lastTopic;
+    private String _lastMessage;
+    private String _lastTopicLocalVariable;
+    private String _lastMessageLocalVariable;
+
+
+    public Subscribe(String sys, String user, MqttSystemConnectionMemo memo)
+            throws BadUserNameException, BadSystemNameException {
+        super(sys, user);
+        _memo = memo;
+    }
+
+    @Override
+    public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws ParserException {
+        DigitalActionManager manager = InstanceManager.getDefault(DigitalActionManager.class);
+        String sysName = systemNames.get(getSystemName());
+        String userName = userNames.get(getSystemName());
+        if (sysName == null) sysName = manager.getAutoSystemName();
+        Subscribe copy = new Subscribe(sysName, userName, _memo);
+        copy.setComment(getComment());
+        copy._subscribeToTopic = _subscribeToTopic;
+        copy._lastTopicLocalVariable = _lastTopicLocalVariable;
+        copy._lastMessageLocalVariable = _lastMessageLocalVariable;
+        return manager.registerAction(copy);
+    }
+
+    public void setMemo(MqttSystemConnectionMemo memo) {
+        assertListenersAreNotRegistered(log, "setMemo");
+        _memo = memo;
+    }
+
+    public MqttSystemConnectionMemo getMemo() {
+        return _memo;
+    }
+
+    public String getSubscribeToTopic() {
+        return _subscribeToTopic;
+    }
+
+    public void setSubscribeToTopic(String topic) {
+        _subscribeToTopic = topic;
+    }
+
+    public String getLastTopicLocalVariable() {
+        return _lastTopicLocalVariable;
+    }
+
+    public void setLastTopicLocalVariable(String variable) {
+        _lastTopicLocalVariable = variable;
+    }
+
+    public String getLastMessageLocalVariable() {
+        return _lastMessageLocalVariable;
+    }
+
+    public void setLastMessageLocalVariable(String variable) {
+        _lastMessageLocalVariable = variable;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category getCategory() {
+        return Category.ITEM;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void execute() throws JmriException {
+        if ((_lastTopicLocalVariable != null) && (!_lastTopicLocalVariable.isBlank())) {
+            getConditionalNG().getSymbolTable().setValue(_lastTopicLocalVariable, _lastTopic);
+        }
+        if ((_lastTopicLocalVariable != null) && (!_lastMessageLocalVariable.isBlank())) {
+            getConditionalNG().getSymbolTable().setValue(_lastMessageLocalVariable, _lastMessage);
+        }
+    }
+
+    @Override
+    public FemaleSocket getChild(int index) throws IllegalArgumentException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public int getChildCount() {
+        return 0;
+    }
+
+    @Override
+    public String getShortDescription(Locale locale) {
+        return Bundle.getMessage(locale, "Subscribe_Short");
+    }
+
+    @Override
+    public String getLongDescription(Locale locale) {
+        return Bundle.getMessage(locale, "Subscribe_Long", _subscribeToTopic);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setup() {
+        // Do nothing
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void registerListenersForThisClass() {
+        if (! _listenersAreRegistered) {
+            if (_subscribeToTopic == null) return;
+            ThreadingUtil.runOnLayout(() -> {
+                _memo.getMqttAdapter().subscribe(_subscribeToTopic, this);
+            });
+            _listenersAreRegistered = true;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void unregisterListenersForThisClass() {
+        if (_listenersAreRegistered) {
+            if (_subscribeToTopic == null) return;
+            ThreadingUtil.runOnLayout(() -> {
+                _memo.getMqttAdapter().unsubscribe(_subscribeToTopic, this);
+            });
+            _listenersAreRegistered = false;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void notifyMqttMessage(String topic, String message) {
+        _lastTopic = topic;
+        _lastMessage = message;
+        getConditionalNG().execute();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void disposeMe() {
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Subscribe.class);
+
+}

--- a/java/src/jmri/jmrix/mqtt/logixng/Subscribe.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/Subscribe.java
@@ -92,7 +92,7 @@ public class Subscribe extends AbstractDigitalAction
         if ((_lastTopicLocalVariable != null) && (!_lastTopicLocalVariable.isBlank())) {
             getConditionalNG().getSymbolTable().setValue(_lastTopicLocalVariable, _lastTopic);
         }
-        if ((_lastTopicLocalVariable != null) && (!_lastMessageLocalVariable.isBlank())) {
+        if ((_lastMessageLocalVariable != null) && (!_lastMessageLocalVariable.isBlank())) {
             getConditionalNG().getSymbolTable().setValue(_lastMessageLocalVariable, _lastMessage);
         }
     }

--- a/java/src/jmri/jmrix/mqtt/logixng/configurexml/PublishXml.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/configurexml/PublishXml.java
@@ -1,0 +1,91 @@
+package jmri.jmrix.mqtt.logixng.configurexml;
+
+import java.util.List;
+
+import jmri.*;
+import jmri.configurexml.JmriConfigureXmlException;
+import jmri.jmrit.logixng.DigitalActionManager;
+import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
+import jmri.jmrix.mqtt.logixng.Publish;
+import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectStringXml;
+
+import org.jdom2.Element;
+
+/**
+ * Handle XML configuration for Publish objects.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
+ * @author Daniel Bergqvist Copyright (C) 2022
+ */
+public class PublishXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+
+    public PublishXml() {
+    }
+
+    /**
+     * Default implementation for storing the contents of a publish action.
+     *
+     * @param o Object to store, of type Publish
+     * @return Element containing the complete info
+     */
+    @Override
+    public Element store(Object o) {
+        Publish p = (Publish) o;
+
+        var selectTopicXml = new LogixNG_SelectStringXml();
+        var selectDataXml = new LogixNG_SelectStringXml();
+
+        Element element = new Element("MQTTPublish");
+        element.setAttribute("class", this.getClass().getName());
+        element.addContent(new Element("systemName").addContent(p.getSystemName()));
+
+        storeCommon(p, element);
+
+        if (p.getMemo() != null) {
+            element.addContent(new Element("systemConnection")
+                    .addContent(p.getMemo().getSystemPrefix()));
+        }
+
+        element.addContent(selectTopicXml.store(p.getSelectTopic(), "topic"));
+        element.addContent(selectDataXml.store(p.getSelectData(), "data"));
+
+        return element;
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) throws JmriConfigureXmlException {
+        String sys = getSystemName(shared);
+        String uname = getUserName(shared);
+
+        MqttSystemConnectionMemo memo = null;
+
+        Element systemConnection = shared.getChild("systemConnection");
+        if (systemConnection != null) {
+            String systemConnectionName = systemConnection.getTextTrim();
+            List<MqttSystemConnectionMemo> systemConnections =
+                    jmri.InstanceManager.getList(MqttSystemConnectionMemo.class);
+
+            for (MqttSystemConnectionMemo m : systemConnections) {
+                if (m.getSystemPrefix().equals(systemConnectionName)) {
+                    memo = m;
+                    break;
+                }
+            }
+        }
+
+        Publish h = new Publish(sys, uname, memo);
+
+        var selectTopicXml = new LogixNG_SelectStringXml();
+        var selectDataXml = new LogixNG_SelectStringXml();
+
+        loadCommon(h, shared);
+
+        selectTopicXml.load(shared.getChild("topic"), h.getSelectTopic());
+        selectDataXml.load(shared.getChild("data"), h.getSelectData());
+
+        InstanceManager.getDefault(DigitalActionManager.class).registerAction(h);
+        return true;
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PublishXml.class);
+}

--- a/java/src/jmri/jmrix/mqtt/logixng/configurexml/SubscribeXml.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/configurexml/SubscribeXml.java
@@ -6,36 +6,32 @@ import jmri.*;
 import jmri.configurexml.JmriConfigureXmlException;
 import jmri.jmrit.logixng.DigitalActionManager;
 import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
-import jmri.jmrix.mqtt.logixng.Publish;
-import jmri.jmrit.logixng.util.configurexml.LogixNG_SelectStringXml;
+import jmri.jmrix.mqtt.logixng.Subscribe;
 
 import org.jdom2.Element;
 
 /**
- * Handle XML configuration for Publish objects.
+ * Handle XML configuration for Subscribe objects.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
  * @author Daniel Bergqvist Copyright (C) 2022
  */
-public class PublishXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+public class SubscribeXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
 
-    public PublishXml() {
+    public SubscribeXml() {
     }
 
     /**
-     * Default implementation for storing the contents of a publish action.
+     * Default implementation for storing the contents of a subscribe action.
      *
      * @param o Object to store, of type Publish
      * @return Element containing the complete info
      */
     @Override
     public Element store(Object o) {
-        Publish p = (Publish) o;
+        Subscribe p = (Subscribe) o;
 
-        var selectTopicXml = new LogixNG_SelectStringXml();
-        var selectDataXml = new LogixNG_SelectStringXml();
-
-        Element element = new Element("MQTTPublish");
+        Element element = new Element("MQTTSubscribe");
         element.setAttribute("class", this.getClass().getName());
         element.addContent(new Element("systemName").addContent(p.getSystemName()));
 
@@ -46,8 +42,20 @@ public class PublishXml extends jmri.managers.configurexml.AbstractNamedBeanMana
                     .addContent(p.getMemo().getSystemPrefix()));
         }
 
-        element.addContent(selectTopicXml.store(p.getSelectTopic(), "topic"));
-        element.addContent(selectDataXml.store(p.getSelectMessage(), "message"));
+        if (p.getSubscribeToTopic() != null) {
+            element.addContent(new Element("subscribeToTopic")
+                    .addContent(p.getSubscribeToTopic()));
+        }
+
+        if (p.getLastTopicLocalVariable() != null) {
+            element.addContent(new Element("lastTopicLocalVariable")
+                    .addContent(p.getLastTopicLocalVariable()));
+        }
+
+        if (p.getLastMessageLocalVariable() != null) {
+            element.addContent(new Element("lastMessageLocalVariable")
+                    .addContent(p.getLastMessageLocalVariable()));
+        }
 
         return element;
     }
@@ -73,15 +81,19 @@ public class PublishXml extends jmri.managers.configurexml.AbstractNamedBeanMana
             }
         }
 
-        Publish h = new Publish(sys, uname, memo);
-
-        var selectTopicXml = new LogixNG_SelectStringXml();
-        var selectDataXml = new LogixNG_SelectStringXml();
+        Subscribe h = new Subscribe(sys, uname, memo);
 
         loadCommon(h, shared);
 
-        selectTopicXml.load(shared.getChild("topic"), h.getSelectTopic());
-        selectDataXml.load(shared.getChild("message"), h.getSelectMessage());
+        if (shared.getChild("subscribeToTopic") != null) {
+            h.setSubscribeToTopic(shared.getChild("subscribeToTopic").getTextTrim());
+        }
+        if (shared.getChild("lastTopicLocalVariable") != null) {
+            h.setLastTopicLocalVariable(shared.getChild("lastTopicLocalVariable").getTextTrim());
+        }
+        if (shared.getChild("lastMessageLocalVariable") != null) {
+            h.setLastMessageLocalVariable(shared.getChild("lastMessageLocalVariable").getTextTrim());
+        }
 
         InstanceManager.getDefault(DigitalActionManager.class).registerAction(h);
         return true;

--- a/java/src/jmri/jmrix/mqtt/logixng/swing/Bundle.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/swing/Bundle.java
@@ -1,0 +1,98 @@
+package jmri.jmrix.mqtt.logixng.swing;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Locale;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.CheckForNull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@javax.annotation.concurrent.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.jmrix.mqtt.logixng.Bundle {
+
+    @CheckForNull
+    private static final String name =  "jmri.jmrix.mqtt.logixng.swing.Bundle"; // NOI18N
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return getBundle().handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return getBundle().handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return getBundle().handleGetMessage(locale, key, subs);
+    }
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    protected String bundleName() {
+        return name;
+    }
+
+    protected static jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale,key);
+    }
+
+}

--- a/java/src/jmri/jmrix/mqtt/logixng/swing/Bundle.properties
+++ b/java/src/jmri/jmrix/mqtt/logixng/swing/Bundle.properties
@@ -1,0 +1,6 @@
+# jmri.jmrix.mqtt.logixng.swing.Bundle.properties
+#
+# Default properties for Mqtt connections.
+
+MqttConnection          = Connection
+Publish_Components      = Publish the data {1} to the topic {0}

--- a/java/src/jmri/jmrix/mqtt/logixng/swing/Bundle.properties
+++ b/java/src/jmri/jmrix/mqtt/logixng/swing/Bundle.properties
@@ -3,4 +3,10 @@
 # Default properties for Mqtt connections.
 
 MqttConnection          = Connection
+
 Publish_Components      = Publish the data {1} to the topic {0}
+
+Subscribe_subscribeToAll            = Subscribe to all
+Subscribe_subscribeToTopic          = Subscribe to topic
+Subscribe_lastTopicLocalVariable    = Local variable for topic
+Subscribe_lastMessageLocalVariable  = Local variable for message

--- a/java/src/jmri/jmrix/mqtt/logixng/swing/PublishSwing.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/swing/PublishSwing.java
@@ -1,0 +1,161 @@
+package jmri.jmrix.mqtt.logixng.swing;
+
+import jmri.jmrit.logixng.actions.swing.AbstractDigitalActionSwing;
+
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.*;
+import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
+import jmri.jmrix.mqtt.logixng.Publish;
+import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
+import jmri.jmrit.logixng.util.swing.LogixNG_SelectStringSwing;
+
+/**
+ * Configures an Publish object with a Swing JPanel.
+ *
+ * @author Daniel Bergqvist Copyright 2022
+ */
+public class PublishSwing extends AbstractDigitalActionSwing {
+
+    private JComboBox<MqttConnection> _mqttConnection;
+
+    private LogixNG_SelectStringSwing _selectTopicSwing;
+    private LogixNG_SelectStringSwing _selectDataSwing;
+
+
+    public PublishSwing() {
+    }
+
+    public PublishSwing(JDialog dialog) {
+        super.setJDialog(dialog);
+    }
+
+    @Override
+    protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        Publish action = (Publish) object;
+        if (action == null) {
+            // Create a temporary action
+            action = new Publish("IQDA1", null, null);
+        }
+
+        _selectTopicSwing = new LogixNG_SelectStringSwing(getJDialog(), this);
+        _selectDataSwing = new LogixNG_SelectStringSwing(getJDialog(), this);
+
+        panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+
+        JPanel tabbedPaneTopic;
+        JPanel tabbedPaneData;
+
+        tabbedPaneTopic = _selectTopicSwing.createPanel(action.getSelectTopic());
+        tabbedPaneData = _selectDataSwing.createPanel(action.getSelectData());
+
+
+        JPanel internalPanel = new JPanel();
+
+        JComponent[] components = new JComponent[]{
+            tabbedPaneTopic,
+            tabbedPaneData};
+
+        List<JComponent> componentList = SwingConfiguratorInterface.parseMessage(
+                Bundle.getMessage("Publish_Components"), components);
+
+        for (JComponent c : componentList) internalPanel.add(c);
+
+        JPanel mqttPanel = new JPanel();
+        mqttPanel.add(new JLabel(Bundle.getMessage("MqttConnection")));
+
+        _mqttConnection = new JComboBox<>();
+        List<MqttSystemConnectionMemo> systemConnections =
+                jmri.InstanceManager.getList(MqttSystemConnectionMemo.class);
+        for (MqttSystemConnectionMemo connection : systemConnections) {
+            MqttConnection c = new MqttConnection(connection);
+            _mqttConnection.addItem(c);
+            if (action.getMemo() == connection) {
+                _mqttConnection.setSelectedItem(c);
+            }
+        }
+        mqttPanel.add(_mqttConnection);
+
+        panel.add(internalPanel);
+        panel.add(mqttPanel);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean validate(@Nonnull List<String> errorMessages) {
+        // Create a temporary action to test formula
+        Publish action = new Publish("IQDA1", null, null);
+
+        _selectTopicSwing.validate(action.getSelectTopic(), errorMessages);
+        _selectDataSwing.validate(action.getSelectData(), errorMessages);
+
+        return errorMessages.isEmpty();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getAutoSystemName() {
+        return InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
+        MqttSystemConnectionMemo memo =
+                _mqttConnection.getItemAt(_mqttConnection.getSelectedIndex())._memo;
+
+        Publish action = new Publish(systemName, userName, memo);
+        updateObject(action);
+        return InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        if (! (object instanceof Publish)) {
+            throw new IllegalArgumentException("object must be an Publish but is a: "+object.getClass().getName());
+        }
+        Publish action = (Publish) object;
+
+        _selectTopicSwing.updateObject(action.getSelectTopic());
+        _selectDataSwing.updateObject(action.getSelectData());
+
+        action.setMemo(_mqttConnection.getItemAt(_mqttConnection.getSelectedIndex())._memo);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return Bundle.getMessage("Publish_Short");
+    }
+
+    @Override
+    public void dispose() {
+        _selectTopicSwing.dispose();
+        _selectDataSwing.dispose();
+    }
+
+
+    private static class MqttConnection {
+
+        private MqttSystemConnectionMemo _memo;
+
+        public MqttConnection(MqttSystemConnectionMemo memo) {
+            _memo = memo;
+        }
+
+        @Override
+        public String toString() {
+            return _memo.getUserName();
+        }
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PublishSwing.class);
+
+}

--- a/java/src/jmri/jmrix/mqtt/logixng/swing/PublishSwing.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/swing/PublishSwing.java
@@ -25,7 +25,7 @@ public class PublishSwing extends AbstractDigitalActionSwing {
     private JComboBox<MqttConnection> _mqttConnection;
 
     private LogixNG_SelectStringSwing _selectTopicSwing;
-    private LogixNG_SelectStringSwing _selectDataSwing;
+    private LogixNG_SelectStringSwing _selectMessageSwing;
 
 
     public PublishSwing() {
@@ -44,7 +44,7 @@ public class PublishSwing extends AbstractDigitalActionSwing {
         }
 
         _selectTopicSwing = new LogixNG_SelectStringSwing(getJDialog(), this);
-        _selectDataSwing = new LogixNG_SelectStringSwing(getJDialog(), this);
+        _selectMessageSwing = new LogixNG_SelectStringSwing(getJDialog(), this);
 
         panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
@@ -53,7 +53,7 @@ public class PublishSwing extends AbstractDigitalActionSwing {
         JPanel tabbedPaneData;
 
         tabbedPaneTopic = _selectTopicSwing.createPanel(action.getSelectTopic());
-        tabbedPaneData = _selectDataSwing.createPanel(action.getSelectData());
+        tabbedPaneData = _selectMessageSwing.createPanel(action.getSelectMessage());
 
 
         JPanel internalPanel = new JPanel();
@@ -93,7 +93,7 @@ public class PublishSwing extends AbstractDigitalActionSwing {
         Publish action = new Publish("IQDA1", null, null);
 
         _selectTopicSwing.validate(action.getSelectTopic(), errorMessages);
-        _selectDataSwing.validate(action.getSelectData(), errorMessages);
+        _selectMessageSwing.validate(action.getSelectMessage(), errorMessages);
 
         return errorMessages.isEmpty();
     }
@@ -124,7 +124,7 @@ public class PublishSwing extends AbstractDigitalActionSwing {
         Publish action = (Publish) object;
 
         _selectTopicSwing.updateObject(action.getSelectTopic());
-        _selectDataSwing.updateObject(action.getSelectData());
+        _selectMessageSwing.updateObject(action.getSelectMessage());
 
         action.setMemo(_mqttConnection.getItemAt(_mqttConnection.getSelectedIndex())._memo);
     }
@@ -138,7 +138,7 @@ public class PublishSwing extends AbstractDigitalActionSwing {
     @Override
     public void dispose() {
         _selectTopicSwing.dispose();
-        _selectDataSwing.dispose();
+        _selectMessageSwing.dispose();
     }
 
 

--- a/java/src/jmri/jmrix/mqtt/logixng/swing/SubscribeSwing.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/swing/SubscribeSwing.java
@@ -103,7 +103,7 @@ public class SubscribeSwing extends AbstractDigitalActionSwing {
         c.gridheight = 1;
         c.gridx = 0;
         c.gridy = 3;
-        c.anchor = GridBagConstraints.EAST;
+        c.anchor = GridBagConstraints.CENTER;
         panel.add(mqttPanel, c);
     }
 

--- a/java/src/jmri/jmrix/mqtt/logixng/swing/SubscribeSwing.java
+++ b/java/src/jmri/jmrix/mqtt/logixng/swing/SubscribeSwing.java
@@ -1,0 +1,175 @@
+package jmri.jmrix.mqtt.logixng.swing;
+
+import jmri.jmrit.logixng.actions.swing.AbstractDigitalActionSwing;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.swing.*;
+
+import jmri.InstanceManager;
+import jmri.jmrit.logixng.*;
+import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
+import jmri.jmrix.mqtt.logixng.Subscribe;
+
+/**
+ * Configures an Subscribe object with a Swing JPanel.
+ *
+ * @author Daniel Bergqvist Copyright 2022
+ */
+public class SubscribeSwing extends AbstractDigitalActionSwing {
+
+    private JComboBox<MqttConnection> _mqttConnection;
+
+    JTextField _subscribeToTopicTextField;
+    JTextField _lastTopicLocalVariableTextField;
+    JTextField _lastMessageLocalVariableTextField;
+
+
+    public SubscribeSwing() {
+    }
+
+    public SubscribeSwing(JDialog dialog) {
+        super.setJDialog(dialog);
+    }
+
+    @Override
+    protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
+        Subscribe action = (Subscribe) object;
+        if (action == null) {
+            // Create a temporary action
+            action = new Subscribe("IQDA1", null, null);
+        }
+
+        panel = new JPanel();
+
+        JLabel subscribeToTopicLabel = new JLabel(Bundle.getMessage("Subscribe_subscribeToTopic"));
+        JLabel lastTopicLocalVariableLabel = new JLabel(Bundle.getMessage("Subscribe_lastTopicLocalVariable"));
+        JLabel lastMessageLocalVariableLabel = new JLabel(Bundle.getMessage("Subscribe_lastMessageLocalVariable"));
+
+        _subscribeToTopicTextField = new JTextField(40);
+        _lastTopicLocalVariableTextField = new JTextField(40);
+        _lastMessageLocalVariableTextField = new JTextField(40);
+
+        _subscribeToTopicTextField.setText(action.getSubscribeToTopic());
+        _lastTopicLocalVariableTextField.setText(action.getLastTopicLocalVariable());
+        _lastMessageLocalVariableTextField.setText(action.getLastMessageLocalVariable());
+
+        JPanel mqttPanel = new JPanel();
+        mqttPanel.add(new JLabel(Bundle.getMessage("MqttConnection")));
+
+        _mqttConnection = new JComboBox<>();
+        List<MqttSystemConnectionMemo> systemConnections =
+                jmri.InstanceManager.getList(MqttSystemConnectionMemo.class);
+        for (MqttSystemConnectionMemo connection : systemConnections) {
+            MqttConnection c = new MqttConnection(connection);
+            _mqttConnection.addItem(c);
+            if (action.getMemo() == connection) {
+                _mqttConnection.setSelectedItem(c);
+            }
+        }
+        mqttPanel.add(_mqttConnection);
+
+        panel.setLayout(new GridBagLayout());
+        GridBagConstraints c = new GridBagConstraints();
+        c.gridwidth = 1;
+        c.gridheight = 1;
+        c.gridx = 0;
+        c.gridy = 0;
+        c.anchor = GridBagConstraints.EAST;
+        panel.add(subscribeToTopicLabel, c);
+        subscribeToTopicLabel.setLabelFor(_subscribeToTopicTextField);
+        c.gridy = 1;
+        panel.add(lastTopicLocalVariableLabel, c);
+        lastTopicLocalVariableLabel.setLabelFor(_lastTopicLocalVariableTextField);
+        c.gridy = 2;
+        panel.add(lastMessageLocalVariableLabel, c);
+        lastMessageLocalVariableLabel.setLabelFor(_lastMessageLocalVariableTextField);
+        c.gridx = 1;
+        c.gridy = 0;
+        c.anchor = GridBagConstraints.WEST;
+        panel.add(_subscribeToTopicTextField, c);
+//        _subscribeToTopicTextField.setToolTipText(Bundle.getMessage("SysNameToolTip", "Y"));
+        c.gridy = 1;
+        panel.add(_lastTopicLocalVariableTextField, c);
+//        _lastTopicLocalVariableTextField.setToolTipText(Bundle.getMessage("SysNameToolTip", "Y"));
+        c.gridy = 2;
+        panel.add(_lastMessageLocalVariableTextField, c);
+//        _lastMessageLocalVariableTextField.setToolTipText(Bundle.getMessage("SysNameToolTip", "Y"));
+        c.gridwidth = 2;
+        c.gridheight = 1;
+        c.gridx = 0;
+        c.gridy = 3;
+        c.anchor = GridBagConstraints.EAST;
+        panel.add(mqttPanel, c);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean validate(@Nonnull List<String> errorMessages) {
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getAutoSystemName() {
+        return InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
+        MqttSystemConnectionMemo memo =
+                _mqttConnection.getItemAt(_mqttConnection.getSelectedIndex())._memo;
+
+        Subscribe action = new Subscribe(systemName, userName, memo);
+        updateObject(action);
+        return InstanceManager.getDefault(DigitalActionManager.class).registerAction(action);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateObject(@Nonnull Base object) {
+        if (! (object instanceof Subscribe)) {
+            throw new IllegalArgumentException("object must be an Subscribe but is a: "+object.getClass().getName());
+        }
+        Subscribe action = (Subscribe) object;
+
+        action.setSubscribeToTopic(_subscribeToTopicTextField.getText());
+        action.setLastTopicLocalVariable(_lastTopicLocalVariableTextField.getText());
+        action.setLastMessageLocalVariable(_lastMessageLocalVariableTextField.getText());
+
+        action.setMemo(_mqttConnection.getItemAt(_mqttConnection.getSelectedIndex())._memo);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return Bundle.getMessage("Subscribe_Short");
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+
+    private static class MqttConnection {
+
+        private MqttSystemConnectionMemo _memo;
+
+        public MqttConnection(MqttSystemConnectionMemo memo) {
+            _memo = memo;
+        }
+
+        @Override
+        public String toString() {
+            return _memo.getUserName();
+        }
+    }
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PublishSwing.class);
+
+}

--- a/java/test/jmri/jmrix/mqtt/logixng/PublishTest.java
+++ b/java/test/jmri/jmrix/mqtt/logixng/PublishTest.java
@@ -14,7 +14,7 @@ public class PublishTest {
 
     @Test
     public void testCtor() {
-        Publish e = new Publish("IQDE1", null, null);
+        Publish e = new Publish("IQDA1", null, null);
         Assert.assertNotNull(e);
     }
 

--- a/java/test/jmri/jmrix/mqtt/logixng/PublishTest.java
+++ b/java/test/jmri/jmrix/mqtt/logixng/PublishTest.java
@@ -1,0 +1,44 @@
+package jmri.jmrix.mqtt.logixng;
+
+import jmri.util.JUnitUtil;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+
+/**
+ * Tests for the Publish class
+ *
+ * @author Daniel Bergqvist Copyright 2022
+ */
+public class PublishTest {
+
+    @Test
+    public void testCtor() {
+        Publish e = new Publish("IQDE1", null, null);
+        Assert.assertNotNull(e);
+    }
+
+    // The minimal setup for log4J
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initLogixNGManager();
+
+        // Temporary let the error messages from this test be shown to the user
+//        JUnitAppender.end();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExpressionSlotUsageTest.class);
+
+}

--- a/java/test/jmri/jmrix/mqtt/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrix/mqtt/logixng/configurexml/StoreAndLoadTest.java
@@ -9,10 +9,12 @@ import java.util.*;
 
 import jmri.*;
 import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.actions.DigitalMany;
 import jmri.jmrit.logixng.expressions.And;
 import jmri.jmrit.logixng.util.LogixNG_Thread;
 import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
 import jmri.jmrix.mqtt.logixng.Publish;
+import jmri.jmrix.mqtt.logixng.Subscribe;
 import jmri.util.*;
 
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -32,7 +34,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 public class StoreAndLoadTest {
 
     private MqttSystemConnectionMemo memo1;
-    private MqttSystemConnectionMemo memo2;
+//    private MqttSystemConnectionMemo memo2;
 
     @DisabledIfSystemProperty(named ="java.awt.headless", matches = "true")
     @Test
@@ -61,19 +63,37 @@ public class StoreAndLoadTest {
         maleSocket = digitalExpressionManager.registerExpression(and);
         ifThenElse.getChild(0).connect(maleSocket);
 
-        Publish publish = new Publish(digitalActionManager.getAutoSystemName(), null, null);
-        publish.setComment("A comment");
-        maleSocket = digitalActionManager.registerAction(publish);
+        DigitalMany many = new DigitalMany(digitalActionManager.getAutoSystemName(), null);
+        many.setComment("A comment");
+        maleSocket = digitalActionManager.registerAction(many);
         ifThenElse.getChild(1).connect(maleSocket);
 
-        publish = new Publish(digitalActionManager.getAutoSystemName(), null, null);
+        Publish publish = new Publish(digitalActionManager.getAutoSystemName(), null, memo1);
+        publish.setComment("A comment");
+        maleSocket = digitalActionManager.registerAction(publish);
+        many.getChild(0).connect(maleSocket);
+
+        publish = new Publish(digitalActionManager.getAutoSystemName(), null, memo1);
         publish.setComment("A comment");
         publish.getSelectTopic().setAddressing(NamedBeanAddressing.Direct);
         publish.getSelectTopic().setValue("TheTopic");
-        publish.getSelectData().setAddressing(NamedBeanAddressing.Direct);
-        publish.getSelectData().setValue("TheTopic");
+        publish.getSelectMessage().setAddressing(NamedBeanAddressing.Direct);
+        publish.getSelectMessage().setValue("TheMessage");
         maleSocket = digitalActionManager.registerAction(publish);
-        ifThenElse.getChild(2).connect(maleSocket);
+        many.getChild(1).connect(maleSocket);
+
+        Subscribe subscribe = new Subscribe(digitalActionManager.getAutoSystemName(), null, memo1);
+        subscribe.setComment("A comment");
+        maleSocket = digitalActionManager.registerAction(subscribe);
+        many.getChild(2).connect(maleSocket);
+
+        subscribe = new Subscribe(digitalActionManager.getAutoSystemName(), null, memo1);
+        subscribe.setComment("A comment");
+        subscribe.setSubscribeToTopic("TheTopic");
+        subscribe.setLastTopicLocalVariable("TopicVariable");
+        subscribe.setLastMessageLocalVariable("MessageVariable");
+        maleSocket = digitalActionManager.registerAction(subscribe);
+        many.getChild(3).connect(maleSocket);
 
 /*
         if (1==1) {
@@ -280,13 +300,13 @@ public class StoreAndLoadTest {
         JUnitUtil.initOBlockManager();
         JUnitUtil.initWarrantManager();
 
-        // The class under test uses LocoNet connections that it pulls from the InstanceManager.
+        // The class under test uses MQTT connections that it pulls from the InstanceManager.
         memo1 = new MqttSystemConnectionMemo();
-        jmri.InstanceManager.store(memo1, jmri.jmrix.mqtt.MqttSystemConnectionMemo.class);
+//        jmri.InstanceManager.store(memo1, jmri.jmrix.mqtt.MqttSystemConnectionMemo.class);
 
-        // The class under test uses LocoNet connections that it pulls from the InstanceManager.
-        memo2 = new MqttSystemConnectionMemo();
-        jmri.InstanceManager.store(memo2, MqttSystemConnectionMemo.class);
+        // The class under test uses MQTT connections that it pulls from the InstanceManager.
+//        memo2 = new MqttSystemConnectionMemo();
+//        jmri.InstanceManager.store(memo2, MqttSystemConnectionMemo.class);
     }
 
     @AfterEach

--- a/java/test/jmri/jmrix/mqtt/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrix/mqtt/logixng/configurexml/StoreAndLoadTest.java
@@ -1,0 +1,308 @@
+package jmri.jmrix.mqtt.logixng.configurexml;
+
+import jmri.jmrit.logixng.actions.IfThenElse;
+
+import java.beans.PropertyVetoException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import jmri.*;
+import jmri.jmrit.logixng.*;
+import jmri.jmrit.logixng.expressions.And;
+import jmri.jmrit.logixng.util.LogixNG_Thread;
+import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
+import jmri.jmrix.mqtt.logixng.Publish;
+import jmri.util.*;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+/**
+ * Creates a LogixNG with all actions and expressions to test store and load.
+ * <P>
+ * It uses the Base.printTree(PrintWriter writer, String indent) method to
+ * compare the LogixNGs before and after store and load.
+ *
+ * @author Daniel Bergqvist Copyright 2022
+ */
+public class StoreAndLoadTest {
+
+    private MqttSystemConnectionMemo memo1;
+    private MqttSystemConnectionMemo memo2;
+
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches = "true")
+    @Test
+    public void testLogixNGs() throws PropertyVetoException, Exception {
+
+        LogixNG_Manager logixNG_Manager = InstanceManager.getDefault(LogixNG_Manager.class);
+        ConditionalNG_Manager conditionalNGManager = InstanceManager.getDefault(ConditionalNG_Manager.class);
+        DigitalActionManager digitalActionManager = InstanceManager.getDefault(DigitalActionManager.class);
+        DigitalExpressionManager digitalExpressionManager = InstanceManager.getDefault(DigitalExpressionManager.class);
+
+
+        LogixNG logixNG = logixNG_Manager.createLogixNG("A logixNG");
+        ConditionalNG conditionalNG =
+                conditionalNGManager.createConditionalNG(logixNG, "A conditionalNG");
+        logixNG.setEnabled(false);
+        conditionalNG.setEnabled(true);
+
+        FemaleSocket femaleSocket = conditionalNG.getFemaleSocket();
+
+        IfThenElse ifThenElse = new IfThenElse(digitalActionManager.getAutoSystemName(), null);
+        MaleSocket maleSocket = digitalActionManager.registerAction(ifThenElse);
+        femaleSocket.connect(maleSocket);
+
+        And and = new And(digitalExpressionManager.getAutoSystemName(), null);
+        and.setComment("A comment");
+        maleSocket = digitalExpressionManager.registerExpression(and);
+        ifThenElse.getChild(0).connect(maleSocket);
+
+        Publish publish = new Publish(digitalActionManager.getAutoSystemName(), null, null);
+        publish.setComment("A comment");
+        maleSocket = digitalActionManager.registerAction(publish);
+        ifThenElse.getChild(1).connect(maleSocket);
+
+        publish = new Publish(digitalActionManager.getAutoSystemName(), null, null);
+        publish.setComment("A comment");
+        publish.getSelectTopic().setAddressing(NamedBeanAddressing.Direct);
+        publish.getSelectTopic().setValue("TheTopic");
+        publish.getSelectData().setAddressing(NamedBeanAddressing.Direct);
+        publish.getSelectData().setValue("TheTopic");
+        maleSocket = digitalActionManager.registerAction(publish);
+        ifThenElse.getChild(2).connect(maleSocket);
+
+/*
+        if (1==1) {
+            final String treeIndent = "   ";
+            StringWriter stringWriter = new StringWriter();
+            PrintWriter printWriter = new PrintWriter(stringWriter);
+            logixNG_Manager.printTree(Locale.ENGLISH, printWriter, treeIndent);
+
+            System.out.println("--------------------------------------------");
+            System.out.println("The current tree:");
+            System.out.println("XXX"+stringWriter.toString()+"XXX");
+            System.out.println("--------------------------------------------");
+            System.out.println("--------------------------------------------");
+            System.out.println("--------------------------------------------");
+            System.out.println("--------------------------------------------");
+            System.out.println("--------------------------------------------");
+            System.out.println("--------------------------------------------");
+            System.out.println("--------------------------------------------");
+            System.out.println("--------------------------------------------");
+            System.out.println("--------------------------------------------");
+            System.out.println("--------------------------------------------");
+
+            log.error("--------------------------------------------");
+            log.error("The current tree:");
+            log.error("XXX"+stringWriter.toString()+"XXX");
+            log.error("--------------------------------------------");
+            log.error("--------------------------------------------");
+            log.error("--------------------------------------------");
+            log.error("--------------------------------------------");
+            log.error("--------------------------------------------");
+            log.error("--------------------------------------------");
+            log.error("--------------------------------------------");
+            log.error("--------------------------------------------");
+            log.error("--------------------------------------------");
+            log.error("--------------------------------------------");
+            log.error("--------------------------------------------");
+//            return;
+        }
+*/
+
+
+
+        // Store panels
+        jmri.ConfigureManager cm = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
+        if (cm == null) {
+            log.error("Unable to get default configure manager");
+        } else {
+            FileUtil.createDirectory(FileUtil.getUserFilesPath() + "temp");
+            File firstFile = new File(FileUtil.getUserFilesPath() + "temp/" + "LogixNG_temp.xml");
+            File secondFile = new File(FileUtil.getUserFilesPath() + "temp/" + "LogixNG.xml");
+            log.info("Temporary first file: %s%n", firstFile.getAbsoluteFile());
+            log.info("Temporary second file: %s%n", secondFile.getAbsoluteFile());
+
+            final String treeIndent = "   ";
+            StringWriter stringWriter = new StringWriter();
+            PrintWriter printWriter = new PrintWriter(stringWriter);
+            logixNG_Manager.printTree(Locale.ENGLISH, printWriter, treeIndent, new MutableInt(0));
+            final String originalTree = stringWriter.toString();
+
+            boolean results = cm.storeUser(firstFile);
+            log.debug(results ? "store was successful" : "store failed");
+            if (!results) {
+                log.error("Failed to store panel");
+                throw new RuntimeException("Failed to store panel");
+            }
+
+            // Add the header comment to the xml file
+            addHeader(firstFile, secondFile);
+
+
+            //**********************************
+            // Delete all the LogixNGs, ConditionalNGs, and so on before reading the file.
+            //**********************************
+
+            java.util.Set<LogixNG> logixNG_Set = new java.util.HashSet<>(logixNG_Manager.getNamedBeanSet());
+            for (LogixNG aLogixNG : logixNG_Set) {
+                logixNG_Manager.deleteLogixNG(aLogixNG);
+            }
+
+            java.util.Set<ConditionalNG> conditionalNGSet = new java.util.HashSet<>(conditionalNGManager.getNamedBeanSet());
+            for (ConditionalNG aConditionalNG : conditionalNGSet) {
+                conditionalNGManager.deleteConditionalNG(aConditionalNG);
+            }
+
+            java.util.Set<MaleDigitalActionSocket> digitalActionSet = new java.util.HashSet<>(digitalActionManager.getNamedBeanSet());
+            for (MaleDigitalActionSocket aDigitalActionSocket : digitalActionSet) {
+                digitalActionManager.deleteDigitalAction(aDigitalActionSocket);
+            }
+
+            java.util.Set<MaleDigitalExpressionSocket> digitalExpressionSet = new java.util.HashSet<>(digitalExpressionManager.getNamedBeanSet());
+            for (MaleDigitalExpressionSocket aDigitalExpression : digitalExpressionSet) {
+                digitalExpressionManager.deleteDigitalExpression(aDigitalExpression);
+            }
+
+            Assert.assertEquals(0, logixNG_Manager.getNamedBeanSet().size());
+            Assert.assertEquals(0, conditionalNGManager.getNamedBeanSet().size());
+            Assert.assertEquals(0, digitalActionManager.getNamedBeanSet().size());
+            Assert.assertEquals(0, digitalExpressionManager.getNamedBeanSet().size());
+
+            LogixNG_Thread.stopAllLogixNGThreads();
+            LogixNG_Thread.assertLogixNGThreadNotRunning();
+
+
+            //**********************************
+            // Try to load file
+            //**********************************
+
+            java.util.Set<ConditionalNG> conditionalNG_Set =
+                    new java.util.HashSet<>(conditionalNGManager.getNamedBeanSet());
+            for (ConditionalNG aConditionalNG : conditionalNG_Set) {
+                conditionalNGManager.deleteConditionalNG(aConditionalNG);
+            }
+            java.util.SortedSet<MaleDigitalActionSocket> set3 = digitalActionManager.getNamedBeanSet();
+            List<MaleSocket> l = new ArrayList<>(set3);
+            for (MaleSocket x3 : l) {
+                digitalActionManager.deleteBean((MaleDigitalActionSocket)x3, "DoDelete");
+            }
+            java.util.SortedSet<MaleDigitalExpressionSocket> set4 = digitalExpressionManager.getNamedBeanSet();
+            l = new ArrayList<>(set4);
+            for (MaleSocket x4 : l) {
+                digitalExpressionManager.deleteBean((MaleDigitalExpressionSocket)x4, "DoDelete");
+            }
+
+            results = cm.load(secondFile);
+            log.debug(results ? "load was successful" : "store failed");
+            if (results) {
+                logixNG_Manager.setupAllLogixNGs();
+
+                stringWriter = new StringWriter();
+                printWriter = new PrintWriter(stringWriter);
+                logixNG_Manager.printTree(Locale.ENGLISH, printWriter, treeIndent, new MutableInt(0));
+
+                if (!originalTree.equals(stringWriter.toString())) {
+                    log.error("--------------------------------------------");
+                    log.error("Old tree:");
+                    log.error("XXX"+originalTree+"XXX");
+                    log.error("--------------------------------------------");
+                    log.error("New tree:");
+                    log.error("XXX"+stringWriter.toString()+"XXX");
+                    log.error("--------------------------------------------");
+/*
+                    System.out.println("--------------------------------------------");
+                    System.out.println("Old tree:");
+                    System.out.println("XXX"+originalTree+"XXX");
+                    System.out.println("--------------------------------------------");
+                    System.out.println("New tree:");
+                    System.out.println("XXX"+stringWriter.toString()+"XXX");
+                    System.out.println("--------------------------------------------");
+*/
+//                    log.error(conditionalNGManager.getBySystemName(originalTree).getChild(0).getConnectedSocket().getSystemName());
+
+                    Assert.fail("tree has changed");
+//                    throw new RuntimeException("tree has changed");
+                }
+            } else {
+                Assert.fail("Failed to load panel");
+//                throw new RuntimeException("Failed to load panel");
+            }
+        }
+    }
+
+
+    private void addHeader(File inFile, File outFile) throws FileNotFoundException, IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(inFile), StandardCharsets.UTF_8));
+                PrintWriter writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outFile), StandardCharsets.UTF_8)))) {
+
+            String line = reader.readLine();
+            writer.println(line);
+
+            writer.println("<!--");
+            writer.println("*****************************************************************************");
+            writer.println();
+            writer.println("DO NOT EDIT THIS FILE!!!");
+            writer.println();
+            writer.println("This file is created by jmri.jmrit.logixng.configurexml.StoreAndLoadTest");
+            writer.println("and put in the temp/temp folder. LogixNG uses both the standard JMRI load");
+            writer.println("and store test, and a LogixNG specific store and load test.");
+            writer.println();
+            writer.println("After adding new stuff to StoreAndLoadTest, copy the file temp/temp/LogixNG.xml");
+            writer.println("to the folder java/test/jmri/jmrit/logixng/configurexml/load");
+            writer.println();
+            writer.println("******************************************************************************");
+            writer.println("-->");
+
+            while ((line = reader.readLine()) != null) {
+                writer.println(line);
+            }
+        }
+    }
+
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initInternalLightManager();
+        JUnitUtil.initInternalSensorManager();
+
+        JUnitUtil.initInternalSignalHeadManager();
+        JUnitUtil.initDefaultSignalMastManager();
+        JUnitUtil.initOBlockManager();
+        JUnitUtil.initWarrantManager();
+
+        // The class under test uses LocoNet connections that it pulls from the InstanceManager.
+        memo1 = new MqttSystemConnectionMemo();
+        jmri.InstanceManager.store(memo1, jmri.jmrix.mqtt.MqttSystemConnectionMemo.class);
+
+        // The class under test uses LocoNet connections that it pulls from the InstanceManager.
+        memo2 = new MqttSystemConnectionMemo();
+        jmri.InstanceManager.store(memo2, MqttSystemConnectionMemo.class);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // JUnitAppender.clearBacklog();    // REMOVE THIS!!!
+
+//        JUnitUtil.removeMatchingThreads("LnPowerManager LnTrackStatusUpdateThread");
+//        JUnitUtil.removeMatchingThreads("LnSensorUpdateThread");
+//        JUnitUtil.removeMatchingThreads("LocoNetThrottledTransmitter");
+
+        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+//        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(StoreAndLoadTest.class);
+
+}

--- a/xml/schema/logixng/digital-actions/digital-actions-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/digital-actions-4.23.1.xsd
@@ -63,6 +63,7 @@
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/log-data-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/log-local-variables-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/many-4.23.1.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/mqtt-publish-4.99.7.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/sequence-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/show-dialog-4.25.7.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/shutdown-computer-4.23.1.xsd"/>
@@ -125,6 +126,7 @@
             <xs:element name="LogData"           type="LogixNG_DigitalAction_LogDataType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="LogLocalVariables" type="LogixNG_DigitalAction_LogLocalVariablesType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="DigitalMany"       type="LogixNG_DigitalAction_ManyType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="MQTTPublish"       type="LogixNG_DigitalAction_MQTT_PublishType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="Sequence"          type="LogixNG_DigitalAction_SequenceType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ShowDialog"        type="LogixNG_DigitalAction_ShowDialogType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ShutdownComputer"  type="LogixNG_DigitalAction_ShutdownComputerType" minOccurs="0" maxOccurs="unbounded" />

--- a/xml/schema/logixng/digital-actions/digital-actions-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/digital-actions-4.23.1.xsd
@@ -64,6 +64,7 @@
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/log-local-variables-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/many-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/mqtt-publish-4.99.7.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/mqtt-subscribe-4.99.7.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/sequence-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/show-dialog-4.25.7.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/shutdown-computer-4.23.1.xsd"/>
@@ -127,6 +128,7 @@
             <xs:element name="LogLocalVariables" type="LogixNG_DigitalAction_LogLocalVariablesType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="DigitalMany"       type="LogixNG_DigitalAction_ManyType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="MQTTPublish"       type="LogixNG_DigitalAction_MQTT_PublishType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="MQTTSubscribe"     type="LogixNG_DigitalAction_MQTT_SubscribeType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="Sequence"          type="LogixNG_DigitalAction_SequenceType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ShowDialog"        type="LogixNG_DigitalAction_ShowDialogType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ShutdownComputer"  type="LogixNG_DigitalAction_ShutdownComputerType" minOccurs="0" maxOccurs="unbounded" />

--- a/xml/schema/logixng/digital-actions/mqtt-publish-4.99.7.xsd
+++ b/xml/schema/logixng/digital-actions/mqtt-publish-4.99.7.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../schema2xhtml.xsl" type="text/xsl"?>
+
+<!-- This schema is part of JMRI. Copyright 2018.                           -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+
+<!-- This file contains definitions for LogixNG                             -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi ="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:docbook="http://docbook.org/ns/docbook"
+           xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
+           xsi:schemaLocation="
+                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+            "
+        >
+
+    <xs:complexType name="LogixNG_DigitalAction_MQTT_PublishType">
+      <xs:annotation>
+        <xs:documentation>
+          Define the XML stucture for storing the contents of a ActionClock class.
+        </xs:documentation>
+        <xs:appinfo>
+            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.digital.actions.configurexml.ActionClockXml</jmri:usingclass>
+        </xs:appinfo>
+      </xs:annotation>
+
+            <xs:sequence>
+
+              <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
+              <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+              <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="systemConnection" type="xs:string" minOccurs="0" maxOccurs="1"/>
+
+              <xs:element name="topic" type="LogixNG_SelectStringType" minOccurs="1" maxOccurs="1" />
+              <xs:element name="data" type="LogixNG_SelectStringType" minOccurs="1" maxOccurs="1" />
+
+              <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
+
+            </xs:sequence>
+
+            <xs:attribute name="class" type="classType" use="required"/>
+
+    </xs:complexType>
+
+</xs:schema>

--- a/xml/schema/logixng/digital-actions/mqtt-subscribe-4.99.7.xsd
+++ b/xml/schema/logixng/digital-actions/mqtt-subscribe-4.99.7.xsd
@@ -25,7 +25,7 @@
             "
         >
 
-    <xs:complexType name="LogixNG_DigitalAction_MQTT_PublishType">
+    <xs:complexType name="LogixNG_DigitalAction_MQTT_SubscribeType">
       <xs:annotation>
         <xs:documentation>
           Define the XML stucture for storing the contents of a ActionClock class.
@@ -43,8 +43,9 @@
 
               <xs:element name="systemConnection" type="xs:string" minOccurs="0" maxOccurs="1"/>
 
-              <xs:element name="topic" type="LogixNG_SelectStringType" minOccurs="1" maxOccurs="1" />
-              <xs:element name="message" type="LogixNG_SelectStringType" minOccurs="1" maxOccurs="1" />
+              <xs:element name="subscribeToTopic" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="lastTopicLocalVariable" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <xs:element name="lastMessageLocalVariable" type="xs:string" minOccurs="0" maxOccurs="1" />
 
               <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
 


### PR DESCRIPTION
This PR adds support for MQTT to LogixNG. If there is a MQTT connection active, the category "MQTT" is added to LogixNG. This category has two actions:

* **Publish**
This action publishes a message. Both the topic and the message can be entered directly in the action or indirectly using a local variable or a memory.

* **Subscribe**
This action subscribes to a topic. When someone publishes a message, this action triggers the execution of the CondtionalNG. It can also optional set the topic and the message to local variables. The topic can use wildcard, like `loco/#` where `#` is the wildcard.

---

Example panel file. To test this, you need a MQTT connection and another connection that supports throttles.
[MQTT_LogixNG.txt](https://github.com/JMRI/JMRI/files/8628808/MQTT_LogixNG.txt)

This example demonstrates how to use MQTT to control an engine. Send a message with the topic `/trains/loco/<addr>` where `<addr>` is a number, with the speed as the message. The speed is between -100 and 100. If the speed is less than 0, the direction is reverse.

Example: The message `82` to the topic `trains/loco/35` sets the loco address 35 to speed 0.82 with direction forward.

The example file also has two memories, `MemoryTopic` and `MemoryData`. Set MemoryTopic to the desired topic and then use MemoryData to send messages to this topic.