### PR TITLE
Some jmrit Tests Spotbugs

### DIFF
--- a/java/test/jmri/DccLocoAddressTest.java
+++ b/java/test/jmri/DccLocoAddressTest.java
@@ -13,29 +13,29 @@ public class DccLocoAddressTest {
     @Test
     public void testValue1() {
         DccLocoAddress l = new DccLocoAddress(12, true);
-        Assert.assertEquals("number ", l.getNumber(), 12);
-        Assert.assertEquals("long/short ", l.isLongAddress(), true);
+        Assertions.assertEquals(12, l.getNumber(), "number ");
+        Assertions.assertTrue( l.isLongAddress(), "long/short ");
     }
 
     @Test
     public void testValue2() {
         DccLocoAddress l = new DccLocoAddress(12, false);
-        Assert.assertEquals("number ", l.getNumber(), 12);
-        Assert.assertEquals("long/short ", l.isLongAddress(), false);
+        Assertions.assertEquals(12, l.getNumber(), "number ");
+        Assertions.assertFalse( l.isLongAddress(), "long/short ");
     }
 
     @Test
     public void testValue3() {
         DccLocoAddress l = new DccLocoAddress(121, true);
-        Assert.assertEquals("number ", l.getNumber(), 121);
-        Assert.assertEquals("long/short ", l.isLongAddress(), true);
+        Assertions.assertEquals(121, l.getNumber(), "number ");
+        Assertions.assertTrue( l.isLongAddress(), "long/short ");
     }
 
     @Test
     public void testCopy1() {
         DccLocoAddress l = new DccLocoAddress(new DccLocoAddress(121, true));
-        Assert.assertEquals("number ", l.getNumber(), 121);
-        Assert.assertEquals("long/short ", l.isLongAddress(), true);
+        Assertions.assertEquals(121, l.getNumber(), "number ");
+        Assertions.assertTrue( l.isLongAddress(), "long/short ");
     }
 
     @Test
@@ -48,8 +48,8 @@ public class DccLocoAddressTest {
         Assert.assertTrue("reflexive 1 ", l1.equals(l1));
         Assert.assertTrue("reflexive 2 ", l2.equals(l2));
 
-        Assert.assertTrue("null 1 ", !l1.equals(null));
-        Assert.assertTrue("null 2 ", !l2.equals(null));
+        Assert.assertNotEquals( "null 1 ", null, l1);
+        Assert.assertNotEquals( "null 2 ", null, l2);
         Assert.assertTrue("transitive ", (l2.equals(l1)) == ((l1.equals(l2))));
 
     }
@@ -64,8 +64,8 @@ public class DccLocoAddressTest {
         Assert.assertTrue("reflexive 1 ", l1.equals(l1));
         Assert.assertTrue("reflexive 2 ", l2.equals(l2));
 
-        Assert.assertTrue("null 1 ", !l1.equals(null));
-        Assert.assertTrue("null 2 ", !l2.equals(null));
+        Assert.assertNotEquals( "null 1 ", null, l1);
+        Assert.assertNotEquals( "null 2 ", null, l2);
         Assert.assertTrue("transitive ", (l2.equals(l1)) == ((l1.equals(l2))));
 
     }
@@ -80,8 +80,8 @@ public class DccLocoAddressTest {
         Assert.assertTrue("reflexive 1 ", l1.equals(l1));
         Assert.assertTrue("reflexive 2 ", l2.equals(l2));
 
-        Assert.assertTrue("null 1 ", !l1.equals(null));
-        Assert.assertTrue("null 2 ", !l2.equals(null));
+        Assert.assertNotEquals( "null 1 ", null, l1);
+        Assert.assertNotEquals( "null 2 ", null, l2);
         Assert.assertTrue("transitive ", (l2.equals(l1)) == ((l1.equals(l2))));
 
     }
@@ -96,8 +96,8 @@ public class DccLocoAddressTest {
         Assert.assertTrue("reflexive 1 ", l1.equals(l1));
         Assert.assertTrue("reflexive 2 ", l2.equals(l2));
 
-        Assert.assertTrue("null 1 ", !l1.equals(null));
-        Assert.assertTrue("null 2 ", !l2.equals(null));
+        Assert.assertNotEquals( "null 1 ", null, l1);
+        Assert.assertNotEquals( "null 2 ", null, l2);
         Assert.assertTrue("transitive ", (l2.equals(l1)) == ((l1.equals(l2))));
 
     }

--- a/java/test/jmri/implementation/DefaultCabSignalIT.java
+++ b/java/test/jmri/implementation/DefaultCabSignalIT.java
@@ -1,6 +1,7 @@
 package jmri.implementation;
 
 import java.awt.GraphicsEnvironment;
+
 import jmri.Block;
 import jmri.BlockManager;
 import jmri.JmriException;
@@ -16,9 +17,11 @@ import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import jmri.jmrit.display.layoutEditor.ConnectivityUtil;
 import jmri.util.JUnitUtil;
 import jmri.util.ThreadingUtil;
+
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 
 /**
@@ -30,11 +33,13 @@ public class DefaultCabSignalIT {
 
     protected jmri.CabSignal cs = null;
 
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     @Test
     public void testSignalSequence() throws jmri.JmriException {
         runSequence(new DccLocoAddress(1234,true));
     }
 
+    @DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
     @Test
     public void testSignalSequenceIdTag() throws jmri.JmriException {
         runSequence(new DefaultRailCom("ID1234","Test Tag"));
@@ -161,10 +166,12 @@ public class DefaultCabSignalIT {
         Assert.assertEquals("Block set",bm.getBlock(currentBlock),lcs.getBlock());
         Assert.assertEquals("next Block set",bm.getBlock(nextBlock),lcs.getNextBlock());
         Assert.assertEquals("Mast set",smm.getSignalMast(mastName),lcs.getNextMast());
-        if(mastName!="") {
+        if(!mastName.isEmpty()) {
            new org.netbeans.jemmy.QueueTool().waitEmpty(100); // wait for signal to settle.
            // mast expected, so check the aspect.
-           JUnitUtil.waitFor( () -> { return "Clear".equals(lcs.getNextMast().getAspect().toString());});
+           JUnitUtil.waitFor( () -> {
+               return "Clear".equals(lcs.getNextMast().getAspect());
+           },"Mast " + mastName + " did not go clear");
            Assert.assertEquals("Mast " + mastName + " Aspect clear","Clear",lcs.getNextMast().getAspect());
         }
     }

--- a/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
+++ b/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.entryexit;
 
-import java.awt.GraphicsEnvironment;
 import java.util.HashMap;
 
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
@@ -9,6 +8,7 @@ import jmri.util.JUnitUtil;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
 import org.junit.Assume;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JComboBoxOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
@@ -19,23 +19,20 @@ import org.netbeans.jemmy.operators.JTableOperator;
  * @author Paul Bender Copyright (C) 2017
  * @author Dave Sand Copyright (C) 2018
  */
+@DisabledIfSystemProperty(named ="java.awt.headless", matches ="true")
 public class AddEntryExitPairPanelTest {
 
-    static EntryExitTestTools tools;
-    static HashMap<String, LayoutEditor> panels = new HashMap<>();
-    static EntryExitPairs eep;
+    private HashMap<String, LayoutEditor> panels = new HashMap<>();
 
     @Test
     public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
         AddEntryExitPairPanel t = new AddEntryExitPairPanel(panels.get("Alpha"));  // NOI18N
         Assert.assertNotNull("exists", t);  // NOI18N
     }
 
     @Test
     public void testPanelActions() throws Exception {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-
         Assume.assumeFalse("Ignoring intermittent test", Boolean.getBoolean("jmri.skipTestsRequiringSeparateRunning"));
 
         // Open the NX window
@@ -80,8 +77,7 @@ public class AddEntryExitPairPanelTest {
     @BeforeEach
     public void setUp() throws Exception {
         JUnitUtil.setUp();
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        jmri.util.JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager();
 
         panels = EntryExitTestTools.getPanels();
         Assert.assertEquals("Get LE panels", 2, panels.size());  // NOI18N

--- a/java/test/jmri/jmrit/entryexit/EntryExitTestTools.java
+++ b/java/test/jmri/jmrit/entryexit/EntryExitTestTools.java
@@ -1,14 +1,14 @@
 package jmri.jmrit.entryexit;
 
 import java.util.HashMap;
-import jmri.InstanceManager;
-import jmri.Sensor;
-import jmri.SensorManager;
+
+import jmri.*;
+import jmri.configurexml.JmriConfigureXmlException;
 import jmri.jmrit.display.EditorManager;
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
 
 class EntryExitTestTools {
-    static HashMap<String, LayoutEditor> getPanels() throws Exception {
+    static HashMap<String, LayoutEditor> getPanels() throws JmriConfigureXmlException, JmriException, IllegalArgumentException {
         HashMap<String, LayoutEditor> panels = new HashMap<>();
         jmri.configurexml.ConfigXmlManager cm = new jmri.configurexml.ConfigXmlManager();
         java.io.File f = new java.io.File("java/test/jmri/jmrit/entryexit/load/EntryExitTest.xml");
@@ -27,7 +27,7 @@ class EntryExitTestTools {
             }
         }
 
-        InstanceManager.getDefault(SensorManager.class).getSensor("Reset").setKnownState(Sensor.ACTIVE);
+        InstanceManager.getDefault(SensorManager.class).provideSensor("Reset").setKnownState(Sensor.ACTIVE);
         InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class).initializeLayoutBlockPaths();
         return panels;
     }

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/EngineTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/EngineTest.java
@@ -125,7 +125,7 @@ public class EngineTest extends OperationsTestCase {
         // place engines on tracks
         Assert.assertEquals("place e1", Track.OKAY, e1.setLocation(l1, l1t1));
         // check for failure too.
-        Assert.assertFalse("fail place e1", Track.OKAY == e1.setLocation(l3, l2t1));
+        Assert.assertNotEquals("fail place e1", Track.OKAY, e1.setLocation(l3, l2t1));
 
     }
 
@@ -164,6 +164,6 @@ public class EngineTest extends OperationsTestCase {
         // set destination.
         Assert.assertEquals("destination set e1", Track.OKAY, e1.setDestination(l1, l1t1));
         // check for failure too.
-        Assert.assertFalse("fail to set destination e1", Track.OKAY == e1.setDestination(l3, l1t1));
+        Assert.assertNotEquals("fail to set destination e1", Track.OKAY, e1.setDestination(l3, l1t1));
     }
 }

--- a/java/test/jmri/jmrit/operations/router/OperationsCarRouterTest.java
+++ b/java/test/jmri/jmrit/operations/router/OperationsCarRouterTest.java
@@ -33,7 +33,7 @@ import jmri.util.JUnitOperationsUtil;
  */
 public class OperationsCarRouterTest extends OperationsTestCase {
 
-    private final int DIRECTION_ALL = Location.EAST + Location.WEST + Location.NORTH + Location.SOUTH;
+    private final static int DIRECTION_ALL = Location.EAST + Location.WEST + Location.NORTH + Location.SOUTH;
 
     @Test
     public void testCarRoutingDefaults() {

--- a/java/test/jmri/jmrit/operations/trains/TrainBuilderTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainBuilderTest.java
@@ -44,7 +44,7 @@ import jmri.util.JUnitOperationsUtil;
  */
 public class TrainBuilderTest extends OperationsTestCase {
 
-    private final int DIRECTION_ALL = Location.EAST + Location.WEST + Location.NORTH + Location.SOUTH;
+    private final static int DIRECTION_ALL = Location.EAST + Location.WEST + Location.NORTH + Location.SOUTH;
 
     ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrit.operations.JmritOperationsBundle");
 

--- a/java/test/jmri/jmrit/simpleclock/SimpleTimebaseTest.java
+++ b/java/test/jmri/jmrit/simpleclock/SimpleTimebaseTest.java
@@ -21,13 +21,6 @@ public class SimpleTimebaseTest {
 
     InternalSystemConnectionMemo memo;
 
-    void wait(int msec) {
-        try {
-            super.wait(msec);
-        } catch (Exception e) {
-        }
-    }
-
     // test creation
     @Test
     public void testCreate() {
@@ -170,7 +163,7 @@ public class SimpleTimebaseTest {
         instance.setRun(true);
         JUnitUtil.waitFor(() -> {
             return instance.getTime().getMinutes() != start.getMinutes();
-        });
+        },"getMinutes increased");
         instance.setRun(false);
         Assert.assertNotNull(l1.getTime());
         Assert.assertNotNull(l2.getTime());
@@ -186,7 +179,7 @@ public class SimpleTimebaseTest {
         Date now = new Date();
         p.setTime(now);
         p.setRate(100.);
-        wait(100);
+        JUnitUtil.waitFor(100);
         Date then = p.getTime();
         long delta = then.getTime() - now.getTime();
         Assert.assertTrue("delta ge 50 (nominal value)", delta >= 50);
@@ -203,6 +196,7 @@ public class SimpleTimebaseTest {
 
     @AfterEach
     public void tearDown() {
+        memo.dispose();
         memo = null;
         jmri.util.JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/symbolicprog/CvValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CvValueTest.java
@@ -19,14 +19,15 @@ public class CvValueTest {
 
     @Test
     public void testStart() {
-        new CvValue("12", p);
+        CvValue t = new CvValue("12", p);
+        Assertions.assertNotNull(t);
     }
 
     // can we create one and manipulate info?
     @Test
     public void testCvValCreate() {
         CvValue cv = new CvValue("19", p);
-        Assert.assertTrue(cv.number() == "19");
+        Assert.assertEquals("19", cv.number());
         cv.setValue(23);
         Assert.assertTrue(cv.getValue() == 23);
     }


### PR DESCRIPTION
Update AddEntryExitPairPanelTest.java  - move static field to private
Update EntryExitTestTools.java  - getSensor > provideSensor, general Exception too broad
Update SimpleTimebaseTest.java - Use JUnitUtil.waitFor over custom wait

Update CvValueTest.java - use unused instance

Update TrainBuilderTest.java , OperationsCarRouterTest.java - DIRECTION_ALL can be static

Update EngineTest.java - use of == in comparison
Update DccLocoAddressTest.java - l1.equals(null) is never true.

Update DefaultCabSignalIT.java  - unnecessary toString