### PR TITLE
Refactor Transit and Section to interface/implementation form

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -592,5 +592,12 @@
                 found within a "jre" directory within the JMRI program directory.
                 This lets you install a JVM (JRE or JDK) locally just for
                 JMRI's use.
+            <li>The Transit and Section classes have been refactored into an
+                interface with DefaultTransit and DefaultSection implementations
+                respectively.  Similar transforms have been done to
+                TransitManager and SectionManager. None of the production code
+                nor distributed scripts needed changes, as you still create
+                and access Transits and Sections via their managers obtained
+                from the InstanceManager.
         </ul>
 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -598,6 +598,7 @@
                 TransitManager and SectionManager. None of the production code
                 nor distributed scripts needed changes, as you still create
                 and access Transits and Sections via their managers obtained
-                from the InstanceManager.
+                from the InstanceManager. The SectionType constants in Section
+                has also been converted to an enum.
         </ul>
 

--- a/java/src/jmri/Section.java
+++ b/java/src/jmri/Section.java
@@ -11,17 +11,7 @@ import javax.annotation.Nonnull;
 
 import jmri.implementation.AbstractNamedBean;
 
-import jmri.jmrit.display.layoutEditor.ConnectivityUtil; // normally these would be rolloed
-import jmri.jmrit.display.layoutEditor.HitPointType;     // up into jmri.jmrit.display.layoutEditor.*
-import jmri.jmrit.display.layoutEditor.LayoutBlock;      // but during the LE migration it's
-import jmri.jmrit.display.layoutEditor.LayoutBlockManager; // useful to be able to see
-import jmri.jmrit.display.layoutEditor.LayoutEditor;     // what specific classe are used.
-import jmri.jmrit.display.layoutEditor.LayoutSlip;
-import jmri.jmrit.display.layoutEditor.LayoutTurnout;
-import jmri.jmrit.display.layoutEditor.LevelXing;
-import jmri.jmrit.display.layoutEditor.PositionablePoint;
-import jmri.jmrit.display.layoutEditor.TrackNode;
-import jmri.jmrit.display.layoutEditor.TrackSegment;
+import jmri.jmrit.display.layoutEditor.LayoutEditor;
 
 import jmri.util.JmriJFrame;
 import jmri.util.NonNullArrayList;
@@ -89,11 +79,10 @@ import jmri.util.NonNullArrayList;
  * This Section implementation provides for delayed initialization of blocks and
  * direction sensors to be independent of order of items in panel files.
  *
- * @author Dave Duchamp Copyright (C) 2008,2010
+ * @author Dave Duchamp  Copyright (C) 2008,2010
+ * @author Bob Jacobsen  Copyright (C) 2022
  */
-public class Section extends AbstractNamedBean {
-
-    private static final NamedBean.DisplayOptions USERSYS = NamedBean.DisplayOptions.USERNAME_SYSTEMNAME;
+public interface Section extends NamedBean {
 
     /**
      * The value of {@link #getState()} if section is available for allocation.
@@ -112,14 +101,6 @@ public class Section extends AbstractNamedBean {
      */
     public static final int REVERSE = 0X08;
 
-    public Section(String systemName, String userName) {
-        super(systemName, userName);
-    }
-
-    public Section(String systemName) {
-        super(systemName);
-    }
-
     /**
      * Value representing an occupied section.
      */
@@ -131,102 +112,18 @@ public class Section extends AbstractNamedBean {
     public static final int UNOCCUPIED = Block.UNOCCUPIED;
 
     /**
-     * Persistent instance variables (saved between runs)
-     */
-    private String mForwardBlockingSensorName = "";
-    private String mReverseBlockingSensorName = "";
-    private String mForwardStoppingSensorName = "";
-    private String mReverseStoppingSensorName = "";
-    private final List<Block> mBlockEntries = new NonNullArrayList<>();
-    private final List<EntryPoint> mForwardEntryPoints = new NonNullArrayList<>();
-    private final List<EntryPoint> mReverseEntryPoints = new NonNullArrayList<>();
-
-    /**
-     * Operational instance variables (not saved between runs).
-     */
-    private int mState = FREE;
-    private int mOccupancy = UNOCCUPIED;
-    private boolean mOccupancyInitialized = false;
-    private Block mFirstBlock = null;
-    private Block mLastBlock = null;
-
-    private NamedBeanHandle<Sensor> mForwardBlockingNamedSensor = null;
-    private NamedBeanHandle<Sensor> mReverseBlockingNamedSensor = null;
-    private NamedBeanHandle<Sensor> mForwardStoppingNamedSensor = null;
-    private NamedBeanHandle<Sensor> mReverseStoppingNamedSensor = null;
-
-    private final List<PropertyChangeListener> mBlockListeners = new ArrayList<>();
-    protected jmri.NamedBeanHandleManager nbhm = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class);
-
-    /**
-     * Get the state of the Section.
-     * UNKNOWN, FORWARD, REVERSE, FREE
+     * Provide generic access to internal state.
+     * <p>
+     * This generally shouldn't be used by Java code; use the class-specific
+     * form instead (e.g. setCommandedState in Turnout). This is provided to
+     * make scripts access easier to read.
+     * <p>
+     * This isn't an exact override because it doesn't throw JmriException
      *
-     * @return the section state
+     * @param newState the state
      */
     @Override
-    public int getState() {
-        return mState;
-    }
-
-    /**
-     * Set the state of the Section.
-     * FREE, FORWARD or REVERSE.
-     * <br>
-     * UNKNOWN state not accepted here.
-     * @param state the state to set
-     */
-    @Override
-    public void setState(int state) {
-        if ((state == Section.FREE) || (state == Section.FORWARD) || (state == Section.REVERSE)) {
-            int old = mState;
-            mState = state;
-            firePropertyChange("state", old, mState);
-            // update the forward/reverse blocking sensors as needed
-            switch (state) {
-                case FORWARD:
-                    try {
-                        if ((getForwardBlockingSensor() != null) && (getForwardBlockingSensor().getState() != Sensor.INACTIVE)) {
-                            getForwardBlockingSensor().setState(Sensor.INACTIVE);
-                        }
-                        if ((getReverseBlockingSensor() != null) && (getReverseBlockingSensor().getState() != Sensor.ACTIVE)) {
-                            getReverseBlockingSensor().setKnownState(Sensor.ACTIVE);
-                        }
-                    } catch (jmri.JmriException reason) {
-                        log.error("Exception when setting Sensors for Section {}", getDisplayName(USERSYS));
-                    }
-                    break;
-                case REVERSE:
-                    try {
-                        if ((getReverseBlockingSensor() != null) && (getReverseBlockingSensor().getState() != Sensor.INACTIVE)) {
-                            getReverseBlockingSensor().setKnownState(Sensor.INACTIVE);
-                        }
-                        if ((getForwardBlockingSensor() != null) && (getForwardBlockingSensor().getState() != Sensor.ACTIVE)) {
-                            getForwardBlockingSensor().setKnownState(Sensor.ACTIVE);
-                        }
-                    } catch (jmri.JmriException reason) {
-                        log.error("Exception when setting Sensors for Section {}", getDisplayName(USERSYS));
-                    }
-                    break;
-                case FREE:
-                    try {
-                        if ((getForwardBlockingSensor() != null) && (getForwardBlockingSensor().getState() != Sensor.ACTIVE)) {
-                            getForwardBlockingSensor().setKnownState(Sensor.ACTIVE);
-                        }
-                        if ((getReverseBlockingSensor() != null) && (getReverseBlockingSensor().getState() != Sensor.ACTIVE)) {
-                            getReverseBlockingSensor().setKnownState(Sensor.ACTIVE);
-                        }
-                    } catch (jmri.JmriException reason) {
-                        log.error("Exception when setting Sensors for Section {}", getDisplayName(USERSYS));
-                    }
-                    break;
-                default:
-                    break;
-            }
-        } else {
-            log.error("Attempt to set state of Section {} to illegal value - {}", getDisplayName(USERSYS), state);
-        }
-    }
+    public void setState(int newState);
 
     /**
      * Get the occupancy of a Section.
@@ -234,253 +131,44 @@ public class Section extends AbstractNamedBean {
      * @return {@link #OCCUPIED}, {@link #UNOCCUPIED}, or the state of the first
      *         block that is neither occupied or unoccupied
      */
-    public int getOccupancy() {
-        if (mOccupancyInitialized) {
-            return mOccupancy;
-        }
-        // initialize occupancy
-        mOccupancy = UNOCCUPIED;
-        for (Block block : mBlockEntries) {
-            if (block.getState() == OCCUPIED) {
-                mOccupancy = OCCUPIED;
-            } else if (block.getState() != UNOCCUPIED) {
-                log.warn("Occupancy of block {} is not OCCUPIED or UNOCCUPIED in Section - {}",
-                        block.getDisplayName(USERSYS), getDisplayName(USERSYS));
-                return (block.getState());
-            }
-        }
-        mOccupancyInitialized = true;
-        return mOccupancy;
-    }
+    public int getOccupancy();
 
-    private void setOccupancy(int occupancy) {
-        int old = mOccupancy;
-        mOccupancy = occupancy;
-        firePropertyChange("occupancy", old, mOccupancy);
-    }
+    public String getForwardBlockingSensorName();
 
-    public String getForwardBlockingSensorName() {
-        if (mForwardBlockingNamedSensor != null) {
-            return mForwardBlockingNamedSensor.getName();
-        }
-        return mForwardBlockingSensorName;
-    }
+    public Sensor getForwardBlockingSensor();
 
-    public Sensor getForwardBlockingSensor() {
-        if (mForwardBlockingNamedSensor != null) {
-            return mForwardBlockingNamedSensor.getBean();
-        }
-        if ((mForwardBlockingSensorName != null)
-                && (!mForwardBlockingSensorName.isEmpty())) {
-            Sensor s = InstanceManager.sensorManagerInstance().
-                    getSensor(mForwardBlockingSensorName);
-            if (s == null) {
-                log.error("Missing Sensor - {} - when initializing Section - {}",
-                        mForwardBlockingSensorName, getDisplayName(USERSYS));
-                return null;
-            }
-            mForwardBlockingNamedSensor = nbhm.getNamedBeanHandle(mForwardBlockingSensorName, s);
-            return s;
-        }
-        return null;
-    }
+    public Sensor setForwardBlockingSensorName(String forwardSensor);
 
-    public Sensor setForwardBlockingSensorName(String forwardSensor) {
-        if ((forwardSensor == null) || (forwardSensor.length() <= 0)) {
-            mForwardBlockingSensorName = "";
-            mForwardBlockingNamedSensor = null;
-            return null;
-        }
-        tempSensorName = forwardSensor;
-        Sensor s = validateSensor();
-        if (s == null) {
-            // sensor name not correct or not in sensor table
-            log.error("Sensor name - {} invalid when setting forward sensor in Section {}",
-                    forwardSensor, getDisplayName(USERSYS));
-            return null;
-        }
-        mForwardBlockingNamedSensor = nbhm.getNamedBeanHandle(tempSensorName, s);
-        mForwardBlockingSensorName = tempSensorName;
-        return s;
-    }
+    public void delayedSetForwardBlockingSensorName(String forwardSensor);
 
-    public void delayedSetForwardBlockingSensorName(String forwardSensor) {
-        mForwardBlockingSensorName = forwardSensor;
-    }
+    public String getReverseBlockingSensorName();
 
-    public String getReverseBlockingSensorName() {
-        if (mReverseBlockingNamedSensor != null) {
-            return mReverseBlockingNamedSensor.getName();
-        }
-        return mReverseBlockingSensorName;
-    }
+    public Sensor setReverseBlockingSensorName(String reverseSensor);
 
-    public Sensor setReverseBlockingSensorName(String reverseSensor) {
-        if ((reverseSensor == null) || (reverseSensor.length() <= 0)) {
-            mReverseBlockingNamedSensor = null;
-            mReverseBlockingSensorName = "";
-            return null;
-        }
-        tempSensorName = reverseSensor;
-        Sensor s = validateSensor();
-        if (s == null) {
-            // sensor name not correct or not in sensor table
-            log.error("Sensor name - {} invalid when setting reverse sensor in Section {}",
-                    reverseSensor, getDisplayName(USERSYS));
-            return null;
-        }
-        mReverseBlockingNamedSensor = nbhm.getNamedBeanHandle(tempSensorName, s);
-        mReverseBlockingSensorName = tempSensorName;
-        return s;
-    }
+    public void delayedSetReverseBlockingSensorName(String reverseSensor);
 
-    public void delayedSetReverseBlockingSensorName(String reverseSensor) {
-        mReverseBlockingSensorName = reverseSensor;
-    }
+    public Sensor getReverseBlockingSensor();
 
-    public Sensor getReverseBlockingSensor() {
-        if (mReverseBlockingNamedSensor != null) {
-            return mReverseBlockingNamedSensor.getBean();
-        }
-        if ((mReverseBlockingSensorName != null)
-                && (!mReverseBlockingSensorName.isEmpty())) {
-            Sensor s = InstanceManager.sensorManagerInstance().
-                    getSensor(mReverseBlockingSensorName);
-            if (s == null) {
-                log.error("Missing Sensor - {} - when initializing Section - {}",
-                        mReverseBlockingSensorName, getDisplayName(USERSYS));
-                return null;
-            }
-            mReverseBlockingNamedSensor = nbhm.getNamedBeanHandle(mReverseBlockingSensorName, s);
-            return s;
-        }
-        return null;
-    }
+    public Block getLastBlock();
 
-    public Block getLastBlock() {
-        return mLastBlock;
-    }
-
-    private String tempSensorName = "";
+    public String getForwardStoppingSensorName();
 
     @CheckForNull
-    private Sensor validateSensor() {
-        // check if anything entered
-        if (tempSensorName.length() < 1) {
-            // no sensor specified
-            return null;
-        }
-        // get the sensor corresponding to this name
-        Sensor s = InstanceManager.sensorManagerInstance().getSensor(tempSensorName);
-        if (s == null) {
-            return null;
-        }
-        if (!tempSensorName.equals(s.getUserName()) && s.getUserName() != null) {
-            tempSensorName = s.getUserName();
-        }
-        return s;
-    }
+    public Sensor getForwardStoppingSensor();
 
-    public String getForwardStoppingSensorName() {
-        if (mForwardStoppingNamedSensor != null) {
-            return mForwardStoppingNamedSensor.getName();
-        }
-        return mForwardStoppingSensorName;
-    }
+    public Sensor setForwardStoppingSensorName(String forwardSensor);
+
+    public void delayedSetForwardStoppingSensorName(String forwardSensor);
+
+    public String getReverseStoppingSensorName();
 
     @CheckForNull
-    public Sensor getForwardStoppingSensor() {
-        if (mForwardStoppingNamedSensor != null) {
-            return mForwardStoppingNamedSensor.getBean();
-        }
-        if ((mForwardStoppingSensorName != null)
-                && (!mForwardStoppingSensorName.isEmpty())) {
-            Sensor s = InstanceManager.sensorManagerInstance().
-                    getSensor(mForwardStoppingSensorName);
-            if (s == null) {
-                log.error("Missing Sensor - {} - when initializing Section - {}",
-                        mForwardStoppingSensorName, getDisplayName(USERSYS));
-                return null;
-            }
-            mForwardStoppingNamedSensor = nbhm.getNamedBeanHandle(mForwardStoppingSensorName, s);
-            return s;
-        }
-        return null;
-    }
+    public Sensor setReverseStoppingSensorName(String reverseSensor);
 
-    public Sensor setForwardStoppingSensorName(String forwardSensor) {
-        if ((forwardSensor == null) || (forwardSensor.length() <= 0)) {
-            mForwardStoppingNamedSensor = null;
-            mForwardStoppingSensorName = "";
-            return null;
-        }
-        tempSensorName = forwardSensor;
-        Sensor s = validateSensor();
-        if (s == null) {
-            // sensor name not correct or not in sensor table
-            log.error("Sensor name - {} invalid when setting forward sensor in Section {}",
-                    forwardSensor, getDisplayName(USERSYS));
-            return null;
-        }
-        mForwardStoppingNamedSensor = nbhm.getNamedBeanHandle(tempSensorName, s);
-        mForwardStoppingSensorName = tempSensorName;
-        return s;
-    }
-
-    public void delayedSetForwardStoppingSensorName(String forwardSensor) {
-        mForwardStoppingSensorName = forwardSensor;
-    }
-
-    public String getReverseStoppingSensorName() {
-        if (mReverseStoppingNamedSensor != null) {
-            return mReverseStoppingNamedSensor.getName();
-        }
-        return mReverseStoppingSensorName;
-    }
+    public void delayedSetReverseStoppingSensorName(String reverseSensor);
 
     @CheckForNull
-    public Sensor setReverseStoppingSensorName(String reverseSensor) {
-        if ((reverseSensor == null) || (reverseSensor.length() <= 0)) {
-            mReverseStoppingNamedSensor = null;
-            mReverseStoppingSensorName = "";
-            return null;
-        }
-        tempSensorName = reverseSensor;
-        Sensor s = validateSensor();
-        if (s == null) {
-            // sensor name not correct or not in sensor table
-            log.error("Sensor name - {} invalid when setting reverse sensor in Section {}",
-                    reverseSensor, getDisplayName(USERSYS));
-            return null;
-        }
-        mReverseStoppingNamedSensor = nbhm.getNamedBeanHandle(tempSensorName, s);
-        mReverseStoppingSensorName = tempSensorName;
-        return s;
-    }
-
-    public void delayedSetReverseStoppingSensorName(String reverseSensor) {
-        mReverseStoppingSensorName = reverseSensor;
-    }
-
-    @CheckForNull
-    public Sensor getReverseStoppingSensor() {
-        if (mReverseStoppingNamedSensor != null) {
-            return mReverseStoppingNamedSensor.getBean();
-        }
-        if ((mReverseStoppingSensorName != null)
-                && (!mReverseStoppingSensorName.isEmpty())) {
-            Sensor s = InstanceManager.sensorManagerInstance().
-                    getSensor(mReverseStoppingSensorName);
-            if (s == null) {
-                log.error("Missing Sensor - {}  - when initializing Section - {}",
-                        mReverseStoppingSensorName, getDisplayName(USERSYS));
-                return null;
-            }
-            mReverseStoppingNamedSensor = nbhm.getNamedBeanHandle(mReverseStoppingSensorName, s);
-            return s;
-        }
-        return null;
-    }
+    public Sensor getReverseStoppingSensor();
 
     /**
      * Add a Block to the Section. Block and sequence number must be unique
@@ -491,88 +179,9 @@ public class Section extends AbstractNamedBean {
      * @return true if Block was added or false if Block does not connect to the
      *         current Block, or the Block is not unique.
      */
-    public boolean addBlock(Block b) {
-        // validate that this entry is unique, if not first.
-        if (mBlockEntries.isEmpty()) {
-            mFirstBlock = b;
-        } else {
-            // check that block is unique
-            for (Block block : mBlockEntries) {
-                if (block == b) {
-                    return false; // already present
-                }            // Note: connectivity to current block is assumed to have been checked
-            }
-        }
+    public boolean addBlock(Block b);
 
-        // a lot of this code searches for blocks by their user name.
-        // warn if there isn't one.
-        if (b.getUserName() == null) {
-            log.warn("Block {} does not have a user name, may not work correctly in Section {}",
-                    b.getDisplayName(USERSYS), getDisplayName(USERSYS));
-        }
-        // add Block to the Block list
-        mBlockEntries.add(b);
-        mLastBlock = b;
-        // check occupancy
-        if (b.getState() == OCCUPIED) {
-            if (mOccupancy != OCCUPIED) {
-                setOccupancy(OCCUPIED);
-            }
-        }
-        PropertyChangeListener listener = (PropertyChangeEvent e) -> {
-            handleBlockChange(e);
-        };
-        b.addPropertyChangeListener(listener);
-        mBlockListeners.add(listener);
-        return true;
-    }
-    private boolean initializationNeeded = false;
-    private final List<String> blockNameList = new ArrayList<>();
-
-    public void delayedAddBlock(String blockName) {
-        initializationNeeded = true;
-        blockNameList.add(blockName);
-    }
-
-    private void initializeBlocks() {
-        for (int i = 0; i < blockNameList.size(); i++) {
-            Block b = InstanceManager.getDefault(jmri.BlockManager.class).getBlock(blockNameList.get(i));
-            if (b == null) {
-                log.error("Missing Block - {} - when initializing Section - {}",
-                        blockNameList.get(i), getDisplayName(USERSYS));
-            } else {
-                if (mBlockEntries.isEmpty()) {
-                    mFirstBlock = b;
-                }
-                mBlockEntries.add(b);
-                mLastBlock = b;
-                PropertyChangeListener listener = (PropertyChangeEvent e) -> {
-                    handleBlockChange(e);
-                };
-                b.addPropertyChangeListener(listener);
-                mBlockListeners.add(listener);
-            }
-        }
-        initializationNeeded = false;
-    }
-
-    /**
-     * Handle change in occupancy of a Block in the Section.
-     *
-     * @param e event with change
-     */
-    void handleBlockChange(PropertyChangeEvent e) {
-        int o = UNOCCUPIED;
-        for (Block block : mBlockEntries) {
-            if (block.getState() == OCCUPIED) {
-                o = OCCUPIED;
-                break;
-            }
-        }
-        if (mOccupancy != o) {
-            setOccupancy(o);
-        }
-    }
+    public void delayedAddBlock(String blockName);
 
     /**
      * Get a list of blocks in this section
@@ -580,24 +189,14 @@ public class Section extends AbstractNamedBean {
      * @return a list of blocks
      */
     @Nonnull
-    public List<Block> getBlockList() {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        return new ArrayList<>(mBlockEntries);
-    }
+    public List<Block> getBlockList();
 
     /**
      * Gets the number of Blocks in this Section
      *
      * @return the number of blocks
      */
-    public int getNumBlocks() {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        return mBlockEntries.size();
-    }
+    public int getNumBlocks();
 
     /**
      * Get the scale length of Section. Length of the Section is calculated by
@@ -608,40 +207,16 @@ public class Section extends AbstractNamedBean {
      * @param scale  the scale; one of {@link jmri.Scale}
      * @return the scale length
      */
-    public float getLengthF(boolean meters, Scale scale) {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        float length = 0.0f;
-        for (Block block : mBlockEntries) {
-            length = length + block.getLengthMm();
-        }
-        length = length / (float) (scale.getScaleFactor());
-        if (meters) {
-            return (length * 0.001f);
-        }
-        return (length * 0.00328084f);
-    }
+    public float getLengthF(boolean meters, Scale scale);
 
-    public int getLengthI(boolean meters, Scale scale) {
-        return ((int) ((getLengthF(meters, scale) + 0.5f)));
-    }
+    public int getLengthI(boolean meters, Scale scale);
 
     /**
      * Gets the actual length of the Section without any scaling
      *
      * @return the real length in millimeters
      */
-    public int getActualLength() {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        int len = 0;
-        for (Block b : mBlockEntries) {
-            len = len + ((int) b.getLengthMm());
-        }
-        return len;
-    }
+    public int getActualLength();
 
     /**
      * Get Block by its Sequence number in the Section.
@@ -650,15 +225,7 @@ public class Section extends AbstractNamedBean {
      * @return the block or null if the sequence number is invalid
      */
     @CheckForNull
-    public Block getBlockBySequenceNumber(int seqNumber) {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        if ((seqNumber < mBlockEntries.size()) && (seqNumber >= 0)) {
-            return mBlockEntries.get(seqNumber);
-        }
-        return null;
-    }
+    public Block getBlockBySequenceNumber(int seqNumber);
 
     /**
      * Get the sequence number of a Block.
@@ -666,180 +233,45 @@ public class Section extends AbstractNamedBean {
      * @param b the block to get the sequence of
      * @return the sequence number of b or -1 if b is not in the Section
      */
-    public int getBlockSequenceNumber(Block b) {
-        for (int i = 0; i < mBlockEntries.size(); i++) {
-            if (b == mBlockEntries.get(i)) {
-                return i;
-            }
-        }
-        return -1;
-    }
+    public int getBlockSequenceNumber(Block b);
 
     /**
      * Remove all Blocks, Block Listeners, and Entry Points
      */
-    public void removeAllBlocksFromSection() {
-        for (int i = mBlockEntries.size(); i > 0; i--) {
-            Block b = mBlockEntries.get(i - 1);
-            b.removePropertyChangeListener(mBlockListeners.get(i - 1));
-            mBlockListeners.remove(i - 1);
-            mBlockEntries.remove(i - 1);
-        }
-        for (int i = mForwardEntryPoints.size(); i > 0; i--) {
-            mForwardEntryPoints.remove(i - 1);
-        }
-        for (int i = mReverseEntryPoints.size(); i > 0; i--) {
-            mReverseEntryPoints.remove(i - 1);
-        }
-        initializationNeeded = false;
-    }
-    /**
-     * Gets Blocks in order. If state is FREE or FORWARD, returns Blocks in
-     * forward order. If state is REVERSE, returns Blocks in reverse order.
-     * First call getEntryBlock, then call getNextBlock until null is returned.
-     */
-    private int blockIndex = 0;  // index of last block returned
+    public void removeAllBlocksFromSection();
 
     @CheckForNull
-    public Block getEntryBlock() {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        if (mBlockEntries.size() <= 0) {
-            return null;
-        }
-        if (mState == REVERSE) {
-            blockIndex = mBlockEntries.size();
-        } else {
-            blockIndex = 1;
-        }
-        return mBlockEntries.get(blockIndex - 1);
-    }
+    public Block getEntryBlock();
 
     @CheckForNull
-    public Block getNextBlock() {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        if (mState == REVERSE) {
-            blockIndex--;
-        } else {
-            blockIndex++;
-        }
-        if ((blockIndex > mBlockEntries.size()) || (blockIndex <= 0)) {
-            return null;
-        }
-        return mBlockEntries.get(blockIndex - 1);
-    }
+    public Block getNextBlock();
 
     @CheckForNull
-    public Block getExitBlock() {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        if (mBlockEntries.size() <= 0) {
-            return null;
-        }
-        if (mState == REVERSE) {
-            blockIndex = 1;
-        } else {
-            blockIndex = mBlockEntries.size();
-        }
-        return mBlockEntries.get(blockIndex - 1);
-    }
+    public Block getExitBlock();
 
-    public boolean containsBlock(Block b) {
-        for (Block block : mBlockEntries) {
-            if (b == block) {
-                return true;
-            }
-        }
-        return false;
-    }
+    public boolean containsBlock(Block b);
 
-    public boolean connectsToBlock(Block b) {
-        if (mForwardEntryPoints.stream().anyMatch((ep) -> (ep.getFromBlock() == b))) {
-            return true;
-        }
-        return mReverseEntryPoints.stream().anyMatch((ep) -> (ep.getFromBlock() == b));
-    }
+    public boolean connectsToBlock(Block b);
 
-    public String getBeginBlockName() {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        if (mFirstBlock == null) {
-            return "unknown";
-        }
-        return mFirstBlock.getDisplayName();
-    }
+    public String getBeginBlockName();
 
-    public String getEndBlockName() {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        if (mLastBlock == null) {
-            return "unknown";
-        }
-        return mLastBlock.getDisplayName();
-    }
+    public String getEndBlockName();
 
-    public void addToForwardList(EntryPoint ep) {
-        if (ep != null) {
-            mForwardEntryPoints.add(ep);
-        }
-    }
+    public void addToForwardList(EntryPoint ep);
 
-    public void addToReverseList(EntryPoint ep) {
-        if (ep != null) {
-            mReverseEntryPoints.add(ep);
-        }
-    }
+    public void addToReverseList(EntryPoint ep);
 
-    public void removeEntryPoint(EntryPoint ep) {
-        for (int i = mForwardEntryPoints.size(); i > 0; i--) {
-            if (mForwardEntryPoints.get(i - 1) == ep) {
-                mForwardEntryPoints.remove(i - 1);
-            }
-        }
-        for (int i = mReverseEntryPoints.size(); i > 0; i--) {
-            if (mReverseEntryPoints.get(i - 1) == ep) {
-                mReverseEntryPoints.remove(i - 1);
-            }
-        }
-    }
+    public void removeEntryPoint(EntryPoint ep);
 
-    public List<EntryPoint> getForwardEntryPointList() {
-        return new ArrayList<>(this.mForwardEntryPoints);
-    }
+    public List<EntryPoint> getForwardEntryPointList();
 
-    public List<EntryPoint> getReverseEntryPointList() {
-        return new ArrayList<>(this.mReverseEntryPoints);
-    }
+    public List<EntryPoint> getReverseEntryPointList();
 
-    public List<EntryPoint> getEntryPointList() {
-        List<EntryPoint> list = new ArrayList<>(this.mForwardEntryPoints);
-        list.addAll(this.mReverseEntryPoints);
-        return list;
-    }
+    public List<EntryPoint> getEntryPointList();
 
-    public boolean isForwardEntryPoint(EntryPoint ep) {
-        for (int i = 0; i < mForwardEntryPoints.size(); i++) {
-            if (ep == mForwardEntryPoints.get(i)) {
-                return true;
-            }
-        }
-        return false;
-    }
+    public boolean isForwardEntryPoint(EntryPoint ep);
 
-    public boolean isReverseEntryPoint(EntryPoint ep) {
-        for (int i = 0; i < mReverseEntryPoints.size(); i++) {
-            if (ep == mReverseEntryPoints.get(i)) {
-                return true;
-            }
-        }
-        return false;
-    }
+    public boolean isReverseEntryPoint(EntryPoint ep);
 
     /**
      * Get the EntryPoint for entry from the specified Section for travel in
@@ -851,22 +283,7 @@ public class Section extends AbstractNamedBean {
      * @return the entry point or null if not found
      */
     @CheckForNull
-    public EntryPoint getEntryPointFromSection(Section s, int dir) {
-        if (dir == FORWARD) {
-            for (EntryPoint ep : mForwardEntryPoints) {
-                if (s.containsBlock(ep.getFromBlock())) {
-                    return ep;
-                }
-            }
-        } else if (dir == REVERSE) {
-            for (EntryPoint ep : mReverseEntryPoints) {
-                if (s.containsBlock(ep.getFromBlock())) {
-                    return ep;
-                }
-            }
-        }
-        return null;
-    }
+    public EntryPoint getEntryPointFromSection(Section s, int dir);
 
     /**
      * Get the EntryPoint for exit to specified Section for travel in the
@@ -878,25 +295,7 @@ public class Section extends AbstractNamedBean {
      * @return the entry point or null if not found
      */
     @CheckForNull
-    public EntryPoint getExitPointToSection(Section s, int dir) {
-        if (s == null) {
-            return null;
-        }
-        if (dir == REVERSE) {
-            for (EntryPoint ep : mForwardEntryPoints) {
-                if (s.containsBlock(ep.getFromBlock())) {
-                    return ep;
-                }
-            }
-        } else if (dir == FORWARD) {
-            for (EntryPoint ep : mReverseEntryPoints) {
-                if (s.containsBlock(ep.getFromBlock())) {
-                    return ep;
-                }
-            }
-        }
-        return null;
-    }
+    public EntryPoint getExitPointToSection(Section s, int dir);
 
     /**
      * Get the EntryPoint for entry from the specified Block for travel in the
@@ -908,22 +307,7 @@ public class Section extends AbstractNamedBean {
      * @return the entry point or null if not found
      */
     @CheckForNull
-    public EntryPoint getEntryPointFromBlock(Block b, int dir) {
-        if (dir == FORWARD) {
-            for (EntryPoint ep : mForwardEntryPoints) {
-                if (b == ep.getFromBlock()) {
-                    return ep;
-                }
-            }
-        } else if (dir == REVERSE) {
-            for (EntryPoint ep : mReverseEntryPoints) {
-                if (b == ep.getFromBlock()) {
-                    return ep;
-                }
-            }
-        }
-        return null;
-    }
+    public EntryPoint getEntryPointFromBlock(Block b, int dir);
 
     /**
      * Get the EntryPoint for exit to the specified Block for travel in the
@@ -935,724 +319,7 @@ public class Section extends AbstractNamedBean {
      * @return the entry point or null if not found
      */
     @CheckForNull
-    public EntryPoint getExitPointToBlock(Block b, int dir) {
-        if (dir == REVERSE) {
-            for (EntryPoint ep : mForwardEntryPoints) {
-                if (b == ep.getFromBlock()) {
-                    return ep;
-                }
-            }
-        } else if (dir == FORWARD) {
-            for (EntryPoint ep : mReverseEntryPoints) {
-                if (b == ep.getFromBlock()) {
-                    return ep;
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Returns EntryPoint.FORWARD if proceeding from the throat to the other end
-     * is movement in the forward direction. Returns EntryPoint.REVERSE if
-     * proceeding from the throat to the other end is movement in the reverse
-     * direction. Returns EntryPoint.UNKNOWN if cannot determine direction. This
-     * should only happen if blocks are not set up correctly--if all connections
-     * go to the same Block, or not all Blocks set. An error message is logged
-     * if EntryPoint.UNKNOWN is returned.
-     */
-    private int getDirectionStandardTurnout(LayoutTurnout t, ConnectivityUtil cUtil) {
-        LayoutBlock aBlock = ((TrackSegment) t.getConnectA()).getLayoutBlock();
-        LayoutBlock bBlock = ((TrackSegment) t.getConnectB()).getLayoutBlock();
-        LayoutBlock cBlock = ((TrackSegment) t.getConnectC()).getLayoutBlock();
-        if ((aBlock == null) || (bBlock == null) || (cBlock == null)) {
-            log.error("All blocks not assigned for track segments connecting to turnout - {}.",
-                    t.getTurnout().getDisplayName(USERSYS));
-            return EntryPoint.UNKNOWN;
-        }
-        Block exBlock = checkDualDirection(aBlock, bBlock, cBlock);
-        if ((exBlock != null) || ((aBlock == bBlock) && (aBlock == cBlock))) {
-            // using Entry Points directly will lead to a problem, try following track - first from A following B
-            int dir = EntryPoint.UNKNOWN;
-            Block tBlock = null;
-            TrackNode tn = new TrackNode(t, HitPointType.TURNOUT_A, (TrackSegment) t.getConnectA(),
-                    false, Turnout.CLOSED);
-            while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                tn = cUtil.getNextNode(tn, 0);
-                tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock);
-            }
-            if (tBlock == null) {
-                // try from A following C
-                tn = new TrackNode(t, HitPointType.TURNOUT_A, (TrackSegment) t.getConnectA(),
-                        false, Turnout.THROWN);
-                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                    tn = cUtil.getNextNode(tn, 0);
-                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock);
-                }
-            }
-            if (tBlock != null) {
-                String userName = tBlock.getUserName();
-                if (userName != null) {
-                    LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                    if (lb != null) {
-                        dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
-                    }
-                }
-            }
-            if (dir == EntryPoint.UNKNOWN) {
-                // try from B following A
-                tBlock = null;
-                tn = new TrackNode(t, HitPointType.TURNOUT_B, (TrackSegment) t.getConnectB(),
-                        false, Turnout.CLOSED);
-                while ((tBlock == null) && (tn != null && (!tn.reachedEndOfTrack()))) {
-                    tn = cUtil.getNextNode(tn, 0);
-                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock);
-                }
-                if (tBlock != null) {
-                    String userName = tBlock.getUserName();
-                    if (userName != null) {
-                        LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                        if (lb != null) {
-                            dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, lb);
-                        }
-                    }
-                }
-            }
-            if (dir == EntryPoint.UNKNOWN) {
-                log.error("Block definition ambiguity - cannot determine direction of Turnout {} in Section {}",
-                        t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
-            }
-            return dir;
-        }
-        if ((aBlock != bBlock) && containsBlock(aBlock.getBlock()) && containsBlock(bBlock.getBlock())) {
-            // both blocks are different, but are in this Section
-            if (getBlockSequenceNumber(aBlock.getBlock()) < getBlockSequenceNumber(bBlock.getBlock())) {
-                return EntryPoint.FORWARD;
-            } else {
-                return EntryPoint.REVERSE;
-            }
-        } else if ((aBlock != cBlock) && containsBlock(aBlock.getBlock()) && containsBlock(cBlock.getBlock())) {
-            // both blocks are different, but are in this Section
-            if (getBlockSequenceNumber(aBlock.getBlock()) < getBlockSequenceNumber(cBlock.getBlock())) {
-                return EntryPoint.FORWARD;
-            } else {
-                return EntryPoint.REVERSE;
-            }
-        }
-        LayoutBlock tBlock = t.getLayoutBlock();
-        if (tBlock == null) {
-            log.error("Block not assigned for turnout {}", t.getTurnout().getDisplayName(USERSYS));
-            return EntryPoint.UNKNOWN;
-        }
-        if (containsBlock(aBlock.getBlock()) && (!containsBlock(bBlock.getBlock()))) {
-            // aBlock is in Section, bBlock is not
-            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, bBlock);
-            if (dir != EntryPoint.UNKNOWN) {
-                return dir;
-            }
-            if ((tBlock != bBlock) && (!containsBlock(tBlock.getBlock()))) {
-                dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, tBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-        }
-        if (containsBlock(aBlock.getBlock()) && (!containsBlock(cBlock.getBlock()))) {
-            // aBlock is in Section, cBlock is not
-            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, cBlock);
-            if (dir != EntryPoint.UNKNOWN) {
-                return dir;
-            }
-            if ((tBlock != cBlock) && (!containsBlock(tBlock.getBlock()))) {
-                dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, tBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-        }
-        if ((containsBlock(bBlock.getBlock()) || containsBlock(cBlock.getBlock()))
-                && (!containsBlock(aBlock.getBlock()))) {
-            // bBlock or cBlock is in Section, aBlock is not
-            int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, aBlock);
-            if (dir != EntryPoint.UNKNOWN) {
-                return dir;
-            }
-            if ((tBlock != aBlock) && (!containsBlock(tBlock.getBlock()))) {
-                dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, tBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-        }
-        if (!containsBlock(aBlock.getBlock()) && !containsBlock(bBlock.getBlock()) && !containsBlock(cBlock.getBlock()) && containsBlock(tBlock.getBlock())) {
-            //is the turnout in a section of its own?
-            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, aBlock);
-            return dir;
-        }
-
-        // should never get here
-        log.error("Unexpected error in getDirectionStandardTurnout when working with turnout {}",
-                t.getTurnout().getDisplayName(USERSYS));
-        return EntryPoint.UNKNOWN;
-    }
-
-    /**
-     * Returns EntryPoint.FORWARD if proceeding from A to B (or D to C) is
-     * movement in the forward direction. Returns EntryPoint.REVERSE if
-     * proceeding from A to B (or D to C) is movement in the reverse direction.
-     * Returns EntryPoint.UNKNOWN if cannot determine direction. This should
-     * only happen if blocks are not set up correctly--if all connections go to
-     * the same Block, or not all Blocks set. An error message is logged if
-     * EntryPoint.UNKNOWN is returned.
-     */
-    private int getDirectionXoverTurnout(LayoutTurnout t, ConnectivityUtil cUtil) {
-        LayoutBlock aBlock = ((TrackSegment) t.getConnectA()).getLayoutBlock();
-        LayoutBlock bBlock = ((TrackSegment) t.getConnectB()).getLayoutBlock();
-        LayoutBlock cBlock = ((TrackSegment) t.getConnectC()).getLayoutBlock();
-        LayoutBlock dBlock = ((TrackSegment) t.getConnectD()).getLayoutBlock();
-        if ((aBlock == null) || (bBlock == null) || (cBlock == null) || (dBlock == null)) {
-            log.error("All blocks not assigned for track segments connecting to crossover turnout - {}.",
-                    t.getTurnout().getDisplayName(USERSYS));
-            return EntryPoint.UNKNOWN;
-        }
-        if ((aBlock == bBlock) && (aBlock == cBlock) && (aBlock == dBlock)) {
-            log.error("Block setup problem - All track segments connecting to crossover turnout - {} are assigned to the same Block.",
-                    t.getTurnout().getDisplayName(USERSYS));
-            return EntryPoint.UNKNOWN;
-        }
-        if ((containsBlock(aBlock.getBlock())) || (containsBlock(bBlock.getBlock()))) {
-            LayoutBlock exBlock = null;
-            if (aBlock == bBlock) {
-                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER) && (cBlock == dBlock)) {
-                    exBlock = cBlock;
-                }
-            }
-            if (exBlock != null) {
-                // set direction by tracking from a or b
-                int dir = EntryPoint.UNKNOWN;
-                Block tBlock = null;
-                TrackNode tn = new TrackNode(t, HitPointType.TURNOUT_A, (TrackSegment) t.getConnectA(),
-                        false, Turnout.CLOSED);
-                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                    tn = cUtil.getNextNode(tn, 0);
-                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
-                }
-                if (tBlock != null) {
-                    String userName = tBlock.getUserName();
-                    if (userName != null) {
-                        LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                        if (lb != null) {
-                            dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
-                        }
-                    }
-                } else { // no tBlock found on leg A
-                    tn = new TrackNode(t, HitPointType.TURNOUT_B, (TrackSegment) t.getConnectB(),
-                            false, Turnout.CLOSED);
-                    while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                        tn = cUtil.getNextNode(tn, 0);
-                        tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
-                    }
-                    if (tBlock != null) {
-                        String userName = tBlock.getUserName();
-                        if (userName != null) {
-                            LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                            if (lb != null) {
-                                dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, lb);
-                            }
-                        }
-                    }
-                }
-                if (dir == EntryPoint.UNKNOWN) {
-                    log.error("Block definition ambiguity - cannot determine direction of crossover Turnout {} in Section {}",
-                            t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
-                }
-                return dir;
-            }
-            if ((aBlock != bBlock) && containsBlock(aBlock.getBlock()) && containsBlock(bBlock.getBlock())) {
-                if (getBlockSequenceNumber(aBlock.getBlock()) < getBlockSequenceNumber(bBlock.getBlock())) {
-                    return EntryPoint.FORWARD;
-                } else {
-                    return EntryPoint.REVERSE;
-                }
-            }
-            if (containsBlock(aBlock.getBlock()) && (!containsBlock(bBlock.getBlock()))) {
-                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, bBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-            if (containsBlock(bBlock.getBlock()) && (!containsBlock(aBlock.getBlock()))) {
-                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, aBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-            if ((t.getTurnoutType() != LayoutTurnout.TurnoutType.LH_XOVER) && containsBlock(aBlock.getBlock())
-                    && (!containsBlock(cBlock.getBlock()))) {
-                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, cBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-            if ((t.getTurnoutType() != LayoutTurnout.TurnoutType.RH_XOVER) && containsBlock(bBlock.getBlock())
-                    && (!containsBlock(dBlock.getBlock()))) {
-                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, dBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-        }
-        if ((containsBlock(dBlock.getBlock())) || (containsBlock(cBlock.getBlock()))) {
-            LayoutBlock exBlock = null;
-            if (dBlock == cBlock) {
-                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER) && (bBlock == aBlock)) {
-                    exBlock = aBlock;
-                }
-            }
-            if (exBlock != null) {
-                // set direction by tracking from c or d
-                int dir = EntryPoint.UNKNOWN;
-                Block tBlock = null;
-                TrackNode tn = new TrackNode(t, HitPointType.TURNOUT_D, (TrackSegment) t.getConnectD(),
-                        false, Turnout.CLOSED);
-                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                    tn = cUtil.getNextNode(tn, 0);
-                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
-                }
-                if (tBlock != null) {
-                    String userName = tBlock.getUserName();
-                    if (userName != null) {
-                        LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                        if (lb != null) {
-                            dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
-                        }
-                    }
-                } else {
-                    tn = new TrackNode(t, HitPointType.TURNOUT_C, (TrackSegment) t.getConnectC(),
-                            false, Turnout.CLOSED);
-                    while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                        tn = cUtil.getNextNode(tn, 0);
-                        tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
-                    }
-                    if (tBlock != null) {
-                        String userName = tBlock.getUserName();
-                        if (userName != null) {
-                            LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                            if (lb != null) {
-                                dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, lb);
-                            }
-                        }
-                    }
-                }
-                if (dir == EntryPoint.UNKNOWN) {
-                    log.error("Block definition ambiguity - cannot determine direction of crossover Turnout {} in Section {}.",
-                            t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
-                }
-                return dir;
-            }
-            if ((dBlock != cBlock) && containsBlock(dBlock.getBlock()) && containsBlock(cBlock.getBlock())) {
-                if (getBlockSequenceNumber(dBlock.getBlock()) < getBlockSequenceNumber(cBlock.getBlock())) {
-                    return EntryPoint.FORWARD;
-                } else {
-                    return EntryPoint.REVERSE;
-                }
-            }
-            if (containsBlock(dBlock.getBlock()) && (!containsBlock(cBlock.getBlock()))) {
-                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, cBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-            if (containsBlock(cBlock.getBlock()) && (!containsBlock(dBlock.getBlock()))) {
-                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, dBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-            if ((t.getTurnoutType() != LayoutTurnout.TurnoutType.RH_XOVER) && containsBlock(dBlock.getBlock())
-                    && (!containsBlock(bBlock.getBlock()))) {
-                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, bBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-            if ((t.getTurnoutType() != LayoutTurnout.TurnoutType.LH_XOVER) && containsBlock(cBlock.getBlock())
-                    && (!containsBlock(aBlock.getBlock()))) {
-                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, aBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-        }
-        log.error("Entry point checks failed - cannot determine direction of crossover Turnout {} in Section {}.",
-                t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
-        return EntryPoint.UNKNOWN;
-    }
-
-    /**
-     * Returns EntryPoint.FORWARD if proceeding from A to C or D (or B to D or
-     * C) is movement in the forward direction. Returns EntryPoint.REVERSE if
-     * proceeding from C or D to A (or D or C to B) is movement in the reverse
-     * direction. Returns EntryPoint.UNKNOWN if cannot determine direction. This
-     * should only happen if blocks are not set up correctly--if all connections
-     * go to the same Block, or not all Blocks set. An error message is logged
-     * if EntryPoint.UNKNOWN is returned.
-     *
-     * @param t Actually of type LayoutSlip, this is the track segment to check.
-     */
-    private int getDirectionSlip(LayoutTurnout t, ConnectivityUtil cUtil) {
-        LayoutBlock aBlock = ((TrackSegment) t.getConnectA()).getLayoutBlock();
-        LayoutBlock bBlock = ((TrackSegment) t.getConnectB()).getLayoutBlock();
-        LayoutBlock cBlock = ((TrackSegment) t.getConnectC()).getLayoutBlock();
-        LayoutBlock dBlock = ((TrackSegment) t.getConnectD()).getLayoutBlock();
-        if ((aBlock == null) || (bBlock == null) || (cBlock == null) || (dBlock == null)) {
-            log.error("All blocks not assigned for track segments connecting to crossover turnout - {}.",
-                    t.getTurnout().getDisplayName(USERSYS));
-            return EntryPoint.UNKNOWN;
-        }
-        if ((aBlock == bBlock) && (aBlock == cBlock) && (aBlock == dBlock)) {
-            log.error("Block setup problem - All track segments connecting to crossover turnout - {} are assigned to the same Block.",
-                    t.getTurnout().getDisplayName(USERSYS));
-            return EntryPoint.UNKNOWN;
-        }
-        if ((containsBlock(aBlock.getBlock())) || (containsBlock(cBlock.getBlock()))) {
-            LayoutBlock exBlock = null;
-            if (aBlock == cBlock) {
-                if ((t.getTurnoutType() == LayoutSlip.TurnoutType.DOUBLE_SLIP) && (bBlock == dBlock)) {
-                    exBlock = bBlock;
-                }
-            }
-            if (exBlock != null) {
-                // set direction by tracking from a or b
-                int dir = EntryPoint.UNKNOWN;
-                Block tBlock = null;
-                TrackNode tn = new TrackNode(t, HitPointType.SLIP_A, (TrackSegment) t.getConnectA(),
-                        false, LayoutTurnout.STATE_AC);
-                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                    tn = cUtil.getNextNode(tn, 0);
-                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
-                }
-                if (tBlock != null) {
-                    String userName = tBlock.getUserName();
-                    if (userName != null) {
-                        LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                        if (lb != null) {
-                            dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
-                        }
-                    }
-                } else {
-                    tn = new TrackNode(t, HitPointType.SLIP_C, (TrackSegment) t.getConnectC(),
-                            false, LayoutTurnout.STATE_AC);
-                    while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                        tn = cUtil.getNextNode(tn, 0);
-                        tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
-                    }
-                    if (tBlock != null) {
-                        String userName = tBlock.getUserName();
-                        if (userName != null) {
-                            LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                            if (lb != null) {
-                                dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, lb);
-                            }
-                        }
-                    }
-                }
-                if (dir == EntryPoint.UNKNOWN) {
-                    log.error("Block definition ambiguity - cannot determine direction of crossover slip {} in Section {}.",
-                            t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
-                }
-                return dir;
-            }
-            if ((aBlock != cBlock) && containsBlock(aBlock.getBlock()) && containsBlock(cBlock.getBlock())) {
-                if (getBlockSequenceNumber(aBlock.getBlock()) < getBlockSequenceNumber(cBlock.getBlock())) {
-                    return EntryPoint.FORWARD;
-                } else {
-                    return EntryPoint.REVERSE;
-                }
-            }
-            if (containsBlock(aBlock.getBlock()) && (!containsBlock(cBlock.getBlock()))) {
-                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, cBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-            if (containsBlock(cBlock.getBlock()) && (!containsBlock(aBlock.getBlock()))) {
-                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, aBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, dBlock);
-            if (dir != EntryPoint.UNKNOWN) {
-                return dir;
-            }
-        }
-
-        if ((containsBlock(dBlock.getBlock())) || (containsBlock(bBlock.getBlock()))) {
-            LayoutBlock exBlock = null;
-            if (dBlock == bBlock) {
-                if ((t.getTurnoutType() == LayoutSlip.TurnoutType.DOUBLE_SLIP) && (cBlock == aBlock)) {
-                    exBlock = aBlock;
-                }
-            }
-            if (exBlock != null) {
-                // set direction by tracking from c or d
-                int dir = EntryPoint.UNKNOWN;
-                Block tBlock = null;
-                TrackNode tn = new TrackNode(t, HitPointType.SLIP_D, (TrackSegment) t.getConnectD(),
-                        false, LayoutTurnout.STATE_BD);
-                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                    tn = cUtil.getNextNode(tn, 0);
-                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
-                }
-                if (tBlock != null) {
-                    String userName = tBlock.getUserName();
-                    if (userName != null) {
-                        LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                        if (lb != null) {
-                            dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
-                        }
-                    }
-                } else {
-                    tn = new TrackNode(t, HitPointType.TURNOUT_B, (TrackSegment) t.getConnectB(),
-                            false, LayoutTurnout.STATE_BD);
-                    while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                        tn = cUtil.getNextNode(tn, 0);
-                        tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
-                    }
-                    if (tBlock != null) {
-                        String userName = tBlock.getUserName();
-                        if (userName != null) {
-                            LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                            if (lb != null) {
-                                dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, lb);
-                            }
-                        }
-                    }
-                }
-                if (dir == EntryPoint.UNKNOWN) {
-                    log.error("Block definition ambiguity - cannot determine direction of slip {} in Section {}.",
-                            t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
-                }
-                return dir;
-            }
-            if ((dBlock != bBlock) && containsBlock(dBlock.getBlock()) && containsBlock(bBlock.getBlock())) {
-                if (getBlockSequenceNumber(dBlock.getBlock()) < getBlockSequenceNumber(bBlock.getBlock())) {
-                    return EntryPoint.FORWARD;
-                } else {
-                    return EntryPoint.REVERSE;
-                }
-            }
-            if (containsBlock(dBlock.getBlock()) && (!containsBlock(bBlock.getBlock()))) {
-                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, bBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-            if (containsBlock(bBlock.getBlock()) && (!containsBlock(dBlock.getBlock()))) {
-                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, dBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-            if (t.getTurnoutType() == LayoutSlip.TurnoutType.DOUBLE_SLIP) {
-                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, aBlock);
-                if (dir != EntryPoint.UNKNOWN) {
-                    return dir;
-                }
-            }
-        }
-        //If all else fails the slip must be in a block of its own so we shall work it out from there.
-        if (t.getLayoutBlock() != aBlock) {
-            //Block is not the same as that connected to A
-            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, aBlock);
-            if (dir != EntryPoint.UNKNOWN) {
-                return dir;
-            }
-        }
-        if (t.getLayoutBlock() != bBlock) {
-            //Block is not the same as that connected to B
-            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, bBlock);
-            if (dir != EntryPoint.UNKNOWN) {
-                return dir;
-            }
-        }
-        if (t.getLayoutBlock() != cBlock) {
-            //Block is not the same as that connected to C
-            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, cBlock);
-            if (dir != EntryPoint.UNKNOWN) {
-                return dir;
-            }
-        }
-        if (t.getLayoutBlock() != dBlock) {
-            //Block is not the same as that connected to D
-            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, dBlock);
-            if (dir != EntryPoint.UNKNOWN) {
-                return dir;
-            }
-        }
-        return EntryPoint.UNKNOWN;
-    }
-
-    private boolean placeSensorInCrossover(String b1Name, String b2Name, String c1Name, String c2Name,
-            int direction, ConnectivityUtil cUtil) {
-        SignalHead b1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(b1Name);
-        SignalHead b2Head = null;
-        SignalHead c1Head = null;
-        SignalHead c2Head = null;
-        boolean success = true;
-        if ((b2Name != null) && (!b2Name.isEmpty())) {
-            b2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(b2Name);
-        }
-        if ((c1Name != null) && (!c1Name.isEmpty())) {
-            c1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(c1Name);
-        }
-        if ((c2Name != null) && (!c2Name.isEmpty())) {
-            c2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(c2Name);
-        }
-        if (b2Head != null) {
-            if (!checkDirectionSensor(b1Head, direction, ConnectivityUtil.OVERALL, cUtil)) {
-                success = false;
-            }
-        } else {
-            if (!checkDirectionSensor(b1Head, direction, ConnectivityUtil.CONTINUING, cUtil)) {
-                success = false;
-            }
-        }
-        if (c2Head != null) {
-            if (!checkDirectionSensor(c2Head, direction, ConnectivityUtil.OVERALL, cUtil)) {
-                success = false;
-            }
-        } else if (c1Head != null) {
-            if (!checkDirectionSensor(c1Head, direction, ConnectivityUtil.DIVERGING, cUtil)) {
-                success = false;
-            }
-        }
-        return success;
-    }
-
-    private int checkLists(List<EntryPoint> forwardList, List<EntryPoint> reverseList, LayoutBlock lBlock) {
-        for (int i = 0; i < forwardList.size(); i++) {
-            if (forwardList.get(i).getFromBlock() == lBlock.getBlock()) {
-                return EntryPoint.FORWARD;
-            }
-        }
-        for (int i = 0; i < reverseList.size(); i++) {
-            if (reverseList.get(i).getFromBlock() == lBlock.getBlock()) {
-                return EntryPoint.REVERSE;
-            }
-        }
-        return EntryPoint.UNKNOWN;
-    }
-
-    @CheckForNull
-    private Block checkDualDirection(LayoutBlock aBlock, LayoutBlock bBlock, LayoutBlock cBlock) {
-        for (int i = 0; i < mForwardEntryPoints.size(); i++) {
-            Block b = mForwardEntryPoints.get(i).getFromBlock();
-            for (int j = 0; j < mReverseEntryPoints.size(); j++) {
-                if (mReverseEntryPoints.get(j).getFromBlock() == b) {
-                    // possible dual direction
-                    if (aBlock.getBlock() == b) {
-                        return b;
-                    } else if (bBlock.getBlock() == b) {
-                        return b;
-                    } else if ((cBlock.getBlock() == b) && (aBlock == bBlock)) {
-                        return b;
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Returns the direction for proceeding from LayoutBlock b to LayoutBlock a.
-     * LayoutBlock a must be in the Section. LayoutBlock b may be in this
-     * Section or may be an Entry Point to the Section.
-     */
-    private int getDirectionForBlocks(LayoutBlock a, LayoutBlock b) {
-        if (containsBlock(b.getBlock())) {
-            // both blocks are within this Section
-            if (getBlockSequenceNumber(a.getBlock()) > getBlockSequenceNumber(b.getBlock())) {
-                return EntryPoint.FORWARD;
-            } else {
-                return EntryPoint.REVERSE;
-            }
-        }
-        // bBlock must be an entry point
-        for (int i = 0; i < mForwardEntryPoints.size(); i++) {
-            if (mForwardEntryPoints.get(i).getFromBlock() == b.getBlock()) {
-                return EntryPoint.FORWARD;
-            }
-        }
-        for (int j = 0; j < mReverseEntryPoints.size(); j++) {
-            if (mReverseEntryPoints.get(j).getFromBlock() == b.getBlock()) {
-                return EntryPoint.REVERSE;
-            }
-        }
-        // should never get here
-        log.error("Unexpected error in getDirectionForBlocks when working with LevelCrossing in Section {}",
-                getDisplayName(USERSYS));
-        return EntryPoint.UNKNOWN;
-    }
-
-    /**
-     * @return 'true' if successfully checked direction sensor by follow
-     *         connectivity from specified track node; 'false' if an error
-     *         occurred
-     */
-    private boolean setDirectionSensorByConnectivity(TrackNode tNode, TrackNode altNode, SignalHead sh,
-            Block cBlock, ConnectivityUtil cUtil) {
-        boolean successful = false;
-        TrackNode tn = tNode;
-        if ((tn != null) && (sh != null)) {
-            Block tBlock = null;
-            LayoutBlock lb;
-            int dir = EntryPoint.UNKNOWN;
-            while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                tn = cUtil.getNextNode(tn, 0);
-                tBlock = (tn == null) ? null : cUtil.getExitBlockForTrackNode(tn, null);
-            }
-            if (tBlock != null) {
-                String userName = tBlock.getUserName();
-                if (userName != null) {
-                    lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                    if (lb != null) {
-                        dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
-                    }
-                }
-            } else {
-                tn = altNode;
-                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
-                    tn = cUtil.getNextNode(tn, 0);
-                    tBlock = (tn == null) ? null : cUtil.getExitBlockForTrackNode(tn, null);
-                }
-                if (tBlock != null) {
-                    String userName = tBlock.getUserName();
-                    if (userName != null) {
-                        lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                        if (lb != null) {
-                            dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
-                            if (dir == EntryPoint.REVERSE) {
-                                dir = EntryPoint.FORWARD;
-                            } else if (dir == EntryPoint.FORWARD) {
-                                dir = EntryPoint.REVERSE;
-                            }
-                        }
-                    }
-                }
-            }
-            if (dir != EntryPoint.UNKNOWN) {
-                if (checkDirectionSensor(sh, dir, ConnectivityUtil.OVERALL, cUtil)) {
-                    successful = true;
-                }
-            } else {
-                log.error("Trouble following track in Block {} in Section {}.",
-                        cBlock.getDisplayName(USERSYS), getDisplayName(USERSYS));
-            }
-        }
-        return successful;
-    }
+    public EntryPoint getExitPointToBlock(Block b, int dir);
 
     /**
      * Place direction sensors in SSL for all Signal Heads in this Section if
@@ -1671,731 +338,7 @@ public class Section extends AbstractNamedBean {
      * @return the number or errors placing sensors; 1 is returned if no
      *         direction sensor is defined for this section
      */
-    public int placeDirectionSensors(LayoutEditor panel) {
-        int missingSignalsBB = 0;
-        int missingSignalsTurnouts = 0;
-        int missingSignalsLevelXings = 0;
-        int errorCount = 0;
-        if (panel == null) {
-            log.error("Null Layout Editor panel on call to 'placeDirectionSensors'");
-            return 1;
-        }
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        if ((mForwardBlockingSensorName == null) || (mForwardBlockingSensorName.isEmpty())
-                || (mReverseBlockingSensorName == null) || (mReverseBlockingSensorName.isEmpty())) {
-            log.error("Missing direction sensor in Section {}", getDisplayName(USERSYS));
-            return 1;
-        }
-        LayoutBlockManager layoutBlockManager = InstanceManager.getDefault(LayoutBlockManager.class);
-        ConnectivityUtil cUtil = panel.getConnectivityUtil();
-        LayoutBlock lBlock = null;
-        for (Block cBlock : mBlockEntries) {
-            String userName = cBlock.getUserName();
-            if (userName != null) {
-                lBlock = layoutBlockManager.getByUserName(userName);
-                if (lBlock == null) {
-                    continue;
-                }
-            }
-            List<PositionablePoint> anchorList = cUtil.getAnchorBoundariesThisBlock(cBlock);
-            for (int j = 0; j < anchorList.size(); j++) {
-                PositionablePoint p = anchorList.get(j);
-                if ((!p.getEastBoundSignal().isEmpty()) && (!p.getWestBoundSignal().isEmpty())) {
-                    // have a signalled block boundary
-                    SignalHead sh = cUtil.getSignalHeadAtAnchor(p, cBlock, false);
-                    if (sh == null) {
-                        log.warn("Unexpected missing signal head at boundary of Block {}", cBlock.getDisplayName(USERSYS));
-                        errorCount++;
-                    } else {
-                        int direction = cUtil.getDirectionFromAnchor(mForwardEntryPoints,
-                                mReverseEntryPoints, p);
-                        if (direction == EntryPoint.UNKNOWN) {
-                            // anchor is at a Block boundary within the Section
-                            sh = cUtil.getSignalHeadAtAnchor(p, cBlock, true);
-                            Block otherBlock = ((p.getConnect1()).getLayoutBlock()).getBlock();
-                            if (otherBlock == cBlock) {
-                                otherBlock = ((p.getConnect2()).getLayoutBlock()).getBlock();
-                            }
-                            if (getBlockSequenceNumber(cBlock) < getBlockSequenceNumber(otherBlock)) {
-                                direction = EntryPoint.FORWARD;
-                            } else {
-                                direction = EntryPoint.REVERSE;
-                            }
-                        }
-                        if (!checkDirectionSensor(sh, direction, ConnectivityUtil.OVERALL, cUtil)) {
-                            errorCount++;
-                        }
-                    }
-                } else {
-                    errorCount++;
-                    missingSignalsBB++;
-                }
-            }
-            List<LevelXing> xingList = cUtil.getLevelCrossingsThisBlock(cBlock);
-            for (int k = 0; k < xingList.size(); k++) {
-                LevelXing x = xingList.get(k);
-                LayoutBlock alBlock = ((TrackSegment) x.getConnectA()).getLayoutBlock();
-                LayoutBlock blBlock = ((TrackSegment) x.getConnectB()).getLayoutBlock();
-                LayoutBlock clBlock = ((TrackSegment) x.getConnectC()).getLayoutBlock();
-                LayoutBlock dlBlock = ((TrackSegment) x.getConnectD()).getLayoutBlock();
-                if (cUtil.isInternalLevelXingAC(x, cBlock)) {
-                    // have an internal AC level crossing - is it signaled?
-                    if (!x.getSignalAName().isEmpty() || (!x.getSignalCName().isEmpty())) {
-                        // have a signaled AC level crossing internal to this block
-                        if (!x.getSignalAName().isEmpty()) {
-                            // there is a signal at A in the level crossing
-                            TrackNode tn = new TrackNode(x, HitPointType.LEVEL_XING_A,
-                                    (TrackSegment) x.getConnectA(), false, 0);
-                            TrackNode altNode = new TrackNode(x, HitPointType.LEVEL_XING_C,
-                                    (TrackSegment) x.getConnectC(), false, 0);
-                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    x.getSignalAName());
-                            if (!setDirectionSensorByConnectivity(tn, altNode, sh, cBlock, cUtil)) {
-                                errorCount++;
-                            }
-                        }
-                        if (!x.getSignalCName().isEmpty()) {
-                            // there is a signal at C in the level crossing
-                            TrackNode tn = new TrackNode(x, HitPointType.LEVEL_XING_C,
-                                    (TrackSegment) x.getConnectC(), false, 0);
-                            TrackNode altNode = new TrackNode(x, HitPointType.LEVEL_XING_A,
-                                    (TrackSegment) x.getConnectA(), false, 0);
-                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    x.getSignalCName());
-                            if (!setDirectionSensorByConnectivity(tn, altNode, sh, cBlock, cUtil)) {
-                                errorCount++;
-                            }
-                        }
-                    }
-                } else if (alBlock == lBlock) {
-                    // have a level crossing with AC spanning a block boundary, with A in this Block
-                    int direction = getDirectionForBlocks(alBlock, clBlock);
-                    if (direction != EntryPoint.UNKNOWN) {
-                        if (!x.getSignalCName().isEmpty()) {
-                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    x.getSignalCName());
-                            if (!checkDirectionSensor(sh, direction, ConnectivityUtil.OVERALL, cUtil)) {
-                                errorCount++;
-                            }
-                        }
-                    } else {
-                        errorCount++;
-                    }
-                } else if (clBlock == lBlock) {
-                    // have a level crossing with AC spanning a block boundary, with C in this Block
-                    int direction = getDirectionForBlocks(clBlock, alBlock);
-                    if (direction != EntryPoint.UNKNOWN) {
-                        if (!x.getSignalAName().isEmpty()) {
-                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    x.getSignalAName());
-                            if (!checkDirectionSensor(sh, direction, ConnectivityUtil.OVERALL, cUtil)) {
-                                errorCount++;
-                            }
-                        }
-                    } else {
-                        errorCount++;
-                    }
-                }
-                if (cUtil.isInternalLevelXingBD(x, cBlock)) {
-                    // have an internal BD level crossing - is it signaled?
-                    if ((!x.getSignalBName().isEmpty()) || (!x.getSignalDName().isEmpty())) {
-                        // have a signaled BD level crossing internal to this block
-                        if (!x.getSignalBName().isEmpty()) {
-                            // there is a signal at B in the level crossing
-                            TrackNode tn = new TrackNode(x, HitPointType.LEVEL_XING_B,
-                                    (TrackSegment) x.getConnectB(), false, 0);
-                            TrackNode altNode = new TrackNode(x, HitPointType.LEVEL_XING_D,
-                                    (TrackSegment) x.getConnectD(), false, 0);
-                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    x.getSignalBName());
-                            if (!setDirectionSensorByConnectivity(tn, altNode, sh, cBlock, cUtil)) {
-                                errorCount++;
-                            }
-                        }
-                        if (!x.getSignalDName().isEmpty()) {
-                            // there is a signal at C in the level crossing
-                            TrackNode tn = new TrackNode(x, HitPointType.LEVEL_XING_D,
-                                    (TrackSegment) x.getConnectD(), false, 0);
-                            TrackNode altNode = new TrackNode(x, HitPointType.LEVEL_XING_B,
-                                    (TrackSegment) x.getConnectB(), false, 0);
-                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    x.getSignalDName());
-                            if (!setDirectionSensorByConnectivity(tn, altNode, sh, cBlock, cUtil)) {
-                                errorCount++;
-                            }
-                        }
-                    }
-                } else if (blBlock == lBlock) {
-                    // have a level crossing with BD spanning a block boundary, with B in this Block
-                    int direction = getDirectionForBlocks(blBlock, dlBlock);
-                    if (direction != EntryPoint.UNKNOWN) {
-                        if (!x.getSignalDName().isEmpty()) {
-                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    x.getSignalDName());
-                            if (!checkDirectionSensor(sh, direction, ConnectivityUtil.OVERALL, cUtil)) {
-                                errorCount++;
-                            }
-                        }
-                    } else {
-                        errorCount++;
-                    }
-                } else if (dlBlock == lBlock) {
-                    // have a level crossing with BD spanning a block boundary, with D in this Block
-                    int direction = getDirectionForBlocks(dlBlock, blBlock);
-                    if (direction != EntryPoint.UNKNOWN) {
-                        if (!x.getSignalBName().isEmpty()) {
-                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    x.getSignalBName());
-                            if (!checkDirectionSensor(sh, direction, ConnectivityUtil.OVERALL, cUtil)) {
-                                errorCount++;
-                            }
-                        }
-                    } else {
-                        errorCount++;
-                    }
-                }
-            }
-            List<LayoutTurnout> turnoutList = cUtil.getLayoutTurnoutsThisBlock(cBlock);
-            for (int m = 0; m < turnoutList.size(); m++) {
-                LayoutTurnout t = turnoutList.get(m);
-                if (cUtil.layoutTurnoutHasRequiredSignals(t)) {
-                    // have a signalled turnout
-                    if ((t.getLinkType() == LayoutTurnout.LinkType.NO_LINK)
-                            && ((t.getTurnoutType() == LayoutTurnout.TurnoutType.RH_TURNOUT)
-                            || (t.getTurnoutType() == LayoutTurnout.TurnoutType.LH_TURNOUT)
-                            || (t.getTurnoutType() == LayoutTurnout.TurnoutType.WYE_TURNOUT))) {
-                        // standard turnout - nothing special
-                        // Note: direction is for proceeding from the throat to either other track
-                        int direction = getDirectionStandardTurnout(t, cUtil);
-                        int altDirection = EntryPoint.FORWARD;
-                        if (direction == EntryPoint.FORWARD) {
-                            altDirection = EntryPoint.REVERSE;
-                        }
-                        if (direction == EntryPoint.UNKNOWN) {
-                            errorCount++;
-                        } else {
-                            SignalHead aHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    t.getSignalA1Name());
-                            SignalHead a2Head = null;
-                            String a2Name = t.getSignalA2Name(); // returns "" for empty name, never null
-                            if (!a2Name.isEmpty()) {
-                                a2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(a2Name);
-                            }
-                            SignalHead bHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    t.getSignalB1Name());
-                            SignalHead cHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    t.getSignalC1Name());
-                            if (t.getLayoutBlock().getBlock() == cBlock) {
-                                // turnout is in this block, set direction sensors on all signal heads
-                                // Note: need allocation to traverse this turnout
-                                if (!checkDirectionSensor(aHead, direction,
-                                        ConnectivityUtil.OVERALL, cUtil)) {
-                                    errorCount++;
-                                }
-                                if (a2Head != null) {
-                                    if (!checkDirectionSensor(a2Head, direction,
-                                            ConnectivityUtil.OVERALL, cUtil)) {
-                                        errorCount++;
-                                    }
-                                }
-                                if (!checkDirectionSensor(bHead, altDirection,
-                                        ConnectivityUtil.OVERALL, cUtil)) {
-                                    errorCount++;
-                                }
-                                if (!checkDirectionSensor(cHead, altDirection,
-                                        ConnectivityUtil.OVERALL, cUtil)) {
-                                    errorCount++;
-                                }
-                            } else {
-                                if (((TrackSegment) t.getConnectA()).getLayoutBlock().getBlock() == cBlock) {
-                                    // throat Track Segment is in this Block
-                                    if (!checkDirectionSensor(bHead, altDirection,
-                                            ConnectivityUtil.OVERALL, cUtil)) {
-                                        errorCount++;
-                                    }
-                                    if (!checkDirectionSensor(cHead, altDirection,
-                                            ConnectivityUtil.OVERALL, cUtil)) {
-                                        errorCount++;
-                                    }
-                                } else if (((t.getContinuingSense() == Turnout.CLOSED)
-                                        && (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock))
-                                        || ((t.getContinuingSense() == Turnout.THROWN)
-                                        && (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock))) {
-                                    // continuing track segment is in this block, normal continuing sense - or -
-                                    //  diverging track segment is in this block, reverse continuing sense.
-                                    if (a2Head == null) {
-                                        // single head at throat
-                                        if (!checkDirectionSensor(aHead, direction,
-                                                ConnectivityUtil.CONTINUING, cUtil)) {
-                                            errorCount++;
-                                        }
-                                    } else {
-                                        // two heads at throat
-                                        if (!checkDirectionSensor(aHead, direction,
-                                                ConnectivityUtil.OVERALL, cUtil)) {
-                                            errorCount++;
-                                        }
-                                    }
-                                    if (!checkDirectionSensor(bHead, altDirection,
-                                            ConnectivityUtil.OVERALL, cUtil)) {
-                                        errorCount++;
-                                    }
-                                } else if (((t.getContinuingSense() == Turnout.CLOSED)
-                                        && (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock))
-                                        || ((t.getContinuingSense() == Turnout.THROWN)
-                                        && (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock))) {
-                                    // diverging track segment is in this block, normal continuing sense - or -
-                                    //  continuing track segment is in this block, reverse continuing sense.
-                                    if (a2Head == null) {
-                                        // single head at throat
-                                        if (!checkDirectionSensor(aHead, direction,
-                                                ConnectivityUtil.DIVERGING, cUtil)) {
-                                            errorCount++;
-                                        }
-                                    } else {
-                                        // two heads at throat
-                                        if (!checkDirectionSensor(a2Head, direction,
-                                                ConnectivityUtil.OVERALL, cUtil)) {
-                                            errorCount++;
-                                        }
-                                    }
-                                    if (!checkDirectionSensor(cHead, altDirection,
-                                            ConnectivityUtil.OVERALL, cUtil)) {
-                                        errorCount++;
-                                    }
-                                }
-                            }
-                        }
-                    } else if (t.getLinkType() != LayoutTurnout.LinkType.NO_LINK) {
-                        // special linked turnout
-                        LayoutTurnout tLinked = getLayoutTurnoutFromTurnoutName(t.getLinkedTurnoutName(), panel);
-                        if (tLinked == null) {
-                            log.error("null Layout Turnout linked to turnout {}", t.getTurnout().getDisplayName(USERSYS));
-                        } else if (t.getLinkType() == LayoutTurnout.LinkType.THROAT_TO_THROAT) {
-                            SignalHead b1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    t.getSignalB1Name());
-                            SignalHead b2Head = null;
-                            String hName = t.getSignalB2Name(); // returns "" for empty name, never null
-                            if (!hName.isEmpty()) {
-                                b2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
-                            }
-                            SignalHead c1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    t.getSignalC1Name());
-                            SignalHead c2Head = null;
-                            hName = t.getSignalC2Name(); // returns "" for empty name, never null
-                            if (!hName.isEmpty()) {
-                                c2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
-                            }
-                            int direction = getDirectionStandardTurnout(t, cUtil);
-                            int altDirection = EntryPoint.FORWARD;
-                            if (direction == EntryPoint.FORWARD) {
-                                altDirection = EntryPoint.REVERSE;
-                            }
-                            if (direction != EntryPoint.UNKNOWN) {
-                                if (t.getLayoutBlock().getBlock() == cBlock) {
-                                    // turnout is in this block, set direction sensors on all signal heads
-                                    // Note: need allocation to traverse this turnout
-                                    if (!checkDirectionSensor(b1Head, altDirection,
-                                            ConnectivityUtil.OVERALL, cUtil)) {
-                                        errorCount++;
-                                    }
-                                    if (b2Head != null) {
-                                        if (!checkDirectionSensor(b2Head, altDirection,
-                                                ConnectivityUtil.OVERALL, cUtil)) {
-                                            errorCount++;
-                                        }
-                                    }
-                                    if (!checkDirectionSensor(c1Head, altDirection,
-                                            ConnectivityUtil.OVERALL, cUtil)) {
-                                        errorCount++;
-                                    }
-                                    if (c2Head != null) {
-                                        if (!checkDirectionSensor(c2Head, altDirection,
-                                                ConnectivityUtil.OVERALL, cUtil)) {
-                                            errorCount++;
-                                        }
-                                    }
-                                } else {
-                                    // turnout is not in this block, switch to heads of linked turnout
-                                    b1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                            tLinked.getSignalB1Name());
-                                    hName = tLinked.getSignalB2Name(); // returns "" for empty name, never null
-                                    b2Head = null;
-                                    if (!hName.isEmpty()) {
-                                        b2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
-                                    }
-                                    c1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                            tLinked.getSignalC1Name());
-                                    c2Head = null;
-                                    hName = tLinked.getSignalC2Name(); // returns "" for empty name, never null
-                                    if (!hName.isEmpty()) {
-                                        c2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
-                                    }
-                                    if (((t.getContinuingSense() == Turnout.CLOSED)
-                                            && (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock))
-                                            || ((t.getContinuingSense() == Turnout.THROWN)
-                                            && (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock))) {
-                                        // continuing track segment is in this block
-                                        if (b2Head != null) {
-                                            if (!checkDirectionSensor(b1Head, direction,
-                                                    ConnectivityUtil.OVERALL, cUtil)) {
-                                                errorCount++;
-                                            }
-                                        } else {
-                                            if (!checkDirectionSensor(b1Head, direction,
-                                                    ConnectivityUtil.CONTINUING, cUtil)) {
-                                                errorCount++;
-                                            }
-                                        }
-                                        if (c2Head != null) {
-                                            if (!checkDirectionSensor(c1Head, direction,
-                                                    ConnectivityUtil.OVERALL, cUtil)) {
-                                                errorCount++;
-                                            }
-                                        } else {
-                                            if (!checkDirectionSensor(c1Head, direction,
-                                                    ConnectivityUtil.CONTINUING, cUtil)) {
-                                                errorCount++;
-                                            }
-                                        }
-                                    } else if (((t.getContinuingSense() == Turnout.CLOSED)
-                                            && (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock))
-                                            || ((t.getContinuingSense() == Turnout.THROWN)
-                                            && (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock))) {
-                                        // diverging track segment is in this block
-                                        if (b2Head != null) {
-                                            if (!checkDirectionSensor(b2Head, direction,
-                                                    ConnectivityUtil.OVERALL, cUtil)) {
-                                                errorCount++;
-                                            }
-                                        } else {
-                                            if (!checkDirectionSensor(b1Head, direction,
-                                                    ConnectivityUtil.DIVERGING, cUtil)) {
-                                                errorCount++;
-                                            }
-                                        }
-                                        if (c2Head != null) {
-                                            if (!checkDirectionSensor(c2Head, direction,
-                                                    ConnectivityUtil.OVERALL, cUtil)) {
-                                                errorCount++;
-                                            }
-                                        } else {
-                                            if (!checkDirectionSensor(c1Head, direction,
-                                                    ConnectivityUtil.DIVERGING, cUtil)) {
-                                                errorCount++;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        } else if (t.getLinkType() == LayoutTurnout.LinkType.FIRST_3_WAY) {
-                            SignalHead a1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    t.getSignalA1Name());
-                            SignalHead a2Head = null;
-                            String hName = t.getSignalA2Name();
-                            if (!hName.isEmpty()) {
-                                a2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
-                            }
-                            SignalHead a3Head = null;
-                            hName = t.getSignalA3Name(); // returns "" for empty name, never null
-                            if (!hName.isEmpty()) {
-                                a3Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
-                            }
-                            SignalHead cHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    t.getSignalC1Name());
-                            int direction = getDirectionStandardTurnout(t, cUtil);
-                            int altDirection = EntryPoint.FORWARD;
-                            if (direction == EntryPoint.FORWARD) {
-                                altDirection = EntryPoint.REVERSE;
-                            }
-                            if (direction != EntryPoint.UNKNOWN) {
-                                if (t.getLayoutBlock().getBlock() == cBlock) {
-                                    // turnout is in this block, set direction sensors on all signal heads
-                                    // Note: need allocation to traverse this turnout
-                                    if (!checkDirectionSensor(a1Head, direction,
-                                            ConnectivityUtil.OVERALL, cUtil)) {
-                                        errorCount++;
-                                    }
-                                    if ((a2Head != null) && (a3Head != null)) {
-                                        if (!checkDirectionSensor(a2Head, direction,
-                                                ConnectivityUtil.OVERALL, cUtil)) {
-                                            errorCount++;
-                                        }
-                                        if (!checkDirectionSensor(a3Head, direction,
-                                                ConnectivityUtil.OVERALL, cUtil)) {
-                                            errorCount++;
-                                        }
-                                    }
-                                    if (!checkDirectionSensor(cHead, altDirection,
-                                            ConnectivityUtil.OVERALL, cUtil)) {
-                                        errorCount++;
-                                    }
-                                } else {
-                                    // turnout is not in this block
-                                    if (((TrackSegment) t.getConnectA()).getLayoutBlock().getBlock() == cBlock) {
-                                        // throat Track Segment is in this Block
-                                        if (!checkDirectionSensor(cHead, altDirection,
-                                                ConnectivityUtil.OVERALL, cUtil)) {
-                                            errorCount++;
-                                        }
-                                    } else if (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock) {
-                                        // diverging track segment is in this Block
-                                        if (a2Head != null) {
-                                            if (!checkDirectionSensor(a2Head, direction,
-                                                    ConnectivityUtil.OVERALL, cUtil)) {
-                                                errorCount++;
-                                            }
-                                        } else {
-                                            if (!checkDirectionSensor(a1Head, direction,
-                                                    ConnectivityUtil.DIVERGING, cUtil)) {
-                                                errorCount++;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        } else if (t.getLinkType() == LayoutTurnout.LinkType.SECOND_3_WAY) {
-                            SignalHead bHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    t.getSignalB1Name());
-                            SignalHead cHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    t.getSignalC1Name());
-                            SignalHead a1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
-                                    tLinked.getSignalA1Name());
-                            SignalHead a3Head = null;
-                            String hName = tLinked.getSignalA3Name();
-                            if (!hName.isEmpty()) {
-                                a3Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
-                            }
-                            int direction = getDirectionStandardTurnout(t, cUtil);
-                            int altDirection = EntryPoint.FORWARD;
-                            if (direction == EntryPoint.FORWARD) {
-                                altDirection = EntryPoint.REVERSE;
-                            }
-                            if (direction != EntryPoint.UNKNOWN) {
-                                if (t.getLayoutBlock().getBlock() == cBlock) {
-                                    // turnout is in this block, set direction sensors on b and c signal heads
-                                    // Note: need allocation to traverse this turnout
-                                    if (!checkDirectionSensor(bHead, altDirection,
-                                            ConnectivityUtil.OVERALL, cUtil)) {
-                                        errorCount++;
-                                    }
-                                    if (!checkDirectionSensor(cHead, altDirection,
-                                            ConnectivityUtil.OVERALL, cUtil)) {
-                                        errorCount++;
-                                    }
-                                }
-                                if (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock) {
-                                    // diverging track segment is in this Block
-                                    if (a3Head != null) {
-                                        if (!checkDirectionSensor(a3Head, direction,
-                                                ConnectivityUtil.OVERALL, cUtil)) {
-                                            errorCount++;
-                                        }
-                                    } else {
-                                        log.warn("Turnout {} - SSL for head {} cannot handle direction sensor for second diverging track.",
-                                                tLinked.getTurnout().getDisplayName(USERSYS),( a1Head==null ? "Unknown" : a1Head.getDisplayName(USERSYS)));
-                                        errorCount++;
-                                    }
-                                } else if (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock) {
-                                    // continuing track segment is in this Block
-                                    if (a3Head != null) {
-                                        if (!checkDirectionSensor(a1Head, direction,
-                                                ConnectivityUtil.OVERALL, cUtil)) {
-                                            errorCount++;
-                                        }
-                                    } else {
-                                        if (!checkDirectionSensor(a1Head, direction,
-                                                ConnectivityUtil.CONTINUING, cUtil)) {
-                                            errorCount++;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    } else if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.RH_XOVER)
-                            || (t.getTurnoutType() == LayoutTurnout.TurnoutType.LH_XOVER)
-                            || (t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER)) {
-                        // crossover turnout
-                        // Note: direction is for proceeding from A to B (or D to C)
-                        int direction = getDirectionXoverTurnout(t, cUtil);
-                        int altDirection = EntryPoint.FORWARD;
-                        if (direction == EntryPoint.FORWARD) {
-                            altDirection = EntryPoint.REVERSE;
-                        }
-                        if (direction == EntryPoint.UNKNOWN) {
-                            errorCount++;
-                        } else {
-                            if (((TrackSegment) t.getConnectA()).getLayoutBlock().getBlock() == cBlock) {
-                                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER)
-                                        || (t.getTurnoutType() == LayoutTurnout.TurnoutType.RH_XOVER)) {
-                                    if (!placeSensorInCrossover(t.getSignalB1Name(), t.getSignalB2Name(),
-                                            t.getSignalC1Name(), t.getSignalC2Name(), altDirection, cUtil)) {
-                                        errorCount++;
-                                    }
-                                } else {
-                                    if (!placeSensorInCrossover(t.getSignalB1Name(), t.getSignalB2Name(),
-                                            null, null, altDirection, cUtil)) {
-                                        errorCount++;
-                                    }
-                                }
-                            }
-                            if (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock) {
-                                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER)
-                                        || (t.getTurnoutType() == LayoutTurnout.TurnoutType.LH_XOVER)) {
-                                    if (!placeSensorInCrossover(t.getSignalA1Name(), t.getSignalA2Name(),
-                                            t.getSignalD1Name(), t.getSignalD2Name(), direction, cUtil)) {
-                                        errorCount++;
-                                    }
-                                } else {
-                                    if (!placeSensorInCrossover(t.getSignalA1Name(), t.getSignalA2Name(),
-                                            null, null, direction, cUtil)) {
-                                        errorCount++;
-                                    }
-                                }
-                            }
-                            if (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock) {
-                                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER)
-                                        || (t.getTurnoutType() == LayoutTurnout.TurnoutType.RH_XOVER)) {
-                                    if (!placeSensorInCrossover(t.getSignalD1Name(), t.getSignalD2Name(),
-                                            t.getSignalA1Name(), t.getSignalA2Name(), direction, cUtil)) {
-                                        errorCount++;
-                                    }
-                                } else {
-                                    if (!placeSensorInCrossover(t.getSignalD1Name(), t.getSignalD2Name(),
-                                            null, null, direction, cUtil)) {
-                                        errorCount++;
-                                    }
-                                }
-                            }
-                            if (((TrackSegment) t.getConnectD()).getLayoutBlock().getBlock() == cBlock) {
-                                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER)
-                                        || (t.getTurnoutType() == LayoutTurnout.TurnoutType.LH_XOVER)) {
-                                    if (!placeSensorInCrossover(t.getSignalC1Name(), t.getSignalC2Name(),
-                                            t.getSignalB1Name(), t.getSignalB2Name(), altDirection, cUtil)) {
-                                        errorCount++;
-                                    }
-                                } else {
-                                    if (!placeSensorInCrossover(t.getSignalC1Name(), t.getSignalC2Name(),
-                                            null, null, altDirection, cUtil)) {
-                                        errorCount++;
-                                    }
-                                }
-                            }
-                        }
-                    } else if (t.isTurnoutTypeSlip()) {
-                        int direction = getDirectionSlip(t, cUtil);
-                        int altDirection = EntryPoint.FORWARD;
-                        if (direction == EntryPoint.FORWARD) {
-                            altDirection = EntryPoint.REVERSE;
-                        }
-                        if (direction == EntryPoint.UNKNOWN) {
-                            errorCount++;
-                        } else {
-                            if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalA1Name()), altDirection, ConnectivityUtil.OVERALL, cUtil)) {
-                                errorCount++;
-                            }
-                            if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalA2Name()), altDirection, ConnectivityUtil.OVERALL, cUtil)) {
-                                errorCount++;
-                            }
-                            if (t.getTurnoutType() == LayoutSlip.TurnoutType.SINGLE_SLIP) {
-                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalB1Name()), altDirection, ConnectivityUtil.OVERALL, cUtil)) {
-                                    errorCount++;
-                                }
-                            } else {
-                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalB1Name()), altDirection, ConnectivityUtil.OVERALL, cUtil)) {
-                                    errorCount++;
-                                }
-                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalB2Name()), altDirection, ConnectivityUtil.OVERALL, cUtil)) {
-                                    errorCount++;
-                                }
-                            }
-                            if (t.getTurnoutType() == LayoutSlip.TurnoutType.SINGLE_SLIP) {
-                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalC1Name()), direction, ConnectivityUtil.OVERALL, cUtil)) {
-                                    errorCount++;
-                                }
-                            } else {
-                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalC1Name()), direction, ConnectivityUtil.OVERALL, cUtil)) {
-                                    errorCount++;
-                                }
-                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalC2Name()), direction, ConnectivityUtil.OVERALL, cUtil)) {
-                                    errorCount++;
-                                }
-                            }
-                            if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalD1Name()), direction, ConnectivityUtil.OVERALL, cUtil)) {
-                                errorCount++;
-                            }
-                            if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalD2Name()), direction, ConnectivityUtil.OVERALL, cUtil)) {
-                                errorCount++;
-                            }
-                        }
-                    } else {
-                        log.error("Unknown turnout type for turnout {} in Section {}.",
-                                t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
-                        errorCount++;
-                    }
-                } else {
-                    // signal heads missing in turnout
-                    missingSignalsTurnouts++;
-                }
-            }
-        }
-        // set up missing signal head message, if any
-        if ((missingSignalsBB + missingSignalsTurnouts + missingSignalsLevelXings) > 0) {
-            String s = "";
-            if (missingSignalsBB > 0) {
-                s = ", " + (missingSignalsBB) + " anchor point signal heads missing";
-            }
-            if (missingSignalsTurnouts > 0) {
-                s = ", " + (missingSignalsTurnouts) + " turnouts missing signals";
-            }
-            if (missingSignalsLevelXings > 0) {
-                s = ", " + (missingSignalsLevelXings) + " level crossings missing signals";
-            }
-            log.warn("Section - {} {}",getDisplayName(USERSYS),s);
-        }
-
-        return errorCount;
-    }
-
-    private boolean checkDirectionSensor(SignalHead sh, int direction, int where,
-            ConnectivityUtil cUtil) {
-        String sensorName = "";
-        if (direction == EntryPoint.FORWARD) {
-            sensorName = getForwardBlockingSensorName();
-        } else if (direction == EntryPoint.REVERSE) {
-            sensorName = getReverseBlockingSensorName();
-        }
-        return (cUtil.addSensorToSignalHeadLogic(sensorName, sh, where));
-    }
-
-    private LayoutTurnout getLayoutTurnoutFromTurnoutName(String turnoutName, LayoutEditor panel) {
-        Turnout t = InstanceManager.turnoutManagerInstance().getTurnout(turnoutName);
-        if (t == null) {
-            return null;
-        }
-        for (LayoutTurnout lt : panel.getLayoutTurnouts()) {
-            if (lt.getTurnout() == t) {
-                return lt;
-            }
-        }
-        return null;
-    }
-
-    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "was previously marked with @SuppressWarnings, reason unknown")
-    private List<EntryPoint> getListOfForwardBlockEntryPoints(Block b) {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        List<EntryPoint> a = new ArrayList<>();
-        for (int i = 0; i < mForwardEntryPoints.size(); i++) {
-            if (b == (mForwardEntryPoints.get(i)).getBlock()) {
-                a.add(mForwardEntryPoints.get(i));
-            }
-        }
-        return a;
-    }
+    public int placeDirectionSensors(LayoutEditor panel);
 
     /**
      * Validate the Section. This checks block connectivity, warns of redundant
@@ -2407,125 +350,7 @@ public class Section extends AbstractNamedBean {
      *                initialized; if null no blocks are checked
      * @return an error description or empty string if there are no errors
      */
-    public String validate(LayoutEditor lePanel) {
-        if (initializationNeeded) {
-            initializeBlocks();
-        }
-        // validate Paths and Bean Settings if a Layout Editor panel is available
-        if (lePanel != null) {
-            for (int i = 0; i < (mBlockEntries.size() - 1); i++) {
-                Block test = getBlockBySequenceNumber(i);
-                if (test == null){
-                    log.error("Block {} not found in Block Entries. Paths not checked.",i );
-                    break;
-                }
-                String userName = test.getUserName();
-                if (userName != null) {
-                    LayoutBlock lBlock = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                    if (lBlock == null) {
-                        log.error("Layout Block {} not found. Paths not checked.", userName);
-                    } else {
-                        lBlock.updatePathsUsingPanel(lePanel);
-                    }
-                }
-            }
-        }
-        // check connectivity between internal blocks
-        if (mBlockEntries.size() > 1) {
-            for (int i = 0; i < (mBlockEntries.size() - 1); i++) {
-                Block thisBlock = getBlockBySequenceNumber(i);
-                Block nextBlock = getBlockBySequenceNumber(i + 1);
-                if ( thisBlock == null || nextBlock == null ) {
-                        return "Sequential blocks " + i + " " + thisBlock + " or "
-                            + i+1 + " " + nextBlock + " are empty in Block List.";
-                    }
-                if (!connected(thisBlock, nextBlock)) {
-                    String s = "Sequential Blocks - " + thisBlock.getDisplayName(USERSYS)
-                            + ", " + nextBlock.getDisplayName(USERSYS)
-                            + " - are not connected in Section " + getDisplayName(USERSYS) + ".";
-                    return s;
-                }
-                if (!connected(nextBlock, thisBlock)) {
-                    String s = "Sequential Blocks - " + thisBlock.getDisplayName(USERSYS)
-                            + ", " + nextBlock.getDisplayName(USERSYS)
-                            + " - Paths are not consistent - Section " + getDisplayName(USERSYS) + ".";
-                    return s;
-                }
-            }
-        }
-        // validate entry points
-        if ((mForwardEntryPoints.isEmpty()) && (mReverseEntryPoints.isEmpty())) {
-            String s = "Section " + getDisplayName(USERSYS) + "has no Entry Points.";
-            return s;
-        }
-        if (mForwardEntryPoints.size() > 0) {
-            for (int i = 0; i < mForwardEntryPoints.size(); i++) {
-                EntryPoint ep = mForwardEntryPoints.get(i);
-                if (!containsBlock(ep.getBlock())) {
-                    String s = "Entry Point Block, " + ep.getBlock().getDisplayName(USERSYS)
-                            + ", is not a Block in Section " + getDisplayName(USERSYS) + ".";
-                    return s;
-                }
-                if (!connectsToBlock(ep.getFromBlock())) {
-                    String s = "Entry Point From Block, " + ep.getBlock().getDisplayName(USERSYS)
-                            + ", is not connected to a Block in Section " + getDisplayName(USERSYS) + ".";
-                    return s;
-                }
-                if (!ep.isForwardType()) {
-                    String s = "Direction of FORWARD Entry Point From Block "
-                            + ep.getFromBlock().getDisplayName(USERSYS) + " to Section "
-                            + getDisplayName(USERSYS) + " is incorrectly set.";
-                    return s;
-                }
-                if (!connected(ep.getBlock(), ep.getFromBlock())) {
-                    String s = "Entry Point Blocks, " + ep.getBlock().getDisplayName(USERSYS)
-                            + " and " + ep.getFromBlock().getDisplayName(USERSYS)
-                            + ", are not connected in Section " + getDisplayName(USERSYS) + ".";
-                    return s;
-                }
-            }
-        }
-        if (mReverseEntryPoints.size() > 0) {
-            for (int i = 0; i < mReverseEntryPoints.size(); i++) {
-                EntryPoint ep = mReverseEntryPoints.get(i);
-                if (!containsBlock(ep.getBlock())) {
-                    String s = "Entry Point Block, " + ep.getBlock().getDisplayName(USERSYS)
-                            + ", is not a Block in Section " + getDisplayName(USERSYS) + ".";
-                    return s;
-                }
-                if (!connectsToBlock(ep.getFromBlock())) {
-                    String s = "Entry Point From Block, " + ep.getBlock().getDisplayName(USERSYS)
-                            + ", is not connected to a Block in Section " + getDisplayName(USERSYS) + ".";
-                    return s;
-                }
-                if (!ep.isReverseType()) {
-                    String s = "Direction of REVERSE Entry Point From Block "
-                            + ep.getFromBlock().getDisplayName(USERSYS) + " to Section "
-                            + getDisplayName(USERSYS) + " is incorrectly set.";
-                    return s;
-                }
-                if (!connected(ep.getBlock(), ep.getFromBlock())) {
-                    String s = "Entry Point Blocks, " + ep.getBlock().getDisplayName(USERSYS)
-                            + " and " + ep.getFromBlock().getDisplayName(USERSYS)
-                            + ", are not connected in Section " + getDisplayName(USERSYS) + ".";
-                    return s;
-                }
-            }
-        }
-        return "";
-    }
-
-    private boolean connected(Block b1, Block b2) {
-        if ((b1 != null) && (b2 != null)) {
-            List<Path> paths = b1.getPaths();
-            for (int i = 0; i < paths.size(); i++) {
-                if (paths.get(i).getBlock() == b2) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
+    public String validate(LayoutEditor lePanel);
 
     /**
      * Set/reset the display to use alternate color for unoccupied blocks in
@@ -2534,17 +359,7 @@ public class Section extends AbstractNamedBean {
      *
      * @param set true to use alternate unoccupied color; false otherwise
      */
-    public void setAlternateColor(boolean set) {
-        for (Block b : mBlockEntries) {
-            String userName = b.getUserName();
-            if (userName != null) {
-                LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                if (lb != null) {
-                    lb.setUseExtraColor(set);
-                }
-            }
-        }
-    }
+    public void setAlternateColor(boolean set);
 
     /**
      * Set/reset the display to use alternate color for unoccupied blocks in
@@ -2556,107 +371,28 @@ public class Section extends AbstractNamedBean {
      *
      * @param set true to use alternate unoccupied color; false otherwise
      */
-    public void setAlternateColorFromActiveBlock(boolean set) {
-        LayoutBlockManager lbm = InstanceManager.getDefault(LayoutBlockManager.class);
-        boolean beenSet = false;
-        if (!set || getState() == FREE || getState() == UNKNOWN) {
-            setAlternateColor(set);
-        } else if (getState() == FORWARD) {
-            for (Block b : mBlockEntries) {
-                if (b.getState() == Block.OCCUPIED) {
-                    beenSet = true;
-                }
-                if (beenSet) {
-                    String userName = b.getUserName();
-                    if (userName != null) {
-                        LayoutBlock lb = lbm.getByUserName(userName);
-                        if (lb != null) {
-                            lb.setUseExtraColor(set);
-                        }
-                    }
-                }
-            }
-        } else if (getState() == REVERSE) {
-            for (Block b : mBlockEntries) {
-                if (b.getState() == Block.OCCUPIED) {
-                    beenSet = true;
-                }
-                if (beenSet) {
-                    String userName = b.getUserName();
-                    if (userName != null) {
-                        LayoutBlock lb = lbm.getByUserName(userName);
-                        if (lb != null) {
-                            lb.setUseExtraColor(set);
-                        }
-                    }
-                }
-            }
-        }
-        if (!beenSet) {
-            setAlternateColor(set);
-        }
-    }
+    public void setAlternateColorFromActiveBlock(boolean set);
 
     /**
      * Set the block values for blocks in this Section.
      *
      * @param name the value to set all blocks to
      */
-    public void setNameInBlocks(String name) {
-        for (Block b : mBlockEntries) {
-            b.setValue(name);
-        }
-    }
+    public void setNameInBlocks(String name);
 
     /**
      * Set the block values for blocks in this Section.
      *
      * @param value the name to set block values to
      */
-    public void setNameInBlocks(Object value) {
-        for (Block b : mBlockEntries) {
-            b.setValue(value);
-        }
-    }
+    public void setNameInBlocks(Object value);
 
-    public void setNameFromActiveBlock(Object value) {
-        boolean beenSet = false;
-        if (value == null || getState() == FREE || getState() == UNKNOWN) {
-            setNameInBlocks(value);
-        } else if (getState() == FORWARD) {
-            for (Block b : mBlockEntries) {
-                if (b.getState() == Block.OCCUPIED) {
-                    beenSet = true;
-                }
-                if (beenSet) {
-                    b.setValue(value);
-                }
-            }
-        } else if (getState() == REVERSE) {
-            for (Block b : mBlockEntries) {
-                if (b.getState() == Block.OCCUPIED) {
-                    beenSet = true;
-                }
-                if (beenSet) {
-                    b.setValue(value);
-                }
-            }
-        }
-        if (!beenSet) {
-            setNameInBlocks(value);
-        }
-    }
+    public void setNameFromActiveBlock(Object value);
 
     /**
      * Clear the block values for blocks in this Section.
      */
-    public void clearNameInUnoccupiedBlocks() {
-        for (Block b : mBlockEntries) {
-            if (b.getState() == Block.UNOCCUPIED) {
-                b.setValue(null);
-            }
-        }
-    }
+    public void clearNameInUnoccupiedBlocks();
 
     /**
      * Suppress the update of a memory variable when a block goes to unoccupied,
@@ -2664,23 +400,11 @@ public class Section extends AbstractNamedBean {
      *
      * @param set true to suppress the update; false otherwise
      */
-    public void suppressNameUpdate(boolean set) {
-        for (Block b : mBlockEntries) {
-            String userName = b.getUserName();
-            if (userName != null) {
-                LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
-                if (lb != null) {
-                    lb.setSuppressNameUpdate(set);
-                }
-            }
-        }
-    }
+    public void suppressNameUpdate(boolean set);
 
     final public static int USERDEFINED = 0x01; //Default Save all the information
     final public static int SIGNALMASTLOGIC = 0x02; //Save only the name, blocks will be added by the signalmast logic
     final public static int DYNAMICADHOC = 0x00;  //created on an as required basis, not to be saved.
-
-    private int sectionType = USERDEFINED;
 
     /**
      * Set Section Type.
@@ -2691,82 +415,13 @@ public class Section extends AbstractNamedBean {
      * </ul>
      * @param type constant of section type.
      */
-    public void setSectionType(int type) {
-        sectionType = type;
-    }
+    public void setSectionType(int type);
 
     /**
      * Get Section Type.
      * Defaults to USERDEFINED.
      * @return constant of section type.
      */
-    public int getSectionType() {
-        return sectionType;
-    }
-
-    @Override
-    public String getBeanType() {
-        return Bundle.getMessage("BeanNameSection");
-    }
-
-    @Override
-    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-        if ("CanDelete".equals(evt.getPropertyName())) { // NOI18N
-            NamedBean nb = (NamedBean) evt.getOldValue();
-            if (nb instanceof Sensor) {
-                if (nb.equals(getForwardBlockingSensor())) {
-                    PropertyChangeEvent e = new PropertyChangeEvent(this, "DoNotDelete", null, null);
-                    throw new PropertyVetoException(Bundle.getMessage("VetoBlockingSensor", nb.getBeanType(), Bundle.getMessage("Forward"), Bundle.getMessage("Blocking"), getDisplayName()), e); // NOI18N
-                }
-                if (nb.equals(getForwardStoppingSensor())) {
-                    PropertyChangeEvent e = new PropertyChangeEvent(this, "DoNotDelete", null, null);
-                    throw new PropertyVetoException(Bundle.getMessage("VetoBlockingSensor", nb.getBeanType(), Bundle.getMessage("Forward"), Bundle.getMessage("Stopping"), getDisplayName()), e);
-                }
-                if (nb.equals(getReverseBlockingSensor())) {
-                    PropertyChangeEvent e = new PropertyChangeEvent(this, "DoNotDelete", null, null);
-                    throw new PropertyVetoException(Bundle.getMessage("VetoBlockingSensor", nb.getBeanType(), Bundle.getMessage("Reverse"), Bundle.getMessage("Blocking"), getDisplayName()), e);
-                }
-                if (nb.equals(getReverseStoppingSensor())) {
-                    PropertyChangeEvent e = new PropertyChangeEvent(this, "DoNotDelete", null, null);
-                    throw new PropertyVetoException(Bundle.getMessage("VetoBlockingSensor", nb.getBeanType(), Bundle.getMessage("Reverse"), Bundle.getMessage("Stopping"), getDisplayName()), e);
-                }
-            }
-            if (nb instanceof Block) {
-                Block check = (Block)nb;
-                if (getBlockList().contains(check)) {
-                    PropertyChangeEvent e = new PropertyChangeEvent(this, "DoNotDelete", null, null);
-                    throw new PropertyVetoException(Bundle.getMessage("VetoBlockInSection", getDisplayName()), e);
-                }
-            }
-        }
-        // "DoDelete" case, if needed, should be handled here.
-    }
-
-    @Override
-    public List<NamedBeanUsageReport> getUsageReport(NamedBean bean) {
-        List<NamedBeanUsageReport> report = new ArrayList<>();
-        if (bean != null) {
-            getBlockList().forEach((block) -> {
-                if (bean.equals(block)) {
-                    report.add(new NamedBeanUsageReport("SectionBlock"));
-                }
-            });
-            if (bean.equals(getForwardBlockingSensor())) {
-                report.add(new NamedBeanUsageReport("SectionSensorForwardBlocking"));
-            }
-            if (bean.equals(getForwardStoppingSensor())) {
-                report.add(new NamedBeanUsageReport("SectionSensorForwardStopping"));
-            }
-            if (bean.equals(getReverseBlockingSensor())) {
-                report.add(new NamedBeanUsageReport("SectionSensorReverseBlocking"));
-            }
-            if (bean.equals(getReverseStoppingSensor())) {
-                report.add(new NamedBeanUsageReport("SectionSensorReverseStopping"));
-            }
-        }
-        return report;
-    }
-
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Section.class);
+    public int getSectionType();
 
 }

--- a/java/src/jmri/Section.java
+++ b/java/src/jmri/Section.java
@@ -402,9 +402,14 @@ public interface Section extends NamedBean {
      */
     public void suppressNameUpdate(boolean set);
 
-    final public static int USERDEFINED = 0x01; //Default Save all the information
-    final public static int SIGNALMASTLOGIC = 0x02; //Save only the name, blocks will be added by the signalmast logic
-    final public static int DYNAMICADHOC = 0x00;  //created on an as required basis, not to be saved.
+    enum SectionType {
+        DYNAMICADHOC,   // Created on an as required basis, not to be saved.
+        USERDEFINED,    // Default Save all the information
+        SIGNALMASTLOGIC // Save only the name, blocks will be added by the signalmast logic
+    }
+    final public static SectionType USERDEFINED     = SectionType.USERDEFINED;
+    final public static SectionType SIGNALMASTLOGIC = SectionType.SIGNALMASTLOGIC;
+    final public static SectionType DYNAMICADHOC    = SectionType.DYNAMICADHOC;
 
     /**
      * Set Section Type.
@@ -415,13 +420,13 @@ public interface Section extends NamedBean {
      * </ul>
      * @param type constant of section type.
      */
-    public void setSectionType(int type);
+    public void setSectionType(SectionType SectionType);
 
     /**
      * Get Section Type.
      * Defaults to USERDEFINED.
      * @return constant of section type.
      */
-    public int getSectionType();
+    public SectionType getSectionType();
 
 }

--- a/java/src/jmri/SectionManager.java
+++ b/java/src/jmri/SectionManager.java
@@ -7,12 +7,9 @@ import java.util.Set;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import jmri.managers.AbstractManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
-import jmri.jmrit.display.layoutEditor.LayoutBlock;
+
+import jmri.jmrit.display.layoutEditor.LayoutEditor;
 
 /**
  * Basic Implementation of a SectionManager.
@@ -37,32 +34,9 @@ import jmri.jmrit.display.layoutEditor.LayoutBlock;
  *
  * @author Dave Duchamp Copyright (C) 2008
  */
-public class SectionManager extends AbstractManager<Section> implements InstanceManagerAutoDefault {
+public interface SectionManager extends Manager<Section> {
 
-    public SectionManager() {
-        super();
-        addListeners();
-    }
-    
-    final void addListeners() {
-        InstanceManager.getDefault(SensorManager.class).addVetoableChangeListener(this);
-        InstanceManager.getDefault(BlockManager.class).addVetoableChangeListener(this);
-    }
-
-    @Override
-    public int getXMLOrder() {
-        return Manager.SECTIONS;
-    }
-
-    @Override
-    public char typeLetter() {
-        return 'Y';
-    }
-
-    @Override
-    public Class<Section> getNamedBeanClass() {
-        return Section.class;
-    }
+    // void addListeners();
 
     /**
      * Create a new Section if the Section does not exist.
@@ -75,40 +49,8 @@ public class SectionManager extends AbstractManager<Section> implements Instance
      *         Section.
      */
     @Nonnull
-    public Section createNewSection(@Nonnull String systemName, String userName) throws IllegalArgumentException {
-        Objects.requireNonNull(systemName, "SystemName cannot be null. UserName was " + ((userName == null) ? "null" : userName));  // NOI18N
-        // check system name
-        if (systemName.isEmpty()) {
-            throw new IllegalArgumentException("Section System Name Empty");
-            // no valid system name entered, return without creating
-        }
-        String sysName = systemName;
-        if (!sysName.startsWith(getSystemNamePrefix())) {
-            sysName = makeSystemName(sysName);
-        }
-        // Check that Section does not already exist
-        Section y;
-        if (userName != null && !userName.isEmpty()) {
-            y = getByUserName(userName);
-            if (y != null) {
-                throw new IllegalArgumentException("Section Already Exists with UserName " + userName);
-            }
-        }
-        y = getBySystemName(sysName);
-        if (y != null) {
-            throw new IllegalArgumentException("Section Already Exists with SystemName " + sysName);
-        }
-        // Section does not exist, create a new Section
-        y = new Section(sysName, userName);
-        // save in the maps
-        register(y);
+    public Section createNewSection(@Nonnull String systemName, String userName) throws IllegalArgumentException;
 
-        // Keep track of the last created auto system name
-        updateAutoNumber(systemName);
-
-        return y;
-    }
-    
     /**
      * Create a New Section with Auto System Name.
      * @param userName UserName for new Section
@@ -117,20 +59,14 @@ public class SectionManager extends AbstractManager<Section> implements Instance
      *          unable to create a new Section.
      */
     @Nonnull
-    public Section createNewSection(String userName) throws IllegalArgumentException {
-        return createNewSection(getAutoSystemName(), userName);
-    }
+    public Section createNewSection(String userName) throws IllegalArgumentException;
 
     /**
      * Remove an existing Section.
      *
      * @param y the section to remove
      */
-    public void deleteSection(Section y) {
-        // delete the Section
-        deregister(y);
-        y.dispose();
-    }
+    public void deleteSection(Section y);
 
     /**
      * Get an existing Section. First look up assuming that name is a User
@@ -140,13 +76,7 @@ public class SectionManager extends AbstractManager<Section> implements Instance
      *             followed by system names
      * @return the found section of null if no matching Section found
      */
-    public Section getSection(String name) {
-        Section y = getByUserName(name);
-        if (y != null) {
-            return y;
-        }
-        return getBySystemName(name);
-    }
+    public Section getSection(String name);
 
     /**
      * Validate all Sections.
@@ -156,26 +86,7 @@ public class SectionManager extends AbstractManager<Section> implements Instance
      * @return number or validation errors; -2 is returned if there are no
      *         sections
      */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value="SLF4J_FORMAT_SHOULD_BE_CONST",
-        justification="Error String already evaluated, text from managed class")
-    public int validateAllSections(jmri.util.JmriJFrame frame, LayoutEditor lePanel) {
-        Set<Section> set = getNamedBeanSet();
-        int numSections = 0;
-        int numErrors = 0;
-        if (set.size() <= 0) {
-            return -2;
-        }
-        for (Section section : set) {
-            String s = section.validate(lePanel);
-            if (!s.isEmpty()) {
-                log.error(s);
-                numErrors++;
-            }
-            numSections++;
-        }
-        log.debug("Validated {} Sections - {} errors or warnings.", numSections, numErrors);
-        return numErrors;
-    }
+    public int validateAllSections(jmri.util.JmriJFrame frame, LayoutEditor lePanel);
 
     /**
      * Check direction sensors in SSL for signals.
@@ -184,24 +95,7 @@ public class SectionManager extends AbstractManager<Section> implements Instance
      * @return the number or errors; 0 if no errors; -1 if the panel is null; -2
      *         if there are no sections
      */
-    public int setupDirectionSensors(LayoutEditor lePanel) {
-        if (lePanel == null) {
-            return -1;
-        }
-        Set<Section> set = getNamedBeanSet();
-        int numSections = 0;
-        int numErrors = 0;
-        if (set.size() <= 0) {
-            return -2;
-        }
-        for (Section section : set) {
-            int errors = section.placeDirectionSensors(lePanel);
-            numErrors = numErrors + errors;
-            numSections++;
-        }
-        log.debug("Checked direction sensors for {} Sections - {} errors or warnings.", numSections, numErrors);
-        return numErrors;
-    }
+    public int setupDirectionSensors(LayoutEditor lePanel);
 
     /**
      * Remove direction sensors from SSL for all signals.
@@ -210,159 +104,16 @@ public class SectionManager extends AbstractManager<Section> implements Instance
      * @return the number or errors; 0 if no errors; -1 if the panel is null; -2
      *         if there are no sections
      */
-    public int removeDirectionSensorsFromSSL(LayoutEditor lePanel) {
-        if (lePanel == null) {
-            return -1;
-        }
-        jmri.jmrit.display.layoutEditor.ConnectivityUtil cUtil = lePanel.getConnectivityUtil();
-        Set<Section> set = getNamedBeanSet();
-        if (set.size() <= 0) {
-            return -2;
-        }
-        int numErrors = 0;
-        List<String> sensorList = new ArrayList<>();
-        for (Section s : set) {
-            String name = s.getReverseBlockingSensorName();
-            if ((name != null) && (!name.isEmpty())) {
-                sensorList.add(name);
-            }
-            name = s.getForwardBlockingSensorName();
-            if ((name != null) && (!name.isEmpty())) {
-                sensorList.add(name);
-            }
-        }
-        SignalHeadManager shManager = InstanceManager.getDefault(SignalHeadManager.class);
-        for (SignalHead sh : shManager.getNamedBeanSet()) {
-            if (!cUtil.removeSensorsFromSignalHeadLogic(sensorList, sh)) {
-                numErrors++;
-            }
-        }
-        return numErrors;
-    }
+    public int removeDirectionSensorsFromSSL(LayoutEditor lePanel);
 
     /**
      * Initialize all blocking sensors that exist - set them to 'ACTIVE'.
      */
-    public void initializeBlockingSensors() {
-        for (Section s : getNamedBeanSet()) {
-            try {
-                if (s.getForwardBlockingSensor() != null) {
-                    s.getForwardBlockingSensor().setState(Sensor.ACTIVE);
-                }
-                if (s.getReverseBlockingSensor() != null) {
-                    s.getReverseBlockingSensor().setState(Sensor.ACTIVE);
-                }
-            } catch (JmriException reason) {
-                log.error("Exception when initializing blocking Sensors for Section {}", s.getDisplayName(NamedBean.DisplayOptions.USERNAME_SYSTEMNAME));
-            }
-        }
-    }
-        
+    public void initializeBlockingSensors();
+
     /**
      * Generate Block Sections in stubs/sidings. Called after generating signal logic.
      */
-    
-    
-    public void generateBlockSections() {
-        //find blocks with no paths through i.e. stub (siding)
-        LayoutBlockManager LayoutBlockManager = InstanceManager.getDefault(LayoutBlockManager.class);
-        //print "Layout Block"
-        for (LayoutBlock layoutBlock : LayoutBlockManager.getNamedBeanSet()){
-            if (layoutBlock.getNumberOfThroughPaths() == 0){
-                if (!blockSectionExists(layoutBlock)){
-                    //create block section"
-                    createBlockSection(layoutBlock);
-                }
-            }
-        }
-    }
-                               
-    /**
-     * Check if Block Section already exists
-     * @param layoutBlock
-     * @return true or false
-     */
-    private boolean blockSectionExists(LayoutBlock layoutBlock){
-        
-        for (Section section : getNamedBeanSet()){
-            if (section.getNumBlocks() == 1 
-                    && section.getSectionType() != Section.SIGNALMASTLOGIC 
-                    && layoutBlock.getBlock().equals(section.getEntryBlock())){
-                return true;
-            }
-        }
-        return false;
-    } 
-      
-    private void createBlockSection(LayoutBlock layoutBlock){
-        Section section;
-        try {
-            section = createNewSection(layoutBlock.getUserName());
-        }
-        catch (IllegalArgumentException ex){
-            log.error("Could not create Section from LayoutBlock {}",layoutBlock.getDisplayName());
-            return;
-        }
-        section.addBlock(layoutBlock.getBlock());
-        ArrayList<EntryPoint> entryPointList = new ArrayList<>();
-        Block sb = layoutBlock.getBlock();
-        List <Path> paths = sb.getPaths();
-        for (int j=0; j<paths.size(); j++){
-            Path p = paths.get(j);
-            if (p.getBlock() != sb){
-                //this is path to an outside block, so need an Entry Point
-                String pbDir = Path.decodeDirection(p.getFromBlockDirection());
-                EntryPoint ep = new EntryPoint(sb, p.getBlock(), pbDir);
-                entryPointList.add(ep);
-            }
-        }
-                
-        Block beginBlock = sb;
-        // Set directions where possible
-        List <EntryPoint> epList = getBlockEntryPointsList(beginBlock,entryPointList);
-        if (epList.size() == 1) {
-            (epList.get(0)).setTypeForward();
-        }  
-        Block endBlock = sb;
-        epList = getBlockEntryPointsList(endBlock, entryPointList);
-        if (epList.size() == 1) {
-            (epList.get(0)).setTypeReverse();          
-        }
-            
-        for (int j=0; j<entryPointList.size(); j++){
-            EntryPoint ep = entryPointList.get(j);
-            if (ep.isForwardType()){
-                section.addToForwardList(ep);
-            }else if (ep.isReverseType()){
-                section.addToReverseList(ep);
-            }
-        }
-    }
-            
-    private List <EntryPoint> getBlockEntryPointsList(Block b, List <EntryPoint> entryPointList) {
-        List <EntryPoint> list = new ArrayList<>();
-        for (int i=0; i<entryPointList.size(); i++) {
-            EntryPoint ep = entryPointList.get(i);
-            if (ep.getBlock().equals(b)) {
-                list.add(ep);
-            }
-        }
-        return list;
-    }
-
-    @Override
-    @Nonnull
-    public String getBeanTypeHandled(boolean plural) {
-        return Bundle.getMessage(plural ? "BeanNameSections" : "BeanNameSection");
-    }
-    
-    @Override
-    public void dispose(){
-        InstanceManager.getDefault(SensorManager.class).removeVetoableChangeListener(this);
-        InstanceManager.getDefault(BlockManager.class).removeVetoableChangeListener(this);
-        super.dispose();
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(SectionManager.class);
+    public void generateBlockSections();
 
 }

--- a/java/src/jmri/Transit.java
+++ b/java/src/jmri/Transit.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dave Duchamp Copyright (C) 2008-2011
  */
-public class Transit extends AbstractNamedBean {
+public interface Transit extends NamedBean {
 
     /**
      * The idle, or available for assignment to an ActiveTrain state.
@@ -54,84 +54,39 @@ public class Transit extends AbstractNamedBean {
      */
     public static final int ASSIGNED = 0x04;
 
-    /*
-     * Instance variables (not saved between runs)
-     */
-    private static final NamedBean.DisplayOptions USERSYS = NamedBean.DisplayOptions.USERNAME_SYSTEMNAME;
-    private int mState = Transit.IDLE;
-    private final ArrayList<TransitSection> mTransitSectionList = new ArrayList<>();
-    private int mMaxSequence = 0;
-    private final ArrayList<Integer> blockSecSeqList = new ArrayList<>();
-    private final ArrayList<Integer> destBlocksSeqList = new ArrayList<>();
-
-    public Transit(String systemName, String userName) {
-        super(systemName, userName);
-    }
-
-    public Transit(String systemName) {
-        super(systemName);
-    }
-
-    /**
-     * Query the state of this Transit.
-     *
-     * @return {@link #IDLE} or {@link #ASSIGNED}
-     */
-    @Override
-    public int getState() {
-        return mState;
-    }
-
     /**
      * Set the state of this Transit.
      *
      * @param state {@link #IDLE} or {@link #ASSIGNED}
      */
     @Override
-    public void setState(int state) {
-        if ((state == Transit.IDLE) || (state == Transit.ASSIGNED)) {
-            int old = mState;
-            mState = state;
-            firePropertyChange("state", old, mState);
-        } else {
-            log.error("Attempt to set Transit state to illegal value - {}", state);
-        }
-    }
+    public void setState(int state);
 
     /**
      * Add a Section to this Transit.
      *
      * @param s the Section object to add
      */
-    public void addTransitSection(TransitSection s) {
-        mTransitSectionList.add(s);
-        mMaxSequence = s.getSequenceNumber();
-    }
+    public void addTransitSection(TransitSection s);
 
     /**
      * Get the list of TransitSections.
      *
      * @return a copy of the internal list of TransitSections or an empty list
      */
-    public ArrayList<TransitSection> getTransitSectionList() {
-        return new ArrayList<>(mTransitSectionList);
-    }
+    public ArrayList<TransitSection> getTransitSectionList();
 
     /**
      * Get the maximum sequence number used in this Transit.
      *
      * @return the maximum sequence
      */
-    public int getMaxSequence() {
-        return mMaxSequence;
-    }
+    public int getMaxSequence();
 
     /**
      * Remove all TransitSections in this Transit.
      */
-    public void removeAllSections() {
-        mTransitSectionList.clear();
-    }
+    public void removeAllSections();
 
     /**
      * Check if a Section is in this Transit.
@@ -139,9 +94,7 @@ public class Transit extends AbstractNamedBean {
      * @param s the section to check for
      * @return true if the section is present; false otherwise
      */
-    public boolean containsSection(Section s) {
-        return mTransitSectionList.stream().anyMatch((ts) -> (ts.getSection() == s));
-    }
+    public boolean containsSection(Section s);
 
     /**
      * Get a List of Sections with a given sequence number.
@@ -149,15 +102,7 @@ public class Transit extends AbstractNamedBean {
      * @param seq the sequence number
      * @return the list of of matching sections or an empty list if none
      */
-    public ArrayList<Section> getSectionListBySeq(int seq) {
-        ArrayList<Section> list = new ArrayList<>();
-        for (TransitSection ts : mTransitSectionList) {
-            if (seq == ts.getSequenceNumber()) {
-                list.add(ts.getSection());
-            }
-        }
-        return list;
-    }
+    public ArrayList<Section> getSectionListBySeq(int seq);
 
     /**
      * Get a List of TransitSections with a given sequence number.
@@ -165,15 +110,7 @@ public class Transit extends AbstractNamedBean {
      * @param seq the sequence number
      * @return the list of of matching sections or an empty list if none
      */
-    public ArrayList<TransitSection> getTransitSectionListBySeq(int seq) {
-        ArrayList<TransitSection> list = new ArrayList<>();
-        for (TransitSection ts : mTransitSectionList) {
-            if (seq == ts.getSequenceNumber()) {
-                list.add(ts);
-            }
-        }
-        return list;
-    }
+    public ArrayList<TransitSection> getTransitSectionListBySeq(int seq);
 
     /**
      * Get a List of sequence numbers for a given Section.
@@ -181,15 +118,7 @@ public class Transit extends AbstractNamedBean {
      * @param s the section to match
      * @return the list of matching sequence numbers or an empty list if none
      */
-    public ArrayList<Integer> getSeqListBySection(Section s) {
-        ArrayList<Integer> list = new ArrayList<>();
-        for (TransitSection ts : mTransitSectionList) {
-            if (s == ts.getSection()) {
-                list.add(ts.getSequenceNumber());
-            }
-        }
-        return list;
-    }
+    public ArrayList<Integer> getSeqListBySection(Section s);
 
     /**
      * Check if a Block is in this Transit.
@@ -197,14 +126,7 @@ public class Transit extends AbstractNamedBean {
      * @param block the block to check for
      * @return true if block is present; false otherwise
      */
-    public boolean containsBlock(Block block) {
-        for (Block b : getInternalBlocksList()) {
-            if (b == block) {
-                return true;
-            }
-        }
-        return false;
-    }
+    public boolean containsBlock(Block block);
 
     /**
      * Get the number of times a Block is in this Transit.
@@ -212,15 +134,7 @@ public class Transit extends AbstractNamedBean {
      * @param block the block to check for
      * @return the number of times block is present; 0 if block is not present
      */
-    public int getBlockCount(Block block) {
-        int count = 0;
-        for (Block b : getInternalBlocksList()) {
-            if (b == block) {
-                count++;
-            }
-        }
-        return count;
-    }
+    public int getBlockCount(Block block);
 
     /**
      * Get a Section from one of its Blocks and its sequence number.
@@ -229,17 +143,7 @@ public class Transit extends AbstractNamedBean {
      * @param seq the sequence number of the Section
      * @return the Section or null if no matching Section is present
      */
-    public Section getSectionFromBlockAndSeq(Block b, int seq) {
-        for (TransitSection ts : mTransitSectionList) {
-            if (ts.getSequenceNumber() == seq) {
-                Section s = ts.getSection();
-                if (s.containsBlock(b)) {
-                    return s;
-                }
-            }
-        }
-        return null;
-    }
+    public Section getSectionFromBlockAndSeq(Block b, int seq);
 
     /**
      * Get Section from one of its EntryPoint Blocks and its sequence number.
@@ -248,17 +152,7 @@ public class Transit extends AbstractNamedBean {
      * @param seq the sequence number of the Section
      * @return the Section or null if no matching Section is present
      */
-    public Section getSectionFromConnectedBlockAndSeq(Block b, int seq) {
-        for (TransitSection ts : mTransitSectionList) {
-            if (ts.getSequenceNumber() == seq) {
-                Section s = ts.getSection();
-                if (s.connectsToBlock(b)) {
-                    return s;
-                }
-            }
-        }
-        return null;
-    }
+    public Section getSectionFromConnectedBlockAndSeq(Block b, int seq);
 
     /**
      * Get the direction of a Section in the transit from its sequence number.
@@ -269,14 +163,7 @@ public class Transit extends AbstractNamedBean {
      *         or {@link jmri.Section#REVERSE} or zero if s and seq are not in a
      *         TransitSection together
      */
-    public int getDirectionFromSectionAndSeq(Section s, int seq) {
-        for (TransitSection ts : mTransitSectionList) {
-            if ((ts.getSection() == s) && (ts.getSequenceNumber() == seq)) {
-                return ts.getDirection();
-            }
-        }
-        return 0;
-    }
+    public int getDirectionFromSectionAndSeq(Section s, int seq);
 
     /**
      * Get a TransitSection in the transit from its Section and sequence number.
@@ -285,14 +172,7 @@ public class Transit extends AbstractNamedBean {
      * @param seq the sequence number of the Section
      * @return the transit section or null if not found
      */
-    public TransitSection getTransitSectionFromSectionAndSeq(Section s, int seq) {
-        for (TransitSection ts : mTransitSectionList) {
-            if ((ts.getSection() == s) && (ts.getSequenceNumber() == seq)) {
-                return ts;
-            }
-        }
-        return null;
-    }
+    public TransitSection getTransitSectionFromSectionAndSeq(Section s, int seq);
 
     /**
      * Get a list of all blocks internal to this Transit. Since Sections may be
@@ -303,17 +183,7 @@ public class Transit extends AbstractNamedBean {
      *
      * @return the list of all Blocks or an empty list if none are present
      */
-    public ArrayList<Block> getInternalBlocksList() {
-        ArrayList<Block> list = new ArrayList<>();
-        blockSecSeqList.clear();
-        mTransitSectionList.forEach((ts) -> {
-            ts.getSection().getBlockList().stream().forEach((b) -> {
-                list.add(b);
-                blockSecSeqList.add(ts.getSequenceNumber());
-            });
-        });
-        return list;
-    }
+    public ArrayList<Block> getInternalBlocksList();
 
     /**
      * Get a list of sequence numbers in this Transit. This list is generated by
@@ -323,9 +193,7 @@ public class Transit extends AbstractNamedBean {
      * @return the list of all sequence numbers or an empty list if no Blocks
      *         are present
      */
-    public ArrayList<Integer> getBlockSeqList() {
-        return new ArrayList<>(blockSecSeqList);
-    }
+    public ArrayList<Integer> getBlockSeqList();
 
     /**
      * Get a list of all entry Blocks to this Transit. These are Blocks that a
@@ -336,34 +204,7 @@ public class Transit extends AbstractNamedBean {
      *
      * @return the list of all blocks or an empty list if none are present
      */
-    public ArrayList<Block> getEntryBlocksList() {
-        ArrayList<Block> list = new ArrayList<>();
-        ArrayList<Block> internalBlocks = getInternalBlocksList();
-        blockSecSeqList.clear();
-        for (TransitSection ts : mTransitSectionList) {
-            List<EntryPoint> ePointList;
-            if (ts.getDirection() == Section.FORWARD) {
-                ePointList = ts.getSection().getForwardEntryPointList();
-            } else {
-                ePointList = ts.getSection().getReverseEntryPointList();
-            }
-            for (EntryPoint ep : ePointList) {
-                Block eb = ep.getFromBlock();
-                boolean isInternal = false;
-                for (Block ib : internalBlocks) {
-                    if (eb == ib) {
-                        isInternal = true;
-                    }
-                }
-                if (!isInternal) {
-                    // not an internal Block, keep it
-                    list.add(eb);
-                    blockSecSeqList.add(ts.getSequenceNumber());
-                }
-            }
-        }
-        return list;
-    }
+    public ArrayList<Block> getEntryBlocksList();
 
     /**
      * Get a list of all destination blocks that can be reached from a specified
@@ -382,47 +223,7 @@ public class Transit extends AbstractNamedBean {
      *                       otherwise
      * @return a list of destination Blocks or an empty list if none exist
      */
-    public ArrayList<Block> getDestinationBlocksList(Block startBlock, boolean startInTransit) {
-        ArrayList<Block> list = new ArrayList<>();
-        destBlocksSeqList.clear();
-        if (startBlock == null) {
-            return list;
-        }
-        // get the sequence number of the Section of the starting Block
-        int startSeq = -1;
-        ArrayList<Block> startBlocks;
-        if (startInTransit) {
-            startBlocks = getInternalBlocksList();
-        } else {
-            startBlocks = getEntryBlocksList();
-        }
-        // programming note: the above calls initialize blockSecSeqList.
-        for (int k = 0; ((k < startBlocks.size()) && (startSeq == -1)); k++) {
-            if (startBlock == startBlocks.get(k)) {
-                startSeq = (blockSecSeqList.get(k));
-            }
-        }
-        ArrayList<Block> internalBlocks = getInternalBlocksList();
-        //allow for transits of length 1
-        if (startInTransit) {
-            for (int i = internalBlocks.size(); i > 0; i--) {
-                if (blockSecSeqList.get(i - 1) > startSeq) {
-                    // could stop in this block, keep it
-                    list.add(internalBlocks.get(i - 1));
-                    destBlocksSeqList.add(blockSecSeqList.get(i - 1));
-                }
-            }
-        } else {
-            for (int i = internalBlocks.size(); i > 0; i--) {
-                if (blockSecSeqList.get(i - 1) >= startSeq) {
-                    // could stop in this block, keep it
-                    list.add(internalBlocks.get(i - 1));
-                    destBlocksSeqList.add(blockSecSeqList.get(i - 1));
-                }
-            }
-        }
-        return list;
-    }
+    public ArrayList<Block> getDestinationBlocksList(Block startBlock, boolean startInTransit);
 
     /**
      * Get a list of destination Block sequence numbers in this Transit. This
@@ -432,13 +233,7 @@ public class Transit extends AbstractNamedBean {
      * @return the list of all destination Block sequence numbers or an empty
      *         list if no destination Blocks are present
      */
-    public ArrayList<Integer> getDestBlocksSeqList() {
-        ArrayList<Integer> list = new ArrayList<>();
-        for (int i = 0; i < destBlocksSeqList.size(); i++) {
-            list.add(destBlocksSeqList.get(i));
-        }
-        return list;
-    }
+    public ArrayList<Integer> getDestBlocksSeqList();
 
     /**
      * Check if this Transit is capable of continuous running.
@@ -454,30 +249,7 @@ public class Transit extends AbstractNamedBean {
      *
      * @return true if continuous running is possible; otherwise false
      */
-    public boolean canBeResetWhenDone() {
-        TransitSection firstTS = mTransitSectionList.get(0);
-        int lastIndex = mTransitSectionList.size() - 1;
-        TransitSection lastTS = mTransitSectionList.get(lastIndex);
-        boolean OK = false;
-        while (!OK) {
-            if (firstTS.getSection() != lastTS.getSection()) {
-                if (lastTS.isAlternate() && (lastIndex > 1)) {
-                    lastIndex--;
-                    lastTS = mTransitSectionList.get(lastIndex);
-                } else {
-                    log.warn("Section mismatch {} {}", (firstTS.getSection()).getDisplayName(USERSYS), (lastTS.getSection()).getDisplayName(USERSYS));
-                    return false;
-                }
-            }
-            OK = true;
-        }
-        // same Section, check direction
-        if (firstTS.getDirection() != lastTS.getDirection()) {
-            log.warn("Direction mismatch {} {}", (firstTS.getSection()).getDisplayName(USERSYS), (lastTS.getSection()).getDisplayName(USERSYS));
-            return false;
-        }
-        return true;
-    }
+    public boolean canBeResetWhenDone();
 
     /**
      * Initialize blocking sensors for Sections in this Transit. This should be
@@ -488,131 +260,10 @@ public class Transit extends AbstractNamedBean {
      *
      * @return 0 if no errors, number of errors otherwise.
      */
-    public int initializeBlockingSensors() {
-        int numErrors = 0;
-        for (int i = 0; i < mTransitSectionList.size(); i++) {
-            Section s = mTransitSectionList.get(i).getSection();
-            try {
-                if (s.getForwardBlockingSensor() != null) {
-                    if (s.getState() == Section.FREE) {
-                        s.getForwardBlockingSensor().setState(Sensor.ACTIVE);
-                    }
-                } else {
-                    log.warn("Missing forward blocking sensor for section {}", s.getDisplayName(USERSYS));
-                    numErrors++;
-                }
-            } catch (JmriException reason) {
-                log.error("Exception when initializing forward blocking Sensor for Section {}", s.getDisplayName(USERSYS));
-                numErrors++;
-            }
-            try {
-                if (s.getReverseBlockingSensor() != null) {
-                    if (s.getState() == Section.FREE) {
-                        s.getReverseBlockingSensor().setState(Sensor.ACTIVE);
-                    }
-                } else {
-                    log.warn("Missing reverse blocking sensor for section {}", s.getDisplayName(USERSYS));
-                    numErrors++;
-                }
-            } catch (JmriException reason) {
-                log.error("Exception when initializing reverse blocking Sensor for Section {}", s.getDisplayName(USERSYS));
-                numErrors++;
-            }
-        }
-        return numErrors;
-    }
+    public int initializeBlockingSensors();
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "UC_USELESS_OBJECT",
-            justification = "SpotBugs doesn't see that toBeRemoved is being read by the forEach clause")
-    public void removeTemporarySections() {
-        ArrayList<TransitSection> toBeRemoved = new ArrayList<>();
-        for (TransitSection ts : mTransitSectionList) {
-            if (ts.isTemporary()) {
-                toBeRemoved.add(ts);
-            }
-        }
-        toBeRemoved.forEach((ts) -> {
-            mTransitSectionList.remove(ts);
-        });
-    }
+    public void removeTemporarySections();
 
-    public boolean removeLastTemporarySection(Section s) {
-        TransitSection last = mTransitSectionList.get(mTransitSectionList.size() - 1);
-        if (last.getSection() != s) {
-            log.info("Section asked to be removed is not the last one");
-            return false;
-        }
-        if (!last.isTemporary()) {
-            log.info("Section asked to be removed is not a temporary section");
-            return false;
-        }
-        mTransitSectionList.remove(last);
-        return true;
-
-    }
-
-    @Override
-    public String getBeanType() {
-        return Bundle.getMessage("BeanNameTransit");
-    }
-
-    @Override
-    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
-        if ("CanDelete".equals(evt.getPropertyName())) { // NOI18N
-            NamedBean nb = (NamedBean) evt.getOldValue();
-            if (nb instanceof Section) {
-                if (containsSection((Section) nb)) {
-                    throw new PropertyVetoException(Bundle.getMessage("VetoTransitSection", getDisplayName()), evt);
-                }
-            }
-        }
-        // we ignore the property setConfigureManager
-    }
-
-    @Override
-    public List<NamedBeanUsageReport> getUsageReport(NamedBean bean) {
-        List<NamedBeanUsageReport> report = new ArrayList<>();
-        jmri.SensorManager sm = jmri.InstanceManager.getDefault(jmri.SensorManager.class);
-        jmri.SignalHeadManager head = jmri.InstanceManager.getDefault(jmri.SignalHeadManager.class);
-        jmri.SignalMastManager mast = jmri.InstanceManager.getDefault(jmri.SignalMastManager.class);
-        if (bean != null) {
-            getTransitSectionList().forEach((transitSection) -> {
-                if (bean.equals(transitSection.getSection())) {
-                    report.add(new NamedBeanUsageReport("TransitSection"));
-                }
-                if (bean.equals(sm.getSensor(transitSection.getStopAllocatingSensor()))) {
-                    report.add(new NamedBeanUsageReport("TransitSensorStopAllocation"));
-                }
-                // Process actions
-                transitSection.getTransitSectionActionList().forEach((action) -> {
-                    int whenCode = action.getWhenCode();
-                    int whatCode = action.getWhatCode();
-                    if (whenCode == TransitSectionAction.SENSORACTIVE || whenCode == TransitSectionAction.SENSORINACTIVE) {
-                        if (bean.equals(sm.getSensor(action.getStringWhen()))) {
-                            report.add(new NamedBeanUsageReport("TransitActionSensorWhen", transitSection.getSection()));
-                        }
-                    }
-                    if (whatCode == TransitSectionAction.SETSENSORACTIVE || whatCode == TransitSectionAction.SETSENSORINACTIVE) {
-                        if (bean.equals(sm.getSensor(action.getStringWhat()))) {
-                            report.add(new NamedBeanUsageReport("TransitActionSensorWhat", transitSection.getSection()));
-                        }
-                    }
-                    if (whatCode == TransitSectionAction.HOLDSIGNAL || whatCode == TransitSectionAction.RELEASESIGNAL) {
-                        // Could be a signal head or a signal mast.
-                        if (bean.equals(head.getSignalHead(action.getStringWhat()))) {
-                            report.add(new NamedBeanUsageReport("TransitActionSignalHeadWhat", transitSection.getSection()));
-                        }
-                        if (bean.equals(mast.getSignalMast(action.getStringWhat()))) {
-                            report.add(new NamedBeanUsageReport("TransitActionSignalMastWhat", transitSection.getSection()));
-                        }
-                    }
-                });
-            });
-        }
-        return report;
-    }
-
-
-    private final static Logger log = LoggerFactory.getLogger(Transit.class);
+    public boolean removeLastTemporarySection(Section s);
 
 }

--- a/java/src/jmri/Transit.java
+++ b/java/src/jmri/Transit.java
@@ -5,7 +5,7 @@ import java.beans.PropertyVetoException;
 import java.util.ArrayList;
 import java.util.List;
 import jmri.implementation.AbstractNamedBean;
-import jmri.jmrit.display.layoutEditor.LayoutEditor;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java/src/jmri/TransitManager.java
+++ b/java/src/jmri/TransitManager.java
@@ -36,10 +36,10 @@ public class TransitManager extends AbstractManager<Transit> implements Instance
         super();
         addVetoListener();
     }
-    
+
     final void addVetoListener(){
         InstanceManager.getDefault(SectionManager.class).addVetoableChangeListener(this);
-    } 
+    }
 
     @Override
     public int getXMLOrder() {
@@ -88,7 +88,7 @@ public class TransitManager extends AbstractManager<Transit> implements Instance
                 Bundle.getMessage("InvalidSytemNameAlreadyExists",getBeanTypeHandled(false),sysName));
         }
         // Transit does not exist, create a new Transit
-        z = new Transit(sysName, userName);
+        z = new jmri.implementation.DefaultTransit(sysName, userName);
         // save in the maps
         register(z);
 
@@ -184,7 +184,7 @@ public class TransitManager extends AbstractManager<Transit> implements Instance
         }
         return list;
     }
-    
+
     @Override
     @Nonnull
     public String getBeanTypeHandled(boolean plural) {
@@ -198,7 +198,7 @@ public class TransitManager extends AbstractManager<Transit> implements Instance
     public Class<Transit> getNamedBeanClass() {
         return Transit.class;
     }
-    
+
     @Override
     public void dispose() {
         InstanceManager.getDefault(SectionManager.class).removeVetoableChangeListener(this);

--- a/java/src/jmri/TransitManager.java
+++ b/java/src/jmri/TransitManager.java
@@ -30,26 +30,7 @@ import jmri.managers.AbstractManager;
  *
  * @author Dave Duchamp Copyright (C) 2008, 2011
  */
-public class TransitManager extends AbstractManager<Transit> implements InstanceManagerAutoDefault {
-
-    public TransitManager() {
-        super();
-        addVetoListener();
-    }
-
-    final void addVetoListener(){
-        InstanceManager.getDefault(SectionManager.class).addVetoableChangeListener(this);
-    }
-
-    @Override
-    public int getXMLOrder() {
-        return Manager.TRANSITS;
-    }
-
-    @Override
-    public char typeLetter() {
-        return 'Z';
-    }
+public interface TransitManager extends Manager<Transit> {
 
     /**
      * Create a new Transit if the Transit does not exist.
@@ -63,40 +44,7 @@ public class TransitManager extends AbstractManager<Transit> implements Instance
      *         Transit.
      */
     @Nonnull
-    public Transit createNewTransit(@CheckForNull String systemName, String userName) throws NamedBean.BadNameException {
-        // check system name
-        if ((systemName == null) || (systemName.isEmpty())) {
-            throw new NamedBean.BadSystemNameException("Transit System Name cannot be empty or null.", // NOI18N
-                Bundle.getMessage("InvalidBeanSystemNameEmpty",getBeanTypeHandled(false)));
-        }
-        String sysName = systemName;
-        if (!sysName.startsWith(getSystemNamePrefix())) {
-            sysName = makeSystemName(sysName);
-        }
-        // Check that Transit does not already exist
-        Transit z;
-        if (userName != null && !userName.isEmpty()) {
-            z = getByUserName(userName);
-            if (z != null) {
-                throw new NamedBean.BadUserNameException("Transit UserName \""+userName+"\" Already Exists.", // NOI18N
-                Bundle.getMessage("InvalidUserNameAlreadyExists",getBeanTypeHandled(false),sysName));
-            }
-        }
-        z = getBySystemName(sysName);
-        if (z != null) {
-            throw new NamedBean.DuplicateSystemNameException("Transit SytemName \""+sysName+"\" Already Exists.", // NOI18N
-                Bundle.getMessage("InvalidSytemNameAlreadyExists",getBeanTypeHandled(false),sysName));
-        }
-        // Transit does not exist, create a new Transit
-        z = new jmri.implementation.DefaultTransit(sysName, userName);
-        // save in the maps
-        register(z);
-
-        // Keep track of the last created auto system name
-        updateAutoNumber(systemName);
-
-        return z;
-    }
+    public Transit createNewTransit(@CheckForNull String systemName, String userName) throws NamedBean.BadNameException;
 
     /**
      * For use with User GUI, to allow the auto generation of systemNames, where
@@ -112,9 +60,7 @@ public class TransitManager extends AbstractManager<Transit> implements Instance
      *         another Transit
      */
     @Nonnull
-    public Transit createNewTransit(String userName) throws NamedBean.BadNameException {
-        return createNewTransit(getAutoSystemName(), userName);
-    }
+    public Transit createNewTransit(String userName) throws NamedBean.BadNameException;
 
     /**
      * Get an existing Transit.
@@ -126,21 +72,14 @@ public class TransitManager extends AbstractManager<Transit> implements Instance
      * @return null if no match found
      */
     @CheckForNull
-    public Transit getTransit(String name) {
-        Transit z = getByUserName(name);
-        return (z != null ? z : getBySystemName(name));
-    }
+    public Transit getTransit(String name);
 
     /**
      * Remove an existing Transit.
      *
      * @param z the transit to remove
      */
-    public void deleteTransit(Transit z) {
-        // delete the Transit
-        deregister(z);
-        z.dispose();
-    }
+    public void deleteTransit(Transit z);
 
     /**
      * Get a list of Transits which use a specified Section.
@@ -149,62 +88,12 @@ public class TransitManager extends AbstractManager<Transit> implements Instance
      * @return a list, possibly empty, of Transits using section s.
      */
     @Nonnull
-    public ArrayList<Transit> getListUsingSection(Section s) {
-        ArrayList<Transit> list = new ArrayList<>();
-        for (Transit tTransit : getNamedBeanSet()) {
-            if (tTransit.containsSection(s)) {
-                // this Transit uses the specified Section
-                list.add(tTransit);
-            }
-        }
-        return list;
-    }
+    public ArrayList<Transit> getListUsingSection(Section s);
 
     @Nonnull
-    public ArrayList<Transit> getListUsingBlock(Block b) {
-        ArrayList<Transit> list = new ArrayList<>();
-        for (Transit tTransit : getNamedBeanSet()) {
-            if (tTransit.containsBlock(b)) {
-                // this Transit uses the specified Section
-                list.add(tTransit);
-            }
-        }
-        return list;
-    }
+    public ArrayList<Transit> getListUsingBlock(Block b);
 
     @Nonnull
-    public ArrayList<Transit> getListEntryBlock(Block b) {
-        ArrayList<Transit> list = new ArrayList<>();
-        for (Transit tTransit : getNamedBeanSet()) {
-            ArrayList<Block> entryBlock = tTransit.getEntryBlocksList();
-            if (entryBlock.contains(b)) {
-                // this Transit uses the specified Section
-                list.add(tTransit);
-            }
-        }
-        return list;
-    }
-
-    @Override
-    @Nonnull
-    public String getBeanTypeHandled(boolean plural) {
-        return Bundle.getMessage(plural ? "BeanNameTransits" : "BeanNameTransit");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Class<Transit> getNamedBeanClass() {
-        return Transit.class;
-    }
-
-    @Override
-    public void dispose() {
-        InstanceManager.getDefault(SectionManager.class).removeVetoableChangeListener(this);
-        super.dispose();
-    }
-
-    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TransitManager.class);
+    public ArrayList<Transit> getListEntryBlock(Block b);
 
 }

--- a/java/src/jmri/configurexml/ClassMigration.properties
+++ b/java/src/jmri/configurexml/ClassMigration.properties
@@ -71,3 +71,6 @@ jmri.jmrit.display.layoutEditor.configurexml.LayoutXOverXml        = jmri.jmrit.
 jmri.jmrit.display.layoutEditor.configurexml.LayoutRHXOverXml      = jmri.jmrit.display.layoutEditor.configurexml.LayoutRHXOverViewXml
 jmri.jmrit.display.layoutEditor.configurexml.LayoutLHXOverXml      = jmri.jmrit.display.layoutEditor.configurexml.LayoutLHXOverViewXml
 jmri.jmrit.display.layoutEditor.configurexml.LayoutDoubleXOverXml  = jmri.jmrit.display.layoutEditor.configurexml.LayoutDoubleXOverViewXml
+
+# MIgration of Section class in May 2022
+jmri.configurexml.SectionManagerXml         = jmri.managers.configurexml.DefaultSectionManagerXml

--- a/java/src/jmri/configurexml/ClassMigration.properties
+++ b/java/src/jmri/configurexml/ClassMigration.properties
@@ -72,5 +72,6 @@ jmri.jmrit.display.layoutEditor.configurexml.LayoutRHXOverXml      = jmri.jmrit.
 jmri.jmrit.display.layoutEditor.configurexml.LayoutLHXOverXml      = jmri.jmrit.display.layoutEditor.configurexml.LayoutLHXOverViewXml
 jmri.jmrit.display.layoutEditor.configurexml.LayoutDoubleXOverXml  = jmri.jmrit.display.layoutEditor.configurexml.LayoutDoubleXOverViewXml
 
-# MIgration of Section class in May 2022
+# Migration of classes in May 2022
 jmri.configurexml.SectionManagerXml         = jmri.managers.configurexml.DefaultSectionManagerXml
+jmri.configurexml.TransitManagerXml         = jmri.managers.configurexml.DefaultTransitManagerXml

--- a/java/src/jmri/implementation/DefaultSection.java
+++ b/java/src/jmri/implementation/DefaultSection.java
@@ -2649,7 +2649,7 @@ public class DefaultSection extends AbstractNamedBean implements Section {
         }
     }
 
-    private int sectionType = USERDEFINED;
+    private SectionType sectionType = USERDEFINED;
 
     /**
      * Set Section Type.
@@ -2660,7 +2660,7 @@ public class DefaultSection extends AbstractNamedBean implements Section {
      * </ul>
      * @param type constant of section type.
      */
-    public void setSectionType(int type) {
+    public void setSectionType(SectionType type) {
         sectionType = type;
     }
 
@@ -2669,7 +2669,7 @@ public class DefaultSection extends AbstractNamedBean implements Section {
      * Defaults to USERDEFINED.
      * @return constant of section type.
      */
-    public int getSectionType() {
+    public SectionType getSectionType() {
         return sectionType;
     }
 

--- a/java/src/jmri/implementation/DefaultSection.java
+++ b/java/src/jmri/implementation/DefaultSection.java
@@ -95,23 +95,6 @@ public class DefaultSection extends AbstractNamedBean implements Section {
 
     private static final NamedBean.DisplayOptions USERSYS = NamedBean.DisplayOptions.USERNAME_SYSTEMNAME;
 
-    /**
-     * The value of {@link #getState()} if section is available for allocation.
-     */
-    public static final int FREE = 0x02;
-
-    /**
-     * The value of {@link #getState()} if section is allocated for travel in
-     * the forward direction.
-     */
-    public static final int FORWARD = 0x04;
-
-    /**
-     * The value of {@link #getState()} if section is allocated for travel in
-     * the reverse direction.
-     */
-    public static final int REVERSE = 0X08;
-
     public DefaultSection(String systemName, String userName) {
         super(systemName, userName);
     }
@@ -119,16 +102,6 @@ public class DefaultSection extends AbstractNamedBean implements Section {
     public DefaultSection(String systemName) {
         super(systemName);
     }
-
-    /**
-     * Value representing an occupied section.
-     */
-    public static final int OCCUPIED = Block.OCCUPIED;
-
-    /**
-     * Value representing an unoccupied section.
-     */
-    public static final int UNOCCUPIED = Block.UNOCCUPIED;
 
     /**
      * Persistent instance variables (saved between runs)
@@ -2675,10 +2648,6 @@ public class DefaultSection extends AbstractNamedBean implements Section {
             }
         }
     }
-
-    final public static int USERDEFINED = 0x01; //Default Save all the information
-    final public static int SIGNALMASTLOGIC = 0x02; //Save only the name, blocks will be added by the signalmast logic
-    final public static int DYNAMICADHOC = 0x00;  //created on an as required basis, not to be saved.
 
     private int sectionType = USERDEFINED;
 

--- a/java/src/jmri/implementation/DefaultSection.java
+++ b/java/src/jmri/implementation/DefaultSection.java
@@ -1,0 +1,2772 @@
+package jmri.implementation;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.beans.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import jmri.*;
+
+import jmri.jmrit.display.layoutEditor.ConnectivityUtil; // normally these would be rolloed
+import jmri.jmrit.display.layoutEditor.HitPointType;     // up into jmri.jmrit.display.layoutEditor.*
+import jmri.jmrit.display.layoutEditor.LayoutBlock;      // but during the LE migration it's
+import jmri.jmrit.display.layoutEditor.LayoutBlockManager; // useful to be able to see
+import jmri.jmrit.display.layoutEditor.LayoutEditor;     // what specific classe are used.
+import jmri.jmrit.display.layoutEditor.LayoutSlip;
+import jmri.jmrit.display.layoutEditor.LayoutTurnout;
+import jmri.jmrit.display.layoutEditor.LevelXing;
+import jmri.jmrit.display.layoutEditor.PositionablePoint;
+import jmri.jmrit.display.layoutEditor.TrackNode;
+import jmri.jmrit.display.layoutEditor.TrackSegment;
+
+import jmri.util.JmriJFrame;
+import jmri.util.NonNullArrayList;
+
+/**
+ * Sections represent a group of one or more connected Blocks that may be
+ * allocated to a train traveling in a given direction.
+ * <p>
+ * A Block may be in multiple Sections. All Blocks contained in a given section
+ * must be unique. Blocks are kept in order--the first block is connected to the
+ * second, the second is connected to the third, etc.
+ * <p>
+ * A Block in a Section must be connected to the Block before it (if there is
+ * one) and to the Block after it (if there is one), but may not be connected to
+ * any other Block in the Section. This restriction is enforced when a Section
+ * is created, and checked when a Section is loaded from disk.
+ * <p>
+ * A Section has a "direction" defined by the sequence in which Blocks are added
+ * to the Section. A train may run through a Section in either the forward
+ * direction (from first block to last block) or reverse direction (from last
+ * block to first block).
+ * <p>
+ * A Section has one or more EntryPoints. Each EntryPoint is a Path of one of
+ * the Blocks in the Section that defines a connection to a Block outside of the
+ * Section. EntryPoints are grouped into two lists: "forwardEntryPoints" - entry
+ * through which will result in a train traveling in the "forward" direction
+ * "reverseEntryPoints" - entry through which will result in a train traveling
+ * in the "reverse" direction Note that "forwardEntryPoints" are also reverse
+ * exit points, and vice versa.
+ * <p>
+ * A Section has one of the following states" FREE - available for allocation by
+ * a dispatcher FORWARD - allocated for travel in the forward direction REVERSE
+ * - allocated for travel in the reverse direction
+ * <p>
+ * A Section has an occupancy. A Section is OCCUPIED if any of its Blocks is
+ * OCCUPIED. A Section is UNOCCUPIED if all of its Blocks are UNOCCUPIED
+ * <p>
+ * A Section of may be allocated to only one train at a time, even if the trains
+ * are travelling in the same direction. If a Section has sufficient space for
+ * multiple trains travelling in the same direction it should be broken up into
+ * multiple Sections so the trains can follow each other through the original
+ * Section.
+ * <p>
+ * A Section may not contain any reverse loops. The track that is reversed in a
+ * reverse loop must be in a separate Section.
+ * <p>
+ * Each Section optionally carries two direction sensors, one for the forward
+ * direction and one for the reverse direction. These sensors force signals for
+ * travel in their respective directions to "RED" when they are active. When the
+ * Section is free, both the sensors are Active. These internal sensors follow
+ * the state of the Section, permitting signals to function normally in the
+ * direction of allocation.
+ * <p>
+ * Each Section optionally carries two stopping sensors, one for the forward
+ * direction and one for the reverse direction. These sensors change to active
+ * when a train traversing the Section triggers its sensing device. Stopping
+ * sensors are physical layout sensors, and may be either point sensors or
+ * occupancy sensors for short blocks at the end of the Section. A stopping
+ * sensor is used during automatic running to stop a train that has reached the
+ * end of its allocated Section. This is needed, for example, to allow a train
+ * to enter a passing siding and clear the track behind it. When not running
+ * automatically, these sensors may be used to light panel lights to notify the
+ * dispatcher that the train has reached the end of the Section.
+ * <p>
+ * This Section implementation provides for delayed initialization of blocks and
+ * direction sensors to be independent of order of items in panel files.
+ *
+ * @author Dave Duchamp Copyright (C) 2008,2010
+ */
+public class DefaultSection extends AbstractNamedBean implements Section {
+
+    private static final NamedBean.DisplayOptions USERSYS = NamedBean.DisplayOptions.USERNAME_SYSTEMNAME;
+
+    /**
+     * The value of {@link #getState()} if section is available for allocation.
+     */
+    public static final int FREE = 0x02;
+
+    /**
+     * The value of {@link #getState()} if section is allocated for travel in
+     * the forward direction.
+     */
+    public static final int FORWARD = 0x04;
+
+    /**
+     * The value of {@link #getState()} if section is allocated for travel in
+     * the reverse direction.
+     */
+    public static final int REVERSE = 0X08;
+
+    public DefaultSection(String systemName, String userName) {
+        super(systemName, userName);
+    }
+
+    public DefaultSection(String systemName) {
+        super(systemName);
+    }
+
+    /**
+     * Value representing an occupied section.
+     */
+    public static final int OCCUPIED = Block.OCCUPIED;
+
+    /**
+     * Value representing an unoccupied section.
+     */
+    public static final int UNOCCUPIED = Block.UNOCCUPIED;
+
+    /**
+     * Persistent instance variables (saved between runs)
+     */
+    private String mForwardBlockingSensorName = "";
+    private String mReverseBlockingSensorName = "";
+    private String mForwardStoppingSensorName = "";
+    private String mReverseStoppingSensorName = "";
+    private final List<Block> mBlockEntries = new NonNullArrayList<>();
+    private final List<EntryPoint> mForwardEntryPoints = new NonNullArrayList<>();
+    private final List<EntryPoint> mReverseEntryPoints = new NonNullArrayList<>();
+
+    /**
+     * Operational instance variables (not saved between runs).
+     */
+    private int mState = FREE;
+    private int mOccupancy = UNOCCUPIED;
+    private boolean mOccupancyInitialized = false;
+    private Block mFirstBlock = null;
+    private Block mLastBlock = null;
+
+    private NamedBeanHandle<Sensor> mForwardBlockingNamedSensor = null;
+    private NamedBeanHandle<Sensor> mReverseBlockingNamedSensor = null;
+    private NamedBeanHandle<Sensor> mForwardStoppingNamedSensor = null;
+    private NamedBeanHandle<Sensor> mReverseStoppingNamedSensor = null;
+
+    private final List<PropertyChangeListener> mBlockListeners = new ArrayList<>();
+    protected jmri.NamedBeanHandleManager nbhm = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class);
+
+    /**
+     * Get the state of the Section.
+     * UNKNOWN, FORWARD, REVERSE, FREE
+     *
+     * @return the section state
+     */
+    @Override
+    public int getState() {
+        return mState;
+    }
+
+    /**
+     * Set the state of the Section.
+     * FREE, FORWARD or REVERSE.
+     * <br>
+     * UNKNOWN state not accepted here.
+     * @param state the state to set
+     */
+    @Override
+    public void setState(int state) {
+        if ((state == Section.FREE) || (state == Section.FORWARD) || (state == Section.REVERSE)) {
+            int old = mState;
+            mState = state;
+            firePropertyChange("state", old, mState);
+            // update the forward/reverse blocking sensors as needed
+            switch (state) {
+                case FORWARD:
+                    try {
+                        if ((getForwardBlockingSensor() != null) && (getForwardBlockingSensor().getState() != Sensor.INACTIVE)) {
+                            getForwardBlockingSensor().setState(Sensor.INACTIVE);
+                        }
+                        if ((getReverseBlockingSensor() != null) && (getReverseBlockingSensor().getState() != Sensor.ACTIVE)) {
+                            getReverseBlockingSensor().setKnownState(Sensor.ACTIVE);
+                        }
+                    } catch (jmri.JmriException reason) {
+                        log.error("Exception when setting Sensors for Section {}", getDisplayName(USERSYS));
+                    }
+                    break;
+                case REVERSE:
+                    try {
+                        if ((getReverseBlockingSensor() != null) && (getReverseBlockingSensor().getState() != Sensor.INACTIVE)) {
+                            getReverseBlockingSensor().setKnownState(Sensor.INACTIVE);
+                        }
+                        if ((getForwardBlockingSensor() != null) && (getForwardBlockingSensor().getState() != Sensor.ACTIVE)) {
+                            getForwardBlockingSensor().setKnownState(Sensor.ACTIVE);
+                        }
+                    } catch (jmri.JmriException reason) {
+                        log.error("Exception when setting Sensors for Section {}", getDisplayName(USERSYS));
+                    }
+                    break;
+                case FREE:
+                    try {
+                        if ((getForwardBlockingSensor() != null) && (getForwardBlockingSensor().getState() != Sensor.ACTIVE)) {
+                            getForwardBlockingSensor().setKnownState(Sensor.ACTIVE);
+                        }
+                        if ((getReverseBlockingSensor() != null) && (getReverseBlockingSensor().getState() != Sensor.ACTIVE)) {
+                            getReverseBlockingSensor().setKnownState(Sensor.ACTIVE);
+                        }
+                    } catch (jmri.JmriException reason) {
+                        log.error("Exception when setting Sensors for Section {}", getDisplayName(USERSYS));
+                    }
+                    break;
+                default:
+                    break;
+            }
+        } else {
+            log.error("Attempt to set state of Section {} to illegal value - {}", getDisplayName(USERSYS), state);
+        }
+    }
+
+    /**
+     * Get the occupancy of a Section.
+     *
+     * @return {@link #OCCUPIED}, {@link #UNOCCUPIED}, or the state of the first
+     *         block that is neither occupied or unoccupied
+     */
+    public int getOccupancy() {
+        if (mOccupancyInitialized) {
+            return mOccupancy;
+        }
+        // initialize occupancy
+        mOccupancy = UNOCCUPIED;
+        for (Block block : mBlockEntries) {
+            if (block.getState() == OCCUPIED) {
+                mOccupancy = OCCUPIED;
+            } else if (block.getState() != UNOCCUPIED) {
+                log.warn("Occupancy of block {} is not OCCUPIED or UNOCCUPIED in Section - {}",
+                        block.getDisplayName(USERSYS), getDisplayName(USERSYS));
+                return (block.getState());
+            }
+        }
+        mOccupancyInitialized = true;
+        return mOccupancy;
+    }
+
+    private void setOccupancy(int occupancy) {
+        int old = mOccupancy;
+        mOccupancy = occupancy;
+        firePropertyChange("occupancy", old, mOccupancy);
+    }
+
+    public String getForwardBlockingSensorName() {
+        if (mForwardBlockingNamedSensor != null) {
+            return mForwardBlockingNamedSensor.getName();
+        }
+        return mForwardBlockingSensorName;
+    }
+
+    public Sensor getForwardBlockingSensor() {
+        if (mForwardBlockingNamedSensor != null) {
+            return mForwardBlockingNamedSensor.getBean();
+        }
+        if ((mForwardBlockingSensorName != null)
+                && (!mForwardBlockingSensorName.isEmpty())) {
+            Sensor s = InstanceManager.sensorManagerInstance().
+                    getSensor(mForwardBlockingSensorName);
+            if (s == null) {
+                log.error("Missing Sensor - {} - when initializing Section - {}",
+                        mForwardBlockingSensorName, getDisplayName(USERSYS));
+                return null;
+            }
+            mForwardBlockingNamedSensor = nbhm.getNamedBeanHandle(mForwardBlockingSensorName, s);
+            return s;
+        }
+        return null;
+    }
+
+    public Sensor setForwardBlockingSensorName(String forwardSensor) {
+        if ((forwardSensor == null) || (forwardSensor.length() <= 0)) {
+            mForwardBlockingSensorName = "";
+            mForwardBlockingNamedSensor = null;
+            return null;
+        }
+        tempSensorName = forwardSensor;
+        Sensor s = validateSensor();
+        if (s == null) {
+            // sensor name not correct or not in sensor table
+            log.error("Sensor name - {} invalid when setting forward sensor in Section {}",
+                    forwardSensor, getDisplayName(USERSYS));
+            return null;
+        }
+        mForwardBlockingNamedSensor = nbhm.getNamedBeanHandle(tempSensorName, s);
+        mForwardBlockingSensorName = tempSensorName;
+        return s;
+    }
+
+    public void delayedSetForwardBlockingSensorName(String forwardSensor) {
+        mForwardBlockingSensorName = forwardSensor;
+    }
+
+    public String getReverseBlockingSensorName() {
+        if (mReverseBlockingNamedSensor != null) {
+            return mReverseBlockingNamedSensor.getName();
+        }
+        return mReverseBlockingSensorName;
+    }
+
+    public Sensor setReverseBlockingSensorName(String reverseSensor) {
+        if ((reverseSensor == null) || (reverseSensor.length() <= 0)) {
+            mReverseBlockingNamedSensor = null;
+            mReverseBlockingSensorName = "";
+            return null;
+        }
+        tempSensorName = reverseSensor;
+        Sensor s = validateSensor();
+        if (s == null) {
+            // sensor name not correct or not in sensor table
+            log.error("Sensor name - {} invalid when setting reverse sensor in Section {}",
+                    reverseSensor, getDisplayName(USERSYS));
+            return null;
+        }
+        mReverseBlockingNamedSensor = nbhm.getNamedBeanHandle(tempSensorName, s);
+        mReverseBlockingSensorName = tempSensorName;
+        return s;
+    }
+
+    public void delayedSetReverseBlockingSensorName(String reverseSensor) {
+        mReverseBlockingSensorName = reverseSensor;
+    }
+
+    public Sensor getReverseBlockingSensor() {
+        if (mReverseBlockingNamedSensor != null) {
+            return mReverseBlockingNamedSensor.getBean();
+        }
+        if ((mReverseBlockingSensorName != null)
+                && (!mReverseBlockingSensorName.isEmpty())) {
+            Sensor s = InstanceManager.sensorManagerInstance().
+                    getSensor(mReverseBlockingSensorName);
+            if (s == null) {
+                log.error("Missing Sensor - {} - when initializing Section - {}",
+                        mReverseBlockingSensorName, getDisplayName(USERSYS));
+                return null;
+            }
+            mReverseBlockingNamedSensor = nbhm.getNamedBeanHandle(mReverseBlockingSensorName, s);
+            return s;
+        }
+        return null;
+    }
+
+    public Block getLastBlock() {
+        return mLastBlock;
+    }
+
+    private String tempSensorName = "";
+
+    @CheckForNull
+    private Sensor validateSensor() {
+        // check if anything entered
+        if (tempSensorName.length() < 1) {
+            // no sensor specified
+            return null;
+        }
+        // get the sensor corresponding to this name
+        Sensor s = InstanceManager.sensorManagerInstance().getSensor(tempSensorName);
+        if (s == null) {
+            return null;
+        }
+        if (!tempSensorName.equals(s.getUserName()) && s.getUserName() != null) {
+            tempSensorName = s.getUserName();
+        }
+        return s;
+    }
+
+    public String getForwardStoppingSensorName() {
+        if (mForwardStoppingNamedSensor != null) {
+            return mForwardStoppingNamedSensor.getName();
+        }
+        return mForwardStoppingSensorName;
+    }
+
+    @CheckForNull
+    public Sensor getForwardStoppingSensor() {
+        if (mForwardStoppingNamedSensor != null) {
+            return mForwardStoppingNamedSensor.getBean();
+        }
+        if ((mForwardStoppingSensorName != null)
+                && (!mForwardStoppingSensorName.isEmpty())) {
+            Sensor s = InstanceManager.sensorManagerInstance().
+                    getSensor(mForwardStoppingSensorName);
+            if (s == null) {
+                log.error("Missing Sensor - {} - when initializing Section - {}",
+                        mForwardStoppingSensorName, getDisplayName(USERSYS));
+                return null;
+            }
+            mForwardStoppingNamedSensor = nbhm.getNamedBeanHandle(mForwardStoppingSensorName, s);
+            return s;
+        }
+        return null;
+    }
+
+    public Sensor setForwardStoppingSensorName(String forwardSensor) {
+        if ((forwardSensor == null) || (forwardSensor.length() <= 0)) {
+            mForwardStoppingNamedSensor = null;
+            mForwardStoppingSensorName = "";
+            return null;
+        }
+        tempSensorName = forwardSensor;
+        Sensor s = validateSensor();
+        if (s == null) {
+            // sensor name not correct or not in sensor table
+            log.error("Sensor name - {} invalid when setting forward sensor in Section {}",
+                    forwardSensor, getDisplayName(USERSYS));
+            return null;
+        }
+        mForwardStoppingNamedSensor = nbhm.getNamedBeanHandle(tempSensorName, s);
+        mForwardStoppingSensorName = tempSensorName;
+        return s;
+    }
+
+    public void delayedSetForwardStoppingSensorName(String forwardSensor) {
+        mForwardStoppingSensorName = forwardSensor;
+    }
+
+    public String getReverseStoppingSensorName() {
+        if (mReverseStoppingNamedSensor != null) {
+            return mReverseStoppingNamedSensor.getName();
+        }
+        return mReverseStoppingSensorName;
+    }
+
+    @CheckForNull
+    public Sensor setReverseStoppingSensorName(String reverseSensor) {
+        if ((reverseSensor == null) || (reverseSensor.length() <= 0)) {
+            mReverseStoppingNamedSensor = null;
+            mReverseStoppingSensorName = "";
+            return null;
+        }
+        tempSensorName = reverseSensor;
+        Sensor s = validateSensor();
+        if (s == null) {
+            // sensor name not correct or not in sensor table
+            log.error("Sensor name - {} invalid when setting reverse sensor in Section {}",
+                    reverseSensor, getDisplayName(USERSYS));
+            return null;
+        }
+        mReverseStoppingNamedSensor = nbhm.getNamedBeanHandle(tempSensorName, s);
+        mReverseStoppingSensorName = tempSensorName;
+        return s;
+    }
+
+    public void delayedSetReverseStoppingSensorName(String reverseSensor) {
+        mReverseStoppingSensorName = reverseSensor;
+    }
+
+    @CheckForNull
+    public Sensor getReverseStoppingSensor() {
+        if (mReverseStoppingNamedSensor != null) {
+            return mReverseStoppingNamedSensor.getBean();
+        }
+        if ((mReverseStoppingSensorName != null)
+                && (!mReverseStoppingSensorName.isEmpty())) {
+            Sensor s = InstanceManager.sensorManagerInstance().
+                    getSensor(mReverseStoppingSensorName);
+            if (s == null) {
+                log.error("Missing Sensor - {}  - when initializing Section - {}",
+                        mReverseStoppingSensorName, getDisplayName(USERSYS));
+                return null;
+            }
+            mReverseStoppingNamedSensor = nbhm.getNamedBeanHandle(mReverseStoppingSensorName, s);
+            return s;
+        }
+        return null;
+    }
+
+    /**
+     * Add a Block to the Section. Block and sequence number must be unique
+     * within the Section. Block sequence numbers are set automatically as
+     * blocks are added.
+     *
+     * @param b the block to add
+     * @return true if Block was added or false if Block does not connect to the
+     *         current Block, or the Block is not unique.
+     */
+    public boolean addBlock(Block b) {
+        // validate that this entry is unique, if not first.
+        if (mBlockEntries.isEmpty()) {
+            mFirstBlock = b;
+        } else {
+            // check that block is unique
+            for (Block block : mBlockEntries) {
+                if (block == b) {
+                    return false; // already present
+                }            // Note: connectivity to current block is assumed to have been checked
+            }
+        }
+
+        // a lot of this code searches for blocks by their user name.
+        // warn if there isn't one.
+        if (b.getUserName() == null) {
+            log.warn("Block {} does not have a user name, may not work correctly in Section {}",
+                    b.getDisplayName(USERSYS), getDisplayName(USERSYS));
+        }
+        // add Block to the Block list
+        mBlockEntries.add(b);
+        mLastBlock = b;
+        // check occupancy
+        if (b.getState() == OCCUPIED) {
+            if (mOccupancy != OCCUPIED) {
+                setOccupancy(OCCUPIED);
+            }
+        }
+        PropertyChangeListener listener = (PropertyChangeEvent e) -> {
+            handleBlockChange(e);
+        };
+        b.addPropertyChangeListener(listener);
+        mBlockListeners.add(listener);
+        return true;
+    }
+    private boolean initializationNeeded = false;
+    private final List<String> blockNameList = new ArrayList<>();
+
+    public void delayedAddBlock(String blockName) {
+        initializationNeeded = true;
+        blockNameList.add(blockName);
+    }
+
+    private void initializeBlocks() {
+        for (int i = 0; i < blockNameList.size(); i++) {
+            Block b = InstanceManager.getDefault(jmri.BlockManager.class).getBlock(blockNameList.get(i));
+            if (b == null) {
+                log.error("Missing Block - {} - when initializing Section - {}",
+                        blockNameList.get(i), getDisplayName(USERSYS));
+            } else {
+                if (mBlockEntries.isEmpty()) {
+                    mFirstBlock = b;
+                }
+                mBlockEntries.add(b);
+                mLastBlock = b;
+                PropertyChangeListener listener = (PropertyChangeEvent e) -> {
+                    handleBlockChange(e);
+                };
+                b.addPropertyChangeListener(listener);
+                mBlockListeners.add(listener);
+            }
+        }
+        initializationNeeded = false;
+    }
+
+    /**
+     * Handle change in occupancy of a Block in the Section.
+     *
+     * @param e event with change
+     */
+    void handleBlockChange(PropertyChangeEvent e) {
+        int o = UNOCCUPIED;
+        for (Block block : mBlockEntries) {
+            if (block.getState() == OCCUPIED) {
+                o = OCCUPIED;
+                break;
+            }
+        }
+        if (mOccupancy != o) {
+            setOccupancy(o);
+        }
+    }
+
+    /**
+     * Get a list of blocks in this section
+     *
+     * @return a list of blocks
+     */
+    @Nonnull
+    public List<Block> getBlockList() {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        return new ArrayList<>(mBlockEntries);
+    }
+
+    /**
+     * Gets the number of Blocks in this Section
+     *
+     * @return the number of blocks
+     */
+    public int getNumBlocks() {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        return mBlockEntries.size();
+    }
+
+    /**
+     * Get the scale length of Section. Length of the Section is calculated by
+     * summing the lengths of all Blocks in the section. If all Block lengths
+     * have not been entered, length will not be correct.
+     *
+     * @param meters true to return length in meters, false to use feet
+     * @param scale  the scale; one of {@link jmri.Scale}
+     * @return the scale length
+     */
+    public float getLengthF(boolean meters, Scale scale) {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        float length = 0.0f;
+        for (Block block : mBlockEntries) {
+            length = length + block.getLengthMm();
+        }
+        length = length / (float) (scale.getScaleFactor());
+        if (meters) {
+            return (length * 0.001f);
+        }
+        return (length * 0.00328084f);
+    }
+
+    public int getLengthI(boolean meters, Scale scale) {
+        return ((int) ((getLengthF(meters, scale) + 0.5f)));
+    }
+
+    /**
+     * Gets the actual length of the Section without any scaling
+     *
+     * @return the real length in millimeters
+     */
+    public int getActualLength() {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        int len = 0;
+        for (Block b : mBlockEntries) {
+            len = len + ((int) b.getLengthMm());
+        }
+        return len;
+    }
+
+    /**
+     * Get Block by its Sequence number in the Section.
+     *
+     * @param seqNumber the sequence number
+     * @return the block or null if the sequence number is invalid
+     */
+    @CheckForNull
+    public Block getBlockBySequenceNumber(int seqNumber) {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        if ((seqNumber < mBlockEntries.size()) && (seqNumber >= 0)) {
+            return mBlockEntries.get(seqNumber);
+        }
+        return null;
+    }
+
+    /**
+     * Get the sequence number of a Block.
+     *
+     * @param b the block to get the sequence of
+     * @return the sequence number of b or -1 if b is not in the Section
+     */
+    public int getBlockSequenceNumber(Block b) {
+        for (int i = 0; i < mBlockEntries.size(); i++) {
+            if (b == mBlockEntries.get(i)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Remove all Blocks, Block Listeners, and Entry Points
+     */
+    public void removeAllBlocksFromSection() {
+        for (int i = mBlockEntries.size(); i > 0; i--) {
+            Block b = mBlockEntries.get(i - 1);
+            b.removePropertyChangeListener(mBlockListeners.get(i - 1));
+            mBlockListeners.remove(i - 1);
+            mBlockEntries.remove(i - 1);
+        }
+        for (int i = mForwardEntryPoints.size(); i > 0; i--) {
+            mForwardEntryPoints.remove(i - 1);
+        }
+        for (int i = mReverseEntryPoints.size(); i > 0; i--) {
+            mReverseEntryPoints.remove(i - 1);
+        }
+        initializationNeeded = false;
+    }
+    /**
+     * Gets Blocks in order. If state is FREE or FORWARD, returns Blocks in
+     * forward order. If state is REVERSE, returns Blocks in reverse order.
+     * First call getEntryBlock, then call getNextBlock until null is returned.
+     */
+    private int blockIndex = 0;  // index of last block returned
+
+    @CheckForNull
+    public Block getEntryBlock() {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        if (mBlockEntries.size() <= 0) {
+            return null;
+        }
+        if (mState == REVERSE) {
+            blockIndex = mBlockEntries.size();
+        } else {
+            blockIndex = 1;
+        }
+        return mBlockEntries.get(blockIndex - 1);
+    }
+
+    @CheckForNull
+    public Block getNextBlock() {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        if (mState == REVERSE) {
+            blockIndex--;
+        } else {
+            blockIndex++;
+        }
+        if ((blockIndex > mBlockEntries.size()) || (blockIndex <= 0)) {
+            return null;
+        }
+        return mBlockEntries.get(blockIndex - 1);
+    }
+
+    @CheckForNull
+    public Block getExitBlock() {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        if (mBlockEntries.size() <= 0) {
+            return null;
+        }
+        if (mState == REVERSE) {
+            blockIndex = 1;
+        } else {
+            blockIndex = mBlockEntries.size();
+        }
+        return mBlockEntries.get(blockIndex - 1);
+    }
+
+    public boolean containsBlock(Block b) {
+        for (Block block : mBlockEntries) {
+            if (b == block) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean connectsToBlock(Block b) {
+        if (mForwardEntryPoints.stream().anyMatch((ep) -> (ep.getFromBlock() == b))) {
+            return true;
+        }
+        return mReverseEntryPoints.stream().anyMatch((ep) -> (ep.getFromBlock() == b));
+    }
+
+    public String getBeginBlockName() {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        if (mFirstBlock == null) {
+            return "unknown";
+        }
+        return mFirstBlock.getDisplayName();
+    }
+
+    public String getEndBlockName() {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        if (mLastBlock == null) {
+            return "unknown";
+        }
+        return mLastBlock.getDisplayName();
+    }
+
+    public void addToForwardList(EntryPoint ep) {
+        if (ep != null) {
+            mForwardEntryPoints.add(ep);
+        }
+    }
+
+    public void addToReverseList(EntryPoint ep) {
+        if (ep != null) {
+            mReverseEntryPoints.add(ep);
+        }
+    }
+
+    public void removeEntryPoint(EntryPoint ep) {
+        for (int i = mForwardEntryPoints.size(); i > 0; i--) {
+            if (mForwardEntryPoints.get(i - 1) == ep) {
+                mForwardEntryPoints.remove(i - 1);
+            }
+        }
+        for (int i = mReverseEntryPoints.size(); i > 0; i--) {
+            if (mReverseEntryPoints.get(i - 1) == ep) {
+                mReverseEntryPoints.remove(i - 1);
+            }
+        }
+    }
+
+    public List<EntryPoint> getForwardEntryPointList() {
+        return new ArrayList<>(this.mForwardEntryPoints);
+    }
+
+    public List<EntryPoint> getReverseEntryPointList() {
+        return new ArrayList<>(this.mReverseEntryPoints);
+    }
+
+    public List<EntryPoint> getEntryPointList() {
+        List<EntryPoint> list = new ArrayList<>(this.mForwardEntryPoints);
+        list.addAll(this.mReverseEntryPoints);
+        return list;
+    }
+
+    public boolean isForwardEntryPoint(EntryPoint ep) {
+        for (int i = 0; i < mForwardEntryPoints.size(); i++) {
+            if (ep == mForwardEntryPoints.get(i)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isReverseEntryPoint(EntryPoint ep) {
+        for (int i = 0; i < mReverseEntryPoints.size(); i++) {
+            if (ep == mReverseEntryPoints.get(i)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the EntryPoint for entry from the specified Section for travel in
+     * specified direction.
+     *
+     * @param s   the section
+     * @param dir the direction of travel; one of {@link #FORWARD} or
+     *            {@link #REVERSE}
+     * @return the entry point or null if not found
+     */
+    @CheckForNull
+    public EntryPoint getEntryPointFromSection(Section s, int dir) {
+        if (dir == FORWARD) {
+            for (EntryPoint ep : mForwardEntryPoints) {
+                if (s.containsBlock(ep.getFromBlock())) {
+                    return ep;
+                }
+            }
+        } else if (dir == REVERSE) {
+            for (EntryPoint ep : mReverseEntryPoints) {
+                if (s.containsBlock(ep.getFromBlock())) {
+                    return ep;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the EntryPoint for exit to specified Section for travel in the
+     * specified direction.
+     *
+     * @param s   the section
+     * @param dir the direction of travel; one of {@link #FORWARD} or
+     *            {@link #REVERSE}
+     * @return the entry point or null if not found
+     */
+    @CheckForNull
+    public EntryPoint getExitPointToSection(Section s, int dir) {
+        if (s == null) {
+            return null;
+        }
+        if (dir == REVERSE) {
+            for (EntryPoint ep : mForwardEntryPoints) {
+                if (s.containsBlock(ep.getFromBlock())) {
+                    return ep;
+                }
+            }
+        } else if (dir == FORWARD) {
+            for (EntryPoint ep : mReverseEntryPoints) {
+                if (s.containsBlock(ep.getFromBlock())) {
+                    return ep;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the EntryPoint for entry from the specified Block for travel in the
+     * specified direction.
+     *
+     * @param b   the block
+     * @param dir the direction of travel; one of {@link #FORWARD} or
+     *            {@link #REVERSE}
+     * @return the entry point or null if not found
+     */
+    @CheckForNull
+    public EntryPoint getEntryPointFromBlock(Block b, int dir) {
+        if (dir == FORWARD) {
+            for (EntryPoint ep : mForwardEntryPoints) {
+                if (b == ep.getFromBlock()) {
+                    return ep;
+                }
+            }
+        } else if (dir == REVERSE) {
+            for (EntryPoint ep : mReverseEntryPoints) {
+                if (b == ep.getFromBlock()) {
+                    return ep;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the EntryPoint for exit to the specified Block for travel in the
+     * specified direction.
+     *
+     * @param b   the block
+     * @param dir the direction of travel; one of {@link #FORWARD} or
+     *            {@link #REVERSE}
+     * @return the entry point or null if not found
+     */
+    @CheckForNull
+    public EntryPoint getExitPointToBlock(Block b, int dir) {
+        if (dir == REVERSE) {
+            for (EntryPoint ep : mForwardEntryPoints) {
+                if (b == ep.getFromBlock()) {
+                    return ep;
+                }
+            }
+        } else if (dir == FORWARD) {
+            for (EntryPoint ep : mReverseEntryPoints) {
+                if (b == ep.getFromBlock()) {
+                    return ep;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns EntryPoint.FORWARD if proceeding from the throat to the other end
+     * is movement in the forward direction. Returns EntryPoint.REVERSE if
+     * proceeding from the throat to the other end is movement in the reverse
+     * direction. Returns EntryPoint.UNKNOWN if cannot determine direction. This
+     * should only happen if blocks are not set up correctly--if all connections
+     * go to the same Block, or not all Blocks set. An error message is logged
+     * if EntryPoint.UNKNOWN is returned.
+     */
+    private int getDirectionStandardTurnout(LayoutTurnout t, ConnectivityUtil cUtil) {
+        LayoutBlock aBlock = ((TrackSegment) t.getConnectA()).getLayoutBlock();
+        LayoutBlock bBlock = ((TrackSegment) t.getConnectB()).getLayoutBlock();
+        LayoutBlock cBlock = ((TrackSegment) t.getConnectC()).getLayoutBlock();
+        if ((aBlock == null) || (bBlock == null) || (cBlock == null)) {
+            log.error("All blocks not assigned for track segments connecting to turnout - {}.",
+                    t.getTurnout().getDisplayName(USERSYS));
+            return EntryPoint.UNKNOWN;
+        }
+        Block exBlock = checkDualDirection(aBlock, bBlock, cBlock);
+        if ((exBlock != null) || ((aBlock == bBlock) && (aBlock == cBlock))) {
+            // using Entry Points directly will lead to a problem, try following track - first from A following B
+            int dir = EntryPoint.UNKNOWN;
+            Block tBlock = null;
+            TrackNode tn = new TrackNode(t, HitPointType.TURNOUT_A, (TrackSegment) t.getConnectA(),
+                    false, Turnout.CLOSED);
+            while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                tn = cUtil.getNextNode(tn, 0);
+                tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock);
+            }
+            if (tBlock == null) {
+                // try from A following C
+                tn = new TrackNode(t, HitPointType.TURNOUT_A, (TrackSegment) t.getConnectA(),
+                        false, Turnout.THROWN);
+                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                    tn = cUtil.getNextNode(tn, 0);
+                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock);
+                }
+            }
+            if (tBlock != null) {
+                String userName = tBlock.getUserName();
+                if (userName != null) {
+                    LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                    if (lb != null) {
+                        dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
+                    }
+                }
+            }
+            if (dir == EntryPoint.UNKNOWN) {
+                // try from B following A
+                tBlock = null;
+                tn = new TrackNode(t, HitPointType.TURNOUT_B, (TrackSegment) t.getConnectB(),
+                        false, Turnout.CLOSED);
+                while ((tBlock == null) && (tn != null && (!tn.reachedEndOfTrack()))) {
+                    tn = cUtil.getNextNode(tn, 0);
+                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock);
+                }
+                if (tBlock != null) {
+                    String userName = tBlock.getUserName();
+                    if (userName != null) {
+                        LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                        if (lb != null) {
+                            dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, lb);
+                        }
+                    }
+                }
+            }
+            if (dir == EntryPoint.UNKNOWN) {
+                log.error("Block definition ambiguity - cannot determine direction of Turnout {} in Section {}",
+                        t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
+            }
+            return dir;
+        }
+        if ((aBlock != bBlock) && containsBlock(aBlock.getBlock()) && containsBlock(bBlock.getBlock())) {
+            // both blocks are different, but are in this Section
+            if (getBlockSequenceNumber(aBlock.getBlock()) < getBlockSequenceNumber(bBlock.getBlock())) {
+                return EntryPoint.FORWARD;
+            } else {
+                return EntryPoint.REVERSE;
+            }
+        } else if ((aBlock != cBlock) && containsBlock(aBlock.getBlock()) && containsBlock(cBlock.getBlock())) {
+            // both blocks are different, but are in this Section
+            if (getBlockSequenceNumber(aBlock.getBlock()) < getBlockSequenceNumber(cBlock.getBlock())) {
+                return EntryPoint.FORWARD;
+            } else {
+                return EntryPoint.REVERSE;
+            }
+        }
+        LayoutBlock tBlock = t.getLayoutBlock();
+        if (tBlock == null) {
+            log.error("Block not assigned for turnout {}", t.getTurnout().getDisplayName(USERSYS));
+            return EntryPoint.UNKNOWN;
+        }
+        if (containsBlock(aBlock.getBlock()) && (!containsBlock(bBlock.getBlock()))) {
+            // aBlock is in Section, bBlock is not
+            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, bBlock);
+            if (dir != EntryPoint.UNKNOWN) {
+                return dir;
+            }
+            if ((tBlock != bBlock) && (!containsBlock(tBlock.getBlock()))) {
+                dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, tBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+        }
+        if (containsBlock(aBlock.getBlock()) && (!containsBlock(cBlock.getBlock()))) {
+            // aBlock is in Section, cBlock is not
+            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, cBlock);
+            if (dir != EntryPoint.UNKNOWN) {
+                return dir;
+            }
+            if ((tBlock != cBlock) && (!containsBlock(tBlock.getBlock()))) {
+                dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, tBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+        }
+        if ((containsBlock(bBlock.getBlock()) || containsBlock(cBlock.getBlock()))
+                && (!containsBlock(aBlock.getBlock()))) {
+            // bBlock or cBlock is in Section, aBlock is not
+            int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, aBlock);
+            if (dir != EntryPoint.UNKNOWN) {
+                return dir;
+            }
+            if ((tBlock != aBlock) && (!containsBlock(tBlock.getBlock()))) {
+                dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, tBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+        }
+        if (!containsBlock(aBlock.getBlock()) && !containsBlock(bBlock.getBlock()) && !containsBlock(cBlock.getBlock()) && containsBlock(tBlock.getBlock())) {
+            //is the turnout in a section of its own?
+            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, aBlock);
+            return dir;
+        }
+
+        // should never get here
+        log.error("Unexpected error in getDirectionStandardTurnout when working with turnout {}",
+                t.getTurnout().getDisplayName(USERSYS));
+        return EntryPoint.UNKNOWN;
+    }
+
+    /**
+     * Returns EntryPoint.FORWARD if proceeding from A to B (or D to C) is
+     * movement in the forward direction. Returns EntryPoint.REVERSE if
+     * proceeding from A to B (or D to C) is movement in the reverse direction.
+     * Returns EntryPoint.UNKNOWN if cannot determine direction. This should
+     * only happen if blocks are not set up correctly--if all connections go to
+     * the same Block, or not all Blocks set. An error message is logged if
+     * EntryPoint.UNKNOWN is returned.
+     */
+    private int getDirectionXoverTurnout(LayoutTurnout t, ConnectivityUtil cUtil) {
+        LayoutBlock aBlock = ((TrackSegment) t.getConnectA()).getLayoutBlock();
+        LayoutBlock bBlock = ((TrackSegment) t.getConnectB()).getLayoutBlock();
+        LayoutBlock cBlock = ((TrackSegment) t.getConnectC()).getLayoutBlock();
+        LayoutBlock dBlock = ((TrackSegment) t.getConnectD()).getLayoutBlock();
+        if ((aBlock == null) || (bBlock == null) || (cBlock == null) || (dBlock == null)) {
+            log.error("All blocks not assigned for track segments connecting to crossover turnout - {}.",
+                    t.getTurnout().getDisplayName(USERSYS));
+            return EntryPoint.UNKNOWN;
+        }
+        if ((aBlock == bBlock) && (aBlock == cBlock) && (aBlock == dBlock)) {
+            log.error("Block setup problem - All track segments connecting to crossover turnout - {} are assigned to the same Block.",
+                    t.getTurnout().getDisplayName(USERSYS));
+            return EntryPoint.UNKNOWN;
+        }
+        if ((containsBlock(aBlock.getBlock())) || (containsBlock(bBlock.getBlock()))) {
+            LayoutBlock exBlock = null;
+            if (aBlock == bBlock) {
+                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER) && (cBlock == dBlock)) {
+                    exBlock = cBlock;
+                }
+            }
+            if (exBlock != null) {
+                // set direction by tracking from a or b
+                int dir = EntryPoint.UNKNOWN;
+                Block tBlock = null;
+                TrackNode tn = new TrackNode(t, HitPointType.TURNOUT_A, (TrackSegment) t.getConnectA(),
+                        false, Turnout.CLOSED);
+                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                    tn = cUtil.getNextNode(tn, 0);
+                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
+                }
+                if (tBlock != null) {
+                    String userName = tBlock.getUserName();
+                    if (userName != null) {
+                        LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                        if (lb != null) {
+                            dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
+                        }
+                    }
+                } else { // no tBlock found on leg A
+                    tn = new TrackNode(t, HitPointType.TURNOUT_B, (TrackSegment) t.getConnectB(),
+                            false, Turnout.CLOSED);
+                    while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                        tn = cUtil.getNextNode(tn, 0);
+                        tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
+                    }
+                    if (tBlock != null) {
+                        String userName = tBlock.getUserName();
+                        if (userName != null) {
+                            LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                            if (lb != null) {
+                                dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, lb);
+                            }
+                        }
+                    }
+                }
+                if (dir == EntryPoint.UNKNOWN) {
+                    log.error("Block definition ambiguity - cannot determine direction of crossover Turnout {} in Section {}",
+                            t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
+                }
+                return dir;
+            }
+            if ((aBlock != bBlock) && containsBlock(aBlock.getBlock()) && containsBlock(bBlock.getBlock())) {
+                if (getBlockSequenceNumber(aBlock.getBlock()) < getBlockSequenceNumber(bBlock.getBlock())) {
+                    return EntryPoint.FORWARD;
+                } else {
+                    return EntryPoint.REVERSE;
+                }
+            }
+            if (containsBlock(aBlock.getBlock()) && (!containsBlock(bBlock.getBlock()))) {
+                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, bBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+            if (containsBlock(bBlock.getBlock()) && (!containsBlock(aBlock.getBlock()))) {
+                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, aBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+            if ((t.getTurnoutType() != LayoutTurnout.TurnoutType.LH_XOVER) && containsBlock(aBlock.getBlock())
+                    && (!containsBlock(cBlock.getBlock()))) {
+                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, cBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+            if ((t.getTurnoutType() != LayoutTurnout.TurnoutType.RH_XOVER) && containsBlock(bBlock.getBlock())
+                    && (!containsBlock(dBlock.getBlock()))) {
+                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, dBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+        }
+        if ((containsBlock(dBlock.getBlock())) || (containsBlock(cBlock.getBlock()))) {
+            LayoutBlock exBlock = null;
+            if (dBlock == cBlock) {
+                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER) && (bBlock == aBlock)) {
+                    exBlock = aBlock;
+                }
+            }
+            if (exBlock != null) {
+                // set direction by tracking from c or d
+                int dir = EntryPoint.UNKNOWN;
+                Block tBlock = null;
+                TrackNode tn = new TrackNode(t, HitPointType.TURNOUT_D, (TrackSegment) t.getConnectD(),
+                        false, Turnout.CLOSED);
+                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                    tn = cUtil.getNextNode(tn, 0);
+                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
+                }
+                if (tBlock != null) {
+                    String userName = tBlock.getUserName();
+                    if (userName != null) {
+                        LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                        if (lb != null) {
+                            dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
+                        }
+                    }
+                } else {
+                    tn = new TrackNode(t, HitPointType.TURNOUT_C, (TrackSegment) t.getConnectC(),
+                            false, Turnout.CLOSED);
+                    while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                        tn = cUtil.getNextNode(tn, 0);
+                        tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
+                    }
+                    if (tBlock != null) {
+                        String userName = tBlock.getUserName();
+                        if (userName != null) {
+                            LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                            if (lb != null) {
+                                dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, lb);
+                            }
+                        }
+                    }
+                }
+                if (dir == EntryPoint.UNKNOWN) {
+                    log.error("Block definition ambiguity - cannot determine direction of crossover Turnout {} in Section {}.",
+                            t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
+                }
+                return dir;
+            }
+            if ((dBlock != cBlock) && containsBlock(dBlock.getBlock()) && containsBlock(cBlock.getBlock())) {
+                if (getBlockSequenceNumber(dBlock.getBlock()) < getBlockSequenceNumber(cBlock.getBlock())) {
+                    return EntryPoint.FORWARD;
+                } else {
+                    return EntryPoint.REVERSE;
+                }
+            }
+            if (containsBlock(dBlock.getBlock()) && (!containsBlock(cBlock.getBlock()))) {
+                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, cBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+            if (containsBlock(cBlock.getBlock()) && (!containsBlock(dBlock.getBlock()))) {
+                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, dBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+            if ((t.getTurnoutType() != LayoutTurnout.TurnoutType.RH_XOVER) && containsBlock(dBlock.getBlock())
+                    && (!containsBlock(bBlock.getBlock()))) {
+                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, bBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+            if ((t.getTurnoutType() != LayoutTurnout.TurnoutType.LH_XOVER) && containsBlock(cBlock.getBlock())
+                    && (!containsBlock(aBlock.getBlock()))) {
+                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, aBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+        }
+        log.error("Entry point checks failed - cannot determine direction of crossover Turnout {} in Section {}.",
+                t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
+        return EntryPoint.UNKNOWN;
+    }
+
+    /**
+     * Returns EntryPoint.FORWARD if proceeding from A to C or D (or B to D or
+     * C) is movement in the forward direction. Returns EntryPoint.REVERSE if
+     * proceeding from C or D to A (or D or C to B) is movement in the reverse
+     * direction. Returns EntryPoint.UNKNOWN if cannot determine direction. This
+     * should only happen if blocks are not set up correctly--if all connections
+     * go to the same Block, or not all Blocks set. An error message is logged
+     * if EntryPoint.UNKNOWN is returned.
+     *
+     * @param t Actually of type LayoutSlip, this is the track segment to check.
+     */
+    private int getDirectionSlip(LayoutTurnout t, ConnectivityUtil cUtil) {
+        LayoutBlock aBlock = ((TrackSegment) t.getConnectA()).getLayoutBlock();
+        LayoutBlock bBlock = ((TrackSegment) t.getConnectB()).getLayoutBlock();
+        LayoutBlock cBlock = ((TrackSegment) t.getConnectC()).getLayoutBlock();
+        LayoutBlock dBlock = ((TrackSegment) t.getConnectD()).getLayoutBlock();
+        if ((aBlock == null) || (bBlock == null) || (cBlock == null) || (dBlock == null)) {
+            log.error("All blocks not assigned for track segments connecting to crossover turnout - {}.",
+                    t.getTurnout().getDisplayName(USERSYS));
+            return EntryPoint.UNKNOWN;
+        }
+        if ((aBlock == bBlock) && (aBlock == cBlock) && (aBlock == dBlock)) {
+            log.error("Block setup problem - All track segments connecting to crossover turnout - {} are assigned to the same Block.",
+                    t.getTurnout().getDisplayName(USERSYS));
+            return EntryPoint.UNKNOWN;
+        }
+        if ((containsBlock(aBlock.getBlock())) || (containsBlock(cBlock.getBlock()))) {
+            LayoutBlock exBlock = null;
+            if (aBlock == cBlock) {
+                if ((t.getTurnoutType() == LayoutSlip.TurnoutType.DOUBLE_SLIP) && (bBlock == dBlock)) {
+                    exBlock = bBlock;
+                }
+            }
+            if (exBlock != null) {
+                // set direction by tracking from a or b
+                int dir = EntryPoint.UNKNOWN;
+                Block tBlock = null;
+                TrackNode tn = new TrackNode(t, HitPointType.SLIP_A, (TrackSegment) t.getConnectA(),
+                        false, LayoutTurnout.STATE_AC);
+                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                    tn = cUtil.getNextNode(tn, 0);
+                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
+                }
+                if (tBlock != null) {
+                    String userName = tBlock.getUserName();
+                    if (userName != null) {
+                        LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                        if (lb != null) {
+                            dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
+                        }
+                    }
+                } else {
+                    tn = new TrackNode(t, HitPointType.SLIP_C, (TrackSegment) t.getConnectC(),
+                            false, LayoutTurnout.STATE_AC);
+                    while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                        tn = cUtil.getNextNode(tn, 0);
+                        tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
+                    }
+                    if (tBlock != null) {
+                        String userName = tBlock.getUserName();
+                        if (userName != null) {
+                            LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                            if (lb != null) {
+                                dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, lb);
+                            }
+                        }
+                    }
+                }
+                if (dir == EntryPoint.UNKNOWN) {
+                    log.error("Block definition ambiguity - cannot determine direction of crossover slip {} in Section {}.",
+                            t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
+                }
+                return dir;
+            }
+            if ((aBlock != cBlock) && containsBlock(aBlock.getBlock()) && containsBlock(cBlock.getBlock())) {
+                if (getBlockSequenceNumber(aBlock.getBlock()) < getBlockSequenceNumber(cBlock.getBlock())) {
+                    return EntryPoint.FORWARD;
+                } else {
+                    return EntryPoint.REVERSE;
+                }
+            }
+            if (containsBlock(aBlock.getBlock()) && (!containsBlock(cBlock.getBlock()))) {
+                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, cBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+            if (containsBlock(cBlock.getBlock()) && (!containsBlock(aBlock.getBlock()))) {
+                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, aBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, dBlock);
+            if (dir != EntryPoint.UNKNOWN) {
+                return dir;
+            }
+        }
+
+        if ((containsBlock(dBlock.getBlock())) || (containsBlock(bBlock.getBlock()))) {
+            LayoutBlock exBlock = null;
+            if (dBlock == bBlock) {
+                if ((t.getTurnoutType() == LayoutSlip.TurnoutType.DOUBLE_SLIP) && (cBlock == aBlock)) {
+                    exBlock = aBlock;
+                }
+            }
+            if (exBlock != null) {
+                // set direction by tracking from c or d
+                int dir = EntryPoint.UNKNOWN;
+                Block tBlock = null;
+                TrackNode tn = new TrackNode(t, HitPointType.SLIP_D, (TrackSegment) t.getConnectD(),
+                        false, LayoutTurnout.STATE_BD);
+                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                    tn = cUtil.getNextNode(tn, 0);
+                    tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
+                }
+                if (tBlock != null) {
+                    String userName = tBlock.getUserName();
+                    if (userName != null) {
+                        LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                        if (lb != null) {
+                            dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
+                        }
+                    }
+                } else {
+                    tn = new TrackNode(t, HitPointType.TURNOUT_B, (TrackSegment) t.getConnectB(),
+                            false, LayoutTurnout.STATE_BD);
+                    while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                        tn = cUtil.getNextNode(tn, 0);
+                        tBlock = cUtil.getExitBlockForTrackNode(tn, exBlock.getBlock());
+                    }
+                    if (tBlock != null) {
+                        String userName = tBlock.getUserName();
+                        if (userName != null) {
+                            LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                            if (lb != null) {
+                                dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, lb);
+                            }
+                        }
+                    }
+                }
+                if (dir == EntryPoint.UNKNOWN) {
+                    log.error("Block definition ambiguity - cannot determine direction of slip {} in Section {}.",
+                            t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
+                }
+                return dir;
+            }
+            if ((dBlock != bBlock) && containsBlock(dBlock.getBlock()) && containsBlock(bBlock.getBlock())) {
+                if (getBlockSequenceNumber(dBlock.getBlock()) < getBlockSequenceNumber(bBlock.getBlock())) {
+                    return EntryPoint.FORWARD;
+                } else {
+                    return EntryPoint.REVERSE;
+                }
+            }
+            if (containsBlock(dBlock.getBlock()) && (!containsBlock(bBlock.getBlock()))) {
+                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, bBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+            if (containsBlock(bBlock.getBlock()) && (!containsBlock(dBlock.getBlock()))) {
+                int dir = checkLists(mForwardEntryPoints, mReverseEntryPoints, dBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+            if (t.getTurnoutType() == LayoutSlip.TurnoutType.DOUBLE_SLIP) {
+                int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, aBlock);
+                if (dir != EntryPoint.UNKNOWN) {
+                    return dir;
+                }
+            }
+        }
+        //If all else fails the slip must be in a block of its own so we shall work it out from there.
+        if (t.getLayoutBlock() != aBlock) {
+            //Block is not the same as that connected to A
+            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, aBlock);
+            if (dir != EntryPoint.UNKNOWN) {
+                return dir;
+            }
+        }
+        if (t.getLayoutBlock() != bBlock) {
+            //Block is not the same as that connected to B
+            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, bBlock);
+            if (dir != EntryPoint.UNKNOWN) {
+                return dir;
+            }
+        }
+        if (t.getLayoutBlock() != cBlock) {
+            //Block is not the same as that connected to C
+            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, cBlock);
+            if (dir != EntryPoint.UNKNOWN) {
+                return dir;
+            }
+        }
+        if (t.getLayoutBlock() != dBlock) {
+            //Block is not the same as that connected to D
+            int dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, dBlock);
+            if (dir != EntryPoint.UNKNOWN) {
+                return dir;
+            }
+        }
+        return EntryPoint.UNKNOWN;
+    }
+
+    private boolean placeSensorInCrossover(String b1Name, String b2Name, String c1Name, String c2Name,
+            int direction, ConnectivityUtil cUtil) {
+        SignalHead b1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(b1Name);
+        SignalHead b2Head = null;
+        SignalHead c1Head = null;
+        SignalHead c2Head = null;
+        boolean success = true;
+        if ((b2Name != null) && (!b2Name.isEmpty())) {
+            b2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(b2Name);
+        }
+        if ((c1Name != null) && (!c1Name.isEmpty())) {
+            c1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(c1Name);
+        }
+        if ((c2Name != null) && (!c2Name.isEmpty())) {
+            c2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(c2Name);
+        }
+        if (b2Head != null) {
+            if (!checkDirectionSensor(b1Head, direction, ConnectivityUtil.OVERALL, cUtil)) {
+                success = false;
+            }
+        } else {
+            if (!checkDirectionSensor(b1Head, direction, ConnectivityUtil.CONTINUING, cUtil)) {
+                success = false;
+            }
+        }
+        if (c2Head != null) {
+            if (!checkDirectionSensor(c2Head, direction, ConnectivityUtil.OVERALL, cUtil)) {
+                success = false;
+            }
+        } else if (c1Head != null) {
+            if (!checkDirectionSensor(c1Head, direction, ConnectivityUtil.DIVERGING, cUtil)) {
+                success = false;
+            }
+        }
+        return success;
+    }
+
+    private int checkLists(List<EntryPoint> forwardList, List<EntryPoint> reverseList, LayoutBlock lBlock) {
+        for (int i = 0; i < forwardList.size(); i++) {
+            if (forwardList.get(i).getFromBlock() == lBlock.getBlock()) {
+                return EntryPoint.FORWARD;
+            }
+        }
+        for (int i = 0; i < reverseList.size(); i++) {
+            if (reverseList.get(i).getFromBlock() == lBlock.getBlock()) {
+                return EntryPoint.REVERSE;
+            }
+        }
+        return EntryPoint.UNKNOWN;
+    }
+
+    @CheckForNull
+    private Block checkDualDirection(LayoutBlock aBlock, LayoutBlock bBlock, LayoutBlock cBlock) {
+        for (int i = 0; i < mForwardEntryPoints.size(); i++) {
+            Block b = mForwardEntryPoints.get(i).getFromBlock();
+            for (int j = 0; j < mReverseEntryPoints.size(); j++) {
+                if (mReverseEntryPoints.get(j).getFromBlock() == b) {
+                    // possible dual direction
+                    if (aBlock.getBlock() == b) {
+                        return b;
+                    } else if (bBlock.getBlock() == b) {
+                        return b;
+                    } else if ((cBlock.getBlock() == b) && (aBlock == bBlock)) {
+                        return b;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the direction for proceeding from LayoutBlock b to LayoutBlock a.
+     * LayoutBlock a must be in the Section. LayoutBlock b may be in this
+     * Section or may be an Entry Point to the Section.
+     */
+    private int getDirectionForBlocks(LayoutBlock a, LayoutBlock b) {
+        if (containsBlock(b.getBlock())) {
+            // both blocks are within this Section
+            if (getBlockSequenceNumber(a.getBlock()) > getBlockSequenceNumber(b.getBlock())) {
+                return EntryPoint.FORWARD;
+            } else {
+                return EntryPoint.REVERSE;
+            }
+        }
+        // bBlock must be an entry point
+        for (int i = 0; i < mForwardEntryPoints.size(); i++) {
+            if (mForwardEntryPoints.get(i).getFromBlock() == b.getBlock()) {
+                return EntryPoint.FORWARD;
+            }
+        }
+        for (int j = 0; j < mReverseEntryPoints.size(); j++) {
+            if (mReverseEntryPoints.get(j).getFromBlock() == b.getBlock()) {
+                return EntryPoint.REVERSE;
+            }
+        }
+        // should never get here
+        log.error("Unexpected error in getDirectionForBlocks when working with LevelCrossing in Section {}",
+                getDisplayName(USERSYS));
+        return EntryPoint.UNKNOWN;
+    }
+
+    /**
+     * @return 'true' if successfully checked direction sensor by follow
+     *         connectivity from specified track node; 'false' if an error
+     *         occurred
+     */
+    private boolean setDirectionSensorByConnectivity(TrackNode tNode, TrackNode altNode, SignalHead sh,
+            Block cBlock, ConnectivityUtil cUtil) {
+        boolean successful = false;
+        TrackNode tn = tNode;
+        if ((tn != null) && (sh != null)) {
+            Block tBlock = null;
+            LayoutBlock lb;
+            int dir = EntryPoint.UNKNOWN;
+            while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                tn = cUtil.getNextNode(tn, 0);
+                tBlock = (tn == null) ? null : cUtil.getExitBlockForTrackNode(tn, null);
+            }
+            if (tBlock != null) {
+                String userName = tBlock.getUserName();
+                if (userName != null) {
+                    lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                    if (lb != null) {
+                        dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
+                    }
+                }
+            } else {
+                tn = altNode;
+                while ((tBlock == null) && (tn != null) && (!tn.reachedEndOfTrack())) {
+                    tn = cUtil.getNextNode(tn, 0);
+                    tBlock = (tn == null) ? null : cUtil.getExitBlockForTrackNode(tn, null);
+                }
+                if (tBlock != null) {
+                    String userName = tBlock.getUserName();
+                    if (userName != null) {
+                        lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                        if (lb != null) {
+                            dir = checkLists(mReverseEntryPoints, mForwardEntryPoints, lb);
+                            if (dir == EntryPoint.REVERSE) {
+                                dir = EntryPoint.FORWARD;
+                            } else if (dir == EntryPoint.FORWARD) {
+                                dir = EntryPoint.REVERSE;
+                            }
+                        }
+                    }
+                }
+            }
+            if (dir != EntryPoint.UNKNOWN) {
+                if (checkDirectionSensor(sh, dir, ConnectivityUtil.OVERALL, cUtil)) {
+                    successful = true;
+                }
+            } else {
+                log.error("Trouble following track in Block {} in Section {}.",
+                        cBlock.getDisplayName(USERSYS), getDisplayName(USERSYS));
+            }
+        }
+        return successful;
+    }
+
+    /**
+     * Place direction sensors in SSL for all Signal Heads in this Section if
+     * the Sensors are not already present in the SSL.
+     * <p>
+     * Only anchor point block boundaries that have assigned signals are
+     * considered. Only turnouts that have assigned signals are considered. Only
+     * level crossings that have assigned signals are considered. Turnouts and
+     * anchor points without signals are counted, and reported in warning
+     * messages during this procedure, if there are any missing signals.
+     * <p>
+     * If this method has trouble, an error message is placed in the log
+     * describing the trouble.
+     *
+     * @param panel the panel to place direction sensors on
+     * @return the number or errors placing sensors; 1 is returned if no
+     *         direction sensor is defined for this section
+     */
+    public int placeDirectionSensors(LayoutEditor panel) {
+        int missingSignalsBB = 0;
+        int missingSignalsTurnouts = 0;
+        int missingSignalsLevelXings = 0;
+        int errorCount = 0;
+        if (panel == null) {
+            log.error("Null Layout Editor panel on call to 'placeDirectionSensors'");
+            return 1;
+        }
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        if ((mForwardBlockingSensorName == null) || (mForwardBlockingSensorName.isEmpty())
+                || (mReverseBlockingSensorName == null) || (mReverseBlockingSensorName.isEmpty())) {
+            log.error("Missing direction sensor in Section {}", getDisplayName(USERSYS));
+            return 1;
+        }
+        LayoutBlockManager layoutBlockManager = InstanceManager.getDefault(LayoutBlockManager.class);
+        ConnectivityUtil cUtil = panel.getConnectivityUtil();
+        LayoutBlock lBlock = null;
+        for (Block cBlock : mBlockEntries) {
+            String userName = cBlock.getUserName();
+            if (userName != null) {
+                lBlock = layoutBlockManager.getByUserName(userName);
+                if (lBlock == null) {
+                    continue;
+                }
+            }
+            List<PositionablePoint> anchorList = cUtil.getAnchorBoundariesThisBlock(cBlock);
+            for (int j = 0; j < anchorList.size(); j++) {
+                PositionablePoint p = anchorList.get(j);
+                if ((!p.getEastBoundSignal().isEmpty()) && (!p.getWestBoundSignal().isEmpty())) {
+                    // have a signalled block boundary
+                    SignalHead sh = cUtil.getSignalHeadAtAnchor(p, cBlock, false);
+                    if (sh == null) {
+                        log.warn("Unexpected missing signal head at boundary of Block {}", cBlock.getDisplayName(USERSYS));
+                        errorCount++;
+                    } else {
+                        int direction = cUtil.getDirectionFromAnchor(mForwardEntryPoints,
+                                mReverseEntryPoints, p);
+                        if (direction == EntryPoint.UNKNOWN) {
+                            // anchor is at a Block boundary within the Section
+                            sh = cUtil.getSignalHeadAtAnchor(p, cBlock, true);
+                            Block otherBlock = ((p.getConnect1()).getLayoutBlock()).getBlock();
+                            if (otherBlock == cBlock) {
+                                otherBlock = ((p.getConnect2()).getLayoutBlock()).getBlock();
+                            }
+                            if (getBlockSequenceNumber(cBlock) < getBlockSequenceNumber(otherBlock)) {
+                                direction = EntryPoint.FORWARD;
+                            } else {
+                                direction = EntryPoint.REVERSE;
+                            }
+                        }
+                        if (!checkDirectionSensor(sh, direction, ConnectivityUtil.OVERALL, cUtil)) {
+                            errorCount++;
+                        }
+                    }
+                } else {
+                    errorCount++;
+                    missingSignalsBB++;
+                }
+            }
+            List<LevelXing> xingList = cUtil.getLevelCrossingsThisBlock(cBlock);
+            for (int k = 0; k < xingList.size(); k++) {
+                LevelXing x = xingList.get(k);
+                LayoutBlock alBlock = ((TrackSegment) x.getConnectA()).getLayoutBlock();
+                LayoutBlock blBlock = ((TrackSegment) x.getConnectB()).getLayoutBlock();
+                LayoutBlock clBlock = ((TrackSegment) x.getConnectC()).getLayoutBlock();
+                LayoutBlock dlBlock = ((TrackSegment) x.getConnectD()).getLayoutBlock();
+                if (cUtil.isInternalLevelXingAC(x, cBlock)) {
+                    // have an internal AC level crossing - is it signaled?
+                    if (!x.getSignalAName().isEmpty() || (!x.getSignalCName().isEmpty())) {
+                        // have a signaled AC level crossing internal to this block
+                        if (!x.getSignalAName().isEmpty()) {
+                            // there is a signal at A in the level crossing
+                            TrackNode tn = new TrackNode(x, HitPointType.LEVEL_XING_A,
+                                    (TrackSegment) x.getConnectA(), false, 0);
+                            TrackNode altNode = new TrackNode(x, HitPointType.LEVEL_XING_C,
+                                    (TrackSegment) x.getConnectC(), false, 0);
+                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    x.getSignalAName());
+                            if (!setDirectionSensorByConnectivity(tn, altNode, sh, cBlock, cUtil)) {
+                                errorCount++;
+                            }
+                        }
+                        if (!x.getSignalCName().isEmpty()) {
+                            // there is a signal at C in the level crossing
+                            TrackNode tn = new TrackNode(x, HitPointType.LEVEL_XING_C,
+                                    (TrackSegment) x.getConnectC(), false, 0);
+                            TrackNode altNode = new TrackNode(x, HitPointType.LEVEL_XING_A,
+                                    (TrackSegment) x.getConnectA(), false, 0);
+                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    x.getSignalCName());
+                            if (!setDirectionSensorByConnectivity(tn, altNode, sh, cBlock, cUtil)) {
+                                errorCount++;
+                            }
+                        }
+                    }
+                } else if (alBlock == lBlock) {
+                    // have a level crossing with AC spanning a block boundary, with A in this Block
+                    int direction = getDirectionForBlocks(alBlock, clBlock);
+                    if (direction != EntryPoint.UNKNOWN) {
+                        if (!x.getSignalCName().isEmpty()) {
+                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    x.getSignalCName());
+                            if (!checkDirectionSensor(sh, direction, ConnectivityUtil.OVERALL, cUtil)) {
+                                errorCount++;
+                            }
+                        }
+                    } else {
+                        errorCount++;
+                    }
+                } else if (clBlock == lBlock) {
+                    // have a level crossing with AC spanning a block boundary, with C in this Block
+                    int direction = getDirectionForBlocks(clBlock, alBlock);
+                    if (direction != EntryPoint.UNKNOWN) {
+                        if (!x.getSignalAName().isEmpty()) {
+                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    x.getSignalAName());
+                            if (!checkDirectionSensor(sh, direction, ConnectivityUtil.OVERALL, cUtil)) {
+                                errorCount++;
+                            }
+                        }
+                    } else {
+                        errorCount++;
+                    }
+                }
+                if (cUtil.isInternalLevelXingBD(x, cBlock)) {
+                    // have an internal BD level crossing - is it signaled?
+                    if ((!x.getSignalBName().isEmpty()) || (!x.getSignalDName().isEmpty())) {
+                        // have a signaled BD level crossing internal to this block
+                        if (!x.getSignalBName().isEmpty()) {
+                            // there is a signal at B in the level crossing
+                            TrackNode tn = new TrackNode(x, HitPointType.LEVEL_XING_B,
+                                    (TrackSegment) x.getConnectB(), false, 0);
+                            TrackNode altNode = new TrackNode(x, HitPointType.LEVEL_XING_D,
+                                    (TrackSegment) x.getConnectD(), false, 0);
+                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    x.getSignalBName());
+                            if (!setDirectionSensorByConnectivity(tn, altNode, sh, cBlock, cUtil)) {
+                                errorCount++;
+                            }
+                        }
+                        if (!x.getSignalDName().isEmpty()) {
+                            // there is a signal at C in the level crossing
+                            TrackNode tn = new TrackNode(x, HitPointType.LEVEL_XING_D,
+                                    (TrackSegment) x.getConnectD(), false, 0);
+                            TrackNode altNode = new TrackNode(x, HitPointType.LEVEL_XING_B,
+                                    (TrackSegment) x.getConnectB(), false, 0);
+                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    x.getSignalDName());
+                            if (!setDirectionSensorByConnectivity(tn, altNode, sh, cBlock, cUtil)) {
+                                errorCount++;
+                            }
+                        }
+                    }
+                } else if (blBlock == lBlock) {
+                    // have a level crossing with BD spanning a block boundary, with B in this Block
+                    int direction = getDirectionForBlocks(blBlock, dlBlock);
+                    if (direction != EntryPoint.UNKNOWN) {
+                        if (!x.getSignalDName().isEmpty()) {
+                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    x.getSignalDName());
+                            if (!checkDirectionSensor(sh, direction, ConnectivityUtil.OVERALL, cUtil)) {
+                                errorCount++;
+                            }
+                        }
+                    } else {
+                        errorCount++;
+                    }
+                } else if (dlBlock == lBlock) {
+                    // have a level crossing with BD spanning a block boundary, with D in this Block
+                    int direction = getDirectionForBlocks(dlBlock, blBlock);
+                    if (direction != EntryPoint.UNKNOWN) {
+                        if (!x.getSignalBName().isEmpty()) {
+                            SignalHead sh = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    x.getSignalBName());
+                            if (!checkDirectionSensor(sh, direction, ConnectivityUtil.OVERALL, cUtil)) {
+                                errorCount++;
+                            }
+                        }
+                    } else {
+                        errorCount++;
+                    }
+                }
+            }
+            List<LayoutTurnout> turnoutList = cUtil.getLayoutTurnoutsThisBlock(cBlock);
+            for (int m = 0; m < turnoutList.size(); m++) {
+                LayoutTurnout t = turnoutList.get(m);
+                if (cUtil.layoutTurnoutHasRequiredSignals(t)) {
+                    // have a signalled turnout
+                    if ((t.getLinkType() == LayoutTurnout.LinkType.NO_LINK)
+                            && ((t.getTurnoutType() == LayoutTurnout.TurnoutType.RH_TURNOUT)
+                            || (t.getTurnoutType() == LayoutTurnout.TurnoutType.LH_TURNOUT)
+                            || (t.getTurnoutType() == LayoutTurnout.TurnoutType.WYE_TURNOUT))) {
+                        // standard turnout - nothing special
+                        // Note: direction is for proceeding from the throat to either other track
+                        int direction = getDirectionStandardTurnout(t, cUtil);
+                        int altDirection = EntryPoint.FORWARD;
+                        if (direction == EntryPoint.FORWARD) {
+                            altDirection = EntryPoint.REVERSE;
+                        }
+                        if (direction == EntryPoint.UNKNOWN) {
+                            errorCount++;
+                        } else {
+                            SignalHead aHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    t.getSignalA1Name());
+                            SignalHead a2Head = null;
+                            String a2Name = t.getSignalA2Name(); // returns "" for empty name, never null
+                            if (!a2Name.isEmpty()) {
+                                a2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(a2Name);
+                            }
+                            SignalHead bHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    t.getSignalB1Name());
+                            SignalHead cHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    t.getSignalC1Name());
+                            if (t.getLayoutBlock().getBlock() == cBlock) {
+                                // turnout is in this block, set direction sensors on all signal heads
+                                // Note: need allocation to traverse this turnout
+                                if (!checkDirectionSensor(aHead, direction,
+                                        ConnectivityUtil.OVERALL, cUtil)) {
+                                    errorCount++;
+                                }
+                                if (a2Head != null) {
+                                    if (!checkDirectionSensor(a2Head, direction,
+                                            ConnectivityUtil.OVERALL, cUtil)) {
+                                        errorCount++;
+                                    }
+                                }
+                                if (!checkDirectionSensor(bHead, altDirection,
+                                        ConnectivityUtil.OVERALL, cUtil)) {
+                                    errorCount++;
+                                }
+                                if (!checkDirectionSensor(cHead, altDirection,
+                                        ConnectivityUtil.OVERALL, cUtil)) {
+                                    errorCount++;
+                                }
+                            } else {
+                                if (((TrackSegment) t.getConnectA()).getLayoutBlock().getBlock() == cBlock) {
+                                    // throat Track Segment is in this Block
+                                    if (!checkDirectionSensor(bHead, altDirection,
+                                            ConnectivityUtil.OVERALL, cUtil)) {
+                                        errorCount++;
+                                    }
+                                    if (!checkDirectionSensor(cHead, altDirection,
+                                            ConnectivityUtil.OVERALL, cUtil)) {
+                                        errorCount++;
+                                    }
+                                } else if (((t.getContinuingSense() == Turnout.CLOSED)
+                                        && (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock))
+                                        || ((t.getContinuingSense() == Turnout.THROWN)
+                                        && (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock))) {
+                                    // continuing track segment is in this block, normal continuing sense - or -
+                                    //  diverging track segment is in this block, reverse continuing sense.
+                                    if (a2Head == null) {
+                                        // single head at throat
+                                        if (!checkDirectionSensor(aHead, direction,
+                                                ConnectivityUtil.CONTINUING, cUtil)) {
+                                            errorCount++;
+                                        }
+                                    } else {
+                                        // two heads at throat
+                                        if (!checkDirectionSensor(aHead, direction,
+                                                ConnectivityUtil.OVERALL, cUtil)) {
+                                            errorCount++;
+                                        }
+                                    }
+                                    if (!checkDirectionSensor(bHead, altDirection,
+                                            ConnectivityUtil.OVERALL, cUtil)) {
+                                        errorCount++;
+                                    }
+                                } else if (((t.getContinuingSense() == Turnout.CLOSED)
+                                        && (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock))
+                                        || ((t.getContinuingSense() == Turnout.THROWN)
+                                        && (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock))) {
+                                    // diverging track segment is in this block, normal continuing sense - or -
+                                    //  continuing track segment is in this block, reverse continuing sense.
+                                    if (a2Head == null) {
+                                        // single head at throat
+                                        if (!checkDirectionSensor(aHead, direction,
+                                                ConnectivityUtil.DIVERGING, cUtil)) {
+                                            errorCount++;
+                                        }
+                                    } else {
+                                        // two heads at throat
+                                        if (!checkDirectionSensor(a2Head, direction,
+                                                ConnectivityUtil.OVERALL, cUtil)) {
+                                            errorCount++;
+                                        }
+                                    }
+                                    if (!checkDirectionSensor(cHead, altDirection,
+                                            ConnectivityUtil.OVERALL, cUtil)) {
+                                        errorCount++;
+                                    }
+                                }
+                            }
+                        }
+                    } else if (t.getLinkType() != LayoutTurnout.LinkType.NO_LINK) {
+                        // special linked turnout
+                        LayoutTurnout tLinked = getLayoutTurnoutFromTurnoutName(t.getLinkedTurnoutName(), panel);
+                        if (tLinked == null) {
+                            log.error("null Layout Turnout linked to turnout {}", t.getTurnout().getDisplayName(USERSYS));
+                        } else if (t.getLinkType() == LayoutTurnout.LinkType.THROAT_TO_THROAT) {
+                            SignalHead b1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    t.getSignalB1Name());
+                            SignalHead b2Head = null;
+                            String hName = t.getSignalB2Name(); // returns "" for empty name, never null
+                            if (!hName.isEmpty()) {
+                                b2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
+                            }
+                            SignalHead c1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    t.getSignalC1Name());
+                            SignalHead c2Head = null;
+                            hName = t.getSignalC2Name(); // returns "" for empty name, never null
+                            if (!hName.isEmpty()) {
+                                c2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
+                            }
+                            int direction = getDirectionStandardTurnout(t, cUtil);
+                            int altDirection = EntryPoint.FORWARD;
+                            if (direction == EntryPoint.FORWARD) {
+                                altDirection = EntryPoint.REVERSE;
+                            }
+                            if (direction != EntryPoint.UNKNOWN) {
+                                if (t.getLayoutBlock().getBlock() == cBlock) {
+                                    // turnout is in this block, set direction sensors on all signal heads
+                                    // Note: need allocation to traverse this turnout
+                                    if (!checkDirectionSensor(b1Head, altDirection,
+                                            ConnectivityUtil.OVERALL, cUtil)) {
+                                        errorCount++;
+                                    }
+                                    if (b2Head != null) {
+                                        if (!checkDirectionSensor(b2Head, altDirection,
+                                                ConnectivityUtil.OVERALL, cUtil)) {
+                                            errorCount++;
+                                        }
+                                    }
+                                    if (!checkDirectionSensor(c1Head, altDirection,
+                                            ConnectivityUtil.OVERALL, cUtil)) {
+                                        errorCount++;
+                                    }
+                                    if (c2Head != null) {
+                                        if (!checkDirectionSensor(c2Head, altDirection,
+                                                ConnectivityUtil.OVERALL, cUtil)) {
+                                            errorCount++;
+                                        }
+                                    }
+                                } else {
+                                    // turnout is not in this block, switch to heads of linked turnout
+                                    b1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                            tLinked.getSignalB1Name());
+                                    hName = tLinked.getSignalB2Name(); // returns "" for empty name, never null
+                                    b2Head = null;
+                                    if (!hName.isEmpty()) {
+                                        b2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
+                                    }
+                                    c1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                            tLinked.getSignalC1Name());
+                                    c2Head = null;
+                                    hName = tLinked.getSignalC2Name(); // returns "" for empty name, never null
+                                    if (!hName.isEmpty()) {
+                                        c2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
+                                    }
+                                    if (((t.getContinuingSense() == Turnout.CLOSED)
+                                            && (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock))
+                                            || ((t.getContinuingSense() == Turnout.THROWN)
+                                            && (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock))) {
+                                        // continuing track segment is in this block
+                                        if (b2Head != null) {
+                                            if (!checkDirectionSensor(b1Head, direction,
+                                                    ConnectivityUtil.OVERALL, cUtil)) {
+                                                errorCount++;
+                                            }
+                                        } else {
+                                            if (!checkDirectionSensor(b1Head, direction,
+                                                    ConnectivityUtil.CONTINUING, cUtil)) {
+                                                errorCount++;
+                                            }
+                                        }
+                                        if (c2Head != null) {
+                                            if (!checkDirectionSensor(c1Head, direction,
+                                                    ConnectivityUtil.OVERALL, cUtil)) {
+                                                errorCount++;
+                                            }
+                                        } else {
+                                            if (!checkDirectionSensor(c1Head, direction,
+                                                    ConnectivityUtil.CONTINUING, cUtil)) {
+                                                errorCount++;
+                                            }
+                                        }
+                                    } else if (((t.getContinuingSense() == Turnout.CLOSED)
+                                            && (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock))
+                                            || ((t.getContinuingSense() == Turnout.THROWN)
+                                            && (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock))) {
+                                        // diverging track segment is in this block
+                                        if (b2Head != null) {
+                                            if (!checkDirectionSensor(b2Head, direction,
+                                                    ConnectivityUtil.OVERALL, cUtil)) {
+                                                errorCount++;
+                                            }
+                                        } else {
+                                            if (!checkDirectionSensor(b1Head, direction,
+                                                    ConnectivityUtil.DIVERGING, cUtil)) {
+                                                errorCount++;
+                                            }
+                                        }
+                                        if (c2Head != null) {
+                                            if (!checkDirectionSensor(c2Head, direction,
+                                                    ConnectivityUtil.OVERALL, cUtil)) {
+                                                errorCount++;
+                                            }
+                                        } else {
+                                            if (!checkDirectionSensor(c1Head, direction,
+                                                    ConnectivityUtil.DIVERGING, cUtil)) {
+                                                errorCount++;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        } else if (t.getLinkType() == LayoutTurnout.LinkType.FIRST_3_WAY) {
+                            SignalHead a1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    t.getSignalA1Name());
+                            SignalHead a2Head = null;
+                            String hName = t.getSignalA2Name();
+                            if (!hName.isEmpty()) {
+                                a2Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
+                            }
+                            SignalHead a3Head = null;
+                            hName = t.getSignalA3Name(); // returns "" for empty name, never null
+                            if (!hName.isEmpty()) {
+                                a3Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
+                            }
+                            SignalHead cHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    t.getSignalC1Name());
+                            int direction = getDirectionStandardTurnout(t, cUtil);
+                            int altDirection = EntryPoint.FORWARD;
+                            if (direction == EntryPoint.FORWARD) {
+                                altDirection = EntryPoint.REVERSE;
+                            }
+                            if (direction != EntryPoint.UNKNOWN) {
+                                if (t.getLayoutBlock().getBlock() == cBlock) {
+                                    // turnout is in this block, set direction sensors on all signal heads
+                                    // Note: need allocation to traverse this turnout
+                                    if (!checkDirectionSensor(a1Head, direction,
+                                            ConnectivityUtil.OVERALL, cUtil)) {
+                                        errorCount++;
+                                    }
+                                    if ((a2Head != null) && (a3Head != null)) {
+                                        if (!checkDirectionSensor(a2Head, direction,
+                                                ConnectivityUtil.OVERALL, cUtil)) {
+                                            errorCount++;
+                                        }
+                                        if (!checkDirectionSensor(a3Head, direction,
+                                                ConnectivityUtil.OVERALL, cUtil)) {
+                                            errorCount++;
+                                        }
+                                    }
+                                    if (!checkDirectionSensor(cHead, altDirection,
+                                            ConnectivityUtil.OVERALL, cUtil)) {
+                                        errorCount++;
+                                    }
+                                } else {
+                                    // turnout is not in this block
+                                    if (((TrackSegment) t.getConnectA()).getLayoutBlock().getBlock() == cBlock) {
+                                        // throat Track Segment is in this Block
+                                        if (!checkDirectionSensor(cHead, altDirection,
+                                                ConnectivityUtil.OVERALL, cUtil)) {
+                                            errorCount++;
+                                        }
+                                    } else if (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock) {
+                                        // diverging track segment is in this Block
+                                        if (a2Head != null) {
+                                            if (!checkDirectionSensor(a2Head, direction,
+                                                    ConnectivityUtil.OVERALL, cUtil)) {
+                                                errorCount++;
+                                            }
+                                        } else {
+                                            if (!checkDirectionSensor(a1Head, direction,
+                                                    ConnectivityUtil.DIVERGING, cUtil)) {
+                                                errorCount++;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        } else if (t.getLinkType() == LayoutTurnout.LinkType.SECOND_3_WAY) {
+                            SignalHead bHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    t.getSignalB1Name());
+                            SignalHead cHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    t.getSignalC1Name());
+                            SignalHead a1Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(
+                                    tLinked.getSignalA1Name());
+                            SignalHead a3Head = null;
+                            String hName = tLinked.getSignalA3Name();
+                            if (!hName.isEmpty()) {
+                                a3Head = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(hName);
+                            }
+                            int direction = getDirectionStandardTurnout(t, cUtil);
+                            int altDirection = EntryPoint.FORWARD;
+                            if (direction == EntryPoint.FORWARD) {
+                                altDirection = EntryPoint.REVERSE;
+                            }
+                            if (direction != EntryPoint.UNKNOWN) {
+                                if (t.getLayoutBlock().getBlock() == cBlock) {
+                                    // turnout is in this block, set direction sensors on b and c signal heads
+                                    // Note: need allocation to traverse this turnout
+                                    if (!checkDirectionSensor(bHead, altDirection,
+                                            ConnectivityUtil.OVERALL, cUtil)) {
+                                        errorCount++;
+                                    }
+                                    if (!checkDirectionSensor(cHead, altDirection,
+                                            ConnectivityUtil.OVERALL, cUtil)) {
+                                        errorCount++;
+                                    }
+                                }
+                                if (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock) {
+                                    // diverging track segment is in this Block
+                                    if (a3Head != null) {
+                                        if (!checkDirectionSensor(a3Head, direction,
+                                                ConnectivityUtil.OVERALL, cUtil)) {
+                                            errorCount++;
+                                        }
+                                    } else {
+                                        log.warn("Turnout {} - SSL for head {} cannot handle direction sensor for second diverging track.",
+                                                tLinked.getTurnout().getDisplayName(USERSYS),( a1Head==null ? "Unknown" : a1Head.getDisplayName(USERSYS)));
+                                        errorCount++;
+                                    }
+                                } else if (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock) {
+                                    // continuing track segment is in this Block
+                                    if (a3Head != null) {
+                                        if (!checkDirectionSensor(a1Head, direction,
+                                                ConnectivityUtil.OVERALL, cUtil)) {
+                                            errorCount++;
+                                        }
+                                    } else {
+                                        if (!checkDirectionSensor(a1Head, direction,
+                                                ConnectivityUtil.CONTINUING, cUtil)) {
+                                            errorCount++;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } else if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.RH_XOVER)
+                            || (t.getTurnoutType() == LayoutTurnout.TurnoutType.LH_XOVER)
+                            || (t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER)) {
+                        // crossover turnout
+                        // Note: direction is for proceeding from A to B (or D to C)
+                        int direction = getDirectionXoverTurnout(t, cUtil);
+                        int altDirection = EntryPoint.FORWARD;
+                        if (direction == EntryPoint.FORWARD) {
+                            altDirection = EntryPoint.REVERSE;
+                        }
+                        if (direction == EntryPoint.UNKNOWN) {
+                            errorCount++;
+                        } else {
+                            if (((TrackSegment) t.getConnectA()).getLayoutBlock().getBlock() == cBlock) {
+                                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER)
+                                        || (t.getTurnoutType() == LayoutTurnout.TurnoutType.RH_XOVER)) {
+                                    if (!placeSensorInCrossover(t.getSignalB1Name(), t.getSignalB2Name(),
+                                            t.getSignalC1Name(), t.getSignalC2Name(), altDirection, cUtil)) {
+                                        errorCount++;
+                                    }
+                                } else {
+                                    if (!placeSensorInCrossover(t.getSignalB1Name(), t.getSignalB2Name(),
+                                            null, null, altDirection, cUtil)) {
+                                        errorCount++;
+                                    }
+                                }
+                            }
+                            if (((TrackSegment) t.getConnectB()).getLayoutBlock().getBlock() == cBlock) {
+                                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER)
+                                        || (t.getTurnoutType() == LayoutTurnout.TurnoutType.LH_XOVER)) {
+                                    if (!placeSensorInCrossover(t.getSignalA1Name(), t.getSignalA2Name(),
+                                            t.getSignalD1Name(), t.getSignalD2Name(), direction, cUtil)) {
+                                        errorCount++;
+                                    }
+                                } else {
+                                    if (!placeSensorInCrossover(t.getSignalA1Name(), t.getSignalA2Name(),
+                                            null, null, direction, cUtil)) {
+                                        errorCount++;
+                                    }
+                                }
+                            }
+                            if (((TrackSegment) t.getConnectC()).getLayoutBlock().getBlock() == cBlock) {
+                                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER)
+                                        || (t.getTurnoutType() == LayoutTurnout.TurnoutType.RH_XOVER)) {
+                                    if (!placeSensorInCrossover(t.getSignalD1Name(), t.getSignalD2Name(),
+                                            t.getSignalA1Name(), t.getSignalA2Name(), direction, cUtil)) {
+                                        errorCount++;
+                                    }
+                                } else {
+                                    if (!placeSensorInCrossover(t.getSignalD1Name(), t.getSignalD2Name(),
+                                            null, null, direction, cUtil)) {
+                                        errorCount++;
+                                    }
+                                }
+                            }
+                            if (((TrackSegment) t.getConnectD()).getLayoutBlock().getBlock() == cBlock) {
+                                if ((t.getTurnoutType() == LayoutTurnout.TurnoutType.DOUBLE_XOVER)
+                                        || (t.getTurnoutType() == LayoutTurnout.TurnoutType.LH_XOVER)) {
+                                    if (!placeSensorInCrossover(t.getSignalC1Name(), t.getSignalC2Name(),
+                                            t.getSignalB1Name(), t.getSignalB2Name(), altDirection, cUtil)) {
+                                        errorCount++;
+                                    }
+                                } else {
+                                    if (!placeSensorInCrossover(t.getSignalC1Name(), t.getSignalC2Name(),
+                                            null, null, altDirection, cUtil)) {
+                                        errorCount++;
+                                    }
+                                }
+                            }
+                        }
+                    } else if (t.isTurnoutTypeSlip()) {
+                        int direction = getDirectionSlip(t, cUtil);
+                        int altDirection = EntryPoint.FORWARD;
+                        if (direction == EntryPoint.FORWARD) {
+                            altDirection = EntryPoint.REVERSE;
+                        }
+                        if (direction == EntryPoint.UNKNOWN) {
+                            errorCount++;
+                        } else {
+                            if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalA1Name()), altDirection, ConnectivityUtil.OVERALL, cUtil)) {
+                                errorCount++;
+                            }
+                            if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalA2Name()), altDirection, ConnectivityUtil.OVERALL, cUtil)) {
+                                errorCount++;
+                            }
+                            if (t.getTurnoutType() == LayoutSlip.TurnoutType.SINGLE_SLIP) {
+                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalB1Name()), altDirection, ConnectivityUtil.OVERALL, cUtil)) {
+                                    errorCount++;
+                                }
+                            } else {
+                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalB1Name()), altDirection, ConnectivityUtil.OVERALL, cUtil)) {
+                                    errorCount++;
+                                }
+                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalB2Name()), altDirection, ConnectivityUtil.OVERALL, cUtil)) {
+                                    errorCount++;
+                                }
+                            }
+                            if (t.getTurnoutType() == LayoutSlip.TurnoutType.SINGLE_SLIP) {
+                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalC1Name()), direction, ConnectivityUtil.OVERALL, cUtil)) {
+                                    errorCount++;
+                                }
+                            } else {
+                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalC1Name()), direction, ConnectivityUtil.OVERALL, cUtil)) {
+                                    errorCount++;
+                                }
+                                if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalC2Name()), direction, ConnectivityUtil.OVERALL, cUtil)) {
+                                    errorCount++;
+                                }
+                            }
+                            if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalD1Name()), direction, ConnectivityUtil.OVERALL, cUtil)) {
+                                errorCount++;
+                            }
+                            if (!checkDirectionSensor(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(t.getSignalD2Name()), direction, ConnectivityUtil.OVERALL, cUtil)) {
+                                errorCount++;
+                            }
+                        }
+                    } else {
+                        log.error("Unknown turnout type for turnout {} in Section {}.",
+                                t.getTurnout().getDisplayName(USERSYS), getDisplayName(USERSYS));
+                        errorCount++;
+                    }
+                } else {
+                    // signal heads missing in turnout
+                    missingSignalsTurnouts++;
+                }
+            }
+        }
+        // set up missing signal head message, if any
+        if ((missingSignalsBB + missingSignalsTurnouts + missingSignalsLevelXings) > 0) {
+            String s = "";
+            if (missingSignalsBB > 0) {
+                s = ", " + (missingSignalsBB) + " anchor point signal heads missing";
+            }
+            if (missingSignalsTurnouts > 0) {
+                s = ", " + (missingSignalsTurnouts) + " turnouts missing signals";
+            }
+            if (missingSignalsLevelXings > 0) {
+                s = ", " + (missingSignalsLevelXings) + " level crossings missing signals";
+            }
+            log.warn("Section - {} {}",getDisplayName(USERSYS),s);
+        }
+
+        return errorCount;
+    }
+
+    private boolean checkDirectionSensor(SignalHead sh, int direction, int where,
+            ConnectivityUtil cUtil) {
+        String sensorName = "";
+        if (direction == EntryPoint.FORWARD) {
+            sensorName = getForwardBlockingSensorName();
+        } else if (direction == EntryPoint.REVERSE) {
+            sensorName = getReverseBlockingSensorName();
+        }
+        return (cUtil.addSensorToSignalHeadLogic(sensorName, sh, where));
+    }
+
+    private LayoutTurnout getLayoutTurnoutFromTurnoutName(String turnoutName, LayoutEditor panel) {
+        Turnout t = InstanceManager.turnoutManagerInstance().getTurnout(turnoutName);
+        if (t == null) {
+            return null;
+        }
+        for (LayoutTurnout lt : panel.getLayoutTurnouts()) {
+            if (lt.getTurnout() == t) {
+                return lt;
+            }
+        }
+        return null;
+    }
+
+    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "was previously marked with @SuppressWarnings, reason unknown")
+    private List<EntryPoint> getListOfForwardBlockEntryPoints(Block b) {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        List<EntryPoint> a = new ArrayList<>();
+        for (int i = 0; i < mForwardEntryPoints.size(); i++) {
+            if (b == (mForwardEntryPoints.get(i)).getBlock()) {
+                a.add(mForwardEntryPoints.get(i));
+            }
+        }
+        return a;
+    }
+
+    /**
+     * Validate the Section. This checks block connectivity, warns of redundant
+     * EntryPoints, and otherwise checks internal consistency of the Section. An
+     * appropriate error message is logged if a problem is found. This method
+     * assumes that Block Paths are correctly initialized.
+     *
+     * @param lePanel panel containing blocks that will be checked to be
+     *                initialized; if null no blocks are checked
+     * @return an error description or empty string if there are no errors
+     */
+    public String validate(LayoutEditor lePanel) {
+        if (initializationNeeded) {
+            initializeBlocks();
+        }
+        // validate Paths and Bean Settings if a Layout Editor panel is available
+        if (lePanel != null) {
+            for (int i = 0; i < (mBlockEntries.size() - 1); i++) {
+                Block test = getBlockBySequenceNumber(i);
+                if (test == null){
+                    log.error("Block {} not found in Block Entries. Paths not checked.",i );
+                    break;
+                }
+                String userName = test.getUserName();
+                if (userName != null) {
+                    LayoutBlock lBlock = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                    if (lBlock == null) {
+                        log.error("Layout Block {} not found. Paths not checked.", userName);
+                    } else {
+                        lBlock.updatePathsUsingPanel(lePanel);
+                    }
+                }
+            }
+        }
+        // check connectivity between internal blocks
+        if (mBlockEntries.size() > 1) {
+            for (int i = 0; i < (mBlockEntries.size() - 1); i++) {
+                Block thisBlock = getBlockBySequenceNumber(i);
+                Block nextBlock = getBlockBySequenceNumber(i + 1);
+                if ( thisBlock == null || nextBlock == null ) {
+                        return "Sequential blocks " + i + " " + thisBlock + " or "
+                            + i+1 + " " + nextBlock + " are empty in Block List.";
+                    }
+                if (!connected(thisBlock, nextBlock)) {
+                    String s = "Sequential Blocks - " + thisBlock.getDisplayName(USERSYS)
+                            + ", " + nextBlock.getDisplayName(USERSYS)
+                            + " - are not connected in Section " + getDisplayName(USERSYS) + ".";
+                    return s;
+                }
+                if (!connected(nextBlock, thisBlock)) {
+                    String s = "Sequential Blocks - " + thisBlock.getDisplayName(USERSYS)
+                            + ", " + nextBlock.getDisplayName(USERSYS)
+                            + " - Paths are not consistent - Section " + getDisplayName(USERSYS) + ".";
+                    return s;
+                }
+            }
+        }
+        // validate entry points
+        if ((mForwardEntryPoints.isEmpty()) && (mReverseEntryPoints.isEmpty())) {
+            String s = "Section " + getDisplayName(USERSYS) + "has no Entry Points.";
+            return s;
+        }
+        if (mForwardEntryPoints.size() > 0) {
+            for (int i = 0; i < mForwardEntryPoints.size(); i++) {
+                EntryPoint ep = mForwardEntryPoints.get(i);
+                if (!containsBlock(ep.getBlock())) {
+                    String s = "Entry Point Block, " + ep.getBlock().getDisplayName(USERSYS)
+                            + ", is not a Block in Section " + getDisplayName(USERSYS) + ".";
+                    return s;
+                }
+                if (!connectsToBlock(ep.getFromBlock())) {
+                    String s = "Entry Point From Block, " + ep.getBlock().getDisplayName(USERSYS)
+                            + ", is not connected to a Block in Section " + getDisplayName(USERSYS) + ".";
+                    return s;
+                }
+                if (!ep.isForwardType()) {
+                    String s = "Direction of FORWARD Entry Point From Block "
+                            + ep.getFromBlock().getDisplayName(USERSYS) + " to Section "
+                            + getDisplayName(USERSYS) + " is incorrectly set.";
+                    return s;
+                }
+                if (!connected(ep.getBlock(), ep.getFromBlock())) {
+                    String s = "Entry Point Blocks, " + ep.getBlock().getDisplayName(USERSYS)
+                            + " and " + ep.getFromBlock().getDisplayName(USERSYS)
+                            + ", are not connected in Section " + getDisplayName(USERSYS) + ".";
+                    return s;
+                }
+            }
+        }
+        if (mReverseEntryPoints.size() > 0) {
+            for (int i = 0; i < mReverseEntryPoints.size(); i++) {
+                EntryPoint ep = mReverseEntryPoints.get(i);
+                if (!containsBlock(ep.getBlock())) {
+                    String s = "Entry Point Block, " + ep.getBlock().getDisplayName(USERSYS)
+                            + ", is not a Block in Section " + getDisplayName(USERSYS) + ".";
+                    return s;
+                }
+                if (!connectsToBlock(ep.getFromBlock())) {
+                    String s = "Entry Point From Block, " + ep.getBlock().getDisplayName(USERSYS)
+                            + ", is not connected to a Block in Section " + getDisplayName(USERSYS) + ".";
+                    return s;
+                }
+                if (!ep.isReverseType()) {
+                    String s = "Direction of REVERSE Entry Point From Block "
+                            + ep.getFromBlock().getDisplayName(USERSYS) + " to Section "
+                            + getDisplayName(USERSYS) + " is incorrectly set.";
+                    return s;
+                }
+                if (!connected(ep.getBlock(), ep.getFromBlock())) {
+                    String s = "Entry Point Blocks, " + ep.getBlock().getDisplayName(USERSYS)
+                            + " and " + ep.getFromBlock().getDisplayName(USERSYS)
+                            + ", are not connected in Section " + getDisplayName(USERSYS) + ".";
+                    return s;
+                }
+            }
+        }
+        return "";
+    }
+
+    private boolean connected(Block b1, Block b2) {
+        if ((b1 != null) && (b2 != null)) {
+            List<Path> paths = b1.getPaths();
+            for (int i = 0; i < paths.size(); i++) {
+                if (paths.get(i).getBlock() == b2) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Set/reset the display to use alternate color for unoccupied blocks in
+     * this section. If Layout Editor panel is not present, Layout Blocks will
+     * not be present, and nothing will be set.
+     *
+     * @param set true to use alternate unoccupied color; false otherwise
+     */
+    public void setAlternateColor(boolean set) {
+        for (Block b : mBlockEntries) {
+            String userName = b.getUserName();
+            if (userName != null) {
+                LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                if (lb != null) {
+                    lb.setUseExtraColor(set);
+                }
+            }
+        }
+    }
+
+    /**
+     * Set/reset the display to use alternate color for unoccupied blocks in
+     * this Section. If the Section already contains an active block, then the
+     * alternative color will be set from the active block, if no active block
+     * is found or we are clearing the alternative color then all the blocks in
+     * the Section will be set. If Layout Editor panel is not present, Layout
+     * Blocks will not be present, and nothing will be set.
+     *
+     * @param set true to use alternate unoccupied color; false otherwise
+     */
+    public void setAlternateColorFromActiveBlock(boolean set) {
+        LayoutBlockManager lbm = InstanceManager.getDefault(LayoutBlockManager.class);
+        boolean beenSet = false;
+        if (!set || getState() == FREE || getState() == UNKNOWN) {
+            setAlternateColor(set);
+        } else if (getState() == FORWARD) {
+            for (Block b : mBlockEntries) {
+                if (b.getState() == Block.OCCUPIED) {
+                    beenSet = true;
+                }
+                if (beenSet) {
+                    String userName = b.getUserName();
+                    if (userName != null) {
+                        LayoutBlock lb = lbm.getByUserName(userName);
+                        if (lb != null) {
+                            lb.setUseExtraColor(set);
+                        }
+                    }
+                }
+            }
+        } else if (getState() == REVERSE) {
+            for (Block b : mBlockEntries) {
+                if (b.getState() == Block.OCCUPIED) {
+                    beenSet = true;
+                }
+                if (beenSet) {
+                    String userName = b.getUserName();
+                    if (userName != null) {
+                        LayoutBlock lb = lbm.getByUserName(userName);
+                        if (lb != null) {
+                            lb.setUseExtraColor(set);
+                        }
+                    }
+                }
+            }
+        }
+        if (!beenSet) {
+            setAlternateColor(set);
+        }
+    }
+
+    /**
+     * Set the block values for blocks in this Section.
+     *
+     * @param name the value to set all blocks to
+     */
+    public void setNameInBlocks(String name) {
+        for (Block b : mBlockEntries) {
+            b.setValue(name);
+        }
+    }
+
+    /**
+     * Set the block values for blocks in this Section.
+     *
+     * @param value the name to set block values to
+     */
+    public void setNameInBlocks(Object value) {
+        for (Block b : mBlockEntries) {
+            b.setValue(value);
+        }
+    }
+
+    public void setNameFromActiveBlock(Object value) {
+        boolean beenSet = false;
+        if (value == null || getState() == FREE || getState() == UNKNOWN) {
+            setNameInBlocks(value);
+        } else if (getState() == FORWARD) {
+            for (Block b : mBlockEntries) {
+                if (b.getState() == Block.OCCUPIED) {
+                    beenSet = true;
+                }
+                if (beenSet) {
+                    b.setValue(value);
+                }
+            }
+        } else if (getState() == REVERSE) {
+            for (Block b : mBlockEntries) {
+                if (b.getState() == Block.OCCUPIED) {
+                    beenSet = true;
+                }
+                if (beenSet) {
+                    b.setValue(value);
+                }
+            }
+        }
+        if (!beenSet) {
+            setNameInBlocks(value);
+        }
+    }
+
+    /**
+     * Clear the block values for blocks in this Section.
+     */
+    public void clearNameInUnoccupiedBlocks() {
+        for (Block b : mBlockEntries) {
+            if (b.getState() == Block.UNOCCUPIED) {
+                b.setValue(null);
+            }
+        }
+    }
+
+    /**
+     * Suppress the update of a memory variable when a block goes to unoccupied,
+     * so the text set above doesn't get wiped out.
+     *
+     * @param set true to suppress the update; false otherwise
+     */
+    public void suppressNameUpdate(boolean set) {
+        for (Block b : mBlockEntries) {
+            String userName = b.getUserName();
+            if (userName != null) {
+                LayoutBlock lb = InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(userName);
+                if (lb != null) {
+                    lb.setSuppressNameUpdate(set);
+                }
+            }
+        }
+    }
+
+    final public static int USERDEFINED = 0x01; //Default Save all the information
+    final public static int SIGNALMASTLOGIC = 0x02; //Save only the name, blocks will be added by the signalmast logic
+    final public static int DYNAMICADHOC = 0x00;  //created on an as required basis, not to be saved.
+
+    private int sectionType = USERDEFINED;
+
+    /**
+     * Set Section Type.
+     * <ul>
+     * <li>USERDEFINED - Default Save all the information.
+     * <li>SIGNALMASTLOGIC - Save only the name, blocks will be added by the SignalMast logic.
+     * <li>DYNAMICADHOC - Created on an as required basis, not to be saved.
+     * </ul>
+     * @param type constant of section type.
+     */
+    public void setSectionType(int type) {
+        sectionType = type;
+    }
+
+    /**
+     * Get Section Type.
+     * Defaults to USERDEFINED.
+     * @return constant of section type.
+     */
+    public int getSectionType() {
+        return sectionType;
+    }
+
+    @Override
+    public String getBeanType() {
+        return Bundle.getMessage("BeanNameSection");
+    }
+
+    @Override
+    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
+        if ("CanDelete".equals(evt.getPropertyName())) { // NOI18N
+            NamedBean nb = (NamedBean) evt.getOldValue();
+            if (nb instanceof Sensor) {
+                if (nb.equals(getForwardBlockingSensor())) {
+                    PropertyChangeEvent e = new PropertyChangeEvent(this, "DoNotDelete", null, null);
+                    throw new PropertyVetoException(Bundle.getMessage("VetoBlockingSensor", nb.getBeanType(), Bundle.getMessage("Forward"), Bundle.getMessage("Blocking"), getDisplayName()), e); // NOI18N
+                }
+                if (nb.equals(getForwardStoppingSensor())) {
+                    PropertyChangeEvent e = new PropertyChangeEvent(this, "DoNotDelete", null, null);
+                    throw new PropertyVetoException(Bundle.getMessage("VetoBlockingSensor", nb.getBeanType(), Bundle.getMessage("Forward"), Bundle.getMessage("Stopping"), getDisplayName()), e);
+                }
+                if (nb.equals(getReverseBlockingSensor())) {
+                    PropertyChangeEvent e = new PropertyChangeEvent(this, "DoNotDelete", null, null);
+                    throw new PropertyVetoException(Bundle.getMessage("VetoBlockingSensor", nb.getBeanType(), Bundle.getMessage("Reverse"), Bundle.getMessage("Blocking"), getDisplayName()), e);
+                }
+                if (nb.equals(getReverseStoppingSensor())) {
+                    PropertyChangeEvent e = new PropertyChangeEvent(this, "DoNotDelete", null, null);
+                    throw new PropertyVetoException(Bundle.getMessage("VetoBlockingSensor", nb.getBeanType(), Bundle.getMessage("Reverse"), Bundle.getMessage("Stopping"), getDisplayName()), e);
+                }
+            }
+            if (nb instanceof Block) {
+                Block check = (Block)nb;
+                if (getBlockList().contains(check)) {
+                    PropertyChangeEvent e = new PropertyChangeEvent(this, "DoNotDelete", null, null);
+                    throw new PropertyVetoException(Bundle.getMessage("VetoBlockInSection", getDisplayName()), e);
+                }
+            }
+        }
+        // "DoDelete" case, if needed, should be handled here.
+    }
+
+    @Override
+    public List<NamedBeanUsageReport> getUsageReport(NamedBean bean) {
+        List<NamedBeanUsageReport> report = new ArrayList<>();
+        if (bean != null) {
+            getBlockList().forEach((block) -> {
+                if (bean.equals(block)) {
+                    report.add(new NamedBeanUsageReport("SectionBlock"));
+                }
+            });
+            if (bean.equals(getForwardBlockingSensor())) {
+                report.add(new NamedBeanUsageReport("SectionSensorForwardBlocking"));
+            }
+            if (bean.equals(getForwardStoppingSensor())) {
+                report.add(new NamedBeanUsageReport("SectionSensorForwardStopping"));
+            }
+            if (bean.equals(getReverseBlockingSensor())) {
+                report.add(new NamedBeanUsageReport("SectionSensorReverseBlocking"));
+            }
+            if (bean.equals(getReverseStoppingSensor())) {
+                report.add(new NamedBeanUsageReport("SectionSensorReverseStopping"));
+            }
+        }
+        return report;
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultSection.class);
+
+}

--- a/java/src/jmri/implementation/DefaultTransit.java
+++ b/java/src/jmri/implementation/DefaultTransit.java
@@ -1,0 +1,625 @@
+package jmri.implementation;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyVetoException;
+import java.util.ArrayList;
+import java.util.List;
+
+import jmri.Block;
+import jmri.EntryPoint;
+import jmri.JmriException;
+import jmri.NamedBean;
+import jmri.NamedBeanUsageReport;
+import jmri.Section;
+import jmri.Sensor;
+import jmri.Transit;
+import jmri.TransitSection;
+import jmri.TransitSectionAction;
+
+/**
+ * A Transit is a group of Sections representing a specified path through a
+ * layout.
+ * <p>
+ * A Transit may have the following states:
+ * <dl>
+ * <dt>IDLE</dt>
+ * <dd>available for assignment to a train</dd>
+ * <dt>ASSIGNED</dt>
+ * <dd>linked to a train in an {@link jmri.jmrit.dispatcher.ActiveTrain}</dd>
+ * </dl>
+ * <p>
+ * When assigned to a Transit, options may be set for the assigned Section. The
+ * Section and its options are kept in a {@link jmri.TransitSection} object.
+ * <p>
+ * To accommodate passing sidings and other track features, there may be
+ * multiple Sections connecting two other Sections in a Transit. If so, one
+ * Section is assigned as primary, and the other connecting Sections are
+ * assigned as alternates.
+ * <p>
+ * A Section may be in a Transit more than once, for example if a train is to
+ * make two or more loops around a layout before going elsewhere.
+ * <p>
+ * A Transit is normally traversed in the forward direction, that is, the
+ * direction of increasing Section Numbers. When a Transit traversal is started
+ * up, it is always started in the forward direction. However, to accommodate
+ * point-to-point (back and forth) route designs, the direction of travel in a
+ * Transit may be "reversed". While the Transit direction is "reversed", the
+ * direction of travel is the direction of decreasing Section numbers. Whether a
+ * Transit is in the "reversed" direction is kept in the ActiveTrain using the
+ * Transit.
+ *
+ * @author Dave Duchamp Copyright (C) 2008-2011
+ */
+public class DefaultTransit extends AbstractNamedBean implements Transit {
+
+    /**
+     * The idle, or available for assignment to an ActiveTrain state.
+     */
+    public static final int IDLE = 0x02;
+    /**
+     * The assigned to an ActiveTrain state.
+     */
+    public static final int ASSIGNED = 0x04;
+
+    /*
+     * Instance variables (not saved between runs)
+     */
+    private static final NamedBean.DisplayOptions USERSYS = NamedBean.DisplayOptions.USERNAME_SYSTEMNAME;
+    private int mState = Transit.IDLE;
+    private final ArrayList<TransitSection> mTransitSectionList = new ArrayList<>();
+    private int mMaxSequence = 0;
+    private final ArrayList<Integer> blockSecSeqList = new ArrayList<>();
+    private final ArrayList<Integer> destBlocksSeqList = new ArrayList<>();
+
+    public DefaultTransit(String systemName, String userName) {
+        super(systemName, userName);
+    }
+
+    public DefaultTransit(String systemName) {
+        super(systemName);
+    }
+
+    /**
+     * Query the state of this Transit.
+     *
+     * @return {@link #IDLE} or {@link #ASSIGNED}
+     */
+    @Override
+    public int getState() {
+        return mState;
+    }
+
+    /**
+     * Set the state of this Transit.
+     *
+     * @param state {@link #IDLE} or {@link #ASSIGNED}
+     */
+    @Override
+    public void setState(int state) {
+        if ((state == Transit.IDLE) || (state == Transit.ASSIGNED)) {
+            int old = mState;
+            mState = state;
+            firePropertyChange("state", old, mState);
+        } else {
+            log.error("Attempt to set Transit state to illegal value - {}", state);
+        }
+    }
+
+    /**
+     * Add a Section to this Transit.
+     *
+     * @param s the Section object to add
+     */
+    public void addTransitSection(TransitSection s) {
+        mTransitSectionList.add(s);
+        mMaxSequence = s.getSequenceNumber();
+    }
+
+    /**
+     * Get the list of TransitSections.
+     *
+     * @return a copy of the internal list of TransitSections or an empty list
+     */
+    public ArrayList<TransitSection> getTransitSectionList() {
+        return new ArrayList<>(mTransitSectionList);
+    }
+
+    /**
+     * Get the maximum sequence number used in this Transit.
+     *
+     * @return the maximum sequence
+     */
+    public int getMaxSequence() {
+        return mMaxSequence;
+    }
+
+    /**
+     * Remove all TransitSections in this Transit.
+     */
+    public void removeAllSections() {
+        mTransitSectionList.clear();
+    }
+
+    /**
+     * Check if a Section is in this Transit.
+     *
+     * @param s the section to check for
+     * @return true if the section is present; false otherwise
+     */
+    public boolean containsSection(Section s) {
+        return mTransitSectionList.stream().anyMatch((ts) -> (ts.getSection() == s));
+    }
+
+    /**
+     * Get a List of Sections with a given sequence number.
+     *
+     * @param seq the sequence number
+     * @return the list of of matching sections or an empty list if none
+     */
+    public ArrayList<Section> getSectionListBySeq(int seq) {
+        ArrayList<Section> list = new ArrayList<>();
+        for (TransitSection ts : mTransitSectionList) {
+            if (seq == ts.getSequenceNumber()) {
+                list.add(ts.getSection());
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Get a List of TransitSections with a given sequence number.
+     *
+     * @param seq the sequence number
+     * @return the list of of matching sections or an empty list if none
+     */
+    public ArrayList<TransitSection> getTransitSectionListBySeq(int seq) {
+        ArrayList<TransitSection> list = new ArrayList<>();
+        for (TransitSection ts : mTransitSectionList) {
+            if (seq == ts.getSequenceNumber()) {
+                list.add(ts);
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Get a List of sequence numbers for a given Section.
+     *
+     * @param s the section to match
+     * @return the list of matching sequence numbers or an empty list if none
+     */
+    public ArrayList<Integer> getSeqListBySection(Section s) {
+        ArrayList<Integer> list = new ArrayList<>();
+        for (TransitSection ts : mTransitSectionList) {
+            if (s == ts.getSection()) {
+                list.add(ts.getSequenceNumber());
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Check if a Block is in this Transit.
+     *
+     * @param block the block to check for
+     * @return true if block is present; false otherwise
+     */
+    public boolean containsBlock(Block block) {
+        for (Block b : getInternalBlocksList()) {
+            if (b == block) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the number of times a Block is in this Transit.
+     *
+     * @param block the block to check for
+     * @return the number of times block is present; 0 if block is not present
+     */
+    public int getBlockCount(Block block) {
+        int count = 0;
+        for (Block b : getInternalBlocksList()) {
+            if (b == block) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Get a Section from one of its Blocks and its sequence number.
+     *
+     * @param b   the block within the Section
+     * @param seq the sequence number of the Section
+     * @return the Section or null if no matching Section is present
+     */
+    public Section getSectionFromBlockAndSeq(Block b, int seq) {
+        for (TransitSection ts : mTransitSectionList) {
+            if (ts.getSequenceNumber() == seq) {
+                Section s = ts.getSection();
+                if (s.containsBlock(b)) {
+                    return s;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get Section from one of its EntryPoint Blocks and its sequence number.
+     *
+     * @param b   the connecting block to the Section
+     * @param seq the sequence number of the Section
+     * @return the Section or null if no matching Section is present
+     */
+    public Section getSectionFromConnectedBlockAndSeq(Block b, int seq) {
+        for (TransitSection ts : mTransitSectionList) {
+            if (ts.getSequenceNumber() == seq) {
+                Section s = ts.getSection();
+                if (s.connectsToBlock(b)) {
+                    return s;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the direction of a Section in the transit from its sequence number.
+     *
+     * @param s   the Section to check
+     * @param seq the sequence number of the Section
+     * @return the direction of the Section (one of {@link jmri.Section#FORWARD}
+     *         or {@link jmri.Section#REVERSE} or zero if s and seq are not in a
+     *         TransitSection together
+     */
+    public int getDirectionFromSectionAndSeq(Section s, int seq) {
+        for (TransitSection ts : mTransitSectionList) {
+            if ((ts.getSection() == s) && (ts.getSequenceNumber() == seq)) {
+                return ts.getDirection();
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Get a TransitSection in the transit from its Section and sequence number.
+     *
+     * @param s   the Section to check
+     * @param seq the sequence number of the Section
+     * @return the transit section or null if not found
+     */
+    public TransitSection getTransitSectionFromSectionAndSeq(Section s, int seq) {
+        for (TransitSection ts : mTransitSectionList) {
+            if ((ts.getSection() == s) && (ts.getSequenceNumber() == seq)) {
+                return ts;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get a list of all blocks internal to this Transit. Since Sections may be
+     * present more than once, blocks may be listed more than once. The sequence
+     * numbers of the Section the Block was found in are accumulated in a
+     * parallel list, which can be accessed by immediately calling
+     * {@link #getBlockSeqList()}.
+     *
+     * @return the list of all Blocks or an empty list if none are present
+     */
+    public ArrayList<Block> getInternalBlocksList() {
+        ArrayList<Block> list = new ArrayList<>();
+        blockSecSeqList.clear();
+        mTransitSectionList.forEach((ts) -> {
+            ts.getSection().getBlockList().stream().forEach((b) -> {
+                list.add(b);
+                blockSecSeqList.add(ts.getSequenceNumber());
+            });
+        });
+        return list;
+    }
+
+    /**
+     * Get a list of sequence numbers in this Transit. This list is generated by
+     * calling {@link #getInternalBlocksList()} or
+     * {@link #getEntryBlocksList()}.
+     *
+     * @return the list of all sequence numbers or an empty list if no Blocks
+     *         are present
+     */
+    public ArrayList<Integer> getBlockSeqList() {
+        return new ArrayList<>(blockSecSeqList);
+    }
+
+    /**
+     * Get a list of all entry Blocks to this Transit. These are Blocks that a
+     * Train might enter from and be going in the direction of this Transit. The
+     * sequence numbers of the Section the Block will enter are accumulated in a
+     * parallel list, which can be accessed by immediately calling
+     * {@link #getBlockSeqList()}.
+     *
+     * @return the list of all blocks or an empty list if none are present
+     */
+    public ArrayList<Block> getEntryBlocksList() {
+        ArrayList<Block> list = new ArrayList<>();
+        ArrayList<Block> internalBlocks = getInternalBlocksList();
+        blockSecSeqList.clear();
+        for (TransitSection ts : mTransitSectionList) {
+            List<EntryPoint> ePointList;
+            if (ts.getDirection() == Section.FORWARD) {
+                ePointList = ts.getSection().getForwardEntryPointList();
+            } else {
+                ePointList = ts.getSection().getReverseEntryPointList();
+            }
+            for (EntryPoint ep : ePointList) {
+                Block eb = ep.getFromBlock();
+                boolean isInternal = false;
+                for (Block ib : internalBlocks) {
+                    if (eb == ib) {
+                        isInternal = true;
+                    }
+                }
+                if (!isInternal) {
+                    // not an internal Block, keep it
+                    list.add(eb);
+                    blockSecSeqList.add(ts.getSequenceNumber());
+                }
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Get a list of all destination blocks that can be reached from a specified
+     * starting block. The sequence numbers of the Sections destination blocks
+     * were found in are accumulated in a parallel list, which can be accessed
+     * by immediately calling {@link #getDestBlocksSeqList()}.
+     * <p>
+     * <strong>Note:</strong> A Train may not terminate in the same Section in
+     * which it starts.
+     * <p>
+     * <strong>Note:</strong> A Train must terminate in a Block within the
+     * Transit.
+     *
+     * @param startBlock     the starting Block to find destinations for
+     * @param startInTransit true if startBlock is within this Transit; false
+     *                       otherwise
+     * @return a list of destination Blocks or an empty list if none exist
+     */
+    public ArrayList<Block> getDestinationBlocksList(Block startBlock, boolean startInTransit) {
+        ArrayList<Block> list = new ArrayList<>();
+        destBlocksSeqList.clear();
+        if (startBlock == null) {
+            return list;
+        }
+        // get the sequence number of the Section of the starting Block
+        int startSeq = -1;
+        ArrayList<Block> startBlocks;
+        if (startInTransit) {
+            startBlocks = getInternalBlocksList();
+        } else {
+            startBlocks = getEntryBlocksList();
+        }
+        // programming note: the above calls initialize blockSecSeqList.
+        for (int k = 0; ((k < startBlocks.size()) && (startSeq == -1)); k++) {
+            if (startBlock == startBlocks.get(k)) {
+                startSeq = (blockSecSeqList.get(k));
+            }
+        }
+        ArrayList<Block> internalBlocks = getInternalBlocksList();
+        //allow for transits of length 1
+        if (startInTransit) {
+            for (int i = internalBlocks.size(); i > 0; i--) {
+                if (blockSecSeqList.get(i - 1) > startSeq) {
+                    // could stop in this block, keep it
+                    list.add(internalBlocks.get(i - 1));
+                    destBlocksSeqList.add(blockSecSeqList.get(i - 1));
+                }
+            }
+        } else {
+            for (int i = internalBlocks.size(); i > 0; i--) {
+                if (blockSecSeqList.get(i - 1) >= startSeq) {
+                    // could stop in this block, keep it
+                    list.add(internalBlocks.get(i - 1));
+                    destBlocksSeqList.add(blockSecSeqList.get(i - 1));
+                }
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Get a list of destination Block sequence numbers in this Transit. This
+     * list is generated by calling
+     * {@link #getDestinationBlocksList(jmri.Block, boolean)}.
+     *
+     * @return the list of all destination Block sequence numbers or an empty
+     *         list if no destination Blocks are present
+     */
+    public ArrayList<Integer> getDestBlocksSeqList() {
+        ArrayList<Integer> list = new ArrayList<>();
+        for (int i = 0; i < destBlocksSeqList.size(); i++) {
+            list.add(destBlocksSeqList.get(i));
+        }
+        return list;
+    }
+
+    /**
+     * Check if this Transit is capable of continuous running.
+     * <p>
+     * A Transit is capable of continuous running if, after an Active Train
+     * completes the Transit, it can automatically be restarted. To be
+     * restartable, the first Section and the last Section must be the same
+     * Section, and the first and last Sections must be defined to run in the
+     * same direction. If the last Section is an alternate Section, the previous
+     * Section is tested. However, if the Active Train does not complete its
+     * Transit in the same Section it started in, the restart will not take
+     * place.
+     *
+     * @return true if continuous running is possible; otherwise false
+     */
+    public boolean canBeResetWhenDone() {
+        TransitSection firstTS = mTransitSectionList.get(0);
+        int lastIndex = mTransitSectionList.size() - 1;
+        TransitSection lastTS = mTransitSectionList.get(lastIndex);
+        boolean OK = false;
+        while (!OK) {
+            if (firstTS.getSection() != lastTS.getSection()) {
+                if (lastTS.isAlternate() && (lastIndex > 1)) {
+                    lastIndex--;
+                    lastTS = mTransitSectionList.get(lastIndex);
+                } else {
+                    log.warn("Section mismatch {} {}", (firstTS.getSection()).getDisplayName(USERSYS), (lastTS.getSection()).getDisplayName(USERSYS));
+                    return false;
+                }
+            }
+            OK = true;
+        }
+        // same Section, check direction
+        if (firstTS.getDirection() != lastTS.getDirection()) {
+            log.warn("Direction mismatch {} {}", (firstTS.getSection()).getDisplayName(USERSYS), (lastTS.getSection()).getDisplayName(USERSYS));
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Initialize blocking sensors for Sections in this Transit. This should be
+     * done before any Sections are allocated for this Transit. Only Sections
+     * that are {@link jmri.Section#FREE} are initialized, so as not to
+     * interfere with running active trains. If any Section does not have
+     * blocking sensors, warning messages are logged.
+     *
+     * @return 0 if no errors, number of errors otherwise.
+     */
+    public int initializeBlockingSensors() {
+        int numErrors = 0;
+        for (int i = 0; i < mTransitSectionList.size(); i++) {
+            Section s = mTransitSectionList.get(i).getSection();
+            try {
+                if (s.getForwardBlockingSensor() != null) {
+                    if (s.getState() == Section.FREE) {
+                        s.getForwardBlockingSensor().setState(Sensor.ACTIVE);
+                    }
+                } else {
+                    log.warn("Missing forward blocking sensor for section {}", s.getDisplayName(USERSYS));
+                    numErrors++;
+                }
+            } catch (JmriException reason) {
+                log.error("Exception when initializing forward blocking Sensor for Section {}", s.getDisplayName(USERSYS));
+                numErrors++;
+            }
+            try {
+                if (s.getReverseBlockingSensor() != null) {
+                    if (s.getState() == Section.FREE) {
+                        s.getReverseBlockingSensor().setState(Sensor.ACTIVE);
+                    }
+                } else {
+                    log.warn("Missing reverse blocking sensor for section {}", s.getDisplayName(USERSYS));
+                    numErrors++;
+                }
+            } catch (JmriException reason) {
+                log.error("Exception when initializing reverse blocking Sensor for Section {}", s.getDisplayName(USERSYS));
+                numErrors++;
+            }
+        }
+        return numErrors;
+    }
+
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "UC_USELESS_OBJECT",
+            justification = "SpotBugs doesn't see that toBeRemoved is being read by the forEach clause")
+    public void removeTemporarySections() {
+        ArrayList<TransitSection> toBeRemoved = new ArrayList<>();
+        for (TransitSection ts : mTransitSectionList) {
+            if (ts.isTemporary()) {
+                toBeRemoved.add(ts);
+            }
+        }
+        toBeRemoved.forEach((ts) -> {
+            mTransitSectionList.remove(ts);
+        });
+    }
+
+    public boolean removeLastTemporarySection(Section s) {
+        TransitSection last = mTransitSectionList.get(mTransitSectionList.size() - 1);
+        if (last.getSection() != s) {
+            log.info("Section asked to be removed is not the last one");
+            return false;
+        }
+        if (!last.isTemporary()) {
+            log.info("Section asked to be removed is not a temporary section");
+            return false;
+        }
+        mTransitSectionList.remove(last);
+        return true;
+
+    }
+
+    @Override
+    public String getBeanType() {
+        return Bundle.getMessage("BeanNameTransit");
+    }
+
+    @Override
+    public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
+        if ("CanDelete".equals(evt.getPropertyName())) { // NOI18N
+            NamedBean nb = (NamedBean) evt.getOldValue();
+            if (nb instanceof Section) {
+                if (containsSection((Section) nb)) {
+                    throw new PropertyVetoException(Bundle.getMessage("VetoTransitSection", getDisplayName()), evt);
+                }
+            }
+        }
+        // we ignore the property setConfigureManager
+    }
+
+    @Override
+    public List<NamedBeanUsageReport> getUsageReport(NamedBean bean) {
+        List<NamedBeanUsageReport> report = new ArrayList<>();
+        jmri.SensorManager sm = jmri.InstanceManager.getDefault(jmri.SensorManager.class);
+        jmri.SignalHeadManager head = jmri.InstanceManager.getDefault(jmri.SignalHeadManager.class);
+        jmri.SignalMastManager mast = jmri.InstanceManager.getDefault(jmri.SignalMastManager.class);
+        if (bean != null) {
+            getTransitSectionList().forEach((transitSection) -> {
+                if (bean.equals(transitSection.getSection())) {
+                    report.add(new NamedBeanUsageReport("TransitSection"));
+                }
+                if (bean.equals(sm.getSensor(transitSection.getStopAllocatingSensor()))) {
+                    report.add(new NamedBeanUsageReport("TransitSensorStopAllocation"));
+                }
+                // Process actions
+                transitSection.getTransitSectionActionList().forEach((action) -> {
+                    int whenCode = action.getWhenCode();
+                    int whatCode = action.getWhatCode();
+                    if (whenCode == TransitSectionAction.SENSORACTIVE || whenCode == TransitSectionAction.SENSORINACTIVE) {
+                        if (bean.equals(sm.getSensor(action.getStringWhen()))) {
+                            report.add(new NamedBeanUsageReport("TransitActionSensorWhen", transitSection.getSection()));
+                        }
+                    }
+                    if (whatCode == TransitSectionAction.SETSENSORACTIVE || whatCode == TransitSectionAction.SETSENSORINACTIVE) {
+                        if (bean.equals(sm.getSensor(action.getStringWhat()))) {
+                            report.add(new NamedBeanUsageReport("TransitActionSensorWhat", transitSection.getSection()));
+                        }
+                    }
+                    if (whatCode == TransitSectionAction.HOLDSIGNAL || whatCode == TransitSectionAction.RELEASESIGNAL) {
+                        // Could be a signal head or a signal mast.
+                        if (bean.equals(head.getSignalHead(action.getStringWhat()))) {
+                            report.add(new NamedBeanUsageReport("TransitActionSignalHeadWhat", transitSection.getSection()));
+                        }
+                        if (bean.equals(mast.getSignalMast(action.getStringWhat()))) {
+                            report.add(new NamedBeanUsageReport("TransitActionSignalMastWhat", transitSection.getSection()));
+                        }
+                    }
+                });
+            });
+        }
+        return report;
+    }
+
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultTransit.class);
+
+}

--- a/java/src/jmri/implementation/DefaultTransit.java
+++ b/java/src/jmri/implementation/DefaultTransit.java
@@ -52,15 +52,6 @@ import jmri.TransitSectionAction;
  */
 public class DefaultTransit extends AbstractNamedBean implements Transit {
 
-    /**
-     * The idle, or available for assignment to an ActiveTrain state.
-     */
-    public static final int IDLE = 0x02;
-    /**
-     * The assigned to an ActiveTrain state.
-     */
-    public static final int ASSIGNED = 0x04;
-
     /*
      * Instance variables (not saved between runs)
      */

--- a/java/src/jmri/jmrit/beantable/SectionTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SectionTableAction.java
@@ -196,7 +196,7 @@ public class SectionTableAction extends AbstractTableAction<Section> {
                     case VALUECOL: // not a button
                     case BEGINBLOCKCOL: // not a button
                     case ENDBLOCKCOL: // not a button
-                        return String.class; 
+                        return String.class;
                     case EDITCOL:
                         return JButton.class;
                     default:
@@ -583,13 +583,13 @@ public class SectionTableAction extends AbstractTableAction<Section> {
     private void initializeEditInformation() {
         userName.setText(curSection.getUserName());
         switch (curSection.getSectionType()) {
-            case Section.SIGNALMASTLOGIC:
+            case SIGNALMASTLOGIC:
                 generationStateLabel.setText(rbx.getString("SectionTypeSMLLabel"));
                 break;
-            case Section.DYNAMICADHOC:
+            case DYNAMICADHOC:
                 generationStateLabel.setText(rbx.getString("SectionTypeDynLabel"));
                 break;
-            case Section.USERDEFINED:
+            case USERDEFINED:
             default:
                 generationStateLabel.setText("");
                 break;
@@ -1211,11 +1211,11 @@ public class SectionTableAction extends AbstractTableAction<Section> {
             super();
             init();
         }
-        
+
         final void init(){
             blockManager.addPropertyChangeListener(this);
         }
-        
+
         public void dispose(){
             blockManager.removePropertyChangeListener(this);
         }

--- a/java/src/jmri/managers/DefaultInstanceInitializer.java
+++ b/java/src/jmri/managers/DefaultInstanceInitializer.java
@@ -138,6 +138,10 @@ public class DefaultInstanceInitializer extends AbstractInstanceInitializer {
             return new ProxyTurnoutManager();
         }
 
+        if (type == TransitManager.class) {
+            return new DefaultTransitManager();
+        }
+
         if (type == VSDecoderManager.class) {
             return VSDecoderManager.instance();
         }
@@ -174,6 +178,7 @@ public class DefaultInstanceInitializer extends AbstractInstanceInitializer {
                 SignalSystemManager.class,
                 StringIOManager.class,
                 Timebase.class,
+                TransitManager.class,
                 TurnoutManager.class,
                 VariableLightManager.class,
                 VSDecoderManager.class

--- a/java/src/jmri/managers/DefaultInstanceInitializer.java
+++ b/java/src/jmri/managers/DefaultInstanceInitializer.java
@@ -92,6 +92,10 @@ public class DefaultInstanceInitializer extends AbstractInstanceInitializer {
             return new DefaultRouteManager(memo);
         }
 
+        if (type == SectionManager.class) {
+            return new DefaultSectionManager();
+        }
+
         if (type == SensorManager.class) {
             return new ProxySensorManager();
         }
@@ -161,6 +165,7 @@ public class DefaultInstanceInitializer extends AbstractInstanceInitializer {
                 RailComManager.class,
                 ReporterManager.class,
                 RouteManager.class,
+                SectionManager.class,
                 SensorManager.class,
                 SignalGroupManager.class,
                 SignalHeadManager.class,

--- a/java/src/jmri/managers/DefaultSectionManager.java
+++ b/java/src/jmri/managers/DefaultSectionManager.java
@@ -173,8 +173,6 @@ public class DefaultSectionManager extends AbstractManager<Section> implements j
      * @return number or validation errors; -2 is returned if there are no
      *         sections
      */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value="SLF4J_FORMAT_SHOULD_BE_CONST",
-        justification="Error String already evaluated, text from managed class")
     public int validateAllSections(jmri.util.JmriJFrame frame, LayoutEditor lePanel) {
         Set<Section> set = getNamedBeanSet();
         int numSections = 0;

--- a/java/src/jmri/managers/DefaultSectionManager.java
+++ b/java/src/jmri/managers/DefaultSectionManager.java
@@ -1,0 +1,385 @@
+package jmri.managers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import jmri.Block;
+import jmri.BlockManager;
+import jmri.EntryPoint;
+import jmri.InstanceManager;
+import jmri.JmriException;
+import jmri.NamedBean;
+import jmri.Manager;
+import jmri.Path;
+import jmri.Section;
+import jmri.Sensor;
+import jmri.SensorManager;
+import jmri.SignalHead;
+import jmri.SignalHeadManager;
+
+import jmri.implementation.DefaultSection;
+
+import jmri.jmrit.display.layoutEditor.LayoutEditor;
+import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
+import jmri.jmrit.display.layoutEditor.LayoutBlock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Basic Implementation of a SectionManager.
+ * <p>
+ * This doesn't have a "new" interface, since Sections are independently
+ * implemented, instead of being system-specific.
+ * <p>
+ * Note that Section system names must begin with system prefix and type character,
+ * usually IY, and be followed by a string, usually, but not always, a number. This
+ * is enforced when a Section is created.
+ * <br>
+ * <hr>
+ * This file is part of JMRI.
+ * <p>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * <p>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Dave Duchamp Copyright (C) 2008
+ */
+public class DefaultSectionManager extends AbstractManager<Section> implements jmri.SectionManager {
+
+    public DefaultSectionManager() {
+        super();
+        addListeners();
+    }
+
+    final void addListeners() {
+        InstanceManager.getDefault(SensorManager.class).addVetoableChangeListener(this);
+        InstanceManager.getDefault(BlockManager.class).addVetoableChangeListener(this);
+    }
+
+    @Override
+    public int getXMLOrder() {
+        return Manager.SECTIONS;
+    }
+
+    @Override
+    public char typeLetter() {
+        return 'Y';
+    }
+
+    @Override
+    public Class<Section> getNamedBeanClass() {
+        return Section.class;
+    }
+
+    /**
+     * Create a new Section if the Section does not exist.
+     *
+     * @param systemName the desired system name
+     * @param userName   the desired user name
+     * @return a new Section or
+     * @throws IllegalArgumentException if a Section with the same systemName or
+     *         userName already exists, or if there is trouble creating a new
+     *         Section.
+     */
+    @Nonnull
+    public Section createNewSection(@Nonnull String systemName, String userName) throws IllegalArgumentException {
+        Objects.requireNonNull(systemName, "SystemName cannot be null. UserName was " + ((userName == null) ? "null" : userName));  // NOI18N
+        // check system name
+        if (systemName.isEmpty()) {
+            throw new IllegalArgumentException("Section System Name Empty");
+            // no valid system name entered, return without creating
+        }
+        String sysName = systemName;
+        if (!sysName.startsWith(getSystemNamePrefix())) {
+            sysName = makeSystemName(sysName);
+        }
+        // Check that Section does not already exist
+        Section y;
+        if (userName != null && !userName.isEmpty()) {
+            y = getByUserName(userName);
+            if (y != null) {
+                throw new IllegalArgumentException("Section Already Exists with UserName " + userName);
+            }
+        }
+        y = getBySystemName(sysName);
+        if (y != null) {
+            throw new IllegalArgumentException("Section Already Exists with SystemName " + sysName);
+        }
+        // Section does not exist, create a new Section
+        y = new DefaultSection(sysName, userName);
+        // save in the maps
+        register(y);
+
+        // Keep track of the last created auto system name
+        updateAutoNumber(systemName);
+
+        return y;
+    }
+
+    /**
+     * Create a New Section with Auto System Name.
+     * @param userName UserName for new Section
+     * @return new Section with Auto System Name.
+     * @throws IllegalArgumentException if existing Section, or
+     *          unable to create a new Section.
+     */
+    @Nonnull
+    public Section createNewSection(String userName) throws IllegalArgumentException {
+        return createNewSection(getAutoSystemName(), userName);
+    }
+
+    /**
+     * Remove an existing Section.
+     *
+     * @param y the section to remove
+     */
+    public void deleteSection(Section y) {
+        // delete the Section
+        deregister(y);
+        y.dispose();
+    }
+
+    /**
+     * Get an existing Section. First look up assuming that name is a User
+     * Name. If this fails look up assuming that name is a System Name.
+     *
+     * @param name the name to find; user names are searched for a match first,
+     *             followed by system names
+     * @return the found section of null if no matching Section found
+     */
+    public Section getSection(String name) {
+        Section y = getByUserName(name);
+        if (y != null) {
+            return y;
+        }
+        return getBySystemName(name);
+    }
+
+    /**
+     * Validate all Sections.
+     *
+     * @param frame   ignored
+     * @param lePanel the panel containing sections to validate
+     * @return number or validation errors; -2 is returned if there are no
+     *         sections
+     */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value="SLF4J_FORMAT_SHOULD_BE_CONST",
+        justification="Error String already evaluated, text from managed class")
+    public int validateAllSections(jmri.util.JmriJFrame frame, LayoutEditor lePanel) {
+        Set<Section> set = getNamedBeanSet();
+        int numSections = 0;
+        int numErrors = 0;
+        if (set.size() <= 0) {
+            return -2;
+        }
+        for (Section section : set) {
+            String s = section.validate(lePanel);
+            if (!s.isEmpty()) {
+                log.error(s);
+                numErrors++;
+            }
+            numSections++;
+        }
+        log.debug("Validated {} Sections - {} errors or warnings.", numSections, numErrors);
+        return numErrors;
+    }
+
+    /**
+     * Check direction sensors in SSL for signals.
+     *
+     * @param lePanel the panel containing direction sensors
+     * @return the number or errors; 0 if no errors; -1 if the panel is null; -2
+     *         if there are no sections
+     */
+    public int setupDirectionSensors(LayoutEditor lePanel) {
+        if (lePanel == null) {
+            return -1;
+        }
+        Set<Section> set = getNamedBeanSet();
+        int numSections = 0;
+        int numErrors = 0;
+        if (set.size() <= 0) {
+            return -2;
+        }
+        for (Section section : set) {
+            int errors = section.placeDirectionSensors(lePanel);
+            numErrors = numErrors + errors;
+            numSections++;
+        }
+        log.debug("Checked direction sensors for {} Sections - {} errors or warnings.", numSections, numErrors);
+        return numErrors;
+    }
+
+    /**
+     * Remove direction sensors from SSL for all signals.
+     *
+     * @param lePanel the panel containing direction sensors
+     * @return the number or errors; 0 if no errors; -1 if the panel is null; -2
+     *         if there are no sections
+     */
+    public int removeDirectionSensorsFromSSL(LayoutEditor lePanel) {
+        if (lePanel == null) {
+            return -1;
+        }
+        jmri.jmrit.display.layoutEditor.ConnectivityUtil cUtil = lePanel.getConnectivityUtil();
+        Set<Section> set = getNamedBeanSet();
+        if (set.size() <= 0) {
+            return -2;
+        }
+        int numErrors = 0;
+        List<String> sensorList = new ArrayList<>();
+        for (Section s : set) {
+            String name = s.getReverseBlockingSensorName();
+            if ((name != null) && (!name.isEmpty())) {
+                sensorList.add(name);
+            }
+            name = s.getForwardBlockingSensorName();
+            if ((name != null) && (!name.isEmpty())) {
+                sensorList.add(name);
+            }
+        }
+        SignalHeadManager shManager = InstanceManager.getDefault(SignalHeadManager.class);
+        for (SignalHead sh : shManager.getNamedBeanSet()) {
+            if (!cUtil.removeSensorsFromSignalHeadLogic(sensorList, sh)) {
+                numErrors++;
+            }
+        }
+        return numErrors;
+    }
+
+    /**
+     * Initialize all blocking sensors that exist - set them to 'ACTIVE'.
+     */
+    public void initializeBlockingSensors() {
+        for (Section s : getNamedBeanSet()) {
+            try {
+                if (s.getForwardBlockingSensor() != null) {
+                    s.getForwardBlockingSensor().setState(Sensor.ACTIVE);
+                }
+                if (s.getReverseBlockingSensor() != null) {
+                    s.getReverseBlockingSensor().setState(Sensor.ACTIVE);
+                }
+            } catch (JmriException reason) {
+                log.error("Exception when initializing blocking Sensors for Section {}", s.getDisplayName(NamedBean.DisplayOptions.USERNAME_SYSTEMNAME));
+            }
+        }
+    }
+
+    /**
+     * Generate Block Sections in stubs/sidings. Called after generating signal logic.
+     */
+
+
+    public void generateBlockSections() {
+        //find blocks with no paths through i.e. stub (siding)
+        LayoutBlockManager LayoutBlockManager = InstanceManager.getDefault(LayoutBlockManager.class);
+        //print "Layout Block"
+        for (LayoutBlock layoutBlock : LayoutBlockManager.getNamedBeanSet()){
+            if (layoutBlock.getNumberOfThroughPaths() == 0){
+                if (!blockSectionExists(layoutBlock)){
+                    //create block section"
+                    createBlockSection(layoutBlock);
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if Block Section already exists
+     * @param layoutBlock
+     * @return true or false
+     */
+    private boolean blockSectionExists(LayoutBlock layoutBlock){
+
+        for (Section section : getNamedBeanSet()){
+            if (section.getNumBlocks() == 1
+                    && section.getSectionType() != Section.SIGNALMASTLOGIC
+                    && layoutBlock.getBlock().equals(section.getEntryBlock())){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void createBlockSection(LayoutBlock layoutBlock){
+        Section section;
+        try {
+            section = createNewSection(layoutBlock.getUserName());
+        }
+        catch (IllegalArgumentException ex){
+            log.error("Could not create Section from LayoutBlock {}",layoutBlock.getDisplayName());
+            return;
+        }
+        section.addBlock(layoutBlock.getBlock());
+        ArrayList<EntryPoint> entryPointList = new ArrayList<>();
+        Block sb = layoutBlock.getBlock();
+        List <Path> paths = sb.getPaths();
+        for (int j=0; j<paths.size(); j++){
+            Path p = paths.get(j);
+            if (p.getBlock() != sb){
+                //this is path to an outside block, so need an Entry Point
+                String pbDir = Path.decodeDirection(p.getFromBlockDirection());
+                EntryPoint ep = new EntryPoint(sb, p.getBlock(), pbDir);
+                entryPointList.add(ep);
+            }
+        }
+
+        Block beginBlock = sb;
+        // Set directions where possible
+        List <EntryPoint> epList = getBlockEntryPointsList(beginBlock,entryPointList);
+        if (epList.size() == 1) {
+            (epList.get(0)).setTypeForward();
+        }
+        Block endBlock = sb;
+        epList = getBlockEntryPointsList(endBlock, entryPointList);
+        if (epList.size() == 1) {
+            (epList.get(0)).setTypeReverse();
+        }
+
+        for (int j=0; j<entryPointList.size(); j++){
+            EntryPoint ep = entryPointList.get(j);
+            if (ep.isForwardType()){
+                section.addToForwardList(ep);
+            }else if (ep.isReverseType()){
+                section.addToReverseList(ep);
+            }
+        }
+    }
+
+    private List <EntryPoint> getBlockEntryPointsList(Block b, List <EntryPoint> entryPointList) {
+        List <EntryPoint> list = new ArrayList<>();
+        for (int i=0; i<entryPointList.size(); i++) {
+            EntryPoint ep = entryPointList.get(i);
+            if (ep.getBlock().equals(b)) {
+                list.add(ep);
+            }
+        }
+        return list;
+    }
+
+    @Override
+    @Nonnull
+    public String getBeanTypeHandled(boolean plural) {
+        return Bundle.getMessage(plural ? "BeanNameSections" : "BeanNameSection");
+    }
+
+    @Override
+    public void dispose(){
+        InstanceManager.getDefault(SensorManager.class).removeVetoableChangeListener(this);
+        InstanceManager.getDefault(BlockManager.class).removeVetoableChangeListener(this);
+        super.dispose();
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(DefaultSectionManager.class);
+
+}

--- a/java/src/jmri/managers/DefaultTransitManager.java
+++ b/java/src/jmri/managers/DefaultTransitManager.java
@@ -1,0 +1,219 @@
+package jmri.managers;
+
+import java.util.ArrayList;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import jmri.Block;
+import jmri.InstanceManager;
+import jmri.Manager;
+import jmri.NamedBean;
+import jmri.Section;
+import jmri.SectionManager;
+import jmri.Transit;
+import jmri.TransitManager;
+
+import jmri.managers.AbstractManager;
+
+/**
+ * Implementation of a Transit Manager
+ * <p>
+ * This doesn't need an interface, since Transits are globaly implemented,
+ * instead of being system-specific.
+ * <p>
+ * Note that Transit system names must begin with system prefix and type character,
+ * usually IZ, and be followed by a string, usually, but not always, a number. This
+ * is enforced when a Transit is created.
+ * <br>
+ * <hr>
+ * This file is part of JMRI.
+ * <p>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * <p>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Dave Duchamp Copyright (C) 2008, 2011
+ */
+public class DefaultTransitManager extends AbstractManager<Transit> implements jmri.TransitManager {
+
+    public DefaultTransitManager() {
+        super();
+        addVetoListener();
+    }
+
+    final void addVetoListener(){
+        InstanceManager.getDefault(SectionManager.class).addVetoableChangeListener(this);
+    }
+
+    @Override
+    public int getXMLOrder() {
+        return Manager.TRANSITS;
+    }
+
+    @Override
+    public char typeLetter() {
+        return 'Z';
+    }
+
+    /**
+     * Create a new Transit if the Transit does not exist.
+     * This is NOT a provide method.
+     *
+     * @param systemName the desired system name
+     * @param userName   the desired user name
+     * @return a new Transit
+     * @throws NamedBean.BadNameException if a Transit with the same systemName or
+     *         userName already exists, or if there is trouble creating a new
+     *         Transit.
+     */
+    @Nonnull
+    public Transit createNewTransit(@CheckForNull String systemName, String userName) throws NamedBean.BadNameException {
+        // check system name
+        if ((systemName == null) || (systemName.isEmpty())) {
+            throw new NamedBean.BadSystemNameException("Transit System Name cannot be empty or null.", // NOI18N
+                Bundle.getMessage("InvalidBeanSystemNameEmpty",getBeanTypeHandled(false)));
+        }
+        String sysName = systemName;
+        if (!sysName.startsWith(getSystemNamePrefix())) {
+            sysName = makeSystemName(sysName);
+        }
+        // Check that Transit does not already exist
+        Transit z;
+        if (userName != null && !userName.isEmpty()) {
+            z = getByUserName(userName);
+            if (z != null) {
+                throw new NamedBean.BadUserNameException("Transit UserName \""+userName+"\" Already Exists.", // NOI18N
+                Bundle.getMessage("InvalidUserNameAlreadyExists",getBeanTypeHandled(false),sysName));
+            }
+        }
+        z = getBySystemName(sysName);
+        if (z != null) {
+            throw new NamedBean.DuplicateSystemNameException("Transit SytemName \""+sysName+"\" Already Exists.", // NOI18N
+                Bundle.getMessage("InvalidSytemNameAlreadyExists",getBeanTypeHandled(false),sysName));
+        }
+        // Transit does not exist, create a new Transit
+        z = new jmri.implementation.DefaultTransit(sysName, userName);
+        // save in the maps
+        register(z);
+
+        // Keep track of the last created auto system name
+        updateAutoNumber(systemName);
+
+        return z;
+    }
+
+    /**
+     * For use with User GUI, to allow the auto generation of systemNames, where
+     * the user can optionally supply a username.
+     * <p>
+     * Note: Since system names should be kept short for use in Dispatcher,
+     * automatically generated system names are in the form {@code IZnn}, where
+     * {@code nn} is the first available number.
+     *
+     * @param userName the desired user name
+     * @return a new Transit
+     * @throws NamedBean.BadNameException if userName is already associated with
+     *         another Transit
+     */
+    @Nonnull
+    public Transit createNewTransit(String userName) throws NamedBean.BadNameException {
+        return createNewTransit(getAutoSystemName(), userName);
+    }
+
+    /**
+     * Get an existing Transit.
+     * First looks up assuming that name is a User
+     * Name. If this fails looks up assuming that name is a System Name.
+     * If both fail, returns null.
+     *
+     * @param name User name or system name to match
+     * @return null if no match found
+     */
+    @CheckForNull
+    public Transit getTransit(String name) {
+        Transit z = getByUserName(name);
+        return (z != null ? z : getBySystemName(name));
+    }
+
+    /**
+     * Remove an existing Transit.
+     *
+     * @param z the transit to remove
+     */
+    public void deleteTransit(Transit z) {
+        // delete the Transit
+        deregister(z);
+        z.dispose();
+    }
+
+    /**
+     * Get a list of Transits which use a specified Section.
+     *
+     * @param s the section to check Transits against
+     * @return a list, possibly empty, of Transits using section s.
+     */
+    @Nonnull
+    public ArrayList<Transit> getListUsingSection(Section s) {
+        ArrayList<Transit> list = new ArrayList<>();
+        for (Transit tTransit : getNamedBeanSet()) {
+            if (tTransit.containsSection(s)) {
+                // this Transit uses the specified Section
+                list.add(tTransit);
+            }
+        }
+        return list;
+    }
+
+    @Nonnull
+    public ArrayList<Transit> getListUsingBlock(Block b) {
+        ArrayList<Transit> list = new ArrayList<>();
+        for (Transit tTransit : getNamedBeanSet()) {
+            if (tTransit.containsBlock(b)) {
+                // this Transit uses the specified Section
+                list.add(tTransit);
+            }
+        }
+        return list;
+    }
+
+    @Nonnull
+    public ArrayList<Transit> getListEntryBlock(Block b) {
+        ArrayList<Transit> list = new ArrayList<>();
+        for (Transit tTransit : getNamedBeanSet()) {
+            ArrayList<Block> entryBlock = tTransit.getEntryBlocksList();
+            if (entryBlock.contains(b)) {
+                // this Transit uses the specified Section
+                list.add(tTransit);
+            }
+        }
+        return list;
+    }
+
+    @Override
+    @Nonnull
+    public String getBeanTypeHandled(boolean plural) {
+        return Bundle.getMessage(plural ? "BeanNameTransits" : "BeanNameTransit");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<Transit> getNamedBeanClass() {
+        return Transit.class;
+    }
+
+    @Override
+    public void dispose() {
+        InstanceManager.getDefault(SectionManager.class).removeVetoableChangeListener(this);
+        super.dispose();
+    }
+
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultTransitManager.class);
+
+}

--- a/java/src/jmri/managers/configurexml/DefaultSectionManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultSectionManagerXml.java
@@ -1,4 +1,4 @@
-package jmri.configurexml;
+package jmri.managers.configurexml;
 
 import java.util.List;
 import java.util.SortedSet;
@@ -19,9 +19,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dave Duchamp Copyright (c) 2008
  */
-public class SectionManagerXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+public class DefaultSectionManagerXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
 
-    public SectionManagerXml() {
+    public DefaultSectionManagerXml() {
     }
 
     /**
@@ -178,7 +178,7 @@ public class SectionManagerXml extends jmri.managers.configurexml.AbstractNamedB
         log.debug("Found {} Sections", sectionList.size());
         SectionManager sctm = InstanceManager.getDefault(jmri.SectionManager.class);
         sctm.setPropertyChangesSilenced("beans", true);
-        
+
         for (Element s : sectionList) {
             String sysName = getSystemName(s);
             String userName = getUserName(s);
@@ -260,6 +260,6 @@ public class SectionManagerXml extends jmri.managers.configurexml.AbstractNamedB
         return InstanceManager.getDefault(jmri.SectionManager.class).getXMLOrder();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SectionManagerXml.class);
+    private final static Logger log = LoggerFactory.getLogger(DefaultSectionManagerXml.class);
 
 }

--- a/java/src/jmri/managers/configurexml/DefaultTransitManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultTransitManagerXml.java
@@ -1,4 +1,4 @@
-package jmri.configurexml;
+package jmri.managers.configurexml;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,9 +21,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dave Duchamp Copyright (c) 2008
  */
-public class TransitManagerXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
+public class DefaultTransitManagerXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
 
-    public TransitManagerXml() {
+    public DefaultTransitManagerXml() {
     }
 
     /**
@@ -232,6 +232,6 @@ public class TransitManagerXml extends jmri.managers.configurexml.AbstractNamedB
         return InstanceManager.getDefault(TransitManager.class).getXMLOrder();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TransitManagerXml.class);
+    private final static Logger log = LoggerFactory.getLogger(DefaultTransitManagerXml.class);
 
 }

--- a/java/test/jmri/SectionManagerTest.java
+++ b/java/test/jmri/SectionManagerTest.java
@@ -13,7 +13,13 @@ public class SectionManagerTest {
 
     @Test
     public void testCTor() {
-        SectionManager t = new SectionManager();
+        SectionManager t = new jmri.managers.DefaultSectionManager();
+        Assert.assertNotNull("exists",t);
+    }
+
+    @Test
+    public void testInstanceManagerAccess() {
+        SectionManager t = InstanceManager.getDefault(SectionManager.class);
         Assert.assertNotNull("exists",t);
     }
 

--- a/java/test/jmri/SectionTest.java
+++ b/java/test/jmri/SectionTest.java
@@ -2,6 +2,8 @@ package jmri;
 
 import jmri.util.JUnitUtil;
 
+import jmri.implementation.DefaultSection;
+
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
 
@@ -16,17 +18,17 @@ public class SectionTest {
 
    @Test
    public void SysNameConstructorTest(){
-      Assert.assertNotNull("Constructor", new Section("TS1"));
+      Assert.assertNotNull("Constructor", new DefaultSection("TS1"));
    }
 
    @Test
    public void TwoNameStringConstructorTest(){
-      Assert.assertNotNull("Constructor", new Section("TS1", "user name"));
+      Assert.assertNotNull("Constructor", new DefaultSection("TS1", "user name"));
    }
 
    @Test
    public void warnOnBlockAdd() {
-    Section  s = new Section("TS1");
+    Section  s = new DefaultSection("TS1");
     Assert.assertEquals(0, s.getBlockList().size());
     s.addBlock(new Block("IB1", "user"));
     Assert.assertEquals(1, s.getBlockList().size());
@@ -34,13 +36,13 @@ public class SectionTest {
 
    @Test
    public void warnOnBlockAddWithNoUserName() {
-    Section  s = new Section("TS1");
+    Section  s = new DefaultSection("TS1");
     Assert.assertEquals(0, s.getBlockList().size());
     s.addBlock(new Block("IB1"));
     jmri.util.JUnitAppender.assertWarnMessage("Block IB1 does not have a user name, may not work correctly in Section TS1");
     Assert.assertEquals(1, s.getBlockList().size());
    }
-   
+
    @BeforeEach
    public void setUp() {
         JUnitUtil.setUp();

--- a/java/test/jmri/TransitManagerTest.java
+++ b/java/test/jmri/TransitManagerTest.java
@@ -13,7 +13,7 @@ public class TransitManagerTest {
 
     @Test
     public void testCTor() {
-        TransitManager t = new TransitManager();
+        TransitManager t = new jmri.managers.DefaultTransitManager();
         Assert.assertNotNull("exists",t);
     }
 

--- a/java/test/jmri/TransitTest.java
+++ b/java/test/jmri/TransitTest.java
@@ -5,6 +5,8 @@ import jmri.util.JUnitUtil;
 import org.junit.jupiter.api.*;
 import org.junit.Assert;
 
+import jmri.implementation.DefaultTransit;
+
 /**
  * Tests for Transit class.
  *
@@ -16,12 +18,12 @@ public class TransitTest {
 
    @Test
    public void SysNameConstructorTest(){
-      Assert.assertNotNull("Constructor", new Transit("TT1"));
+      Assert.assertNotNull("Constructor", new DefaultTransit("TT1"));
    }
 
    @Test
    public void TwoNameStringConstructorTest(){
-      Assert.assertNotNull("Constructor", new Transit("TT1", "user name"));
+      Assert.assertNotNull("Constructor", new DefaultTransit("TT1", "user name"));
    }
 
    @BeforeEach

--- a/java/test/jmri/configurexml/TransitManagerXmlTest.java
+++ b/java/test/jmri/configurexml/TransitManagerXmlTest.java
@@ -1,6 +1,8 @@
 package jmri.configurexml;
 
 import jmri.*;
+import jmri.managers.DefaultTransitManager;
+import jmri.managers.configurexml.DefaultTransitManagerXml;
 import jmri.util.JUnitUtil;
 
 import org.junit.jupiter.api.*;
@@ -17,20 +19,20 @@ public class TransitManagerXmlTest {
 
    @Test
    public void BaseTest(){
-      Assert.assertNotNull("Constructor", new TransitManagerXml());
+      Assert.assertNotNull("Constructor", new DefaultTransitManagerXml());
    }
 
    @Test
    public void NoElementIfEmptyTest(){
-      TransitManagerXml tmx = new TransitManagerXml();
-      TransitManager tm = new TransitManager();
+      var tmx = new DefaultTransitManagerXml();
+      TransitManager tm = new DefaultTransitManager();
       Assert.assertNull("No elements", tmx.store(tm));
    }
 
    @Test
    public void StoreOneTransitTest() throws Exception {
-      TransitManagerXml tmx = new TransitManagerXml();
-      TransitManager tm = new TransitManager();
+      var tmx = new DefaultTransitManagerXml();
+      TransitManager tm = new DefaultTransitManager();
       Transit t = tm.createNewTransit("TS1", "user");
 
       Section s = new jmri.implementation.DefaultSection("SS1");

--- a/java/test/jmri/configurexml/TransitManagerXmlTest.java
+++ b/java/test/jmri/configurexml/TransitManagerXmlTest.java
@@ -33,7 +33,7 @@ public class TransitManagerXmlTest {
       TransitManager tm = new TransitManager();
       Transit t = tm.createNewTransit("TS1", "user");
 
-      Section s = new Section("SS1");
+      Section s = new jmri.implementation.DefaultSection("SS1");
       TransitSection ts = new TransitSection(s,0,0,false);
 
       TransitSectionAction ta = new TransitSectionAction(0,0);

--- a/java/test/jmri/implementation/DefaultSectionTest.java
+++ b/java/test/jmri/implementation/DefaultSectionTest.java
@@ -1,0 +1,59 @@
+package jmri.implementation;
+
+import jmri.*;
+import jmri.util.JUnitUtil;
+
+import jmri.implementation.DefaultSection;
+
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+
+/**
+ * Tests for Section class.
+ *
+ * @author Bob Jacobsen Copyright (C) 2017
+ * @author Paul Bender Copyright (C) 2016
+ **/
+
+public class DefaultSectionTest {
+
+   @Test
+   public void SysNameConstructorTest(){
+      Assert.assertNotNull("Constructor", new DefaultSection("TS1"));
+   }
+
+   @Test
+   public void TwoNameStringConstructorTest(){
+      Assert.assertNotNull("Constructor", new DefaultSection("TS1", "user name"));
+   }
+
+   @Test
+   public void warnOnBlockAdd() {
+    Section  s = new DefaultSection("TS1");
+    Assert.assertEquals(0, s.getBlockList().size());
+    s.addBlock(new Block("IB1", "user"));
+    Assert.assertEquals(1, s.getBlockList().size());
+   }
+
+   @Test
+   public void warnOnBlockAddWithNoUserName() {
+    Section  s = new DefaultSection("TS1");
+    Assert.assertEquals(0, s.getBlockList().size());
+    s.addBlock(new Block("IB1"));
+    jmri.util.JUnitAppender.assertWarnMessage("Block IB1 does not have a user name, may not work correctly in Section TS1");
+    Assert.assertEquals(1, s.getBlockList().size());
+   }
+
+   @BeforeEach
+   public void setUp() {
+        JUnitUtil.setUp();
+
+        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
+   }
+
+   @AfterEach
+   public void tearDown(){
+        JUnitUtil.tearDown();
+   }
+
+}

--- a/java/test/jmri/implementation/DefaultTransitTest.java
+++ b/java/test/jmri/implementation/DefaultTransitTest.java
@@ -1,0 +1,42 @@
+package jmri.implementation;
+
+import jmri.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+
+import jmri.implementation.DefaultTransit;
+
+/**
+ * Tests for Transit class.
+ *
+ * @author Bob Jacobsen Copyright (C) 2017
+ * @author Paul Bender Copyright (C) 2016
+ **/
+
+public class DefaultTransitTest {
+
+   @Test
+   public void SysNameConstructorTest(){
+      Assert.assertNotNull("Constructor", new DefaultTransit("TT1"));
+   }
+
+   @Test
+   public void TwoNameStringConstructorTest(){
+      Assert.assertNotNull("Constructor", new DefaultTransit("TT1", "user name"));
+   }
+
+   @BeforeEach
+   public void setUp() {
+        JUnitUtil.setUp();
+
+        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
+   }
+
+   @AfterEach
+   public void tearDown(){
+        JUnitUtil.tearDown();
+   }
+
+}

--- a/java/test/jmri/jmrit/dispatcher/ActiveTrainTest.java
+++ b/java/test/jmri/jmrit/dispatcher/ActiveTrainTest.java
@@ -13,7 +13,7 @@ public class ActiveTrainTest {
 
     @Test
     public void testCTor() {
-        jmri.Transit transit = new jmri.Transit("TT1");
+        jmri.Transit transit = new jmri.implementation.DefaultTransit("TT1");
         ActiveTrain t = new ActiveTrain(transit,"Train",ActiveTrain.USER);
         Assert.assertNotNull("exists",t);
     }

--- a/java/test/jmri/jmrit/dispatcher/AllocatedSectionTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AllocatedSectionTest.java
@@ -22,8 +22,8 @@ public class AllocatedSectionTest {
         DispatcherFrame d = InstanceManager.getDefault(DispatcherFrame.class);
         jmri.Transit transit = new jmri.Transit("TT1");
         ActiveTrain at = new ActiveTrain(transit, "Train", ActiveTrain.USER);
-        jmri.Section section1 = new jmri.Section("TS1");
-        jmri.Section section2 = new jmri.Section("TS2");
+        jmri.Section section1 = new jmri.implementation.DefaultSection("TS1");
+        jmri.Section section2 = new jmri.implementation.DefaultSection("TS2");
         AllocatedSection t = new AllocatedSection(section1, at, 1, section2, 2);
         Assert.assertNotNull("exists", t);
         JUnitUtil.dispose(d);

--- a/java/test/jmri/jmrit/dispatcher/AllocatedSectionTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AllocatedSectionTest.java
@@ -20,7 +20,7 @@ public class AllocatedSectionTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         OptionsFile.setDefaultFileName("java/test/jmri/jmrit/dispatcher/dispatcheroptions.xml");  // exist?
         DispatcherFrame d = InstanceManager.getDefault(DispatcherFrame.class);
-        jmri.Transit transit = new jmri.Transit("TT1");
+        jmri.Transit transit = new jmri.implementation.DefaultTransit("TT1");
         ActiveTrain at = new ActiveTrain(transit, "Train", ActiveTrain.USER);
         jmri.Section section1 = new jmri.implementation.DefaultSection("TS1");
         jmri.Section section2 = new jmri.implementation.DefaultSection("TS2");

--- a/java/test/jmri/jmrit/dispatcher/AllocationRequestTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AllocationRequestTest.java
@@ -15,7 +15,7 @@ public class AllocationRequestTest {
     public void testCTor() {
         jmri.Transit transit = new jmri.Transit("TT1");
         ActiveTrain at = new ActiveTrain(transit,"Train",ActiveTrain.USER);
-        jmri.Section section1 = new jmri.Section("TS1");
+        jmri.Section section1 = new jmri.implementation.DefaultSection("TS1");
         AllocationRequest t = new AllocationRequest(section1,1,1,at);
         Assert.assertNotNull("exists",t);
     }

--- a/java/test/jmri/jmrit/dispatcher/AllocationRequestTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AllocationRequestTest.java
@@ -13,7 +13,7 @@ public class AllocationRequestTest {
 
     @Test
     public void testCTor() {
-        jmri.Transit transit = new jmri.Transit("TT1");
+        jmri.Transit transit = new jmri.implementation.DefaultTransit("TT1");
         ActiveTrain at = new ActiveTrain(transit,"Train",ActiveTrain.USER);
         jmri.Section section1 = new jmri.implementation.DefaultSection("TS1");
         AllocationRequest t = new AllocationRequest(section1,1,1,at);

--- a/java/test/jmri/jmrit/dispatcher/AutoActiveTrainTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AutoActiveTrainTest.java
@@ -22,7 +22,7 @@ public class AutoActiveTrainTest {
         DispatcherFrame df = Mockito.mock(DispatcherFrame.class);
         InstanceManager.setDefault(DispatcherFrame.class,df);
 
-        Transit transit = new Transit("TT1");
+        Transit transit = new jmri.implementation.DefaultTransit("TT1");
         ActiveTrain at = new ActiveTrain(transit,"Train",ActiveTrain.USER);
         AutoActiveTrain t = new AutoActiveTrain(at);
         Assertions.assertNotNull(t, "exists");

--- a/java/test/jmri/jmrit/dispatcher/AutoTrainActionTest.java
+++ b/java/test/jmri/jmrit/dispatcher/AutoTrainActionTest.java
@@ -15,11 +15,11 @@ public class AutoTrainActionTest {
 
     @Test
     public void testCTor() {
-        
+
         DispatcherFrame df = Mockito.mock(DispatcherFrame.class);
         InstanceManager.setDefault(DispatcherFrame.class,df);
-        
-        jmri.Transit transit = new jmri.Transit("TT1");
+
+        jmri.Transit transit = new jmri.implementation.DefaultTransit("TT1");
         ActiveTrain at = new ActiveTrain(transit,"Train",ActiveTrain.USER);
         AutoActiveTrain aat = new AutoActiveTrain(at);
         AutoTrainAction t = new AutoTrainAction(aat);

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionDispatcherTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionDispatcherTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jmri.*;
+import jmri.implementation.DefaultSection;
 import jmri.jmrit.dispatcher.*;
 import jmri.jmrit.logixng.Category;
 import jmri.jmrit.logixng.ConditionalNG;
@@ -225,13 +226,13 @@ public class ExpressionDispatcherTest extends AbstractDigitalExpressionTestBase 
 
     private void setupActiveTrain() throws IOException, JDOMException {
         Transit transit = InstanceManager.getDefault(jmri.TransitManager.class).createNewTransit("MyTransit");
-        Section section1 = new Section("Section1");
+        Section section1 = new DefaultSection("Section1");
         section1.addBlock(InstanceManager.getDefault(jmri.BlockManager.class).createNewBlock("StartBlock"));
-        Section section2 = new Section("Section2");
+        Section section2 = new DefaultSection("Section2");
         section2.addBlock(InstanceManager.getDefault(jmri.BlockManager.class).createNewBlock("Block2"));
-        Section section3 = new Section("Section3");
+        Section section3 = new DefaultSection("Section3");
         section3.addBlock(InstanceManager.getDefault(jmri.BlockManager.class).createNewBlock("Block3"));
-        Section section4 = new Section("Section4");
+        Section section4 = new DefaultSection("Section4");
         section4.addBlock(InstanceManager.getDefault(jmri.BlockManager.class).createNewBlock("EndBlock"));
 
 

--- a/java/test/jmri/managers/DefaultSectionManagerTest.java
+++ b/java/test/jmri/managers/DefaultSectionManagerTest.java
@@ -1,0 +1,41 @@
+package jmri.managers;
+
+import jmri.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+
+/**
+ *
+ * @author Paul Bender Copyright (C) 2017
+ */
+public class DefaultSectionManagerTest {
+
+    @Test
+    public void testCTor() {
+        SectionManager t = new jmri.managers.DefaultSectionManager();
+        Assert.assertNotNull("exists",t);
+    }
+
+    @Test
+    public void testInstanceManagerAccess() {
+        SectionManager t = InstanceManager.getDefault(SectionManager.class);
+        Assert.assertNotNull("exists",t);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.deregisterEditorManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+
+    // private final static Logger log = LoggerFactory.getLogger(SectionManagerTest.class);
+
+}

--- a/java/test/jmri/managers/DefaultTransitManagerTest.java
+++ b/java/test/jmri/managers/DefaultTransitManagerTest.java
@@ -1,0 +1,35 @@
+package jmri.managers;
+
+import jmri.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import org.junit.Assert;
+
+/**
+ *
+ * @author Paul Bender Copyright (C) 2017
+ */
+public class DefaultTransitManagerTest {
+
+    @Test
+    public void testCTor() {
+        TransitManager t = new jmri.managers.DefaultTransitManager();
+        Assert.assertNotNull("exists",t);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        JUnitUtil.deregisterEditorManagerShutdownTask();
+        JUnitUtil.tearDown();
+    }
+
+    // private final static Logger log = LoggerFactory.getLogger(TransitManagerTest.class);
+
+}

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -804,7 +804,7 @@ public class JUnitUtil {
     }
 
     public static void initSectionManager() {
-        jmri.SectionManager w = new jmri.SectionManager();
+        jmri.SectionManager w = new jmri.managers.DefaultSectionManager();
         if (InstanceManager.getNullableDefault(ConfigureManager.class) != null) {
             InstanceManager.getDefault(ConfigureManager.class).registerConfig(w, jmri.Manager.SECTIONS);
         }


### PR DESCRIPTION
 - The jmri.Transit class is split into an interface and jmri.implementation.DefaultTransit class
 - The jmri.TransitManager class is split into an interface and jmri.managers.DefaultTransitManager class
 - The jmri.Section class is split into an interface and jmri.implementation.DefaultSection class
 - The jmri.SectionManager class is split into an interface and jmri.managers.DefaultSectionManager class

This puts these classes in the form commonly used by other classes: Turnout, Sensor, etc.  As such, it reduces the coupling between classes significantly.  Only LayoutEditor itself is left as a jmri.jmrit dependency. This didn't require any changes to existing production code nor scripts because these classes were always referenced through InstanceManager and their managers. (Some test changes required)

Also converts the int constants for SectionType into an enum.  The jython/DispatcherSystem/CreateSignalLogicAndSections.py and jython/DispatcherSystem/CreateTransits.py distributed scripts reference the constants. The references look OK, but I don't have a way test them thoroughly.