### PR TITLE
Fix issue with OpenLCB hub at high rates

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -116,7 +116,9 @@
 
         <h4><a href="http://openlcb.org">OpenLCB</a> / LCC</h4>
             <ul>
-                <li></li>
+                <li>Fix a problem with the OpenLCB hub at high data rates. Overlapping
+                    messages and replies would be echoed out incorrectly.
+                </li>
             </ul>
 
         <h4>RFID</h4>


### PR DESCRIPTION
With high enough data rates, the OpenLCB hub was losing track of which messages it had sent and not send due to overlapping sends and receives.  This fixes that.  