### PR TITLE
Add programming on main for mxulf

### DIFF
--- a/java/src/jmri/jmrix/zimo/Mx1OpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/zimo/Mx1OpsModeProgrammer.java
@@ -135,6 +135,6 @@ public class Mx1OpsModeProgrammer extends Mx1Programmer implements AddressedProg
         return "" + getAddressNumber() + " " + getLongAddress();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Mx1Programmer.class);
+    private final static Logger log = LoggerFactory.getLogger(Mx1OpsModeProgrammer.class);
 
 }

--- a/java/src/jmri/jmrix/zimo/Mx1OpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/zimo/Mx1OpsModeProgrammer.java
@@ -1,0 +1,138 @@
+package jmri.jmrix.zimo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import jmri.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Programmer support for Zimo MXULF.  
+ * Provide an Ops Mode Programmer via a wrapper that works with the
+ * EasyDccCommandStation object.
+ * <p>
+ * Functionally, this just creates packets to send via the Command Station.
+ *
+ * @see jmri.Programmer
+ * @author Bob Jacobsen Copyright (c) 2002
+ *
+ * Adapted by Alger Pike for use with zimo MXULF
+ *
+ */
+public class Mx1OpsModeProgrammer extends Mx1Programmer implements AddressedProgrammer {
+
+    int mAddress;
+    boolean mLongAddr;
+
+     public Mx1OpsModeProgrammer(int pAddress, boolean pLongAddr, Mx1TrafficController tc) {
+        super(tc);
+        mAddress = pAddress;
+        mLongAddr = pLongAddr;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Types implemented here.
+     */
+    @Override
+    @Nonnull
+    public List<ProgrammingMode> getSupportedModes() {
+        List<ProgrammingMode> ret = new ArrayList<ProgrammingMode>();
+        ret.add(ProgrammingMode.OPSBYTEMODE);
+        return ret;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    synchronized public void writeCV(String CVname, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+        final int CV = Integer.parseInt(CVname);
+        if (log.isDebugEnabled()) {
+            log.debug("writeCV {} listens {}", CV, p);
+        }
+        useProgrammer(p);
+        _progRead = false;
+        // set new state & save values
+        progState = INQUIRESENT;
+        _val = val;
+        _cv = CV;
+        // start the error timer
+        startShortTimer();
+        // format and send message to go to program mode
+        if (getMode() == ProgrammingMode.OPSBYTEMODE) {
+            if (tc.getProtocol() == Mx1Packetizer.ASCII) {
+                // Not supporting ASCII protocol for now.
+                throw new ProgrammerException();
+            } else {
+                tc.sendMx1Message(Mx1Message.getDecProgCmd(mAddress, _cv, val, true), this);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    synchronized public void readCV(String CVname, jmri.ProgListener p) throws jmri.ProgrammerException {
+        final int CV = Integer.parseInt(CVname);
+        log.debug("read CV={}", CV);
+        log.error("readCV not available in this protocol");
+        throw new ProgrammerException();
+    }
+
+    /** 
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
+        log.debug("confirm CV={}", CV);
+        log.error("confirmCV not available in this protocol");
+        throw new ProgrammerException();
+    }
+    
+    /** 
+     * {@inheritDoc}
+     *
+     * Can this ops-mode programmer read back values? For now, no, but maybe
+     * later.
+     *
+     * @return always false for now
+     */
+    @Override
+    public boolean getCanRead() {
+        return false;
+    }
+
+    /** 
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getLongAddress() {
+        return mLongAddr;
+    }
+
+    /** 
+     * {@inheritDoc}
+     */
+    @Override
+    public int getAddressNumber() {
+        return mAddress;
+    }
+
+    /** 
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAddress() {
+        return "" + getAddressNumber() + " " + getLongAddress();
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(Mx1Programmer.class);
+
+}

--- a/java/src/jmri/jmrix/zimo/Mx1OpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/zimo/Mx1OpsModeProgrammer.java
@@ -11,16 +11,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Programmer support for Zimo MXULF.  
+ * Programmer support for Zimo MXULF operations mode.  
  * Provide an Ops Mode Programmer via a wrapper that works with the
- * EasyDccCommandStation object.
+ * MX1Programmer object.
  * <p>
- * Functionally, this just creates packets to send via the Command Station.
+ * Functionally, this just creates packets to send via the MXULF.
  *
  * @see jmri.Programmer
  * @author Bob Jacobsen Copyright (c) 2002
  *
- * Adapted by Alger Pike for use with zimo MXULF
+ * Adapted by
+ * @author Alger Pike Copyright (c) 2022
+ * for use with zimo MXULF
  *
  */
 public class Mx1OpsModeProgrammer extends Mx1Programmer implements AddressedProgrammer {

--- a/java/src/jmri/jmrix/zimo/Mx1ProgrammerManager.java
+++ b/java/src/jmri/jmrix/zimo/Mx1ProgrammerManager.java
@@ -16,9 +16,12 @@ import jmri.managers.DefaultProgrammerManager;
  *
  */
 public class Mx1ProgrammerManager extends DefaultProgrammerManager {
+    
+    private Mx1SystemConnectionMemo _memo = null;
 
     public Mx1ProgrammerManager(Programmer serviceModeProgrammer, Mx1SystemConnectionMemo memo) {
         super(serviceModeProgrammer, memo);
+        _memo = memo;
     }
 
     /**
@@ -28,7 +31,14 @@ public class Mx1ProgrammerManager extends DefaultProgrammerManager {
      */
     @Override
     public boolean isAddressedModePossible() {
-        return false;
+        if (_memo.getConnectionType() == Mx1SystemConnectionMemo.MXULF)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
     }
 
     @Override
@@ -38,7 +48,14 @@ public class Mx1ProgrammerManager extends DefaultProgrammerManager {
 
     @Override
     public AddressedProgrammer getAddressedProgrammer(boolean pLongAddress, int pAddress) {
-        return null;
+        if (_memo.getConnectionType() == Mx1SystemConnectionMemo.MXULF)
+        {
+            return new Mx1OpsModeProgrammer(pAddress, pLongAddress, _memo.getMx1TrafficController());
+        }
+        else
+        {
+            return null;
+        }
     }
 
     @Override

--- a/java/src/jmri/jmrix/zimo/Mx1ProgrammerManager.java
+++ b/java/src/jmri/jmrix/zimo/Mx1ProgrammerManager.java
@@ -7,12 +7,14 @@ import jmri.managers.DefaultProgrammerManager;
 
 /**
  * Extend DefaultProgrammerManager to provide ops mode programmers for Zimo
- * systems.
+ * systems. Adding operations mode programming support July 2022.
  *
  * @see jmri.managers.DefaultProgrammerManager
  * @author Bob Jacobsen Copyright (C) 2002
  * @author Ken Cameron Copyright (C) 2014
  * @author Kevin Dickerson Copyright (C) 2014
+ * @author Alger Pike Copyright (c) 2022
+ * 
  *
  */
 public class Mx1ProgrammerManager extends DefaultProgrammerManager {
@@ -33,6 +35,10 @@ public class Mx1ProgrammerManager extends DefaultProgrammerManager {
     public boolean isAddressedModePossible() {
         if (_memo.getConnectionType() == Mx1SystemConnectionMemo.MXULF)
         {
+            
+            // currently only supporting MXULF. In theory I think any Zimo
+            // system that supports the binary protocol would work but I am
+            // unable to test said systems.
             return true;
         }
         else
@@ -50,6 +56,10 @@ public class Mx1ProgrammerManager extends DefaultProgrammerManager {
     public AddressedProgrammer getAddressedProgrammer(boolean pLongAddress, int pAddress) {
         if (_memo.getConnectionType() == Mx1SystemConnectionMemo.MXULF)
         {
+            
+            // currently only supporting MXULF. In theory I think any Zimo
+            // system that supports the binary protocol would work but I am
+            // unable to test said systems.
             return new Mx1OpsModeProgrammer(pAddress, pLongAddress, _memo.getMx1TrafficController());
         }
         else


### PR DESCRIPTION
Was running into decoders that only support programming on the main. The MXULF supports this functionality.  This support was added following the EasyDcc OpsMode Programmer as a template.

Being reasonably conservative here i.e. currently only supports binary protocol and MXULF since I have no way to test ASCII protocol and/or other zimo products.

I can confirm that the following changes do work on a MXULF and have allowed me to program the decoders that only support ops mode.