### PR TITLE
Improve LogixNG tests. Fix bugs

### DIFF
--- a/java/src/jmri/jmrit/logixng/actions/configurexml/ActionTurnoutLockXml.java
+++ b/java/src/jmri/jmrit/logixng/actions/configurexml/ActionTurnoutLockXml.java
@@ -60,16 +60,8 @@ public class ActionTurnoutLockXml extends jmri.managers.configurexml.AbstractNam
         var selectEnumXml = new LogixNG_SelectEnumXml<ActionTurnoutLock.TurnoutLock>();
 
         selectNamedBeanXml.load(shared.getChild("namedBean"), h.getSelectNamedBean());
-        selectNamedBeanXml.loadLegacy(shared, h.getSelectNamedBean(), "turnout");
 
         selectEnumXml.load(shared.getChild("state"), h.getSelectEnum());
-        selectEnumXml.loadLegacy(
-                shared, h.getSelectEnum(),
-                "stateAddressing",
-                "turnoutLock",
-                "stateReference",
-                "stateLocalVariable",
-                "stateFormula");
 
         InstanceManager.getDefault(DigitalActionManager.class).registerAction(h);
         return true;

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionDispatcherSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionDispatcherSwing.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.logixng.actions.swing;
 
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.util.List;
 
 import javax.annotation.CheckForNull;
@@ -43,6 +45,9 @@ public class ActionDispatcherSwing extends AbstractDigitalActionSwing {
     private JPanel _panelDataLocalVariable;
     private JPanel _panelDataFormula;
 
+    JLabel _priorityLabel;
+    JLabel _resetLabel;
+    JLabel _terminateLabel;
     private JSpinner _priority;
     private JCheckBox _resetOption;
     private JCheckBox _terminateOption;
@@ -121,13 +126,39 @@ public class ActionDispatcherSwing extends AbstractDigitalActionSwing {
         _tabbedPaneData.addTab(NamedBeanAddressing.LocalVariable.toString(), _panelDataLocalVariable);
         _tabbedPaneData.addTab(NamedBeanAddressing.Formula.toString(), _panelDataFormula);
 
-        JPanel dataGroup = new JPanel();
+
+        _priorityLabel = new JLabel(Bundle.getMessage("ActionDispatcher_Priority"));
         _priority = new JSpinner(new SpinnerNumberModel(5, 0, 100, 1));
-        dataGroup.add(_priority);
+        _resetLabel = new JLabel(Bundle.getMessage("ActionDispatcher_Reset"));
         _resetOption = new JCheckBox();
-        dataGroup.add(_resetOption);
+        _terminateLabel = new JLabel(Bundle.getMessage("ActionDispatcher_Terminate"));
         _terminateOption = new JCheckBox();
-        dataGroup.add(_terminateOption);
+
+        JPanel dataGroup = new JPanel();
+        dataGroup.setLayout(new GridBagLayout());
+        GridBagConstraints constraint = new GridBagConstraints();
+        constraint.gridwidth = 1;
+        constraint.gridheight = 1;
+        constraint.gridx = 0;
+        constraint.gridy = 0;
+        constraint.anchor = GridBagConstraints.EAST;
+        dataGroup.add(_priorityLabel, constraint);
+        _priorityLabel.setLabelFor(_priority);
+        constraint.gridy = 1;
+        dataGroup.add(_resetLabel, constraint);
+        _resetLabel.setLabelFor(_resetOption);
+        constraint.gridy = 2;
+        dataGroup.add(_terminateLabel, constraint);
+        _terminateLabel.setLabelFor(_terminateOption);
+        constraint.gridx = 1;
+        constraint.gridy = 0;
+        constraint.anchor = GridBagConstraints.WEST;
+        dataGroup.add(_priority, constraint);
+        constraint.gridy = 1;
+        dataGroup.add(_resetOption, constraint);
+        constraint.gridy = 2;
+        dataGroup.add(_terminateOption, constraint);
+
         _panelDataDirect.add(dataGroup);
 
         _dispatcherDataReferenceTextField = new JTextField();
@@ -141,8 +172,6 @@ public class ActionDispatcherSwing extends AbstractDigitalActionSwing {
         _dispatcherDataFormulaTextField = new JTextField();
         _dispatcherDataFormulaTextField.setColumns(30);
         _panelDataFormula.add(_dispatcherDataFormulaTextField);
-
-        setDataPanelState();
 
 
         if (action != null) {
@@ -171,8 +200,12 @@ public class ActionDispatcherSwing extends AbstractDigitalActionSwing {
             _dispatcherDataReferenceTextField.setText(action.getDataReference());
             _dispatcherDataLocalVariableTextField.setText(action.getDataLocalVariable());
             _dispatcherDataFormulaTextField.setText(action.getDataFormula());
-
         }
+
+        setDataPanelState();
+
+        _selectOperationSwing.addAddressingListener((evt) -> { setDataPanelState(); });
+        _selectOperationSwing.addEnumListener((evt) -> { setDataPanelState(); });
 
         JComponent[] components = new JComponent[]{
             _tabbedPaneDispatcher,
@@ -186,26 +219,33 @@ public class ActionDispatcherSwing extends AbstractDigitalActionSwing {
     }
 
     private void setDataPanelState() {
+
+        _priorityLabel.setVisible(false);
         _priority.setVisible(false);
+        _resetLabel.setVisible(false);
         _resetOption.setVisible(false);
+        _terminateLabel.setVisible(false);
         _terminateOption.setVisible(false);
 
         boolean newState = false;
 
         if (_selectOperationSwing.isEnumSelectedOrIndirectAddressing(
                 DirectOperation.TrainPriority)) {
+            _priorityLabel.setVisible(true);
             _priority.setVisible(true);
             newState = true;
         }
 
         if (_selectOperationSwing.isEnumSelectedOrIndirectAddressing(
                 DirectOperation.ResetWhenDoneOption)) {
+            _resetLabel.setVisible(true);
             _resetOption.setVisible(true);
             newState = true;
         }
 
         if (_selectOperationSwing.isEnumSelectedOrIndirectAddressing(
                 DirectOperation.TerminateWhenDoneOption)) {
+            _terminateLabel.setVisible(true);
             _terminateOption.setVisible(true);
             newState = true;
         }
@@ -224,6 +264,11 @@ public class ActionDispatcherSwing extends AbstractDigitalActionSwing {
 
         validateInfoFileSection(errorMessages);
         _selectOperationSwing.validate(action.getSelectEnum(), errorMessages);
+
+        if ((_selectOperationSwing.getAddressing() == NamedBeanAddressing.Direct)
+                && (_selectOperationSwing.getEnum() == DirectOperation.None)) {
+            errorMessages.add(Bundle.getMessage("ActionDispatcher_ErrorDispatcherActionNotSelected"));
+        }
         validateDataSection(errorMessages);
         return errorMessages.isEmpty();
     }

--- a/java/src/jmri/jmrit/logixng/actions/swing/ActionDispatcherSwing.java
+++ b/java/src/jmri/jmrit/logixng/actions/swing/ActionDispatcherSwing.java
@@ -410,9 +410,7 @@ public class ActionDispatcherSwing extends AbstractDigitalActionSwing {
 
     @Override
     public void setDefaultValues() {
-//        if (_stateComboBox.getSelectedIndex() < 1) {
-//            _stateComboBox.setSelectedIndex(1);
-//        }
+        _selectOperationSwing.setEnum(DirectOperation.LoadTrainFromFile);
     }
 
     @Override

--- a/java/src/jmri/jmrit/logixng/actions/swing/DigitalActionSwingBundle.properties
+++ b/java/src/jmri/jmrit/logixng/actions/swing/DigitalActionSwingBundle.properties
@@ -20,6 +20,10 @@ ActionClock_LabelTimeFormat             = Enter time as hh:mm or as minutes sinc
 ActionClockRate_Components              = {0} {1} {2}
 ActionClockRate_LabelTo                 = to
 
+ActionDispatcher_Priority               = Priority
+ActionDispatcher_Reset                  = Reset
+ActionDispatcher_Terminate              = Terminate
+ActionDispatcher_ErrorDispatcherActionNotSelected   = Dispatcher action not selected
 ActionDispatcher_Components             = Set dispatcher train {0} to {1} {2}
 
 ActionEntryExit_Components              = Set entry exit {0} to {1}

--- a/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectEnumSwing.java
+++ b/java/src/jmri/jmrit/logixng/util/swing/LogixNG_SelectEnumSwing.java
@@ -230,6 +230,10 @@ public class LogixNG_SelectEnumSwing<E extends Enum<?>> {
         return _enumComboBox.getItemAt(_enumComboBox.getSelectedIndex());
     }
 
+    public void setEnum(E e) {
+        _enumComboBox.setSelectedItem(e);
+    }
+
     public void dispose() {
         _selectTableSwing.dispose();
     }

--- a/java/src/jmri/jmrix/loconet/logixng/ActionClearSlots.java
+++ b/java/src/jmri/jmrix/loconet/logixng/ActionClearSlots.java
@@ -12,30 +12,30 @@ import jmri.jmrix.loconet.*;
 
 /**
  * Sets all engine slots to status common
- * 
+ *
  * @author Daniel Bergqvist Copyright 2020
  */
 public class ActionClearSlots extends AbstractDigitalAction {
 
     private static final int NUM_LOCO_SLOTS_TO_CLEAR = 119;
-    
+
     private LocoNetSystemConnectionMemo _memo;
-    
+
     public ActionClearSlots(String sys, String user, LocoNetSystemConnectionMemo memo) {
         super(sys, user);
         _memo = memo;
     }
-    
+
     @Override
     public Base getDeepCopy(Map<String, String> systemNames, Map<String, String> userNames) throws JmriException {
         DigitalActionManager manager = InstanceManager.getDefault(DigitalActionManager.class);
         String sysName = systemNames.get(getSystemName());
         String userName = userNames.get(getSystemName());
         if (sysName == null) sysName = manager.getAutoSystemName();
-        ActionUpdateSlots copy = new ActionUpdateSlots(sysName, userName, _memo);
+        ActionClearSlots copy = new ActionClearSlots(sysName, userName, _memo);
         return manager.registerAction(copy).deepCopyChildren(this, systemNames, userNames);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public Category getCategory() {
@@ -46,11 +46,11 @@ public class ActionClearSlots extends AbstractDigitalAction {
         assertListenersAreNotRegistered(log, "setMemo");
         _memo = memo;
     }
-    
+
     public LocoNetSystemConnectionMemo getMemo() {
         return _memo;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void execute() {
@@ -89,7 +89,7 @@ public class ActionClearSlots extends AbstractDigitalAction {
     public void setup() {
         // Do nothing
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void registerListenersForThisClass() {
@@ -97,13 +97,13 @@ public class ActionClearSlots extends AbstractDigitalAction {
             _listenersAreRegistered = true;
         }
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void unregisterListenersForThisClass() {
         _listenersAreRegistered = false;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void disposeMe() {

--- a/java/src/jmri/jmrix/loconet/logixng/swing/ExpressionSlotUsageSwing.java
+++ b/java/src/jmri/jmrix/loconet/logixng/swing/ExpressionSlotUsageSwing.java
@@ -2,15 +2,12 @@ package jmri.jmrix.loconet.logixng.swing;
 
 import java.awt.Color;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.text.NumberFormat;
 import java.util.*;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.swing.*;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import javax.swing.text.NumberFormatter;
 
 import jmri.*;
@@ -29,7 +26,7 @@ import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 
 /**
  * Configures an ExpressionTurnout object with a Swing JPanel.
- * 
+ *
  * @author Daniel Bergqvist Copyright 2020
  */
 public class ExpressionSlotUsageSwing extends AbstractDigitalExpressionSwing {
@@ -50,26 +47,26 @@ public class ExpressionSlotUsageSwing extends AbstractDigitalExpressionSwing {
     private JComboBox<PercentPieces> _percentPiecesComboBox;
     private JTextField _totalSlotsField;
     private JPanel _slotsPanel;
-    
+
     @Override
     protected void createPanel(@CheckForNull Base object, @Nonnull JPanel buttonPanel) {
         if ((object != null) && !(object instanceof ExpressionSlotUsage)) {
             throw new IllegalArgumentException("object must be an ExpressionSlotUsage but is a: "+object.getClass().getName());
         }
-        
+
         ExpressionSlotUsage expression = (ExpressionSlotUsage)object;
-        
+
         _slotsPanel = new JPanel();
-        
+
         panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        
+
         JPanel queryPanel = new JPanel();
         queryPanel.setBorder(BorderFactory.createLineBorder(Color.black));
-        
+
         JPanel locoNetPanel = new JPanel();
         locoNetPanel.add(new JLabel(Bundle.getMessage("LocoNetConnection")));
-        
+
         _locoNetConnection = new JComboBox<>();
         List<LocoNetSystemConnectionMemo> systemConnections =
                 jmri.InstanceManager.getList(LocoNetSystemConnectionMemo.class);
@@ -81,31 +78,31 @@ public class ExpressionSlotUsageSwing extends AbstractDigitalExpressionSwing {
             }
         }
         locoNetPanel.add(_locoNetConnection);
-        
+
         _has_HasNot_ComboBox = new JComboBox<>();
         for (Has_HasNot e : Has_HasNot.values()) {
             _has_HasNot_ComboBox.addItem(e);
         }
-        
+
         _simpleStateComboBox = new JComboBox<>();
         for (SimpleState e : SimpleState.values()) {
             _simpleStateComboBox.addItem(e);
         }
-        
+
         _tabbedPane = new JTabbedPane();
         _simplePanel = new javax.swing.JPanel();
         _advancedPanel = new javax.swing.JPanel();
         _advancedPanel.setLayout(new BoxLayout(_advancedPanel, BoxLayout.Y_AXIS));
-        
+
         _tabbedPane.addTab(Bundle.getMessage("TabbedPaneSimple"), _simplePanel); // NOI1aa8N
         _tabbedPane.addTab(Bundle.getMessage("TabbedPaneAdvanced"), _advancedPanel); // NOIaa18N
-        
+
         _simpleStateComboBox = new JComboBox<>();
         for (SimpleState e : SimpleState.values()) {
             _simpleStateComboBox.addItem(e);
         }
         _simplePanel.add(_simpleStateComboBox);
-        
+
         _inUseCheckBox = new JCheckBox(Bundle.getMessage("AdvancedStateType_InUse"));
         _idleCheckBox = new JCheckBox(Bundle.getMessage("AdvancedStateType_Idle"));
         _commonCheckBox = new JCheckBox(Bundle.getMessage("AdvancedStateType_Common"));
@@ -114,13 +111,12 @@ public class ExpressionSlotUsageSwing extends AbstractDigitalExpressionSwing {
         _advancedPanel.add(_idleCheckBox);
         _advancedPanel.add(_commonCheckBox);
         _advancedPanel.add(_freeCheckBox);
-        
+
         _compareComboBox = new JComboBox<>();
         for (Compare e : Compare.values()) {
             _compareComboBox.addItem(e);
         }
-        
-//        _numberField = new JTextField("99");
+
         NumberFormat format = NumberFormat.getInstance();
         NumberFormatter formatter = new NumberFormatter(format);
         formatter.setValueClass(Integer.class);
@@ -131,24 +127,24 @@ public class ExpressionSlotUsageSwing extends AbstractDigitalExpressionSwing {
         formatter.setCommitsOnValidEdit(true);
         _numberField = new JFormattedTextField();
         _numberField.setColumns(3);
-        
+
         _percentPiecesComboBox = new JComboBox<>();
         for (PercentPieces e : PercentPieces.values()) {
             _percentPiecesComboBox.addItem(e);
         }
-/*        
+/*
         _percentPiecesComboBox.addActionListener((ActionEvent e) -> {
             PercentPieces pp = _percentPiecesComboBox.getItemAt(_percentPiecesComboBox.getSelectedIndex());
             if (pp == PercentPieces.Percent) _slotsPanel.setVisible(true);
             else _slotsPanel.setVisible(false);
             ExpressionSlotUsageSwing.this.getFrame().pack();
         });
-*/        
+*/
         if (expression != null) {
             if (expression.getAdvanced()) {
                 _tabbedPane.setSelectedComponent(_advancedPanel);
             }
-            
+
             if (expression.getAdvancedStates().contains(AdvancedState.InUse)) {
                 _inUseCheckBox.setSelected(true);
             }
@@ -161,16 +157,16 @@ public class ExpressionSlotUsageSwing extends AbstractDigitalExpressionSwing {
             if (expression.getAdvancedStates().contains(AdvancedState.Free)) {
                 _freeCheckBox.setSelected(true);
             }
-            
+
             _has_HasNot_ComboBox.setSelectedItem(expression.get_Has_HasNot());
             _simpleStateComboBox.setSelectedItem(expression.getSimpleState());
             _compareComboBox.setSelectedItem(expression.getCompare());
             _numberField.setText(Integer.toString(expression.getNumber()));
             _percentPiecesComboBox.setSelectedItem(expression.getPercentPieces());
         }
-        
+
         panel.add(locoNetPanel);
-        
+
         JComponent[] components = new JComponent[]{
             _has_HasNot_ComboBox,
             _tabbedPane,
@@ -178,18 +174,18 @@ public class ExpressionSlotUsageSwing extends AbstractDigitalExpressionSwing {
             _numberField,
             _percentPiecesComboBox
             };
-        
+
         List<JComponent> componentList = SwingConfiguratorInterface.parseMessage(Bundle.getMessage("ExpressionSlotUsage_Long"), components);
-        
+
         for (JComponent c : componentList) queryPanel.add(c);
-        
+
         panel.add(queryPanel);
-        
+
         _slotsPanel.setLayout(new BoxLayout(_slotsPanel, BoxLayout.Y_AXIS));
         _slotsPanel.add(new JLabel(Bundle.getMessage("InfoTotalSlots1")));
         _slotsPanel.add(new JLabel(Bundle.getMessage("InfoTotalSlots2")));
         _slotsPanel.add(new JLabel(Bundle.getMessage("InfoTotalSlots3")));
-        
+
         JPanel numSlotsPanel = new JPanel();
         numSlotsPanel.add(new JLabel(Bundle.getMessage("TotalNumSlots")));
         format = NumberFormat.getInstance();
@@ -214,10 +210,10 @@ public class ExpressionSlotUsageSwing extends AbstractDigitalExpressionSwing {
             _totalSlotsField.setText(Integer.toString(expression.getTotalSlots()));
         }
         _slotsPanel.add(numSlotsPanel);
-        
+
         panel.add(_slotsPanel);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public boolean validate(@Nonnull List<String> errorMessages) {
@@ -229,39 +225,39 @@ public class ExpressionSlotUsageSwing extends AbstractDigitalExpressionSwing {
         }
         return true;
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public MaleSocket createNewObject(@Nonnull String systemName, @CheckForNull String userName) {
         LocoNetSystemConnectionMemo memo =
                 _locoNetConnection.getItemAt(_locoNetConnection.getSelectedIndex())._memo;
-        
+
         ExpressionSlotUsage expression = new ExpressionSlotUsage(systemName, userName, memo);
         updateObject(expression);
-        
+
         return InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expression);
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void updateObject(@Nonnull Base object) {
         if (! (object instanceof ExpressionSlotUsage)) {
             throw new IllegalArgumentException("object must be an ExpressionTurnout but is a: "+object.getClass().getName());
         }
-        
+
         ExpressionSlotUsage expression = (ExpressionSlotUsage)object;
-        
+
         expression.setMemo(_locoNetConnection.getItemAt(_locoNetConnection.getSelectedIndex())._memo);
-        
+
         expression.setAdvanced(_tabbedPane.getSelectedComponent() == _advancedPanel);
-        
+
         Set<AdvancedState> advancedStates = new HashSet<>();
         if (_inUseCheckBox.isSelected()) advancedStates.add(AdvancedState.InUse);
         if (_idleCheckBox.isSelected()) advancedStates.add(AdvancedState.Idle);
         if (_commonCheckBox.isSelected()) advancedStates.add(AdvancedState.Common);
         if (_freeCheckBox.isSelected()) advancedStates.add(AdvancedState.Free);
         expression.setAdvancedStates(advancedStates);
-        
+
         expression.set_Has_HasNot(_has_HasNot_ComboBox.getItemAt(_has_HasNot_ComboBox.getSelectedIndex()));
         expression.setSimpleState(_simpleStateComboBox.getItemAt(_simpleStateComboBox.getSelectedIndex()));
         expression.setCompare(_compareComboBox.getItemAt(_compareComboBox.getSelectedIndex()));
@@ -269,33 +265,39 @@ public class ExpressionSlotUsageSwing extends AbstractDigitalExpressionSwing {
         expression.setPercentPieces(_percentPiecesComboBox.getItemAt(_percentPiecesComboBox.getSelectedIndex()));
         expression.setTotalSlots(Integer.parseInt(_totalSlotsField.getText()));
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public String toString() {
         return Bundle.getMessage("ExpressionSlotUsage_Short");
     }
-    
+
     @Override
     public void dispose() {
     }
-    
-    
-    
+
+
+
     private static class LocoNetConnection {
-        
+
         private LocoNetSystemConnectionMemo _memo;
-        
+
         public LocoNetConnection(LocoNetSystemConnectionMemo memo) {
             _memo = memo;
         }
-        
+
         @Override
         public String toString() {
             return _memo.getUserName();
         }
     }
-    
+
+    @Override
+    public void setDefaultValues() {
+        _numberField.setText("10");
+        _totalSlotsField.setText("100");
+    }
+
 //    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ExpressionSlotUsageSwing.class);
 
 }

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -16,6 +16,9 @@ import jmri.jmrit.logixng.expressions.*;
 import jmri.jmrit.logixng.util.LogixNG_SelectTable;
 import jmri.jmrit.logixng.util.LogixNG_Thread;
 import jmri.jmrit.logixng.util.parser.ParserException;
+import jmri.jmrix.loconet.*;
+import jmri.jmrix.mqtt.MqttSystemConnectionMemo;
+import jmri.util.JUnitUtil;
 
 import org.junit.*;
 
@@ -26,6 +29,11 @@ import org.junit.*;
  * compare the LogixNGs before and after store and load.
  */
 public class CreateLogixNGTreeScaffold {
+
+    private static boolean setupHasBeenCalled = false;
+
+    private static LocoNetSystemConnectionMemo _locoNetMemo;
+    private static MqttSystemConnectionMemo _mqttMemo;
 
 //    private AudioManager audioManager;
 
@@ -39,6 +47,9 @@ public class CreateLogixNGTreeScaffold {
 
     public static void createLogixNGTree() throws PropertyVetoException, Exception {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+        // Ensure the setUp() and tearDown() methods of this class are called.
+        Assert.assertTrue(setupHasBeenCalled);
 /*
         audioManager = new jmri.jmrit.audio.DefaultAudioManager(
                 InstanceManager.getDefault(jmri.jmrix.internal.InternalSystemConnectionMemo.class));
@@ -515,6 +526,13 @@ public class CreateLogixNGTreeScaffold {
         actionClockRate.getSelectSpeed().setValue(1.22);
 
         maleSocket = digitalActionManager.registerAction(actionClockRate);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+
+        ActionDispatcher actionDispatcher = new ActionDispatcher(digitalActionManager.getAutoSystemName(), null);
+        actionDispatcher.getSelectEnum().setEnum(ActionDispatcher.DirectOperation.TrainPriority);
+        maleSocket = digitalActionManager.registerAction(actionDispatcher);
         maleSocket.setEnabled(false);
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
@@ -1162,6 +1180,12 @@ public class CreateLogixNGTreeScaffold {
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
 
+        ActionReporter actionReporter = new ActionReporter(digitalActionManager.getAutoSystemName(), null);
+        maleSocket = digitalActionManager.registerAction(actionReporter);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+
         ActionScript simpleScript = new ActionScript(digitalActionManager.getAutoSystemName(), null);
         maleSocket = digitalActionManager.registerAction(simpleScript);
         maleSocket.setEnabled(false);
@@ -1789,6 +1813,12 @@ public class CreateLogixNGTreeScaffold {
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
 
+        ActionTurnoutLock actionTurnoutLock = new ActionTurnoutLock(digitalActionManager.getAutoSystemName(), null);
+        maleSocket = digitalActionManager.registerAction(actionTurnoutLock);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+
         ActionWarrant actionWarrant = new ActionWarrant(digitalActionManager.getAutoSystemName(), null);
         maleSocket = digitalActionManager.registerAction(actionWarrant);
         maleSocket.setEnabled(false);
@@ -1906,6 +1936,47 @@ public class CreateLogixNGTreeScaffold {
 
         maleSocket = digitalActionManager.registerAction(actionWarrant);
         maleSocket.setErrorHandlingType(MaleSocket.ErrorHandlingType.AbortExecution);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+
+        WebBrowser webBrowser = new WebBrowser(digitalActionManager.getAutoSystemName(), null);
+        maleSocket = digitalActionManager.registerAction(webBrowser);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+
+        jmri.jmrit.display.logixng.ActionPositionable actionPositionable =
+                new jmri.jmrit.display.logixng.ActionPositionable(digitalActionManager.getAutoSystemName(), null);
+        maleSocket = digitalActionManager.registerAction(actionPositionable);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+
+        jmri.jmrix.loconet.logixng.ActionClearSlots actionClearSlots =
+                new jmri.jmrix.loconet.logixng.ActionClearSlots(digitalActionManager.getAutoSystemName(), null, _locoNetMemo);
+        maleSocket = digitalActionManager.registerAction(actionClearSlots);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+
+        jmri.jmrix.loconet.logixng.ActionUpdateSlots actionUpdateSlots =
+                new jmri.jmrix.loconet.logixng.ActionUpdateSlots(digitalActionManager.getAutoSystemName(), null, _locoNetMemo);
+        maleSocket = digitalActionManager.registerAction(actionUpdateSlots);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+
+        jmri.jmrix.mqtt.logixng.Publish publish =
+                new jmri.jmrix.mqtt.logixng.Publish(digitalActionManager.getAutoSystemName(), null, _mqttMemo);
+        maleSocket = digitalActionManager.registerAction(publish);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+
+        jmri.jmrix.mqtt.logixng.Subscribe subscribe =
+                new jmri.jmrix.mqtt.logixng.Subscribe(digitalActionManager.getAutoSystemName(), null, _mqttMemo);
+        maleSocket = digitalActionManager.registerAction(subscribe);
+        maleSocket.setEnabled(false);
         actionManySocket.getChild(indexAction++).connect(maleSocket);
 
 
@@ -2812,6 +2883,12 @@ public class CreateLogixNGTreeScaffold {
         and.getChild(indexExpr++).connect(maleSocket);
 
 
+        ExpressionDispatcher expressionDispatcher = new ExpressionDispatcher(digitalExpressionManager.getAutoSystemName(), null);
+        maleSocket = digitalExpressionManager.registerExpression(expressionDispatcher);
+        maleSocket.setEnabled(false);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+
         ExpressionEntryExit expressionEntryExit = new ExpressionEntryExit(digitalExpressionManager.getAutoSystemName(), null);
         maleSocket = digitalExpressionManager.registerExpression(expressionEntryExit);
         maleSocket.setEnabled(false);
@@ -3215,6 +3292,12 @@ public class CreateLogixNGTreeScaffold {
         expressionReference.setPointsTo(ExpressionReference.PointsTo.Light);
         expressionReference.set_Is_IsNot(Is_IsNot_Enum.IsNot);
         maleSocket = digitalExpressionManager.registerExpression(expressionReference);
+        and.getChild(indexExpr++).connect(maleSocket);
+
+
+        ExpressionReporter expressionReporter = new ExpressionReporter(digitalExpressionManager.getAutoSystemName(), null);
+        maleSocket = digitalExpressionManager.registerExpression(expressionReporter);
+        maleSocket.setEnabled(false);
         and.getChild(indexExpr++).connect(maleSocket);
 
 
@@ -3750,6 +3833,12 @@ public class CreateLogixNGTreeScaffold {
         and.getChild(indexExpr++).connect(maleSocket);
 
 
+        jmri.jmrix.loconet.logixng.ExpressionSlotUsage expressionSlotUsage =
+                new jmri.jmrix.loconet.logixng.ExpressionSlotUsage(digitalExpressionManager.getAutoSystemName(), null, _locoNetMemo);
+        maleSocket = digitalExpressionManager.registerExpression(expressionSlotUsage);
+        maleSocket.setEnabled(false);
+        and.getChild(indexExpr++).connect(maleSocket);
+
 
 
         doAnalogAction = new DoAnalogAction(digitalActionManager.getAutoSystemName(), null);
@@ -3830,6 +3919,11 @@ public class CreateLogixNGTreeScaffold {
         maleSocket.setEnabled(false);
         doAnalogAction.getChild(0).connect(maleSocket);
 
+        AnalogActionLightIntensity analogActionLightIntensity = new AnalogActionLightIntensity(analogActionManager.getAutoSystemName(), null);
+        maleSocket = analogActionManager.registerAction(analogActionLightIntensity);
+        maleSocket.setEnabled(false);
+        doAnalogAction.getChild(1).connect(maleSocket);
+
 
         doAnalogAction = new DoAnalogAction(digitalActionManager.getAutoSystemName(), null);
         maleSocket = digitalActionManager.registerAction(doAnalogAction);
@@ -3840,6 +3934,17 @@ public class CreateLogixNGTreeScaffold {
         analogFormula.setComment("A comment");
         analogFormula.setFormula("sin(a)*2 + 14");
         maleSocket = analogExpressionManager.registerExpression(analogFormula);
+        doAnalogAction.getChild(0).connect(maleSocket);
+
+
+        doAnalogAction = new DoAnalogAction(digitalActionManager.getAutoSystemName(), null);
+        maleSocket = digitalActionManager.registerAction(doAnalogAction);
+        maleSocket.setEnabled(false);
+        actionManySocket.getChild(indexAction++).connect(maleSocket);
+
+        AnalogExpressionAnalogIO analogExpressionAnalogIO = new AnalogExpressionAnalogIO(analogExpressionManager.getAutoSystemName(), null);
+        maleSocket = analogExpressionManager.registerExpression(analogExpressionAnalogIO);
+        maleSocket.setEnabled(false);
         doAnalogAction.getChild(0).connect(maleSocket);
 
 
@@ -3947,6 +4052,11 @@ public class CreateLogixNGTreeScaffold {
         maleSocket.setEnabled(false);
         doStringAction.getChild(0).connect(maleSocket);
 
+        StringActionStringIO stringActionStringIO = new StringActionStringIO(stringActionManager.getAutoSystemName(), null);
+        maleSocket = stringActionManager.registerAction(stringActionStringIO);
+        maleSocket.setEnabled(false);
+        doStringAction.getChild(1).connect(maleSocket);
+
 
         doStringAction = new DoStringAction(digitalActionManager.getAutoSystemName(), null);
         maleSocket = digitalActionManager.registerAction(doStringAction);
@@ -3993,6 +4103,51 @@ public class CreateLogixNGTreeScaffold {
             }
         });
 
+
+        // Verify that we have all the actions and expressions in the tree, even
+        // actions and expressions defined outside of the jmri.jmrit.logixng tree.
+
+        Set<Class<? extends Base>> testedClasses = new HashSet<>();
+        Map<Class<? extends FemaleSocket>, FemaleSocket> femaleSocketMap = new HashMap<>();
+        List<Class<? extends Base>> missingClasses = new ArrayList<>();
+
+        femaleRootSocket.forEntireTree((Base b) -> {
+//            if (!(b instanceof FemaleSocket) && !(b instanceof MaleSocket)) {
+            if (b instanceof MaleSocket) {
+                Base o = ((MaleSocket) b).getObject();
+                while (o instanceof MaleSocket) {
+                    o = ((MaleSocket) o).getObject();
+                }
+//                System.out.format("Class: %s%n", o.getClass().getName());
+                testedClasses.add(o.getClass());
+                for (int i=0; i < o.getChildCount(); i++) {
+                    FemaleSocket fs = o.getChild(i);
+                    femaleSocketMap.put(fs.getClass(), fs);
+                }
+            }
+        });
+
+        for (var femaleSocket : femaleSocketMap.values()) {
+            var connectableClasses = femaleSocket.getConnectableClasses();
+
+            for (var list : connectableClasses.values()) {
+                for (var clazz : list) {
+                    if (!testedClasses.contains(clazz)) {
+//                        System.out.format("Class is not tested: %s%n", clazz.getName());
+                        missingClasses.add(clazz);
+                    }
+                }
+            }
+        }
+
+        Collections.sort(missingClasses, (o1,o2) -> {
+            return o1.getName().compareTo(o2.getName());
+        });
+
+        for (var clazz : missingClasses) {
+            log.error("Class {} is not added by CreateLogixNGTreeScaffold.createLogixNGTree()", clazz.getName());
+        }
+        Assert.assertTrue(missingClasses.isEmpty());
 
 /*
         if (1==1) {
@@ -4210,6 +4365,54 @@ public class CreateLogixNGTreeScaffold {
     }
 
 
-//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CreateLogixNGTreeScaffold.class);
+    public static void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initInternalLightManager();
+        JUnitUtil.initInternalSensorManager();
+        JUnitUtil.initDebugPowerManager();
+
+        JUnitUtil.initInternalSignalHeadManager();
+        JUnitUtil.initDefaultSignalMastManager();
+//        JUnitUtil.initSignalMastLogicManager();
+        JUnitUtil.initOBlockManager();
+        JUnitUtil.initWarrantManager();
+
+        LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold();
+        SlotManager sm = new SlotManager(lnis);
+        _locoNetMemo = new LocoNetSystemConnectionMemo(lnis, sm);
+        sm.setSystemConnectionMemo(_locoNetMemo);
+        InstanceManager.setDefault(LocoNetSystemConnectionMemo.class, _locoNetMemo);
+
+        _mqttMemo = new MqttSystemConnectionMemo();
+        InstanceManager.setDefault(MqttSystemConnectionMemo.class, _mqttMemo);
+
+//        JUnitUtil.initLogixNGManager();
+
+        setupHasBeenCalled = true;
+    }
+
+    public static void tearDown() {
+        setupHasBeenCalled = false;     // Reset for the next test
+
+        _locoNetMemo = null;
+        _mqttMemo = null;
+
+//        JUnitAppender.clearBacklog();    // REMOVE THIS!!!
+        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
+
+        // Delete all the LogixNGs, ConditionalNGs, and so on.
+        cleanup();
+
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.deregisterEditorManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CreateLogixNGTreeScaffold.class);
 
 }

--- a/java/test/jmri/jmrit/logixng/DeepCopyTest.java
+++ b/java/test/jmri/jmrit/logixng/DeepCopyTest.java
@@ -85,34 +85,13 @@ public class DeepCopyTest {
 
     @Before
     public void setUp() {
-        JUnitUtil.setUp();
-        JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
-        JUnitUtil.initConfigureManager();
-        JUnitUtil.initInternalTurnoutManager();
-        JUnitUtil.initInternalLightManager();
-        JUnitUtil.initInternalSensorManager();
-        JUnitUtil.initDebugPowerManager();
-
-        JUnitUtil.initInternalSignalHeadManager();
-        JUnitUtil.initDefaultSignalMastManager();
-//        JUnitUtil.initSignalMastLogicManager();
-        JUnitUtil.initOBlockManager();
-        JUnitUtil.initWarrantManager();
-
-//        JUnitUtil.initLogixNGManager();
+        CreateLogixNGTreeScaffold.setUp();
     }
 
     @After
     public void tearDown() {
 //        JUnitAppender.clearBacklog();    // REMOVE THIS!!!
-        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
-
-        // Delete all the LogixNGs, ConditionalNGs, and so on.
-        CreateLogixNGTreeScaffold.cleanup();
-        
-        JUnitUtil.deregisterBlockManagerShutdownTask();
-        JUnitUtil.tearDown();
+        CreateLogixNGTreeScaffold.tearDown();
     }
 
 

--- a/java/test/jmri/jmrit/logixng/SocketOperationTest.java
+++ b/java/test/jmri/jmrit/logixng/SocketOperationTest.java
@@ -146,6 +146,8 @@ public class SocketOperationTest {
             sciSet.put(clazz, sci);
         }
 
+        sci.setDefaultValues();
+
         MaleSocket maleSocket = sci.createNewObject(sci.getAutoSystemName(), null);
         child.connect(maleSocket);
 
@@ -168,35 +170,13 @@ public class SocketOperationTest {
 
     @Before
     public void setUp() {
-        JUnitUtil.setUp();
-        JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
-        JUnitUtil.initConfigureManager();
-        JUnitUtil.initInternalTurnoutManager();
-        JUnitUtil.initInternalLightManager();
-        JUnitUtil.initInternalSensorManager();
-        JUnitUtil.initDebugPowerManager();
-
-        JUnitUtil.initInternalSignalHeadManager();
-        JUnitUtil.initDefaultSignalMastManager();
-//        JUnitUtil.initSignalMastLogicManager();
-        JUnitUtil.initOBlockManager();
-        JUnitUtil.initWarrantManager();
-
-//        JUnitUtil.initLogixNGManager();
+        CreateLogixNGTreeScaffold.setUp();
     }
 
     @After
     public void tearDown() {
 //        JUnitAppender.clearBacklog();    // REMOVE THIS!!!
-        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
-
-        // Delete all the LogixNGs, ConditionalNGs, and so on.
-        CreateLogixNGTreeScaffold.cleanup();
-
-        JUnitUtil.deregisterBlockManagerShutdownTask();
-        JUnitUtil.deregisterEditorManagerShutdownTask();
-        JUnitUtil.tearDown();
+        CreateLogixNGTreeScaffold.tearDown();
     }
 
 

--- a/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
+++ b/java/test/jmri/jmrit/logixng/configurexml/StoreAndLoadTest.java
@@ -186,34 +186,13 @@ public class StoreAndLoadTest {
 
     @Before
     public void setUp() {
-        JUnitUtil.setUp();
-        JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
-        JUnitUtil.initConfigureManager();
-        JUnitUtil.initInternalTurnoutManager();
-        JUnitUtil.initInternalLightManager();
-        JUnitUtil.initInternalSensorManager();
-        JUnitUtil.initDebugPowerManager();
-
-        JUnitUtil.initInternalSignalHeadManager();
-        JUnitUtil.initDefaultSignalMastManager();
-//        JUnitUtil.initSignalMastLogicManager();
-        JUnitUtil.initOBlockManager();
-        JUnitUtil.initWarrantManager();
-
-//        JUnitUtil.initLogixNGManager();
+        CreateLogixNGTreeScaffold.setUp();
     }
 
     @After
     public void tearDown() {
 //        JUnitAppender.clearBacklog();    // REMOVE THIS!!!
-        jmri.jmrit.logixng.util.LogixNG_Thread.stopAllLogixNGThreads();
-
-        // Delete all the LogixNGs, ConditionalNGs, and so on.
-        CreateLogixNGTreeScaffold.cleanup();
-
-        JUnitUtil.deregisterBlockManagerShutdownTask();
-        JUnitUtil.tearDown();
+        CreateLogixNGTreeScaffold.tearDown();
     }
 
 

--- a/xml/schema/logixng/digital-actions/action-dispatcher-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/action-dispatcher-4.23.1.xsd
@@ -47,8 +47,12 @@
               <xs:element name="localVariable" type="xs:string" minOccurs="0" maxOccurs="1" />
               <xs:element name="formula" type="xs:string" minOccurs="0" maxOccurs="1" />
 
-              <xs:element name="operationAddressing" type="LogixNG_Addressing_Type" minOccurs="0" maxOccurs="1" />
+              <xs:element name="memoryNamedBean" type="LogixNG_SelectNamedBeanType" minOccurs="0" maxOccurs="1" />
 
+              <xs:element name="operation" type="LogixNG_SelectEnumType" minOccurs="0" maxOccurs="1" />
+
+              <!-- These are for backwards compability up until JMRI 4.99.5 -->
+              <xs:element name="operationAddressing" type="LogixNG_Addressing_Type" minOccurs="0" maxOccurs="1" />
               <xs:element name="operationDirect" minOccurs="0" maxOccurs="1">
                 <xs:simpleType>
                   <xs:restriction base="xs:token">
@@ -60,10 +64,10 @@
                   </xs:restriction>
                 </xs:simpleType>
               </xs:element>
-
               <xs:element name="operationReference" type="xs:string" minOccurs="0" maxOccurs="1" />
               <xs:element name="operationLocalVariable" type="xs:string" minOccurs="0" maxOccurs="1" />
               <xs:element name="operationFormula" type="xs:string" minOccurs="0" maxOccurs="1" />
+              <!-- These are for backwards compability up until JMRI 4.99.5 -->
 
               <xs:element name="dataAddressing" type="LogixNG_Addressing_Type" minOccurs="0" maxOccurs="1" />
               <xs:element name="dataReference" type="xs:string" minOccurs="0" maxOccurs="1" />

--- a/xml/schema/logixng/digital-actions/action-reporter-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/action-reporter-4.23.1.xsd
@@ -42,6 +42,7 @@
               <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
 
               <xs:element name="namedBean" type="LogixNG_SelectNamedBeanType" minOccurs="0" maxOccurs="1" />
+              <xs:element name="memoryNamedBean" type="LogixNG_SelectNamedBeanType" minOccurs="0" maxOccurs="1" />
 
               <!-- These are for backwards compability up until JMRI 4.99.5 -->
               <xs:element name="reporter" type="beanNameType" minOccurs="0" maxOccurs="1"/>

--- a/xml/schema/logixng/digital-actions/action-turnout-lock-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/action-turnout-lock-4.23.1.xsd
@@ -25,38 +25,29 @@
             "
         >
 
-    <xs:complexType name="LogixNG_DigitalAction_WebBrowserType">
+    <xs:complexType name="LogixNG_DigitalAction_ActionTurnoutLockType">
       <xs:annotation>
         <xs:documentation>
-          Define the XML stucture for storing the contents of a WebBrowser class.
+          Define the XML stucture for storing the contents of a ActionTurnout class.
         </xs:documentation>
         <xs:appinfo>
-            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.digital.actions.configurexml.WebBrowserXml</jmri:usingclass>
+            <jmri:usingclass configurexml="true">jmri.jmrit.logixng.digital.actions.configurexml.ActionTurnoutXml</jmri:usingclass>
         </xs:appinfo>
       </xs:annotation>
         
             <xs:sequence>
+
               <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
               <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
               <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
 
-              <xs:element name="Socket" minOccurs="1" maxOccurs="unbounded">
-                <xs:complexType>
-                  <xs:sequence>
-                    <xs:element name="socketName" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                    <xs:element name="systemName" type="systemNameType" minOccurs="0" maxOccurs="1"/>
-                  </xs:sequence>
-                </xs:complexType>
-              </xs:element>
-
-			  <!-- These are for backwards compability up until JMRI 4.99.7 -->
-              <xs:element name="expressionSystemName" type="systemNameType" minOccurs="0" maxOccurs="1"/>
-			  <!-- These are for backwards compability up until JMRI 4.99.7 -->
+              <xs:element name="namedBean" type="LogixNG_SelectNamedBeanType" minOccurs="0" maxOccurs="1" />
+              <xs:element name="state" type="LogixNG_SelectEnumType" minOccurs="0" maxOccurs="1" />
 
               <xs:element name="MaleSocket" type="LogixNG_MaleSocket_Type" minOccurs="0" maxOccurs="1"/>
 
             </xs:sequence>
-<!--            <xs:attribute name="enabled" type="yesNoType" /> -->
+            
             <xs:attribute name="class" type="classType" use="required"/>
         
     </xs:complexType>

--- a/xml/schema/logixng/digital-actions/digital-actions-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/digital-actions-4.23.1.xsd
@@ -49,6 +49,7 @@
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/action-sound-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/action-timer-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/action-turnout-4.23.1.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/action-turnout-lock-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/action-warrant-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/digital-call-module-4.23.1.xsd"/>
   <xs:include schemaLocation="http://jmri.org/xml/schema/logixng/digital-actions/display-action-positionable-4.23.4.xsd"/>
@@ -113,6 +114,7 @@
             <xs:element name="ActionSound"       type="LogixNG_DigitalAction_ActionSoundType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ActionTimer"       type="LogixNG_DigitalAction_ActionTimerType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ActionTurnout"     type="LogixNG_DigitalAction_ActionTurnoutType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="ActionTurnoutLock" type="LogixNG_DigitalAction_ActionTurnoutLockType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="ActionWarrant"     type="LogixNG_DigitalAction_ActionWarrantType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="CallModule"        type="LogixNG_DigitalAction_CallModuleType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="DigitalFormula"    type="LogixNG_DigitalAction_FormulaType" minOccurs="0" maxOccurs="unbounded" />

--- a/xml/schema/logixng/digital-actions/if-then-else-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/if-then-else-4.23.1.xsd
@@ -39,7 +39,7 @@
               <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
               <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
               <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
-              <xs:element name="IfSocket" minOccurs="1" maxOccurs="unbounded">
+              <xs:element name="IfSocket" minOccurs="1" maxOccurs="1">
                 <xs:complexType>
                   <xs:sequence>
                     <xs:element name="socketName" type="xs:string" minOccurs="1" maxOccurs="1"/>

--- a/xml/schema/logixng/digital-actions/web-browser-4.23.1.xsd
+++ b/xml/schema/logixng/digital-actions/web-browser-4.23.1.xsd
@@ -40,7 +40,7 @@
               <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
               <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
 
-              <xs:element name="Socket" minOccurs="1" maxOccurs="unbounded">
+              <xs:element name="Socket" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
                   <xs:sequence>
                     <xs:element name="socketName" type="xs:string" minOccurs="1" maxOccurs="1"/>

--- a/xml/schema/logixng/digital-expressions/expression-reporter-4.23.1.xsd
+++ b/xml/schema/logixng/digital-expressions/expression-reporter-4.23.1.xsd
@@ -42,6 +42,7 @@
               <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="unbounded"/>
 
               <xs:element name="namedBean" type="LogixNG_SelectNamedBeanType" minOccurs="0" maxOccurs="1" />
+              <xs:element name="memoryNamedBean" type="LogixNG_SelectNamedBeanType" minOccurs="0" maxOccurs="1" />
 
               <!-- These are for backwards compability up until JMRI 4.99.5 -->
               <xs:element name="reporter" type="beanNameType" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
I have improved the tests of LogixNG and as a result found more bugs which are fixed by this PR.

**Turnout Lock**
This action had no schema file so if someone added it, loading the panel would have failed.
Due to this, I have removed the legacy code since there are probably no one using this action today.

**WebBrowser**
This action did not stored the female socket name to the panel file.

**LocoNet action Clear slots**
Deep copy did created the wrong action.

**Action Dispatcher**
The schema file wasn't updated for the refactorization of LogixNG.

**Action Reporter**
The schema file wasn't updated for memory named bean.

**Expression Reporter**
The schema file wasn't updated for memory named bean.

**CreateLogixNGTreeScaffold**
This test class now checks that all known LogixNG actions and expressions are created by this class. If a new action or expression is added to LogixNG, it needs to be added manually to CreateLogixNGTreeScaffold. This class now checks that that is done. CreateLogixNGTreeScaffold is used for several test classes, for example StoreAndLoad that checks that panels are stored and loaded correctly.