### PR TITLE
Update some Beantable tests

### DIFF
--- a/java/test/jmri/jmrit/beantable/ReporterTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/ReporterTableActionTest.java
@@ -1,7 +1,5 @@
 package jmri.jmrit.beantable;
 
-import java.awt.GraphicsEnvironment;
-
 import javax.annotation.Nonnull;
 import javax.swing.JFrame;
 import javax.swing.JTextField;
@@ -13,8 +11,8 @@ import jmri.util.JUnitUtil;
 import jmri.util.swing.JemmyUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import org.netbeans.jemmy.operators.*;
 import org.netbeans.jemmy.util.NameComponentChooser;
@@ -51,11 +49,12 @@ public class ReporterTableActionTest extends AbstractTableActionBase<Reporter> {
         Assert.assertTrue("Default include add button", a.includeAddButton());
     }
 
+    
     @Test
     @Override
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testAddButton() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeTrue(a.includeAddButton());
+        Assert.assertTrue(a.includeAddButton());
         a.actionPerformed(null);
         JFrame f = JFrameOperator.waitJFrame(getTableFrameName(), true, true);
 
@@ -63,7 +62,7 @@ public class ReporterTableActionTest extends AbstractTableActionBase<Reporter> {
         jmri.util.swing.JemmyUtil.pressButton(new JFrameOperator(f), Bundle.getMessage("ButtonAdd"));
         new org.netbeans.jemmy.QueueTool().waitEmpty();
         JFrame f1 = JFrameOperator.waitJFrame(getAddFrameName(), true, true);
-        jmri.util.swing.JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonClose")); // not sure why this is close in this frame.
+        JemmyUtil.pressButton(new JFrameOperator(f1), Bundle.getMessage("ButtonClose")); // not sure why this is close in this frame.
         JUnitUtil.dispose(f1);
         JUnitUtil.dispose(f);
     }
@@ -78,15 +77,15 @@ public class ReporterTableActionTest extends AbstractTableActionBase<Reporter> {
     @Disabled("No Edit button on Reporter table")
     public void testEditButton() {
     }
-    
+
     @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testAddFailureCreate() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         
-        InstanceManager.setDefault(ReporterManager.class, new CreateNewReporterAlwaysException());
+        InstanceManager.setDefault(ReporterManager.class, new AlwaysExceptionCreateNewReporter());
         
         a = new ReporterTableAction();
-        Assume.assumeTrue(a.includeAddButton());
+        Assert.assertTrue(a.includeAddButton());
         
         a.actionPerformed(null);
         JFrame f = JFrameOperator.waitJFrame(getTableFrameName(), true, true);
@@ -109,10 +108,10 @@ public class ReporterTableActionTest extends AbstractTableActionBase<Reporter> {
         JUnitUtil.dispose(f1);
         JUnitUtil.dispose(f);
     }
-    
-    private class CreateNewReporterAlwaysException extends InternalReporterManager {
 
-        public CreateNewReporterAlwaysException() {
+    private static class AlwaysExceptionCreateNewReporter extends InternalReporterManager {
+
+        AlwaysExceptionCreateNewReporter() {
             super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
         }
 
@@ -129,7 +128,7 @@ public class ReporterTableActionTest extends AbstractTableActionBase<Reporter> {
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
+        JUnitUtil.resetProfileManager();
         helpTarget = "package.jmri.jmrit.beantable.ReporterTable";
         a = new ReporterTableAction();
     }

--- a/java/test/jmri/jmrit/beantable/SensorTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/SensorTableActionTest.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.beantable;
 
 import jmri.util.gui.GuiLafPreferencesManager;
-import java.awt.GraphicsEnvironment;
 
 import javax.annotation.Nonnull;
 import javax.swing.JFrame;
@@ -16,8 +15,9 @@ import jmri.util.JUnitUtil;
 import jmri.util.swing.JemmyUtil;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
 import org.netbeans.jemmy.operators.*;
 import org.netbeans.jemmy.util.NameComponentChooser;
 import org.slf4j.Logger;
@@ -62,8 +62,8 @@ public class SensorTableActionTest extends AbstractTableActionBase<Sensor> {
      * @since 4.7.4
      */
     @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testAddAndInvoke() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         a.actionPerformed(null); // show table
         // create 2 sensors and see if they exist
@@ -113,9 +113,9 @@ public class SensorTableActionTest extends AbstractTableActionBase<Sensor> {
 
     @Test
     @Override
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testAddButton() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeTrue(a.includeAddButton());
+        Assert.assertTrue(a.includeAddButton());
         a.actionPerformed(null);
         JFrame f = JFrameOperator.waitJFrame(getTableFrameName(), true, true);
 
@@ -123,16 +123,17 @@ public class SensorTableActionTest extends AbstractTableActionBase<Sensor> {
         jmri.util.swing.JemmyUtil.pressButton(new JFrameOperator(f),Bundle.getMessage("ButtonAdd"));
         new org.netbeans.jemmy.QueueTool().waitEmpty();
         JFrame f1 = JFrameOperator.waitJFrame(getAddFrameName(), true, true);
-        jmri.util.swing.JemmyUtil.pressButton(new JFrameOperator(f1),Bundle.getMessage("ButtonClose")); // not sure why this is close in this frame.
+        JemmyUtil.pressButton(new JFrameOperator(f1),Bundle.getMessage("ButtonClose")); // not sure why this is close in this frame.
         JUnitUtil.dispose(f1);
         JUnitUtil.dispose(f);
     }
 
     @Test
     @Override
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testEditButton() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assume.assumeTrue(a.includeAddButton());
+
+        Assert.assertTrue(a.includeAddButton());
         a.actionPerformed(null);
         JFrame f = JFrameOperator.waitJFrame(getTableFrameName(), true, true);
 
@@ -168,13 +169,13 @@ public class SensorTableActionTest extends AbstractTableActionBase<Sensor> {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
     public void testAddFailureCreate() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
-        InstanceManager.setDefault(SensorManager.class, new CreateNewSensorAlwaysException());
+        InstanceManager.setDefault(SensorManager.class, new AlwaysExceptionCreateNewSensor());
 
         a = new SensorTableAction();
-        Assume.assumeTrue(a.includeAddButton());
+        Assert.assertTrue(a.includeAddButton());
 
         a.actionPerformed(null);
         JFrame f = JFrameOperator.waitJFrame(getTableFrameName(), true, true);
@@ -198,9 +199,9 @@ public class SensorTableActionTest extends AbstractTableActionBase<Sensor> {
         JUnitUtil.dispose(f);
     }
 
-    private class CreateNewSensorAlwaysException extends InternalSensorManager {
+    private static class AlwaysExceptionCreateNewSensor extends InternalSensorManager {
 
-        public CreateNewSensorAlwaysException() {
+        AlwaysExceptionCreateNewSensor() {
             super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
         }
 

--- a/java/test/jmri/jmrit/beantable/TurnoutTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/TurnoutTableActionTest.java
@@ -180,7 +180,7 @@ public class TurnoutTableActionTest extends AbstractTableActionBase<Turnout> {
     @Test
     public void testAddFailureCreate() {
 
-        InstanceManager.setDefault(TurnoutManager.class, new CreateNewTurnoutAlwaysException());
+        InstanceManager.setDefault(TurnoutManager.class, new AlwaysExceptionCreateNewTurnout());
         
         a = new TurnoutTableAction();
         Assert.assertTrue(a.includeAddButton());
@@ -216,9 +216,9 @@ public class TurnoutTableActionTest extends AbstractTableActionBase<Turnout> {
 
     }
     
-    private class CreateNewTurnoutAlwaysException extends InternalTurnoutManager {
+    private static class AlwaysExceptionCreateNewTurnout extends InternalTurnoutManager {
 
-        protected CreateNewTurnoutAlwaysException() {
+        protected AlwaysExceptionCreateNewTurnout() {
             super(InstanceManager.getDefault(InternalSystemConnectionMemo.class));
         }
 

--- a/java/test/jmri/jmrit/beantable/signalmast/DccSignalMastAddPaneTest.java
+++ b/java/test/jmri/jmrit/beantable/signalmast/DccSignalMastAddPaneTest.java
@@ -41,13 +41,14 @@ public class DccSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase 
         Assert.assertFalse(vp.canHandleMast(m1));
         
         vp.setMast(null);
-        
-        vp.setAspectNames(s1.getAppearanceMap(), 
-            InstanceManager.getDefault(jmri.SignalSystemManager.class).getSystem("AAR-1946"));
+        SignalSystem aar1946system = InstanceManager.getDefault(SignalSystemManager.class).getSystem("AAR-1946");
+        Assertions.assertNotNull(aar1946system);
+        vp.setAspectNames(s1.getAppearanceMap(), aar1946system );
         vp.setMast(s1);
-        
-        vp.setAspectNames(m1.getAppearanceMap(),
-            InstanceManager.getDefault(jmri.SignalSystemManager.class).getSystem("basic"));
+
+        SignalSystem basic = InstanceManager.getDefault(SignalSystemManager.class).getSystem("basic");
+        Assertions.assertNotNull(basic);
+        vp.setAspectNames(m1.getAppearanceMap(), basic );
         vp.setMast(m1);
         JUnitAppender.assertErrorMessage("mast was wrong type: IF$xsm:basic:one-low($0001)-3t jmri.implementation.MatrixSignalMast");
     }
@@ -63,8 +64,8 @@ public class DccSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase 
         CommandStation c = new CommandStation() {
             @Override
             public boolean sendPacket(byte[] packet, int repeats) {
-                lastSentPacket = packet;
-                sentPacketCount++;
+                // lastSentPacket = packet;
+                // sentPacketCount++;
                 return true;
             }
 
@@ -79,11 +80,12 @@ public class DccSignalMastAddPaneTest extends AbstractSignalMastAddPaneTestBase 
             }
         };
         InstanceManager.store(c, CommandStation.class);
-        lastSentPacket = null;
-        sentPacketCount = 0;
+        // lastSentPacket = null;
+        // sentPacketCount = 0;
     }
-    byte[] lastSentPacket;
-    int sentPacketCount;
+
+    // byte[] lastSentPacket;
+    // int sentPacketCount;
 
     @AfterEach
     @Override

--- a/java/test/jmri/jmrit/beantable/signalmast/SignalMastAddPaneTest.java
+++ b/java/test/jmri/jmrit/beantable/signalmast/SignalMastAddPaneTest.java
@@ -22,14 +22,16 @@ public class SignalMastAddPaneTest {
         // group these in a single test, as the services can only be loaded once.
         Assert.assertNotNull(SignalMastAddPane.SignalMastAddPaneProvider.getInstancesCollection());
         Assert.assertNotNull(SignalMastAddPane.SignalMastAddPaneProvider.getInstancesMap());
-        Assert.assertTrue(SignalMastAddPane.SignalMastAddPaneProvider.getInstancesMap().size() > 0); // found at least one service
+        Assert.assertFalse(SignalMastAddPane.SignalMastAddPaneProvider.getInstancesMap().isEmpty()); // found at least one service
         Assert.assertEquals(SignalMastAddPane.SignalMastAddPaneProvider.getInstancesMap().size(), SignalMastAddPane.SignalMastAddPaneProvider.getInstancesCollection().size()); // same size
         
         // check map is in sorted order; also check lookup works
         Map<String, SignalMastAddPane.SignalMastAddPaneProvider> map = SignalMastAddPane.SignalMastAddPaneProvider.getInstancesMap();
         Collection<SignalMastAddPane.SignalMastAddPaneProvider> collection = SignalMastAddPane.SignalMastAddPaneProvider.getInstancesCollection();
         String last = "";
-        for (String name : map.keySet()) {
+        
+        for ( Map.Entry<String,?> entry : map.entrySet() ) {
+            String name = entry.getKey();
             Assert.assertTrue(name.compareTo(last) > 0);  // no identical ones
             Assert.assertTrue(collection.contains(map.get(name)));
             last = name;
@@ -59,10 +61,11 @@ public class SignalMastAddPaneTest {
         // check all the classes
         for (SignalMastAddPane.SignalMastAddPaneProvider pane : collection) {
         
-                Assert.assertTrue(pane.getPaneName() != null);
-                Assert.assertTrue(! pane.getPaneName().isEmpty());
+                Assert.assertFalse( pane.getPaneName().isBlank());
 
-               if (pane.isAvailable()) Assert.assertTrue(pane.getPaneName() != null);         
+               if (pane.isAvailable()) {
+                   Assert.assertFalse(pane.getPaneName().isBlank());
+                }
         }
 
     }


### PR DESCRIPTION
Exception managers to static, renamed to not end with exception
LightTableActionTest - minor simplifications

SignalMastAddPaneTest.java - map.keySet() to map.entrySet(), SignalMastAddPaneProvider.getPaneName() never null

DccSignalMastAddPaneTest.java - unused variables commented out for future use, ensure signalsystem not null