### PR TITLE
Cleanup CsvImporter

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -362,7 +362,8 @@
     <h3>DecoderPro</h3>
         <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
-            <li></li>
+            <li>Fixed a problem preventing import of CSV files exported from JMRI.
+            </li>
         </ul>
 
     <h3>CTC Tool</h3>

--- a/java/src/jmri/jmrit/symbolicprog/CsvExportAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/CsvExportAction.java
@@ -51,7 +51,7 @@ public class CsvExportAction extends AbstractAction {
             }
 
             try (CSVPrinter str = new CSVPrinter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8), CSVFormat.DEFAULT)) {
-                str.printRecord("CV, value");
+                str.printRecord(CV, value);
                 for (int i = 0; i < mModel.getRowCount(); i++) {
                     CvValue cv = mModel.getCvByRow(i);
                     if (isWritable(cv)) {

--- a/java/src/jmri/jmrit/symbolicprog/CsvExportAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/CsvExportAction.java
@@ -51,7 +51,7 @@ public class CsvExportAction extends AbstractAction {
             }
 
             try (CSVPrinter str = new CSVPrinter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8), CSVFormat.DEFAULT)) {
-                str.printRecord(CV, value);
+                str.printRecord("CV", "value");
                 for (int i = 0; i < mModel.getRowCount(); i++) {
                     CvValue cv = mModel.getCvByRow(i);
                     if (isWritable(cv)) {

--- a/java/src/jmri/jmrit/symbolicprog/CsvImportAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/CsvImportAction.java
@@ -23,8 +23,11 @@ public class CsvImportAction extends GenericImportAction {
                 // ctor launches operation
                 new CsvImporter(file, mModel);
                 return true;
-            } catch (IOException ex) {
+            } catch (IOException | NumberFormatException ex) {
+                log.error("Error reading file", ex);
                 return false;
         }
     }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CsvImportAction.class);
 }

--- a/java/src/jmri/jmrit/symbolicprog/CsvImporter.java
+++ b/java/src/jmri/jmrit/symbolicprog/CsvImporter.java
@@ -4,8 +4,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Import CV values from a generic CSV format CV list file such as those written
@@ -28,20 +26,13 @@ import org.slf4j.LoggerFactory;
  */
 public class CsvImporter {
 
-    private final static Logger log = LoggerFactory.getLogger(CsvImporter.class);
+    public CsvImporter(File file, CvTableModel cvModel)
+            throws IOException, NumberFormatException {
 
-    public CsvImporter(File file, CvTableModel cvModel) throws IOException {
-        FileReader fileReader=null;
-        BufferedReader bufferedReader=null;
+        try (FileReader fileReader = new FileReader(file);
+                BufferedReader bufferedReader=new BufferedReader(fileReader)) {
 
-        try {
-            CvValue cvObject;
-            String line = null;
-            String name = null;
-            int value = 0;
-
-            fileReader = new FileReader(file);
-            bufferedReader = new BufferedReader(fileReader);
+            String line;
 
             while ((line = bufferedReader.readLine()) != null) {
                 String[] lineStrings = line.split(" *, *");
@@ -51,9 +42,9 @@ public class CsvImporter {
                 } else if (lineStrings[0].contains("CV")) {
                     log.debug("Header OK");
                 } else {
-                    name = lineStrings[0].trim();
-                    value = Integer.parseInt(lineStrings[1].trim());
-                    cvObject = cvModel.allCvMap().get(name);
+                    String name = lineStrings[0].trim();
+                    int value = Integer.parseInt(lineStrings[1].trim());
+                    CvValue cvObject = cvModel.allCvMap().get(name);
                     if (cvObject == null) {
                         log.warn("CV {} was in import file, but not defined by the decoder definition", name);
                         cvModel.addCV(name, false, false, false);
@@ -62,16 +53,8 @@ public class CsvImporter {
                     cvObject.setValue(value);
                 }
             }
-        } catch (IOException e) {
-            log.error("Error reading file", e);
-        } finally {
-            if(bufferedReader!=null) {
-               bufferedReader.close();
-            }
-            if(fileReader!=null) {
-               fileReader.close();
-            }
         }
     }
 
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(CsvImporter.class);
 }

--- a/java/src/jmri/jmrit/symbolicprog/CsvImporter.java
+++ b/java/src/jmri/jmrit/symbolicprog/CsvImporter.java
@@ -30,7 +30,7 @@ public class CsvImporter {
             throws IOException, NumberFormatException {
 
         try (FileReader fileReader = new FileReader(file);
-                BufferedReader bufferedReader=new BufferedReader(fileReader)) {
+                BufferedReader bufferedReader = new BufferedReader(fileReader)) {
 
             String line;
 

--- a/java/src/jmri/jmrit/symbolicprog/CsvImporter.java
+++ b/java/src/jmri/jmrit/symbolicprog/CsvImporter.java
@@ -48,7 +48,7 @@ public class CsvImporter {
                 if (lineStrings.length < 2) {
                     bufferedReader.close();
                     throw new IOException();
-                } else if (lineStrings[0].equals("CV")) {
+                } else if (lineStrings[0].contains("CV")) {
                     log.debug("Header OK");
                 } else {
                     name = lineStrings[0].trim();


### PR DESCRIPTION
This PR is based on #11096 which solves #11094.

This PR does some extra cleanup to `CsvImporter`:
* CsvImporter uses try-with-resources to ensure files are closed. Also, some assigned values that was never used has been removed.
* CsvImportAction.launchImporter() catches both IOException and NumberFormatException so it can handle an invalid CSV file.
* If the csv file has an invalid CV value, the status line will show: `Error importing file "thefile.csv"`.