### PR TITLE
Do not set the dirty flag during gui preferences innitialization changes

### DIFF
--- a/java/src/apps/gui3/tabbedpreferences/TabbedPreferencesFrame.java
+++ b/java/src/apps/gui3/tabbedpreferences/TabbedPreferencesFrame.java
@@ -13,7 +13,7 @@ import jmri.util.JmriJFrame;
  *<p>
  * The {@link TabbedPreferences} object is requested from the InstanceManager, and
  * if need-be created and initialized in the process of doing that.
- * 
+ *
  * @author Kevin Dickerson Copyright 2010
  * @author Bob Jacobsen Copyright 2019
  */
@@ -62,10 +62,14 @@ public class TabbedPreferencesFrame extends JmriJFrame {
             }
         }
         if (getTabbedPreferences().isDirty()) {
+            var buttons = JOptionPane.YES_NO_CANCEL_OPTION;
+            if (sdm.isShuttingDown()) {
+                buttons = JOptionPane.YES_NO_OPTION;
+            }
             switch (JOptionPane.showConfirmDialog(this,
                     Bundle.getMessage("UnsavedChangesMessage", getTabbedPreferences().getTitle()), // NOI18N
                     Bundle.getMessage("UnsavedChangesTitle"), // NOI18N
-                    JOptionPane.YES_NO_CANCEL_OPTION,
+                    buttons,
                     JOptionPane.QUESTION_MESSAGE)) {
                 case JOptionPane.YES_OPTION:
                     // save preferences

--- a/java/src/jmri/util/gui/GuiLafPreferencesManager.java
+++ b/java/src/jmri/util/gui/GuiLafPreferencesManager.java
@@ -578,9 +578,11 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesManager
      * @param dirty true if preferences need to be saved
      */
     private void setDirty(boolean dirty) {
-        boolean oldDirty = this.dirty;
-        this.dirty = dirty;
-        super.firePropertyChange(PROP_DIRTY, oldDirty, dirty);
+        if (this.initialized) {
+            boolean oldDirty = this.dirty;
+            this.dirty = dirty;
+            super.firePropertyChange(PROP_DIRTY, oldDirty, dirty);
+        }
     }
 
     /**


### PR DESCRIPTION
The locale, look and feel, and font information is set during JMRI startup and preferences initialization.  This results in the dirty flag being set.

If the preferences are then displayed later with no changes, it "appears" that changes were made and a save dialog is displayed.  