### PR TITLE
Don't listen to memory if _listenToMemory is false

### DIFF
--- a/java/src/jmri/jmrit/logixng/util/LogixNG_SelectString.java
+++ b/java/src/jmri/jmrit/logixng/util/LogixNG_SelectString.java
@@ -260,7 +260,8 @@ public class LogixNG_SelectString implements VetoableChangeListener {
     public void registerListeners() {
         if (!_listenersAreRegistered
                 && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)) {
+                && (_memoryHandle != null)
+                && _listenToMemory) {
             _memoryHandle.getBean().addPropertyChangeListener("value", _listener);
             _listenersAreRegistered = true;
         }
@@ -272,7 +273,8 @@ public class LogixNG_SelectString implements VetoableChangeListener {
     public void unregisterListeners() {
         if (_listenersAreRegistered
                 && (_addressing == NamedBeanAddressing.Memory)
-                && (_memoryHandle != null)) {
+                && (_memoryHandle != null)
+                && _listenToMemory) {
             _memoryHandle.getBean().removePropertyChangeListener("value", _listener);
             _listenersAreRegistered = false;
         }


### PR DESCRIPTION
Closes #11109

I have checked the other `LogixNG_Select*` classes and they don't have this error.