### PR TITLE
LogixNG Test Updates

### DIFF
--- a/java/test/jmri/jmrit/logixng/ActionsAndExpressionsTest.java
+++ b/java/test/jmri/jmrit/logixng/ActionsAndExpressionsTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.Assert;
 
 /**
- * Test that all the action and expression classes are registed and have
+ * Test that all the action and expression classes are registered and have
  * configurexml and swing classes.
  * <P>
  * Requirements that this class checks for:
@@ -56,7 +56,7 @@ public class ActionsAndExpressionsTest {
                 .filter(p -> p.getFileName().toString().contains("_"))
                 .forEach(p -> {
                     String file = p.getFileName().toString();
-                    languages.add(file.substring(file.indexOf("_")+1, file.length()-".properties".length()));
+                    languages.add(file.substring(file.indexOf('_')+1, file.length()-".properties".length()));
                 });
 
         for (String lang : languages) {
@@ -78,12 +78,16 @@ public class ActionsAndExpressionsTest {
 
         filesLoop:
         for (String file : files) {
-            if (file.endsWith(".properties")) continue;
+            if (file.endsWith(".properties")) {
+                continue;
+            }
 
-            file = file.substring(0, file.indexOf('.'));
+            String firstPartOfFileName = file.substring(0, file.indexOf('.'));
 
             for (String c : classesToIgnore) {
-                if (file.equals(c)) continue filesLoop;
+                if (firstPartOfFileName.equals(c)) {
+                    continue filesLoop;
+                }
             }
 
             // Check that all actions and expressions is registered in its manager
@@ -92,7 +96,9 @@ public class ActionsAndExpressionsTest {
             for (Map.Entry<Category, List<Class<? extends Base>>> entry : registeredClasses.entrySet()) {
                 for (Class<? extends Base> c : entry.getValue()) {
 //                    System.out.format("Registered class: %s%n", c.getName());
-                    if (c.getName().equals(packageName+"."+file)) isRegistered = true;
+                    if (c.getName().equals(packageName+"."+firstPartOfFileName)) {
+                        isRegistered = true;
+                    }
 
                     Assert.assertFalse(String.format("Class %s is registered more than once in the manager", packageName+"."+c.getName()), setOfClasses.contains(c));
 
@@ -107,10 +113,10 @@ public class ActionsAndExpressionsTest {
             }
 
 //            if (!isRegistered) {
-//                System.out.format("Class %s.%s is not registered in the manager%n", packageName, file);
+//                System.out.format("Class %s.%s is not registered in the manager%n", packageName, firstPartOfFileName);
 //                errorsFound = true;
 //            }
-            Assert.assertTrue(String.format("Class %s is registred%n", file), isRegistered);
+            Assert.assertTrue(String.format("Class %s is registred%n", firstPartOfFileName), isRegistered);
 
             String fullConfigName;
 
@@ -118,7 +124,7 @@ public class ActionsAndExpressionsTest {
 
             // Check that all actions and expressions has a xml class
             Object configureXml = null;
-            fullConfigName = packageName + ".configurexml." + file + "Xml";
+            fullConfigName = packageName + ".configurexml." + firstPartOfFileName + "Xml";
             log.debug("getAdapter looks for {}", fullConfigName);
             try {
                 Class<?> configClass = Class.forName(fullConfigName);
@@ -126,16 +132,16 @@ public class ActionsAndExpressionsTest {
             } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException | java.lang.reflect.InvocationTargetException e) {
             }
             if (configureXml == null) {
-                System.out.format("Class %s.%s has no configurexml class%n", packageName, file);
+                System.out.format("Class %s.%s has no configurexml class%n", packageName, firstPartOfFileName);
                 errorsFound = true;
             }
 
             // Disable for now
-//            Assert.assertNotNull(String.format("Class %s has xml class%n", file), configureXml);
+//            Assert.assertNotNull(String.format("Class %s has xml class%n", firstPartOfFileName), configureXml);
 
             // Check that all actions and expressions has a swing class
             SwingConfiguratorInterface configureSwing;
-            fullConfigName = packageName + ".swing." + file + "Swing";
+            fullConfigName = packageName + ".swing." + firstPartOfFileName + "Swing";
             log.debug("getAdapter looks for {}", fullConfigName);
 
             Class<?> configClass = Class.forName(fullConfigName);
@@ -145,13 +151,16 @@ public class ActionsAndExpressionsTest {
 
             MaleSocket socket = configureSwing.createNewObject(configureSwing.getAutoSystemName(), null);
             MaleSocket lastMaleSocket = socket;
+            Assert.assertNotNull(lastMaleSocket);
             Base base = socket;
-            while ((base != null) && (base instanceof MaleSocket)) {
+            Assert.assertNotNull(base);
+            
+            while ((base instanceof MaleSocket)) {
                 lastMaleSocket = (MaleSocket) base;
                 base = ((MaleSocket)base).getObject();
             }
             Assert.assertNotNull(base);
-            Assert.assertEquals("SwingConfiguratorInterface creates an object of correct type", base.getClass().getName(), packageName+"."+file);
+            Assert.assertEquals("SwingConfiguratorInterface creates an object of correct type", base.getClass().getName(), packageName+"."+firstPartOfFileName);
 //                System.out.format("Swing: %s, Class: %s, class: %s%n", configureSwing.toString(), socket.getShortDescription(), socket.getObject().getClass().getName());
             Assert.assertEquals("Swing class has correct name", socket.getShortDescription(), configureSwing.toString());
 //                System.out.format("MaleSocket class: %s, socket class: %s%n",
@@ -169,16 +178,16 @@ public class ActionsAndExpressionsTest {
             Locale.setDefault(DEFAULT_LOCALE);
 
 //            if (configureSwing == null) {
-//                System.out.format("Class %s.%s has no swing class%n", packageName, file);
+//                System.out.format("Class %s.%s has no swing class%n", packageName, firstPartOfFileName);
 //                errorsFound = true;
 //            }
-            Assert.assertNotNull(String.format("Class %s has swing class%n", file), configureSwing);
+            Assert.assertNotNull(String.format("Class %s has swing class%n", firstPartOfFileName), configureSwing);
 
             // Ignore for now
 /*
             // Check that all actions and expressions has a test class for the swing class
 //            Class configureSwingTest = null;
-            fullConfigName = packageName + ".swing." + file + "SwingTest";
+            fullConfigName = packageName + ".swing." + firstPartOfFileName + "SwingTest";
             log.debug("getAdapter looks for {}", fullConfigName);
             Class<?> configClass = null;
             try {
@@ -186,14 +195,14 @@ public class ActionsAndExpressionsTest {
             } catch (ClassNotFoundException e) {
             }
             if (configClass == null) {
-                System.out.format("Class %s.%s has no test class for its swing class%n", packageName, file);
+                System.out.format("Class %s.%s has no test class for its swing class%n", packageName, firstPartOfFile);
                 errorsFound = true;
             }
 //            Assert.assertNotNull("The swing class has a test class", configClass);
 */
 
 /*
-            System.out.format("Class: %s%n", packageName+"."+file);
+            System.out.format("Class: %s%n", packageName+"."+firstPartOfFileName);
             Level severity = Level.ERROR; // level at or above which we'll complain
             boolean unexpectedMessageSeen = JUnitAppender.unexpectedMessageSeen(severity);
             String unexpectedMessageContent = JUnitAppender.unexpectedMessageContent(severity);

--- a/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
+++ b/java/test/jmri/jmrit/logixng/CreateLogixNGTreeScaffold.java
@@ -4312,7 +4312,7 @@ public class CreateLogixNGTreeScaffold {
 
 
     private static final PrimitiveIterator.OfInt iterator =
-            new Random(215).ints('a', 'z'+10).iterator();
+            JUnitUtil.getRandom().ints('a', 'z'+10).iterator();
 
     private static String getRandomString(int count) {
         StringBuilder s = new StringBuilder();

--- a/java/test/jmri/jmrit/logixng/LogixNG_InitializationManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/LogixNG_InitializationManagerTest.java
@@ -82,12 +82,12 @@ public class LogixNG_InitializationManagerTest {
         
         String expectedResult =
                 // These are registered in the init manager
-                "LogixNG 7: start\n" +
-                "LogixNG 7: end\n" +
-                "LogixNG 2: start\n" +
-                "LogixNG 2: end\n" +
-                "LogixNG 8: start\n" +
-                "LogixNG 8: end\n";
+                "LogixNG 7: start" + System.lineSeparator() +
+                "LogixNG 7: end" + System.lineSeparator() +
+                "LogixNG 2: start" + System.lineSeparator() +
+                "LogixNG 2: end" + System.lineSeparator() +
+                "LogixNG 8: start" + System.lineSeparator() +
+                "LogixNG 8: end";
         Assert.assertTrue(stringWriter.toString().startsWith(expectedResult));
     }
     

--- a/java/test/jmri/jmrit/logixng/LogixNG_InitializationManagerTest.java
+++ b/java/test/jmri/jmrit/logixng/LogixNG_InitializationManagerTest.java
@@ -10,7 +10,6 @@ import jmri.*;
 import jmri.jmrit.logixng.actions.*;
 import jmri.jmrit.logixng.implementation.DefaultConditionalNGScaffold;
 import jmri.jmrit.logixng.util.LogixNG_Thread;
-import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
 import org.junit.After;
@@ -35,7 +34,9 @@ public class LogixNG_InitializationManagerTest {
     
     private boolean checkAB() {
         for (AtomicBoolean ab : abList) {
-            if (!ab.get()) return false;
+            if (!ab.get()) {
+                return false;
+            }
         }
         return true;
     }
@@ -116,7 +117,7 @@ public class LogixNG_InitializationManagerTest {
         private final PrintWriter _printWriter;
         private final long _delay;
         
-        public MyAction(
+        MyAction(
                 String userName,
                 AtomicBoolean ab,
                 PrintWriter printWriter,
@@ -132,14 +133,14 @@ public class LogixNG_InitializationManagerTest {
         @Override
         public void execute() {
 //            System.out.format("%s: start\n", getUserName());
-            _printWriter.format("%s: start\n", getUserName());
+            _printWriter.format("%s: start%n", getUserName());
             try {
                 Thread.sleep(_delay);
             } catch (InterruptedException ex) {
                 ex.printStackTrace(_printWriter);
             }
 //            System.out.format("%s: end\n", getUserName());
-            _printWriter.format("%s: end\n", getUserName());
+            _printWriter.format("%s: end%n", getUserName());
             _printWriter.flush();
             _ab.set(true);
         }

--- a/java/test/jmri/jmrit/logixng/SocketOperationTest.java
+++ b/java/test/jmri/jmrit/logixng/SocketOperationTest.java
@@ -7,7 +7,7 @@ import java.util.*;
 import jmri.*;
 import jmri.jmrit.logixng.swing.SwingConfiguratorInterface;
 import jmri.jmrit.logixng.swing.SwingTools;
-import jmri.util.*;
+import jmri.util.JUnitUtil;
 
 import org.junit.*;
 
@@ -83,7 +83,7 @@ public class SocketOperationTest {
 
                 if (socket.getChildCount() > 0) {
                     FemaleSocket child = socket.getChild(
-                            random(socket.getChildCount()));
+                            JUnitUtil.getRandom().nextInt(socket.getChildCount()));
 
                     if (addRemoveChildren) {
                         testAddRemoveChild(child);
@@ -98,7 +98,7 @@ public class SocketOperationTest {
     }
 
     private void testAddRemoveChild(FemaleSocket child) throws SocketAlreadyConnectedException {
-        int oper = random(5);
+        int oper = JUnitUtil.getRandom().nextInt(5);
 
         switch (oper) {
             case 0:  // Add
@@ -132,14 +132,14 @@ public class SocketOperationTest {
         List<Class<? extends Base>> categoryList = null;
 
         while (count++ < 50 && (categoryList == null || categoryList.isEmpty())) {
-            Category category = Category.values().get(random(Category.values().size()));
+            Category category = Category.values().get(JUnitUtil.getRandom().nextInt(Category.values().size()));
             categoryList = connectableClasses.get(category);
         }
 
         Assert.assertNotNull(categoryList);
         Assert.assertFalse(categoryList.isEmpty());
 
-        Class<? extends Base> clazz = categoryList.get(random(categoryList.size()));
+        Class<? extends Base> clazz = categoryList.get(JUnitUtil.getRandom().nextInt(categoryList.size()));
 
         SwingConfiguratorInterface sci = sciSet.get(clazz);
         if (sci == null) {
@@ -159,17 +159,12 @@ public class SocketOperationTest {
 
     private void testFemaleSocketOperations(FemaleSocket child) {
         FemaleSocketOperation fso = FemaleSocketOperation.values()[
-                random(FemaleSocketOperation.values().length)];
+                JUnitUtil.getRandom().nextInt(FemaleSocketOperation.values().length)];
 
         if (child.isSocketOperationAllowed(fso)) {
             child.doSocketOperation(fso);
         }
     }
-
-    private int random(int count) {
-        return (int) (Math.random() * count);
-    }
-
 
     @Before
     public void setUp() {

--- a/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
+++ b/java/test/jmri/jmrit/logixng/actions/ActionScriptTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
  */
 public class ActionScriptTest extends AbstractDigitalActionTestBase {
 
-    private final String _scriptText = "lights.provideLight(\"IL1\").commandedState = ON";
-    private final String _ecmaScript = "var DigitalIO = Java.type(\"jmri.DigitalIO\"); lights.provideLight(\"IL1\").setState(DigitalIO.ON);";
+    private final static String SCRIPT_TEXT = "lights.provideLight(\"IL1\").commandedState = ON";
+    private final static String ECMA_SCRIPT = "var DigitalIO = Java.type(\"jmri.DigitalIO\"); lights.provideLight(\"IL1\").setState(DigitalIO.ON);";
 
 
     private LogixNG logixNG;
@@ -89,13 +89,13 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         ActionScript action2;
 
         action2 = new ActionScript("IQDA321", null);
-        action2.setScript(_scriptText);
+        action2.setScript(SCRIPT_TEXT);
         Assert.assertNotNull("object exists", action2);
         Assert.assertNull("Username matches", action2.getUserName());
         Assert.assertEquals("String matches", "Execute script: Single line command. Script lights.provideLight(\"IL1\").commandedState = ON", action2.getLongDescription());
 
         action2 = new ActionScript("IQDA321", "My action");
-        action2.setScript(_scriptText);
+        action2.setScript(SCRIPT_TEXT);
         Assert.assertNotNull("object exists", action2);
         Assert.assertEquals("Username matches", "My action", action2.getUserName());
         Assert.assertEquals("String matches", "Execute script: Single line command. Script lights.provideLight(\"IL1\").commandedState = ON", action2.getLongDescription());
@@ -103,7 +103,8 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         boolean thrown = false;
         try {
             // Illegal system name
-            new ActionScript("IQA55:12:XY11", null);
+            ActionScript aScript = new ActionScript("IQA55:12:XY11", null);
+            Assert.fail("action script created: " + aScript.toString() );
         } catch (IllegalArgumentException ex) {
             thrown = true;
         }
@@ -112,7 +113,8 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         thrown = false;
         try {
             // Illegal system name
-            new ActionScript("IQA55:12:XY11", "A name");
+            ActionScript aScript = new ActionScript("IQA55:12:XY11", "A name");
+            Assert.fail("action script created: " + aScript.toString() );
         } catch (IllegalArgumentException ex) {
             thrown = true;
         }
@@ -138,7 +140,7 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         Assert.assertTrue("Exception is thrown", hasThrown);
 
         // Test with script
-        actionScript.setScript(_scriptText);
+        actionScript.setScript(SCRIPT_TEXT);
         Assert.assertTrue("getChildCount() returns 0", 0 == actionScript.getChildCount());
     }
 
@@ -218,7 +220,7 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
     @Test
     public void testAction_SingleEcmaCommand() throws Exception {
         actionScript.getScriptEngineSelector().setSelectedEngine(ScriptEngineSelector.ECMA_SCRIPT);
-        actionScript.setScript(_ecmaScript);
+        actionScript.setScript(ECMA_SCRIPT);
 
         // Test action
         Light light = InstanceManager.getDefault(LightManager.class).provide("IL1");
@@ -361,8 +363,7 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         conditionalNG.setEnabled(false);
 
         // Test setScript() when listeners are registered
-        Assert.assertNotNull("Script is not null", _scriptText);
-        actionScript.setScript(_scriptText);
+        actionScript.setScript(SCRIPT_TEXT);
         Assert.assertNotNull("Script is not null", actionScript.getScript());
 
         // Test bad script
@@ -406,7 +407,7 @@ public class ActionScriptTest extends AbstractDigitalActionTestBase {
         ifThenElse.getChild(0).connect(maleSocket2);
 
         actionScript = new ActionScript(InstanceManager.getDefault(DigitalActionManager.class).getAutoSystemName(), null);
-        actionScript.setScript(_scriptText);
+        actionScript.setScript(SCRIPT_TEXT);
         MaleSocket socketActionSimpleScript = InstanceManager.getDefault(DigitalActionManager.class).registerAction(actionScript);
         ifThenElse.getChild(1).connect(socketActionSimpleScript);
 

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionReferenceTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionReferenceTest.java
@@ -106,7 +106,8 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         boolean thrown = false;
         try {
             // Illegal system name
-            new ExpressionReference("IQE55:12:XY11", null);
+            ExpressionReference eRef = new ExpressionReference("IQE55:12:XY11", null);
+            Assert.fail("eref created: " + eRef.toString() );
         } catch (IllegalArgumentException ex) {
             thrown = true;
         }
@@ -115,7 +116,8 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
         thrown = false;
         try {
             // Illegal system name
-            new ExpressionReference("IQE55:12:XY11", "A name");
+            ExpressionReference eRef = new ExpressionReference("IQE55:12:XY11", "A name");
+            Assert.fail("eref created: " + eRef.toString() );
         } catch (IllegalArgumentException ex) {
             thrown = true;
         }
@@ -294,13 +296,12 @@ public class ExpressionReferenceTest extends AbstractDigitalExpressionTestBase {
     public void testSetReferenceException() {
         String reference = "{IM1}";
         // Test setScript() when listeners are registered
-        Assert.assertNotNull("Reference is not null", reference);
         expressionReference.setReference(reference);
         Assert.assertNotNull("Reference is not null", expressionReference.getReference());
         expressionReference.registerListeners();
         boolean thrown = false;
         try {
-            expressionReference.setReference((String)null);
+            expressionReference.setReference(null);
         } catch (RuntimeException ex) {
             thrown = true;
         }

--- a/java/test/jmri/jmrit/logixng/expressions/ExpressionScriptTest.java
+++ b/java/test/jmri/jmrit/logixng/expressions/ExpressionScriptTest.java
@@ -22,8 +22,8 @@ import org.junit.Test;
  */
 public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
 
-    private final String _scriptText = "result.setValue( sensors.provideSensor(\"IS1\").getState() == ACTIVE )";
-    private final String _ecmaScript = "var Sensor = Java.type(\"jmri.Sensor\"); result.setValue( sensors.provideSensor(\"IS1\").getState() == Sensor.ACTIVE )";
+    private static final String SCRIPT_TEXT = "result.setValue( sensors.provideSensor(\"IS1\").getState() == ACTIVE )";
+    private static final String ECMA_SCRIPT = "var Sensor = Java.type(\"jmri.Sensor\"); result.setValue( sensors.provideSensor(\"IS1\").getState() == Sensor.ACTIVE )";
 
 
     private LogixNG logixNG;
@@ -87,13 +87,13 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         ExpressionScript expression2;
 
         expression2 = new ExpressionScript("IQDE321", null);
-        expression2.setScript(_scriptText);
+        expression2.setScript(SCRIPT_TEXT);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertNull("Username matches", expression2.getUserName());
         Assert.assertEquals("String matches", "Evaluate script: Single line command. Script result.setValue( sensors.provideSensor(\"IS1\").getState() == ACTIVE )", expression2.getLongDescription());
 
         expression2 = new ExpressionScript("IQDE321", "My expression");
-        expression2.setScript(_scriptText);
+        expression2.setScript(SCRIPT_TEXT);
         Assert.assertNotNull("object exists", expression2);
         Assert.assertEquals("Username matches", "My expression", expression2.getUserName());
         Assert.assertEquals("String matches", "Evaluate script: Single line command. Script result.setValue( sensors.provideSensor(\"IS1\").getState() == ACTIVE )", expression2.getLongDescription());
@@ -101,7 +101,8 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         boolean thrown = false;
         try {
             // Illegal system name
-            new ExpressionScript("IQA55:12:XY11", null);
+            ExpressionScript escipt = new ExpressionScript("IQA55:12:XY11", null);
+            Assert.fail("escript created: " + escipt.toString() );
         } catch (IllegalArgumentException ex) {
             thrown = true;
         }
@@ -110,7 +111,8 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         thrown = false;
         try {
             // Illegal system name
-            new ExpressionScript("IQA55:12:XY11", "A name");
+            ExpressionScript escipt = new ExpressionScript("IQA55:12:XY11", "A name");
+            Assert.fail("escript created: " + escipt.toString() );
         } catch (IllegalArgumentException ex) {
             thrown = true;
         }
@@ -136,7 +138,7 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         Assert.assertTrue("Exception is thrown", hasThrown);
 
         // Test with script
-        expressionScript.setScript(_scriptText);
+        expressionScript.setScript(SCRIPT_TEXT);
         Assert.assertTrue("getChildCount() returns 0", 0 == expressionScript.getChildCount());
     }
 
@@ -209,7 +211,7 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
     @Test
     public void testExpression_SingleEcmaCommand() throws Exception {
         expressionScript.getScriptEngineSelector().setSelectedEngine(ScriptEngineSelector.ECMA_SCRIPT);
-        expressionScript.setScript(_ecmaScript);
+        expressionScript.setScript(ECMA_SCRIPT);
 
         // Test expression
         Light light = InstanceManager.getDefault(LightManager.class).provide("IL1");
@@ -296,8 +298,7 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         conditionalNG.setEnabled(false);
 
         // Test setScript() when listeners are registered
-        Assert.assertNotNull("Script is not null", _scriptText);
-        expressionScript.setScript(_scriptText);
+        expressionScript.setScript(SCRIPT_TEXT);
         Assert.assertNotNull("Script is not null", expressionScript.getScript());
 
         // Test bad script
@@ -335,7 +336,7 @@ public class ExpressionScriptTest extends AbstractDigitalExpressionTestBase {
         sensor = InstanceManager.getDefault(SensorManager.class).provide("IS1");
 
         expressionScript = new ExpressionScript(InstanceManager.getDefault(DigitalExpressionManager.class).getAutoSystemName(), null);
-        expressionScript.setScript(_scriptText);
+        expressionScript.setScript(SCRIPT_TEXT);
         expressionScript.setRegisterListenerScript("sensors.provideSensor(\"IS1\").addPropertyChangeListener(self)");
         expressionScript.setUnregisterListenerScript("sensors.provideSensor(\"IS1\").removePropertyChangeListener(self)");
         MaleSocket socketExpressionScript = InstanceManager.getDefault(DigitalExpressionManager.class).registerExpression(expressionScript);

--- a/java/test/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocketTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/DefaultMaleAnalogActionSocketTest.java
@@ -43,7 +43,9 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
     @Test
     public void testSetValue() throws JmriException {
         ConditionalNG conditionalNG = new DefaultConditionalNGScaffold("IQC1", "A conditionalNG");  // NOI18N;
-        
+
+        double TOLERANCE = 0.0001; 
+
         MyAnalogAction action = new MyAnalogAction("IQAA321");
         action.setParent(conditionalNG);
         
@@ -57,11 +59,11 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
         action.je = null;
         action.re = null;
         socket.setValue(9.121);
-        Assert.assertTrue(9.121 == action._value);
+        Assert.assertEquals(9.121, action._value, TOLERANCE);
         socket.setValue(572.1);
-        Assert.assertTrue(572.1 == action._value);
+        Assert.assertEquals(572.1, action._value, TOLERANCE);
         socket.setValue(0.0);
-        Assert.assertTrue(0.0 == action._value);
+        Assert.assertEquals(0.0 , action._value, TOLERANCE);
         
         action.je = new JmriException("Test JmriException");
         action.re = null;
@@ -98,11 +100,11 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
         config._dontExecute = true;
         action._value = 19.23;
         socket.setValue(32.11);
-        Assert.assertTrue(19.23 == action._value);
+        Assert.assertEquals(19.23, action._value, TOLERANCE);
         config._dontExecute = false;
         action._value = 23.111;
         socket.setValue(9.23);
-        Assert.assertTrue(9.23 == action._value);
+        Assert.assertEquals(9.23, action._value, TOLERANCE);
     }
     
     @Test
@@ -224,7 +226,7 @@ public class DefaultMaleAnalogActionSocketTest extends MaleSocketTestBase {
      * This action is different from AnalogActionMemory and is used to test the
      * male socket.
      */
-    private class MyAnalogAction extends AbstractAnalogAction {
+    private static class MyAnalogAction extends AbstractAnalogAction {
         
         JmriException je = null;
         RuntimeException re = null;

--- a/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogActionManagerXmlTest.java
+++ b/java/test/jmri/jmrit/logixng/implementation/configurexml/DefaultAnalogActionManagerXmlTest.java
@@ -211,6 +211,8 @@ public class DefaultAnalogActionManagerXmlTest {
     
     class MyManager extends DefaultAnalogActionManager {
         
+        @edu.umd.cs.findbugs.annotations.SuppressFBWarnings( value = "OVERRIDING_METHODS_MUST_INVOKE_SUPER",
+            justification = "We don't want to save config for this class")
         @Override
         protected void registerSelf() {
             // We don't want to save config for this class


### PR DESCRIPTION
ActionScriptTest.java - final strings to static, assert new instance failure
ActionsAndExpressionsTest.java - rename string to avoid assignment to-for loop parameter
CreateLogixNGTreeScaffold.java - use JUnitUtil Random
ExpressionReferenceTest.java - assert new instance failures, no need to cast null to String
ExpressionScriptTest.java - final strings to static, assert new instance fails
DefaultAnalogActionManagerXmlTest.java - no need to super registerSelf as not saving test framework config
DefaultMaleAnalogActionSocketTest.java - add TOLERANCE to check values, framework class to static
LogixNG_InitializationManagerTest.java  use format %n over \n for new line character. System.lineSeparator
SocketOperationTest.java - use JUnitUtil.getRandom() over Math.random()