### PR TITLE
Update TurnoutOperation Edit Dialog

### DIFF
--- a/java/src/jmri/configurexml/turnoutoperations/RawTurnoutOperationXml.java
+++ b/java/src/jmri/configurexml/turnoutoperations/RawTurnoutOperationXml.java
@@ -32,10 +32,10 @@ public class RawTurnoutOperationXml extends CommonTurnoutOperationXml {
                     RawTurnoutOperation.getDefaultIntervalStatic(),
                     RawTurnoutOperation.getDefaultMaxTriesStatic());
         } catch (ClassNotFoundException e1) {
-            log.error("while creating NoFeedbackTurnoutOperation", e1);
+            log.error("while creating RawTurnoutOperation", e1);
             return null;
         } catch (NoSuchMethodException e2) {
-            log.error("while creating NoFeedbackTurnoutOperation", e2);
+            log.error("while creating RawTurnoutOperation", e2);
             return null;
         }
     }

--- a/java/src/jmri/jmrit/turnoutoperations/CommonTurnoutOperationConfig.java
+++ b/java/src/jmri/jmrit/turnoutoperations/CommonTurnoutOperationConfig.java
@@ -68,9 +68,9 @@ public class CommonTurnoutOperationConfig extends TurnoutOperationConfig {
      */
     @Override
     public void endConfigure() {
-        int newInterval = ((Integer) intervalSpinner.getValue()).intValue();
+        int newInterval = ((Integer) intervalSpinner.getValue());
         myOp.setInterval(newInterval);
-        int newMaxTries = ((Integer) maxTriesSpinner.getValue()).intValue();
+        int newMaxTries = ((Integer) maxTriesSpinner.getValue());
         myOp.setMaxTries(newMaxTries);
     }
 

--- a/java/src/jmri/jmrit/turnoutoperations/SensorTurnoutOperationConfig.java
+++ b/java/src/jmri/jmrit/turnoutoperations/SensorTurnoutOperationConfig.java
@@ -3,8 +3,8 @@ package jmri.jmrit.turnoutoperations;
 import jmri.TurnoutOperation;
 
 /**
- * Configuration for NoFeedbackTurnoutOperation class All the work is done by
- * the Common... class
+ * Configuration for SensorTurnoutOperation class.
+ * All the work is done by the Common... class
  *
  * @author John Harper Copyright 2005
  */


### PR DESCRIPTION
UI Improvements
OK Button saves all tabs ( not just current tab )
Delete button ( now in tab pane, not bottom bar ) only displayed when Operation is deletable
OK / Cancel buttons dropping from bottom of Dialog display ( after adding Operations ) fixed.

Remove TurnoutOperationManager listener on dispose

Minor code lint