### PR TITLE
Exclude DecoderPro; handle edge cases

### DIFF
--- a/help/en/package/apps/TabbedPreferences.shtml
+++ b/help/en/package/apps/TabbedPreferences.shtml
@@ -281,14 +281,14 @@
         </div>
 
         <p><strong><em>Check for changes that have not been stored</em></strong> is the master
-        switch for the process.  If this is unchecked, no checking will occur.  Unchecked is the
-        default setting.  This is also the recommended setting when <strong>DecoderPro</strong> is
-        the primary JMRI application.  Starting either PanelPro or DecoderPro creates some default
-        table entries which will create a store request every time DecoderPro is stopped if
-        checking is enabled.</p>
+        switch for the process.  If this is unchecked, no checking will occur.  Checked is the
+        default setting.  Starting PanelPro creates some default <strong>Fast Clock</strong>
+        table entries. If these are the only table entries, a store request will not occur.</p>
 
         <p>If the check process has been enabled and there are changes that should be stored, a
-        dialog will be displayed.</p>
+        dialog will be displayed.  The changes normally occur due to table and panel changes.
+        They can also occur when a connection, such as Digitrax, automatically adds sensors and
+        turnouts.</p>
 
         <div style="margin-left: 2em">
           <a href="images/StoreRequest.png"><img src="images/StoreRequest.png" alt="store reqquest"></a>

--- a/java/src/jmri/configurexml/ShutdownPreferences.java
+++ b/java/src/jmri/configurexml/ShutdownPreferences.java
@@ -29,7 +29,7 @@ public final class ShutdownPreferences extends PreferencesBean implements Instan
     }
 
     private void readPreferences(Preferences sharedPreferences) {
-        _enableStoreCheck = sharedPreferences.getBoolean(ENABLE_STORE_CHECK, false);
+        _enableStoreCheck = sharedPreferences.getBoolean(ENABLE_STORE_CHECK, true);
         var display = sharedPreferences.get(DISPLAY_DIALOG, "ShowDialog");
         _displayDialog = DialogDisplayOptions.valueOf(display);
         setIsDirty(false);

--- a/java/src/jmri/configurexml/StoreAndCompare.java
+++ b/java/src/jmri/configurexml/StoreAndCompare.java
@@ -49,7 +49,7 @@ public class StoreAndCompare extends AbstractAction {
     }
 
     public static void requestStoreIfNeeded() {
-        if (!Application.getApplicationName().equals("DecoderPro")) {
+        if (Application.getApplicationName().equals("PanelPro")) {
             if (_preferences.isStoreCheckEnabled()) {
                 if (dataHasChanged() && !GraphicsEnvironment.isHeadless()) {
                     jmri.configurexml.swing.StoreAndCompareDialog.showDialog();

--- a/java/src/jmri/configurexml/StoreAndCompare.java
+++ b/java/src/jmri/configurexml/StoreAndCompare.java
@@ -95,6 +95,9 @@ public class StoreAndCompare extends AbstractAction {
         return result;
     }
 
+    @SuppressFBWarnings(value = {"RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"},
+            justification =
+                    "spotbugs did not like the protection provided by the result boolean, but the second test was declared redundant")
     private static boolean haveOnlyTimeBeans() {
         var result = true;
 

--- a/java/src/jmri/configurexml/StoreAndCompare.java
+++ b/java/src/jmri/configurexml/StoreAndCompare.java
@@ -76,18 +76,20 @@ public class StoreAndCompare extends AbstractAction {
         File file2 = new File(tempDir + fileName + ".xml");
 
         // Store the current data using the temp file.
-        jmri.ConfigureManager cm = jmri.InstanceManager.getDefault(jmri.ConfigureManager.class);
-        boolean stored = cm.storeUser(file2);
-        log.debug("temp file '{}' stored :: {}", file2, stored);
+        jmri.ConfigureManager cm = jmri.InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
+        if (cm != null) {
+            boolean stored = cm.storeUser(file2);
+            log.debug("temp file '{}' stored :: {}", file2, stored);
 
-        try {
-            result = checkFile(file1, file2);
-        } catch (Exception ex) {
-            log.debug("checkFile exception: ", ex);
-        }
+            try {
+                result = checkFile(file1, file2);
+            } catch (Exception ex) {
+                log.debug("checkFile exception: ", ex);
+            }
 
-        if (!file2.delete()) {
-            log.warn("An error occurred while deleting temporary file {}", file2.getPath());
+            if (!file2.delete()) {
+                log.warn("An error occurred while deleting temporary file {}", file2.getPath());
+            }
         }
 
         return result;
@@ -101,7 +103,7 @@ public class StoreAndCompare extends AbstractAction {
 
         if (sMgr == null || mMgr == null) result = false;
 
-        if (result) {
+        if (result && sMgr != null) {
             if (sMgr.getNamedBeanSet().size() != 1) {
                 result = false;
             } else {
@@ -111,7 +113,7 @@ public class StoreAndCompare extends AbstractAction {
             }
         }
 
-        if (result) {
+        if (result && mMgr != null) {
             if (mMgr.getNamedBeanSet().size() != 2) {
                 result = false;
             } else {

--- a/java/test/jmri/managers/DefaultShutDownManagerTest.java
+++ b/java/test/jmri/managers/DefaultShutDownManagerTest.java
@@ -220,6 +220,7 @@ public class DefaultShutDownManagerTest {
         JUnitUtil.setUp();
         dsdm = new DefaultShutDownManager();
         runs = 0;
+        InstanceManager.getDefault(jmri.configurexml.ShutdownPreferences.class).setEnableStoreCheck(false);
     }
 
     @AfterEach


### PR DESCRIPTION
The default setting for the **enableStoreCheck** shutdown preference has been changed to **true**.  The primary purpose is to see what kind of issues occur with test release 5.1.1.

If he current application is DecoderPro, no checking will occur.  There is a risk if the user chooses the **File &rArr; Open Panel Window** menu option since no checks will occur.

A category of unexpected changes that has not been discussed is automatic sensor and turnout creation.  This can occur for Loconet connections and possibly others.  If this occurs as an example for an "Operations Only" scenario, then the user can disable the check or store the file and load it using a start up action.

For other edge cases, a check is made for just the 3 time related beans along with a check for no panels.

