### PR TITLE
Force store check enabled to false for tests

### DIFF
--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -286,6 +286,7 @@ public class JUnitUtil {
 
         // Do a minimal amount of de-novo setup
         resetInstanceManager();
+        InstanceManager.getDefault(jmri.configurexml.ShutdownPreferences.class).setEnableStoreCheck(false);
 
     }
 
@@ -700,6 +701,7 @@ public class JUnitUtil {
         InstanceManager.getDefault().clearAll();
         // ensure the auto-default UserPreferencesManager is not created by installing a test one
         InstanceManager.setDefault(UserPreferencesManager.class, new TestUserPreferencesManager());
+        InstanceManager.getDefault(jmri.configurexml.ShutdownPreferences.class).setEnableStoreCheck(false);
     }
 
     public static void resetTurnoutOperationManager() {
@@ -1197,6 +1199,7 @@ public class JUnitUtil {
      */
     public static void resetProfileManager(Profile profile) {
         ProfileManager.getDefault().setActiveProfile(profile);
+        InstanceManager.getDefault(jmri.configurexml.ShutdownPreferences.class).setEnableStoreCheck(false);
     }
 
     /**


### PR DESCRIPTION
Some tests expect the reminders dialog to be displayed which are now bypassed when store check is enabled.