### PR TITLE
Update jmrix LightManagerTests / TurnoutManagerTests

### DIFF
--- a/java/test/jmri/jmrix/acela/AcelaLightManagerTest.java
+++ b/java/test/jmri/jmrix/acela/AcelaLightManagerTest.java
@@ -5,8 +5,6 @@ import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the jmri.jmrix.acela.AcelaLightManager class.
@@ -33,21 +31,13 @@ public class AcelaLightManagerTest extends jmri.managers.AbstractLightMgrTestBas
     public void testAsAbstractFactory() {
         Light tl = l.newLight("AL21", "my name");
 
-        if (log.isDebugEnabled()) {
-            log.debug("received light value {}", tl);
-        }
-        Assert.assertTrue(null != (AcelaLight) tl);
+        Assert.assertNotNull( tl);
+        Assert.assertTrue(tl instanceof AcelaLight);
 
         // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", l.getBySystemName("AL21"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", l.getByUserName("my name"));
-        }
 
-        Assert.assertTrue(null != l.getBySystemName("AL21"));
-        Assert.assertTrue(null != l.getByUserName("my name"));
+        Assert.assertNotNull( l.getBySystemName("AL21"));
+        Assert.assertNotNull( l.getByUserName("my name"));
 
     }
 
@@ -79,6 +69,6 @@ public class AcelaLightManagerTest extends jmri.managers.AbstractLightMgrTestBas
 
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AcelaLightManagerTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AcelaLightManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutManagerTest.java
@@ -3,10 +3,7 @@ package jmri.jmrix.cmri.serial;
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the jmri.jmrix.cmri.SerialTurnoutManager class
@@ -34,7 +31,9 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
 
     @AfterEach
     public void tearDown() {
-        if (stcs != null) stcs.terminateThreads();
+        if (stcs != null) {
+            stcs.terminateThreads();
+        }
         stcs = null;
         memo = null;
 
@@ -52,24 +51,14 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
         // ask for a Turnout, and check type
         Turnout o = l.newTurnout("CT21", "my name");
 
-        if (log.isDebugEnabled()) {
-            log.debug("received turnout value {}", o);
-        }
-        Assert.assertTrue(null != (SerialTurnout) o);
+        Assertions.assertNotNull( o);
+        Assertions.assertTrue(o instanceof SerialTurnout);
 
-        // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", l.getBySystemName("CT21"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", l.getByUserName("my name"));
-        }
-
-        Assert.assertTrue(null != l.getBySystemName("CT21"));
-        Assert.assertTrue(null != l.getByUserName("my name"));
+        Assertions.assertNotNull( l.getBySystemName("CT21"));
+        Assertions.assertNotNull( l.getByUserName("my name"));
 
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/easydcc/EasyDccTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccTurnoutManagerTest.java
@@ -3,10 +3,7 @@ package jmri.jmrix.easydcc;
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the jmri.jmrix.easydcc.EasyDccTurnoutManager class
@@ -42,25 +39,15 @@ public class EasyDccTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrT
     public void testAsAbstractFactory() {
         // ask for a Turnout, and check type
         Turnout o = l.newTurnout("ET21", "my name");
-
-        if (log.isDebugEnabled()) {
-            log.debug("received turnout value {}", o);
-        }
-        Assert.assertTrue(null != (EasyDccTurnout) o);
+        Assertions.assertNotNull( o);
+        Assertions.assertTrue( o instanceof EasyDccTurnout );
 
         // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", l.getBySystemName("ET21"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", l.getByUserName("my name"));
-        }
-
-        Assert.assertTrue(null != l.getBySystemName("ET21"));
-        Assert.assertTrue(null != l.getByUserName("my name"));
+        Assertions.assertNotNull( l.getBySystemName("ET21"));
+        Assertions.assertNotNull( l.getByUserName("my name"));
 
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EasyDccTurnoutManagerTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(EasyDccTurnoutManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/grapevine/SerialLightManagerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialLightManagerTest.java
@@ -7,9 +7,6 @@ import java.beans.PropertyVetoException;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 /**
  * Tests for the SerialLightManager class
@@ -23,7 +20,7 @@ public class SerialLightManagerTest extends jmri.managers.AbstractLightMgrTestBa
     @BeforeEach
     @Override
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
 
         // replace the SerialTrafficController
         memo = new GrapevineSystemConnectionMemo();
@@ -49,22 +46,12 @@ public class SerialLightManagerTest extends jmri.managers.AbstractLightMgrTestBa
     public void testAsAbstractFactory() {
         // ask for a Light, and check type
         Light o = l.newLight("GL1105", "my name");
-
-        if (log.isDebugEnabled()) {
-            log.debug("received light value {}", o);
-        }
-        Assert.assertTrue(null != (SerialLight) o);
+        Assert.assertNotNull( o);
+        Assert.assertTrue(o instanceof SerialLight);
 
         // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", l.getBySystemName("GL1105"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", l.getByUserName("my name"));
-        }
-
-        Assert.assertTrue(null != l.getBySystemName("GL1105"));
-        Assert.assertTrue(null != l.getByUserName("my name"));
+        Assert.assertNotNull( l.getBySystemName("GL1105"));
+        Assert.assertNotNull( l.getByUserName("my name"));
 
     }
 
@@ -98,14 +85,12 @@ public class SerialLightManagerTest extends jmri.managers.AbstractLightMgrTestBa
         return 1107;
     }
 
-
     @AfterEach
     public void tearDown() {
         JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
         JUnitUtil.tearDown();
-
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialLightManagerTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialLightManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/grapevine/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialTurnoutManagerTest.java
@@ -7,8 +7,6 @@ import java.beans.PropertyVetoException;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the SerialTurnoutManager class.
@@ -48,21 +46,12 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
         // ask for a Turnout, and check type
         Turnout o = l.newTurnout("GT1105", "my name");
 
-        if (log.isDebugEnabled()) {
-            log.debug("received turnout value {}", o);
-        }
-        Assert.assertTrue(null != (SerialTurnout) o);
+        Assertions.assertNotNull( o);
+        Assertions.assertTrue(o instanceof SerialTurnout);
 
         // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", l.getBySystemName("GT1105"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", l.getByUserName("my name"));
-        }
-
-        Assert.assertTrue(null != l.getBySystemName("GT1105"));
-        Assert.assertTrue(null != l.getByUserName("my name"));
+        Assertions.assertNotNull( l.getBySystemName("GT1105"));
+        Assertions.assertNotNull( l.getByUserName("my name"));
 
     }
 
@@ -85,6 +74,7 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
 
     /**
      * Number of turnout to test. Use 9th output on node 1.
+     * {@inheritDoc}
      */ 
     @Override
     protected int getNumToTest1() {
@@ -103,6 +93,6 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
 
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
@@ -5,9 +5,6 @@ import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 /**
  * Tests for the jmri.jmrix.internal.InternalLightManager class.
@@ -32,21 +29,15 @@ public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTest
 
         Light tl = lm.newLight("IL21", "my name");
 
-        if (log.isDebugEnabled()) {
-            log.debug("received light value {}", tl);
-        }
-        Assert.assertTrue(null != tl);
+        Assert.assertNotNull( tl);
 
         // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", lm.getBySystemName("IL21"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", lm.getByUserName("my name"));
-        }
 
-        Assert.assertTrue(null != lm.getBySystemName("IL21"));
-        Assert.assertTrue(null != lm.getByUserName("my name"));
+        Assert.assertNotNull( lm.getBySystemName("IL21"));
+        Assert.assertNotNull( lm.getByUserName("my name"));
+        
+        Assert.assertTrue( tl == lm.getBySystemName("IL21") );
+        Assert.assertTrue( tl == lm.getByUserName("my name") );
 
     }
 
@@ -82,5 +73,5 @@ public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTest
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(InternalLightManagerTest.class);
+    // private final static import org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(InternalLightManagerTest.class);
 }

--- a/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
@@ -5,16 +5,12 @@ import java.beans.PropertyChangeListener;
 import java.util.*;
 
 import jmri.*;
-import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 /**
  * Tests for the jmri.managers.InternalSensorManager class.
@@ -40,28 +36,32 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         // ask for a Sensor, and check type
         Sensor tl = l.newSensor("IS21", "my name");
 
-        log.debug("received sensor value {}", tl);
-
-        Assert.assertTrue(null != tl);
+        Assert.assertNotNull(tl);
 
         // make sure loaded into tables
-        Assert.assertTrue(null != l.getBySystemName("IS21"));
-        Assert.assertTrue(null != l.getByUserName("my name"));
+        Assert.assertNotNull( l.getBySystemName("IS21"));
+        Assert.assertNotNull( l.getByUserName("my name"));
 
     }
 
     public void testSensorNameCase() {
         Assert.assertEquals(0, l.getObjectCount());
         // create
-        Sensor t = l.provideSensor("IS:XYZ");
-        t = l.provideSensor("IS:xyz");  // upper canse and lower case are the same object
+        Sensor ta = l.provideSensor("IS:XYZ");
+        Sensor tb = l.provideSensor("IS:xyz");  // upper canse and lower case are the same object
         // check
-        Assert.assertTrue("real object returned ", t != null);
-        Assert.assertEquals("IS:XYZ", t.getSystemName());  // we force upper
-        Assert.assertTrue("system name correct ", t == l.getBySystemName("IS:XYZ"));
+        Assert.assertNotNull("real object returned ", ta );
+        Assert.assertEquals("IS:XYZ", ta.getSystemName());  // we force upper
+        Assert.assertTrue("system name correct ", ta == l.getBySystemName("IS:XYZ"));
+        
+        Assert.assertNotNull("real object returned ", tb );
+        Assert.assertEquals("IS:XYZ", tb.getSystemName());  // we force upper
+        Assert.assertTrue("system name correct ", tb == l.getBySystemName("IS:XYZ"));
+        
         Assert.assertEquals(1, l.getObjectCount());
 
-        t = l.provideSensor("IS:XYZ");
+        Sensor t = l.provideSensor("IS:XYZ");
+        Assert.assertNotNull(t);
         Assert.assertEquals(1, l.getObjectCount());
     }
 
@@ -185,15 +185,16 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         l.provideSensor("IS2");
 
         java.util.SortedSet<Sensor> set = l.getNamedBeanSet();
-        Assert.assertThrows(UnsupportedOperationException.class, () -> set.add(null));
+        assertThatThrownBy(() -> set.add(null))
+            .isInstanceOf(UnsupportedOperationException.class);
 
     }
 
     // from here down is testing infrastructure
 
     // Property listen & audit methods
-    static protected int propertyListenerCount = 0;
-    static protected String propertyListenerLast = null;
+    protected int propertyListenerCount = 0;
+    protected String propertyListenerLast = null;
 
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
@@ -307,6 +308,6 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(InternalSensorManagerTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(InternalSensorManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/LnSensorManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnSensorManagerTest.java
@@ -46,8 +46,8 @@ public class LnSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase
         Assert.assertNotNull("exists", t);
 
         // try to get nonexistant turnouts
-        Assert.assertTrue(null == l.getByUserName("foo"));
-        Assert.assertTrue(null == l.getBySystemName("bar"));
+        Assert.assertNull( l.getByUserName("foo"));
+        Assert.assertNull( l.getBySystemName("bar"));
     }
 
     @Test
@@ -62,7 +62,7 @@ public class LnSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase
         lnis.sendTestMessage(m1);
 
         // see if sensor exists
-        Assert.assertTrue(null != l.getBySystemName("LS44"));
+        Assert.assertNotNull( l.getBySystemName("LS44"));
     }
 
     @Test
@@ -75,18 +75,14 @@ public class LnSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase
         if (log.isDebugEnabled()) {
             log.debug("received sensor value {}", o);
         }
-        Assert.assertTrue(null != (LnSensor) o);
+        
+        Assert.assertNotNull(o);
+        Assert.assertTrue(o instanceof LnSensor );
 
         // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", t.getBySystemName("LS21"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", t.getByUserName("my name"));
-        }
 
-        Assert.assertTrue(null != t.getBySystemName("LS21"));
-        Assert.assertTrue(null != t.getByUserName("my name"));
+        Assert.assertNotNull( t.getBySystemName("LS21"));
+        Assert.assertNotNull( t.getByUserName("my name"));
 
     }
 

--- a/java/test/jmri/jmrix/maple/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/maple/SerialTurnoutManagerTest.java
@@ -3,13 +3,10 @@ package jmri.jmrix.maple;
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * JUnit tests for the jmri.jmrix.maple.SerialTurnoutManager class
+ * JUnit tests for the jmri.jmrix.maple.SerialTurnoutManager class.
  *
  * @author Bob Jacobsen
  */
@@ -26,7 +23,7 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
     public void testConstructor() {
         // create and register the manager object
         SerialTurnoutManager atm = new SerialTurnoutManager(new MapleSystemConnectionMemo());
-        Assert.assertNotNull("Maple Turnout Manager creation with memo", atm);
+        Assertions.assertNotNull( atm, "Maple Turnout Manager creation with memo" );
     }
 
     @Test
@@ -34,21 +31,13 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
         // ask for a Turnout, and check type
         Turnout o = l.newTurnout("KT21", "my name");
 
-        if (log.isDebugEnabled()) {
-            log.debug("received turnout value {}", o);
-        }
-        Assert.assertTrue(null != (SerialTurnout) o);
+        Assertions.assertNotNull(o);
+        Assertions.assertTrue( o instanceof SerialTurnout );
 
         // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", l.getBySystemName("KT21"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", l.getByUserName("my name"));
-        }
 
-        Assert.assertTrue(null != l.getBySystemName("KT21"));
-        Assert.assertTrue(null != l.getByUserName("my name"));
+        Assertions.assertNotNull( l.getBySystemName("KT21"));
+        Assertions.assertNotNull( l.getByUserName("my name"));
 
     }
 
@@ -77,6 +66,6 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
 
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/oaktree/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/oaktree/SerialTurnoutManagerTest.java
@@ -3,10 +3,7 @@ package jmri.jmrix.oaktree;
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * JUnit tests for the SerialTurnoutManager class
@@ -26,14 +23,14 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
     public void testCtor() {
         // create and register the manager object
         SerialTurnoutManager atm = new SerialTurnoutManager(memo);
-        Assert.assertNotNull("Oak Tree Turnout Manager creation", atm);
+        Assertions.assertNotNull( atm, "Oak Tree Turnout Manager creation" );
     }
 
     @Test
     public void testConstructor() {
         // create and register the manager object
         SerialTurnoutManager atm = new SerialTurnoutManager(new OakTreeSystemConnectionMemo());
-        Assert.assertNotNull("Oak Tree Turnout Manager creation with memo", atm);
+        Assertions.assertNotNull(atm, "Oak Tree Turnout Manager creation with memo" );
     }
 
     @Test
@@ -41,19 +38,12 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
         // ask for a Turnout, and check type
         Turnout o = l.newTurnout("OT21", "my name");
 
-        log.debug("received turnout value {}", o);
-        Assert.assertTrue(null != (SerialTurnout) o);
+        Assertions.assertNotNull( o );
+        Assertions.assertTrue(o instanceof SerialTurnout );
 
         // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", l.getBySystemName("OT21"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", l.getByUserName("my name"));
-        }
-
-        Assert.assertTrue(null != l.getBySystemName("OT21"));
-        Assert.assertTrue(null != l.getByUserName("my name"));
+        Assertions.assertNotNull( l.getBySystemName("OT21"));
+        Assertions.assertNotNull( l.getByUserName("my name"));
     }
 
     @BeforeEach
@@ -78,6 +68,6 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
 
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/powerline/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/powerline/SerialTurnoutManagerTest.java
@@ -10,8 +10,6 @@ import java.beans.PropertyVetoException;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * SerialTurnoutManagerTest.java
@@ -54,22 +52,12 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
     public void testAsAbstractFactory() {
         // ask for a Turnout, and check type
         Turnout o = l.newTurnout("PTB1", "my name");
-
-        if (log.isDebugEnabled()) {
-            log.debug("received turnout value {}", o);
-        }
-        Assert.assertTrue(null != (SerialTurnout) o);
+        Assert.assertNotNull( o );
+        Assert.assertTrue( o instanceof SerialTurnout );
 
         // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", l.getBySystemName("PTB1"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", l.getByUserName("my name"));
-        }
-
-        Assert.assertTrue(null != l.getBySystemName("PTB1"));
-        Assert.assertTrue(null != l.getByUserName("my name"));
+        Assert.assertNotNull( l.getBySystemName("PTB1"));
+        Assert.assertNotNull( l.getByUserName("my name"));
 
     }
 
@@ -79,7 +67,7 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
         // create
         Turnout t = l.provide(getSystemName(getNumToTest1()));
         // check
-        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertNotNull("real object returned ", t );
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
@@ -89,7 +77,7 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
         // create
         Turnout t = l.provideTurnout(getSystemName(getNumToTest1()));
         // check
-        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertNotNull("real object returned ", t );
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
@@ -132,6 +120,6 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
 
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
@@ -3,10 +3,7 @@ package jmri.jmrix.tams;
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the TurnoutManager class
@@ -48,24 +45,13 @@ public class TamsTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         // ask for a Turnout, and check type
         Turnout o = l.newTurnout("TT21", "my name");
 
-        if (log.isDebugEnabled()) {
-            log.debug("received turnout value {}", o);
-        }
-        Assert.assertTrue(null != (TamsTurnout) o);
+        Assertions.assertNotNull(o);
+        Assertions.assertTrue(o instanceof TamsTurnout );
 
-        // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", l.getBySystemName("TT21"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", l.getByUserName("my name"));
-        }
-
-        Assert.assertTrue(null != l.getBySystemName("TT21"));
-        Assert.assertTrue(null != l.getByUserName("my name"));
-
+        Assertions.assertNotNull( l.getBySystemName("TT21"));
+        Assertions.assertNotNull( l.getByUserName("my name"));
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TamsTurnoutManagerTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TamsTurnoutManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/tmcc/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/tmcc/SerialTurnoutManagerTest.java
@@ -3,10 +3,7 @@ package jmri.jmrix.tmcc;
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the SerialTurnoutManager class.
@@ -43,24 +40,16 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
         // ask for a Turnout, and check type
         Turnout o = l.newTurnout("TT21", "my name");
 
-        if (log.isDebugEnabled()) {
-            log.debug("received turnout value {}", o);
-        }
-        Assert.assertTrue(null != (SerialTurnout) o);
+        Assertions.assertNotNull(o);
+        Assertions.assertTrue( o instanceof SerialTurnout );
 
         // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", l.getBySystemName("TT21"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", l.getByUserName("my name"));
-        }
 
-        Assert.assertTrue(null != l.getBySystemName("TT21"));
-        Assert.assertTrue(null != l.getByUserName("my name"));
+        Assertions.assertNotNull( l.getBySystemName("TT21"));
+        Assertions.assertNotNull( l.getByUserName("my name"));
 
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SerialTurnoutManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/ztc/ztc611/ZTC611XNetTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/ztc/ztc611/ZTC611XNetTurnoutManagerTest.java
@@ -8,8 +8,6 @@ import jmri.util.JUnitUtil;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the jmri.jmrix.ztc.ztc611.ZTC611XNetTurnoutManager class.
@@ -27,31 +25,19 @@ public class ZTC611XNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutM
 
     @Test
     public void testAsAbstractFactory() {
-        lnis = new XNetInterfaceScaffold(new LenzCommandStation());
-        // create and register the manager object
-        ZTC611XNetTurnoutManager l = new ZTC611XNetTurnoutManager(lnis.getSystemConnectionMemo());
-        jmri.InstanceManager.setTurnoutManager(l);
 
         // ask for a Turnout, and check type
-        TurnoutManager t = jmri.InstanceManager.turnoutManagerInstance();
+        TurnoutManager t = jmri.InstanceManager.getDefault(TurnoutManager.class);
+        Assertions.assertTrue(t instanceof ZTC611XNetTurnoutManager );
 
         Turnout o = t.newTurnout("XT21", "my name");
 
-        if (log.isDebugEnabled()) {
-            log.debug("received turnout value {}", o);
-        }
-        Assert.assertTrue(null != (ZTC611XNetTurnout) o);
+        Assertions.assertNotNull( o );
+        Assertions.assertTrue( o instanceof ZTC611XNetTurnout );
 
         // make sure loaded into tables
-        if (log.isDebugEnabled()) {
-            log.debug("by system name: {}", t.getBySystemName("XT21"));
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("by user name:   {}", t.getByUserName("my name"));
-        }
-
-        Assert.assertTrue(null != t.getBySystemName("XT21"));
-        Assert.assertTrue(null != t.getByUserName("my name"));
+        Assertions.assertNotNull( t.getBySystemName("XT21"));
+        Assertions.assertNotNull( t.getByUserName("my name"));
 
     }
 
@@ -67,25 +53,26 @@ public class ZTC611XNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutM
          Assert.assertEquals("closed text","Closed (-)",l.getClosedText());
     }
 
-    @AfterEach
-    public void tearDown() {
-        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
-        JUnitUtil.tearDown();
-
-    }
+    
 
     @Override
     @BeforeEach
     public void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetInstanceManager();
         // prepare an interface, register
         lnis = new XNetInterfaceScaffold(new LenzCommandStation());
         // create and register the manager object
         l = new ZTC611XNetTurnoutManager(lnis.getSystemConnectionMemo());
-        jmri.InstanceManager.setTurnoutManager(l);
+        jmri.InstanceManager.setDefault(TurnoutManager.class,l);
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ZTC611XNetTurnoutManagerTest.class);
+    @AfterEach
+    public void tearDown() {
+        JUnitUtil.clearShutDownManager(); // put in place because AbstractMRTrafficController implementing subclass was not terminated properly
+        JUnitUtil.tearDown();
+    }
+
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ZTC611XNetTurnoutManagerTest.class);
 
 }


### PR DESCRIPTION
use assertNotNull instead of assertTrue(null !=
removes unneccessary logging

InternalSensorManagerTest.java - moves propertyListener variables from static to instance
ZTC611XNetTurnoutManagerTest.java - testAsAbstractFactory does not need a 2nd InterfaceScaffold / TurnoutManager