### PR TITLE
Set EnableStoreCheck for new profiles

### DIFF
--- a/java/src/jmri/configurexml/ShutdownPreferences.java
+++ b/java/src/jmri/configurexml/ShutdownPreferences.java
@@ -4,6 +4,7 @@ import java.util.prefs.Preferences;
 
 import jmri.InstanceManagerAutoDefault;
 import jmri.beans.PreferencesBean;
+import jmri.profile.Profile;
 import jmri.profile.ProfileManager;
 import jmri.profile.ProfileUtils;
 
@@ -22,9 +23,13 @@ public final class ShutdownPreferences extends PreferencesBean implements Instan
 
 
     public ShutdownPreferences() {
-        super(ProfileManager.getDefault().getActiveProfile());
+        this(ProfileManager.getDefault().getActiveProfile());
+    }
+
+    public ShutdownPreferences(Profile profile) {
+        super(profile);
         Preferences sharedPreferences = ProfileUtils.getPreferences(
-                super.getProfile(), this.getClass(), true);
+                profile, this.getClass(), true);
         this.readPreferences(sharedPreferences);
     }
 

--- a/java/src/jmri/profile/Profile.java
+++ b/java/src/jmri/profile/Profile.java
@@ -19,11 +19,11 @@ import javax.annotation.Nonnull;
  * each file individually. This would also allow a profile to be opened by
  * double clicking on it, and to have a unique icon within the iOS Files app and
  * macOS Finder.
- * 
+ *
  * Note that JMRI itself is not currently capable of supporting opening a
  * profile by double clicking on it, even if other applications on the same
  * computer can.
- * 
+ *
  * @author Randall Wood Copyright (C) 2013, 2014, 2015, 2018
  */
 public class Profile implements Comparable<Profile> {
@@ -116,6 +116,10 @@ public class Profile implements Comparable<Profile> {
         if (!this.path.isDirectory()) {
             throw new IllegalArgumentException(path + " is not a directory"); // NOI18N
         }
+        var preferences = new jmri.configurexml.ShutdownPreferences(this);
+        preferences.setEnableStoreCheck(true);
+        preferences.setDisplayDialog(jmri.configurexml.ShutdownPreferences.DialogDisplayOptions.ShowDialog);
+        preferences.save();
         this.save();
         if (!Profile.isProfile(this.path)) {
             throw new IllegalArgumentException(path + " does not contain a profile.properties file"); // NOI18N

--- a/java/src/jmri/profile/Profile.java
+++ b/java/src/jmri/profile/Profile.java
@@ -116,11 +116,18 @@ public class Profile implements Comparable<Profile> {
         if (!this.path.isDirectory()) {
             throw new IllegalArgumentException(path + " is not a directory"); // NOI18N
         }
+
+        // Set property "Check for changes that have not been stored" to true.
+        // This ensures that new users have this setting enabled.
+        // Existing profiles are not affected by this.
         var preferences = new jmri.configurexml.ShutdownPreferences(this);
         preferences.setEnableStoreCheck(true);
         preferences.setDisplayDialog(jmri.configurexml.ShutdownPreferences.DialogDisplayOptions.ShowDialog);
         preferences.save();
+
+        // Create the profile on disk
         this.save();
+
         if (!Profile.isProfile(this.path)) {
             throw new IllegalArgumentException(path + " does not contain a profile.properties file"); // NOI18N
         }


### PR DESCRIPTION
This is an extension to #11077. With this PR, new profiles have EnableStoreCheck enabled. This is important for new users since they have the highest risk to forget to store their changes.

Existing profiles should not be affected by this PR.