### PR TITLE
Correction to CMRI.shtml regarding escape bytes

### DIFF
--- a/help/en/html/hardware/cmri/CMRI.shtml
+++ b/help/en/html/hardware/cmri/CMRI.shtml
@@ -1367,7 +1367,7 @@
       <p style="margin-left:2em;">C/MRI bits 1, 2, 3, 4 set to 1 display as F (computer bits 0, 1,
       2, 3)<br>
       C/MRI bits 2, 4, 8 set to 1 display as 8A (computer bits 1, 3, 7)<br>
-      C/MRI bits 2, 3 set to 1 display as 10 3 (computer bits 1, 2, preceded by the escape byte value of "10")<br>
+      C/MRI bits 1, 2 set to 1 display as 10 3 (computer bits 0, 1, preceded by the escape byte value of "10")<br>
       C/MRI bits 3, 4 set to 1 display as C (computer bits 2, 3)<br>
       C/MRI bits 3, 4, 6, 7 set to 1 display as 6C (computer bits 2, 3, 5, 6)<br>
       C/MRI bits 6, 8 set to 1 display as A0 (computer bits 5, 7)</p>

--- a/help/en/html/hardware/cmri/CMRI.shtml
+++ b/help/en/html/hardware/cmri/CMRI.shtml
@@ -1333,6 +1333,10 @@
       and bit 0 is the rightmost bit displayed (if bits 4-7 are 0, only one hexadecimal digit will
       be shown).</p>
 
+      <p>Note that the byte values "2", "3" and "10" have special meaning to CMRI (start of text, end of text, and escape).
+      To avoid confusion, an additional byte of "10" is put in the string in front of any other byte whose value is "2", 
+      "3" or "10" (see below for examples).</p>
+
       <p><strong>Be aware:</strong> JMRI numbers C/MRI bits starting at 1 rather than 0 which may
       cause some confusion in interpreting the C/MRI Monitor output versus the C/MRI bit
       assignments. Some devices receiving C/MRI transmission from JMRI, such as the arduino, are
@@ -1347,13 +1351,14 @@
       7, 15, 23)<br>
       C/MRI bits 7, 15, 23 set to 1 display as 40 40 40 (computer bits 6, 14, 22)<br>
       C/MRI bits 6, 14, 22 set to 1 display as 20 20 20 (computer bits 5, 13, 21)<br>
-      C/MRI bits 5, 13, 21 set to 1 display as 10 10 10 (computer bits 4, 12, 20)</p>
+      C/MRI bits 5, 13, 21 set to 1 display as 10 10 10 10 10 10 (computer bits 4, 12, 20, each preceded
+      preceded by the escape byte value of "10")</p>
 
       <p style="margin-left:2em;">C/MRI bits 4, 12, 20 set to 1 display as 8 8 8 (computer bits 3,
       11, 19)<br>
       C/MRI bits 3, 11, 19 set to 1 display as 4 4 4 (computer bits 2, 10, 18)<br>
-      C/MRI bits 2, 10, 18 set to 1 display as 10 2 2 2 (computer bits 1, 9, 17) (an "escape"
-      character is put in the string as a "10" if the first byte is a 2)<br>
+      C/MRI bits 2, 10, 18 set to 1 display as 10 2 10 2 10 2 (computer bits 1, 9, 17, each preceded by
+      the escape byte value of "10")<br>
       C/MRI bits 1, 9, 17 set to 1 display as 1 1 1 (computer bits 0, 8, 16)</p>
 
       <p>If multiple bits are set to 1 within the same byte, then output appears as in these
@@ -1362,6 +1367,7 @@
       <p style="margin-left:2em;">C/MRI bits 1, 2, 3, 4 set to 1 display as F (computer bits 0, 1,
       2, 3)<br>
       C/MRI bits 2, 4, 8 set to 1 display as 8A (computer bits 1, 3, 7)<br>
+      C/MRI bits 2, 3 set to 1 display as 10 3 (computer bits 1, 2, preceded by the escape byte value of "10")<br>
       C/MRI bits 3, 4 set to 1 display as C (computer bits 2, 3)<br>
       C/MRI bits 3, 4, 6, 7 set to 1 display as 6C (computer bits 2, 3, 5, 6)<br>
       C/MRI bits 6, 8 set to 1 display as A0 (computer bits 5, 7)</p>


### PR DESCRIPTION
The documentation was incorrect regarding the placement of DLE (10) bytes in CMRI transmit strings.