### PR TITLE
Timetable Tests Spotbugs

### DIFF
--- a/java/src/jmri/jmrit/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/entryexit/DestinationPoints.java
@@ -52,7 +52,11 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean {
 
     final static int NXMESSAGEBOXCLEARTIMEOUT = 30;
 
-    boolean isEnabled() {
+    /**
+     * public for testing purposes.
+     * @return true if enabled, else false.
+     */
+    public boolean isEnabled() {
         return enabled;
     }
 

--- a/java/src/jmri/jmrit/timetable/configurexml/TimeTableXml.java
+++ b/java/src/jmri/jmrit/timetable/configurexml/TimeTableXml.java
@@ -503,6 +503,10 @@ public class TimeTableXml {
             }
             return fileLocation;
         }
+
+        public static void resetFileLocation() {
+            fileLocation = null;
+        }
     }
 
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimeTableXml.class);

--- a/java/src/jmri/jmrit/timetable/configurexml/TimeTableXml.java
+++ b/java/src/jmri/jmrit/timetable/configurexml/TimeTableXml.java
@@ -504,6 +504,10 @@ public class TimeTableXml {
             return fileLocation;
         }
 
+        /**
+         * Reset the static file location.
+         * Only required for unit testing purposes.
+         */
         public static void resetFileLocation() {
             fileLocation = null;
         }

--- a/java/test/apps/TrainCrew/InstallFromURLTest.java
+++ b/java/test/apps/TrainCrew/InstallFromURLTest.java
@@ -1,9 +1,9 @@
 package apps.TrainCrew;
 
-import org.junit.Test;
+import org.junit.jupiter.api.*;
 
 /**
- * Tests for the Bundle class
+ * Tests for the InstallFromURL class.
  *
  * @author Bob Jacobsen Copyright (C) 2018
  */
@@ -11,6 +11,18 @@ public class InstallFromURLTest  {
 
     @Test
     public void testCtor() {
-        new InstallFromURL();
+        InstallFromURL t = new InstallFromURL();
+        Assertions.assertNotNull(t);
     }
+
+    @BeforeEach
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
@@ -49,26 +49,14 @@ public class ImportEntryExitTest {
         }
     }
 
-    private boolean isEnabled(DestinationPoints dp) {
-//        Method retrieveItems = dp.getClass().getDeclaredMethod("isEnabled", String.class);
-        try {
-            Method isEnabled = dp.getClass().getDeclaredMethod("isEnabled");
-            isEnabled.setAccessible(true);
-            return (boolean)isEnabled.invoke(dp);
-        }
-        catch ( IllegalAccessException | IllegalArgumentException | NoSuchMethodException | SecurityException | InvocationTargetException ex ){
-            return false;
-        }
-    }
-
     private void runTestActionEntryExit(DestinationPoints dp, Sensor sensor) throws JmriException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-        Assert.assertFalse(isEnabled(dp));
+        Assert.assertFalse(dp.isEnabled());
         sensor.setState(Sensor.INACTIVE);
-        JUnitUtil.waitFor(() -> (isEnabled(dp)),"destination point enabled");
-        Assert.assertTrue(isEnabled(dp));
+        JUnitUtil.waitFor(() -> (dp.isEnabled()),"destination point enabled");
+        Assert.assertTrue(dp.isEnabled());
         sensor.setState(Sensor.ACTIVE);
-        JUnitUtil.waitFor(() -> (!isEnabled(dp)),"destination point disabled");
-        Assert.assertFalse(isEnabled(dp));
+        JUnitUtil.waitFor(() -> (!dp.isEnabled()),"destination point disabled");
+        Assert.assertFalse(dp.isEnabled());
     }
 
     @Test

--- a/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportEntryExitTest.java
@@ -49,20 +49,25 @@ public class ImportEntryExitTest {
         }
     }
 
-    private boolean isEnabled(DestinationPoints dp) throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    private boolean isEnabled(DestinationPoints dp) {
 //        Method retrieveItems = dp.getClass().getDeclaredMethod("isEnabled", String.class);
-        Method isEnabled = dp.getClass().getDeclaredMethod("isEnabled");
-        isEnabled.setAccessible(true);
-        return (boolean)isEnabled.invoke(dp);
+        try {
+            Method isEnabled = dp.getClass().getDeclaredMethod("isEnabled");
+            isEnabled.setAccessible(true);
+            return (boolean)isEnabled.invoke(dp);
+        }
+        catch ( IllegalAccessException | IllegalArgumentException | NoSuchMethodException | SecurityException | InvocationTargetException ex ){
+            return false;
+        }
     }
 
     private void runTestActionEntryExit(DestinationPoints dp, Sensor sensor) throws JmriException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         Assert.assertFalse(isEnabled(dp));
         sensor.setState(Sensor.INACTIVE);
-        JUnitUtil.waitFor(() -> (isEnabled(dp)));
+        JUnitUtil.waitFor(() -> (isEnabled(dp)),"destination point enabled");
         Assert.assertTrue(isEnabled(dp));
         sensor.setState(Sensor.ACTIVE);
-        JUnitUtil.waitFor(() -> (!isEnabled(dp)));
+        JUnitUtil.waitFor(() -> (!isEnabled(dp)),"destination point disabled");
         Assert.assertFalse(isEnabled(dp));
     }
 
@@ -90,7 +95,7 @@ public class ImportEntryExitTest {
         sensor201.setState(Sensor.ACTIVE);
         Assert.assertEquals(Sensor.ACTIVE, sensor201.getState());
 
-        DestinationPoints dp = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean("NX-Left-TO-A (Left-TO-A) to NX-Right-TO-B (Right-TO-B)");
+        DestinationPoints dp = InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean("NX-Left-TO-A (Left-TO-A) to NX-Right-TO-B (Right-TO-B)");
         Assert.assertNotNull(dp);
 
         // Test entry/exit
@@ -118,10 +123,10 @@ public class ImportEntryExitTest {
     private void runTestExpressionEntryExit(DestinationPoints dp, Sensor sensor) throws JmriException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         Assert.assertEquals(Sensor.INACTIVE, sensor.getState());
         setActiveEntryExit(dp, true);
-        JUnitUtil.waitFor(() -> (Sensor.ACTIVE == sensor.getState()));
+        JUnitUtil.waitFor(() -> (Sensor.ACTIVE == sensor.getState()),"Sensor goes active");
         Assert.assertEquals(Sensor.ACTIVE, sensor.getState());
         setActiveEntryExit(dp, false);
-        JUnitUtil.waitFor(() -> (Sensor.INACTIVE == sensor.getState()));
+        JUnitUtil.waitFor(() -> (Sensor.INACTIVE == sensor.getState()),"Sensor goes inactive");
         Assert.assertEquals(Sensor.INACTIVE, sensor.getState());
     }
 

--- a/java/test/jmri/jmrit/logixng/tools/ImportTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportTest.java
@@ -1,8 +1,6 @@
 package jmri.jmrit.logixng.tools;
 
 import java.awt.GraphicsEnvironment;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 import org.junit.*;
 
@@ -51,30 +49,19 @@ public class ImportTest {
         }
     }
 
-    private boolean destinationPointsIsEnabled(DestinationPoints dp) {
-//        Method retrieveItems = dp.getClass().getDeclaredMethod("isEnabled", String.class);
-        try {
-            Method isEnabled = dp.getClass().getDeclaredMethod("isEnabled");
-            isEnabled.setAccessible(true);
-            return (boolean)isEnabled.invoke(dp);
-        } catch ( IllegalAccessException | IllegalArgumentException | NoSuchMethodException | SecurityException | InvocationTargetException ex ) {
-            return false;
-        }
-    }
-
     private void runTestEntryExit(DestinationPoints dp, Sensor sensor) throws JmriException {
-        Assert.assertFalse(destinationPointsIsEnabled(dp));
+        Assert.assertFalse(dp.isEnabled());
         sensor.setState(Sensor.INACTIVE);
-        JUnitUtil.waitFor(() -> (destinationPointsIsEnabled(dp)),"destination point enabled");
-        Assert.assertTrue(destinationPointsIsEnabled(dp));
+        JUnitUtil.waitFor(() -> (dp.isEnabled()),"destination point enabled");
+        Assert.assertTrue(dp.isEnabled());
         sensor.setState(Sensor.ACTIVE);
-        JUnitUtil.waitFor(() -> (!destinationPointsIsEnabled(dp)),"destination point disabled");
-        Assert.assertFalse(destinationPointsIsEnabled(dp));
+        JUnitUtil.waitFor(() -> (!dp.isEnabled()),"destination point disabled");
+        Assert.assertFalse(dp.isEnabled());
     }
 
     @Test
     @Ignore
-    public void testEntryExit() throws InterruptedException, JmriException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    public void testEntryExit() throws JmriException {
         // ENTRYEXIT
         // SET_NXPAIR_ENABLED
 /*

--- a/java/test/jmri/jmrit/logixng/tools/ImportTest.java
+++ b/java/test/jmri/jmrit/logixng/tools/ImportTest.java
@@ -51,20 +51,24 @@ public class ImportTest {
         }
     }
 
-    private boolean destinationPointsIsEnabled(DestinationPoints dp) throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    private boolean destinationPointsIsEnabled(DestinationPoints dp) {
 //        Method retrieveItems = dp.getClass().getDeclaredMethod("isEnabled", String.class);
-        Method isEnabled = dp.getClass().getDeclaredMethod("isEnabled");
-        isEnabled.setAccessible(true);
-        return (boolean)isEnabled.invoke(dp);
+        try {
+            Method isEnabled = dp.getClass().getDeclaredMethod("isEnabled");
+            isEnabled.setAccessible(true);
+            return (boolean)isEnabled.invoke(dp);
+        } catch ( IllegalAccessException | IllegalArgumentException | NoSuchMethodException | SecurityException | InvocationTargetException ex ) {
+            return false;
+        }
     }
 
-    private void runTestEntryExit(DestinationPoints dp, Sensor sensor) throws JmriException, NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+    private void runTestEntryExit(DestinationPoints dp, Sensor sensor) throws JmriException {
         Assert.assertFalse(destinationPointsIsEnabled(dp));
         sensor.setState(Sensor.INACTIVE);
-        JUnitUtil.waitFor(() -> (destinationPointsIsEnabled(dp)));
+        JUnitUtil.waitFor(() -> (destinationPointsIsEnabled(dp)),"destination point enabled");
         Assert.assertTrue(destinationPointsIsEnabled(dp));
         sensor.setState(Sensor.ACTIVE);
-        JUnitUtil.waitFor(() -> (!destinationPointsIsEnabled(dp)));
+        JUnitUtil.waitFor(() -> (!destinationPointsIsEnabled(dp)),"destination point disabled");
         Assert.assertFalse(destinationPointsIsEnabled(dp));
     }
 
@@ -123,8 +127,8 @@ public class ImportTest {
 
         sensor.setState(Sensor.ACTIVE);
 
-        JUnitUtil.waitFor(() -> (turnout101.getState() == Turnout.CLOSED));
-        JUnitUtil.waitFor(() -> (turnout102.getState() == Turnout.CLOSED));
+        JUnitUtil.waitFor(() -> (turnout101.getState() == Turnout.CLOSED),"turnout 101 closed");
+        JUnitUtil.waitFor(() -> (turnout102.getState() == Turnout.CLOSED),"turnout 102 closed");
 
         Assert.assertEquals(Turnout.CLOSED, turnout101.getState());
         Assert.assertEquals(Turnout.CLOSED, turnout102.getState());

--- a/java/test/jmri/jmrit/timetable/StopTest.java
+++ b/java/test/jmri/jmrit/timetable/StopTest.java
@@ -18,9 +18,10 @@ public class StopTest {
     @Test
     public void testCreate() {
         try {
-            new Stop(0, 1);
+            Stop t = new Stop(0, 1);
+            Assertions.fail("stop should have not been created " + t.toString() );
         } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "StopAddFail");  // NOI18N
+            Assert.assertEquals("StopAddFail", ex.getMessage());  // NOI18N
         }
     }
 
@@ -47,24 +48,24 @@ public class StopTest {
         try {
             stop.setDuration(-2);
         } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "StopDurationLt0");  // NOI18N
+            Assert.assertEquals("StopDurationLt0", ex.getMessage());  // NOI18N
         }
         try {
             stop.setDuration(240);
         } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "TimeOutOfRange");  // NOI18N
+            Assert.assertEquals("TimeOutOfRange", ex.getMessage());  // NOI18N
         }
         stop.setDuration(15);
         Assert.assertEquals(15, stop.getDuration());
         try {
             stop.setNextSpeed(-2);
         } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "NextSpeedLt0");  // NOI18N
+            Assert.assertEquals("NextSpeedLt0", ex.getMessage());  // NOI18N
         }
         try {
             stop.setNextSpeed(1);
         } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "TimeOutOfRange");  // NOI18N
+            Assert.assertEquals("TimeOutOfRange", ex.getMessage());  // NOI18N
         }
         stop.setNextSpeed(30);
         Assert.assertEquals(30, stop.getNextSpeed());
@@ -75,7 +76,7 @@ public class StopTest {
         try {
             stop.setStagingTrack(2);
         } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "StagingRange");  // NOI18N
+            Assert.assertEquals("StagingRange", ex.getMessage());  // NOI18N
         }
         stop.setStagingTrack(0);
         Assert.assertEquals(0, stop.getStagingTrack());
@@ -86,7 +87,7 @@ public class StopTest {
 
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
@@ -94,15 +95,8 @@ public class StopTest {
 
     @AfterEach
     public void tearDown() {
-       // use reflection to reset the static file location.
-       try {
-            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-            f.setAccessible(true);
-            f.set(new String(), null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
-        }
-        jmri.util.JUnitUtil.tearDown();
+        // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/timetable/TimeTableCsvExportTest.java
+++ b/java/test/jmri/jmrit/timetable/TimeTableCsvExportTest.java
@@ -74,19 +74,16 @@ public class TimeTableCsvExportTest {
 
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager(new NullProfile(folder));
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
-        // use reflection to reset the static file location.
-        Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-        java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-        f.setAccessible(true);
-        f.set(new String(), null);
+    public void tearDown() {
+        // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/timetable/TimeTableCsvImportTest.java
+++ b/java/test/jmri/jmrit/timetable/TimeTableCsvImportTest.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 
 import jmri.util.FileUtil;
@@ -27,13 +26,13 @@ public class TimeTableCsvImportTest {
     public void testImport() {
         TimeTableDataManager dm = new TimeTableDataManager(false);
         TimeTableCsvImport imp = new TimeTableCsvImport();
-        List<String> feedback = new ArrayList<>();
+        List<String> feedback;
         try {
             File file = FileUtil.getFile("preference:TestCsvImport.csv");  // NOI18N
             createCsvFile(file);
             feedback = imp.importCsv(file);
         } catch (IOException ex) {
-            log.error("Unable to test the CSV export process");  // NOI18N
+            Assertions.fail("Unable to test the CSV import process: " + ex); // NOI18N
             return;
         }
         Assert.assertEquals("feedback:", 0, feedback.size());
@@ -75,13 +74,13 @@ public class TimeTableCsvImportTest {
     @Test
     public void testMinimalImport() {
         TimeTableCsvImport imp = new TimeTableCsvImport();
-        List<String> feedback = new ArrayList<>();
+        List<String> feedback;
         try {
             File file = FileUtil.getFile("preference:TestMinimalCsvImport.csv");  // NOI18N
             createMinimalCsvFile(file);
             feedback = imp.importCsv(file);
         } catch (IOException ex) {
-            log.error("Unable to test the CSV export process");  // NOI18N
+            Assertions.fail("Unable to test the CSV minimal import process: " + ex ); // NOI18N
             return;
         }
         Assert.assertEquals("Minimal:", 0, feedback.size());
@@ -90,13 +89,13 @@ public class TimeTableCsvImportTest {
     @Test
     public void testBadImport() {
         TimeTableCsvImport imp = new TimeTableCsvImport();
-        List<String> feedback = new ArrayList<>();
+        List<String> feedback;
         try {
             File file = FileUtil.getFile("preference:TestBadCsvImport.csv");  // NOI18N
             createBadCsvFile(file);
             feedback = imp.importCsv(file);
         } catch (IOException ex) {
-            log.error("Unable to test the CSV export process");  // NOI18N
+            Assertions.fail("Unable to test the CSV bad import process: " + ex ); // NOI18N
             return;
         }
         jmri.util.JUnitAppender.assertWarnMessage("Unable to process record 2, content = [Layout]");  // NOI18N
@@ -124,7 +123,7 @@ public class TimeTableCsvImportTest {
            writer.write("Stop,1\n");
            writer.close();
         } catch (IOException ex) {
-            log.warn("Unable to create the test import CSV file ", ex);
+            Assertions.fail("Unable to create the test import CSV file " + ex );
         }
     }
 
@@ -143,7 +142,7 @@ public class TimeTableCsvImportTest {
            writer.write("Stop,2\n");
            writer.close();
         } catch (IOException ex) {
-            log.warn("Unable to create the minimal test import CSV file ", ex);
+            Assertions.fail("Unable to create the minimal test import CSV file " + ex );
         }
     }
 
@@ -158,12 +157,12 @@ public class TimeTableCsvImportTest {
            writer.write("Station, UseSegmentStations\n");
            writer.close();
         } catch (IOException ex) {
-            log.warn("Unable to create the bad test import CSV file ", ex);
+            Assertions.fail("Unable to create the bad test import CSV file " + ex );
         }
     }
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
@@ -171,16 +170,10 @@ public class TimeTableCsvImportTest {
 
     @AfterEach
     public void tearDown() {
-       // use reflection to reset the static file location.
-       try {
-            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-            f.setAccessible(true);
-            f.set(new String(), null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
-        }
-        jmri.util.JUnitUtil.tearDown();
+       // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
+        JUnitUtil.tearDown();
     }
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimeTableCsvImportTest.class);
+
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimeTableCsvImportTest.class);
 }

--- a/java/test/jmri/jmrit/timetable/TimeTableDataManagerTest.java
+++ b/java/test/jmri/jmrit/timetable/TimeTableDataManagerTest.java
@@ -3,6 +3,8 @@ package jmri.jmrit.timetable;
 import java.io.File;
 import java.io.IOException;
 
+import jmri.util.JUnitUtil;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
@@ -17,7 +19,6 @@ public class TimeTableDataManagerTest {
     public void testCreate() {
         TimeTableDataManager dx = new TimeTableDataManager(false);
         jmri.InstanceManager.deregister(dx, TimeTableDataManager.class);
-        dx = null;
     }
 
     @Test
@@ -81,27 +82,20 @@ public class TimeTableDataManagerTest {
 
         // Release data manager
         jmri.InstanceManager.deregister(dm, TimeTableDataManager.class);
-        dm = null;
+
     }
 
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
+        JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
     }
 
     @AfterEach
     public void tearDown() {
-       // use reflection to reset the static file location.
-       try {
-            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-            f.setAccessible(true);
-            f.set(new String(), null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
-        }
-        jmri.util.JUnitUtil.tearDown();
+        // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
+        JUnitUtil.tearDown();
     }
 
 //     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimeTableDataManagerTest.class);

--- a/java/test/jmri/jmrit/timetable/TimeTableImportTest.java
+++ b/java/test/jmri/jmrit/timetable/TimeTableImportTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 
 import jmri.util.FileUtil;
+import jmri.util.JUnitUtil;
 
 import java.util.List;
 
@@ -19,7 +20,8 @@ public class TimeTableImportTest {
 
     @Test
     public void testCreate() {
-        new TimeTableImport();
+        TimeTableImport t = new TimeTableImport();
+        Assertions.assertNotNull(t);
     }
 
     @Test
@@ -30,7 +32,7 @@ public class TimeTableImportTest {
             File file = FileUtil.getFile("program:xml/demoTimetable/TestSample.sgn");  // NOI18N
             imp.importSgn(dm, file);
         } catch (IOException ex) {
-            log.error("Unable to test the import process");  // NOI18N
+            Assertions.fail("Unable to test the import process: " + ex ); // NOI18N
             return;
         }
 
@@ -57,22 +59,16 @@ public class TimeTableImportTest {
 
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
+        JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
     }
 
     @AfterEach
     public void tearDown() {
-       // use reflection to reset the static file location.
-       try {
-            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-            f.setAccessible(true);
-            f.set(new String(), null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
-        }
-        jmri.util.JUnitUtil.tearDown();
+        // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
+        JUnitUtil.tearDown();
     }
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimeTableImportTest.class);
+
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimeTableImportTest.class);
 }

--- a/java/test/jmri/jmrit/timetable/TrainTest.java
+++ b/java/test/jmri/jmrit/timetable/TrainTest.java
@@ -18,9 +18,10 @@ public class TrainTest {
     @Test
     public void testCreate() {
         try {
-            new Train(0);
+            Train t = new Train(0);
+            Assertions.fail("train t created: " + t.toString());
         } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "TrainAddFail");  // NOI18N
+            Assert.assertEquals("TrainAddFail", ex.getMessage());  // NOI18N
         }
     }
 
@@ -45,12 +46,12 @@ public class TrainTest {
         try {
             train.setDefaultSpeed(-5);
         } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "DefaultSpeedLt0");  // NOI18N
+            Assert.assertEquals("DefaultSpeedLt0", ex.getMessage());  // NOI18N
         }
         try {
             train.setDefaultSpeed(1);
         } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "TimeOutOfRange");  // NOI18N
+            Assert.assertEquals("TimeOutOfRange", ex.getMessage());  // NOI18N
         }
         train.setDefaultSpeed(45);
         Assert.assertEquals(45, train.getDefaultSpeed());
@@ -65,7 +66,7 @@ public class TrainTest {
         try {
             train.setThrottle(2);
         } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "ThrottleRange");  // NOI18N
+            Assert.assertEquals("ThrottleRange", ex.getMessage());  // NOI18N
         }
         train.setRouteDuration(120); // two hours
         Assert.assertEquals(120, train.getRouteDuration());
@@ -76,22 +77,15 @@ public class TrainTest {
 
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
     }
 
     @AfterEach
     public void tearDown() {
-       // use reflection to reset the static file location.
-       try {
-            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-            f.setAccessible(true);
-            f.set(new String(), null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
-        }
-        jmri.util.JUnitUtil.tearDown();
+        // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/timetable/TrainTypeTest.java
+++ b/java/test/jmri/jmrit/timetable/TrainTypeTest.java
@@ -18,9 +18,10 @@ public class TrainTypeTest {
     @Test
     public void testCreate() {
         try {
-            new TrainType(0);
+            TrainType t = new TrainType(0);
+            Assertions.fail("TrainType t created: " + t);
         } catch (IllegalArgumentException ex) {
-            Assert.assertEquals(ex.getMessage(), "TypeAddFail");  // NOI18N
+            Assert.assertEquals("TypeAddFail", ex.getMessage());  // NOI18N
         }
     }
 
@@ -38,21 +39,14 @@ public class TrainTypeTest {
 
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
         JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
     }
 
     @AfterEach
     public void tearDown() {
-       // use reflection to reset the static file location.
-       try {
-            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-            f.setAccessible(true);
-            f.set(new String(), null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
-        }
-        jmri.util.JUnitUtil.tearDown();
+        // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/timetable/configurexml/TimeTableXmlTest.java
+++ b/java/test/jmri/jmrit/timetable/configurexml/TimeTableXmlTest.java
@@ -1,16 +1,14 @@
 package jmri.jmrit.timetable.configurexml;
 
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.IOException;
-
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.jupiter.api.*;
 
 import jmri.jmrit.timetable.swing.*;
 import jmri.util.JUnitUtil;
 
+import org.junit.Assert;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -19,14 +17,9 @@ import org.junit.jupiter.api.io.TempDir;
  */
 public class TimeTableXmlTest {
 
-    @Test
-    public void testCreate() {
-        new TimeTableXml();
-    }
-
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     @Test
     public void testLoadAndStore() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         TimeTableFrame f = new TimeTableFrame("");
         Assert.assertNotNull(f);
         boolean loadResult = TimeTableXml.doLoad();
@@ -37,7 +30,7 @@ public class TimeTableXmlTest {
 
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
@@ -45,15 +38,8 @@ public class TimeTableXmlTest {
 
     @AfterEach
     public void tearDown() {
-       // use reflection to reset the static file location.
-       try {
-            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-            f.setAccessible(true);
-            f.set(new String(), null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
-        }
+         // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
         JUnitUtil.resetWindows(false,false);
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/timetable/swing/TimeTableActionTest.java
+++ b/java/test/jmri/jmrit/timetable/swing/TimeTableActionTest.java
@@ -1,59 +1,51 @@
 package jmri.jmrit.timetable.swing;
 
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.IOException;
 
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests for the TimeTableAction Class
  * @author Dave Sand Copyright (C) 2018
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class TimeTableActionTest {
 
     @Test
     public void testCreate() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        new TimeTableAction();
+        TimeTableAction t = new TimeTableAction();
+        Assertions.assertNotNull(t);
     }
 
     @Test
     public void testAction() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         new TimeTableAction().actionPerformed(null);
         new TimeTableAction().actionPerformed(null);
     }
 
     @Test
     public void testMakePanel() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertThrows(IllegalArgumentException.class, () -> new TimeTableAction().makePanel());
+        IllegalArgumentException assertThrows = Assert.assertThrows(IllegalArgumentException.class, () -> new TimeTableAction().makePanel());
+        Assertions.assertEquals("Should not be invoked", assertThrows.getMessage());
     }
 
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
     }
 
     @AfterEach
     public void tearDown() {
-       // use reflection to reset the static file location.
-       try {
-            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-            f.setAccessible(true);
-            f.set(new String(), null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
-        }
+        // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
         JUnitUtil.resetWindows(false,false);
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/timetable/swing/TimeTableDisplayGraphTest.java
+++ b/java/test/jmri/jmrit/timetable/swing/TimeTableDisplayGraphTest.java
@@ -1,7 +1,7 @@
 package jmri.jmrit.timetable.swing;
 
 import java.awt.Dimension;
-import java.awt.GraphicsEnvironment;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -10,8 +10,8 @@ import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.io.TempDir;
  */
 public class TimeTableDisplayGraphTest {
 
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     @Test
     public void testGraph() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         TimeTableDisplayGraph g = new TimeTableDisplayGraph(1, 1, true);
 
@@ -39,9 +39,10 @@ public class TimeTableDisplayGraphTest {
         JUnitAppender.suppressWarnMessage("No scale found, defaulting to HO");
 
     }
+
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
@@ -49,15 +50,8 @@ public class TimeTableDisplayGraphTest {
 
     @AfterEach
     public void tearDown() {
-       // use reflection to reset the static file location.
-       try {
-            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-            f.setAccessible(true);
-            f.set(new String(), null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
-        }
+        // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/timetable/swing/TimeTableFrameTest.java
+++ b/java/test/jmri/jmrit/timetable/swing/TimeTableFrameTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.timetable.swing;
 
-import java.awt.GraphicsEnvironment;
 import java.beans.PropertyVetoException;
 import java.io.File;
 import java.io.IOException;
@@ -11,8 +10,8 @@ import javax.swing.JMenuItem;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 import org.netbeans.jemmy.operators.*;
 
@@ -20,6 +19,7 @@ import org.netbeans.jemmy.operators.*;
  * Tests for the TimeTableFrame Class
  * @author Dave Sand Copyright (C) 2018
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class TimeTableFrameTest {
 
     TimeTableFrame _ttf = null;
@@ -30,14 +30,12 @@ public class TimeTableFrameTest {
 
     @Test
     public void testCreatEmpty() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         TimeTableFrame f = new TimeTableFrame();
         Assert.assertNotNull(f);
     }
 
     @Test
     public void testDriver() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         _ttf = new TimeTableFrame("");
         Assert.assertNotNull(_ttf);
         _ttf.setVisible(true);
@@ -490,7 +488,7 @@ public class TimeTableFrameTest {
 
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
@@ -498,15 +496,8 @@ public class TimeTableFrameTest {
 
     @AfterEach
     public  void tearDown() {
-       // use reflection to reset the static file location.
-       try {
-            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-            f.setAccessible(true);
-            f.set(new String(), null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
-        }
+        // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
         JUnitUtil.resetWindows(false,false);
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/timetable/swing/TimeTablePrintGraphTest.java
+++ b/java/test/jmri/jmrit/timetable/swing/TimeTablePrintGraphTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.timetable.swing;
 
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.IOException;
 
@@ -8,8 +7,8 @@ import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -18,9 +17,9 @@ import org.junit.jupiter.api.io.TempDir;
  */
 public class TimeTablePrintGraphTest {
 
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     @Test
     public void testGraph() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         TimeTablePrintGraph g = new TimeTablePrintGraph(1, 1, true, false);
         Assert.assertNotNull(g);
@@ -30,7 +29,7 @@ public class TimeTablePrintGraphTest {
     }
     @BeforeEach
     public void setUp(@TempDir File folder) throws IOException {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder));
@@ -38,15 +37,8 @@ public class TimeTablePrintGraphTest {
 
     @AfterEach
     public void tearDown() {
-       // use reflection to reset the static file location.
-       try {
-            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
-            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
-            f.setAccessible(true);
-            f.set(new String(), null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
-            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
-        }
+        // reset the static file location.
+        jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.resetFileLocation();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/loconet/swing/LocoNetMenuItemTest.java
+++ b/java/test/jmri/jmrix/loconet/swing/LocoNetMenuItemTest.java
@@ -1,10 +1,11 @@
 package jmri.jmrix.loconet.swing;
 
-import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import jmri.jmrix.loconet.locomon.LocoMonPane;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for LocoNetMenuItem.
@@ -17,45 +18,44 @@ public class LocoNetMenuItemTest {
     public void testIsInterfaceOnly() {
         LocoNetMenuItem instance = new LocoNetMenuItem("a.b.c.d",
                 LocoMonPane.class, false, true);
-        boolean expResult = false;
-        boolean result = instance.isInterfaceOnly();
-        assertEquals("isInterfaceOnly expect false", expResult, result);
+        assertFalse( instance.isInterfaceOnly(), "isInterfaceOnly expect false");
         instance = new LocoNetMenuItem("a.b.c.d",
                 LocoMonPane.class, true, false);
-        expResult = true;
-        result = instance.isInterfaceOnly();
-        assertEquals("isInterfaceOnly expect true", expResult, result);
+        assertTrue( instance.isInterfaceOnly(), "isInterfaceOnly expect true");
     }
 
     @Test
     public void testGetName() {
         LocoNetMenuItem instance = new LocoNetMenuItem("a.b.c.d",
                 LocoMonPane.class, false, true);
-        String expResult = "a.b.c.d";
-        String result = instance.getName();
-        assertEquals("getName expect 'a.b.c.d'", expResult, result);
+        assertEquals("a.b.c.d", instance.getName(), "getName expect 'a.b.c.d'");
     }
 
     @Test
     public void testGetClassToLoad() {
         LocoNetMenuItem instance = new LocoNetMenuItem("a.b.c.d",
                 LocoMonPane.class, false, true);
-        Class expResult = LocoMonPane.class;
-        Class result = instance.getClassToLoad();
-        assertEquals("getClassToLoad test", expResult, result);
+        assertEquals( LocoMonPane.class, instance.getClassToLoad(), "getClassToLoad test");
     }
 
     @Test
     public void testHasGui() {
         LocoNetMenuItem instance = new LocoNetMenuItem("a.b.c.d",
                 LocoMonPane.class, false, true);
-        boolean expResult = true;
-        boolean result = instance.hasGui();
-        assertEquals("hasGui expect true", expResult, result);
+        assertTrue( instance.hasGui(), "hasGui expect true");
         instance = new LocoNetMenuItem("a.b.c.d",
                 LocoMonPane.class, true, false);
-        expResult = false;
-        result = instance.hasGui();
-        assertEquals("hasGui expect false", expResult, result);    }
+        assertFalse( instance.hasGui(), "hasGui expect false");
+    }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
 
 }

--- a/java/test/jmri/jmrix/loconet/swing/menuitemspi/MenuItemsServiceTest.java
+++ b/java/test/jmri/jmrix/loconet/swing/menuitemspi/MenuItemsServiceTest.java
@@ -8,8 +8,11 @@ import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import jmri.util.swing.WindowInterface;
 import jmri.jmrix.loconet.swing.menuitemspi.spi.MenuItemsInterface;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -17,7 +20,6 @@ import org.openide.util.lookup.ServiceProvider;
  * <br>
  * @author Bob Milhaupt  Copyright (C) 2022
  */
-
 @ServiceProvider(service = jmri.jmrix.loconet.swing.menuitemspi.spi.MenuItemsInterface.class)
 public class MenuItemsServiceTest implements MenuItemsInterface {
 
@@ -25,7 +27,7 @@ public class MenuItemsServiceTest implements MenuItemsInterface {
     public void testGetInstance() {
         MenuItemsService result = MenuItemsService.getInstance();
         assertNotNull( result);
-        assertEquals("check class returned", MenuItemsService.class, result.getClass());
+        assertEquals(MenuItemsService.class, result.getClass(),"check class returned");
     }
 
     @Test
@@ -35,19 +37,15 @@ public class MenuItemsServiceTest implements MenuItemsInterface {
         LocoNetSystemConnectionMemo memo = null;
         MenuItemsService instance = MenuItemsService.getInstance();
         List<JMenu> result = instance.getMenuExtensionsItems(isLocoNetInterface, wi, memo);
-        assertEquals("result number of menus", 2, result.size());
+        assertEquals(2 , result.size(), "result number of menus");
         JMenu j1 = result.get(0);
-        assertEquals("result's  first item is a JMenu", JMenu.class,
-                j1.getClass());
-        assertEquals("result element 0's name", "A menu", j1.getName());
-        assertEquals("result menu 1's number of items",
-                0, j1.getItemCount());
+        assertEquals( JMenu.class, j1.getClass(), "result's  first item is a JMenu");
+        assertEquals( "A menu", j1.getName(), "result element 0's name");
+        assertEquals( 0, j1.getItemCount(), "result menu 1's number of items");
         JMenu j2 = result.get(1);
-        assertEquals("result's  second item is a JMenu", JMenu.class,
-                j2.getClass());
-        assertEquals("result second item's name", "B menu", j2.getName());
-        assertEquals("result second item's number of items",
-                0, j2.getItemCount());
+        assertEquals( JMenu.class, j2.getClass(), "result's  second item is a JMenu");
+        assertEquals( "B menu", j2.getName(), "result second item's name");
+        assertEquals( 0, j2.getItemCount(), "result second item's number of items");
     }
 
     @Override
@@ -62,4 +60,15 @@ public class MenuItemsServiceTest implements MenuItemsInterface {
         j.add(jm); // add another menu so there's something more to check on.
         return j;
     }
+
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/managers/ProxyIdTagManagerTest.java
+++ b/java/test/jmri/managers/ProxyIdTagManagerTest.java
@@ -1,0 +1,34 @@
+package jmri.managers;
+
+import jmri.*;
+import jmri.jmrix.internal.InternalSystemConnectionMemo;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
+/**
+ *
+ * @author Steve
+ */
+public class ProxyIdTagManagerTest extends AbstractProxyManagerTestBase<ProxyIdTagManager, IdTag> {
+    
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        // create and register the manager object
+        IdTagManager itm = new DefaultIdTagManager(new InternalSystemConnectionMemo("J", "Juliet"));
+        InstanceManager.setIdTagManager(itm);
+        IdTagManager pl = InstanceManager.getDefault(IdTagManager.class);
+        if ( pl instanceof ProxyIdTagManager ) {
+            l = (ProxyIdTagManager) pl;
+        } else {
+            Assertions.fail("IdTagManager is not a ProxyIdTagManager");
+        }
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+    
+}

--- a/java/test/jmri/managers/ProxyMeterManagerTest.java
+++ b/java/test/jmri/managers/ProxyMeterManagerTest.java
@@ -1,0 +1,34 @@
+package jmri.managers;
+
+import jmri.*;
+import jmri.jmrix.internal.InternalSystemConnectionMemo;
+import jmri.util.JUnitUtil;
+
+import org.junit.jupiter.api.*;
+
+/**
+ *
+ * @author Steve Young Copyright(c) 2022
+ */
+public class ProxyMeterManagerTest extends AbstractProxyManagerTestBase<ProxyMeterManager, Meter> {
+    
+    @BeforeEach
+    public void setUp() {
+        JUnitUtil.setUp();
+        // create and register the manager object
+        MeterManager itm = new jmri.jmrix.internal.InternalMeterManager(new InternalSystemConnectionMemo("J", "Juliet"));
+        InstanceManager.setMeterManager(itm);
+        MeterManager pl = InstanceManager.getDefault(MeterManager.class);
+        if ( pl instanceof ProxyMeterManager ) {
+            l = (ProxyMeterManager) pl;
+        } else {
+            Assertions.fail("IdTagManager is not a ProxyIdTagManager");
+        }
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+    
+}

--- a/java/test/jmri/managers/ProxyReporterManagerTest.java
+++ b/java/test/jmri/managers/ProxyReporterManagerTest.java
@@ -16,9 +16,8 @@ import org.junit.jupiter.api.*;
  * @author Mark Underwood 2012
  * @author Paul Bender 2016
  */
-public class ProxyReporterManagerTest extends AbstractReporterMgrTestBase {
+public class ProxyReporterManagerTest extends AbstractProxyManagerTestBase<ProxyReporterManager, Reporter> {
 
-    @Override
     public String getSystemName(String i) {
         return "IR" + i;
     }
@@ -26,11 +25,11 @@ public class ProxyReporterManagerTest extends AbstractReporterMgrTestBase {
     @Test
     public void testReporterPutGet() {
         // create
-        Reporter t = l.newReporter(getSystemName(getNameToTest1()), "mine");
+        Reporter t = l.newReporter(getSystemName("sysName"), "mine");
         // check
-        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertNotNull("real object returned ", t );
         Assert.assertTrue("user name correct ", t == l.getByUserName("mine"));
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNameToTest1())));
+        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName("sysName")));
     }
 
     @Test
@@ -71,10 +70,10 @@ public class ProxyReporterManagerTest extends AbstractReporterMgrTestBase {
 
     @Test
     public void testInstanceManagerIntegration() {
-        jmri.util.JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetInstanceManager();
         Assert.assertNotNull(InstanceManager.getDefault(ReporterManager.class));
 
-        jmri.util.JUnitUtil.initReporterManager();
+        JUnitUtil.initReporterManager();
 
         Assert.assertTrue(InstanceManager.getDefault(ReporterManager.class) instanceof ProxyReporterManager);
 
@@ -88,22 +87,16 @@ public class ProxyReporterManagerTest extends AbstractReporterMgrTestBase {
         Assert.assertNotNull(InstanceManager.getDefault(ReporterManager.class).provideReporter("IR2"));
     }
 
-    // No manager-specific system name validation
-    @Test
-    @Override
-    public void testMakeSystemNameWithNoPrefixNotASystemName() {}
-
-    // No manager-specific system name validation
-    @Test
-    @Override
-    public void testMakeSystemNameWithPrefixNotASystemName() {}
-
     @BeforeEach
-    @Override
     public void setUp() {
         JUnitUtil.setUp();
         // create and register the manager object
-        l = InstanceManager.getDefault(jmri.ReporterManager.class);
+        ReporterManager irman = InstanceManager.getDefault(ReporterManager.class);
+        if ( irman instanceof ProxyReporterManager ) {
+            l = (ProxyReporterManager) irman;
+        } else {
+            Assertions.fail("ReporterManager is not a ProxyReporterManager");
+        }
     }
 
     @AfterEach


### PR DESCRIPTION
Adds method for tests to reset the static file location
Use method to reset file location
Order of assertEquals
Improve headless checks
Remove new instance check on a class with only static methods

Also . . . .

Updates jmrix/loconet/swing/LocoNetMenuItemTest.java to Junit5 / beforeEach / afterEach
Updates jmrix/loconet/swing/menuitemspi/MenuItemsServiceTest.java to Junit5 / beforeEach / afterEach

Adds jmri/managers/ProxyIdTagManagerTest.java
Adds jmri/managers/ProxyMeterManagerTest.java
Updates jmri/managers/ProxyReporterManagerTest.java to extend from AbstractProxyManagerTestBase