### PR TITLE
WIP - Replace MouseEvent with JmriMouseEvent

### DIFF
--- a/java/src/jmri/jmrit/display/AnalogClock2Display.java
+++ b/java/src/jmri/jmrit/display/AnalogClock2Display.java
@@ -10,7 +10,6 @@ import java.awt.Image;
 import java.awt.Polygon;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
 import java.util.Date;
 
@@ -23,6 +22,8 @@ import javax.swing.JRadioButtonMenuItem;
 import jmri.*;
 import jmri.jmrit.catalog.NamedIcon;
 import jmri.util.swing.JmriColorChooser;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -438,7 +439,7 @@ public class AnalogClock2Display extends PositionableJComponent implements Linki
     }
 
     @Override
-    public void doMouseClicked(MouseEvent event) {
+    public void doMouseClicked(JmriMouseEvent event) {
         log.debug("click to {}", _url);
         if (_url == null || _url.trim().length() == 0) {
             return;

--- a/java/src/jmri/jmrit/display/BlockContentsIcon.java
+++ b/java/src/jmri/jmrit/display/BlockContentsIcon.java
@@ -3,12 +3,14 @@ package jmri.jmrit.display;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Map;
+
 import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import javax.swing.JTextField;
+
 import jmri.Block;
 import jmri.InstanceManager;
 import jmri.NamedBeanHandle;
@@ -16,6 +18,8 @@ import jmri.NamedBean.DisplayOptions;
 import jmri.jmrit.catalog.NamedIcon;
 import jmri.jmrit.throttle.ThrottleFrame;
 import jmri.jmrit.throttle.ThrottleFrameManager;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -289,7 +293,7 @@ public class BlockContentsIcon extends MemoryIcon {
     }
 
     @Override
-    public void doMouseClicked(java.awt.event.MouseEvent e) {
+    public void doMouseClicked(JmriMouseEvent e) {
         if (e.getClickCount() == 2) { // double click?
             editBlockValue();
         }

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -36,6 +36,7 @@ import jmri.jmrit.roster.swing.RosterEntrySelectorPanel;
 import jmri.util.DnDStringImportHandler;
 import jmri.util.JmriJFrame;
 import jmri.util.swing.JmriColorChooser;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * This is the Model and a Controller for panel editor Views. (Panel Editor,
@@ -2621,7 +2622,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
     /*
      * **************** Mouse Methods **********************
      */
-    public void showToolTip(Positionable selection, MouseEvent event) {
+    public void showToolTip(Positionable selection, JmriMouseEvent event) {
         ToolTip tip = selection.getToolTip();
         tip.setLocation(selection.getX() + selection.getWidth() / 2, selection.getY() + selection.getHeight());
         setToolTip(tip);
@@ -2759,7 +2760,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
      * @param event contains the mouse position.
      * @return a list of positionable items or an empty list.
      */
-    protected List<Positionable> getSelectedItems(MouseEvent event) {
+    protected List<Positionable> getSelectedItems(JmriMouseEvent event) {
         Rectangle rect = new Rectangle();
         ArrayList<Positionable> selections = new ArrayList<>();
         for (Positionable p : _contents) {
@@ -2805,7 +2806,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
      * Gather all items inside _selectRect
      * Keep old group if Control key is down
      */
-    protected void makeSelectionGroup(MouseEvent event) {
+    protected void makeSelectionGroup(JmriMouseEvent event) {
         if (!event.isControlDown() || _selectionGroup == null) {
             _selectionGroup = new ArrayList<>();
         }
@@ -2843,7 +2844,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
      * If there, delete.
      * make new group if Cntl key is not held down
      */
-    protected void modifySelectionGroup(Positionable selection, MouseEvent event) {
+    protected void modifySelectionGroup(Positionable selection, JmriMouseEvent event) {
         if (!event.isControlDown() || _selectionGroup == null) {
             _selectionGroup = new ArrayList<>();
         }
@@ -3130,29 +3131,57 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
         }
     }
 
+    @Override
+    public final void mousePressed(MouseEvent event) {
+        mousePressed(new JmriMouseEvent(event));
+    }
+
+    @Override
+    public final void mouseReleased(MouseEvent event) {
+        mouseReleased(new JmriMouseEvent(event));
+    }
+
+    @Override
+    public final void mouseClicked(MouseEvent event) {
+        mouseClicked(new JmriMouseEvent(event));
+    }
+
+    @Override
+    public final void mouseDragged(MouseEvent event) {
+        mouseDragged(new JmriMouseEvent(event));
+    }
+
+    @Override
+    public final void mouseMoved(MouseEvent event) {
+        mouseMoved(new JmriMouseEvent(event));
+    }
+
+    @Override
+    public final void mouseEntered(MouseEvent event) {
+        mouseEntered(new JmriMouseEvent(event));
+    }
+
+    @Override
+    public final void mouseExited(MouseEvent event) {
+        mouseExited(new JmriMouseEvent(event));
+    }
+
     /*
      * ********************* Abstract Methods ***********************
      */
-    @Override
-    abstract public void mousePressed(MouseEvent event);
+    abstract public void mousePressed(JmriMouseEvent event);
 
-    @Override
-    abstract public void mouseReleased(MouseEvent event);
+    abstract public void mouseReleased(JmriMouseEvent event);
 
-    @Override
-    abstract public void mouseClicked(MouseEvent event);
+    abstract public void mouseClicked(JmriMouseEvent event);
 
-    @Override
-    abstract public void mouseDragged(MouseEvent event);
+    abstract public void mouseDragged(JmriMouseEvent event);
 
-    @Override
-    abstract public void mouseMoved(MouseEvent event);
+    abstract public void mouseMoved(JmriMouseEvent event);
 
-    @Override
-    abstract public void mouseEntered(MouseEvent event);
+    abstract public void mouseEntered(JmriMouseEvent event);
 
-    @Override
-    abstract public void mouseExited(MouseEvent event);
+    abstract public void mouseExited(JmriMouseEvent event);
 
     /*
      * set up target panel, frame etc.
@@ -3186,7 +3215,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
      * @param p     the item containing or requiring the context menu
      * @param event the event triggering the menu
      */
-    abstract protected void showPopUp(Positionable p, MouseEvent event);
+    abstract protected void showPopUp(Positionable p, JmriMouseEvent event);
 
     /**
      * After construction, initialize all the widgets to their saved config

--- a/java/src/jmri/jmrit/display/LightIcon.java
+++ b/java/src/jmri/jmrit/display/LightIcon.java
@@ -2,10 +2,13 @@ package jmri.jmrit.display;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+
 import jmri.InstanceManager;
 import jmri.Light;
 import jmri.NamedBean.DisplayOptions;
 import jmri.jmrit.catalog.NamedIcon;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,7 +154,7 @@ public class LightIcon extends PositionableLabel implements java.beans.PropertyC
     int lightState() {
         if (light != null) {
             return light.getState();
-        } // This doesn't seem right. (Light.UNKNOWN = Light.ON = 0X01)  
+        } // This doesn't seem right. (Light.UNKNOWN = Light.ON = 0X01)
         //else return Light.UNKNOWN;
         else {
             return Light.INCONSISTENT;
@@ -286,7 +289,7 @@ public class LightIcon extends PositionableLabel implements java.beans.PropertyC
      * @param e the mouse click
      */
     @Override
-    public void doMouseClicked(java.awt.event.MouseEvent e) {
+    public void doMouseClicked(JmriMouseEvent e) {
         if (!_editor.getFlag(Editor.OPTION_CONTROLS, isControlling())) {
             return;
         }

--- a/java/src/jmri/jmrit/display/LinkingLabel.java
+++ b/java/src/jmri/jmrit/display/LinkingLabel.java
@@ -1,14 +1,11 @@
 package jmri.jmrit.display;
 
-import java.awt.event.MouseEvent;
-import java.io.IOException;
-import java.net.URISyntaxException;
-
 import javax.annotation.Nonnull;
 import javax.swing.JPopupMenu;
 
 import jmri.JmriException;
 import jmri.jmrit.catalog.NamedIcon;
+import jmri.util.swing.JmriMouseEvent;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,7 +68,7 @@ public class LinkingLabel extends PositionableLabel implements LinkingObject {
 //    public void doMousePressed(MouseEvent event) {}
 //    public void doMouseReleased(MouseEvent event) {}
     @Override
-    public void doMouseClicked(MouseEvent event) {
+    public void doMouseClicked(JmriMouseEvent event) {
         log.debug("click to {}", url);
         try {
             if (url.startsWith("frame:")) {

--- a/java/src/jmri/jmrit/display/LocoIcon.java
+++ b/java/src/jmri/jmrit/display/LocoIcon.java
@@ -3,19 +3,22 @@ package jmri.jmrit.display;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 import java.util.List;
+
 import javax.swing.AbstractAction;
 import javax.swing.ButtonGroup;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
+
 import jmri.InstanceManager;
 import jmri.jmrit.catalog.NamedIcon;
 import jmri.jmrit.logix.TrackerTableAction;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.jmrit.throttle.ThrottleFrameManager;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -214,7 +217,7 @@ public class LocoIcon extends PositionableLabel {
     public static String[] getLocoColors() {
         return new String[]{WHITE, GREEN, GRAY, RED, BLUE, YELLOW};
     }
-    
+
     public Color getLocoColor() {
         return _locoColor;
     }
@@ -313,7 +316,7 @@ public class LocoIcon extends PositionableLabel {
      * Set display attributes for Tracker
      */
     @Override
-    public void doMouseReleased(MouseEvent event) {
+    public void doMouseReleased(JmriMouseEvent event) {
         List<Positionable> selections = _editor.getSelectedItems(event);
         for (Positionable selection : selections) {
             if (selection instanceof IndicatorTrack) {

--- a/java/src/jmri/jmrit/display/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryIcon.java
@@ -7,12 +7,14 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Map;
+
 import javax.swing.AbstractAction;
 import javax.swing.JComponent;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import javax.swing.JTextField;
+
 import jmri.InstanceManager;
 import jmri.Memory;
 import jmri.NamedBeanHandle;
@@ -24,6 +26,8 @@ import jmri.jmrit.roster.RosterIconFactory;
 import jmri.jmrit.throttle.ThrottleFrame;
 import jmri.jmrit.throttle.ThrottleFrameManager;
 import jmri.util.datatransfer.RosterEntrySelection;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -563,7 +567,7 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
     }
 
     @Override
-    public void doMouseClicked(java.awt.event.MouseEvent e) {
+    public void doMouseClicked(JmriMouseEvent e) {
         if (e.getClickCount() == 2) { // double click?
             editMemoryValue();
         }

--- a/java/src/jmri/jmrit/display/MultiSensorIcon.java
+++ b/java/src/jmri/jmrit/display/MultiSensorIcon.java
@@ -2,19 +2,21 @@ package jmri.jmrit.display;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
 import javax.swing.AbstractAction;
 import javax.swing.JPopupMenu;
+
 import jmri.InstanceManager;
 import jmri.NamedBeanHandle;
 import jmri.Sensor;
 import jmri.jmrit.catalog.NamedIcon;
 import jmri.jmrit.display.palette.MultiSensorItemPanel;
 import jmri.jmrit.picker.PickListModel;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -397,7 +399,7 @@ public class MultiSensorIcon extends PositionableLabel implements java.beans.Pro
         }
     }
 
-    // Use largest size. If icons are not same size, 
+    // Use largest size. If icons are not same size,
     // this can result in drawing artifacts.
     @Override
     public int maxHeight() {
@@ -414,7 +416,7 @@ public class MultiSensorIcon extends PositionableLabel implements java.beans.Pro
         return size;
     }
 
-    // Use largest size. If icons are not same size, 
+    // Use largest size. If icons are not same size,
     // this can result in drawing artifacts.
     @Override
     public int maxWidth() {
@@ -431,7 +433,7 @@ public class MultiSensorIcon extends PositionableLabel implements java.beans.Pro
         return size;
     }
 
-    public void performMouseClicked(java.awt.event.MouseEvent e, int xx, int yy) {
+    public void performMouseClicked(JmriMouseEvent e, int xx, int yy) {
         if (log.isDebugEnabled()) {
             log.debug("performMouseClicked: location ({}, {}), click from ({}, {}) displaying={}",
                     getX(), getY(), xx, yy, displaying);
@@ -491,7 +493,7 @@ public class MultiSensorIcon extends PositionableLabel implements java.beans.Pro
     }
 
     @Override
-    public void doMouseClicked(MouseEvent e) {
+    public void doMouseClicked(JmriMouseEvent e) {
         if (!e.isAltDown() && !e.isMetaDown()) {
             performMouseClicked(e, e.getX(), e.getY());
         }

--- a/java/src/jmri/jmrit/display/Positionable.java
+++ b/java/src/jmri/jmrit/display/Positionable.java
@@ -6,11 +6,13 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.event.MouseEvent;
+
 import javax.swing.JComponent;
 import javax.swing.JPopupMenu;
 import javax.swing.border.Border;
+
 import jmri.JmriException;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * Defines display objects.
@@ -224,19 +226,19 @@ public interface Positionable extends Cloneable {
 
     // Mouse-handling events.  See
     // Editor class for more information on how these are used.
-    void doMousePressed(MouseEvent event);
+    void doMousePressed(JmriMouseEvent event);
 
-    void doMouseReleased(MouseEvent event);
+    void doMouseReleased(JmriMouseEvent event);
 
-    void doMouseClicked(MouseEvent event);
+    void doMouseClicked(JmriMouseEvent event);
 
-    void doMouseDragged(MouseEvent event);
+    void doMouseDragged(JmriMouseEvent event);
 
-    void doMouseMoved(MouseEvent event);
+    void doMouseMoved(JmriMouseEvent event);
 
-    void doMouseEntered(MouseEvent event);
+    void doMouseEntered(JmriMouseEvent event);
 
-    void doMouseExited(MouseEvent event);
+    void doMouseExited(JmriMouseEvent event);
 
     // The following are common for all JComponents
     Rectangle getBounds(Rectangle r);

--- a/java/src/jmri/jmrit/display/PositionableJComponent.java
+++ b/java/src/jmri/jmrit/display/PositionableJComponent.java
@@ -1,12 +1,13 @@
 package jmri.jmrit.display;
 
-import java.awt.event.MouseEvent;
 import java.util.Objects;
 
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
+
+import jmri.util.swing.JmriMouseEvent;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -225,31 +226,31 @@ public class PositionableJComponent extends JComponent implements Positionable {
 
     // overide where used - e.g. momentary
     @Override
-    public void doMousePressed(MouseEvent event) {
+    public void doMousePressed(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseReleased(MouseEvent event) {
+    public void doMouseReleased(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseClicked(MouseEvent event) {
+    public void doMouseClicked(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseDragged(MouseEvent event) {
+    public void doMouseDragged(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseMoved(MouseEvent event) {
+    public void doMouseMoved(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseEntered(MouseEvent event) {
+    public void doMouseEntered(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseExited(MouseEvent event) {
+    public void doMouseExited(JmriMouseEvent event) {
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/PositionableJPanel.java
+++ b/java/src/jmri/jmrit/display/PositionableJPanel.java
@@ -19,11 +19,12 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jmri.jmrit.display.palette.ItemPanel;
 import jmri.jmrit.display.palette.TextItemPanel;
+import jmri.util.swing.JmriMouseEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <a href="doc-files/Heirarchy.png"><img src="doc-files/Heirarchy.png" alt="UML class diagram for package" height="33%" width="33%"></a>
@@ -293,31 +294,31 @@ public class PositionableJPanel extends JPanel implements Positionable, MouseLis
 
     // overide where used - e.g. momentary
     @Override
-    public void doMousePressed(MouseEvent event) {
+    public void doMousePressed(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseReleased(MouseEvent event) {
+    public void doMouseReleased(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseClicked(MouseEvent event) {
+    public void doMouseClicked(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseDragged(MouseEvent event) {
+    public void doMouseDragged(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseMoved(MouseEvent event) {
+    public void doMouseMoved(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseEntered(MouseEvent event) {
+    public void doMouseEntered(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseExited(MouseEvent event) {
+    public void doMouseExited(JmriMouseEvent event) {
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/PositionableLabel.java
+++ b/java/src/jmri/jmrit/display/PositionableLabel.java
@@ -8,7 +8,6 @@ import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
@@ -25,6 +24,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 
 import jmri.jmrit.catalog.NamedIcon;
+import jmri.util.swing.JmriMouseEvent;
 import jmri.jmrit.display.palette.IconItemPanel;
 import jmri.jmrit.display.palette.ItemPanel;
 import jmri.jmrit.display.palette.TextItemPanel;
@@ -324,31 +324,31 @@ public class PositionableLabel extends JLabel implements Positionable {
 
     // overide where used - e.g. momentary
     @Override
-    public void doMousePressed(MouseEvent event) {
+    public void doMousePressed(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseReleased(MouseEvent event) {
+    public void doMouseReleased(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseClicked(MouseEvent event) {
+    public void doMouseClicked(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseDragged(MouseEvent event) {
+    public void doMouseDragged(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseMoved(MouseEvent event) {
+    public void doMouseMoved(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseEntered(MouseEvent event) {
+    public void doMouseEntered(JmriMouseEvent event) {
     }
 
     @Override
-    public void doMouseExited(MouseEvent event) {
+    public void doMouseExited(JmriMouseEvent event) {
     }
 
     @Override

--- a/java/src/jmri/jmrit/display/SensorIcon.java
+++ b/java/src/jmri/jmrit/display/SensorIcon.java
@@ -3,11 +3,11 @@ package jmri.jmrit.display;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map.Entry;
+
 import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.JCheckBoxMenuItem;
@@ -16,6 +16,7 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.Timer;
+
 import jmri.InstanceManager;
 import jmri.NamedBeanHandle;
 import jmri.Sensor;
@@ -24,6 +25,8 @@ import jmri.jmrit.catalog.NamedIcon;
 import jmri.jmrit.display.palette.TableItemPanel;
 import jmri.jmrit.picker.PickListModel;
 import jmri.util.swing.JmriColorChooser;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -578,7 +581,7 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
     }
 
     @Override
-    public void doMousePressed(MouseEvent e) {
+    public void doMousePressed(JmriMouseEvent e) {
         log.debug("doMousePressed buttonLive={}, getMomentary={}", buttonLive(), getMomentary());
         if (getMomentary() && buttonLive() && !e.isMetaDown() && !e.isAltDown()) {
             // this is a momentary button press
@@ -592,7 +595,7 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
     }
 
     @Override
-    public void doMouseReleased(MouseEvent e) {
+    public void doMouseReleased(JmriMouseEvent e) {
         if (getMomentary() && buttonLive() && !e.isMetaDown() && !e.isAltDown()) {
             // this is a momentary button release
             try {
@@ -605,7 +608,7 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
     }
 
     @Override
-    public void doMouseClicked(MouseEvent e) {
+    public void doMouseClicked(JmriMouseEvent e) {
         if (buttonLive() && !getMomentary()) {
             // this button responds to clicks
             if (!e.isMetaDown() && !e.isAltDown()) {

--- a/java/src/jmri/jmrit/display/SignalHeadIcon.java
+++ b/java/src/jmri/jmrit/display/SignalHeadIcon.java
@@ -5,18 +5,22 @@ import java.awt.event.ActionListener;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map.Entry;
+
 import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.ButtonGroup;
 import javax.swing.JMenu;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
+
 import jmri.InstanceManager;
 import jmri.NamedBeanHandle;
 import jmri.SignalHead;
 import jmri.jmrit.catalog.NamedIcon;
 import jmri.jmrit.display.palette.SignalHeadItemPanel;
 import jmri.jmrit.picker.PickListModel;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -486,7 +490,7 @@ public class SignalHeadIcon extends PositionableIcon implements java.beans.Prope
      * head.
      */
     @Override
-    public void doMouseClicked(java.awt.event.MouseEvent e) {
+    public void doMouseClicked(JmriMouseEvent e) {
         if (!_editor.getFlag(Editor.OPTION_CONTROLS, isControlling())) {
             return;
         }
@@ -499,7 +503,7 @@ public class SignalHeadIcon extends PositionableIcon implements java.beans.Prope
      *
      * @param e the mouse click event
      */
-    public void performMouseClicked(java.awt.event.MouseEvent e) {
+    public void performMouseClicked(JmriMouseEvent e) {
         if (e.isMetaDown() || e.isAltDown()) {
             return;
         }

--- a/java/src/jmri/jmrit/display/SignalMastIcon.java
+++ b/java/src/jmri/jmrit/display/SignalMastIcon.java
@@ -2,12 +2,14 @@ package jmri.jmrit.display;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+
 import javax.swing.AbstractAction;
 import javax.swing.ButtonGroup;
 import javax.swing.JMenu;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
+
 import jmri.InstanceManager;
 import jmri.NamedBeanHandle;
 import jmri.SignalMast;
@@ -16,6 +18,8 @@ import jmri.NamedBean.DisplayOptions;
 import jmri.jmrit.catalog.NamedIcon;
 import jmri.jmrit.display.palette.SignalMastItemPanel;
 import jmri.jmrit.picker.PickListModel;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -411,7 +415,7 @@ public class SignalMastIcon extends PositionableIcon implements java.beans.Prope
      *
      */
     @Override
-    public void doMouseClicked(java.awt.event.MouseEvent e) {
+    public void doMouseClicked(JmriMouseEvent e) {
         if (!_editor.getFlag(Editor.OPTION_CONTROLS, isControlling())) {
             return;
         }
@@ -424,7 +428,7 @@ public class SignalMastIcon extends PositionableIcon implements java.beans.Prope
      *
      * @param e the mouse click event
      */
-    public void performMouseClicked(java.awt.event.MouseEvent e) {
+    public void performMouseClicked(JmriMouseEvent e) {
         if (e.isMetaDown() || e.isAltDown()) {
             return;
         }

--- a/java/src/jmri/jmrit/display/SlipTurnoutIcon.java
+++ b/java/src/jmri/jmrit/display/SlipTurnoutIcon.java
@@ -3,6 +3,7 @@ package jmri.jmrit.display;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.HashMap;
+
 import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.JMenuItem;
@@ -12,6 +13,8 @@ import jmri.InstanceManager;
 import jmri.NamedBeanHandle;
 import jmri.Turnout;
 import jmri.jmrit.catalog.NamedIcon;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -858,7 +861,7 @@ public class SlipTurnoutIcon extends PositionableLabel implements java.beans.Pro
      * @param e the click event
      */
     @Override
-    public void doMouseClicked(java.awt.event.MouseEvent e) {
+    public void doMouseClicked(JmriMouseEvent e) {
         if (!_editor.getFlag(Editor.OPTION_CONTROLS, isControlling())) {
             return;
         }

--- a/java/src/jmri/jmrit/display/TurnoutIcon.java
+++ b/java/src/jmri/jmrit/display/TurnoutIcon.java
@@ -2,12 +2,13 @@ package jmri.jmrit.display;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map.Entry;
+
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JPopupMenu;
+
 import jmri.InstanceManager;
 import jmri.NamedBeanHandle;
 import jmri.Turnout;
@@ -15,6 +16,8 @@ import jmri.NamedBean.DisplayOptions;
 import jmri.jmrit.catalog.NamedIcon;
 import jmri.jmrit.display.palette.TableItemPanel;
 import jmri.jmrit.picker.PickListModel;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -454,7 +457,7 @@ public class TurnoutIcon extends PositionableIcon implements java.beans.Property
     }
 
     @Override
-    public void doMousePressed(MouseEvent e) {
+    public void doMousePressed(JmriMouseEvent e) {
         if (getMomentary() && buttonLive() && !e.isMetaDown() && !e.isAltDown()) {
             // this is a momentary button press
             getTurnout().setCommandedState(jmri.Turnout.THROWN);
@@ -463,7 +466,7 @@ public class TurnoutIcon extends PositionableIcon implements java.beans.Property
     }
 
     @Override
-    public void doMouseReleased(MouseEvent e) {
+    public void doMouseReleased(JmriMouseEvent e) {
         if (getMomentary() && buttonLive() && !e.isMetaDown() && !e.isAltDown()) {
             // this is a momentary button release
             getTurnout().setCommandedState(jmri.Turnout.CLOSED);
@@ -472,7 +475,7 @@ public class TurnoutIcon extends PositionableIcon implements java.beans.Property
     }
 
     @Override
-    public void doMouseClicked(java.awt.event.MouseEvent e) {
+    public void doMouseClicked(JmriMouseEvent e) {
         if (!_editor.getFlag(Editor.OPTION_CONTROLS, isControlling())) {
             return;
         }

--- a/java/src/jmri/jmrit/display/controlPanelEditor/CircuitBuilder.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/CircuitBuilder.java
@@ -7,7 +7,6 @@ import java.awt.FlowLayout;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -27,15 +26,9 @@ import jmri.NamedBeanHandleManager;
 import jmri.SignalHeadManager;
 import jmri.SignalMastManager;
 import jmri.jmrit.catalog.NamedIcon;
+import jmri.jmrit.display.*;
 import jmri.jmrit.display.Editor.TargetPane;
 import jmri.jmrit.display.palette.ItemPalette;
-import jmri.jmrit.display.IndicatorTrack;
-import jmri.jmrit.display.Positionable;
-import jmri.jmrit.display.PositionableLabel;
-import jmri.jmrit.display.PositionableIcon;
-import jmri.jmrit.display.SignalHeadIcon;
-import jmri.jmrit.display.SignalMastIcon;
-import jmri.jmrit.display.TurnoutIcon;
 import jmri.jmrit.logix.OBlock;
 import jmri.jmrit.logix.OBlockManager;
 import jmri.jmrit.logix.Portal;
@@ -43,6 +36,7 @@ import jmri.jmrit.logix.PortalManager;
 import jmri.jmrit.logix.WarrantTableAction;
 import jmri.jmrit.picker.PickListModel;
 import jmri.util.HelpUtil;
+import jmri.util.swing.JmriMouseEvent;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1433,7 +1427,7 @@ public class CircuitBuilder {
      * @param selection the selection
      * @return true
      */
-    protected boolean doMousePressed(MouseEvent event, Positionable selection) {
+    protected boolean doMousePressed(JmriMouseEvent event, Positionable selection) {
         _selection = selection;
         return true;
     }
@@ -1444,7 +1438,7 @@ public class CircuitBuilder {
      * @param event     the triggering event
      * @return true if the selection group is restored; false otherwise
      */
-    protected boolean doMousePressed(MouseEvent event) {
+    protected boolean doMousePressed(JmriMouseEvent event) {
         if (_editFrame != null) {
             _editFrame.toFront();
             _editor.setSelectionGroup(_saveSelectionGroup);
@@ -1488,7 +1482,7 @@ public class CircuitBuilder {
     }
 
     // Return true if CircuitBuilder is editing
-    protected boolean doMouseClicked(List<Positionable> selections, MouseEvent event) {
+    protected boolean doMouseClicked(List<Positionable> selections, JmriMouseEvent event) {
         if (_editFrame != null) {
             if (selections != null && selections.size() > 0) {
                 ArrayList<Positionable> tracks = new ArrayList<>();
@@ -1578,7 +1572,7 @@ public class CircuitBuilder {
      * @param event     the triggering event
      * @return true to prevent dragging; false otherwise
      */
-    public boolean doMouseDragged(Positionable selection, MouseEvent event) {
+    public boolean doMouseDragged(Positionable selection, JmriMouseEvent event) {
         if (_editFrame != null) {
             if (selection instanceof PortalIcon) {
                 if (_editFrame instanceof EditPortalFrame) {
@@ -1611,7 +1605,7 @@ public class CircuitBuilder {
      * If not there, add.
      * If there, delete.
      */
-    private void handleSelection(Positionable selection, MouseEvent event) {
+    private void handleSelection(Positionable selection, JmriMouseEvent event) {
         if (_editFrame == null) {
             return;
         }

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ResourceBundle;
+
 import javax.annotation.Nonnull;
 import javax.swing.*;
 
@@ -39,6 +40,7 @@ import jmri.jmrit.catalog.NamedIcon;
 import jmri.jmrit.display.CoordinateEdit;
 import jmri.jmrit.display.Editor;
 import jmri.jmrit.display.IndicatorTrack;
+import jmri.util.swing.JmriMouseEvent;
 import jmri.jmrit.display.LinkingObject;
 import jmri.jmrit.display.LocoIcon;
 import jmri.jmrit.display.MemoryIcon;
@@ -59,6 +61,7 @@ import jmri.jmrit.logix.WarrantTableAction;
 import jmri.util.HelpUtil;
 import jmri.util.SystemType;
 import jmri.util.gui.GuiLafPreferencesManager;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -983,7 +986,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
         super.deselectSelectionGroup();
     }
 
-    protected Positionable getCurrentSelection(MouseEvent event) {
+    protected Positionable getCurrentSelection(JmriMouseEvent event) {
         if (_pastePending && !event.isPopupTrigger() && !event.isMetaDown() && !event.isAltDown()) {
             return getCopySelection(event);
         }
@@ -1081,7 +1084,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
         return selection;
     }
 
-    private Positionable getCopySelection(MouseEvent event) {
+    private Positionable getCopySelection(JmriMouseEvent event) {
         if (_selectionGroup == null) {
             return null;
         }
@@ -1160,7 +1163,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
     private long _mouseDownTime = 0;
 
     @Override
-    public void mousePressed(MouseEvent event) {
+    public void mousePressed(JmriMouseEvent event) {
         _mouseDownTime = System.currentTimeMillis();
         setToolTip(null); // ends tooltip if displayed
         log.debug("mousePressed at ({},{}) _dragging={}", event.getX(), event.getY(), _dragging);
@@ -1202,7 +1205,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
     }
 
     @Override
-    public void mouseReleased(MouseEvent event) {
+    public void mouseReleased(JmriMouseEvent event) {
         _mouseDownTime = 0;
         setToolTip(null); // ends tooltip if displayed
         if (log.isDebugEnabled()) { // avoid string concatination if not debug
@@ -1271,7 +1274,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
     private long _clickTime;
 
     @Override
-    public void mouseClicked(MouseEvent event) {
+    public void mouseClicked(JmriMouseEvent event) {
         if (InstanceManager.getDefault(GuiLafPreferencesManager.class).isNonStandardMouseEvent()) {
             long time = System.currentTimeMillis();
             if (time - _clickTime < 20) {
@@ -1312,7 +1315,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
     }
 
     @Override
-    public void mouseDragged(MouseEvent event) {
+    public void mouseDragged(JmriMouseEvent event) {
         //if (_debug) log.debug("mouseDragged at ("+event.getX()+","+event.getY()+")");
         setToolTip(null); // ends tooltip if displayed
 
@@ -1377,7 +1380,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
     }
 
     @Override
-    public void mouseMoved(MouseEvent event) {
+    public void mouseMoved(JmriMouseEvent event) {
         //if (_debug) log.debug("mouseMoved at ("+event.getX()+","+event.getY()+")");
         if (_dragging || event.isPopupTrigger() || event.isMetaDown() || event.isAltDown()) {
             return;
@@ -1395,12 +1398,12 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
     }
 
     @Override
-    public void mouseEntered(MouseEvent event) {
+    public void mouseEntered(JmriMouseEvent event) {
         _targetPanel.repaint();
     }
 
     @Override
-    public void mouseExited(MouseEvent event) {
+    public void mouseExited(JmriMouseEvent event) {
         setToolTip(null);
         _targetPanel.repaint();  // needed for ToolTip
     }
@@ -1571,7 +1574,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
      * only to specific Positionable types.
      */
     @Override
-    protected void showPopUp(Positionable p, MouseEvent event) {
+    protected void showPopUp(Positionable p, JmriMouseEvent event) {
         if (!((JComponent) p).isVisible()) {
             return;     // component must be showing on the screen to determine its location
         }

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/DrawPolygon.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/DrawPolygon.java
@@ -5,16 +5,19 @@ import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.awt.geom.GeneralPath;
 import java.awt.geom.PathIterator;
 import java.util.ArrayList;
+
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+
 import jmri.jmrit.display.Editor;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +50,7 @@ public class DrawPolygon extends DrawFrame {
                 iter.currentSegment(coord);
                 _vertices.add(new Point(x + Math.round(coord[0]), y + Math.round(coord[1])));
                 iter.next();
-            }            
+            }
         }
         ((PositionablePolygon)_shape).editing(_editing);
         _shape.drawHandles();
@@ -71,7 +74,7 @@ public class DrawPolygon extends DrawFrame {
         return panel;
     }
 
-    // double click was made - 
+    // double click was made -
     @Override
     protected PositionableShape makeFigure(Rectangle r, Editor ed) {
 /*        Point pt = new Point(event.getX(), event.getY());
@@ -133,7 +136,7 @@ public class DrawPolygon extends DrawFrame {
         }
     }
 
-    protected void makeVertex(MouseEvent event, Editor ed) {
+    protected void makeVertex(JmriMouseEvent event, Editor ed) {
         log.debug("makeVertex point= ({}, {}), _editing= {}", event.getX(), event.getY(), _editing);
         if (!_editing) {    // creating new polygon
              Point pt = new Point(event.getX(), event.getY());
@@ -149,7 +152,7 @@ public class DrawPolygon extends DrawFrame {
         p.x += pt.x;
         p.y += pt.y;
         if (_editing) {
-            _shape.setShape(makePath(getStartPoint()));            
+            _shape.setShape(makePath(getStartPoint()));
         }
         return false;
     }
@@ -164,7 +167,7 @@ public class DrawPolygon extends DrawFrame {
             path.lineTo(_vertices.get(i).x - pt.x, _vertices.get(i).y - pt.y);
         }
 //        if (closed) {
-//            path.lineTo(_vertices.get(0).x - pt.x, _vertices.get(0).y - pt.y);            
+//            path.lineTo(_vertices.get(0).x - pt.x, _vertices.get(0).y - pt.y);
 //        }
         return path;
     }
@@ -256,7 +259,7 @@ public class DrawPolygon extends DrawFrame {
             }
             _vertices.remove(hitIndex);
             if (hitIndex > 0) {
-                _shape._hitIndex--;                
+                _shape._hitIndex--;
             }
             _shape.setShape(makePath(getStartPoint()));
             _shape.drawHandles();

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/LocoLabel.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/LocoLabel.java
@@ -3,12 +3,12 @@ package jmri.jmrit.display.controlPanelEditor.shape;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.event.MouseEvent;
 
 import javax.swing.JPopupMenu;
 
 import jmri.jmrit.display.Editor;
 import jmri.jmrit.logix.OBlock;
+import jmri.util.swing.JmriMouseEvent;
 
 public class LocoLabel extends PositionableRoundRect {
 
@@ -59,7 +59,7 @@ public class LocoLabel extends PositionableRoundRect {
     }
 
     @Override
-    protected boolean doHandleMove(MouseEvent event) {
+    protected boolean doHandleMove(JmriMouseEvent event) {
         return false;
     }
 

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionablePolygon.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionablePolygon.java
@@ -6,13 +6,15 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.awt.geom.GeneralPath;
 import java.awt.geom.PathIterator;
 import java.util.ArrayList;
+
 import javax.swing.JPopupMenu;
-import jmri.jmrit.display.Editor;
-import jmri.jmrit.display.Positionable;
+
+import jmri.jmrit.display.*;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,7 +123,7 @@ public class PositionablePolygon extends PositionableShape {
     }
 
     @Override
-    public void doMousePressed(MouseEvent event) {
+    public void doMousePressed(JmriMouseEvent event) {
         _hitIndex = -1;
         if (!_editor.isEditable()) {
             return;
@@ -152,7 +154,7 @@ public class PositionablePolygon extends PositionableShape {
     }
 
     @Override
-    protected boolean doHandleMove(MouseEvent event) {
+    protected boolean doHandleMove(JmriMouseEvent event) {
         if (_hitIndex >= 0 && _editor.isEditable()) {
             if (_editing) {
                 Point pt = new Point(event.getX() - _lastX, event.getY() - _lastY);

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionableShape.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionableShape.java
@@ -14,18 +14,20 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.PathIterator;
 import java.beans.PropertyChangeListener;
 import java.util.Optional;
+
 import javax.annotation.Nonnull;
 import javax.swing.JPopupMenu;
+
 import jmri.InstanceManager;
 import jmri.NamedBeanHandle;
 import jmri.NamedBeanHandleManager;
 import jmri.Sensor;
 import jmri.SensorManager;
-import jmri.jmrit.display.Editor;
-import jmri.jmrit.display.Positionable;
-import jmri.jmrit.display.PositionableJComponent;
+import jmri.jmrit.display.*;
 import jmri.jmrit.display.controlPanelEditor.ControlPanelEditor;
 import jmri.util.SystemType;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +58,7 @@ public abstract class PositionableShape extends PositionableJComponent implement
     protected int _height;
 
     protected DrawFrame _editFrame;
-    
+
     static final int TOP = 0;
     static final int RIGHT = 1;
     static final int BOTTOM = 2;
@@ -491,7 +493,7 @@ public abstract class PositionableShape extends PositionableJComponent implement
     }
 
     @Override
-    public void doMousePressed(MouseEvent event) {
+    public void doMousePressed(JmriMouseEvent event) {
         _hitIndex = -1;
         if (!_editor.isEditable()) {
             return;
@@ -517,7 +519,7 @@ public abstract class PositionableShape extends PositionableJComponent implement
         }
     }
 
-    protected boolean doHandleMove(MouseEvent event) {
+    protected boolean doHandleMove(JmriMouseEvent event) {
         if (_hitIndex >= 0 && _editor.isEditable()) {
             int deltaX = event.getX() - _lastX;
             int deltaY = event.getY() - _lastY;

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/ShapeDrawer.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/ShapeDrawer.java
@@ -4,12 +4,14 @@ import java.awt.Graphics;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
+
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
-import jmri.jmrit.display.Editor;
-import jmri.jmrit.display.Positionable;
+
+import jmri.jmrit.display.*;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,7 +132,7 @@ public class ShapeDrawer {
      * @param pos   the item to check
      * @return true if creating or editing; false otherwise
      */
-    public boolean doMousePressed(MouseEvent event, Positionable pos) {
+    public boolean doMousePressed(JmriMouseEvent event, Positionable pos) {
         log.debug("Mouse Pressed _drawFrame= {}, _currentSelection= {}",
                (_drawFrame==null ? "null" : _drawFrame.getTitle()),
                (_currentSelection == null ? "null" :_currentSelection.getClass().getName()));
@@ -164,7 +166,7 @@ public class ShapeDrawer {
      * creation of the PositionablePolygon, and the above actions are done at doMouseClicked
      *
      */
-    public boolean doMouseReleased(Positionable selection, MouseEvent event, Editor ed) {
+    public boolean doMouseReleased(Positionable selection, JmriMouseEvent event, Editor ed) {
         log.debug("Mouse Released _drawFrame= {}", (_drawFrame==null ? "null" : _drawFrame.getTitle()));
         if (_drawFrame != null && _drawFrame._shape == null && _drawFrame._create) {
             if (_drawFrame instanceof DrawPolygon) {
@@ -195,7 +197,7 @@ public class ShapeDrawer {
         return false;
     }
 
-    public boolean doMouseClicked(MouseEvent event, Editor ed) {
+    public boolean doMouseClicked(JmriMouseEvent event, Editor ed) {
         log.debug("Mouse Clicked _drawFrame= {}", (_drawFrame==null ? "null" : _drawFrame.getTitle()));
         if (_drawFrame != null && _drawFrame._create) {
             PositionableShape shape;
@@ -220,7 +222,7 @@ public class ShapeDrawer {
         return false;
     }
 
-    public boolean doMouseDragged(MouseEvent event) {
+    public boolean doMouseDragged(JmriMouseEvent event) {
         log.debug("Mouse Dragged _drawFrame= {}, _currentSelection= {}",
                 (_drawFrame==null ? "null" : _drawFrame.getTitle()),
                 (_currentSelection == null ? "null" :_currentSelection.getClass().getName()));
@@ -236,7 +238,7 @@ public class ShapeDrawer {
     /*
      * Make rubber band line
      */
-    public boolean doMouseMoved(MouseEvent event) {
+    public boolean doMouseMoved(JmriMouseEvent event) {
         if (_drawFrame instanceof DrawPolygon) {
             ((DrawPolygon) _drawFrame).moveTo(event.getX(), event.getY());
             return true;     // no dragging when editing

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -19,7 +19,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
@@ -39,6 +38,7 @@ import jmri.swing.NamedBeanComboBox;
 import jmri.util.*;
 import jmri.util.swing.JComboBoxUtil;
 import jmri.util.swing.JmriColorChooser;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * Provides a scrollable Layout Panel and editor toolbars (that can be hidden)
@@ -2915,14 +2915,14 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     * Side effects on xLoc, yLoc and dLoc
      */
     @Nonnull
-    private Point2D calcLocation(MouseEvent event, int dX, int dY) {
+    private Point2D calcLocation(JmriMouseEvent event, int dX, int dY) {
         xLoc = (int) ((event.getX() + dX) / getZoom());
         yLoc = (int) ((event.getY() + dY) / getZoom());
         dLoc = new Point2D.Double(xLoc, yLoc);
         return dLoc;
     }
 
-    private Point2D calcLocation(MouseEvent event) {
+    private Point2D calcLocation(JmriMouseEvent event) {
         return calcLocation(event, 0, 0);
     }
 
@@ -2932,10 +2932,10 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
      * Side-effects on _anchorX, _anchorY,_lastX, _lastY, xLoc, yLoc, dLoc,
      * selectionActive, xLabel, yLabel
      *
-     * @param event the MouseEvent
+     * @param event the JmriMouseEvent
      */
     @Override
-    public void mousePressed(MouseEvent event) {
+    public void mousePressed(JmriMouseEvent event) {
         // initialize cursor position
         _anchorX = xLoc;
         _anchorY = yLoc;
@@ -2950,7 +2950,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             leToolBarPanel.setLocationText(dLoc);
 
             if (event.isPopupTrigger()) {
-                if (isMetaDown(event) || event.isAltDown()) {
+                if (event.isMetaDown() || event.isAltDown()) {
                     // if requesting a popup and it might conflict with moving, delay the request to mouseReleased
                     delayedPopupTrigger = true;
                 } else {
@@ -2959,7 +2959,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                 }
             }
 
-            if (isMetaDown(event) || event.isAltDown()) {
+            if (event.isMetaDown() || event.isAltDown()) {
                 // if dragging an item, identify the item for mouseDragging
                 selectedObject = null;
                 selectedHitPointType = HitPointType.NONE;
@@ -3085,12 +3085,12 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                 redrawPanel();
             }
         } else if (allControlling()
-                && !isMetaDown(event) && !event.isPopupTrigger()
+                && !event.isMetaDown() && !event.isPopupTrigger()
                 && !event.isAltDown() && !event.isShiftDown() && !event.isControlDown()) {
             // not in edit mode - check if mouse is on a turnout (using wider search range)
             selectedObject = null;
             checkControls(true);
-        } else if ((isMetaDown(event) || event.isAltDown())
+        } else if ((event.isMetaDown() || event.isAltDown())
                 && !event.isShiftDown() && !event.isControlDown()) {
             // not in edit mode - check if moving a marker if there are any
             selectedObject = checkMarkerPopUps(dLoc);
@@ -3460,7 +3460,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     }
 
     @Override
-    public void mouseReleased(MouseEvent event) {
+    public void mouseReleased(JmriMouseEvent event) {
         super.setToolTip(null);
 
         // initialize mouse position
@@ -3473,7 +3473,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             leToolBarPanel.setLocationText(dLoc);
 
             // released the mouse with shift down... see what we're adding
-            if (!event.isPopupTrigger() && !isMetaDown(event) && event.isShiftDown()) {
+            if (!event.isPopupTrigger() && !event.isMetaDown() && event.isShiftDown()) {
 
                 currentPoint = new Point2D.Double(xLoc, yLoc);
 
@@ -3554,20 +3554,20 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                 whenReleased = event.getWhen();
                 showEditPopUps(event);
             } else if ((selectedObject != null) && (selectedHitPointType == HitPointType.TURNOUT_CENTER)
-                    && allControlling() && (!isMetaDown(event) && !event.isAltDown()) && !event.isPopupTrigger()
+                    && allControlling() && (!event.isMetaDown() && !event.isAltDown()) && !event.isPopupTrigger()
                     && !event.isShiftDown() && !event.isControlDown()) {
                 // controlling turnouts, in edit mode
                 LayoutTurnout t = (LayoutTurnout) selectedObject;
                 t.toggleTurnout();
             } else if ((selectedObject != null) && ((selectedHitPointType == HitPointType.SLIP_LEFT)
                     || (selectedHitPointType == HitPointType.SLIP_RIGHT))
-                    && allControlling() && (!isMetaDown(event) && !event.isAltDown()) && !event.isPopupTrigger()
+                    && allControlling() && (!event.isMetaDown() && !event.isAltDown()) && !event.isPopupTrigger()
                     && !event.isShiftDown() && !event.isControlDown()) {
                 // controlling slips, in edit mode
                 LayoutSlip sl = (LayoutSlip) selectedObject;
                 sl.toggleState(selectedHitPointType);
             } else if ((selectedObject != null) && (HitPointType.isTurntableRayHitType(selectedHitPointType))
-                    && allControlling() && (!isMetaDown(event) && !event.isAltDown()) && !event.isPopupTrigger()
+                    && allControlling() && (!event.isMetaDown() && !event.isAltDown()) && !event.isPopupTrigger()
                     && !event.isShiftDown() && !event.isControlDown()) {
                 // controlling turntable, in edit mode
                 LayoutTurntable t = (LayoutTurntable) selectedObject;
@@ -3576,12 +3576,12 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                     || (selectedHitPointType == HitPointType.SLIP_CENTER)
                     || (selectedHitPointType == HitPointType.SLIP_LEFT)
                     || (selectedHitPointType == HitPointType.SLIP_RIGHT))
-                    && allControlling() && (isMetaDown(event) && !event.isAltDown())
+                    && allControlling() && (event.isMetaDown() && !event.isAltDown())
                     && !event.isShiftDown() && !event.isControlDown() && isDragging) {
                 // We just dropped a turnout (or slip)... see if it will connect to anything
                 hitPointCheckLayoutTurnouts((LayoutTurnout) selectedObject);
             } else if ((selectedObject != null) && (selectedHitPointType == HitPointType.POS_POINT)
-                    && allControlling() && (isMetaDown(event))
+                    && allControlling() && (event.isMetaDown())
                     && !event.isShiftDown() && !event.isControlDown() && isDragging) {
                 // We just dropped a PositionablePoint... see if it will connect to anything
                 PositionablePoint p = (PositionablePoint) selectedObject;
@@ -3600,7 +3600,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             }
             createSelectionGroups();
         } else if ((selectedObject != null) && (selectedHitPointType == HitPointType.TURNOUT_CENTER)
-                && allControlling() && !isMetaDown(event) && !event.isAltDown() && !event.isPopupTrigger()
+                && allControlling() && !event.isMetaDown() && !event.isAltDown() && !event.isPopupTrigger()
                 && !event.isShiftDown() && (!delayedPopupTrigger)) {
             // controlling turnout out of edit mode
             LayoutTurnout t = (LayoutTurnout) selectedObject;
@@ -3611,13 +3611,13 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
             }
         } else if ((selectedObject != null) && ((selectedHitPointType == HitPointType.SLIP_LEFT)
                 || (selectedHitPointType == HitPointType.SLIP_RIGHT))
-                && allControlling() && !isMetaDown(event) && !event.isAltDown() && !event.isPopupTrigger()
+                && allControlling() && !event.isMetaDown() && !event.isAltDown() && !event.isPopupTrigger()
                 && !event.isShiftDown() && (!delayedPopupTrigger)) {
             // controlling slip out of edit mode
             LayoutSlip sl = (LayoutSlip) selectedObject;
             sl.toggleState(selectedHitPointType);
         } else if ((selectedObject != null) && (HitPointType.isTurntableRayHitType(selectedHitPointType))
-                && allControlling() && !isMetaDown(event) && !event.isAltDown() && !event.isPopupTrigger()
+                && allControlling() && !event.isMetaDown() && !event.isAltDown() && !event.isPopupTrigger()
                 && !event.isShiftDown() && (!delayedPopupTrigger)) {
             // controlling turntable out of edit mode
             LayoutTurntable t = (LayoutTurntable) selectedObject;
@@ -3707,7 +3707,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         requestFocusInWindow();
     }   // mouseReleased
 
-    private void showEditPopUps(@Nonnull MouseEvent event) {
+    private void showEditPopUps(@Nonnull JmriMouseEvent event) {
         if (findLayoutTracksHitPoint(dLoc)) {
             if (HitPointType.isBezierHitType(foundHitPointType)) {
                 getTrackSegmentView((TrackSegment) foundTrack).showBezierPopUp(event, foundHitPointType);
@@ -3793,7 +3793,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
      * Select the menu items to display for the Positionable's popup.
      */
     @Override
-    public void showPopUp(@Nonnull Positionable p, @Nonnull MouseEvent event) {
+    public void showPopUp(@Nonnull Positionable p, @Nonnull JmriMouseEvent event) {
         assert p != null;
 
         if (!((Component) p).isVisible()) {
@@ -3891,14 +3891,14 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     private boolean awaitingIconChange = false;
 
     @Override
-    public void mouseClicked(@Nonnull MouseEvent event) {
+    public void mouseClicked(@Nonnull JmriMouseEvent event) {
         // initialize mouse position
         calcLocation(event);
 
         // if alt modifier is down invert the snap to grid behaviour
         snapToGridInvert = event.isAltDown();
 
-        if (!isMetaDown(event) && !event.isPopupTrigger() && !event.isAltDown()
+        if (!event.isMetaDown() && !event.isPopupTrigger() && !event.isAltDown()
                 && !awaitingIconChange && !event.isShiftDown() && !event.isControlDown()) {
             List<Positionable> selections = getSelectedItems(event);
 
@@ -4659,7 +4659,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     int _prevNumSel = 0;
 
     @Override
-    public void mouseMoved(@Nonnull MouseEvent event) {
+    public void mouseMoved(@Nonnull JmriMouseEvent event) {
         // initialize mouse position
         calcLocation(event);
 
@@ -4705,7 +4705,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     private boolean isDragging = false;
 
     @Override
-    public void mouseDragged(@Nonnull MouseEvent event) {
+    public void mouseDragged(@Nonnull JmriMouseEvent event) {
         // initialize mouse position
         calcLocation(event);
 
@@ -4725,7 +4725,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         // don't allow negative placement, objects could become unreachable
         currentPoint = MathUtil.max(currentPoint, MathUtil.zeroPoint2D);
 
-        if ((selectedObject != null) && (isMetaDown(event) || event.isAltDown())
+        if ((selectedObject != null) && (event.isMetaDown() || event.isAltDown())
                 && (selectedHitPointType == HitPointType.MARKER)) {
             // marker moves regardless of editMode or positionable
             PositionableLabel pl = (PositionableLabel) selectedObject;
@@ -4736,7 +4736,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
         }
 
         if (isEditable()) {
-            if ((selectedObject != null) && isMetaDown(event) && allPositionable()) {
+            if ((selectedObject != null) && event.isMetaDown() && allPositionable()) {
                 if (snapToGridOnMove != snapToGridInvert) {
                     // this snaps currentPoint to the grid
                     currentPoint = MathUtil.granulize(currentPoint, gContext.getGridSize());
@@ -4920,7 +4920,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
                     && leToolBarPanel.shapeButton.isSelected() && (selectedObject != null)) {
                 // dragging from end of shape
                 currentLocation = new Point2D.Double(xLoc, yLoc);
-            } else if (selectionActive && !event.isShiftDown() && !isMetaDown(event)) {
+            } else if (selectionActive && !event.isShiftDown() && !event.isMetaDown()) {
                 selectionWidth = xLoc - selectionX;
                 selectionHeight = yLoc - selectionY;
             }
@@ -4932,7 +4932,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     }   // mouseDragged
 
     @Override
-    public void mouseEntered(@Nonnull MouseEvent event) {
+    public void mouseEntered(@Nonnull JmriMouseEvent event) {
         _targetPanel.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
     }
 
@@ -8205,7 +8205,7 @@ final public class LayoutEditor extends PanelEditor implements MouseWheelListene
     @Override
     public void showToolTip(
             @Nonnull Positionable selection,
-            @Nonnull MouseEvent event) {
+            @Nonnull JmriMouseEvent event) {
         ToolTip tip = selection.getToolTip();
         tip.setLocation(selection.getX() + selection.getWidth() / 2, selection.getY() + selection.getHeight());
         setToolTip(tip);

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
@@ -4,17 +4,19 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.GeneralPath;
 import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.*;
+
 import javax.annotation.*;
 import javax.swing.*;
+
 import jmri.util.*;
 import jmri.util.swing.JmriColorChooser;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * A LayoutShape is a set of LayoutShapePoint used to draw a shape. Each point
@@ -417,7 +419,7 @@ public class LayoutShape {
     private JPopupMenu popup = null;
 
     @Nonnull
-    protected JPopupMenu showShapePopUp(@CheckForNull MouseEvent mouseEvent, HitPointType hitPointType) {
+    protected JPopupMenu showShapePopUp(@CheckForNull JmriMouseEvent mouseEvent, HitPointType hitPointType) {
         if (popup != null) {
             popup.removeAll();
         } else {
@@ -818,7 +820,7 @@ public class LayoutShape {
      * enum LayoutShapeType
      */
     public enum LayoutShapeType {
-        Open, 
+        Open,
         Closed,
         Filled;
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutSlipView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutSlipView.java
@@ -3,7 +3,6 @@ package jmri.jmrit.display.layoutEditor;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.awt.geom.*;
 import java.util.List;
 
@@ -16,6 +15,7 @@ import jmri.Turnout;
 import jmri.jmrit.display.layoutEditor.LayoutTurnout.TurnoutType;
 import jmri.jmrit.display.layoutEditor.blockRoutingTable.LayoutBlockRouteTableAction;
 import jmri.util.MathUtil;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * MVC View component for the LayoutSlip class.
@@ -352,7 +352,7 @@ public class LayoutSlipView extends LayoutTurnoutView {
      */
     @Override
     @Nonnull
-    protected JPopupMenu showPopup(@CheckForNull MouseEvent mouseEvent) {
+    protected JPopupMenu showPopup(@CheckForNull JmriMouseEvent mouseEvent) {
         if (popup != null) {
             popup.removeAll();
         } else {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTrackView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTrackView.java
@@ -13,6 +13,7 @@ import javax.swing.*;
 import jmri.JmriException;
 import jmri.Turnout;
 import jmri.util.*;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * MVC View component abstract base for the LayoutTrack hierarchy.
@@ -461,7 +462,7 @@ abstract public class LayoutTrackView {
      * @return the popup menu for this layout track
      */
     @Nonnull
-    abstract protected JPopupMenu showPopup(@Nonnull MouseEvent mouseEvent);
+    abstract protected JPopupMenu showPopup(@Nonnull JmriMouseEvent mouseEvent);
 
     /**
      * show the popup menu for this layout track
@@ -471,14 +472,15 @@ abstract public class LayoutTrackView {
      */
     @Nonnull
     final protected JPopupMenu showPopup(Point2D where) {
-        return this.showPopup(new MouseEvent(
-                layoutEditor.getTargetPanel(), // source
-                MouseEvent.MOUSE_CLICKED, // id
-                System.currentTimeMillis(), // when
-                0, // modifiers
-                (int) where.getX(), (int) where.getY(), // where
-                0, // click count
-                true));                         // popup trigger
+        return this.showPopup(new JmriMouseEvent(
+                new MouseEvent(
+                        layoutEditor.getTargetPanel(), // source
+                        MouseEvent.MOUSE_CLICKED, // id
+                        System.currentTimeMillis(), // when
+                        0, // modifiers
+                        (int) where.getX(), (int) where.getY(), // where
+                        0, // click count
+                        true)));                         // popup trigger
 
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnoutView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnoutView.java
@@ -3,7 +3,6 @@ package jmri.jmrit.display.layoutEditor;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.awt.geom.*;
 import static java.lang.Float.POSITIVE_INFINITY;
 import java.util.*;
@@ -18,6 +17,7 @@ import jmri.jmrit.display.layoutEditor.LayoutTurnout.LinkType;
 import jmri.jmrit.display.layoutEditor.LayoutTurnout.TurnoutType;
 import jmri.jmrit.display.layoutEditor.blockRoutingTable.LayoutBlockRouteTableAction;
 import jmri.util.MathUtil;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * MVC View component for the LayoutTurnout class.
@@ -1544,7 +1544,7 @@ public class LayoutTurnoutView extends LayoutTrackView {
      */
     @Override
     @Nonnull
-    protected JPopupMenu showPopup(@CheckForNull MouseEvent mouseEvent) {
+    protected JPopupMenu showPopup(@CheckForNull JmriMouseEvent mouseEvent) {
         if (popup != null) {
             popup.removeAll();
         } else {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntableView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntableView.java
@@ -2,7 +2,6 @@ package jmri.jmrit.display.layoutEditor;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.awt.geom.*;
 import static java.lang.Float.POSITIVE_INFINITY;
 import java.text.MessageFormat;
@@ -16,6 +15,7 @@ import javax.swing.*;
 import jmri.*;
 import jmri.jmrit.display.layoutEditor.LayoutTurntable.RayTrack;
 import jmri.util.MathUtil;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * MVC View component for the LayoutTurntable class.
@@ -586,7 +586,7 @@ public class LayoutTurntableView extends LayoutTrackView {
      */
     @Override
     @Nonnull
-    protected JPopupMenu showPopup(@Nonnull MouseEvent mouseEvent) {
+    protected JPopupMenu showPopup(@Nonnull JmriMouseEvent mouseEvent) {
         if (popupMenu != null) {
             popupMenu.removeAll();
         } else {
@@ -649,7 +649,7 @@ public class LayoutTurntableView extends LayoutTrackView {
 
     private JPopupMenu rayPopup = null;
 
-    protected void showRayPopUp(MouseEvent e, int index) {
+    protected void showRayPopUp(JmriMouseEvent e, int index) {
         if (rayPopup != null) {
             rayPopup.removeAll();
         } else {

--- a/java/src/jmri/jmrit/display/layoutEditor/LevelXingView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LevelXingView.java
@@ -3,7 +3,6 @@ package jmri.jmrit.display.layoutEditor;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.awt.geom.*;
 import static java.lang.Float.POSITIVE_INFINITY;
 import static java.lang.Math.PI;
@@ -17,12 +16,13 @@ import jmri.*;
 import jmri.jmrit.display.layoutEditor.LevelXing.Geometry;
 import jmri.jmrit.display.layoutEditor.blockRoutingTable.LayoutBlockRouteTableAction;
 import jmri.util.MathUtil;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * MVC View component for the LevelXing class
  *
  * @author Bob Jacobsen  Copyright (c) 2020
- * 
+ *
  */
 public class LevelXingView extends LayoutTrackView {
 
@@ -37,7 +37,7 @@ public class LevelXingView extends LayoutTrackView {
         this.xing = xing;
         editor = new jmri.jmrit.display.layoutEditor.LayoutEditorDialogs.LevelXingEditor(layoutEditor);
     }
-        
+
     /**
      * constructor method
      * @param xing the level crossing.
@@ -62,7 +62,7 @@ public class LevelXingView extends LayoutTrackView {
     // temporary?
     @Nonnull
     public LevelXing getLevelXing() { return xing; }
-    
+
     // this should only be used for debugging
     @Override
     public String toString() {
@@ -368,7 +368,7 @@ public class LevelXingView extends LayoutTrackView {
 //             } else {
 //                 namedLayoutBlockAC = null;
 //             }
-// 
+//
 //             // decrement use if block was previously counted
 //             if ((blockAC != null) && (blockAC == blockBD)) {
 //                 blockAC.decrementUse();
@@ -396,9 +396,9 @@ public class LevelXingView extends LayoutTrackView {
 //                 blockBD.decrementUse();
 //             }
 //         }
-// 
+//
 //     }
-// 
+//
 //     public void updateBlockInfo() {
 //         LayoutBlock blockAC = getLayoutBlockAC();
 //         LayoutBlock blockBD = getLayoutBlockBD();
@@ -436,7 +436,7 @@ public class LevelXingView extends LayoutTrackView {
 //         }
 //         reCheckBlockBoundary();
 //     }
-// 
+//
 //     void removeSML(SignalMast signalMast) {
 //         if (signalMast == null) {
 //             return;
@@ -599,7 +599,7 @@ public class LevelXingView extends LayoutTrackView {
 //     public String connectBName = "";
 //     public String connectCName = "";
 //     public String connectDName = "";
-// 
+//
 //     public String tLayoutBlockNameAC = "";
 //     public String tLayoutBlockNameBD = "";
 
@@ -674,7 +674,7 @@ public class LevelXingView extends LayoutTrackView {
      */
     @Override
     @Nonnull
-    protected JPopupMenu showPopup(@CheckForNull MouseEvent mouseEvent) {
+    protected JPopupMenu showPopup(@CheckForNull JmriMouseEvent mouseEvent) {
         if (popup != null) {
             popup.removeAll();
         } else {
@@ -894,13 +894,13 @@ public class LevelXingView extends LayoutTrackView {
 
 //     public String[] getBlockBoundaries() {
 //         final String[] boundaryBetween = new String[4];
-// 
+//
 //         String blockNameAC = getBlockNameAC();
 //         String blockNameBD = getBlockNameBD();
-// 
+//
 //         LayoutBlock blockAC = getLayoutBlockAC();
 //         LayoutBlock blockBD = getLayoutBlockAC();
-// 
+//
 //         if (!blockNameAC.isEmpty() && (blockAC != null)) {
 //             if ((connectA instanceof TrackSegment) && (((TrackSegment) connectA).getLayoutBlock() != blockAC)) {
 //                 try {
@@ -958,9 +958,9 @@ public class LevelXingView extends LayoutTrackView {
 //         // remove from persistance by flagging inactive
 //         active = false;
 //     }
-// 
+//
 //     boolean active = true;
-// 
+//
 //     *
 //      * "active" means that the object is still displayed, and should be stored.
 //      */
@@ -969,7 +969,7 @@ public class LevelXingView extends LayoutTrackView {
 //     }
 
 //     ArrayList<SignalMast> sml = new ArrayList<>();
-// 
+//
 //     public void addSignalMastLogic(SignalMast sm) {
 //         if (sml.contains(sm)) {
 //             return;
@@ -988,7 +988,7 @@ public class LevelXingView extends LayoutTrackView {
 //         }
 //         sml.add(sm);
 //     }
-// 
+//
 //     public void removeSignalMastLogic(SignalMast sm) {
 //         if (!sml.contains(sm)) {
 //             return;
@@ -1042,7 +1042,7 @@ public class LevelXingView extends LayoutTrackView {
 
     /**
      * Draw track decorations.
-     * 
+     *
      * This type of track has none, so this method is empty.
      */
     @Override
@@ -1241,22 +1241,22 @@ public class LevelXingView extends LayoutTrackView {
      public List<HitPointType> checkForFreeConnections() {
         throw new IllegalArgumentException("should have called Object instead of view temporary");
 //         List<HitPointType> result = new ArrayList<>();
-// 
+//
 //         //check the A connection point
 //         if (getConnectA() == null) {
 //             result.add(HitPointType.LEVEL_XING_A);
 //         }
-// 
+//
 //         //check the B connection point
 //         if (getConnectB() == null) {
 //             result.add(HitPointType.LEVEL_XING_B);
 //         }
-// 
+//
 //         //check the C connection point
 //         if (getConnectC() == null) {
 //             result.add(HitPointType.LEVEL_XING_C);
 //         }
-// 
+//
 //         //check the D connection point
 //         if (getConnectD() == null) {
 //             result.add(HitPointType.LEVEL_XING_D);
@@ -1309,13 +1309,13 @@ public class LevelXingView extends LayoutTrackView {
 //         if ((getLayoutBlockBD() != null) && (connectD != null)) {
 //             blocksAndTracksMap.put(connectD, getLayoutBlockBD().getDisplayName());
 //         }
-// 
+//
 //         List<Set<String>> TrackNameSets = null;
 //         Set<String> TrackNameSet = null;
 //         for (Map.Entry<LayoutTrack, String> entry : blocksAndTracksMap.entrySet()) {
 //             LayoutTrack theConnect = entry.getKey();
 //             String theBlockName = entry.getValue();
-// 
+//
 //             TrackNameSet = null;    // assume not found (pessimist!)
 //             TrackNameSets = blockNamesToTrackNameSetsMap.get(theBlockName);
 //             if (TrackNameSets != null) { // (#1)

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePointView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePointView.java
@@ -18,6 +18,7 @@ import jmri.jmrit.signalling.SignallingGuiTools;
 import jmri.util.*;
 import jmri.util.swing.JCBHandle;
 import jmri.util.swing.JmriColorChooser;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * MVC View component for the PositionablePoint class.
@@ -727,20 +728,20 @@ public class PositionablePointView extends LayoutTrackView {
         yClick = e.getY();
         // if (debug) log.debug("Pressed: "+where(e));
         if (e.isPopupTrigger()) {
-            showPopup(e);
+            showPopup(new JmriMouseEvent(e));
         }
     }
 
     public void mouseReleased(MouseEvent e) {
         // if (debug) log.debug("Release: "+where(e));
         if (e.isPopupTrigger()) {
-            showPopup(e);
+            showPopup(new JmriMouseEvent(e));
         }
     }
 
     public void mouseClicked(MouseEvent e) {
         if (e.isPopupTrigger()) {
-            showPopup(e);
+            showPopup(new JmriMouseEvent(e));
         }
     }
 
@@ -751,7 +752,7 @@ public class PositionablePointView extends LayoutTrackView {
      */
     @Override
     @Nonnull
-    protected JPopupMenu showPopup(@Nonnull MouseEvent mouseEvent) {
+    protected JPopupMenu showPopup(@Nonnull JmriMouseEvent mouseEvent) {
         if (popup != null) {
             popup.removeAll();
         } else {

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegmentView.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegmentView.java
@@ -2,7 +2,6 @@ package jmri.jmrit.display.layoutEditor;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.awt.geom.*;
 import java.util.List;
 import java.util.*;
@@ -15,6 +14,7 @@ import javax.swing.*;
 import jmri.jmrit.display.layoutEditor.blockRoutingTable.LayoutBlockRouteTableAction;
 import jmri.util.*;
 import jmri.util.swing.JmriColorChooser;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * MVC View component for the TrackSegment class.
@@ -653,7 +653,7 @@ public class TrackSegmentView extends LayoutTrackView {
      */
     @Override
     @Nonnull
-    protected JPopupMenu showPopup(@Nonnull MouseEvent mouseEvent) {
+    protected JPopupMenu showPopup(@Nonnull JmriMouseEvent mouseEvent) {
         if (popupMenu != null) {
             popupMenu.removeAll();
         } else {
@@ -1587,7 +1587,7 @@ public class TrackSegmentView extends LayoutTrackView {
      * @param e            The original event causing this
      * @param hitPointType the type of the underlying hit
      */
-    protected void showBezierPopUp(MouseEvent e, HitPointType hitPointType) {
+    protected void showBezierPopUp(JmriMouseEvent e, HitPointType hitPointType) {
         int bezierControlPointIndex = hitPointType.bezierPointIndex();
         if (popupMenu != null) {
             popupMenu.removeAll();

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -13,13 +13,13 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
-import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+
 import javax.swing.AbstractAction;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -37,7 +37,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JTextField;
-import javax.swing.SwingUtilities;
+
 import jmri.CatalogTreeManager;
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
@@ -46,13 +46,14 @@ import jmri.configurexml.XmlAdapter;
 import jmri.jmrit.catalog.ImageIndexEditor;
 import jmri.jmrit.display.Editor;
 import jmri.jmrit.display.EditorManager;
+import jmri.util.swing.JmriMouseEvent;
 import jmri.jmrit.display.Positionable;
 import jmri.jmrit.display.PositionablePopupUtil;
 import jmri.jmrit.display.ToolTip;
 import jmri.util.JmriJFrame;
-import jmri.util.SystemType;
 import jmri.util.gui.GuiLafPreferencesManager;
 import jmri.util.swing.JmriColorChooser;
+
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -587,7 +588,7 @@ public class PanelEditor extends Editor implements ItemListener {
      * only to specific Positionable types.
      */
     @Override
-    protected void showPopUp(Positionable p, MouseEvent event) {
+    protected void showPopUp(Positionable p, JmriMouseEvent event) {
         if (!((JComponent) p).isVisible()) {
             return;     // component must be showing on the screen to determine its location
         }
@@ -660,7 +661,7 @@ public class PanelEditor extends Editor implements ItemListener {
     private boolean delayedPopupTrigger;
 
     @Override
-    public void mousePressed(MouseEvent event) {
+    public void mousePressed(JmriMouseEvent event) {
         setToolTip(null); // ends tooltip if displayed
         if (log.isDebugEnabled()) {
             log.debug("mousePressed at ({},{}) _dragging= {}", event.getX(), event.getY(), _dragging);
@@ -681,7 +682,7 @@ public class PanelEditor extends Editor implements ItemListener {
             }
             if (event.isPopupTrigger()) {
                 log.debug("mousePressed calls showPopUp");
-                if (isMetaDown(event) || event.isAltDown()) {
+                if (event.isMetaDown() || event.isAltDown()) {
                     // if requesting a popup and it might conflict with moving, delay the request to mouseReleased
                     delayedPopupTrigger = true;
                 } else {
@@ -702,7 +703,7 @@ public class PanelEditor extends Editor implements ItemListener {
             }
         } else {
             if (event.isPopupTrigger()) {
-                if (isMetaDown(event) || event.isAltDown()) {
+                if (event.isMetaDown() || event.isAltDown()) {
                     // if requesting a popup and it might conflict with moving, delay the request to mouseReleased
                     delayedPopupTrigger = true;
                 } else {
@@ -720,7 +721,7 @@ public class PanelEditor extends Editor implements ItemListener {
             }
         }
         // if ((event.isControlDown() || _selectionGroup!=null) && _currentSelection!=null){
-        if ((event.isControlDown()) || isMetaDown(event) || event.isAltDown()) {
+        if ((event.isControlDown()) || event.isMetaDown() || event.isAltDown()) {
             //Don't want to do anything, just want to catch it, so that the next two else ifs are not
             //executed
         } else if ((_currentSelection == null && _multiItemCopyGroup == null)
@@ -735,7 +736,7 @@ public class PanelEditor extends Editor implements ItemListener {
     }
 
     @Override
-    public void mouseReleased(MouseEvent event) {
+    public void mouseReleased(JmriMouseEvent event) {
         setToolTip(null); // ends tooltip if displayed
         if (log.isDebugEnabled()) {
             // in if statement to avoid inline conditional unless logging
@@ -801,9 +802,9 @@ public class PanelEditor extends Editor implements ItemListener {
     }
 
     @Override
-    public void mouseDragged(MouseEvent event) {
+    public void mouseDragged(JmriMouseEvent event) {
         setToolTip(null); // ends tooltip if displayed
-        if ((event.isPopupTrigger()) || (!isMetaDown(event) && !event.isAltDown())) {
+        if ((event.isPopupTrigger()) || (!event.isMetaDown() && !event.isAltDown())) {
             if (_currentSelection != null) {
                 List<Positionable> selections = getSelectedItems(event);
                 if (selections.size() > 0) {
@@ -855,7 +856,7 @@ public class PanelEditor extends Editor implements ItemListener {
     }
 
     @Override
-    public void mouseMoved(MouseEvent event) {
+    public void mouseMoved(JmriMouseEvent event) {
         // log.debug("mouseMoved at ({},{})", event.getX(), event.getY());
         if (_dragging || event.isPopupTrigger()) {
             return;
@@ -889,7 +890,7 @@ public class PanelEditor extends Editor implements ItemListener {
     }
 
     @Override
-    public void mouseClicked(MouseEvent event) {
+    public void mouseClicked(JmriMouseEvent event) {
         setToolTip(null); // ends tooltip if displayed
         if (log.isDebugEnabled()) {
             log.debug("mouseClicked at ({},{}) dragging= {} selectRect is {}",
@@ -933,11 +934,11 @@ public class PanelEditor extends Editor implements ItemListener {
     }
 
     @Override
-    public void mouseEntered(MouseEvent event) {
+    public void mouseEntered(JmriMouseEvent event) {
     }
 
     @Override
-    public void mouseExited(MouseEvent event) {
+    public void mouseExited(JmriMouseEvent event) {
         setToolTip(null);
         _targetPanel.repaint();  // needed for ToolTip
     }
@@ -950,7 +951,7 @@ public class PanelEditor extends Editor implements ItemListener {
         _multiItemCopyGroup.add(p);
     }
 
-    protected void pasteItemPopUp(final MouseEvent event) {
+    protected void pasteItemPopUp(final JmriMouseEvent event) {
         if (!isEditable()) {
             return;
         }
@@ -966,7 +967,7 @@ public class PanelEditor extends Editor implements ItemListener {
         popup.show(event.getComponent(), event.getX(), event.getY());
     }
 
-    protected void backgroundPopUp(MouseEvent event) {
+    protected void backgroundPopUp(JmriMouseEvent event) {
         if (!isEditable()) {
             return;
         }
@@ -976,7 +977,7 @@ public class PanelEditor extends Editor implements ItemListener {
         popup.show(event.getComponent(), event.getX(), event.getY());
     }
 
-    protected void showMultiSelectPopUp(final MouseEvent event, Positionable p) {
+    protected void showMultiSelectPopUp(final JmriMouseEvent event, Positionable p) {
         JPopupMenu popup = new JPopupMenu();
         JMenuItem copy = new JMenuItem(Bundle.getMessage("MenuItemCopy")); // changed "edit" to "copy"
         if (p.isPositionable()) {
@@ -999,7 +1000,7 @@ public class PanelEditor extends Editor implements ItemListener {
         popup.show(event.getComponent(), event.getX(), event.getY());
     }
 
-    protected void showAddItemPopUp(final MouseEvent event, JPopupMenu popup) {
+    protected void showAddItemPopUp(final JmriMouseEvent event, JPopupMenu popup) {
         if (!isEditable()) {
             return;
         }
@@ -1086,7 +1087,7 @@ public class PanelEditor extends Editor implements ItemListener {
 
     protected boolean pasteItemFlag = false;
 
-    protected void pasteItem(MouseEvent e) {
+    protected void pasteItem(JmriMouseEvent e) {
         pasteItemFlag = true;
         XmlAdapter adapter;
         String className;
@@ -1243,19 +1244,6 @@ public class PanelEditor extends Editor implements ItemListener {
            }
         });
         popup.add(edit);
-    }
-
-    // The meta key was until Java 8 the right mouse button on Windows.
-    // On Java 9 on Windows 10, there is no more meta key. Note that this
-    // method is called both on mouse button events and mouse move events,
-    // and therefore "event.getButton() == MouseEvent.BUTTON3" doesn't work.
-    // event.getButton() always return 0 for MouseMoveEvent.
-    protected boolean isMetaDown(MouseEvent event) {
-        if (SystemType.isWindows() || SystemType.isLinux()) {
-            return SwingUtilities.isRightMouseButton(event);
-        } else {
-            return event.isMetaDown();
-        }
     }
 
     private final static Logger log = LoggerFactory.getLogger(PanelEditor.class);

--- a/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
@@ -4,12 +4,14 @@ import java.awt.*;
 import java.awt.event.*;
 import java.util.*;
 import java.util.List;
+
 import javax.annotation.Nonnull;
 //import javax.annotation.concurrent.GuardedBy;
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
 
 //import com.alexandriasoftware.swing.Validation;
+
 import jmri.*;
 import jmri.jmrit.display.CoordinateEdit;
 import jmri.jmrit.display.Editor;
@@ -21,6 +23,8 @@ import jmri.swing.ManagerComboBox;
 import jmri.util.ColorUtil;
 import jmri.util.JmriJFrame;
 import jmri.util.swing.JmriColorChooser;
+import jmri.util.swing.JmriMouseEvent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1633,32 +1637,32 @@ public class SwitchboardEditor extends Editor {
     }
 
     @Override
-    public void mousePressed(MouseEvent event) {
+    public void mousePressed(JmriMouseEvent event) {
     }
 
     @Override
-    public void mouseReleased(MouseEvent event) {
+    public void mouseReleased(JmriMouseEvent event) {
     }
 
     @Override
-    public void mouseClicked(MouseEvent event) {
+    public void mouseClicked(JmriMouseEvent event) {
     }
 
     @Override
-    public void mouseDragged(MouseEvent event) {
+    public void mouseDragged(JmriMouseEvent event) {
     }
 
     @Override
-    public void mouseMoved(MouseEvent event) {
+    public void mouseMoved(JmriMouseEvent event) {
     }
 
     @Override
-    public void mouseEntered(MouseEvent event) {
+    public void mouseEntered(JmriMouseEvent event) {
         _targetPanel.repaint();
     }
 
     @Override
-    public void mouseExited(MouseEvent event) {
+    public void mouseExited(JmriMouseEvent event) {
         setToolTip(null);
         _targetPanel.repaint(); // needed for ToolTip on targetPane
     }
@@ -1805,7 +1809,7 @@ public class SwitchboardEditor extends Editor {
      * @param event MouseEvent heard
      */
     @Override
-    protected void showPopUp(Positionable p, MouseEvent event) {
+    protected void showPopUp(Positionable p, JmriMouseEvent event) {
     }
 
     protected ArrayList<Positionable> getSelectionGroup() {

--- a/java/src/jmri/jmrit/operations/trains/TrainIcon.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainIcon.java
@@ -2,7 +2,6 @@ package jmri.jmrit.operations.trains;
 
 import java.awt.Point;
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.text.MessageFormat;
 import java.util.List;
 
@@ -15,14 +14,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jmri.InstanceManager;
-import jmri.jmrit.display.Editor;
-import jmri.jmrit.display.LocoIcon;
+import jmri.jmrit.display.*;
 import jmri.jmrit.operations.rollingstock.cars.Car;
 import jmri.jmrit.operations.rollingstock.cars.CarManager;
 import jmri.jmrit.operations.routes.Route;
 import jmri.jmrit.operations.routes.RouteLocation;
+import jmri.jmrit.operations.trains.Bundle;
 import jmri.jmrit.operations.trains.tools.ShowCarsInTrainAction;
 import jmri.jmrit.throttle.ThrottleFrameManager;
+import jmri.util.swing.JmriMouseEvent;
 
 /**
  * An icon that displays the position of a train icon on a panel.
@@ -232,7 +232,7 @@ public class TrainIcon extends LocoIcon {
      * route.
      */
     @Override
-    public void doMouseDragged(MouseEvent event) {
+    public void doMouseDragged(JmriMouseEvent event) {
         log.debug("Mouse dragged, X={} Y={}", getX(), getY());
         if (_train != null) {
             RouteLocation next = _train.getNextRouteLocation(_train.getCurrentRouteLocation());

--- a/java/src/jmri/util/swing/JmriMouseEvent.java
+++ b/java/src/jmri/util/swing/JmriMouseEvent.java
@@ -1,0 +1,380 @@
+package jmri.util.swing;
+
+import java.awt.Component;
+import java.awt.Point;
+import java.awt.event.MouseEvent;
+
+import javax.swing.SwingUtilities;
+
+import jmri.util.SystemType;
+
+/**
+ * Adaptor for MouseEvent.
+ * This class is used to fix some issues with MouseEvent on Windows.
+ *
+ * @author Daniel Bergqvist (C) 2022
+ */
+public class JmriMouseEvent {
+
+    private final MouseEvent event;
+
+    public JmriMouseEvent(MouseEvent event) {
+        this.event = event;
+    }
+
+    /**
+     * Returns the absolute x, y position of the event.
+     * In a virtual device multi-screen environment in which the
+     * desktop area could span multiple physical screen devices,
+     * these coordinates are relative to the virtual coordinate system.
+     * Otherwise, these coordinates are relative to the coordinate system
+     * associated with the Component's GraphicsConfiguration.
+     *
+     * @return a {@code Point} object containing the absolute  x
+     *  and y coordinates.
+     *
+     * @see java.awt.GraphicsConfiguration
+     * @since 1.6
+     */
+    public Point getLocationOnScreen(){
+        return event.getLocationOnScreen();
+    }
+
+    /**
+     * Returns the absolute horizontal x position of the event.
+     * In a virtual device multi-screen environment in which the
+     * desktop area could span multiple physical screen devices,
+     * this coordinate is relative to the virtual coordinate system.
+     * Otherwise, this coordinate is relative to the coordinate system
+     * associated with the Component's GraphicsConfiguration.
+     *
+     * @return x  an integer indicating absolute horizontal position.
+     *
+     * @see java.awt.GraphicsConfiguration
+     * @since 1.6
+     */
+    public int getXOnScreen() {
+        return event.getXOnScreen();
+    }
+
+    /**
+     * Returns the absolute vertical y position of the event.
+     * In a virtual device multi-screen environment in which the
+     * desktop area could span multiple physical screen devices,
+     * this coordinate is relative to the virtual coordinate system.
+     * Otherwise, this coordinate is relative to the coordinate system
+     * associated with the Component's GraphicsConfiguration.
+     *
+     * @return y  an integer indicating absolute vertical position.
+     *
+     * @see java.awt.GraphicsConfiguration
+     * @since 1.6
+     */
+    public int getYOnScreen() {
+        return event.getYOnScreen();
+    }
+
+    /**
+     * Returns the horizontal x position of the event relative to the
+     * source component.
+     *
+     * @return x  an integer indicating horizontal position relative to
+     *            the component
+     */
+    public int getX() {
+        return event.getX();
+    }
+
+    /**
+     * Returns the vertical y position of the event relative to the
+     * source component.
+     *
+     * @return y  an integer indicating vertical position relative to
+     *            the component
+     */
+    public int getY() {
+        return event.getY();
+    }
+
+    /**
+     * Returns the x,y position of the event relative to the source component.
+     *
+     * @return a {@code Point} object containing the x and y coordinates
+     *         relative to the source component
+     *
+     */
+    public Point getPoint() {
+        return event.getPoint();
+    }
+
+    /**
+     * Translates the event's coordinates to a new position
+     * by adding specified {@code x} (horizontal) and {@code y}
+     * (vertical) offsets.
+     *
+     * @param x the horizontal x value to add to the current x
+     *          coordinate position
+     * @param y the vertical y value to add to the current y
+                coordinate position
+     */
+    public synchronized void translatePoint(int x, int y) {
+        event.translatePoint(x, y);
+    }
+
+    /**
+     * Returns the number of mouse clicks associated with this event.
+     *
+     * @return integer value for the number of clicks
+     */
+    public int getClickCount() {
+        return event.getClickCount();
+    }
+
+    /**
+     * Returns which, if any, of the mouse buttons has changed state.
+     * The returned value is ranged
+     * from 0 to the {@link java.awt.MouseInfo#getNumberOfButtons() MouseInfo.getNumberOfButtons()}
+     * value.
+     * The returned value includes at least the following constants:
+     * <ul>
+     * <li> {@code NOBUTTON}
+     * <li> {@code BUTTON1}
+     * <li> {@code BUTTON2}
+     * <li> {@code BUTTON3}
+     * </ul>
+     * It is allowed to use those constants to compare with the returned button number in the application.
+     * For example,
+     * <pre>
+     * if (anEvent.getButton() == MouseEvent.BUTTON1) {
+     * </pre>
+     * In particular, for a mouse with one, two, or three buttons this method may return the following values:
+     * <ul>
+     * <li> 0 ({@code NOBUTTON})
+     * <li> 1 ({@code BUTTON1})
+     * <li> 2 ({@code BUTTON2})
+     * <li> 3 ({@code BUTTON3})
+     * </ul>
+     * Button numbers greater than {@code BUTTON3} have no constant identifier.
+     * So if a mouse with five buttons is
+     * installed, this method may return the following values:
+     * <ul>
+     * <li> 0 ({@code NOBUTTON})
+     * <li> 1 ({@code BUTTON1})
+     * <li> 2 ({@code BUTTON2})
+     * <li> 3 ({@code BUTTON3})
+     * <li> 4
+     * <li> 5
+     * </ul>
+     * <p>
+     * Note: If support for extended mouse buttons is {@link Toolkit#areExtraMouseButtonsEnabled() disabled} by Java
+     * then the AWT event subsystem does not produce mouse events for the extended mouse
+     * buttons. So it is not expected that this method returns anything except {@code NOBUTTON}, {@code BUTTON1},
+     * {@code BUTTON2}, {@code BUTTON3}.
+     *
+     * @return one of the values from 0 to {@link java.awt.MouseInfo#getNumberOfButtons() MouseInfo.getNumberOfButtons()}
+     *         if support for the extended mouse buttons is {@link Toolkit#areExtraMouseButtonsEnabled() enabled} by Java.
+     *         That range includes {@code NOBUTTON}, {@code BUTTON1}, {@code BUTTON2}, {@code BUTTON3};
+     *         <br>
+     *         {@code NOBUTTON}, {@code BUTTON1}, {@code BUTTON2} or {@code BUTTON3}
+     *         if support for the extended mouse buttons is {@link Toolkit#areExtraMouseButtonsEnabled() disabled} by Java
+     * @since 1.4
+     * @see Toolkit#areExtraMouseButtonsEnabled()
+     * @see java.awt.MouseInfo#getNumberOfButtons()
+     * @see #MouseEvent(Component, int, long, int, int, int, int, int, int, boolean, int)
+     * @see InputEvent#getMaskForButton(int)
+     */
+    public int getButton() {
+        return event.getButton();
+    }
+
+    /**
+     * Returns whether or not this mouse event is the popup menu
+     * trigger event for the platform.
+     * <p><b>Note</b>: Popup menus are triggered differently
+     * on different systems. Therefore, {@code isPopupTrigger}
+     * should be checked in both {@code mousePressed}
+     * and {@code mouseReleased}
+     * for proper cross-platform functionality.
+     *
+     * @return boolean, true if this event is the popup menu trigger
+     *         for this platform
+     */
+    public boolean isPopupTrigger() {
+        return event.isPopupTrigger();
+    }
+
+    /**
+     * Returns a {@code String} instance describing the modifier keys and
+     * mouse buttons that were down during the event, such as "Shift",
+     * or "Ctrl+Shift". These strings can be localized by changing
+     * the {@code awt.properties} file.
+     * <p>
+     * Note that the {@code InputEvent.ALT_MASK} and
+     * {@code InputEvent.BUTTON2_MASK} have equal values,
+     * so the "Alt" string is returned for both modifiers.  Likewise,
+     * the {@code InputEvent.META_MASK} and
+     * {@code InputEvent.BUTTON3_MASK} have equal values,
+     * so the "Meta" string is returned for both modifiers.
+     * <p>
+     * Note that passing negative parameter is incorrect,
+     * and will cause the returning an unspecified string.
+     * Zero parameter means that no modifiers were passed and will
+     * cause the returning an empty string.
+     *
+     * @param modifiers A modifier mask describing the modifier keys and
+     *                  mouse buttons that were down during the event
+     * @return string   string text description of the combination of modifier
+     *                  keys and mouse buttons that were down during the event
+     * @see InputEvent#getModifiersExText(int)
+     * @since 1.4
+     */
+    public static String getMouseModifiersText(int modifiers) {
+        return MouseEvent.getMouseModifiersText(modifiers);
+    }
+
+    /**
+     * Returns a parameter string identifying this event.
+     * This method is useful for event-logging and for debugging.
+     *
+     * @return a string identifying the event and its attributes
+     */
+    public String paramString() {
+        return event.paramString();
+    }
+
+    /**
+     * Returns whether or not the Shift modifier is down on this event.
+     * @return whether or not the Shift modifier is down on this event
+     */
+    public boolean isShiftDown() {
+        return event.isShiftDown();
+    }
+
+    /**
+     * Returns whether or not the Control modifier is down on this event.
+     * @return whether or not the Control modifier is down on this event
+     */
+    public boolean isControlDown() {
+        return event.isControlDown();
+    }
+
+    /**
+     * Returns whether or not the Meta modifier is down on this event.
+     *
+     * The meta key was until Java 8 the right mouse button on Windows.
+     * On Java 9 on Windows 10, there is no more meta key. Note that this
+     * method is called both on mouse button events and mouse move events,
+     * and therefore "event.getButton() == MouseEvent.BUTTON3" doesn't work.
+     * event.getButton() always return 0 for MouseMoveEvent.
+     *
+     * @return whether or not the Meta modifier is down on this event
+     */
+    public boolean isMetaDown() {
+        if (SystemType.isWindows() || SystemType.isLinux()) {
+            return SwingUtilities.isRightMouseButton(event);
+        } else {
+            return event.isMetaDown();
+        }
+    }
+
+    /**
+     * Returns whether or not the Alt modifier is down on this event.
+     * @return whether or not the Alt modifier is down on this event
+     */
+    public boolean isAltDown() {
+        return event.isAltDown();
+    }
+
+    /**
+     * Returns whether or not the AltGraph modifier is down on this event.
+     * @return whether or not the AltGraph modifier is down on this event
+     */
+    public boolean isAltGraphDown() {
+        return event.isAltGraphDown();
+    }
+
+    /**
+     * Returns the difference in milliseconds between the timestamp of when this event occurred and
+     * midnight, January 1, 1970 UTC.
+     * @return the difference in milliseconds between the timestamp and midnight, January 1, 1970 UTC
+     */
+    public long getWhen() {
+        return event.getWhen();
+    }
+
+    /**
+     * Returns the modifier mask for this event.
+     *
+     * @return the modifier mask for this event
+     * @deprecated It is recommended that extended modifier keys and
+     *             {@link #getModifiersEx()} be used instead
+     */
+    @Deprecated(since = "9")
+    @SuppressWarnings("deprecation")
+    public int getModifiers() {
+        return event.getModifiers();
+    }
+
+    /**
+     * Returns the extended modifier mask for this event.
+     * <P>
+     * Extended modifiers are the modifiers that ends with the _DOWN_MASK suffix,
+     * such as ALT_DOWN_MASK, BUTTON1_DOWN_MASK, and others.
+     * <P>
+     * Extended modifiers represent the state of all modal keys,
+     * such as ALT, CTRL, META, and the mouse buttons just after
+     * the event occurred.
+     * <P>
+     * For example, if the user presses <b>button 1</b> followed by
+     * <b>button 2</b>, and then releases them in the same order,
+     * the following sequence of events is generated:
+     * <PRE>
+     *    {@code MOUSE_PRESSED}:  {@code BUTTON1_DOWN_MASK}
+     *    {@code MOUSE_PRESSED}:  {@code BUTTON1_DOWN_MASK | BUTTON2_DOWN_MASK}
+     *    {@code MOUSE_RELEASED}: {@code BUTTON2_DOWN_MASK}
+     *    {@code MOUSE_CLICKED}:  {@code BUTTON2_DOWN_MASK}
+     *    {@code MOUSE_RELEASED}:
+     *    {@code MOUSE_CLICKED}:
+     * </PRE>
+     * <P>
+     * It is not recommended to compare the return value of this method
+     * using {@code ==} because new modifiers can be added in the future.
+     * For example, the appropriate way to check that SHIFT and BUTTON1 are
+     * down, but CTRL is up is demonstrated by the following code:
+     * <PRE>
+     *    int onmask = SHIFT_DOWN_MASK | BUTTON1_DOWN_MASK;
+     *    int offmask = CTRL_DOWN_MASK;
+     *    if ((event.getModifiersEx() &amp; (onmask | offmask)) == onmask) {
+     *        ...
+     *    }
+     * </PRE>
+     * The above code will work even if new modifiers are added.
+     *
+     * @return the extended modifier mask for this event
+     * @since 1.4
+     */
+    public int getModifiersEx() {
+        return event.getModifiersEx();
+    }
+
+    /**
+     * Returns the originator of the event.
+     *
+     * @return the {@code Component} object that originated
+     * the event, or {@code null} if the object is not a
+     * {@code Component}.
+     */
+    public Component getComponent() {
+        return event.getComponent();
+    }
+
+    /**
+     * The object on which the Event initially occurred.
+     *
+     * @return the object on which the Event initially occurred
+     */
+    public Object getSource() {
+        return event.getSource();
+    }
+
+}

--- a/java/src/jmri/web/servlet/frameimage/JmriJFrameServlet.java
+++ b/java/src/jmri/web/servlet/frameimage/JmriJFrameServlet.java
@@ -7,6 +7,7 @@ import static jmri.web.servlet.ServletUtil.UTF8;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.event.MouseEvent;
@@ -24,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
 import javax.servlet.ServletException;
@@ -36,6 +38,7 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFrame;
 import javax.swing.JRadioButton;
+
 import jmri.InstanceManager;
 import jmri.jmrit.display.Editor;
 import jmri.jmrit.display.Positionable;
@@ -43,7 +46,9 @@ import jmri.server.json.JSON;
 import jmri.server.json.JsonException;
 import jmri.server.json.util.JsonUtilHttpService;
 import jmri.util.JmriJFrame;
+import jmri.util.swing.JmriMouseEvent;
 import jmri.web.server.WebServerPreferences;
+
 import org.openide.util.lookup.ServiceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +102,7 @@ public class JmriJFrameServlet extends HttpServlet {
                     1, // one click
                     false // not a popup
             );
-            ((Positionable) c).doMouseClicked(e);
+            ((Positionable) c).doMouseClicked(new JmriMouseEvent(e));
         } else if (Positionable.class.isAssignableFrom(c.getClass())) {
             log.debug("Invoke Pressed, Released and Clicked on Positionable");
             MouseEvent e = new MouseEvent(c,
@@ -108,7 +113,7 @@ public class JmriJFrameServlet extends HttpServlet {
                     1, // one click
                     false // not a popup
             );
-            ((jmri.jmrit.display.Positionable) c).doMousePressed(e);
+            ((jmri.jmrit.display.Positionable) c).doMousePressed(new JmriMouseEvent(e));
 
             e = new MouseEvent(c,
                     MouseEvent.MOUSE_RELEASED,
@@ -118,7 +123,7 @@ public class JmriJFrameServlet extends HttpServlet {
                     1, // one click
                     false // not a popup
             );
-            ((jmri.jmrit.display.Positionable) c).doMouseReleased(e);
+            ((jmri.jmrit.display.Positionable) c).doMouseReleased(new JmriMouseEvent(e));
 
             e = new MouseEvent(c,
                     MouseEvent.MOUSE_CLICKED,
@@ -128,7 +133,7 @@ public class JmriJFrameServlet extends HttpServlet {
                     1, // one click
                     false // not a popup
             );
-            ((jmri.jmrit.display.Positionable) c).doMouseClicked(e);
+            ((jmri.jmrit.display.Positionable) c).doMouseClicked(new JmriMouseEvent(e));
         } else {
             MouseListener[] la = c.getMouseListeners();
             log.debug("Invoke {} contained mouse listeners", la.length);
@@ -208,15 +213,15 @@ public class JmriJFrameServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         // because we work with Swing, we do this on the AWT thread
-        
+
         if (javax.swing.SwingUtilities.isEventDispatchThread()) {
             doGetOnSwing(request, response);
             return;
         }
-        
+
         try {
             javax.swing.SwingUtilities.invokeAndWait(
-                () -> { 
+                () -> {
                     try {
                         doGetOnSwing(request, response);
                     } catch ( ServletException | IOException ex ) {

--- a/java/test/jmri/jmrit/display/EditorScaffold.java
+++ b/java/test/jmri/jmrit/display/EditorScaffold.java
@@ -1,10 +1,11 @@
 package jmri.jmrit.display;
 
 import java.awt.Graphics;
-import java.awt.event.MouseEvent;
+
+import jmri.util.swing.JmriMouseEvent;
 
 /**
- * This class provides a concrete implementation of the Abstract Editor 
+ * This class provides a concrete implementation of the Abstract Editor
  * class to be used in testing.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2002, 2003, 2007
@@ -35,31 +36,31 @@ public class EditorScaffold extends Editor {
      * ********************* Abstract Methods ***********************
      */
     @Override
-    public void mousePressed(MouseEvent event){
+    public void mousePressed(JmriMouseEvent event){
     }
 
     @Override
-    public void mouseReleased(MouseEvent event){
+    public void mouseReleased(JmriMouseEvent event){
     }
 
     @Override
-    public void mouseClicked(MouseEvent event){
+    public void mouseClicked(JmriMouseEvent event){
     }
 
     @Override
-    public void mouseDragged(MouseEvent event){
+    public void mouseDragged(JmriMouseEvent event){
     }
 
     @Override
-    public void mouseMoved(MouseEvent event){
+    public void mouseMoved(JmriMouseEvent event){
     }
 
     @Override
-    public void mouseEntered(MouseEvent event){
+    public void mouseEntered(JmriMouseEvent event){
     }
 
     @Override
-    public void mouseExited(MouseEvent event){
+    public void mouseExited(JmriMouseEvent event){
     }
 
     /*
@@ -99,7 +100,7 @@ public class EditorScaffold extends Editor {
      *
      */
     @Override
-    protected void showPopUp(Positionable p, MouseEvent event){
+    protected void showPopUp(Positionable p, JmriMouseEvent event){
     }
 
     /**


### PR DESCRIPTION
There are differences in how mouse events works on different platforms. Windows is different from Linux and Mac.

This PR is experimental and uses `jmri.util.swing.JmriMouseEvent` for the mouse events of panels in JMRI. It allows all special handling to be moved to a single class.

This PR or a successor to it could also standardize the mouse handling in JMRI if desired, to replace statements like:
`if (!e.isAltDown() && !e.isMetaDown()) {`

with something like:
`if (!e.isRightMouseButton()) {`

where `isRightMouseButton()` is a JMRI method that takes care of differences between Windows, Mac and Linux.