### PR TITLE
Only one listener for mouse wheel events on throttle window.

### DIFF
--- a/java/src/jmri/jmrit/throttle/ThrottleWindow.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleWindow.java
@@ -59,7 +59,6 @@ public class ThrottleWindow extends JmriJFrame {
     private final PowerManager powerMgr;
     private SmallPowerManagerButton smallPowerMgmtButton;
 
-    private final ThrottleWindowInputsListener myInputsListener;
     private final ThrottleWindowActionsFactory myActionFactory;
 
     private HashMap<String, ThrottleFrame> throttleFrames = new HashMap<>(5);
@@ -92,7 +91,6 @@ public class ThrottleWindow extends JmriJFrame {
             log.debug("Creating new ThrottlesPreference Instance");
             jmri.InstanceManager.store(new ThrottlesPreferences(), ThrottlesPreferences.class);
         }
-        myInputsListener = new ThrottleWindowInputsListener(this);
         myActionFactory = new ThrottleWindowActionsFactory(this);
         powerMgr = InstanceManager.getNullableDefault(PowerManager.class);
         if (powerMgr == null) {
@@ -152,6 +150,8 @@ public class ThrottleWindow extends JmriJFrame {
         for (Object k : am.allKeys()) {
             getRootPane().getActionMap().put(k, am.get(k));
         }
+        
+        addMouseWheelListener( new ThrottleWindowInputsListener(this) );
 
         this.addWindowListener(new WindowAdapter() {
             @Override
@@ -784,7 +784,6 @@ public class ThrottleWindow extends JmriJFrame {
     private void installInputsListenerOnAllComponents(Container c) {
         c.setFocusTraversalKeysEnabled(false); // make tab and shift tab available
         if (! ( c instanceof JTextField)) {
-            c.addMouseWheelListener(myInputsListener);
             c.setFocusable(false);
         }
         for (Component component : c.getComponents()) {
@@ -792,7 +791,6 @@ public class ThrottleWindow extends JmriJFrame {
                 installInputsListenerOnAllComponents( (Container) component);
             } else {
                 if (! ( component instanceof JTextField)) {
-                    component.addMouseWheelListener(myInputsListener);
                     component.setFocusable(false);
                 }
             }


### PR DESCRIPTION
Only one mouse wheel listener per throttle window, will fix [this issue](https://groups.io/g/jmriusers/topic/mouse_wheel_steps_twice_per/92116721?p=,,,50,0,0,0::recentpostdate/sticky,,,50,2,0,92116721,previd%3D9223372036854775807,nextid%3D1656083292670221644&previd=9223372036854775807&nextid=1656083292670221644).