### PR TITLE
Avoid throttle loading error for old files.

### DIFF
--- a/java/src/jmri/jmrit/throttle/ThrottleFrame.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleFrame.java
@@ -83,6 +83,7 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
 
     private boolean isEditMode = true;
     private boolean willSwitch = false;
+    private boolean isLoadingDefault = false;
 
     private static final String DEFAULT_THROTTLE_FILENAME = "JMRI_ThrottlePreference.xml";
 
@@ -221,12 +222,17 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
     }
 
     private void loadDefaultThrottle() {
+        if (isLoadingDefault) { // avoid looping on this method
+            return; 
+        }
+        isLoadingDefault = true;
         String dtf = InstanceManager.getDefault(ThrottlesPreferences.class).getDefaultThrottleFilePath();
         if (dtf == null || dtf.isEmpty()) {
             return;
         }
         log.debug("Loading default throttle file : {}", dtf);
         loadThrottle(dtf);
+        isLoadingDefault = false;
     }
 
     public void loadThrottle() {

--- a/xml/DTD/throttle-config.dtd
+++ b/xml/DTD/throttle-config.dtd
@@ -33,9 +33,9 @@
 <!ATTLIST FunctionButton text CDATA #REQUIRED>
 <!ATTLIST FunctionButton isLockable CDATA #REQUIRED>
 <!ATTLIST FunctionButton isVisible CDATA #REQUIRED>
-<!ATTLIST FunctionButton fontSize CDATA #REQUIRED>
-<!ATTLIST FunctionButton iconPath CDATA #REQUIRED>
-<!ATTLIST FunctionButton selectedIconPath CDATA #REQUIRED>
+<!ATTLIST FunctionButton fontSize CDATA #IMPLIED>
+<!ATTLIST FunctionButton iconPath CDATA #IMPLIED>
+<!ATTLIST FunctionButton selectedIconPath CDATA #IMPLIED>
 <!ATTLIST FunctionButton buttonImageSize CDATA #IMPLIED>
 
 <!ELEMENT AddressPanel (window, address*, locoaddress*) >


### PR DESCRIPTION
Made throttle file dtd less strict for reverse compatibility.
Avoid looping on loadDefaultThrottle if error in loading.