### PR TITLE
MQTT channel default is now the null string

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -97,6 +97,9 @@
         <h4>MQTT</h4>
             <ul>
                 <li>Rewrite and expansion of documentation.</li>
+                <li>The default value of the channel is now "", the null string.
+                    The channel name is prefixed to all of JMRI's publish and subscribe
+                    operations.  The previous default was "/trains/"
             </ul>
 
         <h4>MRC</h4>

--- a/java/src/jmri/jmrix/mqtt/Bundle.properties
+++ b/java/src/jmri/jmrix/mqtt/Bundle.properties
@@ -33,7 +33,7 @@ NameMessageLastWill=Last will message
 
 # The following are default topic segments - may not need to be translated
 
-TopicBase=/trains/
+TopicBase=
 
 TopicTurnoutSend=track/turnout/
 TopicTurnoutRcv=track/turnout/


### PR DESCRIPTION
The default channel (prefix to all operations) was "/trains/".  To allow the use of a null-channel (requested by users), this default is now changed to the empty string "".