### PR TITLE
Layout Editor Dialog Tests

### DIFF
--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutDoubleSlipTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutDoubleSlipTest.java
@@ -1,10 +1,13 @@
 package jmri.jmrit.display.layoutEditor;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 /**
  * Test common functioning of LayoutDoubleSlip
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LayoutDoubleSlipTest extends LayoutSlipTest {
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/EnterReporterDialogTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/EnterReporterDialogTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Rectangle2D;
 import javax.swing.JTextField;
 
@@ -8,10 +7,11 @@ import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
-import jmri.util.junit.rules.RetryRule;
 import jmri.util.swing.JemmyUtil;
-import org.junit.*;
-import org.junit.rules.Timeout;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JLabelOperator;
@@ -22,56 +22,18 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
  *
  * @author George Warner Copyright (C) 2019
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class EnterReporterDialogTest {
-
-    private static LayoutEditor layoutEditor = null;
-    private static EnterReporterDialog enterReporterDialog = null;
-
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(10); // 10 second timeout for methods in this test class.
-
-    @Rule    // allow 2 retries of intermittent tests
-    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
-
-    /*
-     * This is called before each test
-     */
-    @Before
-    public void setUp() {
-        JUnitUtil.setUp();
-        if (!GraphicsEnvironment.isHeadless()) {
-            layoutEditor = new LayoutEditor();
-            enterReporterDialog = new EnterReporterDialog(layoutEditor);
-            layoutEditor.setPanelBounds(new Rectangle2D.Double(0, 0, 640, 480));
-            layoutEditor.setVisible(true);
-        }
-    }
-
-    /*
-     * This is called after each test
-     */
-    @After
-    public void tearDown() {
-        if (!GraphicsEnvironment.isHeadless()) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
-            efo.closeFrameWithConfirmations();
-            layoutEditor = null;
-            enterReporterDialog = null;
-        }
-        JUnitUtil.deregisterBlockManagerShutdownTask();
-        JUnitUtil.tearDown();
-    }
 
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertNotNull("layoutEditor exists", layoutEditor);
-        Assert.assertNotNull("EnterReporterDialog exists", enterReporterDialog);
+
+        Assertions.assertNotNull(layoutEditor, "layoutEditor exists");
+        Assertions.assertNotNull(enterReporterDialog, "EnterReporterDialog exists");
     }
 
     @Test
     public void testEnterReporterCanceled() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         enterReporterDialog.enterReporter(150, 200);
         JFrameOperator jFrameOperator = new JFrameOperator(Bundle.getMessage("AddReporter"));
@@ -83,7 +45,6 @@ public class EnterReporterDialogTest {
 
     @Test
     public void testEnterReporter() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         enterReporterDialog.enterReporter(150, 200);
         JFrameOperator jFrameOperator = new JFrameOperator(Bundle.getMessage("AddReporter"));
@@ -160,4 +121,38 @@ public class EnterReporterDialogTest {
         addNewLabelButtonOperator.doClick();
         jFrameOperator.waitClosed();    // make sure the dialog actually closed
     }
+
+    private LayoutEditor layoutEditor = null;
+    private EnterReporterDialog enterReporterDialog = null;
+
+    /*
+     * This is called before each test
+     */
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+
+        layoutEditor = new LayoutEditor();
+        enterReporterDialog = new EnterReporterDialog(layoutEditor);
+        layoutEditor.setPanelBounds(new Rectangle2D.Double(0, 0, 640, 480));
+        layoutEditor.setVisible(true);
+
+    }
+
+    /*
+     * This is called after each test
+     */
+    @AfterEach
+    public void tearDown() {
+
+        EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
+        efo.closeFrameWithConfirmations();
+        layoutEditor = null;
+        enterReporterDialog = null;
+
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        EditorFrameOperator.clearEditorFrameOperatorThreads();
+        JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutDoubleSlipEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutDoubleSlipEditorTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
 
 import javax.swing.*;
@@ -12,6 +11,7 @@ import jmri.util.swing.JemmyUtil;
 
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.*;
 
 /**
@@ -19,18 +19,19 @@ import org.netbeans.jemmy.operators.*;
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class LayoutDoubleSlipEditorTest extends LayoutSlipEditorTest {
 
     @Test
+    @Override
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
-        new LayoutDoubleSlipEditor(null);
+        Assertions.assertNotNull(new LayoutDoubleSlipEditor(layoutEditor));
+
     }
 
     @Test
     public void testEditDoubleSlipDone() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         createTurnouts();
@@ -92,7 +93,6 @@ public class LayoutDoubleSlipEditorTest extends LayoutSlipEditorTest {
 
     @Test
     public void testEditSlipCancel() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         LayoutDoubleSlipEditor editor = new LayoutDoubleSlipEditor(layoutEditor);
 
@@ -115,7 +115,6 @@ public class LayoutDoubleSlipEditorTest extends LayoutSlipEditorTest {
 
     @Test
     public void testEditSlipClose() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         LayoutDoubleSlipEditor editor = new LayoutDoubleSlipEditor(layoutEditor);
 
@@ -127,9 +126,6 @@ public class LayoutDoubleSlipEditorTest extends LayoutSlipEditorTest {
         jFrameOperator.waitClosed();    // make sure the dialog actually closed
     }
 
-
-
-    private LayoutEditor layoutEditor = null;
     private LayoutDoubleSlip doubleLayoutSlip = null;
     private LayoutDoubleSlipView doubleLayoutSlipView = null;
 
@@ -137,25 +133,16 @@ public class LayoutDoubleSlipEditorTest extends LayoutSlipEditorTest {
     @Override
     public void setUp() {
         super.setUp();
-        JUnitUtil.resetProfileManager();
-        JUnitUtil.initLayoutBlockManager();
-        JUnitUtil.initInternalTurnoutManager();
-        JUnitUtil.initInternalSensorManager();
-        if (!GraphicsEnvironment.isHeadless()) {
 
-            layoutEditor = new LayoutEditor();
-            layoutEditor.setVisible(true);
+        Point2D point = new Point2D.Double(150.0, 100.0);
+        Point2D delta = new Point2D.Double(50.0, 10.0);
 
-            Point2D point = new Point2D.Double(150.0, 100.0);
-            Point2D delta = new Point2D.Double(50.0, 10.0);
+        // doubleLayoutSlip
+        point = MathUtil.add(point, delta);
+        doubleLayoutSlip = new LayoutDoubleSlip("Double Slip", layoutEditor); // point, 0.0,
+        doubleLayoutSlipView = new LayoutDoubleSlipView(doubleLayoutSlip, point, 0.0, layoutEditor);
+        layoutEditor.addLayoutTrack(doubleLayoutSlip, doubleLayoutSlipView);
 
-            // doubleLayoutSlip
-            point = MathUtil.add(point, delta);
-            doubleLayoutSlip = new LayoutDoubleSlip("Double Slip", layoutEditor); // point, 0.0,
-            doubleLayoutSlipView = new LayoutDoubleSlipView(doubleLayoutSlip, point, 0.0, layoutEditor);
-            layoutEditor.addLayoutTrack(doubleLayoutSlip, doubleLayoutSlipView);
-
-        }
     }
 
     @AfterEach
@@ -165,13 +152,7 @@ public class LayoutDoubleSlipEditorTest extends LayoutSlipEditorTest {
             doubleLayoutSlip.remove();
         }
 
-        if (layoutEditor != null) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
-            efo.closeFrameWithConfirmations();
-        }
-
         doubleLayoutSlip = null;
-        layoutEditor = null;
 
         JUnitUtil.resetWindows(false, false);
         JUnitUtil.deregisterBlockManagerShutdownTask();

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutDoubleXOverEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutDoubleXOverEditorTest.java
@@ -1,22 +1,22 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
-
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of LayoutDoubleXOverEditor.
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LayoutDoubleXOverEditorTest extends LayoutXOverEditorTest {
 
     @Test
+    @Override
     public void testCtor() {
-        new LayoutDoubleXOverEditor(null);
+        LayoutDoubleXOverEditor t = new LayoutDoubleXOverEditor(layoutEditor);
+        Assertions.assertNotNull(t);
 
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
     }
  
     // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LayoutDoubleXOverEditorTest.class);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutLHTurnoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutLHTurnoutEditorTest.java
@@ -1,86 +1,70 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
 
-import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.*;
 import jmri.util.*;
 
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of LayoutLHTurnoutEditor.
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LayoutLHTurnoutEditorTest extends LayoutTurnoutEditorTest {
 
     @Test
+    @Override
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
-        new LayoutLHTurnoutEditor(null);
+        LayoutLHTurnoutEditor t = new LayoutLHTurnoutEditor(layoutEditor);
+        Assertions.assertNotNull(t);
     }
 
     @Test
     public void testEditLHTurnoutDone() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         LayoutTurnoutEditor editor = new LayoutLHTurnoutEditor(layoutEditor);
         turnoutTestSequence(editor, leftHandLayoutTurnoutView);
     }
 
-
-    private LayoutEditor layoutEditor = null;
     private LayoutLHTurnout leftHandLayoutTurnout = null;
     private LayoutLHTurnoutView leftHandLayoutTurnoutView = null;
 
     @BeforeEach
+    @Override
     public void setUp() {
         super.setUp();
-        JUnitUtil.resetProfileManager();
-        JUnitUtil.initLayoutBlockManager();
-        JUnitUtil.initInternalTurnoutManager();
-        JUnitUtil.initInternalSensorManager();
-        if (!GraphicsEnvironment.isHeadless()) {
 
-            layoutEditor = new LayoutEditor();
-            layoutEditor.setVisible(true);
+        Point2D point = new Point2D.Double(150.0, 100.0);
+        Point2D delta = new Point2D.Double(50.0, 10.0);
 
-            Point2D point = new Point2D.Double(150.0, 100.0);
-            Point2D delta = new Point2D.Double(50.0, 10.0);
+        // LH Turnout
+        point = MathUtil.add(point, delta);
+        leftHandLayoutTurnout = new LayoutLHTurnout("LH Turnout", layoutEditor); // point, 33.0, 1.1, 1.2,
+        leftHandLayoutTurnoutView = new LayoutLHTurnoutView(leftHandLayoutTurnout,
+                                            point, 33.0, 1.1, 1.2,
+                                            layoutEditor);
+        layoutEditor.addLayoutTrack(leftHandLayoutTurnout, leftHandLayoutTurnoutView);
 
-            // LH Turnout
-            point = MathUtil.add(point, delta);
-            leftHandLayoutTurnout = new LayoutLHTurnout("LH Turnout", layoutEditor); // point, 33.0, 1.1, 1.2,
-            leftHandLayoutTurnoutView = new LayoutLHTurnoutView(leftHandLayoutTurnout,
-                                                point, 33.0, 1.1, 1.2,
-                                                layoutEditor);
-            layoutEditor.addLayoutTrack(leftHandLayoutTurnout, leftHandLayoutTurnoutView);
-        }
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
 
         if (leftHandLayoutTurnout != null) {
             leftHandLayoutTurnout.remove();
         }
 
-        if (layoutEditor != null) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
-            efo.closeFrameWithConfirmations();
-        }
-
         leftHandLayoutTurnout = null;
         leftHandLayoutTurnoutView = null;
-        layoutEditor = null;
 
-        JUnitUtil.resetWindows(false, false);
-        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutLHXOverEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutLHXOverEditorTest.java
@@ -1,22 +1,23 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of LayoutLHXOverEditor.
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LayoutLHXOverEditorTest extends LayoutXOverEditorTest {
 
     @Test
+    @Override
     public void testCtor() {
-        new LayoutLHXOverEditor(null);
+        LayoutLHXOverEditor t = new LayoutLHXOverEditor(layoutEditor);
+        Assertions.assertNotNull(t);
 
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
     }
 
     // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LayoutLHXOverEditorTest.class);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutRHTurnoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutRHTurnoutEditorTest.java
@@ -1,83 +1,67 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
 
-import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.*;
 import jmri.util.*;
 
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of LayoutRHTurnoutEditor.
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LayoutRHTurnoutEditorTest extends LayoutTurnoutEditorTest  {
 
     @Test
+    @Override
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
-        new LayoutRHTurnoutEditor(null);
+        LayoutRHTurnoutEditor t = new LayoutRHTurnoutEditor(layoutEditor);
+        Assertions.assertNotNull(t);
     }
 
     @Test
     public void testEditRHTurnoutDone() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         LayoutTurnoutEditor editor = new LayoutRHTurnoutEditor(layoutEditor);
         turnoutTestSequence(editor, rightHandLayoutTurnoutView);
     }
 
-
-    private LayoutEditor layoutEditor = null;
     private LayoutRHTurnout rightHandLayoutTurnout = null;
     private LayoutRHTurnoutView rightHandLayoutTurnoutView = null;
 
     @BeforeEach
+    @Override
     public void setUp() {
         super.setUp();
-        JUnitUtil.resetProfileManager();
-        JUnitUtil.initLayoutBlockManager();
-        JUnitUtil.initInternalTurnoutManager();
-        JUnitUtil.initInternalSensorManager();
-        if (!GraphicsEnvironment.isHeadless()) {
 
-            layoutEditor = new LayoutEditor();
-            layoutEditor.setVisible(true);
+        Point2D point = new Point2D.Double(150.0, 100.0);
+        Point2D delta = new Point2D.Double(50.0, 10.0);
 
-            Point2D point = new Point2D.Double(150.0, 100.0);
-            Point2D delta = new Point2D.Double(50.0, 10.0);
+        // RH Turnout
+        point = MathUtil.add(point, delta);
+        rightHandLayoutTurnout = new LayoutRHTurnout("RH Turnout", layoutEditor); //  point, 33.0, 1.1, 1.2,
+        rightHandLayoutTurnoutView = new LayoutRHTurnoutView(rightHandLayoutTurnout, point, 33.0, 1.1, 1.2, layoutEditor);
+        layoutEditor.addLayoutTrack(rightHandLayoutTurnout, rightHandLayoutTurnoutView);
 
-            // RH Turnout
-            point = MathUtil.add(point, delta);
-            rightHandLayoutTurnout = new LayoutRHTurnout("RH Turnout", layoutEditor); //  point, 33.0, 1.1, 1.2,
-            rightHandLayoutTurnoutView = new LayoutRHTurnoutView(rightHandLayoutTurnout, point, 33.0, 1.1, 1.2, layoutEditor);
-            layoutEditor.addLayoutTrack(rightHandLayoutTurnout, rightHandLayoutTurnoutView);
-        }
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
 
         if (rightHandLayoutTurnout != null) {
             rightHandLayoutTurnout.remove();
         }
 
-        if (layoutEditor != null) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
-            efo.closeFrameWithConfirmations();
-        }
-
         rightHandLayoutTurnout = null;
-        layoutEditor = null;
 
-        JUnitUtil.resetWindows(false, false);
-        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutRHXOverEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutRHXOverEditorTest.java
@@ -1,22 +1,21 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
-
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of LayoutRHXOverEditor.
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LayoutRHXOverEditorTest extends LayoutXOverEditorTest {
 
     @Test
+    @Override
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-
-        new LayoutRHXOverEditor(null);
+        LayoutRHXOverEditor t = new LayoutRHXOverEditor(layoutEditor);
+        Assertions.assertNotNull(t);
     }
 
     // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LayoutRHOXOverEditorTest.class);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutSingleSlipEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutSingleSlipEditorTest.java
@@ -1,38 +1,36 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.Component;
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
 
 import javax.swing.*;
 
-import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.*;
 import jmri.util.*;
 
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
-import org.netbeans.jemmy.ComponentChooser;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import org.netbeans.jemmy.operators.*;
-import org.netbeans.jemmy.operators.Operator.StringComparator;
 
 /**
  * Test simple functioning of LayoutSingleSlipEditor.
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LayoutSingleSlipEditorTest extends LayoutSlipEditorTest {
 
     @Test
+    @Override
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-
-        new LayoutSingleSlipEditor(null);
+        LayoutSingleSlipEditor t = new LayoutSingleSlipEditor(layoutEditor);
+        Assertions.assertNotNull(t);
+        
     }
 
     @Test
     public void testEditSingleSlipDone() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         createTurnouts();
@@ -90,77 +88,39 @@ public class LayoutSingleSlipEditorTest extends LayoutSlipEditorTest {
         jFrameOperator.waitClosed();    // make sure the dialog actually closed
     }
 
-    private LayoutEditor layoutEditor = null;
     private LayoutSingleSlip singleLayoutSlip = null;
     private LayoutSingleSlipView singleLayoutSlipView = null;
 
     @BeforeEach
+    @Override
     public void setUp() {
         super.setUp();
-        JUnitUtil.resetProfileManager();
-        JUnitUtil.initLayoutBlockManager();
-        JUnitUtil.initInternalTurnoutManager();
-        JUnitUtil.initInternalSensorManager();
-        if (!GraphicsEnvironment.isHeadless()) {
+        
+        Point2D point = new Point2D.Double(150.0, 100.0);
+        Point2D delta = new Point2D.Double(50.0, 10.0);
 
-            layoutEditor = new LayoutEditor();
-            layoutEditor.setVisible(true);
+        // Single doubleLayoutSlip
+        point = MathUtil.add(point, delta);
+        singleLayoutSlip = new LayoutSingleSlip("Single Slip",  // point, 0.0,
+                layoutEditor);
+        singleLayoutSlipView = new LayoutSingleSlipView(singleLayoutSlip,
+                point, 0.0,
+                layoutEditor);
+        layoutEditor.addLayoutTrack(singleLayoutSlip, singleLayoutSlipView);
 
-            Point2D point = new Point2D.Double(150.0, 100.0);
-            Point2D delta = new Point2D.Double(50.0, 10.0);
-
-            // Single doubleLayoutSlip
-            point = MathUtil.add(point, delta);
-            singleLayoutSlip = new LayoutSingleSlip("Single Slip",  // point, 0.0,
-                    layoutEditor);
-            singleLayoutSlipView = new LayoutSingleSlipView(singleLayoutSlip,
-                    point, 0.0,
-                    layoutEditor);
-            layoutEditor.addLayoutTrack(singleLayoutSlip, singleLayoutSlipView);
-
-        }
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         if (singleLayoutSlip != null) {
             singleLayoutSlip.remove();
         }
 
-        if (layoutEditor != null) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
-            efo.closeFrameWithConfirmations();
-        }
-
         singleLayoutSlip = null;
-        layoutEditor = null;
 
-        JUnitUtil.resetWindows(false, false);
-        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
-
-    /*
-     * This is used to find a component by matching against its tooltip
-     */
-    protected static class ToolTipComponentChooser implements ComponentChooser {
-
-        private String buttonTooltip;
-        private StringComparator comparator = Operator.getDefaultStringComparator();
-
-        public ToolTipComponentChooser(String buttonTooltip) {
-            this.buttonTooltip = buttonTooltip;
-        }
-
-        public boolean checkComponent(Component comp) {
-            return comparator.equals(((JComponent) comp).getToolTipText(), buttonTooltip);
-        }
-
-        public String getDescription() {
-            return "Component with tooltip \"" + buttonTooltip + "\".";
-        }
-    }
-
 
     // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LayoutSingleSlipEditorTest.class);
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutSlipEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutSlipEditorTest.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LayoutSlipEditorTest extends LayoutTurnoutEditorTest {
 
-    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     @Override
     public void testCtor() {

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutSlipEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutSlipEditorTest.java
@@ -1,9 +1,7 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
-
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of LayoutSlipEditor.
@@ -12,11 +10,13 @@ import org.junit.jupiter.api.*;
  */
 public class LayoutSlipEditorTest extends LayoutTurnoutEditorTest {
 
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
+    @Override
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
-        new LayoutSlipEditor(null);
+        LayoutSlipEditor t = new LayoutSlipEditor(layoutEditor);
+        Assertions.assertNotNull(t);
     }
     
     // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LayoutSlipEditorTest.class);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTrackEditorTest.java
@@ -6,8 +6,10 @@ import javax.swing.*;
 import javax.annotation.*;
 
 import jmri.*;
+import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.*;
 import jmri.util.*;
+import jmri.util.junit.annotations.ToDo;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -25,18 +27,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LayoutTrackEditorTest {
 
+    @ToDo("Implementing subclasses should use own instance on this method")
     @Test
     public void testHasNxSensorPairsNull() {
-        LayoutTrackEditor layoutTrackEditor = new LayoutTrackEditor(null) { // core of abstract class
+        LayoutTrackEditor layoutTrackEditor = new LayoutTrackEditor(layoutEditor) { // core of abstract class
+            @Override
             public void editLayoutTrack(@Nonnull LayoutTrackView layoutTrack) {}
         };
 
         assertThat(layoutTrackEditor.hasNxSensorPairs(null)).withFailMessage("null block NxSensorPairs").isFalse();
     }
 
+    @ToDo("Implementing subclasses should use own instance on this method")
     @Test
     public void testHasNxSensorPairsDisconnectedBlock() {
-        LayoutTrackEditor layoutTrackEditor = new LayoutTrackEditor(null) { // core of abstract class
+        LayoutTrackEditor layoutTrackEditor = new LayoutTrackEditor(layoutEditor) { // core of abstract class
+            @Override
             public void editLayoutTrack(@Nonnull LayoutTrackView layoutTrack) {}
         };
 
@@ -44,9 +50,11 @@ public class LayoutTrackEditorTest {
         assertThat(layoutTrackEditor.hasNxSensorPairs(b)).withFailMessage("disconnected block NxSensorPairs").isFalse();
     }
 
+    @ToDo("Implementing subclasses should use own instance on this method")
     @Test
     public void testShowSensorMessage() {
-        LayoutTrackEditor layoutTrackEditor = new LayoutTrackEditor(null) { // core of abstract class
+        LayoutTrackEditor layoutTrackEditor = new LayoutTrackEditor(layoutEditor) { // core of abstract class
+            @Override
             public void editLayoutTrack(@Nonnull LayoutTrackView layoutTrack) {}
         };
 
@@ -56,16 +64,36 @@ public class LayoutTrackEditorTest {
         layoutTrackEditor.showSensorMessage();
     }
 
+    protected LayoutEditor layoutEditor = null;
+
     @BeforeEach
     @OverridingMethodsMustInvokeSuper  // invoke first
     public void setUp() {
         JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initLayoutBlockManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initInternalSensorManager();
+
+        layoutEditor = new LayoutEditor();
+        layoutEditor.setVisible(true);
+
     }
 
     @AfterEach
     @OverridingMethodsMustInvokeSuper  // invoke last
     public void tearDown()  {
+        if (layoutEditor != null) {
+            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
+            efo.closeFrameWithConfirmations();
+        }
+        layoutEditor = null;
         jmri.jmrit.display.EditorFrameOperator.clearEditorFrameOperatorThreads();
+        
+        
+        JUnitUtil.resetWindows(false, false);
+        JUnitUtil.deregisterBlockManagerShutdownTask();
+        
         JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
@@ -78,17 +106,19 @@ public class LayoutTrackEditorTest {
      */
     protected static class ToolTipComponentChooser implements ComponentChooser {
 
-        private String buttonTooltip;
-        private StringComparator comparator = Operator.getDefaultStringComparator();
+        private final String buttonTooltip;
+        private final StringComparator comparator = Operator.getDefaultStringComparator();
 
-        public ToolTipComponentChooser(String buttonTooltip) {
+        ToolTipComponentChooser(String buttonTooltip) {
             this.buttonTooltip = buttonTooltip;
         }
 
+        @Override
         public boolean checkComponent(Component comp) {
             return comparator.equals(((JComponent) comp).getToolTipText(), buttonTooltip);
         }
 
+        @Override
         public String getDescription() {
             return "Component with tooltip \"" + buttonTooltip + "\".";
         }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurnoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurnoutEditorTest.java
@@ -1,15 +1,12 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
-
 import javax.swing.*;
 
 import jmri.jmrit.display.layoutEditor.*;
 
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
 import org.netbeans.jemmy.operators.*;
-
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 /**
  * Test simple functioning of LayoutTurnoutEditor.
  *
@@ -17,19 +14,18 @@ import org.netbeans.jemmy.operators.*;
  */
 public class LayoutTurnoutEditorTest extends LayoutTrackEditorTest {
 
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-
-        new LayoutTurnoutEditor(null);
+        Assertions.assertNotNull( new LayoutTurnoutEditor(layoutEditor));
     }
- 
-    protected void turnoutTestSequence(LayoutTurnoutEditor editor, LayoutTurnoutView turnoutView) {
+
+    protected void turnoutTestSequence(LayoutTurnoutEditor ltEeditor, LayoutTurnoutView turnoutView) {
         createTurnouts();
         createBlocks();
 
         // Edit the rh turnout
-        editor.editLayoutTrack(turnoutView);
+        ltEeditor.editLayoutTrack(turnoutView);
         JFrameOperator jFrameOperator = new JFrameOperator(Bundle.getMessage("EditTurnout"));
 
         // Select main turnout

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurnoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurnoutEditorTest.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class LayoutTurnoutEditorTest extends LayoutTrackEditorTest {
 
-    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     @Test
     public void testCtor() {
         Assertions.assertNotNull( new LayoutTurnoutEditor(layoutEditor));

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurntableEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutTurntableEditorTest.java
@@ -1,17 +1,16 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
 
 import javax.swing.*;
 
-import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.*;
 import jmri.util.*;
 import jmri.util.swing.JemmyUtil;
 
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.*;
 
 /**
@@ -19,19 +18,18 @@ import org.netbeans.jemmy.operators.*;
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class LayoutTurntableEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
-        new LayoutTurntableEditor(null);
+        LayoutTurntableEditor t = new LayoutTurntableEditor(layoutEditor);
+        Assertions.assertNotNull(t);
     }
 
-
-     @Test
+    @Test
     public void testEditTurntableDone() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         createTurnouts();
@@ -136,7 +134,6 @@ public class LayoutTurntableEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testEditTurntableCancel() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         LayoutTurntableEditor editor = new LayoutTurntableEditor(layoutEditor);
 
@@ -150,7 +147,6 @@ public class LayoutTurntableEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testEditTurntableClose() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         LayoutTurntableEditor editor = new LayoutTurntableEditor(layoutEditor);
 
@@ -165,7 +161,6 @@ public class LayoutTurntableEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testEditTurntableErrors() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         LayoutTurntableEditor editor = new LayoutTurntableEditor(layoutEditor);
 
@@ -214,49 +209,33 @@ public class LayoutTurntableEditorTest extends LayoutTrackEditorTest {
 
     }
 
-    private LayoutEditor layoutEditor = null;
     private LayoutTurntableView layoutTurntableView = null;
     private LayoutTurntable layoutTurntable = null;
 
     @BeforeEach
+    @Override
     public void setUp() {
         super.setUp();
-        JUnitUtil.resetProfileManager();
-        JUnitUtil.initLayoutBlockManager();
-        JUnitUtil.initInternalTurnoutManager();
-        JUnitUtil.initInternalSensorManager();
-        if (!GraphicsEnvironment.isHeadless()) {
 
-            layoutEditor = new LayoutEditor();
-            layoutEditor.setVisible(true);
+        Point2D point = new Point2D.Double(150.0, 100.0);
+        Point2D delta = new Point2D.Double(50.0, 10.0);
 
-            Point2D point = new Point2D.Double(150.0, 100.0);
-            Point2D delta = new Point2D.Double(50.0, 10.0);
+        // Turntable
+        point = MathUtil.add(point, delta);
+        layoutTurntable = new LayoutTurntable("Turntable", layoutEditor);
+        layoutTurntableView = new LayoutTurntableView(layoutTurntable, point, layoutEditor);
+        layoutEditor.addLayoutTrack(layoutTurntable, layoutTurntableView);
 
-            // Turntable
-            point = MathUtil.add(point, delta);
-            layoutTurntable = new LayoutTurntable("Turntable", layoutEditor);
-            layoutTurntableView = new LayoutTurntableView(layoutTurntable, point, layoutEditor);
-            layoutEditor.addLayoutTrack(layoutTurntable, layoutTurntableView);
-        }
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         if (layoutTurntable != null) {
             layoutTurntable.remove();
         }
-
-        if (layoutEditor != null) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
-            efo.closeFrameWithConfirmations();
-        }
-
         layoutTurntable = null;
-        layoutEditor = null;
 
-        JUnitUtil.resetWindows(false, false);
-        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutWyeEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutWyeEditorTest.java
@@ -7,12 +7,14 @@ import jmri.util.MathUtil;
 
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of LayoutWyeEditor.
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class LayoutWyeEditorTest extends LayoutTurnoutEditorTest {
 
     @Test

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutWyeEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutWyeEditorTest.java
@@ -1,11 +1,9 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
 
-import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.*;
-import jmri.util.*;
+import jmri.util.MathUtil;
 
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
@@ -18,66 +16,48 @@ import org.junit.jupiter.api.*;
 public class LayoutWyeEditorTest extends LayoutTurnoutEditorTest {
 
     @Test
+    @Override
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-
-        new LayoutWyeEditor(null);
+        LayoutWyeEditor t = new LayoutWyeEditor(layoutEditor);
+        Assertions.assertNotNull(t);
     }
 
     @Test
     public void testEditLHTurnoutDone() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         LayoutWyeEditor editor = new LayoutWyeEditor(layoutEditor);
         turnoutTestSequence(editor, layoutWyeView);
     }
 
-
-    private LayoutEditor layoutEditor = null;
     private LayoutWye layoutWye = null;
     private LayoutWyeView layoutWyeView = null;
 
     @BeforeEach
+    @Override
     public void setUp() {
         super.setUp();
-        JUnitUtil.resetProfileManager();
-        JUnitUtil.initLayoutBlockManager();
-        JUnitUtil.initInternalTurnoutManager();
-        JUnitUtil.initInternalSensorManager();
-        if (!GraphicsEnvironment.isHeadless()) {
 
-            layoutEditor = new LayoutEditor();
-            layoutEditor.setVisible(true);
+        Point2D point = new Point2D.Double(150.0, 100.0);
+        Point2D delta = new Point2D.Double(50.0, 10.0);
 
-            Point2D point = new Point2D.Double(150.0, 100.0);
-            Point2D delta = new Point2D.Double(50.0, 10.0);
+        // Wye
+        point = MathUtil.add(point, delta);
+        layoutWye = new LayoutWye("Wye", layoutEditor);
+        layoutWyeView = new LayoutWyeView(layoutWye, point, 33.0, 1.1, 1.2, layoutEditor);
+        layoutEditor.addLayoutTrack(layoutWye, layoutWyeView);
 
-            // Wye
-            point = MathUtil.add(point, delta);
-            layoutWye = new LayoutWye("Wye", layoutEditor);
-            layoutWyeView = new LayoutWyeView(layoutWye, point, 33.0, 1.1, 1.2, layoutEditor);
-            layoutEditor.addLayoutTrack(layoutWye, layoutWyeView);
-        }
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
 
         if (layoutWye != null) {
             layoutWye.remove();
         }
-
-        if (layoutEditor != null) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor.getTargetFrame());
-            efo.closeFrameWithConfirmations();
-        }
-
         layoutWye = null;
-        layoutEditor = null;
 
-        JUnitUtil.resetWindows(false, false);
-        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutXOverEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LayoutXOverEditorTest.java
@@ -1,17 +1,17 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
 
 import javax.swing.*;
 
-import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.*;
 import jmri.util.*;
 import jmri.util.swing.JemmyUtil;
 
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import org.netbeans.jemmy.operators.*;
 
 /**
@@ -19,18 +19,18 @@ import org.netbeans.jemmy.operators.*;
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LayoutXOverEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
-        new LayoutXOverEditor(null);
+        LayoutXOverEditor t = new LayoutXOverEditor(layoutEditor);
+        Assertions.assertNotNull(t);
     }
 
     @Test
     public void testEditXOverDone() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         createTurnouts();
@@ -123,10 +123,8 @@ public class LayoutXOverEditorTest extends LayoutTrackEditorTest {
         jFrameOperator.waitClosed();    // make sure the dialog actually closed
     }
 
-
-   @Test
+    @Test
     public void testEditTurnoutCancel() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         LayoutDoubleXOverEditor editor = new LayoutDoubleXOverEditor(layoutEditor);
 
@@ -173,7 +171,6 @@ public class LayoutXOverEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testEditDoubleXoverClose() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         LayoutDoubleXOverEditor editor = new LayoutDoubleXOverEditor(layoutEditor);
 
@@ -185,51 +182,40 @@ public class LayoutXOverEditorTest extends LayoutTrackEditorTest {
         jFrameOperator.waitClosed();    // make sure the dialog actually closed
     }
 
-
-    private LayoutEditor layoutEditor = null;
     private LayoutDoubleXOver doubleXoverLayoutTurnout = null;
     private LayoutDoubleXOverView doubleXoverLayoutTurnoutView = null;
 
     @BeforeEach
+    @Override
     public void setUp() {
         super.setUp();
         JUnitUtil.resetProfileManager();
         JUnitUtil.initLayoutBlockManager();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initInternalSensorManager();
-        if (!GraphicsEnvironment.isHeadless()) {
 
-            layoutEditor = new LayoutEditor();
-            layoutEditor.setVisible(true);
+        Point2D point = new Point2D.Double(150.0, 100.0);
+        Point2D delta = new Point2D.Double(50.0, 10.0);
 
-            Point2D point = new Point2D.Double(150.0, 100.0);
-            Point2D delta = new Point2D.Double(50.0, 10.0);
+        point = MathUtil.add(point, delta);
 
-            point = MathUtil.add(point, delta);
+        // Double crossover
+        doubleXoverLayoutTurnout = new LayoutDoubleXOver("Double Xover", layoutEditor); // point, 33.0, 1.1, 1.2,
+        doubleXoverLayoutTurnoutView = new LayoutDoubleXOverView(doubleXoverLayoutTurnout,
+                                                point, 33.0, 1.1, 1.2,
+                                                layoutEditor);
+        layoutEditor.addLayoutTrack(doubleXoverLayoutTurnout, doubleXoverLayoutTurnoutView);
 
-            // Double crossover
-            doubleXoverLayoutTurnout = new LayoutDoubleXOver("Double Xover", layoutEditor); // point, 33.0, 1.1, 1.2,
-            doubleXoverLayoutTurnoutView = new LayoutDoubleXOverView(doubleXoverLayoutTurnout,
-                                                    point, 33.0, 1.1, 1.2,
-                                                    layoutEditor);
-            layoutEditor.addLayoutTrack(doubleXoverLayoutTurnout, doubleXoverLayoutTurnoutView);
-
-        }
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         if (doubleXoverLayoutTurnout != null) {
             doubleXoverLayoutTurnout.remove();
         }
 
-        if (layoutEditor != null) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
-            efo.closeFrameWithConfirmations();
-        }
-
         doubleXoverLayoutTurnout = null;
-        layoutEditor = null;
 
         JUnitUtil.resetWindows(false, false);
         JUnitUtil.deregisterBlockManagerShutdownTask();

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LevelXingEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/LevelXingEditorTest.java
@@ -1,17 +1,17 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
 
 import javax.swing.*;
 
-import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.*;
 import jmri.util.*;
 import jmri.util.swing.JemmyUtil;
 
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import org.netbeans.jemmy.operators.*;
 
 /**
@@ -19,18 +19,18 @@ import org.netbeans.jemmy.operators.*;
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LevelXingEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
-        new LevelXingEditor(null);
+        LevelXingEditor t = new LevelXingEditor(layoutEditor);
+        Assertions.assertNotNull(t);
     }
 
     @Test
     public void testEditXingDone() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         createBlocks();
@@ -93,7 +93,6 @@ public class LevelXingEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testEditXingCancel() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         LevelXingEditor editor = new LevelXingEditor(layoutEditor);
 
@@ -124,7 +123,6 @@ public class LevelXingEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testEditXingClose() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         LevelXingEditor editor = new LevelXingEditor(layoutEditor);
 
@@ -137,49 +135,34 @@ public class LevelXingEditorTest extends LayoutTrackEditorTest {
     }
 
 
-    private LayoutEditor layoutEditor = null;
     private LevelXing levelXing = null;
     private LevelXingView levelXingView = null;
 
     @BeforeEach
+    @Override
     public void setUp() {
         super.setUp();
-        JUnitUtil.resetProfileManager();
-        JUnitUtil.initLayoutBlockManager();
-        JUnitUtil.initInternalTurnoutManager();
-        JUnitUtil.initInternalSensorManager();
-        if (!GraphicsEnvironment.isHeadless()) {
 
-            layoutEditor = new LayoutEditor();
-            layoutEditor.setVisible(true);
+        Point2D point = new Point2D.Double(150.0, 100.0);
+        Point2D delta = new Point2D.Double(50.0, 10.0);
 
-            Point2D point = new Point2D.Double(150.0, 100.0);
-            Point2D delta = new Point2D.Double(50.0, 10.0);
+        // Level crossing
+        point = MathUtil.add(point, delta);
+        levelXing = new LevelXing("Level Xing", layoutEditor); // point
+        levelXingView = new LevelXingView(levelXing, point, layoutEditor);
+        layoutEditor.addLayoutTrack(levelXing, levelXingView);
 
-            // Level crossing
-            point = MathUtil.add(point, delta);
-            levelXing = new LevelXing("Level Xing", layoutEditor); // point
-            levelXingView = new LevelXingView(levelXing, point, layoutEditor);
-            layoutEditor.addLayoutTrack(levelXing, levelXingView);
-        }
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         if (levelXing != null) {
             levelXing.remove();
         }
 
-        if (layoutEditor != null) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
-            efo.closeFrameWithConfirmations();
-        }
-
-        layoutEditor = null;
         levelXing = null;
 
-        JUnitUtil.resetWindows(false, false);
-        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/PositionablePointEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/PositionablePointEditorTest.java
@@ -1,21 +1,21 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
-
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of PositionablePointEditor.
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class PositionablePointEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        new PositionablePointEditor(null);
+
+        PositionablePointEditor t = new PositionablePointEditor(layoutEditor);
+        Assertions.assertNotNull(t);
     }
     
     // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PositionablePointEditorTest.class);

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/TrackSegmentEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorDialogs/TrackSegmentEditorTest.java
@@ -1,17 +1,16 @@
 package jmri.jmrit.display.layoutEditor.LayoutEditorDialogs;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
 
 import javax.swing.*;
 
-import jmri.jmrit.display.EditorFrameOperator;
 import jmri.jmrit.display.layoutEditor.*;
 import jmri.util.*;
 import jmri.util.swing.JemmyUtil;
 
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.*;
 import org.netbeans.jemmy.util.NameComponentChooser;
 
@@ -20,17 +19,17 @@ import org.netbeans.jemmy.util.NameComponentChooser;
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class TrackSegmentEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testCtor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        new TrackSegmentEditor(null);
+        TrackSegmentEditor t = new TrackSegmentEditor(layoutEditor);
+        Assertions.assertNotNull(t);
     }
 
     @Test
     public void testEditTrackSegmentDone() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         trackSegmentView.setArc(true);
@@ -87,7 +86,6 @@ public class TrackSegmentEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testEditTrackSegmentCancel() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         trackSegmentView.setArc(false);
         trackSegmentView.setCircle(false);
 
@@ -113,7 +111,6 @@ public class TrackSegmentEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testEditTrackSegmentClose() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         TrackSegmentEditor editor = new TrackSegmentEditor(layoutEditor);
 
@@ -128,7 +125,6 @@ public class TrackSegmentEditorTest extends LayoutTrackEditorTest {
 
     @Test
     public void testEditTrackSegmentError() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         trackSegmentView.setArc(true);
         trackSegmentView.setCircle(true);
 
@@ -147,62 +143,44 @@ public class TrackSegmentEditorTest extends LayoutTrackEditorTest {
 
     }
 
-
-
-    private LayoutEditor layoutEditor = null;
     private TrackSegment trackSegment = null;
     private TrackSegmentView trackSegmentView = null;
 
     @BeforeEach
+    @Override
     public void setUp() {
         super.setUp();
 
-        JUnitUtil.resetProfileManager();
-        JUnitUtil.initLayoutBlockManager();
-        JUnitUtil.initInternalTurnoutManager();
-        JUnitUtil.initInternalSensorManager();
-        if (!GraphicsEnvironment.isHeadless()) {
+        Point2D point = new Point2D.Double(150.0, 100.0);
+        Point2D delta = new Point2D.Double(50.0, 10.0);
 
-            layoutEditor = new LayoutEditor();
-            layoutEditor.setVisible(true);
+        // Track Segment
+        PositionablePoint pp1 = new PositionablePoint("a", PositionablePoint.PointType.ANCHOR, layoutEditor);
+        PositionablePointView pp1v = new PositionablePointView(pp1, point, layoutEditor);
+        layoutEditor.addLayoutTrack(pp1, pp1v);
 
-            Point2D point = new Point2D.Double(150.0, 100.0);
-            Point2D delta = new Point2D.Double(50.0, 10.0);
+        point = MathUtil.add(point, delta);
+        PositionablePoint pp2 = new PositionablePoint("b", PositionablePoint.PointType.ANCHOR, layoutEditor);
+        PositionablePointView pp2v = new PositionablePointView(pp2, point, layoutEditor);
+        layoutEditor.addLayoutTrack(pp2, pp2v);
 
-            // Track Segment
-            PositionablePoint pp1 = new PositionablePoint("a", PositionablePoint.PointType.ANCHOR, layoutEditor);
-            PositionablePointView pp1v = new PositionablePointView(pp1, point, layoutEditor);
-            layoutEditor.addLayoutTrack(pp1, pp1v);
+        trackSegment = new TrackSegment("Segment", pp1, HitPointType.POS_POINT, pp2, HitPointType.POS_POINT,
+                                        false, layoutEditor);
+        trackSegmentView = new TrackSegmentView(trackSegment, layoutEditor);
+        layoutEditor.addLayoutTrack(trackSegment, trackSegmentView);
 
-            point = MathUtil.add(point, delta);
-            PositionablePoint pp2 = new PositionablePoint("b", PositionablePoint.PointType.ANCHOR, layoutEditor);
-            PositionablePointView pp2v = new PositionablePointView(pp2, point, layoutEditor);
-            layoutEditor.addLayoutTrack(pp2, pp2v);
-
-            trackSegment = new TrackSegment("Segment", pp1, HitPointType.POS_POINT, pp2, HitPointType.POS_POINT,
-                                            false, layoutEditor);
-            trackSegmentView = new TrackSegmentView(trackSegment, layoutEditor);
-            layoutEditor.addLayoutTrack(trackSegment, trackSegmentView);
-        }
     }
 
     @AfterEach
+    @Override
     public void tearDown() {
         if (trackSegment != null) {
             trackSegmentView.dispose();
             trackSegment.remove();
         }
-
-        if (layoutEditor != null) {
-            EditorFrameOperator efo = new EditorFrameOperator(layoutEditor);
-            efo.closeFrameWithConfirmations();
-        }
         trackSegment = null;
         trackSegmentView = null;
-        layoutEditor = null;
 
-        JUnitUtil.resetWindows(false, false);
-        JUnitUtil.deregisterBlockManagerShutdownTask();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutSingleSlipTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutSingleSlipTest.java
@@ -1,10 +1,13 @@
 package jmri.jmrit.display.layoutEditor;
 
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 /**
  * Test common functioning of LayoutSingleSlip
  *
  * @author Bob Jacobsen Copyright (C) 2020
  */
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
 public class LayoutSingleSlipTest extends LayoutSlipTest {
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutSlipTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutSlipTest.java
@@ -1,25 +1,25 @@
 package jmri.jmrit.display.layoutEditor;
 
-import java.awt.GraphicsEnvironment;
 import java.awt.geom.*;
 
 import jmri.JmriException;
 import jmri.util.*;
 import jmri.util.junit.annotations.*;
+
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
  * Test simple functioning of LayoutSlip
  *
  * @author Paul Bender Copyright (C) 2016
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class LayoutSlipTest {
 
     @Test
     public void testNew() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -27,7 +27,6 @@ public class LayoutSlipTest {
 
     @Test
     public void testToString() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -43,7 +42,6 @@ public class LayoutSlipTest {
 
     @Test
     public void testGetDisplayName() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -54,7 +52,6 @@ public class LayoutSlipTest {
 
     @Test
     public void testGetSlipType() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -65,7 +62,6 @@ public class LayoutSlipTest {
 
     @Test
     public void testGetSlipState() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -76,21 +72,19 @@ public class LayoutSlipTest {
 
     @Test
     public void testTurnoutB() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
 
-        Assert.assertTrue("lts.getTurnoutBName() is ''", lts.getTurnoutBName() == "");
+        Assert.assertTrue("lts.getTurnoutBName() is ''", lts.getTurnoutBName().isEmpty());
         Assert.assertNull("lts.getTurnoutB() is null", lts.getTurnoutB());
 
-        Assert.assertTrue("ltd.getTurnoutBName() is ''", ltd.getTurnoutBName() == "");
+        Assert.assertTrue("ltd.getTurnoutBName() is ''", ltd.getTurnoutBName().isEmpty());
         Assert.assertNull("ltd.getTurnoutB() is null", ltd.getTurnoutB());
     }
 
     @Test
     public void testGetConnectionTypes() throws jmri.JmriException {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -108,7 +102,6 @@ public class LayoutSlipTest {
 
     @Test
     public void testGetConnectionTypesFail() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -131,7 +124,6 @@ public class LayoutSlipTest {
 
     @Test
     public void testSlipState() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -173,7 +165,6 @@ public class LayoutSlipTest {
     @Disabled("No Test yet")
     @ToDo("finish initialization of test and write code to test activation of turnouts")
     public void testActivateTurnout() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -185,7 +176,6 @@ public class LayoutSlipTest {
     @Disabled("No Test yet")
     @ToDo("finish initialization of test and write code to test deactivation of turnouts")
     public void testDeactivateTurnout() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -195,7 +185,6 @@ public class LayoutSlipTest {
 
     @Test
     public void testIsMainline() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -206,7 +195,6 @@ public class LayoutSlipTest {
 
     @Test
     public void testGetConnectionInvalid() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -232,7 +220,6 @@ public class LayoutSlipTest {
 
     @Test
     public void testGetConnectionValid() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -269,7 +256,6 @@ public class LayoutSlipTest {
 
     @Test
     public void testSetConnection() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Assert.assertNotNull("LayoutEditor exists", layoutEditor);
         Assert.assertNotNull("LayoutSlip single not null", lts);
         Assert.assertNotNull("LayoutSlip double not null", ltd);
@@ -330,10 +316,8 @@ public class LayoutSlipTest {
     @BeforeAll
     public static void beforeClass() {
         JUnitUtil.setUp();
-        if (!GraphicsEnvironment.isHeadless()) {
-            JUnitUtil.resetProfileManager();
-            layoutEditor = new LayoutEditor();
-        }
+        JUnitUtil.resetProfileManager();
+        layoutEditor = new LayoutEditor();
     }
 
     @AfterAll
@@ -349,15 +333,15 @@ public class LayoutSlipTest {
     @BeforeEach
     public void setUp() {
         jmri.util.JUnitUtil.resetProfileManager();
-        if (!GraphicsEnvironment.isHeadless()) {
-            lts = new LayoutSingleSlip("single", layoutEditor);
-            lvs = new LayoutSingleSlipView(lts, new Point2D.Double(50.0, 100.0), +45.0, layoutEditor);
-            layoutEditor.addLayoutTrack(lts, lvs);
 
-            ltd = new LayoutDoubleSlip("double", layoutEditor);
-            lvd = new LayoutDoubleSlipView(ltd, new Point2D.Double(100.0, 50.0), -45.0, layoutEditor);
-            layoutEditor.addLayoutTrack(ltd, lvd);
-        }
+        lts = new LayoutSingleSlip("single", layoutEditor);
+        lvs = new LayoutSingleSlipView(lts, new Point2D.Double(50.0, 100.0), +45.0, layoutEditor);
+        layoutEditor.addLayoutTrack(lts, lvs);
+
+        ltd = new LayoutDoubleSlip("double", layoutEditor);
+        lvd = new LayoutDoubleSlipView(ltd, new Point2D.Double(100.0, 50.0), -45.0, layoutEditor);
+        layoutEditor.addLayoutTrack(ltd, lvd);
+
     }
 
     @AfterEach


### PR DESCRIPTION
Main fix is use of null in non-null argument - layoutEditor in constructors.

LayoutTrackEditorTest - add LayoutEditor to this super class for other classes to use.

No test instances currently passed up to super tests, should they be?
ToDo annotation added to explore this in future.

Update tests to DisabledIfSystemProperty headless

LayoutSingleSlipEditorTest - , remove duplicate static class

EnterReporterDialogTest - update to junit5, retryrule negated by move fom static to instance layoutEditor / tested class
