### PR TITLE
Move panel icons on Windows

### DIFF
--- a/java/src/jmri/util/swing/JmriMouseEvent.java
+++ b/java/src/jmri/util/swing/JmriMouseEvent.java
@@ -6,8 +6,6 @@ import java.awt.Toolkit;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 
-import javax.swing.SwingUtilities;
-
 import jmri.util.SystemType;
 
 /**
@@ -299,9 +297,17 @@ public class JmriMouseEvent {
      */
     public boolean isPopupTrigger() {
         if (SystemType.isWindows()) {
-            // event.isPopupTrigger() returns false on mousePressed() on Windows.
-            // The bad news is that SwingUtilities.isRightMouseButton(event) doesn't work either.
-            return (event.getModifiersEx() & InputEvent.BUTTON3_DOWN_MASK) != 0;
+            switch (event.getID()) {
+                case MouseEvent.MOUSE_PRESSED:
+                case MouseEvent.MOUSE_RELEASED:
+                case MouseEvent.MOUSE_CLICKED:
+                    // event.isPopupTrigger() returns false on mousePressed() on Windows.
+                    // The bad news is that SwingUtilities.isRightMouseButton(event) doesn't work either.
+                    return (event.getModifiersEx() & InputEvent.BUTTON3_DOWN_MASK) != 0;
+
+                default:
+                    return event.isPopupTrigger();
+            }
         } else {
             return event.isPopupTrigger();
         }
@@ -375,7 +381,7 @@ public class JmriMouseEvent {
      */
     public boolean isMetaDown() {
         if (SystemType.isWindows() || SystemType.isLinux()) {
-            return SwingUtilities.isRightMouseButton(event);
+            return (event.getModifiersEx() & InputEvent.BUTTON3_DOWN_MASK) != 0;
         } else {
             return event.isMetaDown();
         }


### PR DESCRIPTION
 #11127 had a bug that caused that panel icons cannot be moved on Windows. This PR fixes that.