### PR TITLE
Check not null

### DIFF
--- a/java/src/jmri/jmrit/logixng/SymbolTable.java
+++ b/java/src/jmri/jmrit/logixng/SymbolTable.java
@@ -359,7 +359,7 @@ public interface SymbolTable {
                 List<Object> array = new java.util.ArrayList<>();
                 Object initialValue = array;
                 String initialValueData = initialData;
-                if (!initialValueData.isEmpty()) {
+                if ((initialValueData != null) && !initialValueData.isEmpty()) {
                     Object data = "";
                     String[] parts = initialValueData.split(":", 2);
                     if (parts.length > 1) {


### PR DESCRIPTION
When the user creates a new Global Variable or a new Local Variable in LogixNG, he uses a JTable to configure the new global variable.

If the user doesn't edit a cell, that cell might get a null value. This PR adds a check for not null in a case where it shouldn't matter whenever the value is null or empty string.

For now, the user can fix this issue by edit this cell and ensure it's an empty string. So no need to hold 4.99.8 for this.