### PR TITLE
Deprecate unused method for removal

### DIFF
--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -299,6 +299,8 @@ abstract public class AbstractProxyManager<E extends NamedBean> extends Vetoable
         return createSystemName(curAddress, prefix, getNamedBeanClass());
     }
 
+    // not used
+    @Deprecated(since="4.99.8", forRemoval=true)
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, char typeLetter) throws jmri.JmriException {
         for (Manager<E> m : mgrs) {
             log.debug("NextValidAddress requested for {}", curAddress);


### PR DESCRIPTION
Deprecates for removal
```
public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, char typeLetter)
```
in `jmri.managers.AbstractProxyManager`.  It's not currently used. It doesn't appear in super- or sub-classes. It's been replaced by 
```
public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix, boolean ignoreInitialExisting)
```
and we don't need two of these.