### PR TITLE
Update Common TurnoutOperation Constructor

### DIFF
--- a/java/src/jmri/CommonTurnoutOperation.java
+++ b/java/src/jmri/CommonTurnoutOperation.java
@@ -25,12 +25,23 @@ public abstract class CommonTurnoutOperation extends TurnoutOperation {
     static public final int minMaxTries = 1;
     static public final int maxMaxTries = 10;
 
-    public CommonTurnoutOperation(String n, int i, int mt) {
-        super(n);
-        interval = getDefaultInterval();
-        maxTries = getDefaultMaxTries();
-        setInterval(i);
-        setMaxTries(mt);
+    /**
+     * Create common properties for Turnout Operation.
+     * @param name Operator Name.
+     * @param interval Interval between retries.
+     * @param maxTries maximum retry attempts.
+     */
+    public CommonTurnoutOperation(String name, int interval, int maxTries) {
+        super(name);
+        init(interval, maxTries);
+    }
+
+    private void init(int interval, int maxTries) {
+        setInterval(getDefaultInterval()); // set to default just in case
+        setInterval(interval); // this might not be a valid number.
+        setMaxTries(getDefaultMaxTries()); // set to default just in case
+        setMaxTries(maxTries); // this might not be a valid number.
+        InstanceManager.getDefault(TurnoutOperationManager.class).addOperation(this);
     }
 
     /**
@@ -71,7 +82,10 @@ public abstract class CommonTurnoutOperation extends TurnoutOperation {
     public void setInterval(int newInterval) {
         if (newInterval >= minInterval && newInterval <= maxInterval) {
             interval = newInterval;
+            return;
         }
+        log.warn("Could not set {} Interval to {}, out of range {}-{}",
+            name, newInterval, minInterval, maxInterval);
     }
 
     /**
@@ -84,5 +98,7 @@ public abstract class CommonTurnoutOperation extends TurnoutOperation {
             maxTries = newMaxTries;
         }
     }
+    
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CommonTurnoutOperation.class);
 
 }

--- a/java/src/jmri/RawTurnoutOperation.java
+++ b/java/src/jmri/RawTurnoutOperation.java
@@ -40,7 +40,7 @@ public class RawTurnoutOperation extends CommonTurnoutOperation {
      */
     @Override
     public TurnoutOperation makeCopy(String n) {
-        return new NoFeedbackTurnoutOperation(n, interval, maxTries);
+        return new RawTurnoutOperation(n, interval, maxTries);
     }
 
     @Override

--- a/java/src/jmri/TurnoutOperation.java
+++ b/java/src/jmri/TurnoutOperation.java
@@ -48,9 +48,10 @@ import jmri.implementation.AbstractTurnout;
  * Each subclass also has its own xxxTurnoutOperationXml class, which knows how
  * to store the information in an XML element, and restore it.
  * <p>
- * The current code defines two operations, NoFeedback and Sensor. Because these
- * have so much in common (only the xxxTurnoutOperator class has any
- * differences), most of them is implemented in the CommonTurnout... classes.
+ * The current code defines three operations, NoFeedback, Raw and Sensor.
+ * Because these have so much in common
+ * (only the xxxTurnoutOperator class has any differences),
+ * most of them are implemented in the CommonTurnout... classes.
  * This family is not part of the general structure, although it can be reused
  * if it helps.
  * <p>
@@ -95,7 +96,6 @@ public abstract class TurnoutOperation extends PropertyChangeSupport implements 
 
     TurnoutOperation(@Nonnull String n) {
         name = n;
-        InstanceManager.getDefault(TurnoutOperationManager.class).addOperation(this);
     }
 
     /**
@@ -197,7 +197,7 @@ public abstract class TurnoutOperation extends PropertyChangeSupport implements 
 
     /**
      *
-     * @return true iff this is the "defining instance" of the class, which we
+     * @return true if this is the "defining instance" of the class, which we
      *         determine by the name of the instance being the same as the
      *         prefix of the class
      */
@@ -236,7 +236,7 @@ public abstract class TurnoutOperation extends PropertyChangeSupport implements 
     /**
      * See if operation is in use (needed by the UI).
      *
-     * @return true iff any turnouts are using it
+     * @return true if any turnouts are using it
      */
     public boolean isInUse() {
         TurnoutManager tm = InstanceManager.turnoutManagerInstance();
@@ -272,7 +272,7 @@ public abstract class TurnoutOperation extends PropertyChangeSupport implements 
 
     /**
      * @param mode feedback mode for a turnout
-     * @return true iff this operation's feedback mode is one we know how to
+     * @return true if this operation's feedback mode is one we know how to
      *         deal with
      */
     public boolean matchFeedbackMode(int mode) {


### PR DESCRIPTION
Registers self with TurnoutOperationManager at end of construction, after interval and retry values set.
See #11043 

Updates RawTurnoutOperation to make copy of correct class.