### PR TITLE
Update Server json Tests

### DIFF
--- a/java/test/jmri/server/json/JsonHttpServiceTestBase.java
+++ b/java/test/jmri/server/json/JsonHttpServiceTestBase.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.*;
  * @author Randall Wood Copyright 2018
  * @param <I> The class of JsonHttpService being tested
  */
-public class JsonHttpServiceTestBase<I extends JsonHttpService> {
+public abstract class JsonHttpServiceTestBase<I extends JsonHttpService> {
 
     protected ObjectMapper mapper = null;
     protected Locale locale = Locale.ENGLISH;
@@ -92,6 +92,7 @@ public class JsonHttpServiceTestBase<I extends JsonHttpService> {
         // test an invalid schema
         try {
             schema = service.doSchema("non-existant-type", false, new JsonRequest(locale, JSON.V5, JSON.GET, 42));
+            Assertions.fail("schema should not be valid: " + schema.toPrettyString());
         } catch (JsonException ex) {
             assertThat(ex.getCode()).isEqualTo(500);
             assertThat(ex.getMessage()).isEqualTo("Unknown object type non-existant-type was requested.");

--- a/java/test/jmri/server/json/JsonServiceFactoryTestBase.java
+++ b/java/test/jmri/server/json/JsonServiceFactoryTestBase.java
@@ -36,7 +36,6 @@ public abstract class JsonServiceFactoryTestBase<H extends JsonHttpService, I ex
     protected ObjectMapper mapper = null;
     protected Locale locale = Locale.ENGLISH;
     protected JsonServiceFactory<H, I> factory;
-    protected String[] duplicates;
 
     /**
      * @throws Exception to allow overriding methods to throw any exception

--- a/java/test/jmri/server/json/JsonSocketServiceTest.java
+++ b/java/test/jmri/server/json/JsonSocketServiceTest.java
@@ -26,7 +26,7 @@ public class JsonSocketServiceTest {
     }
 
     @Test
-    public void testLocale() {
+    public void testLocale() throws java.io.IOException {
         JsonConnection connection = new JsonConnection((DataOutputStream) null);
         JsonSocketService<?> instance = new JsonTestSocketService(connection);
         Assert.assertEquals("Default locale", Locale.getDefault(), instance.getLocale());
@@ -34,6 +34,8 @@ public class JsonSocketServiceTest {
         Assert.assertEquals("Italian locale", Locale.ITALY, instance.getLocale());
         connection.setLocale(Locale.ENGLISH);
         Assert.assertEquals("English locale", Locale.ENGLISH, instance.getLocale());
+
+        connection.close();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(JsonSocketServiceTest.class);

--- a/java/test/jmri/server/json/light/JsonLightHttpServiceTest.java
+++ b/java/test/jmri/server/json/light/JsonLightHttpServiceTest.java
@@ -39,7 +39,7 @@ public class JsonLightHttpServiceTest extends JsonNamedBeanHttpServiceTestBase<L
             // allow setting of "illegal" states for testing
             @Override
             public void setState(int newState) {
-                if (newState == Light.ON && newState == Light.OFF) {
+                if (newState == Light.ON || newState == Light.OFF) {
                     // if ON or OFF allow full transition to occur
                     super.setState(newState);
                 } else {

--- a/java/test/jmri/server/json/turnout/JsonTurnoutSocketServiceTest.java
+++ b/java/test/jmri/server/json/turnout/JsonTurnoutSocketServiceTest.java
@@ -104,7 +104,7 @@ public class JsonTurnoutSocketServiceTest {
     }
 
     @Test
-    public void testOnList() throws IOException, JmriException, JsonException, PropertyVetoException {
+    public void testOnList() throws IOException, JmriException, JsonException {
         JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
         JsonNode message;
         JsonTurnoutSocketService service = new JsonTurnoutSocketService(connection);
@@ -122,25 +122,31 @@ public class JsonTurnoutSocketServiceTest {
         manager.register(turnout1);
         JUnitUtil.waitFor(() -> {
             return manager.getBySystemName("IT1") != null;
-        });
+        },"IT1 not null");
         message = connection.getMessage();
         assertNotNull("Message is not null", message);
         assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
         manager.register(turnout2);
         JUnitUtil.waitFor(() -> {
             return manager.getBySystemName("IT2") != null;
-        });
+        },"match for IT2");
         message = connection.getMessage();
         assertNotNull("Message is not null", message);
         assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
         assertNotNull("Turnout 2 exists", turnout2);
-        manager.deleteBean(turnout2, "");
+        try {
+            manager.deleteBean(turnout2, "DoDelete");
+        } catch ( PropertyVetoException ex ){
+            Assertions.fail("Exception deleting bean ", ex);
+        }
         JUnitUtil.waitFor(() -> {
             return manager.getBySystemName("IT2") == null;
-        });
+        },"no match for IT2");
         message = connection.getMessage();
         assertNotNull("Message is not null", message);
         assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
+
+        connection.close();
     }
 
     @Test


### PR DESCRIPTION
JsonHttpServiceTestBase.java - move to abstract class
JsonServiceFactoryTestBase.java - remove unused String[]
JsonSocketServiceTest.java - close connection at end of test ( not auto-closeable )
JsonLightHttpServiceTest.java - Light state cannot be ON and OFF at same time, should use or instead of and
JsonTurnoutSocketServiceTest.java - use DoDelete property in deleteBean, close connection after test