### PR TITLE
Add TemporalQueries to JUnit Runner Excluded

### DIFF
--- a/java/test/junit/runner/excluded.properties
+++ b/java/test/junit/runner/excluded.properties
@@ -15,3 +15,4 @@ excluded.10=junit.*
 excluded.11=apple.*
 excluded.12=jmri.util.JUnitAppender
 excluded.13=apps.SystemConsole
+excluded.14=java.time.temporal.TemporalQueries


### PR DESCRIPTION
As per documentation at bottom of https://jmri.org/help/en/html/doc/Technical/JUnit.shtml
".. suspect that adding the missing class to the test/junit/runner/excluded.properties file would fix it."

java.lang.NoClassDefFoundError: Could not initialize class java.time.temporal.TemporalQueries
is listed in many ( all? ) of the failures.

Typical Failures:
```
Error:    CtcRunWithSignalHeadsTest.testAction:54 "1/2 signal right indicator not active" did not occur in time
Error:    CtcRunWithSignalMastsTest.testAction:55 "1/2 signal right indicator not active" did not occur in time
Error:    ImportTest.testSetRoute:143->runTestSetRoute:117 "turnout 101 closed" did not occur in time
Error:    JsonRouteHttpServiceTest.testDoPostWithRouteSensor:98 "Route to activate" did not occur in time
Error:    JsonRouteSocketServiceTest.testOnMessageChange:100 "Route to activate" did not occur in time
Error:  Errors:
Error:    ActionsAndExpressionsTest.testGetBeanType:263->checkFolder:146 � NoClassDefFound
Error:    TestSwingClasses.testSwingClasses:103->testClasses:88->lambda$testClasses$2:89->lambda$testClasses$1:91->testClass:67 � NoClassDefFound
Error:    DefaultFemaleDigitalActionSocketTest>FemaleSocketTestBase.testCategory:429 � NoClassDefFound
Error:    SplitDateTimeVariableValueTest.testCtor:196->makeVar:72->makeVar:54 � NoClassDefFound
Error:    SplitDateTimeVariableValueTest.testRailComDateDefault:227->makeVar:54 � NoClassDefFound
Error:    SplitDateTimeVariableValueTest.testRailComDateOnly:317->makeVar:54 � NoClassDefFound
Error:    SplitDateTimeVariableValueTest.testRailComTimeOnly:272->makeVar:54 � NoClassDefFound
Error:    SplitDateTimeVariableValueTest>AbstractVariableValueTestBase.testVariableNaming:46->makeVar:72->makeVar:54 � NoClassDefFound
Error:    SplitDateTimeVariableValueTest>AbstractVariableValueTestBase.testVariableValueStateColor:307->makeVar:72->makeVar:54 � NoClassDefFound
Error:    TimeTableFrameTest.testDriver:48->addTests:179 � TimeoutExpired Wait next node...
[INFO]
Error:  Tests run: 31932, Failures: 5, Errors: 10, Skipped: 1061

```
