### PR TITLE
Run SocketOperationTest on Intermittent CI

### DIFF
--- a/java/test/jmri/jmrit/logixng/SocketOperationTest.java
+++ b/java/test/jmri/jmrit/logixng/SocketOperationTest.java
@@ -20,18 +20,21 @@ public class SocketOperationTest {
 
     @Test
     public void testAddRemoveChildren() throws PropertyVetoException, Exception {
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         runTest(true, false);
     }
 
     @Test
     public void testFemaleSockets() throws PropertyVetoException, Exception {
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         runTest(false, true);
     }
 
     @Test
     public void testAddRemoveChildrenAndFemaleSockets() throws PropertyVetoException, Exception {
+        Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         runTest(true, true);
     }
@@ -41,7 +44,7 @@ public class SocketOperationTest {
     Set<Base> listOfSockets = new HashSet<>();
     Map<Class<? extends Base>, SwingConfiguratorInterface> sciSet = new HashMap<>();
 
-    public void runTest(boolean addRemoveChildren, boolean testSocketOperations)
+    private void runTest(boolean addRemoveChildren, boolean testSocketOperations)
             throws PropertyVetoException, Exception {
 
         // Add new LogixNG actions and expressions to jmri.jmrit.logixng.CreateLogixNGTreeScaffold

--- a/java/test/jmri/jmrit/logixng/SocketOperationTest.java
+++ b/java/test/jmri/jmrit/logixng/SocketOperationTest.java
@@ -21,21 +21,18 @@ public class SocketOperationTest {
     @Test
     public void testAddRemoveChildren() throws PropertyVetoException, Exception {
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         runTest(true, false);
     }
 
     @Test
     public void testFemaleSockets() throws PropertyVetoException, Exception {
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         runTest(false, true);
     }
 
     @Test
     public void testAddRemoveChildrenAndFemaleSockets() throws PropertyVetoException, Exception {
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         runTest(true, true);
     }
 

--- a/java/test/jmri/jmrit/logixng/SocketOperationTest.java
+++ b/java/test/jmri/jmrit/logixng/SocketOperationTest.java
@@ -21,18 +21,21 @@ public class SocketOperationTest {
     @Test
     public void testAddRemoveChildren() throws PropertyVetoException, Exception {
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         runTest(true, false);
     }
 
     @Test
     public void testFemaleSockets() throws PropertyVetoException, Exception {
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         runTest(false, true);
     }
 
     @Test
     public void testAddRemoveChildrenAndFemaleSockets() throws PropertyVetoException, Exception {
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         runTest(true, true);
     }
 


### PR DESCRIPTION
@bobjacobsen 
I have added this test some time ago and it fails often and I don't know why. So I try to move it to Intermittent CI.

Does Intermittent CI run with Headless? The test assumes non headless but I'm not sure that's actually needed.

Since this PR only updates a test and not the source tree, it doesn't matter if it's included in the next test release or not.